### PR TITLE
fix: populate ChatRuntime phase field, update PROGRESS.md and RAMP_UP.md

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -398,16 +398,35 @@ Append-only `AuditTrail` with hash-verified integrity, `AuditTrailStore` persist
 
 ---
 
+## Architecture Consolidation — Last-Mile Wiring
+
+> PRs: #270, #272, #274, #275
+
+- **Chunk D** (#270, #272): Dashboard SSE routes, React panels (SkillCard, CatalogBrowser, SecurityPanel, ProviderPanel), dashboard API client, Zustand store. Follow-up fixes for dispatch config stripping, error logging, agent deletion.
+- **R1-R4 Fixes** (#274): Added `providerContext`/`phase` to ChatRuntimeResult, `loadForProvider()` to SkillManager, wired ReflectionEvaluator as reflectionFn, AuditTrail persistence at closure.
+- **Last-Mile Wiring** (#275): Closed 5 critical gaps:
+  - C1: Surfaced skillManager/providerRegistry/dashboardDeps through run.ts → startChatServer() — `/api/skills` and `/api/dashboard` routes now live
+  - C2: Fixed skillsDir to resolve relative to project root
+  - C3: Created ProviderRegistryIAdapter — ProviderRegistry.execute() now active in reflection path
+  - C4: MiddlewareChain wraps ProviderRegistryIAdapter request/response
+  - C5: Extended OrchestratorConfigSchema with security/brain/consolidatedProviders, deleted dead RunConfigV2Schema
+
+**Test counts**: 2,096 orchestrator tests passing. 8/8 turbo build tasks clean.
+
+---
+
 ## Known Limitations
 
 1. **Orchestrator depends on port interfaces, not implementations** (by design — hexagonal architecture). Concrete module wiring is done in `dep-factory.ts` via `createBeastDeps()`.
 2. **No `--non-interactive` flag**: Review loops require stdin. For CI/headless use, pipe `"y\n"` to stdin.
 3. **E2E tests require `npm run build`**: No `pretest:e2e` script yet.
-4. **Dashboard (Chunk D) not yet implemented**: SSE endpoints and React panels in franken-web are pending.
-5. **Provider/dashboard CLI commands are stubs**: `frankenbeast provider` and `frankenbeast dashboard` print instructions but don't execute.
+4. **Provider/dashboard CLI commands are stubs**: `frankenbeast provider` and `frankenbeast dashboard` print instructions but don't execute.
+5. **ProviderRegistry only active in reflection path**: Task execution still flows through CliLlmAdapter → MartinLoop → spawn(). Multi-provider failover applies to heartbeat/reflection LLM calls only. This is by design — middleware applies to prompt text in-process, not subprocess stdio.
+6. **SkillManagerAdapter.execute() and McpSdkAdapter.callTool() are stubs**: Return hardcoded strings. Real MCP tool dispatch is a future effort.
 
 ## Notes
 - Critical path: PR-15 → 19 → 20 → 25 → 26 → 27 → 28 → 29 → 30 → 36 → 37 → 38
 - Phase 5 (PRs 31-35) ran in parallel with Phases 3-4
 - All phases (2–7) complete. 28 PRs implemented (PR-15 through PR-42).
+- Architecture Consolidation residuals fully addressed: Chunks A-F, One-Shots O1-O4, R1-R4, C1-C5.
 - Post-audit fixes: franken-skills vitest config (exclude dist/), critique server wired to real pipeline.

--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -110,7 +110,11 @@ packages/franken-orchestrator/src/
   - `--target-upstream` derive the canonical target repository from the checkout's GitHub `upstream` remote; mutually exclusive with `--repo`
   - `--dry-run` preview triage without executing
 - Build artifacts are plan-scoped under `.frankenbeast/.build/`: `<plan-name>.checkpoint` for execution state, `<plan-name>-<datetime>-build.log` for session logs (written incrementally, crash-safe), `chunk-sessions/<plan>/<chunk>.json` for canonical chunk execution state, and `chunk-session-snapshots/<plan>/<chunk>/...json` for pre-compaction rollback points. Different plans have independent checkpoints and log histories.
-- Current local CLI dep wiring is mixed: observer, CLI adapters, `CliSkillExecutor`, `MartinLoop`, `GitBranchIsolator`, and `FileCheckpointStore` are real, but `firewall`, `skills`, `memory`, `planner`, and `heartbeat` are stubbed in `src/cli/dep-factory.ts`. Critique and governor are dynamically imported when available.
+- `dep-factory.ts` calls `createBeastDeps()` which wires real consolidated adapters for all module ports: `MiddlewareChainFirewallAdapter` (firewall), `SqliteBrainMemoryAdapter` (memory), `SkillManagerAdapter` (skills), `ReflectionHeartbeatAdapter` (heartbeat), `AuditTrailObserverAdapter` (observer). Falls back to passthrough stubs only when `createBeastDeps()` throws (e.g., no providers configured).
+- `ProviderRegistryIAdapter` bridges `ProviderRegistry.execute()` (async generator) to `IAdapter` (Promise), with `MiddlewareChain` applied on request/response. Active in the heartbeat/reflection LLM path.
+- `SkillConfigStore` persists enabled-skill state to `.frankenbeast/config.json`.
+- `OrchestratorConfigSchema` accepts `security`, `brain`, and `consolidatedProviders` fields from config files, threaded through `dep-bridge.ts` → `createBeastDeps()`.
+- `run.ts` surfaces `skillManager`, `providerRegistry`, and `dashboardDeps` from `createCliDeps()` into `startChatServer()`, activating `/api/skills` and `/api/dashboard` routes.
 
 ## Build & Test
 
@@ -143,11 +147,11 @@ Most packages build with `tsc`; `franken-web` uses `tsc && vite build`.
 
 ## Known Limitations
 
-1. The local CLI path is only partially wired: observer and CLI execution are real, but several sibling module deps remain stubbed in `franken-orchestrator/src/cli/dep-factory.ts`
-2. The current CLI path is not purely ports-only: `CliObserverBridge` imports concrete classes from `@frankenbeast/observer`
-3. There is no dedicated `--non-interactive` flag; headless usage currently relies on starting at `plan` or `run` with existing inputs
-4. `--resume` is parsed, but it is not wired as a distinct resume control path; checkpoint-based task skipping still works from existing checkpoint files
-5. CLI-created agents do not yet enter the tracked-agent model through a dedicated CLI init flow; the dashboard and chat-backed init paths are wired, but CLI parity is still a follow-up
+1. **ProviderRegistry only active in reflection path**: Task execution flows through `CliLlmAdapter → MartinLoop → spawn()`. Multi-provider failover applies to heartbeat/reflection calls only. By design — middleware applies to in-process prompt text, not subprocess stdio.
+2. **SkillManagerAdapter.execute() and McpSdkAdapter.callTool() are stubs**: Return hardcoded strings. Real MCP tool dispatch is a future effort.
+3. **No `--non-interactive` flag**: Headless usage relies on starting at `plan` or `run` with existing inputs.
+4. **Provider/dashboard CLI commands are stubs**: `frankenbeast provider` and `frankenbeast dashboard` print instructions but don't execute.
+5. **`--resume` parsed but not a distinct control path**: Checkpoint-based task skipping works from existing checkpoint files.
 
 ## Key Documentation
 

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -116,6 +116,7 @@ export class ChatRuntime {
         ], {
           events: runResult.events,
           tier: 'premium_reasoning',
+          phase: 'planning',
         });
       }
       case '/run': {
@@ -236,6 +237,7 @@ export class ChatRuntime {
           {
             outcome: result.outcome,
             tier: result.tier,
+            phase: 'planning',
           },
         );
       case 'execute':
@@ -268,6 +270,7 @@ export class ChatRuntime {
         ...(pendingApproval ? { pendingApprovalDescription: outcome.taskDescription } : {}),
         state: stateFromRunResult(runResult),
         tier,
+        phase: 'execution',
       },
     );
   }
@@ -282,6 +285,8 @@ export class ChatRuntime {
       pendingApprovalDescription?: string;
       state?: string;
       tier?: string | null;
+      providerContext?: ChatRuntimeResult['providerContext'];
+      phase?: string;
     },
   ): ChatRuntimeResult {
     return {
@@ -292,6 +297,8 @@ export class ChatRuntime {
       ...(extra?.pendingApprovalDescription !== undefined
         ? { pendingApprovalDescription: extra.pendingApprovalDescription }
         : {}),
+      ...(extra?.providerContext ? { providerContext: extra.providerContext } : {}),
+      ...(extra?.phase ? { phase: extra.phase } : {}),
       state: extra?.state ?? 'active',
       tier: extra?.tier ?? null,
       transcript: state.transcript,


### PR DESCRIPTION
## Summary

- **I2 resolved**: `ChatRuntime.result()` now accepts and passes through `providerContext` and `phase` fields. Planning results get `phase: 'planning'`, execution results get `phase: 'execution'`. Previously these fields existed on the type but were never populated.
- **PROGRESS.md updated**: Added last-mile wiring section (PRs #270-275), fixed stale Known Limitations (removed false "Chunk D not implemented" claim, added actual current gaps).
- **RAMP_UP.md updated**: Replaced stale "stubbed deps" description with current consolidated wiring. Updated Known Limitations to reflect actual state.

## Test plan

- [x] 2096/2096 orchestrator tests pass
- [x] 8/8 turbo build tasks clean
- [x] RAMP_UP.md under 5000 token limit (1786 words)

🤖 Generated with [Claude Code](https://claude.com/claude-code)