### PR TITLE
docs(plans): chunked implementation plans for 2026-04-28 security gap-fill

### DIFF
--- a/docs/superpowers/plans/2026-05-17-sechard-1-failclosed-boundaries.md
+++ b/docs/superpowers/plans/2026-05-17-sechard-1-failclosed-boundaries.md
@@ -1,0 +1,332 @@
+# Chunk 1: Fail-Closed HTTP & Approval Boundaries — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the chat HTTP surface authenticated and make HITL approval fail closed instead of fail open.
+
+**Architecture:** Generalize the existing `requireBeastOperatorAuth` middleware into a shared `requireOperatorAuth`, apply it to `/v1/chat/*` when an operator token is configured, and remove the three fail-open approval paths (non-TTY auto-approve, signature-required-without-verifier, governor server unsigned-by-default). No new runtime; pure boundary tightening with TDD.
+
+**Tech Stack:** TypeScript, Hono, Vitest, existing `TransportSecurityService`, existing `GovernorPortAdapter`/`ApprovalGateway`.
+
+---
+
+## Verified Gap Evidence (current `main` @ `610a0ea`, 2026-05-17)
+
+- `packages/franken-orchestrator/src/cli/dep-factory.ts:387-393` — `if (!stdin.isTTY)` wires `GovernorPortAdapter({ defaultDecision: 'approved' })`: non-interactive runs auto-approve every HITL gate.
+- `packages/franken-governor/src/gateway/approval-gateway.ts:42` — `if (this.config.requireSignedApprovals && this.signatureVerifier)`: `requireSignedApprovals: true` with no verifier silently skips verification.
+- `packages/franken-governor/src/server/app.ts:54` — `if (options.signingSecret)`: with no secret configured, `/v1/approval/respond` accepts unsigned responses.
+- `packages/franken-orchestrator/src/http/chat-app.ts:100` — `/v1/chat/*` only has `requestSizeLimit`; no auth middleware. Chat session/message/approve routes are unauthenticated.
+- Existing reusable pattern: `packages/franken-orchestrator/src/beasts/http/beast-auth.ts` already implements the exact bearer / `x-frankenbeast-operator-token` middleware to generalize.
+
+## File Structure
+
+- Create `packages/franken-orchestrator/src/http/operator-auth.ts` — shared `extractOperatorToken` + `requireOperatorAuth` middleware (one responsibility: operator-token gate).
+- Modify `packages/franken-orchestrator/src/beasts/http/beast-auth.ts` — delegate to the shared helper (no behavior change).
+- Modify `packages/franken-orchestrator/src/http/chat-app.ts` — apply `requireOperatorAuth` to `/v1/chat/*` when a token is configured; keep `/health` public.
+- Modify `packages/franken-orchestrator/src/cli/dep-factory.ts` — replace non-TTY `defaultDecision: 'approved'` with a fail-closed `denied`/abort default unless `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`.
+- Modify `packages/franken-governor/src/gateway/approval-gateway.ts` — constructor throws when `requireSignedApprovals && !signatureVerifier`.
+- Modify `packages/franken-governor/src/server/app.ts` — reject unsigned `/v1/approval/respond` when no `signingSecret` unless `allowUnsignedApprovalsForTests: true`.
+- Tests: `tests/integration/chat/chat-routes.test.ts`, `tests/unit/cli/run.test.ts`, `tests/integration/cli/dep-factory-wiring.test.ts`, `franken-governor/tests/unit/gateway/approval-gateway-security.test.ts`, `franken-governor/tests/unit/server/app.test.ts`.
+
+---
+
+## Task 1: Shared operator auth + chat route gating
+
+**Files:**
+- Create: `packages/franken-orchestrator/src/http/operator-auth.ts`
+- Modify: `packages/franken-orchestrator/src/beasts/http/beast-auth.ts`
+- Modify: `packages/franken-orchestrator/src/http/chat-app.ts:31` (`ChatAppOptions`), `:100` (middleware insertion)
+- Test: `packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts`
+
+- [ ] **Step 1: Write the failing chat-auth test**
+
+In `tests/integration/chat/chat-routes.test.ts`, add:
+
+```ts
+describe('chat route operator auth', () => {
+  it('rejects unauthenticated chat requests when an operator token is configured', async () => {
+    const app = createChatApp({ ...baseChatOpts, operatorToken: 'secret-op-token' });
+    const res = await app.request('/v1/chat/sessions', { method: 'POST', body: '{}' });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts chat requests with a valid bearer operator token', async () => {
+    const app = createChatApp({ ...baseChatOpts, operatorToken: 'secret-op-token' });
+    const res = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { authorization: 'Bearer secret-op-token', 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).not.toBe(401);
+  });
+
+  it('keeps /health public', async () => {
+    const app = createChatApp({ ...baseChatOpts, operatorToken: 'secret-op-token' });
+    const res = await app.request('/health');
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+(`baseChatOpts` = the existing fixture used by sibling tests in this file.)
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/integration/chat/chat-routes.test.ts`
+Expected: FAIL — POST `/v1/chat/sessions` returns 2xx/4xx-non-401 because no auth middleware exists.
+
+- [ ] **Step 3: Create the shared middleware**
+
+Create `packages/franken-orchestrator/src/http/operator-auth.ts`:
+
+```ts
+import { createMiddleware } from 'hono/factory';
+import { HttpError } from './middleware.js';
+import { TransportSecurityService } from './security/transport-security.js';
+
+export interface OperatorAuthOptions {
+  operatorToken: string;
+  security: TransportSecurityService;
+}
+
+export function extractOperatorToken(headerValue: string | undefined): string | undefined {
+  if (!headerValue) return undefined;
+  const [scheme, token] = headerValue.split(' ');
+  return scheme?.toLowerCase() === 'bearer' && token ? token : undefined;
+}
+
+export function requireOperatorAuth(options: OperatorAuthOptions) {
+  return createMiddleware(async (c, next) => {
+    const provided = extractOperatorToken(c.req.header('authorization'))
+      ?? c.req.header('x-frankenbeast-operator-token')
+      ?? undefined;
+
+    if (!options.security.verifyOperatorToken(provided, options.operatorToken)) {
+      throw new HttpError(401, 'UNAUTHORIZED', 'Operator authentication is required');
+    }
+
+    await next();
+  });
+}
+```
+
+- [ ] **Step 4: Delegate `beast-auth.ts` to the shared helper**
+
+Replace the body of `requireBeastOperatorAuth` in `beasts/http/beast-auth.ts` so it returns `requireOperatorAuth({ operatorToken: options.operatorToken, security: options.security })`. Keep `BeastAuthOptions` and the export name for callers.
+
+- [ ] **Step 5: Wire chat auth**
+
+In `chat-app.ts`: add `operatorToken?: string;` to `ChatAppOptions` (near line 31). In `createChatApp`, immediately after the existing `app.use('/v1/chat/*', requestSizeLimit(DEFAULT_MAX_BODY_SIZE));` (line 100), add:
+
+```ts
+const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken;
+if (effectiveOperatorToken) {
+  app.use('/v1/chat/*', requireOperatorAuth({
+    operatorToken: effectiveOperatorToken,
+    security: opts.beastControl?.security ?? transportSecurity,
+  }));
+}
+```
+
+`/health` is registered outside `/v1/chat/*`, so it stays public.
+
+- [ ] **Step 6: Run the test, verify it passes**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/integration/chat/chat-routes.test.ts`
+Expected: PASS, including pre-existing chat tests (add `authorization: 'Bearer …'` to any pre-existing test that now 401s — those tests asserting unauthenticated success are the bug).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/http/operator-auth.ts packages/franken-orchestrator/src/beasts/http/beast-auth.ts packages/franken-orchestrator/src/http/chat-app.ts packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+git commit -m "fix(orchestrator): require operator auth on chat HTTP routes"
+```
+
+---
+
+## Task 2: Fail-closed non-interactive approval
+
+**Files:**
+- Modify: `packages/franken-orchestrator/src/cli/dep-factory.ts:387-393`
+- Test: `packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `dep-factory-wiring.test.ts`:
+
+```ts
+it('does not auto-approve HITL in non-interactive mode by default', async () => {
+  const prev = process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL;
+  delete process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL;
+  const paths = createTempPaths();
+  cleanups.push(paths.root);
+  const { deps, finalize } = await createCliDeps({
+    paths, baseBranch: 'main', budget: 1.0, provider: 'claude',
+    noPr: true, verbose: false, reset: false,
+  });
+  const outcome = await deps.governor.requestApproval({
+    requestId: 'r1', summary: 's', risk: 'high',
+  } as never);
+  expect(outcome.decision).not.toBe('approved');
+  await finalize();
+  if (prev !== undefined) process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL = prev;
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/integration/cli/dep-factory-wiring.test.ts`
+Expected: FAIL — decision is `'approved'` (current `dep-factory.ts:393`).
+
+- [ ] **Step 3: Implement fail-closed default**
+
+In `dep-factory.ts`, in the `if (!stdin.isTTY)` branch (line 387), replace `defaultDecision: 'approved' as const` with:
+
+```ts
+defaultDecision: (process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL === '1'
+  ? 'approved'
+  : 'denied') as const,
+```
+
+Update the adjacent comment to: `// Non-interactive mode fails closed (denied) unless FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1 is explicitly set.`
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/integration/cli/dep-factory-wiring.test.ts tests/unit/cli/run.test.ts`
+Expected: PASS. Fix any run.test.ts case that assumed non-interactive auto-approve by setting the env var in that test's arrange block.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/cli/dep-factory.ts packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts packages/franken-orchestrator/tests/unit/cli/run.test.ts
+git commit -m "fix(orchestrator): non-interactive HITL fails closed by default"
+```
+
+---
+
+## Task 3: Governor signed-approval fail-closed
+
+**Files:**
+- Modify: `packages/franken-governor/src/gateway/approval-gateway.ts:32` (constructor), `:42`
+- Modify: `packages/franken-governor/src/server/app.ts:54`
+- Test: `packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts`, `packages/franken-governor/tests/unit/server/app.test.ts`
+
+- [ ] **Step 1: Write the failing gateway test**
+
+In `approval-gateway-security.test.ts`:
+
+```ts
+it('throws at construction when signed approvals are required without a verifier', () => {
+  expect(() => new ApprovalGateway({
+    channel: fakeChannel,
+    auditRecorder: fakeRecorder,
+    config: { requireSignedApprovals: true },
+    // no signatureVerifier
+  } as never)).toThrow(/signed approvals.*verifier/i);
+});
+```
+
+- [ ] **Step 2: Write the failing server test**
+
+In `app.test.ts`:
+
+```ts
+it('rejects unsigned approval responses when no signing secret is configured', async () => {
+  const app = createGovernorApp({ /* no signingSecret, no allowUnsignedApprovalsForTests */ } as never);
+  const res = await app.request('/v1/approval/respond', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ requestId: 'r1', decision: 'approved' }),
+  });
+  expect(res.status).toBe(401);
+});
+```
+
+- [ ] **Step 3: Run both, verify they fail**
+
+Run: `cd packages/franken-governor && npm test -- --run tests/unit/gateway/approval-gateway-security.test.ts tests/unit/server/app.test.ts`
+Expected: FAIL — gateway constructs silently; server returns 2xx on unsigned.
+
+- [ ] **Step 4: Implement gateway fail-closed**
+
+In `approval-gateway.ts` constructor (after `this.signatureVerifier = deps.signatureVerifier;`, ~line 32):
+
+```ts
+if (deps.config.requireSignedApprovals && !deps.signatureVerifier) {
+  throw new Error('Signed approvals are required but no signatureVerifier was supplied');
+}
+```
+
+Then at line 42 the `&& this.signatureVerifier` guard becomes safe to keep (verifier guaranteed present when required).
+
+- [ ] **Step 5: Implement server fail-closed**
+
+In `server/app.ts`, add `allowUnsignedApprovalsForTests?: boolean` to the options type. Replace the `if (options.signingSecret) { … }` block (line 54) so that when `!options.signingSecret`:
+
+```ts
+if (!options.signingSecret) {
+  if (!options.allowUnsignedApprovalsForTests) {
+    return c.json({ error: { message: 'Signing secret required for approval responses' } }, 401);
+  }
+} else {
+  const signature = c.req.header('x-governor-signature');
+  if (!signature) return c.json({ error: { message: 'Missing signature' } }, 401);
+  const rawBody = JSON.stringify(body);
+  const expected = createHmac('sha256', options.signingSecret).update(rawBody).digest('hex');
+  if (signature !== `sha256=${expected}`) return c.json({ error: { message: 'Invalid signature' } }, 401);
+}
+```
+
+- [ ] **Step 6: Run both, verify they pass**
+
+Run: `cd packages/franken-governor && npm test -- --run tests/unit/gateway/approval-gateway-security.test.ts tests/unit/server/app.test.ts`
+Expected: PASS. Update existing governor tests that constructed an app with no secret to pass `allowUnsignedApprovalsForTests: true`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/franken-governor/src/gateway/approval-gateway.ts packages/franken-governor/src/server/app.ts packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts packages/franken-governor/tests/unit/server/app.test.ts
+git commit -m "fix(governor): fail closed on unsigned/unverifiable approvals"
+```
+
+---
+
+## Task 4: Closeout — ADR + audit follow-up + verification
+
+**Files:**
+- Create: `docs/adr/034-fail-closed-http-and-approval-boundaries.md`
+- Modify: `docs/audits/agent-systems-audit-2026-04-28.md`
+
+- [ ] **Step 1: Write ADR-034**
+
+Use the repo ADR template (`docs/adr/ADR-000-template.md`). Record: chat `/v1/chat/*` now requires an operator token when one is configured; non-interactive HITL defaults to `denied` unless `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`; `ApprovalGateway` refuses to construct when signed approvals are required without a verifier; governor server rejects unsigned approval responses unless an explicit test flag is set. State the residual: this does not add OIDC or transport encryption.
+
+- [ ] **Step 2: Audit follow-up**
+
+In `docs/audits/agent-systems-audit-2026-04-28.md`, add/extend a `## Follow-Up Implementation Status` section mapping the Pillar 3 gap lines ("HTTP chat routes are unauthenticated", "Non-interactive CLI can auto-approve HITL", "Signed approval enforcement is misconfigurable", "Governor HTTP server allows unsigned operation") to `fixed`, each citing the commit and test.
+
+- [ ] **Step 3: Verify the chunk**
+
+```bash
+cd packages/franken-orchestrator && npm test -- --run tests/integration/chat/chat-routes.test.ts tests/unit/cli/run.test.ts tests/integration/cli/dep-factory-wiring.test.ts && npm run typecheck
+cd ../franken-governor && npm test -- --run tests/unit/gateway/approval-gateway-security.test.ts tests/unit/server/app.test.ts && npm run typecheck
+```
+Expected: all exit `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adr/034-fail-closed-http-and-approval-boundaries.md docs/audits/agent-systems-audit-2026-04-28.md
+git commit -m "docs: ADR-034 and audit follow-up for fail-closed boundaries"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** All four Pillar-3 boundary gaps (unauth chat, non-TTY auto-approve, signature misconfig, governor unsigned default) are each mapped to a task with a failing-first test. Chat-auth, dep-factory, gateway, and server are all addressed.
+- **Placeholder scan:** Every code step shows the actual code; every test step shows assertions against real symbols (`createChatApp`, `createCliDeps`, `ApprovalGateway`, `createGovernorApp`, `TransportSecurityService.verifyOperatorToken`).
+- **Type consistency:** `requireOperatorAuth`/`OperatorAuthOptions` reused by `beast-auth.ts`; `ChatAppOptions.operatorToken` is the only new field; `allowUnsignedApprovalsForTests` named identically in server code and tests; `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL` used identically in code and tests.
+
+## Execution Handoff
+
+Plan complete. Two execution options: **(1) Subagent-Driven (recommended)** — fresh subagent per task with review between; **(2) Inline Execution** via executing-plans with checkpoints.

--- a/docs/superpowers/plans/2026-05-17-sechard-2-mcp-firewall-containment.md
+++ b/docs/superpowers/plans/2026-05-17-sechard-2-mcp-firewall-containment.md
@@ -1,0 +1,264 @@
+# Chunk 2: MCP Schema Enforcement & Firewall Path Containment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce advertised MCP tool input schemas centrally before any handler runs, and constrain firewall file scanning to the configured project root.
+
+**Architecture:** Add a single `validateToolArguments` gate in `createMcpServer`'s `CallTool` path so every tool inherits required/type/no-extra-property validation from its already-declared `inputSchema`. Add real-path root containment to the firewall adapter's `scanFile`. Self-contained to `franken-mcp-suite`; no cross-package changes.
+
+**Tech Stack:** TypeScript, `@modelcontextprotocol/sdk`, Node `fs`/`path`, Vitest.
+
+---
+
+## Verified Gap Evidence (current `main` @ `610a0ea`, 2026-05-17)
+
+- `packages/franken-mcp-suite/src/shared/server-factory.ts` `CallToolRequestSchema` handler calls `tool.handler((args ?? {}) as Record<string, unknown>)` with **no** validation against `tool.inputSchema` (which is defined and advertised at the `ListTools` path). Required/type/extra-property checks do not happen.
+- `packages/franken-mcp-suite/src/adapters/firewall-adapter.ts` `scanFile(path)` does `readFileSync(path, 'utf8')` directly — any caller-supplied absolute or `../` path is read.
+
+## File Structure
+
+- Modify `packages/franken-mcp-suite/src/shared/server-factory.ts` — add `validateToolArguments(tool, args)` and call it in the `CallTool` handler before `tool.handler`.
+- Modify `packages/franken-mcp-suite/src/shared/server-factory.test.ts` — required/type/extra-property red tests.
+- Modify `packages/franken-mcp-suite/src/adapters/firewall-adapter.ts` — root-contained `scanFile`.
+- Modify `packages/franken-mcp-suite/src/servers/firewall.ts` — pass the intended root to the adapter.
+- Modify `packages/franken-mcp-suite/src/servers/firewall.test.ts` — outside-root rejection tests.
+
+---
+
+## Task 1: Central MCP input-schema validation
+
+**Files:**
+- Modify: `packages/franken-mcp-suite/src/shared/server-factory.ts` (`CallTool` handler)
+- Test: `packages/franken-mcp-suite/src/shared/server-factory.test.ts`
+
+- [ ] **Step 1: Write failing validation tests**
+
+In `server-factory.test.ts`:
+
+```ts
+function makeServerWithSpy() {
+  const calls: unknown[] = [];
+  const tool: ToolDef = {
+    name: 'echo',
+    description: 'echo',
+    inputSchema: { type: 'object', properties: { msg: { type: 'string', description: 'm' } }, required: ['msg'] },
+    handler: async (args) => { calls.push(args); return { content: [{ type: 'text', text: 'ok' }] }; },
+  };
+  return { srv: createMcpServer('t', '1', [tool]), calls, tool };
+}
+
+it('rejects missing required property without calling the handler', async () => {
+  const { srv, calls } = makeServerWithSpy();
+  const res = await callTool(srv, 'echo', {}); // helper invokes the CallTool handler
+  expect(res.isError).toBe(true);
+  expect(calls).toHaveLength(0);
+});
+
+it('rejects wrong property type', async () => {
+  const { srv, calls } = makeServerWithSpy();
+  const res = await callTool(srv, 'echo', { msg: 123 });
+  expect(res.isError).toBe(true);
+  expect(calls).toHaveLength(0);
+});
+
+it('rejects unknown extra property', async () => {
+  const { srv, calls } = makeServerWithSpy();
+  const res = await callTool(srv, 'echo', { msg: 'hi', extra: 1 });
+  expect(res.isError).toBe(true);
+  expect(calls).toHaveLength(0);
+});
+
+it('passes a valid argument object through to the handler', async () => {
+  const { srv, calls } = makeServerWithSpy();
+  const res = await callTool(srv, 'echo', { msg: 'hi' });
+  expect(res.isError).toBeFalsy();
+  expect(calls).toEqual([{ msg: 'hi' }]);
+});
+```
+
+If `server-factory.test.ts` has no `callTool` helper, add one that constructs the server and calls the registered `CallToolRequestSchema` handler with `{ params: { name, arguments } }` (mirror the SDK request shape used by sibling tests).
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-mcp-suite && npm test -- --run src/shared/server-factory.test.ts`
+Expected: FAIL — handler is called with raw args; `calls` is non-empty, `isError` falsy.
+
+- [ ] **Step 3: Implement `validateToolArguments`**
+
+In `server-factory.ts`, add before `createMcpServer`:
+
+```ts
+function validateToolArguments(
+  tool: ToolDef,
+  args: unknown,
+): { ok: true; value: Record<string, unknown> } | { ok: false; message: string } {
+  if (args === null || typeof args !== 'object' || Array.isArray(args)) {
+    return { ok: false, message: `Tool ${tool.name} expects an object argument` };
+  }
+  const obj = args as Record<string, unknown>;
+  const schema = tool.inputSchema;
+  for (const req of schema.required ?? []) {
+    if (!(req in obj) || obj[req] === undefined) {
+      return { ok: false, message: `Tool ${tool.name} missing required property: ${req}` };
+    }
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    const prop = schema.properties[key];
+    if (!prop) {
+      return { ok: false, message: `Tool ${tool.name} received unknown property: ${key}` };
+    }
+    const actual = Array.isArray(value) ? 'array' : typeof value;
+    if (prop.type === 'integer' ? !Number.isInteger(value) : actual !== prop.type) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must be ${prop.type}` };
+    }
+  }
+  return { ok: true, value: obj };
+}
+```
+
+In the `CallToolRequestSchema` handler, after the `if (!tool) {...}` block and before `tool.handler(...)`:
+
+```ts
+const validated = validateToolArguments(tool, args ?? {});
+if (!validated.ok) {
+  return { content: [{ type: 'text' as const, text: `Error: ${validated.message}` }], isError: true };
+}
+const result = await tool.handler(validated.value);
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-mcp-suite && npm test -- --run src/shared/server-factory.test.ts`
+Expected: PASS. Run the full suite — `npm test --` — and fix any server whose tests passed loosely-typed args that the schema legitimately forbids (tighten the test's args, not the validator).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-mcp-suite/src/shared/server-factory.ts packages/franken-mcp-suite/src/shared/server-factory.test.ts
+git commit -m "fix(mcp-suite): enforce advertised tool input schemas centrally"
+```
+
+---
+
+## Task 2: Firewall scan-file root containment
+
+**Files:**
+- Modify: `packages/franken-mcp-suite/src/adapters/firewall-adapter.ts` (`scanFile`)
+- Modify: `packages/franken-mcp-suite/src/servers/firewall.ts`
+- Test: `packages/franken-mcp-suite/src/servers/firewall.test.ts`
+
+- [ ] **Step 1: Write failing containment tests**
+
+In `firewall.test.ts`, in a temp project root:
+
+```ts
+it('rejects scanning a path outside the project root', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'fw-root-'));
+  const adapter = createFirewallAdapter(join(root, 'fw.db'), 'standard', { root });
+  await expect(adapter.scanFile('../../etc/passwd')).rejects.toThrow(/outside.*root/i);
+  await expect(adapter.scanFile('/etc/passwd')).rejects.toThrow(/outside.*root/i);
+});
+
+it('allows scanning a file inside the project root', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'fw-root-'));
+  writeFileSync(join(root, 'safe.txt'), 'hello');
+  const adapter = createFirewallAdapter(join(root, 'fw.db'), 'standard', { root });
+  const res = await adapter.scanFile('safe.txt');
+  expect(res.verdict).toBe('clean');
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-mcp-suite && npm test -- --run src/servers/firewall.test.ts`
+Expected: FAIL — `createFirewallAdapter` has no root option; `scanFile` reads any path.
+
+- [ ] **Step 3: Implement containment**
+
+In `firewall-adapter.ts`: add a third options parameter and a containment helper. Change the factory signature to
+`createFirewallAdapter(dbPathOrDeps: string | FirewallAdapterDeps, tier: InjectionTier = 'standard', options: { root?: string } = {})`
+and add at the top of the string branch:
+
+```ts
+import { realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+const root = realpathSync(resolve(options.root ?? process.env.FBEAST_ROOT ?? process.cwd()));
+
+function resolveContained(requested: string): string {
+  const target = resolve(root, requested);
+  const realTarget = realpathSync(target); // throws ENOENT for missing — acceptable, caller handles
+  if (realTarget !== root && !realTarget.startsWith(root + sep)) {
+    throw new Error(`Refusing to scan path outside project root: ${requested}`);
+  }
+  return realTarget;
+}
+```
+
+Change `scanFile` to:
+
+```ts
+async scanFile(path) {
+  const safePath = resolveContained(path);
+  const content = readFileSync(safePath, 'utf8');
+  const result = scanWithPatterns(content, patterns);
+  logScan(content, result);
+  return result;
+},
+```
+
+In `servers/firewall.ts`, pass the intended root when constructing the adapter (use the server's existing project-root/`FBEAST_ROOT` resolution; if none exists there, pass `{ root: process.env.FBEAST_ROOT ?? process.cwd() }`).
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-mcp-suite && npm test -- --run src/servers/firewall.test.ts src/adapters/firewall-adapter.test.ts`
+Expected: PASS. Update existing firewall-adapter tests that scanned absolute temp paths to construct the adapter with `{ root }` pointing at that temp dir.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-mcp-suite/src/adapters/firewall-adapter.ts packages/franken-mcp-suite/src/servers/firewall.ts packages/franken-mcp-suite/src/servers/firewall.test.ts packages/franken-mcp-suite/src/adapters/firewall-adapter.test.ts
+git commit -m "fix(mcp-suite): contain firewall scan_file to project root"
+```
+
+---
+
+## Task 3: Closeout — ADR + audit follow-up + verification
+
+**Files:**
+- Create: `docs/adr/035-mcp-input-validation-and-path-containment.md`
+- Modify: `docs/audits/agent-systems-audit-2026-04-28.md`
+
+- [ ] **Step 1: Write ADR-035**
+
+Record: all MCP tools now validate against their declared `inputSchema` (required, primitive type, integer, no-extra-property) before the handler runs; `fbeast_firewall_scan_file` resolves and real-path-checks against the project root and refuses outside-root reads. Residual: validation is structural (no deep JSON-schema `format`/nested objects) — note the boundary explicitly.
+
+- [ ] **Step 2: Audit follow-up**
+
+In `docs/audits/agent-systems-audit-2026-04-28.md` `Follow-Up Implementation Status`, map the Pillar-1 gap lines "MCP tool schemas are metadata, not enforced validation" and "File scanning can read arbitrary supplied paths" to `fixed`, citing commits/tests.
+
+- [ ] **Step 3: Verify the chunk**
+
+```bash
+cd packages/franken-mcp-suite && npm test -- --run src/shared/server-factory.test.ts src/servers/firewall.test.ts src/adapters/firewall-adapter.test.ts && npm test -- && npm run typecheck
+```
+Expected: all exit `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adr/035-mcp-input-validation-and-path-containment.md docs/audits/agent-systems-audit-2026-04-28.md
+git commit -m "docs: ADR-035 and audit follow-up for MCP/firewall hardening"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Both Pillar-1 input-boundary gaps (unenforced MCP schemas, arbitrary-path file read) each have a failing-first task. Validation is centralized in `createMcpServer` so every tool inherits it (DRY).
+- **Placeholder scan:** Every code step shows real code; the validator handles object/array/`integer` cases explicitly rather than "add validation".
+- **Type consistency:** `validateToolArguments` consumes the existing `ToolDef`/`ToolInputSchema`; `createFirewallAdapter`'s new third arg is `{ root?: string }` used identically in adapter, server, and tests; `resolveContained` is the single containment path used by `scanFile`.
+
+## Execution Handoff
+
+Plan complete. **(1) Subagent-Driven (recommended)** or **(2) Inline Execution** via executing-plans.

--- a/docs/superpowers/plans/2026-05-17-sechard-3-sandboxed-execution.md
+++ b/docs/superpowers/plans/2026-05-17-sechard-3-sandboxed-execution.md
@@ -1,0 +1,404 @@
+# Chunk 3: Sandboxed Beast Execution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the throwing `ContainerBeastExecutor` placeholder with a real Docker `--network=none` executor, and stop process mode from inheriting host secrets by switching to an env allowlist with cwd containment.
+
+**Architecture:** Introduce one shared `sandbox-policy.ts` (env allowlist + policy types) consumed by both execution backends. `DockerContainerRuntime` transforms a `BeastProcessSpec` into a Docker `BeastProcessSpec`; `ContainerBeastExecutor` reuses the existing `ProcessBeastExecutor` lifecycle by delegating through a spec-transforming supervisor (DRY, no real Docker daemon needed for tests). `ProcessSupervisor` builds child env from the allowlist + explicit `spec.env` only, and rejects a `cwd` escaping the configured root.
+
+**Tech Stack:** TypeScript, Node `child_process`, Docker CLI (first concrete backend), Vitest.
+
+---
+
+## Verified Gap Evidence (current `main` @ `610a0ea`, 2026-05-17)
+
+- `packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts` — `start`/`stop`/`kill` all `throw new Error('ContainerBeastExecutor is not implemented yet')`.
+- `packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts:46-49` — child `env: { ...stripClaudeEnvVars(process.env), ...spec.env }`: only `CLAUDE*` is stripped; the entire rest of host env is inherited. `cwd: spec.cwd` is an unchecked passthrough.
+- `packages/franken-orchestrator/src/beasts/create-beast-services.ts:47` — `container: new ContainerBeastExecutor()` (the placeholder).
+- `BeastProcessSpec` (`src/beasts/types.ts:32`): `{ command; args; cwd?; env? }` — the transform target type.
+- `ProcessBeastExecutor` (`src/beasts/execution/process-beast-executor.ts:34`): `constructor(repository, logStore, supervisor: ProcessSupervisorLike, { onRunStatusChange, eventBus })`; calls `this.supervisor.spawn(mergedSpec, …)` at `:75`. Reusable for container mode by swapping the supervisor.
+
+## File Structure
+
+- Create `packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts` — `SandboxPolicy` type + `DEFAULT_BEAST_ENV_ALLOWLIST` (single source of truth for both backends).
+- Create `packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts` — `toDockerSpec(spec, policy): BeastProcessSpec`.
+- Modify `packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts` — real executor delegating to `ProcessBeastExecutor` via a Docker-transforming supervisor.
+- Modify `packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts` — allowlist env + cwd containment.
+- Modify `packages/franken-orchestrator/src/beasts/create-beast-services.ts:47` — construct the real container executor.
+- Tests: add `tests/unit/beasts/execution/docker-container-runtime.test.ts`; modify `tests/unit/beasts/container-beast-executor.test.ts`, `tests/unit/beasts/execution/process-supervisor.test.ts`.
+
+---
+
+## Task 1: Sandbox policy + Docker spec builder
+
+**Files:**
+- Create: `packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts`
+- Create: `packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts`
+- Test: `packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts`
+
+- [ ] **Step 1: Write the failing Docker-spec test**
+
+Create `tests/unit/beasts/execution/docker-container-runtime.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { toDockerSpec } from '../../../../src/beasts/execution/docker-container-runtime.js';
+import { DEFAULT_SANDBOX_POLICY } from '../../../../src/beasts/execution/sandbox-policy.js';
+
+describe('toDockerSpec', () => {
+  const base = { command: 'node', args: ['agent.js', '--run'], cwd: '/proj', env: { FRANKENBEAST_RUN_CONFIG: '/proj/.fbeast/rc.json' } };
+
+  it('runs through docker with no network and a workspace mount', () => {
+    const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj' });
+    expect(spec.command).toBe('docker');
+    expect(spec.args).toEqual(expect.arrayContaining(['run', '--rm', '--network', 'none', '-w', '/workspace']));
+    expect(spec.args).toEqual(expect.arrayContaining(['-v', '/proj:/workspace']));
+  });
+
+  it('passes only allowlisted env via -e and inherits no host env', () => {
+    const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj' });
+    expect(spec.args).toEqual(expect.arrayContaining(['-e', 'FRANKENBEAST_RUN_CONFIG']));
+    expect(spec.args).not.toEqual(expect.arrayContaining(['-e', 'GITHUB_TOKEN']));
+    expect(spec.env).toEqual({}); // docker process itself gets no inherited env
+  });
+
+  it('appends the original command and args after the image', () => {
+    const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, image: 'fbeast/sandbox:1', workspaceHostPath: '/proj' });
+    const i = spec.args.indexOf('fbeast/sandbox:1');
+    expect(spec.args.slice(i + 1)).toEqual(['node', 'agent.js', '--run']);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/execution/docker-container-runtime.test.ts`
+Expected: FAIL — modules do not exist.
+
+- [ ] **Step 3: Create `sandbox-policy.ts`**
+
+```ts
+export interface SandboxPolicy {
+  readonly image: string;
+  readonly network: 'none';
+  readonly workspaceHostPath: string;
+  readonly workspaceContainerPath: '/workspace';
+  readonly envAllowlist: readonly string[];
+}
+
+export const DEFAULT_BEAST_ENV_ALLOWLIST = [
+  'PATH', 'HOME', 'LANG', 'LC_ALL',
+  'FRANKENBEAST_RUN_CONFIG',
+  'FRANKENBEAST_MODULE_FIREWALL',
+  'FRANKENBEAST_MODULE_SKILLS',
+  'FRANKENBEAST_MODULE_MEMORY',
+  'FRANKENBEAST_MODULE_PLANNER',
+  'FRANKENBEAST_MODULE_CRITIQUE',
+  'FRANKENBEAST_MODULE_GOVERNOR',
+  'FRANKENBEAST_MODULE_HEARTBEAT',
+] as const;
+
+export const DEFAULT_SANDBOX_POLICY: SandboxPolicy = {
+  image: 'fbeast/sandbox:latest',
+  network: 'none',
+  workspaceHostPath: process.cwd(),
+  workspaceContainerPath: '/workspace',
+  envAllowlist: DEFAULT_BEAST_ENV_ALLOWLIST,
+};
+```
+
+- [ ] **Step 4: Create `docker-container-runtime.ts`**
+
+```ts
+import type { BeastProcessSpec } from '../types.js';
+import type { SandboxPolicy } from './sandbox-policy.js';
+
+export function toDockerSpec(spec: BeastProcessSpec, policy: SandboxPolicy): BeastProcessSpec {
+  const envArgs: string[] = [];
+  for (const key of policy.envAllowlist) {
+    if (spec.env && key in spec.env) envArgs.push('-e', key);
+  }
+  const args = [
+    'run', '--rm',
+    '--network', policy.network,
+    '-v', `${policy.workspaceHostPath}:${policy.workspaceContainerPath}`,
+    '-w', policy.workspaceContainerPath,
+    ...envArgs,
+    policy.image,
+    spec.command,
+    ...spec.args,
+  ];
+  // Pass allowlisted values through docker's own env so `-e KEY` resolves.
+  const passEnv: Record<string, string> = {};
+  for (const key of policy.envAllowlist) {
+    if (spec.env && spec.env[key] !== undefined) passEnv[key] = spec.env[key] as string;
+  }
+  return { command: 'docker', args, cwd: spec.cwd, env: {} , // docker client inherits nothing
+    // values are forwarded into the container via the supervisor env merge below
+  } as BeastProcessSpec & { passEnv?: Record<string, string> };
+}
+```
+
+Note: keep `spec.env` as `{}` for the docker client process (the test asserts this); the allowlisted values are forwarded by the supervisor (Task 3) which merges `spec.env`. If the codebase prefers explicit `-e KEY=VALUE`, change `envArgs.push('-e', key)` to `envArgs.push('-e', \`${key}=${spec.env[key]}\`)` and drop `passEnv`; update the Step-1 test's `-e` assertion to match. Pick one form and keep it consistent across Task 1 and Task 3.
+
+- [ ] **Step 5: Run, verify pass**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/execution/docker-container-runtime.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
+git commit -m "feat(orchestrator): add sandbox policy and docker spec builder"
+```
+
+---
+
+## Task 2: Real ContainerBeastExecutor
+
+**Files:**
+- Modify: `packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts`
+- Modify: `packages/franken-orchestrator/src/beasts/create-beast-services.ts:47`
+- Test: `packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts`
+
+- [ ] **Step 1: Write the failing executor test**
+
+Replace the placeholder test body with one that injects a fake supervisor and asserts the Docker transform is applied and lifecycle delegates:
+
+```ts
+it('spawns the docker-transformed spec and reports a running attempt', async () => {
+  const spawned: BeastProcessSpec[] = [];
+  const fakeSupervisor = {
+    spawn: async (spec) => { spawned.push(spec); return { pid: 4242 }; },
+    stop: async () => {}, kill: async () => {},
+  };
+  const exec = new ContainerBeastExecutor({
+    repository, logStore, eventBus,
+    supervisorFactory: () => fakeSupervisor,
+    policy: { ...DEFAULT_SANDBOX_POLICY, image: 'fbeast/sandbox:test', workspaceHostPath: '/proj' },
+  });
+  const attempt = await exec.start(run, definition);
+  expect(attempt.pid).toBe(4242);
+  expect(spawned[0].command).toBe('docker');
+  expect(spawned[0].args).toEqual(expect.arrayContaining(['--network', 'none']));
+});
+```
+
+(`repository`, `logStore`, `eventBus`, `run`, `definition` come from the existing test fixtures in this file / sibling `process-beast-executor.test.ts`.)
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/container-beast-executor.test.ts`
+Expected: FAIL — current executor throws "not implemented yet".
+
+- [ ] **Step 3: Implement by delegation**
+
+Rewrite `container-beast-executor.ts` to compose a `ProcessBeastExecutor` whose supervisor wraps `toDockerSpec`:
+
+```ts
+import type { BeastExecutor, StopOptions } from './beast-executor.js';
+import type { BeastDefinition, BeastRun, BeastRunAttempt, BeastProcessSpec } from '../types.js';
+import { ProcessBeastExecutor } from './process-beast-executor.js';
+import { ProcessSupervisor, type ProcessSupervisorLike, type ProcessCallbacks } from './process-supervisor.js';
+import { toDockerSpec } from './docker-container-runtime.js';
+import { DEFAULT_SANDBOX_POLICY, type SandboxPolicy } from './sandbox-policy.js';
+
+export interface ContainerBeastExecutorDeps {
+  repository: ConstructorParameters<typeof ProcessBeastExecutor>[0];
+  logStore: ConstructorParameters<typeof ProcessBeastExecutor>[1];
+  eventBus: { /* same shape passed in create-beast-services */ } | undefined;
+  policy?: SandboxPolicy;
+  supervisorFactory?: () => ProcessSupervisorLike;
+}
+
+class DockerSupervisor implements ProcessSupervisorLike {
+  constructor(private inner: ProcessSupervisorLike, private policy: SandboxPolicy) {}
+  spawn(spec: BeastProcessSpec, cb: ProcessCallbacks) { return this.inner.spawn(toDockerSpec(spec, this.policy), cb); }
+  stop(pid: number) { return this.inner.stop(pid); }
+  kill(pid: number) { return this.inner.kill(pid); }
+}
+
+export class ContainerBeastExecutor implements BeastExecutor {
+  private readonly inner: ProcessBeastExecutor;
+  constructor(deps: ContainerBeastExecutorDeps) {
+    const policy = deps.policy ?? DEFAULT_SANDBOX_POLICY;
+    const base = deps.supervisorFactory ? deps.supervisorFactory() : new ProcessSupervisor();
+    this.inner = new ProcessBeastExecutor(
+      deps.repository, deps.logStore, new DockerSupervisor(base, policy),
+      { onRunStatusChange: () => {}, eventBus: deps.eventBus } as never,
+    );
+  }
+  start(run: BeastRun, definition: BeastDefinition): Promise<BeastRunAttempt> { return this.inner.start(run, definition); }
+  stop(runId: string, attemptId: string, options?: StopOptions): Promise<BeastRunAttempt> { return this.inner.stop(runId, attemptId, options); }
+  kill(runId: string, attemptId: string): Promise<BeastRunAttempt> { return this.inner.kill(runId, attemptId); }
+}
+```
+
+Match `repository`/`logStore`/`eventBus`/`onRunStatusChange` to the exact `ProcessBeastExecutor` constructor types in this repo (read `process-beast-executor.ts:34`) and replace the placeholder `ConstructorParameters` shorthands with the concrete imported types.
+
+- [ ] **Step 4: Wire `create-beast-services.ts`**
+
+Replace `container: new ContainerBeastExecutor()` (line 47) with:
+
+```ts
+container: new ContainerBeastExecutor({
+  repository, logStore, eventBus,
+  policy: { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: process.env.FBEAST_ROOT ?? process.cwd() },
+}),
+```
+
+Add the `DEFAULT_SANDBOX_POLICY` import.
+
+- [ ] **Step 5: Run, verify pass**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/container-beast-executor.test.ts tests/integration/beasts/beast-routes.test.ts tests/integration/beasts/agent-routes.test.ts`
+Expected: PASS (no real Docker daemon — supervisor is faked in unit; integration uses `process` mode).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts packages/franken-orchestrator/src/beasts/create-beast-services.ts packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
+git commit -m "feat(orchestrator): run beast container mode in a no-network sandbox"
+```
+
+---
+
+## Task 3: Process-mode env allowlist + cwd containment
+
+**Files:**
+- Modify: `packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts:38-50`
+- Test: `packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts`
+
+- [ ] **Step 1: Write the failing env/cwd test**
+
+```ts
+it('does not inherit arbitrary host env into the child', async () => {
+  process.env.GITHUB_TOKEN = 'ghp_should_not_leak';
+  process.env.SECRET_X = 'nope';
+  const sup = new ProcessSupervisor({ projectRoot: tmpRoot });
+  const seen = await captureChildEnv(sup, { command: process.execPath, args: ['-e', 'console.log(JSON.stringify(process.env))'], cwd: tmpRoot, env: { FRANKENBEAST_RUN_CONFIG: '/x' } });
+  expect(seen.GITHUB_TOKEN).toBeUndefined();
+  expect(seen.SECRET_X).toBeUndefined();
+  expect(seen.FRANKENBEAST_RUN_CONFIG).toBe('/x');
+  expect(seen.PATH).toBeDefined?.() ?? expect(seen.PATH).toBeTruthy();
+});
+
+it('rejects a cwd outside the configured project root', async () => {
+  const sup = new ProcessSupervisor({ projectRoot: tmpRoot });
+  await expect(sup.spawn({ command: 'node', args: [], cwd: '/etc' }, noopCallbacks))
+    .rejects.toThrow(/cwd.*outside.*root/i);
+});
+```
+
+(`captureChildEnv` = small helper that spawns the spec, collects stdout JSON, resolves on exit; reuse the existing process-supervisor test harness pattern.)
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/execution/process-supervisor.test.ts`
+Expected: FAIL — `GITHUB_TOKEN`/`SECRET_X` leak; no `projectRoot` ctor option.
+
+- [ ] **Step 3: Implement allowlist + containment**
+
+In `process-supervisor.ts`:
+
+```ts
+import { resolve, sep } from 'node:path';
+import { DEFAULT_BEAST_ENV_ALLOWLIST } from './sandbox-policy.js';
+
+function allowlistedEnv(env: NodeJS.ProcessEnv): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const key of DEFAULT_BEAST_ENV_ALLOWLIST) {
+    if (env[key] !== undefined) out[key] = env[key];
+  }
+  return out;
+}
+
+export interface ProcessSupervisorOptions { projectRoot?: string }
+```
+
+Add a constructor: `constructor(private readonly options: ProcessSupervisorOptions = {}) {}`. In `spawn`, before `spawn(...)`:
+
+```ts
+if (this.options.projectRoot && spec.cwd) {
+  const root = resolve(this.options.projectRoot);
+  const target = resolve(spec.cwd);
+  if (target !== root && !target.startsWith(root + sep)) {
+    throw new Error(`Refusing to spawn with cwd outside project root: ${spec.cwd}`);
+  }
+}
+```
+
+Replace the `env:` block with:
+
+```ts
+env: {
+  ...allowlistedEnv(process.env),
+  ...spec.env,
+},
+```
+
+(`stripClaudeEnvVars` is now subsumed by the allowlist — delete it and its usage.)
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/execution/process-supervisor.test.ts`
+Expected: PASS. Update existing process-supervisor tests that relied on inherited host env to pass needed vars via explicit `spec.env`.
+
+- [ ] **Step 5: Wire `projectRoot` at construction**
+
+In `create-beast-services.ts`, change `new ProcessSupervisor()` (line 43) to `new ProcessSupervisor({ projectRoot: process.env.FBEAST_ROOT ?? process.cwd() })`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts packages/franken-orchestrator/src/beasts/create-beast-services.ts packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+git commit -m "fix(orchestrator): allowlist process env and contain cwd"
+```
+
+---
+
+## Task 4: Closeout — ADR + audit follow-up + verification
+
+**Files:**
+- Create: `docs/adr/036-sandboxed-beast-execution.md`
+- Modify: `docs/guides/run-cli-beast.md`
+- Modify: `docs/audits/agent-systems-audit-2026-04-28.md`
+
+- [ ] **Step 1: Write ADR-036**
+
+Document: container mode = Docker `--network none` + explicit single workspace mount + env allowlist; process mode = env allowlist + optional cwd containment, **not** a hard sandbox. Explicitly state gVisor/Firecracker remain future backends and `--network none` must not be marketed as micro-VM isolation.
+
+- [ ] **Step 2: Update `docs/guides/run-cli-beast.md`**
+
+Add an operator section: Docker prerequisite for container mode, how network denial works, the env allowlist (and how to extend it via `spec.env`), and that process mode is not a hard sandbox.
+
+- [ ] **Step 3: Audit follow-up**
+
+Map Pillar-1 gaps "Container mode is not implemented" → `fixed`; "broad environment inheritance" → `fixed`; "No micro-VM/gVisor/Wasm sandbox" / "Network air-gapping not OS-enforced for process mode" → `partially-fixed` (container has `--network none`; process mode does not). Cite commits/tests.
+
+- [ ] **Step 4: Verify the chunk**
+
+```bash
+cd packages/franken-orchestrator && npm test -- --run tests/unit/beasts/execution/docker-container-runtime.test.ts tests/unit/beasts/container-beast-executor.test.ts tests/unit/beasts/execution/process-supervisor.test.ts tests/integration/beasts/beast-routes.test.ts tests/integration/beasts/agent-routes.test.ts && npm run typecheck
+```
+Expected: all exit `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/036-sandboxed-beast-execution.md docs/guides/run-cli-beast.md docs/audits/agent-systems-audit-2026-04-28.md
+git commit -m "docs: ADR-036 and audit follow-up for sandboxed execution"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Container placeholder, host-env inheritance, and (partially) network/process-isolation gaps each have a failing-first task. The `partially-fixed` framing for process-mode network is explicit, not silently overclaimed.
+- **Placeholder scan:** Real code in every step; the one genuine fork (docker `-e KEY` vs `-e KEY=VALUE`) is called out with an instruction to pick one form and keep Task 1/Task 3 consistent — not left vague.
+- **Type consistency:** `BeastProcessSpec` reused unchanged; `SandboxPolicy`/`DEFAULT_BEAST_ENV_ALLOWLIST`/`DEFAULT_SANDBOX_POLICY` named identically across `sandbox-policy.ts`, `docker-container-runtime.ts`, `container-beast-executor.ts`, `process-supervisor.ts`, and tests; `ContainerBeastExecutor` reuses `ProcessBeastExecutor` (DRY); `toDockerSpec` is the single transform.
+
+## Execution Handoff
+
+Plan complete. **(1) Subagent-Driven (recommended)** or **(2) Inline Execution** via executing-plans. The `ProcessBeastExecutor` constructor types must be read from source during Task 2 Step 3 — flagged inline.

--- a/docs/superpowers/plans/2026-05-17-sechard-4-durable-audit-replay.md
+++ b/docs/superpowers/plans/2026-05-17-sechard-4-durable-audit-replay.md
@@ -1,0 +1,415 @@
+# Chunk 4: Durable Audit & Replay — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist hash-addressed replay records for LLM/tool calls and persist the Beast phase state machine after every phase, so a run can be deterministically replayed and resumed from durable state rather than in-memory timeline analysis.
+
+**Architecture:** Add a content-addressed blob store and versioned replay record types in `franken-observer`, persisted next to existing audit trails. Add a deterministic replay path that consumes saved records and verifies hashes. In `franken-orchestrator`, capture LLM/tool inputs/outputs through the audit observer adapter, and snapshot the `BeastContext` phase FSM after each phase to `.fbeast/state/<runId>.jsonl`. Structurally independent of Chunks 1–3; sequence last.
+
+**Tech Stack:** TypeScript, Node `crypto` (sha256), Node `fs`, existing `AuditTrailStore`/`ExecutionReplayer`/`BeastContext`, Vitest.
+
+---
+
+## Verified Gap Evidence (current `main` @ `610a0ea`, 2026-05-17)
+
+- `packages/franken-observer/src/execution-replayer.ts:42` — `replay(trail)` only groups existing `AuditEvent`s into an `ExecutionTimeline`; no re-execution from stored inputs, no hash verification.
+- `packages/franken-observer/src/audit-trail-store.ts:23` — `save(runId, trail)` writes only `.fbeast/audit/<runId>.json`; no replay manifest/blobs.
+- `packages/franken-observer/src/index.ts` — exports no replay record/store/verifier API.
+- `packages/franken-orchestrator/src/beast-loop.ts:28` — `BeastLoop` runs ingestion→hydration→planning→execution→closure with `logger.info` only; no persisted transition.
+- `packages/franken-orchestrator/src/context/franken-context.ts:29` — `BeastContext.phase` is an in-memory field; nothing persists it after each node.
+
+## File Structure
+
+- Create `packages/franken-observer/src/replay/replay-record.ts` — versioned record types + sha256 hashing.
+- Create `packages/franken-observer/src/replay/replay-content-store.ts` — content-addressed blob store under `.fbeast/audit/blobs/`.
+- Create `packages/franken-observer/src/replay/deterministic-replayer.ts` — replay saved records, verify hashes.
+- Modify `packages/franken-observer/src/audit-trail-store.ts` — write a replay manifest alongside the trail.
+- Modify `packages/franken-observer/src/index.ts` — export the new APIs.
+- Modify `packages/franken-orchestrator/src/adapters/audit-observer-adapter.ts`, `src/adapters/cli-llm-adapter.ts`, `src/skills/cli-skill-executor.ts` — emit replay records.
+- Create `packages/franken-orchestrator/src/context/state-snapshot-store.ts` — `.fbeast/state/<runId>.jsonl` appender.
+- Modify `packages/franken-orchestrator/src/beast-loop.ts`, `src/context/franken-context.ts` — snapshot after each phase.
+- Tests: `franken-observer/src/replay/replay-content-store.test.ts`, `…/deterministic-replayer.test.ts`; `franken-orchestrator/tests/unit/beast-loop-state-persistence.test.ts`, plus modified adapter/skill tests.
+
+---
+
+## Task 1: Content-addressed replay record store
+
+**Files:**
+- Create: `packages/franken-observer/src/replay/replay-record.ts`
+- Create: `packages/franken-observer/src/replay/replay-content-store.ts`
+- Test: `packages/franken-observer/src/replay/replay-content-store.test.ts`
+
+- [ ] **Step 1: Write the failing store test**
+
+`replay-content-store.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ReplayContentStore } from './replay-content-store.js';
+import { hashContent } from './replay-record.js';
+
+describe('ReplayContentStore', () => {
+  it('stores content by sha256 and reads it back', () => {
+    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const store = new ReplayContentStore(root);
+    const ref = store.put('hello world');
+    expect(ref).toBe(hashContent('hello world'));
+    expect(store.get(ref)).toBe('hello world');
+  });
+
+  it('detects tampering on read (hash mismatch throws)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const store = new ReplayContentStore(root);
+    const ref = store.put('original');
+    store.__corruptForTest(ref, 'tampered');
+    expect(() => store.get(ref)).toThrow(/hash mismatch/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-observer && npm test -- --run src/replay/replay-content-store.test.ts`
+Expected: FAIL — modules do not exist.
+
+- [ ] **Step 3: Implement record types + store**
+
+`replay-record.ts`:
+
+```ts
+import { createHash } from 'node:crypto';
+
+export type ReplayRecordKind =
+  | 'llm.request' | 'llm.response' | 'tool.call' | 'tool.result' | 'environment.snapshot';
+
+export interface ReplayRecord {
+  readonly version: 1;
+  readonly kind: ReplayRecordKind;
+  readonly runId: string;
+  readonly timestamp: string;
+  readonly provider?: string;
+  readonly model?: string;
+  readonly toolName?: string;
+  readonly contentRef: string; // sha256 of the raw blob
+}
+
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+```
+
+`replay-content-store.ts`:
+
+```ts
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { hashContent } from './replay-record.js';
+
+export class ReplayContentStore {
+  private readonly dir: string;
+  constructor(baseDir: string) {
+    this.dir = join(baseDir, 'blobs');
+    if (!existsSync(this.dir)) mkdirSync(this.dir, { recursive: true });
+  }
+  put(content: string): string {
+    const ref = hashContent(content);
+    const p = join(this.dir, ref);
+    if (!existsSync(p)) writeFileSync(p, content, 'utf8');
+    return ref;
+  }
+  get(ref: string): string {
+    const content = readFileSync(join(this.dir, ref), 'utf8');
+    if (hashContent(content) !== ref) throw new Error(`Replay blob hash mismatch for ${ref}`);
+    return content;
+  }
+  /** test-only: simulate on-disk tampering */
+  __corruptForTest(ref: string, replacement: string): void {
+    writeFileSync(join(this.dir, ref), replacement, 'utf8');
+  }
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-observer && npm test -- --run src/replay/replay-content-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-observer/src/replay/replay-record.ts packages/franken-observer/src/replay/replay-content-store.ts packages/franken-observer/src/replay/replay-content-store.test.ts
+git commit -m "feat(observer): content-addressed replay record store"
+```
+
+---
+
+## Task 2: Deterministic replayer + manifest persistence + exports
+
+**Files:**
+- Create: `packages/franken-observer/src/replay/deterministic-replayer.ts`
+- Modify: `packages/franken-observer/src/audit-trail-store.ts`
+- Modify: `packages/franken-observer/src/index.ts`
+- Test: `packages/franken-observer/src/replay/deterministic-replayer.test.ts`
+
+- [ ] **Step 1: Write the failing replay test**
+
+`deterministic-replayer.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ReplayContentStore } from './replay-content-store.js';
+import { DeterministicReplayer } from './deterministic-replayer.js';
+
+it('replays a saved llm.response without calling a live provider', () => {
+  const root = mkdtempSync(join(tmpdir(), 'replay-'));
+  const store = new ReplayContentStore(root);
+  const ref = store.put(JSON.stringify({ text: 'cached answer' }));
+  const replayer = new DeterministicReplayer(store);
+  const manifest = [{ version: 1, kind: 'llm.response', runId: 'r1', timestamp: 't', contentRef: ref }];
+  const out = replayer.replayLlmResponse(manifest as never, 'r1', 0);
+  expect(JSON.parse(out).text).toBe('cached answer');
+});
+
+it('throws if a referenced blob fails hash verification', () => {
+  const root = mkdtempSync(join(tmpdir(), 'replay-'));
+  const store = new ReplayContentStore(root);
+  const ref = store.put('x');
+  store.__corruptForTest(ref, 'y');
+  const replayer = new DeterministicReplayer(store);
+  expect(() => replayer.replayLlmResponse(
+    [{ version: 1, kind: 'llm.response', runId: 'r1', timestamp: 't', contentRef: ref }] as never, 'r1', 0,
+  )).toThrow(/hash mismatch/i);
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-observer && npm test -- --run src/replay/deterministic-replayer.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the replayer + manifest + exports**
+
+`deterministic-replayer.ts`:
+
+```ts
+import type { ReplayContentStore } from './replay-content-store.js';
+import type { ReplayRecord } from './replay-record.js';
+
+export class DeterministicReplayer {
+  constructor(private readonly store: ReplayContentStore) {}
+  replayLlmResponse(manifest: ReplayRecord[], runId: string, index: number): string {
+    const responses = manifest.filter((r) => r.runId === runId && r.kind === 'llm.response');
+    const rec = responses[index];
+    if (!rec) throw new Error(`No saved llm.response at index ${index} for run ${runId}`);
+    return this.store.get(rec.contentRef); // get() verifies hash
+  }
+  replayToolResult(manifest: ReplayRecord[], runId: string, index: number): string {
+    const results = manifest.filter((r) => r.runId === runId && r.kind === 'tool.result');
+    const rec = results[index];
+    if (!rec) throw new Error(`No saved tool.result at index ${index} for run ${runId}`);
+    return this.store.get(rec.contentRef);
+  }
+}
+```
+
+In `audit-trail-store.ts`, in `save(runId, trail)` after writing the trail JSON, also write the replay manifest if records were collected: add an optional `manifest?: ReplayRecord[]` parameter and write `join(this.auditDir, \`${runId}.replay.json\`)` with `JSON.stringify(manifest ?? [], null, 2)`. Keep the existing trail write unchanged (backward compatible).
+
+In `index.ts`, add:
+
+```ts
+export { ReplayContentStore } from './replay/replay-content-store.js';
+export { DeterministicReplayer } from './replay/deterministic-replayer.js';
+export type { ReplayRecord, ReplayRecordKind } from './replay/replay-record.js';
+export { hashContent } from './replay/replay-record.js';
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-observer && npm test -- --run src/replay/deterministic-replayer.test.ts src/audit-trail-store.test.ts src/execution-replayer.test.ts`
+Expected: PASS (existing replayer/trail tests stay green — additive change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-observer/src/replay/deterministic-replayer.ts packages/franken-observer/src/audit-trail-store.ts packages/franken-observer/src/index.ts packages/franken-observer/src/replay/deterministic-replayer.test.ts
+git commit -m "feat(observer): deterministic replay + replay manifest persistence"
+```
+
+---
+
+## Task 3: Capture LLM/tool replay records in orchestrator
+
+**Files:**
+- Modify: `packages/franken-orchestrator/src/adapters/audit-observer-adapter.ts`
+- Modify: `packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts`
+- Modify: `packages/franken-orchestrator/src/skills/cli-skill-executor.ts`
+- Test: `packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts`, `tests/unit/skills/cli-skill-executor.test.ts`
+
+- [ ] **Step 1: Write the failing capture test**
+
+In `cli-llm-adapter.test.ts`:
+
+```ts
+it('records an llm.request and llm.response replay record per call', async () => {
+  const records: { kind: string; contentRef: string }[] = [];
+  const adapter = makeCliLlmAdapter({ /* existing fixture */ observer: { recordReplay: (r) => records.push(r) } as never });
+  await adapter.complete({ prompt: 'hello', runId: 'r1' } as never);
+  expect(records.map((r) => r.kind)).toEqual(['llm.request', 'llm.response']);
+  expect(records[0].contentRef).toMatch(/^[a-f0-9]{64}$/);
+});
+```
+
+Mirror the pattern in `cli-skill-executor.test.ts` for `tool.call` / `tool.result`.
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/adapters/cli-llm-adapter.test.ts tests/unit/skills/cli-skill-executor.test.ts`
+Expected: FAIL — adapters do not record replay records.
+
+- [ ] **Step 3: Implement capture**
+
+In `audit-observer-adapter.ts`, add a `recordReplay(record: ReplayRecord)` method that `put`s the raw content into a `ReplayContentStore` and appends the returned `ReplayRecord` to an in-run manifest array (flushed via `AuditTrailStore.save(runId, trail, manifest)` where the run already saves its trail). In `cli-llm-adapter.ts`, around the existing provider call, call `observer.recordReplay({ kind: 'llm.request', runId, provider, model, content: prompt })` before and `'llm.response'` after, hashing content via the store. In `cli-skill-executor.ts`, do the same for `tool.call` (args JSON) and `tool.result` (result JSON). Use the existing observer handle already threaded into these adapters — do not introduce a new global.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/adapters/cli-llm-adapter.test.ts tests/unit/skills/cli-skill-executor.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/adapters/audit-observer-adapter.ts packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts packages/franken-orchestrator/src/skills/cli-skill-executor.ts packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+git commit -m "feat(orchestrator): capture llm/tool replay records"
+```
+
+---
+
+## Task 4: Persist Beast phase state machine
+
+**Files:**
+- Create: `packages/franken-orchestrator/src/context/state-snapshot-store.ts`
+- Modify: `packages/franken-orchestrator/src/context/franken-context.ts`
+- Modify: `packages/franken-orchestrator/src/beast-loop.ts`
+- Test: `packages/franken-orchestrator/tests/unit/beast-loop-state-persistence.test.ts`
+
+- [ ] **Step 1: Write the failing state-persistence test**
+
+`tests/unit/beast-loop-state-persistence.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+it('persists a phase snapshot after each phase', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'state-'));
+  const { loop, ctx } = makeBeastLoopWithFakePorts({ stateDir, runId: 'r1' }); // existing beast-loop test harness
+  await loop.run(ctx);
+  const lines = readFileSync(join(stateDir, 'r1.jsonl'), 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+  const phases = lines.map((s) => s.phase);
+  expect(phases).toEqual(expect.arrayContaining(['ingestion', 'hydration', 'planning', 'execution', 'closure']));
+  expect(lines.at(-1)).toMatchObject({ runId: 'r1', phase: 'closure' });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beast-loop-state-persistence.test.ts tests/unit/beast-loop.test.ts`
+Expected: FAIL — no state file written.
+
+- [ ] **Step 3: Implement snapshot store + wiring**
+
+`state-snapshot-store.ts`:
+
+```ts
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export interface PhaseSnapshot {
+  readonly runId: string;
+  readonly phase: string;
+  readonly previousPhase: string | null;
+  readonly timestamp: string;
+  readonly planVersion?: number;
+  readonly provider?: string;
+  readonly lastAuditEventId?: string;
+}
+
+export class StateSnapshotStore {
+  private readonly file: string;
+  private previous: string | null = null;
+  constructor(stateDir: string, runId: string) {
+    if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
+    this.file = join(stateDir, `${runId}.jsonl`);
+  }
+  record(snapshot: Omit<PhaseSnapshot, 'previousPhase' | 'timestamp'>): void {
+    const full: PhaseSnapshot = { ...snapshot, previousPhase: this.previous, timestamp: new Date().toISOString() };
+    appendFileSync(this.file, JSON.stringify(full) + '\n');
+    this.previous = snapshot.phase;
+  }
+}
+```
+
+Add an optional `stateStore?: StateSnapshotStore` to `BeastContext` (`franken-context.ts`). In `beast-loop.ts`, after each existing `logger.info('BeastLoop: phase end', { phase: X })` call (ingestion, hydration, planning, execution, closure), add `ctx.stateStore?.record({ runId: ctx.runId, phase: X, planVersion: ctx.planVersion, provider: ctx.provider });` using the values already on `ctx`. Construct the store where the loop is created (CLI/dep wiring), `stateDir = <fbeastRoot>/.fbeast/state`.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd packages/franken-orchestrator && npm test -- --run tests/unit/beast-loop-state-persistence.test.ts tests/unit/beast-loop.test.ts`
+Expected: PASS (existing beast-loop tests unaffected — `stateStore` is optional).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/franken-orchestrator/src/context/state-snapshot-store.ts packages/franken-orchestrator/src/context/franken-context.ts packages/franken-orchestrator/src/beast-loop.ts packages/franken-orchestrator/tests/unit/beast-loop-state-persistence.test.ts
+git commit -m "feat(orchestrator): persist beast phase state transitions"
+```
+
+---
+
+## Task 5: Closeout — ADR + audit follow-up + verification
+
+**Files:**
+- Create: `docs/adr/037-durable-audit-and-deterministic-replay.md`
+- Modify: `docs/audits/agent-systems-audit-2026-04-28.md`
+
+- [ ] **Step 1: Write ADR-037**
+
+Record: replay records (LLM/tool) are content-addressed under `.fbeast/audit/blobs/` with sha256 verification; a manifest is persisted next to each audit trail; `DeterministicReplayer` replays saved LLM/tool outputs without a live provider; phase FSM snapshots are appended to `.fbeast/state/<runId>.jsonl` after each phase. Residual: full OS-level execution replay (process/syscall) is still out of scope; this is record/state replay only.
+
+- [ ] **Step 2: Audit follow-up**
+
+Map Pillar-2 gaps: "Replay is timeline analysis, not deterministic execution replay" → `fixed` (record-level); "LLM prompts and responses are not universally persisted" → `partially-fixed` (captured at cli-llm/skill adapters; note any uncovered paths); "main Beast loop … not modeled as a persisted finite-state machine" → `fixed`. "Checkpointing is partial" → `partially-fixed` (state snapshots added; full prompt/response in replay store). Cite commits/tests.
+
+- [ ] **Step 3: Verify the chunk**
+
+```bash
+cd packages/franken-observer && npm test -- --run src/replay/replay-content-store.test.ts src/replay/deterministic-replayer.test.ts src/audit-trail-store.test.ts src/execution-replayer.test.ts && npm run typecheck
+cd ../franken-orchestrator && npm test -- --run tests/unit/beast-loop-state-persistence.test.ts tests/unit/beast-loop.test.ts tests/unit/adapters/cli-llm-adapter.test.ts tests/unit/skills/cli-skill-executor.test.ts && npm run typecheck
+```
+Expected: all exit `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adr/037-durable-audit-and-deterministic-replay.md docs/audits/agent-systems-audit-2026-04-28.md
+git commit -m "docs: ADR-037 and audit follow-up for durable audit & replay"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Pillar-2 gaps (timeline-only replay, in-memory FSM, non-universal LLM persistence, partial checkpointing) each map to a task; `partially-fixed` items are flagged honestly rather than overclaimed.
+- **Placeholder scan:** Real code in store/replayer/snapshot steps; the orchestrator capture step names the exact adapters and the existing observer handle (no "add appropriate hooks").
+- **Type consistency:** `ReplayRecord`/`ReplayRecordKind`/`hashContent`/`ReplayContentStore`/`DeterministicReplayer` named identically across observer modules, exports, tests, and orchestrator usage; `StateSnapshotStore.record` signature matches its `beast-loop.ts` call site; `PhaseSnapshot` fields match the test assertions (`runId`, `phase`).
+
+## Execution Handoff
+
+Plan complete. **(1) Subagent-Driven (recommended)** or **(2) Inline Execution** via executing-plans. Task 3 requires reading the existing observer handle threading in `cli-llm-adapter.ts`/`cli-skill-executor.ts` during implementation — flagged inline.

--- a/docs/superpowers/plans/2026-05-17-security-hardening-chunks-index.md
+++ b/docs/superpowers/plans/2026-05-17-security-hardening-chunks-index.md
@@ -1,0 +1,63 @@
+# Security Hardening — Chunked Plan Index
+
+**Source:** `docs/audits/agent-systems-audit-2026-04-28.md` and the monolithic
+`docs/superpowers/plans/2026-04-28-agent-systems-audit-gap-fill-plan.md`.
+
+**Status basis:** Every gap below was re-verified against current `main`
+(`origin/main` @ `610a0ea`) on 2026-05-17 — confirmed unimplemented in code,
+not merely unchecked in docs. Verification evidence is in each chunk plan.
+
+This index splits the gap-fill work into four **independently shippable**
+chunks. Each chunk has its own plan file, produces working/testable software on
+its own, and ends with its own ADR + audit follow-up so it can merge alone.
+
+## Chunks
+
+| # | Chunk | Orig tasks | Subsystems | Risk | Plan |
+|---|-------|-----------|------------|------|------|
+| 1 | Fail-Closed HTTP & Approval Boundaries | T1 | orchestrator http+cli, governor | **Critical** — unauthenticated chat routes, unconditional non-TTY auto-approve, fail-open signature config | `2026-05-17-sechard-1-failclosed-boundaries.md` |
+| 2 | MCP Schema Enforcement & Firewall Path Containment | T2 | mcp-suite | **Critical** — unvalidated MCP tool args, arbitrary-path file read | `2026-05-17-sechard-2-mcp-firewall-containment.md` |
+| 3 | Sandboxed Beast Execution | T3+T4 | orchestrator beasts/execution | **High** — container mode is a throwing placeholder, process mode inherits host secrets | `2026-05-17-sechard-3-sandboxed-execution.md` |
+| 4 | Durable Audit & Replay | T5+T6 | observer, orchestrator beast-loop | **Medium** — replay is timeline-only, phase state is in-memory | `2026-05-17-sechard-4-durable-audit-replay.md` |
+
+## Dependency & Execution Order
+
+```
+Chunk 1 ─┐
+Chunk 2 ─┼─ independent of each other; 1 & 2 are highest priority, parallelizable
+Chunk 3 ─┘
+Chunk 4 ── independent structurally; sequence LAST (replay/state-persistence is
+            most valuable once execution is sandboxed and boundaries are closed)
+```
+
+No chunk imports another chunk's new modules. Chunk 3 defines
+`SandboxPolicy` / `DEFAULT_BEAST_ENV_ALLOWLIST`; nothing outside Chunk 3 depends
+on it, so ordering between 1/2/3 is by risk priority, not by build dependency.
+
+**Recommended order:** 1 → 2 → 3 → 4. If parallelizing, run 1 and 2 in separate
+worktrees (disjoint file sets — `franken-orchestrator+governor` vs
+`franken-mcp-suite`), then 3, then 4.
+
+## ADR Numbering
+
+`docs/adr/033-*` is already taken (beast-run-resume). This work uses:
+
+- Chunk 1 → `docs/adr/034-fail-closed-http-and-approval-boundaries.md`
+- Chunk 2 → `docs/adr/035-mcp-input-validation-and-path-containment.md`
+- Chunk 3 → `docs/adr/036-sandboxed-beast-execution.md`
+- Chunk 4 → `docs/adr/037-durable-audit-and-deterministic-replay.md`
+
+## Deliberately Out Of Scope (carried from source plan)
+
+- OIDC / downscoped cloud-token issuance — separate future spec.
+- gVisor / Firecracker micro-VM backend — Docker `--network none` is the first
+  concrete backend; do not market it as micro-VM isolation.
+- An independently permissioned monitor *process* — Chunk 4's records/state are
+  prerequisites, but the monitor process itself is a later effort.
+
+## Re-Audit Discipline
+
+Each chunk's final task appends a `Follow-Up Implementation Status` row set to
+`docs/audits/agent-systems-audit-2026-04-28.md` mapping its original audit gap
+lines to `fixed | partially-fixed | still-open`. The audit file is the single
+source of truth for remaining risk after each merge.


### PR DESCRIPTION
## Summary

Re-scopes the monolithic `2026-04-28-agent-systems-audit-gap-fill-plan.md` into **4 independently shippable chunks**, each with its own TDD implementation plan. Every gap was **re-verified against current `main` (`610a0ea`) in code, not trusted from docs**.

## Plans added

- `2026-05-17-security-hardening-chunks-index.md` — chunking rationale, dependency/risk order, ADR numbering (034–037), out-of-scope
- **Chunk 1** — fail-closed HTTP chat auth + non-TTY approval + governor signed-approval
- **Chunk 2** — central MCP input-schema enforcement + firewall path containment
- **Chunk 3** — Docker `--network none` sandbox executor + process env allowlist/cwd containment
- **Chunk 4** — content-addressed replay records + deterministic replay + persisted phase FSM

## Verified gap evidence (in code)

- Non-TTY HITL auto-approves (`dep-factory.ts:387-393`); `requireSignedApprovals` fails open w/o verifier (`approval-gateway.ts:42`); governor accepts unsigned when no secret (`app.ts:54`); `/v1/chat/*` unauthenticated (`chat-app.ts:100`)
- MCP `CallTool` handler runs with unvalidated args (`server-factory.ts`); `firewall-adapter.ts scanFile` reads arbitrary paths
- `ContainerBeastExecutor` is a throwing placeholder; `process-supervisor.ts:46` inherits all non-`CLAUDE*` host env
- `execution-replayer.ts:42` is timeline-only; `BeastContext.phase` is in-memory only

Each chunk plan is self-contained: required header, file structure, bite-sized red→green→commit steps with real code anchored to `file:line`, self-review, execution handoff. Recommended order 1→2→3→4; chunks 1 & 2 are parallelizable.

Docs-only — no code changes. Separate from PR #292 to keep scope clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)