### PR TITLE
fix(security): Chunk 2 — MCP schema enforcement & firewall path containment

### DIFF
--- a/docs/adr/035-mcp-input-validation-and-path-containment.md
+++ b/docs/adr/035-mcp-input-validation-and-path-containment.md
@@ -53,6 +53,11 @@ Commits: `acb7265` (schema enforcement), `7085b5c` (path containment).
   Schemas in this codebase are flat `{ type, description }` maps, so this
   matches the advertised contract — but consumers must not assume deep
   JSON-Schema semantics.
+- **Unknown properties are rejected (fail closed), not allowed.** This is a
+  deliberate security posture for first-party tools, not JSON-Schema
+  `additionalProperties` default behavior (the flat `ToolInputSchema` has no
+  such field). A tool that legitimately needs extra fields must declare them
+  in its own `inputSchema`; the global gate is intentionally strict.
 - `realpathSync` throws `ENOENT` for a missing in-root path; the firewall
   server handler already catches and surfaces this as a tool error
   (`isError: true`), which is acceptable behavior.

--- a/docs/adr/035-mcp-input-validation-and-path-containment.md
+++ b/docs/adr/035-mcp-input-validation-and-path-containment.md
@@ -1,0 +1,69 @@
+# ADR-035: MCP Input Validation & Path Containment
+
+- **Date:** 2026-05-18
+- **Status:** Accepted
+- **Deciders:** pfk (with Claude Code), per security-hardening Chunk 2
+
+## Context
+
+The 2026-04-28 agent-systems audit (Pillar 1 — Secure Code Execution) found two
+input-boundary gaps, re-verified against `main` on 2026-05-17:
+
+- **MCP tool schemas were metadata, not enforced.** `createMcpServer` passed raw
+  `args` straight into tool handlers; advertised `inputSchema`
+  (required/type/extra-property) was never checked. Handlers coerced with
+  `String(args['...'])`.
+- **`fbeast_firewall_scan_file` read arbitrary supplied paths.** The adapter's
+  `scanFile` forwarded the caller's path to `readFileSync` with no
+  repository/root containment, so absolute or `../` paths were read.
+
+## Decision
+
+Self-contained to `franken-mcp-suite`; no cross-package changes:
+
+- Add `validateToolArguments(tool, args)` and route **both** the SDK
+  `CallToolRequestSchema` handler and a new in-process
+  `FbeastMcpServer.callTool(name, args)` through a single shared `dispatchTool`.
+  Every tool now inherits structural validation from its declared
+  `inputSchema` before its handler runs: object-shape, required properties,
+  primitive `type` (with `integer` special-cased via `Number.isInteger`), and
+  rejection of unknown extra properties. `callTool` is the single source of
+  truth and is what the unit tests exercise (the SDK keeps its handler map
+  private, so a public in-process entry point is both the testable and the
+  programmatically useful surface).
+- `createFirewallAdapter` gains a third `options: { root?: string }` argument.
+  `scanFile` resolves the requested path against the real-path of the
+  configured root (`options.root` → `FBEAST_ROOT` → `cwd`) and refuses any
+  target that is not the root or under `root + sep`. `servers/firewall.ts`
+  passes `{ root: FBEAST_ROOT ?? cwd }`.
+
+Commits: `acb7265` (schema enforcement), `7085b5c` (path containment).
+
+## Consequences
+
+### Positive
+- Every MCP tool inherits input validation centrally (DRY) — no per-handler
+  validation drift.
+- `fbeast_firewall_scan_file` can no longer be coerced into reading
+  `/etc/passwd` or `../`-escaped paths.
+
+### Negative / Residual
+- **Validation is structural only.** It does not implement full JSON-Schema:
+  no `format`, `enum`, `pattern`, nested-object, or array-item validation.
+  Schemas in this codebase are flat `{ type, description }` maps, so this
+  matches the advertised contract — but consumers must not assume deep
+  JSON-Schema semantics.
+- `realpathSync` throws `ENOENT` for a missing in-root path; the firewall
+  server handler already catches and surfaces this as a tool error
+  (`isError: true`), which is acceptable behavior.
+- Callers passing absolute paths outside the root now get a hard error instead
+  of a silent read.
+
+## Alternatives Considered
+
+| Option | Pros | Cons | Rejected Because |
+|--------|------|------|-----------------|
+| Reach into SDK private `_requestHandlers` from tests | No API change | Brittle, couples tests to SDK internals | A public `callTool` is both testable and a legitimately useful in-process entry point |
+| Full JSON-Schema validator (ajv) | Complete validation | New dependency; schemas here are flat | Structural validation matches the advertised flat schema contract; documented as residual |
+| Per-handler argument validation | Localized | Duplicated, drifts, easy to forget | Central gate in `dispatchTool` is DRY and unmissable |
+| Containment via string `startsWith` only (no realpath) | Simpler | Symlink escape bypasses it | `realpathSync` closes the symlink-escape hole |

--- a/docs/audits/agent-systems-audit-2026-04-28.md
+++ b/docs/audits/agent-systems-audit-2026-04-28.md
@@ -137,6 +137,22 @@ npm test -- --run tests/unit/server/app.test.ts tests/unit/gateway/approval-gate
 
 Result: 4 files passed, 26 tests passed.
 
+## Follow-Up Implementation Status
+
+Updated 2026-05-18 — security-hardening Chunk 2 (ADR-035). See
+`docs/adr/035-mcp-input-validation-and-path-containment.md`. (Chunk 1 /
+Pillar 3 rows are tracked in its own PR and will appear in this section once
+both merge.)
+
+| Pillar 1 gap | Status | Evidence |
+|--------------|--------|----------|
+| MCP tool schemas are metadata, not enforced validation | **fixed** | Commit `acb7265`; `validateToolArguments` + shared `dispatchTool` gate every tool (SDK CallTool path and in-process `callTool`). Tests: `src/shared/server-factory.test.ts` › "rejects missing required property / wrong type / unknown extra property / passes valid". |
+| File scanning can read arbitrary supplied paths | **fixed** | Commit `7085b5c`; `createFirewallAdapter` real-path-contains `scanFile` to the configured project root. Tests: `src/servers/firewall.test.ts` › "rejects scanning a path outside the project root" / "allows scanning a file inside the project root". |
+
+Residual (ADR-035): MCP validation is structural only (no deep JSON-Schema
+`format`/`enum`/nested/array-item validation), matching the flat advertised
+schema contract.
+
 ## Bottom Line
 
 Frankenbeast is strongest today as an orchestration, audit, planning, review, and local-governance framework. It has real observability and some real approval/auth controls.

--- a/packages/franken-mcp-suite/src/adapters/firewall-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/firewall-adapter.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 import { createSqliteStore } from '../shared/sqlite-store.js';
 import { PATTERNS_ALL_TIERS, PATTERNS_STRICT_ONLY } from 'franken-orchestrator';
 import type { InjectionTier } from 'franken-orchestrator';
@@ -22,6 +23,7 @@ interface FirewallAdapterDeps {
 export function createFirewallAdapter(
   dbPathOrDeps: string | FirewallAdapterDeps,
   tier: InjectionTier = 'standard',
+  options: { root?: string } = {},
 ): FirewallAdapter {
   if (typeof dbPathOrDeps !== 'string') {
     return dbPathOrDeps;
@@ -32,6 +34,17 @@ export function createFirewallAdapter(
     ? [...PATTERNS_ALL_TIERS, ...PATTERNS_STRICT_ONLY]
     : PATTERNS_ALL_TIERS;
 
+  const root = realpathSync(resolve(options.root ?? process.env['FBEAST_ROOT'] ?? process.cwd()));
+
+  function resolveContained(requested: string): string {
+    const target = resolve(root, requested);
+    const realTarget = realpathSync(target); // throws ENOENT for missing — acceptable, caller handles
+    if (realTarget !== root && !realTarget.startsWith(root + sep)) {
+      throw new Error(`Refusing to scan path outside project root: ${requested}`);
+    }
+    return realTarget;
+  }
+
   return {
     async scanText(input) {
       const result = scanWithPatterns(input, patterns);
@@ -40,7 +53,8 @@ export function createFirewallAdapter(
     },
 
     async scanFile(path) {
-      const content = readFileSync(path, 'utf8');
+      const safePath = resolveContained(path);
+      const content = readFileSync(safePath, 'utf8');
       const result = scanWithPatterns(content, patterns);
       logScan(content, result);
       return result;

--- a/packages/franken-mcp-suite/src/adapters/firewall-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/firewall-adapter.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFileSync, realpathSync } from 'node:fs';
-import { resolve, sep } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { createSqliteStore } from '../shared/sqlite-store.js';
 import { PATTERNS_ALL_TIERS, PATTERNS_STRICT_ONLY } from 'franken-orchestrator';
 import type { InjectionTier } from 'franken-orchestrator';
@@ -39,7 +39,10 @@ export function createFirewallAdapter(
   function resolveContained(requested: string): string {
     const target = resolve(root, requested);
     const realTarget = realpathSync(target); // throws ENOENT for missing — acceptable, caller handles
-    if (realTarget !== root && !realTarget.startsWith(root + sep)) {
+    // relative() handles the filesystem-root case (root === sep) where a
+    // naive `root + sep` prefix would become a double separator.
+    const rel = relative(root, realTarget);
+    if (rel !== '' && (rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel))) {
       throw new Error(`Refusing to scan path outside project root: ${requested}`);
     }
     return realTarget;

--- a/packages/franken-mcp-suite/src/servers/firewall.test.ts
+++ b/packages/franken-mcp-suite/src/servers/firewall.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createFirewallServer } from './firewall.js';
+import { createFirewallAdapter } from '../adapters/firewall-adapter.js';
 
 describe('Firewall Server', () => {
   it('exposes 2 tools', () => {
@@ -42,5 +46,20 @@ describe('Firewall Server', () => {
     const fileResult = await scanFileTool.handler({ path: '/tmp/prompt.txt' });
     expect(firewall.scanFile).toHaveBeenCalledWith('/tmp/prompt.txt');
     expect(fileResult.content[0]!.text).toContain('clean');
+  });
+
+  it('rejects scanning a path outside the project root', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fw-root-'));
+    const adapter = createFirewallAdapter(join(root, 'fw.db'), 'standard', { root });
+    await expect(adapter.scanFile('../../etc/passwd')).rejects.toThrow(/outside.*root/i);
+    await expect(adapter.scanFile('/etc/passwd')).rejects.toThrow(/outside.*root/i);
+  });
+
+  it('allows scanning a file inside the project root', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fw-root-'));
+    writeFileSync(join(root, 'safe.txt'), 'hello');
+    const adapter = createFirewallAdapter(join(root, 'fw.db'), 'standard', { root });
+    const res = await adapter.scanFile('safe.txt');
+    expect(res.verdict).toBe('clean');
   });
 });

--- a/packages/franken-mcp-suite/src/servers/firewall.test.ts
+++ b/packages/franken-mcp-suite/src/servers/firewall.test.ts
@@ -62,4 +62,14 @@ describe('Firewall Server', () => {
     const res = await adapter.scanFile('safe.txt');
     expect(res.verdict).toBe('clean');
   });
+
+  it('allows children when the configured root is the filesystem root', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fw-fsroot-'));
+    const file = join(dir, 'safe.txt');
+    writeFileSync(file, 'hello');
+    // root '/' previously produced a '//' prefix and rejected every child.
+    const adapter = createFirewallAdapter(join(dir, 'fw.db'), 'standard', { root: '/' });
+    const res = await adapter.scanFile(file);
+    expect(res.verdict).toBe('clean');
+  });
 });

--- a/packages/franken-mcp-suite/src/servers/firewall.ts
+++ b/packages/franken-mcp-suite/src/servers/firewall.ts
@@ -81,7 +81,9 @@ if (isMain(import.meta.url)) {
     },
   });
   const tier = values['tier'] === 'strict' ? 'strict' : 'standard';
-  const firewall = createFirewallAdapter(values['db']!, tier);
+  const firewall = createFirewallAdapter(values['db']!, tier, {
+    root: process.env['FBEAST_ROOT'] ?? process.cwd(),
+  });
   const server = createFirewallServer({ firewall });
   server.start().catch((err) => {
     console.error('fbeast-firewall failed to start:', err);

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -72,6 +72,30 @@ describe('createMcpServer', () => {
     expect(calls).toEqual([{ msg: 'hi' }]);
   });
 
+  it('requires an OWN required property (rejects prototype-chain keys)', async () => {
+    const { calls, callTool } = makeServerWithSpy();
+    const res = await callTool('echo', Object.create({ msg: 'x' }));
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects explicit null wire arguments but defaults absent args to {}', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'noargs',
+      description: 'noargs',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    const nullRes = await srv.callTool('noargs', null);
+    expect(nullRes.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const absentRes = await srv.callTool('noargs', undefined);
+    expect(absentRes.isError).toBeFalsy();
+    expect(calls).toEqual([{}]);
+  });
+
   it('rejects null for an object-typed property (typeof null === "object")', async () => {
     const calls: unknown[] = [];
     const tool: ToolDef = {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -72,6 +72,20 @@ describe('createMcpServer', () => {
     expect(calls).toEqual([{ msg: 'hi' }]);
   });
 
+  it('rejects null for an object-typed property (typeof null === "object")', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'cfg',
+      description: 'cfg',
+      inputSchema: { type: 'object', properties: { args: { type: 'object', description: 'a' } }, required: ['args'] },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    const res = await srv.callTool('cfg', { args: null });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
   it('handler returns correct format', async () => {
     const tools: ToolDef[] = [
       {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -31,6 +31,47 @@ describe('createMcpServer', () => {
     expect(server.tools[0]!.name).toBe('fbeast_memory_query');
   });
 
+  function makeServerWithSpy() {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'echo',
+      description: 'echo',
+      inputSchema: { type: 'object', properties: { msg: { type: 'string', description: 'm' } }, required: ['msg'] },
+      handler: async (args) => { calls.push(args); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    const callTool = (name: string, args: unknown) => srv.callTool(name, args);
+    return { srv, calls, tool, callTool };
+  }
+
+  it('rejects missing required property without calling the handler', async () => {
+    const { calls, callTool } = makeServerWithSpy();
+    const res = await callTool('echo', {});
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects wrong property type', async () => {
+    const { calls, callTool } = makeServerWithSpy();
+    const res = await callTool('echo', { msg: 123 });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects unknown extra property', async () => {
+    const { calls, callTool } = makeServerWithSpy();
+    const res = await callTool('echo', { msg: 'hi', extra: 1 });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes a valid argument object through to the handler', async () => {
+    const { calls, callTool } = makeServerWithSpy();
+    const res = await callTool('echo', { msg: 'hi' });
+    expect(res.isError).toBeFalsy();
+    expect(calls).toEqual([{ msg: 'hi' }]);
+  });
+
   it('handler returns correct format', async () => {
     const tools: ToolDef[] = [
       {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -46,7 +46,7 @@ export function validateToolArguments(
   const obj = args as Record<string, unknown>;
   const schema = tool.inputSchema;
   for (const req of schema.required ?? []) {
-    if (!(req in obj) || obj[req] === undefined) {
+    if (!Object.prototype.hasOwnProperty.call(obj, req) || obj[req] === undefined) {
       return { ok: false, message: `Tool ${tool.name} missing required property: ${req}` };
     }
   }
@@ -72,7 +72,9 @@ async function dispatchTool(
   if (!tool) {
     return { content: [{ type: 'text' as const, text: `Unknown tool: ${toolName}` }], isError: true };
   }
-  const validated = validateToolArguments(tool, args ?? {});
+  // Only an *absent* argument object defaults to {}; an explicit `null` (or any
+  // non-object) on the wire must reach the validator and be rejected.
+  const validated = validateToolArguments(tool, args === undefined ? {} : args);
   if (!validated.ok) {
     return { content: [{ type: 'text' as const, text: `Error: ${validated.message}` }], isError: true };
   }

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -31,7 +31,59 @@ export interface ToolDef {
 export interface FbeastMcpServer {
   name: string;
   tools: ToolDef[];
+  /** Invoke a tool through the same validation gate the MCP CallTool path uses. */
+  callTool(name: string, args: unknown): Promise<ToolResult>;
   start(): Promise<void>;
+}
+
+export function validateToolArguments(
+  tool: ToolDef,
+  args: unknown,
+): { ok: true; value: Record<string, unknown> } | { ok: false; message: string } {
+  if (args === null || typeof args !== 'object' || Array.isArray(args)) {
+    return { ok: false, message: `Tool ${tool.name} expects an object argument` };
+  }
+  const obj = args as Record<string, unknown>;
+  const schema = tool.inputSchema;
+  for (const req of schema.required ?? []) {
+    if (!(req in obj) || obj[req] === undefined) {
+      return { ok: false, message: `Tool ${tool.name} missing required property: ${req}` };
+    }
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    const prop = schema.properties[key];
+    if (!prop) {
+      return { ok: false, message: `Tool ${tool.name} received unknown property: ${key}` };
+    }
+    const actual = Array.isArray(value) ? 'array' : typeof value;
+    if (prop.type === 'integer' ? !Number.isInteger(value) : actual !== prop.type) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must be ${prop.type}` };
+    }
+  }
+  return { ok: true, value: obj };
+}
+
+async function dispatchTool(
+  toolMap: Map<string, ToolDef>,
+  toolName: string,
+  args: unknown,
+): Promise<ToolResult> {
+  const tool = toolMap.get(toolName);
+  if (!tool) {
+    return { content: [{ type: 'text' as const, text: `Unknown tool: ${toolName}` }], isError: true };
+  }
+  const validated = validateToolArguments(tool, args ?? {});
+  if (!validated.ok) {
+    return { content: [{ type: 'text' as const, text: `Error: ${validated.message}` }], isError: true };
+  }
+  try {
+    return await tool.handler(validated.value);
+  } catch (err) {
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
 }
 
 export function createMcpServer(
@@ -52,27 +104,13 @@ export function createMcpServer(
 
   server.setRequestHandler(CallToolRequestSchema, async (request): Promise<Record<string, unknown>> => {
     const { name: toolName, arguments: args } = request.params;
-    const tool = toolMap.get(toolName);
-    if (!tool) {
-      return {
-        content: [{ type: 'text' as const, text: `Unknown tool: ${toolName}` }],
-        isError: true,
-      };
-    }
-    try {
-      const result = await tool.handler((args ?? {}) as Record<string, unknown>);
-      return { ...result };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-        isError: true,
-      };
-    }
+    return { ...(await dispatchTool(toolMap, toolName, args)) };
   });
 
   return {
     name,
     tools,
+    callTool: (toolName, args) => dispatchTool(toolMap, toolName, args),
     async start() {
       const transport = new StdioServerTransport();
       await server.connect(transport);

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -55,7 +55,7 @@ export function validateToolArguments(
     if (!prop) {
       return { ok: false, message: `Tool ${tool.name} received unknown property: ${key}` };
     }
-    const actual = Array.isArray(value) ? 'array' : typeof value;
+    const actual = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
     if (prop.type === 'integer' ? !Number.isInteger(value) : actual !== prop.type) {
       return { ok: false, message: `Tool ${tool.name} property ${key} must be ${prop.type}` };
     }


### PR DESCRIPTION
## Summary

Security-hardening Chunk 2 (per `docs/superpowers/plans/2026-05-17-sechard-2-mcp-firewall-containment.md`). Closes the two Pillar-1 input-boundary gaps from the 2026-04-28 agent-systems audit. Self-contained to `franken-mcp-suite`.

- **MCP schema enforcement** (`acb7265`): `validateToolArguments` + a shared `dispatchTool` now gate every tool — both the SDK `CallTool` path and a new in-process `FbeastMcpServer.callTool(name, args)` route through one place. Validates object shape, required props, primitive `type` (`integer` via `Number.isInteger`), and rejects unknown extra props before the handler runs.
- **Firewall path containment** (`7085b5c`): `createFirewallAdapter` gains `options.root`; `scanFile` real-path-resolves the requested path and refuses anything outside the project root. `servers/firewall.ts` passes `{ root: FBEAST_ROOT ?? cwd }`.
- **Docs** (`114ad87`): ADR-035 + audit Follow-Up Implementation Status (both Pillar-1 gaps → `fixed`).

### Design note
The MCP SDK keeps its request-handler map private, so the validation gate is exposed as a public in-process `callTool` (single source of truth, also what the unit tests drive) rather than reaching into SDK internals. Validation is structural only (no deep JSON-Schema) — matches the flat advertised schema contract; documented as residual in ADR-035.

### Branch base
Off `origin/main` (independent of the Chunk 1 PR #296). Both PRs add a `## Follow-Up Implementation Status` section to the audit file at the same anchor — expect a small, mechanical merge conflict there for whichever merges second (union of the two tables).

## Test Plan
- [x] New TDD tests pass: `src/shared/server-factory.test.ts` (4 new), `src/servers/firewall.test.ts` (2 new) — 11/11 in the two targeted files
- [x] `@fbeast/mcp-suite` typecheck passes (turbo, 8/8 incl. deps)
- [x] No regressions: full suite is 145 pass with these changes vs 139 pass on clean `origin/main` (delta = +6 new tests). The **3 pre-existing failing test files** (`tool-registry.test.ts`, `planner.test.ts`, `server-startup.integration.test.ts`) fail identically on clean `origin/main` and are **out of scope** for this chunk (build/spawn-env issues, not validation-related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)