### PR TITLE
fix(ci): sync package-lock.json with @fbeast/mcp-suite workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1088,6 +1088,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fbeast/mcp-suite": {
+      "resolved": "packages/franken-mcp-suite",
+      "link": true
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "license": "MIT",
@@ -5230,10 +5234,6 @@
       "resolved": "packages/franken-brain",
       "link": true
     },
-    "node_modules/franken-mcp-suite": {
-      "resolved": "packages/franken-mcp-suite",
-      "link": true
-    },
     "node_modules/franken-orchestrator": {
       "resolved": "packages/franken-orchestrator",
       "link": true
@@ -9179,6 +9179,7 @@
       }
     },
     "packages/franken-mcp-suite": {
+      "name": "@fbeast/mcp-suite",
       "version": "0.1.0",
       "dependencies": {
         "@franken/critique": "*",
@@ -9191,9 +9192,11 @@
         "franken-planner": "*"
       },
       "bin": {
+        "fbeast": "dist/cli/main.js",
         "fbeast-critique": "dist/servers/critique.js",
         "fbeast-firewall": "dist/servers/firewall.js",
         "fbeast-governor": "dist/servers/governor.js",
+        "fbeast-hook": "dist/cli/hook.js",
         "fbeast-init": "dist/cli/init.js",
         "fbeast-mcp": "dist/beast.js",
         "fbeast-memory": "dist/servers/memory.js",
@@ -9437,7 +9440,7 @@
       }
     },
     "packages/franken-orchestrator": {
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",


### PR DESCRIPTION
## Summary
- `npm ci` on `main` fails with `Missing: @fbeast/mcp-suite@0.1.0 from lock file` because the mcp-suite workspace package was added without regenerating `package-lock.json`.
- Regenerated via `npm install` — no dependency version changes, only workspace wiring for `packages/franken-mcp-suite`.

## Test plan
- [x] Reproduced failure: `npm ci --dry-run` → EUSAGE, missing workspace entry
- [x] After fix: `npm ci --dry-run` → `up to date in 949ms`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)