### PR TITLE
fix: dashboard review fixes, dispatch config stripping, error logging

### DIFF
--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -38,7 +38,27 @@ export class BeastDispatchService {
 
   async createRun(request: CreateBeastRunRequest): Promise<BeastRun> {
     const definition = this.getDefinitionOrThrow(request.definitionId);
-    const config = definition.configSchema.parse(request.config);
+    // Try parsing as-is first. If it fails with unrecognized_keys (strict schema
+    // rejecting extra fields from agent init config), strip to only known keys.
+    let config: Readonly<Record<string, unknown>>;
+    const firstAttempt = definition.configSchema.safeParse(request.config);
+    if (firstAttempt.success) {
+      config = firstAttempt.data;
+    } else {
+      const hasUnrecognizedKeys = firstAttempt.error.issues.some(
+        (issue) => issue.code === 'unrecognized_keys',
+      );
+      if (!hasUnrecognizedKeys) {
+        // Real validation error — surface it
+        throw firstAttempt.error;
+      }
+      // Extract only the keys the schema knows about
+      const shape = (definition.configSchema as { shape?: Record<string, unknown> }).shape;
+      const stripped = shape
+        ? Object.fromEntries(Object.entries(request.config).filter(([k]) => k in shape))
+        : request.config;
+      config = definition.configSchema.parse(stripped);
+    }
     const moduleConfig = request.moduleConfig ?? this.resolveAgentModuleConfig(request.trackedAgentId);
     const configSnapshot: Readonly<Record<string, unknown>> = moduleConfig
       ? { ...config, modules: moduleConfig }

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -73,6 +73,11 @@ export function requestSizeLimit(maxSize: number) {
 
 export const errorHandler: ErrorHandler = (err, c) => {
   if (err instanceof HttpError) {
+    if (err.statusCode >= 500) {
+      console.error(`[HTTP ${err.statusCode}] ${err.code}: ${err.message}`, err.details ?? '');
+    } else {
+      console.warn(`[HTTP ${err.statusCode}] ${err.code}: ${err.message}`, err.details ?? '');
+    }
     return c.json(
       {
         error: {
@@ -85,7 +90,10 @@ export const errorHandler: ErrorHandler = (err, c) => {
     );
   }
 
-  // Never expose raw stack traces
+  // Log unexpected errors to terminal — essential for debugging
+  console.error('[HTTP 500] Unhandled error:', err instanceof Error ? err.stack ?? err.message : err);
+
+  // Never expose raw stack traces to client
   return c.json(
     {
       error: {

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -328,11 +328,11 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
     const agentId = c.req.param('agentId');
     try {
       const agent = deps.agents.getAgent(agentId);
-      if (agent.status !== 'stopped') {
+      if (agent.status !== 'stopped' && agent.status !== 'failed' && agent.status !== 'completed') {
         throw new HttpError(
           409,
           'TRACKED_AGENT_NOT_DELETABLE',
-          `Tracked agent '${agentId}' is not stopped`,
+          `Tracked agent '${agentId}' must be stopped, failed, or completed to delete`,
         );
       }
       deps.agents.appendEvent(agentId, {

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -114,6 +114,10 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[agent-routes] Dispatch failed for ${agent.id}: ${errorMessage}`);
+      if (error instanceof Error && error.stack) {
+        console.error(error.stack);
+      }
       deps.agents.updateAgent(agent.id, { status: 'failed' });
       deps.agents.appendEvent(agent.id, {
         level: 'error',

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -54,7 +54,7 @@ describe('dashboard routes', () => {
         requireApproval: 'destructive',
       });
       expect(body.providers).toEqual([
-        { name: 'claude', type: 'claude-cli' },
+        { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
       ]);
     });
 

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -16,8 +16,8 @@ function makeMockSnapshot(): DashboardSnapshot {
       outputValidation: true,
     },
     providers: [
-      { name: 'anthropic', type: 'llm' },
-      { name: 'openai', type: 'llm' },
+      { name: 'anthropic', type: 'llm', available: true, failoverOrder: 0 },
+      { name: 'openai', type: 'llm', available: false, failoverOrder: 1 },
     ],
   };
 }

--- a/packages/franken-web/src/stores/dashboard-store.test.ts
+++ b/packages/franken-web/src/stores/dashboard-store.test.ts
@@ -15,7 +15,7 @@ function makeMockSnapshot(): DashboardSnapshot {
       outputValidation: true,
     },
     providers: [
-      { name: 'anthropic', type: 'llm' },
+      { name: 'anthropic', type: 'llm', available: true, failoverOrder: 0 },
     ],
   };
 }


### PR DESCRIPTION
## Summary

Follow-up fixes after #270 (Chunk D) was merged. Addresses review findings + dashboard bugs reported during testing.

### Review Fixes (10 issues from code review)
- SSE `onAbort` combined into single handler (was leaking intervals)
- `encodeURIComponent(name)` in skill PATCH URL (was path-injectable)
- `role="switch"` + `aria-checked` on skill toggle (accessible without Radix dep)
- ProviderPanel shows `[ok]`/`[unavailable]` health + failover sort order (full-stack)
- Stale-flag fetch cleanup in DashboardPage useEffect
- 20 component tests added (SkillCard, CatalogBrowser, SecurityPanel, ProviderPanel)
- `requireApproval` field added to DashboardSecurity type + SecurityPanel
- JSDoc on `dashboardDeps` documenting coupling requirement

### Bug Fixes
- **Dispatch config stripping**: Beast definitions use `.strict()` schemas that reject unknown keys. Dashboard dispatch passes full agent init config. Now `safeParse` first, strip to schema-known keys on `unrecognized_keys` error.
- **Agent delete 409**: Delete route only allowed `stopped` agents. Now accepts `failed` and `completed` too.
- **Silent error swallowing**: `errorHandler` logged nothing to terminal. Now logs all HTTP errors (4xx as warn, 5xx as error with stack). Agent dispatch failures log error + stack trace to console.

### Build Fix
- Test mocks updated for `DashboardProvider` type change (`available`, `failoverOrder` fields)

## Test plan
- [x] 183/183 franken-web tests pass
- [x] 170/170 orchestrator beast + HTTP tests pass
- [x] Full build clean (8/8 turbo tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)