### PR TITLE
fix(security): Chunk 1 — fail-closed HTTP & approval boundaries

### DIFF
--- a/docs/adr/034-fail-closed-http-and-approval-boundaries.md
+++ b/docs/adr/034-fail-closed-http-and-approval-boundaries.md
@@ -28,16 +28,25 @@ hardening with TDD:
 
 - Generalize the existing beast operator-auth middleware into a shared
   `requireOperatorAuth` (`packages/franken-orchestrator/src/http/operator-auth.ts`).
-  `createChatApp` applies it to `/v1/chat/*` when an explicit chat
-  `operatorToken` is configured. `/health` stays public. `beast-auth.ts` now
+  `createChatApp` applies it to `/v1/chat/*` whenever an operator token is
+  configured (explicit `operatorToken` or `beastControl.operatorToken` —
+  matching the existing `VITE_BEAST_OPERATOR_TOKEN` pattern franken-web
+  already uses for beast routes). `/health` stays public. `beast-auth.ts`
   delegates to the shared helper.
-  - **Correction (PR #296 Codex review, P1):** chat auth is gated *only* on an
-    explicit chat `operatorToken`, deliberately **not** on
-    `beastControl.operatorToken`. The beast token authorizes the beast
-    control plane — a different trust domain than user-facing chat — and
-    coupling them silently 401'd existing franken-web chat clients in
-    beast-enabled (`chat-server`) deployments. `startChatServer` now accepts an
-    optional dedicated `operatorToken` to secure chat intentionally.
+- **Fail-closed startup**: `startChatServer` refuses to start when chat is
+  *exposed* (managed-network mode OR non-loopback host) without an effective
+  operator token. Loopback-only dev without a token remains allowed.
+- **First-party client plumbing**: `ChatApiClient` (franken-web) accepts an
+  operator token and sends `Authorization: Bearer …` on every `/v1/chat/*`
+  request — wired from `VITE_BEAST_OPERATOR_TOKEN` via `ChatShell`,
+  consistent with `BeastApiClient`. `network/chat-attach.ts` accepts an
+  operator token and presents it on remote session create; the CLI resolves
+  it via the same `resolveBeastOperatorToken` path as `chat-server`.
+- **Iteration history:** PR #296 Round-1 originally decoupled chat from the
+  beast token to avoid breaking franken-web; Round-2 Codex review correctly
+  flagged that this left the audited gap effectively unwired in the managed
+  path. The final design re-couples and plumbs clients instead — closing
+  the gap in the real deployment path.
 - Non-interactive HITL defaults to **`rejected`** unless
   `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1` is explicitly set. Note: the
   Chunk 1 plan specified the literal `'denied'`, but `ApprovalOutcome.decision`
@@ -75,6 +84,17 @@ Commits: `9cb1259` (chat auth), `b984d2d` (non-interactive HITL),
 
 This chunk does not add OIDC, downscoped cloud-token issuance, or transport
 encryption (TLS/mTLS). Those remain separate future specs.
+
+**Browser static-token limitation.** franken-web carries
+`VITE_BEAST_OPERATOR_TOKEN` as a build-time env var that is therefore embedded
+in the client bundle. This is the *pre-existing*, repo-wide mechanism (already
+used by `BeastApiClient` for beast routes) — chat now follows the same pattern
+for consistency. Replacing the static token with short-lived, server-minted
+bootstrap credentials is a broader hardening initiative tracked separately;
+the present change closes the audited gap (chat requires a token in any
+exposed deployment) without introducing a new secret-exposure pattern. The
+chat session-token mechanism already exists for the WebSocket path;
+extending it to the HTTP bootstrap is the next natural step.
 
 ## Alternatives Considered
 

--- a/docs/adr/034-fail-closed-http-and-approval-boundaries.md
+++ b/docs/adr/034-fail-closed-http-and-approval-boundaries.md
@@ -1,0 +1,78 @@
+# ADR-034: Fail-Closed HTTP & Approval Boundaries
+
+- **Date:** 2026-05-18
+- **Status:** Accepted
+- **Deciders:** pfk (with Claude Code), per security-hardening Chunk 1
+
+## Context
+
+The 2026-04-28 agent-systems audit (Pillar 3 — Identity Boundaries) found four
+fail-open boundaries, re-verified against `main` on 2026-05-17:
+
+- `/v1/chat/*` HTTP routes (session create/read, message submit, approval
+  update) were mounted with no operator/session authentication.
+- Non-interactive CLI runs wired `GovernorPortAdapter` with
+  `defaultDecision: 'approved'`, so every HITL gate auto-approved in CI / piped
+  input.
+- `ApprovalGateway` verified signatures only when *both*
+  `requireSignedApprovals` and a `signatureVerifier` were present —
+  `requireSignedApprovals: true` with no verifier silently skipped
+  verification.
+- The governor HTTP server accepted unsigned `/v1/approval/respond` requests
+  whenever no signing secret was configured.
+
+## Decision
+
+Tighten all four boundaries to fail closed; no new runtime, pure boundary
+hardening with TDD:
+
+- Generalize the existing beast operator-auth middleware into a shared
+  `requireOperatorAuth` (`packages/franken-orchestrator/src/http/operator-auth.ts`).
+  `createChatApp` applies it to `/v1/chat/*` when an operator token is
+  configured (explicit `operatorToken` or `beastControl.operatorToken`).
+  `/health` stays public. `beast-auth.ts` now delegates to the shared helper.
+- Non-interactive HITL defaults to **`rejected`** unless
+  `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1` is explicitly set. Note: the
+  Chunk 1 plan specified the literal `'denied'`, but `ApprovalOutcome.decision`
+  is `'approved' | 'rejected' | 'abort'` — `'denied'` is not a member, so
+  `'rejected'` (the valid "not approved" value) is used to keep typecheck green
+  and semantics correct.
+- `ApprovalGateway` throws at construction when `requireSignedApprovals` is set
+  without a `signatureVerifier`.
+- The governor server rejects unsigned `/v1/approval/respond` with `401` when no
+  signing secret is configured, unless `allowUnsignedApprovalsForTests: true`
+  is explicitly passed.
+
+Commits: `9cb1259` (chat auth), `b984d2d` (non-interactive HITL),
+`05fb8ef` (governor signed-approval).
+
+## Consequences
+
+### Positive
+- The chat HTTP surface and HITL approval paths fail closed by default.
+- Misconfiguration (signed-required-without-verifier, unsigned governor) is now
+  a hard, early failure instead of a silent bypass.
+
+### Negative
+- Existing non-interactive automation that relied on implicit auto-approve must
+  now set `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`.
+- Callers of `createChatApp` with an operator token must send the bearer token
+  on `/v1/chat/*` requests.
+
+### Risks
+- A `'rejected'` default for unanswerable non-interactive HITL gates a single
+  decision rather than aborting the run; downstream loop behavior on repeated
+  rejection is unchanged from existing reject handling.
+
+## Residual (out of scope)
+
+This chunk does not add OIDC, downscoped cloud-token issuance, or transport
+encryption (TLS/mTLS). Those remain separate future specs.
+
+## Alternatives Considered
+
+| Option | Pros | Cons | Rejected Because |
+|--------|------|------|-----------------|
+| Keep plan's literal `'denied'` | Matches plan prose verbatim | Not a member of `ApprovalOutcome.decision`; breaks typecheck | Type-invalid; `'rejected'` is the correct fail-closed enum |
+| Default non-interactive HITL to `'abort'` | Hard stop on unattended gate | Aborts entire run on any gate | Too aggressive for a single-gate default; `'rejected'` is the conservative deny |
+| Always require chat auth (no opt-in) | Strongest default | Breaks unauthenticated local/dev usage with no token configured | Token-gated when configured preserves existing tokenless local flows |

--- a/docs/adr/034-fail-closed-http-and-approval-boundaries.md
+++ b/docs/adr/034-fail-closed-http-and-approval-boundaries.md
@@ -28,9 +28,16 @@ hardening with TDD:
 
 - Generalize the existing beast operator-auth middleware into a shared
   `requireOperatorAuth` (`packages/franken-orchestrator/src/http/operator-auth.ts`).
-  `createChatApp` applies it to `/v1/chat/*` when an operator token is
-  configured (explicit `operatorToken` or `beastControl.operatorToken`).
-  `/health` stays public. `beast-auth.ts` now delegates to the shared helper.
+  `createChatApp` applies it to `/v1/chat/*` when an explicit chat
+  `operatorToken` is configured. `/health` stays public. `beast-auth.ts` now
+  delegates to the shared helper.
+  - **Correction (PR #296 Codex review, P1):** chat auth is gated *only* on an
+    explicit chat `operatorToken`, deliberately **not** on
+    `beastControl.operatorToken`. The beast token authorizes the beast
+    control plane — a different trust domain than user-facing chat — and
+    coupling them silently 401'd existing franken-web chat clients in
+    beast-enabled (`chat-server`) deployments. `startChatServer` now accepts an
+    optional dedicated `operatorToken` to secure chat intentionally.
 - Non-interactive HITL defaults to **`rejected`** unless
   `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1` is explicitly set. Note: the
   Chunk 1 plan specified the literal `'denied'`, but `ApprovalOutcome.decision`

--- a/docs/audits/agent-systems-audit-2026-04-28.md
+++ b/docs/audits/agent-systems-audit-2026-04-28.md
@@ -137,6 +137,21 @@ npm test -- --run tests/unit/server/app.test.ts tests/unit/gateway/approval-gate
 
 Result: 4 files passed, 26 tests passed.
 
+## Follow-Up Implementation Status
+
+Updated 2026-05-18 — security-hardening Chunk 1 (ADR-034). See
+`docs/adr/034-fail-closed-http-and-approval-boundaries.md`.
+
+| Pillar 3 gap | Status | Evidence |
+|--------------|--------|----------|
+| HTTP chat routes are unauthenticated | **fixed** | Commit `9cb1259`; `/v1/chat/*` gated by `requireOperatorAuth` when an operator token is configured. Test: `tests/integration/chat/chat-routes.test.ts` › "chat route operator auth". |
+| Non-interactive CLI can auto-approve HITL | **fixed** | Commit `b984d2d`; non-TTY `defaultDecision` is `'rejected'` unless `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`. Test: `tests/integration/cli/dep-factory-wiring.test.ts` › "does not auto-approve HITL in non-interactive mode by default". |
+| Signed approval enforcement is misconfigurable | **fixed** | Commit `05fb8ef`; `ApprovalGateway` throws when `requireSignedApprovals` is set without a `signatureVerifier`. Test: `tests/unit/gateway/approval-gateway-security.test.ts` › "throws at construction when signed approvals are required without a verifier". |
+| Governor HTTP server allows unsigned operation | **fixed** | Commit `05fb8ef`; `/v1/approval/respond` returns 401 with no signing secret unless `allowUnsignedApprovalsForTests`. Test: `tests/unit/server/app.test.ts` › "rejects unsigned approval responses when no signing secret is configured". |
+
+All four Pillar 3 boundary gaps are `fixed`. Residual (OIDC, downscoped tokens,
+transport encryption) remains out of scope per ADR-034.
+
 ## Bottom Line
 
 Frankenbeast is strongest today as an orchestration, audit, planning, review, and local-governance framework. It has real observability and some real approval/auth controls.

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -31,6 +31,10 @@ export class ApprovalGateway {
     this.config = deps.config;
     this.signatureVerifier = deps.signatureVerifier;
     this.sessionTokenStore = deps.sessionTokenStore;
+
+    if (deps.config.requireSignedApprovals && !deps.signatureVerifier) {
+      throw new Error('Signed approvals are required but no signatureVerifier was supplied');
+    }
   }
 
   async requestApproval(request: ApprovalRequest): Promise<ApprovalOutcome> {

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -4,6 +4,7 @@ import { createHmac } from 'node:crypto';
 export interface GovernorAppOptions {
   signingSecret?: string;
   slackWebhookUrl?: string;
+  allowUnsignedApprovalsForTests?: boolean;
 }
 
 export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
@@ -51,8 +52,13 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   app.post('/v1/approval/respond', async (c) => {
     const body = await c.req.json();
 
-    // Verify signature if signing secret configured
-    if (options.signingSecret) {
+    // Fail closed: unsigned approval responses are rejected unless a signing
+    // secret is configured (then verified) or an explicit test flag is set.
+    if (!options.signingSecret) {
+      if (!options.allowUnsignedApprovalsForTests) {
+        return c.json({ error: { message: 'Signing secret required for approval responses' } }, 401);
+      }
+    } else {
       const signature = c.req.header('x-governor-signature');
       if (!signature) {
         return c.json({ error: { message: 'Missing signature' } }, 401);

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -100,6 +100,15 @@ describe('ApprovalGateway — security integration', () => {
     }
   });
 
+  it('throws at construction when signed approvals are required without a verifier', () => {
+    expect(() => new ApprovalGateway({
+      channel: makeFakeChannel(),
+      auditRecorder: makeFakeAuditRecorder(),
+      config: { ...defaultConfig(), requireSignedApprovals: true },
+      // no signatureVerifier
+    })).toThrow(/signed approvals.*verifier/i);
+  });
+
   it('does not return SessionToken for non-APPROVE decisions', async () => {
     const tokenStore = new SessionTokenStore();
     const channel = makeFakeChannel({ decision: 'REGEN', feedback: 'nope' });

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -46,7 +46,7 @@ describe('Governor Hono Server', () => {
 
   describe('POST /v1/approval/respond', () => {
     it('resolves a pending approval', async () => {
-      const app = createGovernorApp();
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
 
       // Create approval
       await app.request('/v1/approval/request', {
@@ -73,7 +73,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('returns 404 for unknown request', async () => {
-      const app = createGovernorApp();
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -136,6 +136,15 @@ describe('Governor Hono Server', () => {
         body: JSON.stringify({ requestId: 'req-3', decision: 'APPROVE' }),
       });
 
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects unsigned approval responses when no signing secret is configured', async () => {
+      const app = createGovernorApp();
+      const res = await app.request('/v1/approval/respond', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ requestId: 'r1', decision: 'approved' }),
+      });
       expect(res.status).toBe(401);
     });
 

--- a/packages/franken-orchestrator/src/beasts/http/beast-auth.ts
+++ b/packages/franken-orchestrator/src/beasts/http/beast-auth.ts
@@ -1,5 +1,4 @@
-import { createMiddleware } from 'hono/factory';
-import { HttpError } from '../../http/middleware.js';
+import { requireOperatorAuth } from '../../http/operator-auth.js';
 import { TransportSecurityService } from '../../http/security/transport-security.js';
 
 export interface BeastAuthOptions {
@@ -7,27 +6,9 @@ export interface BeastAuthOptions {
   security: TransportSecurityService;
 }
 
-function extractBearerToken(headerValue: string | undefined): string | undefined {
-  if (!headerValue) {
-    return undefined;
-  }
-  const [scheme, token] = headerValue.split(' ');
-  if (scheme?.toLowerCase() !== 'bearer' || !token) {
-    return undefined;
-  }
-  return token;
-}
-
 export function requireBeastOperatorAuth(options: BeastAuthOptions) {
-  return createMiddleware(async (c, next) => {
-    const provided = extractBearerToken(c.req.header('authorization'))
-      ?? c.req.header('x-frankenbeast-operator-token')
-      ?? undefined;
-
-    if (!options.security.verifyOperatorToken(provided, options.operatorToken)) {
-      throw new HttpError(401, 'UNAUTHORIZED', 'Operator authentication is required');
-    }
-
-    await next();
+  return requireOperatorAuth({
+    operatorToken: options.operatorToken,
+    security: options.security,
   });
 }

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -385,12 +385,14 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
       const { stdin, stdout } = await import('node:process');
 
       if (!stdin.isTTY) {
-        // Non-interactive mode (CI, piped input) — auto-approve without readline.
+        // Non-interactive mode fails closed (denied) unless FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1 is explicitly set.
         // defaultDecision short-circuits before gateway is called, so gateway is a no-op placeholder.
         governor = new GovernorPortAdapter({
           gateway: { requestApproval: async () => ({ decision: 'APPROVE' as const }) } as never,
           projectId: basename(paths.root),
-          defaultDecision: 'approved' as const,
+          defaultDecision: process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL === '1'
+            ? ('approved' as const)
+            : ('rejected' as const),
         });
       } else {
         const rl = createInterface({ input: stdin, output: stdout });

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -317,9 +317,16 @@ export async function main(): Promise<void> {
 
   if (args.subcommand === 'chat' || args.subcommand === 'chat-server') {
     if (args.subcommand === 'chat') {
+      // Plumb the operator token so the attach client can authenticate when
+      // the managed chat-server has it configured (which it must, when
+      // exposed). Falls back to env / .env via resolveBeastOperatorToken; no
+      // secret store boot is required for the attach path.
+      const attachOperatorToken = await resolveBeastOperatorToken(root, { config })
+        .catch(() => undefined);
       const managedAttachment = await resolveManagedChatAttachment({
         config,
         frankenbeastDir: paths.frankenbeastDir,
+        ...(attachOperatorToken ? { operatorToken: attachOperatorToken } : {}),
       });
       if (managedAttachment) {
         await runManagedChatRepl({

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -317,12 +317,26 @@ export async function main(): Promise<void> {
 
   if (args.subcommand === 'chat' || args.subcommand === 'chat-server') {
     if (args.subcommand === 'chat') {
-      // Plumb the operator token so the attach client can authenticate when
-      // the managed chat-server has it configured (which it must, when
-      // exposed). Falls back to env / .env via resolveBeastOperatorToken; no
-      // secret store boot is required for the attach path.
-      const attachOperatorToken = await resolveBeastOperatorToken(root, { config })
-        .catch(() => undefined);
+      // Resolve the operator token so the attach client can authenticate
+      // when the managed chat-server has it configured (which it must, when
+      // exposed). Mirror chat-server's boot: try the configured secret
+      // store first (so deployments that keep the token only in the secure
+      // backend still work), then fall through to env / .env via
+      // resolveBeastOperatorToken.
+      let attachSecretStore: ISecretStore | undefined;
+      try {
+        const secureBackend = config.network.secureBackend ?? 'local-encrypted';
+        attachSecretStore = createSecretStore(secureBackend, {
+          projectRoot: root,
+          passphrase: process.env.FRANKENBEAST_PASSPHRASE,
+        });
+      } catch {
+        attachSecretStore = undefined;
+      }
+      const attachOperatorToken = await resolveBeastOperatorToken(root, {
+        ...(attachSecretStore ? { secretStore: attachSecretStore } : {}),
+        config,
+      }).catch(() => undefined);
       const managedAttachment = await resolveManagedChatAttachment({
         config,
         frankenbeastDir: paths.frankenbeastDir,

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -19,6 +19,7 @@ import { errorHandler, requestId, requestSizeLimit } from './middleware.js';
 import { createSessionTokenSecret, issueSessionToken } from './ws-chat-auth.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import { TransportSecurityService } from './security/transport-security.js';
+import { requireOperatorAuth } from './operator-auth.js';
 import { ChatBeastDispatchAdapter } from '../chat/beast-dispatch-adapter.js';
 import type { CommsConfig } from '../comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../comms/core/comms-runtime-port.js';
@@ -36,6 +37,7 @@ export interface ChatAppOptions {
   projectName?: string;
   sessionContinuation?: boolean;
   sessionTokenSecret?: string;
+  operatorToken?: string;
   engine?: ConversationEngine;
   runtime?: ChatRuntime;
   turnRunner?: TurnRunner;
@@ -98,6 +100,13 @@ export function createChatApp(opts: ChatAppOptions): Hono {
   const app = new Hono();
   app.use('*', requestId);
   app.use('/v1/chat/*', requestSizeLimit(DEFAULT_MAX_BODY_SIZE));
+  const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken;
+  if (effectiveOperatorToken) {
+    app.use('/v1/chat/*', requireOperatorAuth({
+      operatorToken: effectiveOperatorToken,
+      security: opts.beastControl?.security ?? transportSecurity,
+    }));
+  }
   app.onError(errorHandler);
 
   const routes = chatRoutes({

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -100,10 +100,14 @@ export function createChatApp(opts: ChatAppOptions): Hono {
   const app = new Hono();
   app.use('*', requestId);
   app.use('/v1/chat/*', requestSizeLimit(DEFAULT_MAX_BODY_SIZE));
-  const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken;
-  if (effectiveOperatorToken) {
+  // Chat auth is gated on an explicit chat operator token only. It is
+  // deliberately NOT coupled to the beast control-plane token
+  // (`beastControl.operatorToken`): that token authorizes the beast control
+  // plane, a different trust domain than user-facing chat, and coupling them
+  // would silently 401 existing chat clients in beast-enabled deployments.
+  if (opts.operatorToken) {
     app.use('/v1/chat/*', requireOperatorAuth({
-      operatorToken: effectiveOperatorToken,
+      operatorToken: opts.operatorToken,
       security: opts.beastControl?.security ?? transportSecurity,
     }));
   }

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -100,14 +100,17 @@ export function createChatApp(opts: ChatAppOptions): Hono {
   const app = new Hono();
   app.use('*', requestId);
   app.use('/v1/chat/*', requestSizeLimit(DEFAULT_MAX_BODY_SIZE));
-  // Chat auth is gated on an explicit chat operator token only. It is
-  // deliberately NOT coupled to the beast control-plane token
-  // (`beastControl.operatorToken`): that token authorizes the beast control
-  // plane, a different trust domain than user-facing chat, and coupling them
-  // would silently 401 existing chat clients in beast-enabled deployments.
-  if (opts.operatorToken) {
+  // Chat /v1/chat/* is gated by an operator token whenever one is configured.
+  // The same operator token authorizes the beast control plane and chat in
+  // this codebase (matching the existing `VITE_BEAST_OPERATOR_TOKEN` pattern
+  // already used by franken-web for beast routes); first-party clients
+  // (franken-web ChatApiClient, network/chat-attach) plumb the token through.
+  // `startChatServer` separately fails closed when chat is exposed without a
+  // token (managed mode or non-loopback host).
+  const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken;
+  if (effectiveOperatorToken) {
     app.use('/v1/chat/*', requireOperatorAuth({
-      operatorToken: opts.operatorToken,
+      operatorToken: effectiveOperatorToken,
       security: opts.beastControl?.security ?? transportSecurity,
     }));
   }

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -30,6 +30,8 @@ export interface StartChatServerOptions {
   executionLlm?: ILlmClient;
   projectName: string;
   sessionContinuation?: boolean;
+  /** Optional dedicated chat operator token; when set, gates all /v1/chat/* routes. */
+  operatorToken?: string;
   networkControl?: {
     root: string;
     frankenbeastDir: string;
@@ -92,6 +94,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     runtime: runtime.runtime,
     turnRunner: runtime.turnRunner,
     sessionTokenSecret: tokenSecret,
+    ...(options.operatorToken ? { operatorToken: options.operatorToken } : {}),
     ...(options.beastControl ? { beastControl: options.beastControl } : {}),
     ...(options.networkControl ? { networkControl: options.networkControl } : {}),
     ...(options.commsConfig ? { commsConfig: options.commsConfig } : {}),

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -32,6 +32,8 @@ export interface StartChatServerOptions {
   sessionContinuation?: boolean;
   /** Optional dedicated chat operator token; when set, gates all /v1/chat/* routes. */
   operatorToken?: string;
+  /** Test-only escape hatch for the fail-closed startup guard. */
+  allowUnauthenticatedChatForTests?: boolean;
   networkControl?: {
     root: string;
     frankenbeastDir: string;
@@ -66,10 +68,26 @@ export function resolveChatServerSessionStore(options: Pick<StartChatServerOptio
   return options.sessionStore ?? new FileSessionStore(options.sessionStoreDir);
 }
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
 export async function startChatServer(options: StartChatServerOptions): Promise<ChatServerHandle> {
   const host = options.host ?? DEFAULT_HOST;
   const port = options.port ?? DEFAULT_PORT;
   const path = options.path ?? DEFAULT_WS_PATH;
+
+  // Fail closed: refuse to expose /v1/chat/* without an operator token when
+  // the server is exposed (managed-network mode OR non-loopback host).
+  // Loopback-only dev without a token is intentionally allowed.
+  const effectiveOperatorToken = options.operatorToken ?? options.beastControl?.operatorToken;
+  const isManaged = process.env['FRANKENBEAST_NETWORK_MANAGED'] === '1';
+  const isExposed = isManaged || !LOOPBACK_HOSTS.has(host);
+  if (isExposed && !effectiveOperatorToken && !options.allowUnauthenticatedChatForTests) {
+    throw new Error(
+      `Refusing to start chat-server on ${host} without an operator token: `
+      + 'set FRANKENBEAST_BEAST_OPERATOR_TOKEN (or pass operatorToken/beastControl) '
+      + 'or bind to a loopback host. Pass allowUnauthenticatedChatForTests in tests.',
+    );
+  }
   const tokenSecret = createSessionTokenSecret();
   const sessionStore = resolveChatServerSessionStore(options);
   const runtime = createChatRuntime({

--- a/packages/franken-orchestrator/src/http/operator-auth.ts
+++ b/packages/franken-orchestrator/src/http/operator-auth.ts
@@ -1,0 +1,28 @@
+import { createMiddleware } from 'hono/factory';
+import { HttpError } from './middleware.js';
+import { TransportSecurityService } from './security/transport-security.js';
+
+export interface OperatorAuthOptions {
+  operatorToken: string;
+  security: TransportSecurityService;
+}
+
+export function extractOperatorToken(headerValue: string | undefined): string | undefined {
+  if (!headerValue) return undefined;
+  const [scheme, token] = headerValue.split(' ');
+  return scheme?.toLowerCase() === 'bearer' && token ? token : undefined;
+}
+
+export function requireOperatorAuth(options: OperatorAuthOptions) {
+  return createMiddleware(async (c, next) => {
+    const provided = extractOperatorToken(c.req.header('authorization'))
+      ?? c.req.header('x-frankenbeast-operator-token')
+      ?? undefined;
+
+    if (!options.security.verifyOperatorToken(provided, options.operatorToken)) {
+      throw new HttpError(401, 'UNAUTHORIZED', 'Operator authentication is required');
+    }
+
+    await next();
+  });
+}

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -15,11 +15,15 @@ interface ManagedNetworkState {
 export interface ManagedChatAttachment {
   baseUrl: string;
   wsUrl: string;
+  /** Operator token to present on /v1/chat/* HTTP requests (Authorization: Bearer). */
+  operatorToken?: string;
 }
 
 export interface ResolveManagedChatAttachmentOptions {
   config: OrchestratorConfig;
   frankenbeastDir: string;
+  /** Operator token resolved by the caller (e.g. from FRANKENBEAST_BEAST_OPERATOR_TOKEN). */
+  operatorToken?: string;
   fetchImpl?: typeof fetch;
 }
 
@@ -50,6 +54,7 @@ export async function resolveManagedChatAttachment(
   return {
     baseUrl,
     wsUrl: baseUrl.replace(/^http/, 'ws') + '/v1/chat/ws',
+    ...(options.operatorToken ? { operatorToken: options.operatorToken } : {}),
   };
 }
 
@@ -60,9 +65,13 @@ interface RemoteChatSession {
 }
 
 async function createRemoteSession(target: ManagedChatAttachment, projectId: string): Promise<RemoteChatSession> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (target.operatorToken) {
+    headers['authorization'] = `Bearer ${target.operatorToken}`;
+  }
   const createResponse = await fetch(`${target.baseUrl}/v1/chat/sessions`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ projectId }),
   });
   if (!createResponse.ok) {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -222,16 +222,21 @@ describe('Chat HTTP Routes', () => {
       },
     });
 
+    const authHeaders = {
+      'Content-Type': 'application/json',
+      authorization: 'Bearer operator-token',
+    };
+
     const createRes = await app.request('/v1/chat/sessions', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ projectId: 'proj' }),
     });
     const { data: created } = await createRes.json();
 
     const promptOneRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'spawn a martin beast' }),
     });
     expect(promptOneRes.status).toBe(200);
@@ -241,7 +246,7 @@ describe('Chat HTTP Routes', () => {
 
     const promptTwoRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'claude' }),
     });
     const promptTwo = await promptTwoRes.json();
@@ -249,7 +254,7 @@ describe('Chat HTTP Routes', () => {
 
     const promptThreeRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'Ship Beast monitoring' }),
     });
     const promptThree = await promptThreeRes.json();
@@ -257,7 +262,7 @@ describe('Chat HTTP Routes', () => {
 
     const dispatchRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'docs/chunks' }),
     });
     const dispatchBody = await dispatchRes.json();
@@ -265,7 +270,9 @@ describe('Chat HTTP Routes', () => {
     expect(dispatchBody.data.outcome.content).toContain('Martin Loop');
     expect(dispatchBody.data.outcome.content).toContain('running');
 
-    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
+    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`, {
+      headers: { authorization: 'Bearer operator-token' },
+    });
     const sessionBody = await sessionRes.json();
     expect(sessionBody.data.transcript.some((message: { content: string }) => message.content.includes('Ship Beast monitoring'))).toBe(true);
     expect(sessionBody.data.beastContext).toBeNull();
@@ -512,5 +519,35 @@ describe('Chat HTTP Routes', () => {
   it('sets an x-request-id response header', async () => {
     const res = await app.request('/health');
     expect(res.headers.get('x-request-id')).toEqual(expect.any(String));
+  });
+
+  describe('chat route operator auth', () => {
+    const baseChatOpts = () => ({
+      sessionStoreDir: TMP,
+      llm: { complete: vi.fn().mockResolvedValue('Mock reply') },
+      projectName: 'test-project',
+    });
+
+    it('rejects unauthenticated chat requests when an operator token is configured', async () => {
+      const app = createChatApp({ ...baseChatOpts(), operatorToken: 'secret-op-token' });
+      const res = await app.request('/v1/chat/sessions', { method: 'POST', body: '{}' });
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts chat requests with a valid bearer operator token', async () => {
+      const app = createChatApp({ ...baseChatOpts(), operatorToken: 'secret-op-token' });
+      const res = await app.request('/v1/chat/sessions', {
+        method: 'POST',
+        headers: { authorization: 'Bearer secret-op-token', 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(res.status).not.toBe(401);
+    });
+
+    it('keeps /health public', async () => {
+      const app = createChatApp({ ...baseChatOpts(), operatorToken: 'secret-op-token' });
+      const res = await app.request('/health');
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -222,21 +222,16 @@ describe('Chat HTTP Routes', () => {
       },
     });
 
-    const authHeaders = {
-      'Content-Type': 'application/json',
-      authorization: 'Bearer operator-token',
-    };
-
     const createRes = await app.request('/v1/chat/sessions', {
       method: 'POST',
-      headers: authHeaders,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectId: 'proj' }),
     });
     const { data: created } = await createRes.json();
 
     const promptOneRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: authHeaders,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: 'spawn a martin beast' }),
     });
     expect(promptOneRes.status).toBe(200);
@@ -246,7 +241,7 @@ describe('Chat HTTP Routes', () => {
 
     const promptTwoRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: authHeaders,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: 'claude' }),
     });
     const promptTwo = await promptTwoRes.json();
@@ -254,7 +249,7 @@ describe('Chat HTTP Routes', () => {
 
     const promptThreeRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: authHeaders,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: 'Ship Beast monitoring' }),
     });
     const promptThree = await promptThreeRes.json();
@@ -262,7 +257,7 @@ describe('Chat HTTP Routes', () => {
 
     const dispatchRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: authHeaders,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: 'docs/chunks' }),
     });
     const dispatchBody = await dispatchRes.json();
@@ -270,9 +265,7 @@ describe('Chat HTTP Routes', () => {
     expect(dispatchBody.data.outcome.content).toContain('Martin Loop');
     expect(dispatchBody.data.outcome.content).toContain('running');
 
-    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`, {
-      headers: { authorization: 'Bearer operator-token' },
-    });
+    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
     const sessionBody = await sessionRes.json();
     expect(sessionBody.data.transcript.some((message: { content: string }) => message.content.includes('Ship Beast monitoring'))).toBe(true);
     expect(sessionBody.data.beastContext).toBeNull();

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -222,16 +222,21 @@ describe('Chat HTTP Routes', () => {
       },
     });
 
+    const authHeaders = {
+      'Content-Type': 'application/json',
+      authorization: 'Bearer operator-token',
+    };
+
     const createRes = await app.request('/v1/chat/sessions', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ projectId: 'proj' }),
     });
     const { data: created } = await createRes.json();
 
     const promptOneRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'spawn a martin beast' }),
     });
     expect(promptOneRes.status).toBe(200);
@@ -241,7 +246,7 @@ describe('Chat HTTP Routes', () => {
 
     const promptTwoRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'claude' }),
     });
     const promptTwo = await promptTwoRes.json();
@@ -249,7 +254,7 @@ describe('Chat HTTP Routes', () => {
 
     const promptThreeRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'Ship Beast monitoring' }),
     });
     const promptThree = await promptThreeRes.json();
@@ -257,7 +262,7 @@ describe('Chat HTTP Routes', () => {
 
     const dispatchRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({ content: 'docs/chunks' }),
     });
     const dispatchBody = await dispatchRes.json();
@@ -265,7 +270,9 @@ describe('Chat HTTP Routes', () => {
     expect(dispatchBody.data.outcome.content).toContain('Martin Loop');
     expect(dispatchBody.data.outcome.content).toContain('running');
 
-    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
+    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`, {
+      headers: { authorization: 'Bearer operator-token' },
+    });
     const sessionBody = await sessionRes.json();
     expect(sessionBody.data.transcript.some((message: { content: string }) => message.content.includes('Ship Beast monitoring'))).toBe(true);
     expect(sessionBody.data.beastContext).toBeNull();

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -126,4 +126,50 @@ describe('chat server bootstrap', () => {
       await server.close();
     }
   });
+
+  it('refuses to start when chat is exposed (managed mode) without an operator token', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const prev = process.env['FRANKENBEAST_NETWORK_MANAGED'];
+    process.env['FRANKENBEAST_NETWORK_MANAGED'] = '1';
+    try {
+      await expect(startChatServer({
+        host: '127.0.0.1', // loopback alone is not enough in managed mode
+        port: 0,
+        sessionStoreDir: TMP,
+        llm: { complete: vi.fn().mockResolvedValue('') },
+        projectName: 'test-project',
+      })).rejects.toThrow(/operator token/i);
+    } finally {
+      if (prev === undefined) delete process.env['FRANKENBEAST_NETWORK_MANAGED'];
+      else process.env['FRANKENBEAST_NETWORK_MANAGED'] = prev;
+    }
+  });
+
+  it('refuses to start on a non-loopback host without an operator token', async () => {
+    mkdirSync(TMP, { recursive: true });
+    await expect(startChatServer({
+      host: '0.0.0.0',
+      port: 0,
+      sessionStoreDir: TMP,
+      llm: { complete: vi.fn().mockResolvedValue('') },
+      projectName: 'test-project',
+    })).rejects.toThrow(/operator token/i);
+  });
+
+  it('starts on loopback without a token (dev mode)', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const server = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir: TMP,
+      llm: { complete: vi.fn().mockResolvedValue('') },
+      projectName: 'test-project',
+    });
+    try {
+      const res = await fetch(`${server.url}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
 });

--- a/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
@@ -87,6 +87,23 @@ describe('dep-factory wiring integration', () => {
     await finalize();
   });
 
+  it('does not auto-approve HITL in non-interactive mode by default', async () => {
+    const prev = process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL;
+    delete process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL;
+    const paths = createTempPaths();
+    cleanups.push(paths.root);
+    const { deps, finalize } = await createCliDeps({
+      paths, baseBranch: 'main', budget: 1.0, provider: 'claude',
+      noPr: true, verbose: false, reset: false,
+    });
+    const outcome = await deps.governor.requestApproval({
+      requestId: 'r1', summary: 's', risk: 'high', requiresHitl: true,
+    } as never);
+    expect(outcome.decision).not.toBe('approved');
+    await finalize();
+    if (prev !== undefined) process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL = prev;
+  });
+
   it('uses real adapters via createBeastDeps even when enabledModules disables flags', async () => {
     const paths = createTempPaths();
     cleanups.push(paths.root);

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -128,12 +128,16 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
     tokenTotals,
   } = useChatSession({
     baseUrl,
+    operatorToken: beastOperatorToken,
     projectId,
     sessionId: selectedSessionId,
     sessionSeed,
   });
 
-  const chatClient = useMemo(() => new ChatApiClient(baseUrl), [baseUrl]);
+  const chatClient = useMemo(
+    () => new ChatApiClient(baseUrl, beastOperatorToken),
+    [baseUrl, beastOperatorToken],
+  );
   const analyticsClient = useMemo(() => new AnalyticsApiClient(baseUrl), [baseUrl]);
   const beastClient = useMemo(
     () => (beastOperatorToken ? new BeastApiClient(baseUrl, beastOperatorToken) : null),

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -189,6 +189,11 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const [tokenTotals, setTokenTotals] = useState<TokenTotals>(EMPTY_TOKEN_TOTALS);
 
   const clientRef = useRef(new ChatApiClient(opts.baseUrl, opts.operatorToken));
+  // Refresh the client when the baseUrl or operatorToken changes (e.g. token
+  // loaded async / rotated after mount); useRef alone would pin the original.
+  useEffect(() => {
+    clientRef.current = new ChatApiClient(opts.baseUrl, opts.operatorToken);
+  }, [opts.baseUrl, opts.operatorToken]);
   const readyRef = useRef(false);
   const socketRef = useRef<WebSocket | null>(null);
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -29,6 +29,7 @@ export interface ActivityEvent {
 
 export interface UseChatSessionOptions {
   baseUrl: string;
+  operatorToken?: string;
   projectId: string;
   sessionId?: string;
   sessionSeed?: number;
@@ -187,7 +188,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const [tier, setTier] = useState<string | null>(null);
   const [tokenTotals, setTokenTotals] = useState<TokenTotals>(EMPTY_TOKEN_TOTALS);
 
-  const clientRef = useRef(new ChatApiClient(opts.baseUrl));
+  const clientRef = useRef(new ChatApiClient(opts.baseUrl, opts.operatorToken));
   const readyRef = useRef(false);
   const socketRef = useRef<WebSocket | null>(null);
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -242,7 +242,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     return () => {
       cancelled = true;
     };
-  }, [opts.projectId, opts.sessionId, opts.sessionSeed]);
+    // Include auth context in deps so a late-loaded / rotated operator
+    // token (or baseUrl change) re-runs the authenticated bootstrap and
+    // recovers from an initial 401.
+  }, [opts.projectId, opts.sessionId, opts.sessionSeed, opts.baseUrl, opts.operatorToken]);
 
   useEffect(() => {
     if (!sessionId || !socketToken) {

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -75,7 +75,10 @@ export function toSocketUrl(baseUrl: string, sessionId: string, token: string): 
 }
 
 export class ChatApiClient {
-  constructor(private readonly baseUrl: string) {}
+  constructor(
+    private readonly baseUrl: string,
+    private readonly operatorToken?: string,
+  ) {}
 
   async createSession(projectId: string): Promise<ChatSession> {
     return this.request<ChatSession>('/v1/chat/sessions', {
@@ -130,7 +133,19 @@ export class ChatApiClient {
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, init);
+    // Plumb the operator token through every chat request when one is set,
+    // matching the `Authorization: Bearer …` convention BeastApiClient uses.
+    // When no token is configured, leave init untouched so callers see the
+    // exact request shape they passed.
+    let effectiveInit: RequestInit = init;
+    if (this.operatorToken) {
+      const headers = new Headers(init.headers);
+      if (!headers.has('authorization')) {
+        headers.set('authorization', `Bearer ${this.operatorToken}`);
+      }
+      effectiveInit = { ...init, headers };
+    }
+    const res = await fetch(`${this.baseUrl}${path}`, effectiveInit);
 
     if (!res.ok) {
       let message = `HTTP ${res.status}`;

--- a/packages/franken-web/tests/lib/api.test.ts
+++ b/packages/franken-web/tests/lib/api.test.ts
@@ -11,6 +11,31 @@ describe('ChatApiClient', () => {
     vi.clearAllMocks();
   });
 
+  describe('operator token plumbing', () => {
+    it('sends Authorization: Bearer when constructed with an operator token', async () => {
+      const tokened = new ChatApiClient('http://localhost:3000', 'op-secret');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 'x', projectId: 'p', transcript: [], state: 'active', socketToken: 't', tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 }, costUsd: 0, createdAt: '2026-03-09T00:00:00Z', updatedAt: '2026-03-09T00:00:00Z' } }),
+      });
+      await tokened.createSession('p');
+      const init = mockFetch.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Headers;
+      expect(headers.get('authorization')).toBe('Bearer op-secret');
+    });
+
+    it('does not add Authorization when constructed without a token', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 'x', projectId: 'p', transcript: [], state: 'active', socketToken: 't', tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 }, costUsd: 0, createdAt: '2026-03-09T00:00:00Z', updatedAt: '2026-03-09T00:00:00Z' } }),
+      });
+      await client.createSession('p');
+      const init = mockFetch.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers).toEqual({ 'Content-Type': 'application/json' });
+    });
+  });
+
   describe('createSession', () => {
     it('sends POST to /v1/chat/sessions and returns session data', async () => {
       mockFetch.mockResolvedValueOnce({

--- a/tasks/sechard-chunk1-chat-auth-progress.md
+++ b/tasks/sechard-chunk1-chat-auth-progress.md
@@ -1,0 +1,13 @@
+# PR #296 Round-2: chat-auth done correctly
+
+Direction: re-couple chat to operator token + fail-closed startup + client plumbing.
+
+- [x] chat-app.ts: restore `operatorToken ?? beastControl?.operatorToken` gate
+- [x] chat-server.ts: fail-closed — refuse to expose chat (managed/non-loopback) without a token
+- [x] cli/run.ts: resolve operator token before chat-attach
+- [x] franken-web/src/lib/api.ts: ChatApiClient sends Authorization: Bearer when token configured (via ChatShell from VITE_BEAST_OPERATOR_TOKEN)
+- [x] network/chat-attach.ts: accepts + presents operator token on remote session create
+- [x] tests: re-added auth headers; added 3 startup-guard tests; 2 api header tests
+- [x] ADR-034: final design + browser-static-token residual recorded
+- [ ] reply+resolve the 2 Round-2 threads with commit hashes
+- [ ] commit + push

--- a/tasks/sechard-chunk1-progress.md
+++ b/tasks/sechard-chunk1-progress.md
@@ -1,0 +1,18 @@
+# Chunk 1: Fail-Closed HTTP & Approval Boundaries — progress
+
+Worktree: `.worktrees/sechard-impl` — branch `codex/sechard-impl` off `origin/main` (bd26d85).
+Baseline: orchestrator 63 tests pass, governor server 10 pass.
+
+- [x] Task 1: Shared operator auth + chat route gating (9cb1259)
+- [x] Task 2: Fail-closed non-interactive approval (b984d2d)
+- [x] Task 3: Governor signed-approval fail-closed (05fb8ef)
+- [x] Task 4: Closeout — ADR-034 + audit follow-up + verification
+
+Chunk 1 complete. Verification: orchestrator chunk tests 67 pass,
+governor chunk tests 17 pass, typecheck 7/7 successful.
+
+Plan deviation: plan's literal `'denied'` non-interactive default is not a
+member of `ApprovalOutcome.decision` (`'approved' | 'rejected' | 'abort'`);
+used `'rejected'` (valid fail-closed value). Documented in ADR-034.
+
+Stopped after Task 4 closeout per instruction. Chunk 2 not started.


### PR DESCRIPTION
## Summary

Security-hardening Chunk 1 (per `docs/superpowers/plans/2026-05-17-sechard-1-failclosed-boundaries.md`). Closes the four Pillar-3 fail-open boundaries from the 2026-04-28 agent-systems audit:

- **Chat HTTP auth** (`9cb1259`): `/v1/chat/*` now requires an operator token when one is configured; `/health` stays public. Shared `requireOperatorAuth` middleware extracted; `beast-auth` delegates to it.
- **Non-interactive HITL** (`b984d2d`): non-TTY runs default to `rejected` (fail closed) unless `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`.
- **Governor signed approvals** (`05fb8ef`): `ApprovalGateway` throws if `requireSignedApprovals` is set without a verifier; server 401s unsigned `/v1/approval/respond` when no signing secret is configured (test-only opt-out flag).
- **Docs** (`454917e`): ADR-034 + audit Follow-Up Implementation Status (all 4 gaps → `fixed`).

### Plan deviation
The plan specified the literal `'denied'` for the non-interactive default, but `ApprovalOutcome.decision` is `'approved' | 'rejected' | 'abort'` — `'denied'` is not a member and breaks typecheck. Used `'rejected'` (valid fail-closed value). Documented in ADR-034.

## Test Plan
- [x] `franken-orchestrator` + `@franken/governor` full test + typecheck suites pass (turbo, 10/10 tasks)
- [x] Chunk verification commands from the plan pass (orchestrator 67, governor chunk 17)
- [x] No regressions in adjacent chat/beast/network suites (107 pass) or full governor suite (113 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)