### PR TITLE
fix(security): reject unsafe safety regex rules

### DIFF
--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -1,5 +1,18 @@
-import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
+import type {
+  Evaluator,
+  EvaluationInput,
+  EvaluationResult,
+  EvaluationFinding,
+} from './evaluator.js';
 import type { GuardrailsPort } from '../types/contracts.js';
+
+const MAX_SAFETY_PATTERN_LENGTH = 1_000;
+
+interface RegexGroupState {
+  startIndex: number;
+  containsQuantifiedAtom: boolean;
+  containsAmbiguousAlternation: boolean;
+}
 
 export class SafetyEvaluator implements Evaluator {
   readonly name = 'safety';
@@ -17,6 +30,13 @@ export class SafetyEvaluator implements Evaluator {
     let hasBlock = false;
 
     for (const rule of rules) {
+      const validationFinding = this.validateRulePattern(rule);
+      if (validationFinding) {
+        if (validationFinding.severity === 'critical') hasBlock = true;
+        findings.push(validationFinding);
+        continue;
+      }
+
       const regex = new RegExp(rule.pattern, 'g');
       if (regex.test(input.content)) {
         const isBlock = rule.severity === 'block';
@@ -25,13 +45,19 @@ export class SafetyEvaluator implements Evaluator {
         findings.push({
           message: `Safety rule violated: ${rule.description}`,
           severity: isBlock ? 'critical' : 'warning',
-          suggestion: `Remove or refactor code matching pattern: ${rule.pattern}`,
+          suggestion: 'Remove or refactor code matching this safety rule.',
         });
       }
     }
 
-    const warningCount = findings.filter((f) => f.severity === 'warning').length;
-    const score = hasBlock ? 0 : warningCount > 0 ? Math.max(0, 1 - warningCount * 0.2) : 1;
+    const warningCount = findings.filter(
+      (f) => f.severity === 'warning',
+    ).length;
+    const score = hasBlock
+      ? 0
+      : warningCount > 0
+        ? Math.max(0, 1 - warningCount * 0.2)
+        : 1;
 
     return {
       evaluatorName: this.name,
@@ -39,5 +65,236 @@ export class SafetyEvaluator implements Evaluator {
       score,
       findings,
     };
+  }
+
+  private validateRulePattern(rule: {
+    pattern: string;
+    description: string;
+    severity: 'block' | 'warn';
+  }): EvaluationFinding | null {
+    const severity = rule.severity === 'block' ? 'critical' : 'warning';
+
+    if (rule.pattern.length > MAX_SAFETY_PATTERN_LENGTH) {
+      return {
+        message: `Unsafe safety rule regex: ${rule.description}`,
+        severity,
+        suggestion: `Shorten safety rule pattern below ${MAX_SAFETY_PATTERN_LENGTH} characters before enabling this rule.`,
+      };
+    }
+
+    if (this.hasUnsafeRegexShape(rule.pattern)) {
+      return {
+        message: `Unsafe safety rule regex: ${rule.description}`,
+        severity,
+        suggestion:
+          'Replace nested or ambiguous quantifiers before enabling this rule.',
+      };
+    }
+
+    try {
+      new RegExp(rule.pattern, 'g');
+    } catch {
+      return {
+        message: `Invalid safety rule regex: ${rule.description}`,
+        severity,
+        suggestion: 'Fix or remove invalid pattern before enabling this rule.',
+      };
+    }
+
+    return null;
+  }
+
+  private hasUnsafeRegexShape(pattern: string): boolean {
+    return this.hasNestedQuantifiedExpression(pattern);
+  }
+
+  private hasNestedQuantifiedExpression(pattern: string): boolean {
+    const stack: RegexGroupState[] = [
+      {
+        startIndex: -1,
+        containsQuantifiedAtom: false,
+        containsAmbiguousAlternation: false,
+      },
+    ];
+    const groupHistory: RegexGroupState[] = [];
+    let previousToken: 'atom' | 'group' | 'none' = 'none';
+
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+
+      if (char === '\\') {
+        i += 1;
+        previousToken = 'atom';
+        continue;
+      }
+
+      if (char === '[') {
+        i = this.skipCharacterClass(pattern, i);
+        previousToken = 'atom';
+        continue;
+      }
+
+      if (char === '(') {
+        stack.push({
+          startIndex: i,
+          containsQuantifiedAtom: false,
+          containsAmbiguousAlternation: false,
+        });
+        if (pattern[i + 1] === '?') {
+          i += 1;
+        }
+        previousToken = 'none';
+        continue;
+      }
+
+      if (char === ')' && stack.length > 1) {
+        const group = stack.pop()!;
+        if (
+          this.hasOverlappingAlternation(pattern.slice(group.startIndex + 1, i))
+        ) {
+          group.containsAmbiguousAlternation = true;
+        }
+        if (group.containsQuantifiedAtom) {
+          stack.at(-1)!.containsQuantifiedAtom = true;
+        }
+        if (group.containsAmbiguousAlternation) {
+          stack.at(-1)!.containsAmbiguousAlternation = true;
+        }
+        groupHistory.push(group);
+        previousToken = 'group';
+        continue;
+      }
+
+      const quantifier = this.quantifierAt(pattern, i);
+      if (quantifier !== null) {
+        if (previousToken === 'group' && quantifier.variable) {
+          const quantifiedGroup = groupHistory.at(-1);
+          if (
+            quantifiedGroup?.containsQuantifiedAtom ||
+            quantifiedGroup?.containsAmbiguousAlternation
+          ) {
+            return true;
+          }
+        }
+
+        if (quantifier.variable) {
+          stack.at(-1)!.containsQuantifiedAtom = true;
+        }
+        i = quantifier.end;
+        previousToken = 'none';
+        continue;
+      }
+
+      if (char !== '^' && char !== '$' && char !== '|') {
+        previousToken = 'atom';
+      } else {
+        previousToken = 'none';
+      }
+    }
+
+    return false;
+  }
+
+  private hasOverlappingAlternation(groupContent: string): boolean {
+    const alternatives = this.splitTopLevelAlternatives(
+      this.stripGroupPrefix(groupContent),
+    );
+    if (alternatives.length < 2) return false;
+
+    return alternatives.some((left, leftIndex) =>
+      alternatives.some(
+        (right, rightIndex) =>
+          leftIndex !== rightIndex &&
+          left.length > 0 &&
+          right.length > 0 &&
+          (left.startsWith(right) || right.startsWith(left)),
+      ),
+    );
+  }
+
+  private stripGroupPrefix(groupContent: string): string {
+    if (groupContent.startsWith('?:')) return groupContent.slice(2);
+    if (groupContent.startsWith('?=') || groupContent.startsWith('?!')) {
+      return groupContent.slice(2);
+    }
+    if (groupContent.startsWith('?<=') || groupContent.startsWith('?<!')) {
+      return groupContent.slice(3);
+    }
+
+    const namedCapture = groupContent.match(/^\?<[^>]+>/);
+    if (namedCapture) return groupContent.slice(namedCapture[0].length);
+
+    return groupContent;
+  }
+
+  private splitTopLevelAlternatives(groupContent: string): string[] {
+    const alternatives: string[] = [];
+    let current = '';
+    let depth = 0;
+
+    for (let i = 0; i < groupContent.length; i += 1) {
+      const char = groupContent[i]!;
+
+      if (char === '\\') {
+        current += groupContent.slice(i, i + 2);
+        i += 1;
+        continue;
+      }
+
+      if (char === '[') {
+        const end = this.skipCharacterClass(groupContent, i);
+        current += groupContent.slice(i, end + 1);
+        i = end;
+        continue;
+      }
+
+      if (char === '(') {
+        depth += 1;
+      } else if (char === ')' && depth > 0) {
+        depth -= 1;
+      }
+
+      if (char === '|' && depth === 0) {
+        alternatives.push(current);
+        current = '';
+        continue;
+      }
+
+      current += char;
+    }
+
+    alternatives.push(current);
+    return alternatives;
+  }
+
+  private skipCharacterClass(pattern: string, start: number): number {
+    for (let i = start + 1; i < pattern.length; i += 1) {
+      if (pattern[i] === '\\') {
+        i += 1;
+        continue;
+      }
+      if (pattern[i] === ']') return i;
+    }
+    return pattern.length - 1;
+  }
+
+  private quantifierAt(
+    pattern: string,
+    start: number,
+  ): { end: number; variable: boolean } | null {
+    const char = pattern[start];
+    if (char === '+' || char === '*' || char === '?') {
+      return { end: start, variable: true };
+    }
+    if (char !== '{') return null;
+
+    const close = pattern.indexOf('}', start + 1);
+    if (close === -1) return null;
+
+    const body = pattern.slice(start + 1, close);
+    const match = body.match(/^(\d+)(?:,(\d*)?)?$/);
+    if (!match) return null;
+
+    return { end: close, variable: body.includes(',') };
   }
 }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -220,7 +220,12 @@ export class SafetyEvaluator implements Evaluator {
           group.containsAmbiguousAlternation = true;
         }
         if (group.containsQuantifiedAtom) {
-          stack.at(-1)!.containsQuantifiedAtom = true;
+          const groupContent = pattern.slice(group.startIndex + 1, i);
+          if (this.hasDeterministicTopLevelAlternation(groupContent)) {
+            group.containsQuantifiedAtom = false;
+          } else {
+            stack.at(-1)!.containsQuantifiedAtom = true;
+          }
         }
         if (
           group.containsAmbiguousAlternation &&
@@ -278,6 +283,13 @@ export class SafetyEvaluator implements Evaluator {
           this.tokenPrefixOverlaps(left, right),
       ),
     );
+  }
+
+  private hasDeterministicTopLevelAlternation(groupContent: string): boolean {
+    const alternatives = this.splitTopLevelAlternatives(
+      this.stripGroupPrefix(groupContent),
+    );
+    return alternatives.length > 1 && !this.hasOverlappingAlternation(groupContent);
   }
 
   private expandSimpleAlternativePrefix(
@@ -482,6 +494,27 @@ export class SafetyEvaluator implements Evaluator {
     return escaped;
   }
 
+  private classEscapedTokenAt(
+    body: string,
+    start: number,
+  ): { value: string; end: number } | null {
+    const escaped = body[start + 1];
+    if (escaped === undefined) return null;
+    if (escaped === 'x' && /^[0-9A-Fa-f]{2}$/.test(body.slice(start + 2, start + 4))) {
+      return {
+        value: String.fromCharCode(Number.parseInt(body.slice(start + 2, start + 4), 16)),
+        end: start + 3,
+      };
+    }
+    if (escaped === 'u' && /^[0-9A-Fa-f]{4}$/.test(body.slice(start + 2, start + 6))) {
+      return {
+        value: String.fromCharCode(Number.parseInt(body.slice(start + 2, start + 6), 16)),
+        end: start + 5,
+      };
+    }
+    return { value: this.escapedAtomToken(escaped), end: start + 1 };
+  }
+
   private characterClassToken(characterClass: string): string {
     if (characterClass === '[0-9]' || characterClass === '[\\d]') return 'DIGIT';
     if (characterClass === '[A-Za-z0-9_]' || characterClass === '[\\w]') {
@@ -641,11 +674,10 @@ export class SafetyEvaluator implements Evaluator {
     for (let i = 0; i < body.length; i += 1) {
       const char = body[i]!;
       if (char === '\\') {
-        const escaped = body[i + 1];
-        if (escaped === undefined) continue;
-        const escapedToken = this.escapedAtomToken(escaped);
-        if (this.regexTokensOverlap(escapedToken, token)) return true;
-        i += 1;
+        const escapedToken = this.classEscapedTokenAt(body, i);
+        if (escapedToken === null) continue;
+        if (this.regexTokensOverlap(escapedToken.value, token)) return true;
+        i = escapedToken.end;
         continue;
       }
 
@@ -664,7 +696,7 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private spaceTokenOverlaps(token: string): boolean {
-    return token === 'SPACE' || /^[\t\n\r\f\v ]$/.test(token);
+    return token === 'SPACE' || /^\s$/u.test(token);
   }
 
   private positiveClassBodyOverlaps(body: string, token: string): boolean {
@@ -713,7 +745,7 @@ export class SafetyEvaluator implements Evaluator {
       if (token.startsWith('RANGE:')) return !this.rangeContainsOnlyWhitespace(token);
       if (token.startsWith('CLASS:')) {
         return this.classBodyContainsOutsideToken(token, (char) =>
-          /^[\t\n\r\f\v ]$/.test(char),
+          /^\s$/u.test(char),
         );
       }
     }
@@ -752,12 +784,11 @@ export class SafetyEvaluator implements Evaluator {
     for (let i = 0; i < body.length; i += 1) {
       const char = body[i]!;
       if (char === '\\') {
-        const escaped = body[i + 1];
-        if (escaped === undefined) continue;
-        const token = this.escapedAtomToken(escaped);
-        if (token.length === 1 && !contains(token)) return true;
-        if (token.startsWith('NOT_')) return true;
-        i += 1;
+        const token = this.classEscapedTokenAt(body, i);
+        if (token === null) continue;
+        if (token.value.length === 1 && !contains(token.value)) return true;
+        if (token.value.startsWith('NOT_')) return true;
+        i = token.end;
         continue;
       }
 
@@ -811,6 +842,7 @@ export class SafetyEvaluator implements Evaluator {
       '-',
       '.',
       '/',
+      '\u00A0',
     ];
     return samples.some(
       (sample) =>
@@ -824,10 +856,10 @@ export class SafetyEvaluator implements Evaluator {
     if (token === 'DOT') return sample !== '\n' && sample !== '\r';
     if (token === 'WORD') return /^[A-Za-z0-9_]$/.test(sample);
     if (token === 'DIGIT') return /^\d$/.test(sample);
-    if (token === 'SPACE') return /^[\t\n\r\f\v ]$/.test(sample);
+    if (token === 'SPACE') return /^\s$/u.test(sample);
     if (token === 'NOT_DIGIT') return !/^\d$/.test(sample);
     if (token === 'NOT_WORD') return !/^[A-Za-z0-9_]$/.test(sample);
-    if (token === 'NOT_SPACE') return !/^[\t\n\r\f\v ]$/.test(sample);
+    if (token === 'NOT_SPACE') return !/^\s$/u.test(sample);
     if (token.startsWith('RANGE:')) {
       const [, start, end] = token.match(/^RANGE:(.)-(.)$/) ?? [];
       return start !== undefined && end !== undefined
@@ -849,11 +881,11 @@ export class SafetyEvaluator implements Evaluator {
     for (let i = 0; i < positiveBody.length; i += 1) {
       const char = positiveBody[i]!;
       if (char === '\\') {
-        const escaped = positiveBody[i + 1];
-        if (escaped !== undefined) {
-          matches = this.tokenMatchesSample(this.escapedAtomToken(escaped), sample);
+        const token = this.classEscapedTokenAt(positiveBody, i);
+        if (token !== null) {
+          matches = this.tokenMatchesSample(token.value, sample);
           if (matches) break;
-          i += 1;
+          i = token.end;
         }
         continue;
       }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -167,7 +167,7 @@ export class SafetyEvaluator implements Evaluator {
 
       const quantifier = this.quantifierAt(pattern, i);
       if (quantifier !== null) {
-        if (previousToken === 'group' && quantifier.variable) {
+        if (previousToken === 'group' && quantifier.repeatsGroup) {
           const quantifiedGroup = groupHistory.at(-1);
           if (
             quantifiedGroup?.containsQuantifiedAtom ||
@@ -198,7 +198,7 @@ export class SafetyEvaluator implements Evaluator {
   private hasOverlappingAlternation(groupContent: string): boolean {
     const alternatives = this.splitTopLevelAlternatives(
       this.stripGroupPrefix(groupContent),
-    );
+    ).map((alternative) => this.expandSimpleAlternativePrefix(alternative));
     if (alternatives.length < 2) return false;
 
     return alternatives.some((left, leftIndex) =>
@@ -207,9 +207,92 @@ export class SafetyEvaluator implements Evaluator {
           leftIndex !== rightIndex &&
           left.length > 0 &&
           right.length > 0 &&
-          (left.startsWith(right) || right.startsWith(left)),
+          this.tokenPrefixOverlaps(left, right),
       ),
     );
+  }
+
+  private expandSimpleAlternativePrefix(alternative: string): string[] {
+    const tokens: string[] = [];
+
+    for (let i = 0; i < alternative.length; i += 1) {
+      const token = this.regexAtomTokenAt(alternative, i);
+      if (token === null) break;
+
+      for (let count = 0; count < token.repeatCount; count += 1) {
+        tokens.push(token.value);
+      }
+      i = token.end;
+    }
+
+    return tokens;
+  }
+
+  private regexAtomTokenAt(
+    pattern: string,
+    start: number,
+  ): { value: string; end: number; repeatCount: number } | null {
+    const char = pattern[start];
+    if (char === undefined || char === '^' || char === '$' || char === '|') {
+      return null;
+    }
+
+    let value: string;
+    let end = start;
+
+    if (char === '[') {
+      end = this.skipCharacterClass(pattern, start);
+      value = this.characterClassToken(pattern.slice(start, end + 1));
+    } else if (char === '\\') {
+      const escaped = pattern[start + 1];
+      if (escaped === undefined) return null;
+      if (
+        escaped === 'x' &&
+        /^[0-9A-Fa-f]{2}$/.test(pattern.slice(start + 2, start + 4))
+      ) {
+        end = start + 3;
+        value = String.fromCharCode(Number.parseInt(pattern.slice(start + 2, start + 4), 16));
+      } else {
+        end = start + 1;
+        value = this.escapedAtomToken(escaped);
+      }
+    } else if (char === '(') {
+      return null;
+    } else {
+      value = char;
+    }
+
+    const quantifier = this.quantifierAt(pattern, end + 1);
+    const repeatCount = quantifier?.fixedCount ?? 1;
+    if (quantifier?.fixedCount !== undefined) {
+      end = quantifier.end;
+    }
+
+    return { value, end, repeatCount };
+  }
+
+  private escapedAtomToken(escaped: string): string {
+    if (escaped === 'd') return 'DIGIT';
+    if (escaped === 'w') return 'WORD';
+    if (escaped === 's') return 'SPACE';
+    if (escaped === 'x') return '\\x';
+    return escaped;
+  }
+
+  private characterClassToken(characterClass: string): string {
+    if (characterClass === '[0-9]' || characterClass === '[\\d]') return 'DIGIT';
+    if (characterClass === '[A-Za-z0-9_]' || characterClass === '[\\w]') {
+      return 'WORD';
+    }
+    return characterClass;
+  }
+
+  private tokenPrefixOverlaps(left: string[], right: string[]): boolean {
+    const limit = Math.min(left.length, right.length);
+    for (let i = 0; i < limit; i += 1) {
+      if (left[i] !== right[i]) return false;
+    }
+    return true;
   }
 
   private stripGroupPrefix(groupContent: string): string {
@@ -281,10 +364,18 @@ export class SafetyEvaluator implements Evaluator {
   private quantifierAt(
     pattern: string,
     start: number,
-  ): { end: number; variable: boolean } | null {
+  ): {
+    end: number;
+    variable: boolean;
+    repeatsGroup: boolean;
+    fixedCount?: number;
+  } | null {
     const char = pattern[start];
-    if (char === '+' || char === '*' || char === '?') {
-      return { end: start, variable: true };
+    if (char === '+' || char === '*') {
+      return { end: start, variable: true, repeatsGroup: true };
+    }
+    if (char === '?') {
+      return { end: start, variable: true, repeatsGroup: false };
     }
     if (char !== '{') return null;
 
@@ -295,6 +386,20 @@ export class SafetyEvaluator implements Evaluator {
     const match = body.match(/^(\d+)(?:,(\d*)?)?$/);
     if (!match) return null;
 
-    return { end: close, variable: body.includes(',') };
+    const min = Number(match[1]!);
+    const hasComma = body.includes(',');
+    const max = !hasComma
+      ? min
+      : match[2] === undefined || match[2] === ''
+        ? Infinity
+        : Number(match[2]);
+    const variable = min !== max;
+    const repeatsGroup = variable && max > 1;
+
+    if (variable) {
+      return { end: close, variable, repeatsGroup };
+    }
+
+    return { end: close, variable, repeatsGroup, fixedCount: min };
   }
 }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -8,6 +8,7 @@ import type { GuardrailsPort } from '../types/contracts.js';
 
 const MAX_SAFETY_PATTERN_LENGTH = 1_000;
 const MAX_ALTERNATIVE_PREFIX_TOKENS = MAX_SAFETY_PATTERN_LENGTH;
+const EMPTY_ALTERNATIVE_TOKEN = 'EMPTY_ALTERNATIVE';
 
 interface RegexGroupState {
   startIndex: number;
@@ -278,8 +279,6 @@ export class SafetyEvaluator implements Evaluator {
       alternatives.some(
         (right, rightIndex) =>
           leftIndex !== rightIndex &&
-          left.tokens.length > 0 &&
-          right.tokens.length > 0 &&
           this.tokenPrefixOverlaps(left, right),
       ),
     );
@@ -307,8 +306,7 @@ export class SafetyEvaluator implements Evaluator {
         )
           .map((nestedAlternative) =>
             this.expandSimpleAlternativePrefix(nestedAlternative),
-          )
-          .filter((prefix) => prefix.tokens.length > 0);
+          );
         if (groupedPrefixes.length > 0) {
           truncated = truncated || groupedPrefixes.some((prefix) => prefix.truncated);
           if (groupedPrefixes.length === 1) {
@@ -321,7 +319,11 @@ export class SafetyEvaluator implements Evaluator {
             }
           } else {
             tokens.push(
-              `ALT:${JSON.stringify(groupedPrefixes.map((prefix) => prefix.tokens))}`,
+              `ALT:${JSON.stringify(
+                groupedPrefixes.map((prefix) =>
+                  prefix.tokens.length > 0 ? prefix.tokens : [EMPTY_ALTERNATIVE_TOKEN],
+                ),
+              )}`,
             );
           }
         }
@@ -471,7 +473,7 @@ export class SafetyEvaluator implements Evaluator {
 
     const quantifier = this.quantifierAt(pattern, end + 1);
     const repeatCount = quantifier?.fixedCount ?? 1;
-    if (quantifier?.fixedCount !== undefined) {
+    if (quantifier !== null) {
       end = quantifier.end;
     }
 
@@ -594,6 +596,8 @@ export class SafetyEvaluator implements Evaluator {
       : [[token]];
     return alternatives.some((alternative) =>
       tokenAlternatives.some((tokenAlternative) =>
+        alternative.includes(EMPTY_ALTERNATIVE_TOKEN) ||
+        tokenAlternative.includes(EMPTY_ALTERNATIVE_TOKEN) ||
         alternative.some((nestedToken) =>
           tokenAlternative.some((otherToken) =>
             this.regexTokensOverlap(nestedToken, otherToken),

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -113,7 +113,10 @@ export class SafetyEvaluator implements Evaluator {
 
   private hasUnsafeRegexShape(pattern: string): boolean {
     return (
-      this.hasBackreference(pattern) || this.hasNestedQuantifiedExpression(pattern)
+      this.hasBackreference(pattern) ||
+      this.hasNestedQuantifiedExpression(pattern) ||
+      (pattern.includes('?s:') &&
+        this.hasNestedQuantifiedExpression(this.expandDotAllLiterals(pattern)))
     );
   }
 
@@ -489,6 +492,12 @@ export class SafetyEvaluator implements Evaluator {
         value = String.fromCharCode(
           Number.parseInt(pattern.slice(start + 2, start + 6), 16),
         );
+      } else if (escaped === 'c' && /^[A-Za-z]$/.test(pattern[start + 2] ?? '')) {
+        end = start + 2;
+        value = String.fromCharCode(pattern.charCodeAt(start + 2) & 31);
+      } else if (escaped === '0' && !/^\d$/.test(pattern[start + 2] ?? '')) {
+        end = start + 1;
+        value = '\0';
       } else {
         end = start + 1;
         value = this.escapedAtomToken(escaped);
@@ -546,6 +555,12 @@ export class SafetyEvaluator implements Evaluator {
         value: String.fromCharCode(Number.parseInt(body.slice(start + 2, start + 6), 16)),
         end: start + 5,
       };
+    }
+    if (escaped === 'c' && /^[A-Za-z]$/.test(body[start + 2] ?? '')) {
+      return { value: String.fromCharCode(body.charCodeAt(start + 2) & 31), end: start + 2 };
+    }
+    if (escaped === '0' && !/^\d$/.test(body[start + 2] ?? '')) {
+      return { value: '\0', end: start + 1 };
     }
     return { value: this.escapedAtomToken(escaped), end: start + 1 };
   }
@@ -987,15 +1002,18 @@ export class SafetyEvaluator implements Evaluator {
   private stripGroupPrefix(groupContent: string): string {
     if (groupContent.startsWith('?:')) return groupContent.slice(2);
     if (groupContent.startsWith('?=') || groupContent.startsWith('?!')) {
-      return groupContent.slice(2);
+      return '';
     }
     if (groupContent.startsWith('?<=') || groupContent.startsWith('?<!')) {
-      return groupContent.slice(3);
+      return '';
     }
 
     const inlineModifier = groupContent.match(/^\?([A-Za-z-]+):/);
     if (inlineModifier) {
-      const content = groupContent.slice(inlineModifier[0].length);
+      let content = groupContent.slice(inlineModifier[0].length);
+      if (inlineModifier[1]?.includes('s')) {
+        content = this.expandDotAllLiterals(content);
+      }
       return inlineModifier[1]?.includes('i')
         ? this.caseFoldRegexLiterals(content)
         : content;
@@ -1005,6 +1023,26 @@ export class SafetyEvaluator implements Evaluator {
     if (namedCapture) return groupContent.slice(namedCapture[0].length);
 
     return groupContent;
+  }
+
+  private expandDotAllLiterals(pattern: string): string {
+    let result = '';
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '\\') {
+        result += pattern.slice(i, i + 2);
+        i += 1;
+        continue;
+      }
+      if (char === '[') {
+        const end = this.skipCharacterClass(pattern, i);
+        result += pattern.slice(i, end + 1);
+        i = end;
+        continue;
+      }
+      result += char === '.' ? '[\\s\\S]' : char;
+    }
+    return result;
   }
 
   private splitTopLevelAlternatives(groupContent: string): string[] {

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -257,7 +257,17 @@ export class SafetyEvaluator implements Evaluator {
         /^[0-9A-Fa-f]{2}$/.test(pattern.slice(start + 2, start + 4))
       ) {
         end = start + 3;
-        value = String.fromCharCode(Number.parseInt(pattern.slice(start + 2, start + 4), 16));
+        value = String.fromCharCode(
+          Number.parseInt(pattern.slice(start + 2, start + 4), 16),
+        );
+      } else if (
+        escaped === 'u' &&
+        /^[0-9A-Fa-f]{4}$/.test(pattern.slice(start + 2, start + 6))
+      ) {
+        end = start + 5;
+        value = String.fromCharCode(
+          Number.parseInt(pattern.slice(start + 2, start + 6), 16),
+        );
       } else {
         end = start + 1;
         value = this.escapedAtomToken(escaped);
@@ -290,6 +300,20 @@ export class SafetyEvaluator implements Evaluator {
     if (characterClass === '[A-Za-z0-9_]' || characterClass === '[\\w]') {
       return 'WORD';
     }
+
+    const singleton = characterClass.match(/^\[([^\\\]^-])\]$/);
+    if (singleton) return singleton[1]!;
+
+    const hexSingleton = characterClass.match(/^\[\\x([0-9A-Fa-f]{2})\]$/);
+    if (hexSingleton) {
+      return String.fromCharCode(Number.parseInt(hexSingleton[1]!, 16));
+    }
+
+    const unicodeSingleton = characterClass.match(/^\[\\u([0-9A-Fa-f]{4})\]$/);
+    if (unicodeSingleton) {
+      return String.fromCharCode(Number.parseInt(unicodeSingleton[1]!, 16));
+    }
+
     return characterClass;
   }
 
@@ -310,8 +334,11 @@ export class SafetyEvaluator implements Evaluator {
       return groupContent.slice(3);
     }
 
-    const inlineModifier = groupContent.match(/^\?[A-Za-z-]+:/);
-    if (inlineModifier) return groupContent.slice(inlineModifier[0].length);
+    const inlineModifier = groupContent.match(/^\?([A-Za-z-]+):/);
+    if (inlineModifier) {
+      const content = groupContent.slice(inlineModifier[0].length);
+      return inlineModifier[1]?.includes('i') ? content.toLowerCase() : content;
+    }
 
     const namedCapture = groupContent.match(/^\?<[^>]+>/);
     if (namedCapture) return groupContent.slice(namedCapture[0].length);

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -117,7 +117,40 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private hasBackreference(pattern: string): boolean {
-    return /\\(?:[1-9]\d*|k<[^>]+>)/.test(pattern);
+    const namedGroups = new Set(
+      [...pattern.matchAll(/\(\?<([^=!][^>]*)>/g)].map((match) => match[1]!),
+    );
+    let captureCount = 0;
+
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '[') {
+        i = this.skipCharacterClass(pattern, i);
+        continue;
+      }
+      if (char === '\\') {
+        const numeric = pattern.slice(i + 1).match(/^[1-9]\d*/);
+        if (numeric && Number(numeric[0]) <= captureCount) return true;
+        const named = pattern.slice(i + 1).match(/^k<([^>]+)>/);
+        if (named && namedGroups.has(named[1]!)) return true;
+        i += 1;
+        continue;
+      }
+      if (char === '(' && this.isCapturingGroup(pattern, i)) {
+        captureCount += 1;
+      }
+    }
+
+    return false;
+  }
+
+  private isCapturingGroup(pattern: string, start: number): boolean {
+    if (pattern[start + 1] !== '?') return true;
+    return (
+      pattern[start + 2] === '<' &&
+      pattern[start + 3] !== '=' &&
+      pattern[start + 3] !== '!'
+    );
   }
 
   private hasNestedQuantifiedExpression(pattern: string): boolean {
@@ -169,7 +202,10 @@ export class SafetyEvaluator implements Evaluator {
         if (group.containsQuantifiedAtom) {
           stack.at(-1)!.containsQuantifiedAtom = true;
         }
-        if (group.containsAmbiguousAlternation) {
+        if (
+          group.containsAmbiguousAlternation &&
+          !this.hasFollowingAtomInCurrentAlternative(pattern, i + 1)
+        ) {
           stack.at(-1)!.containsAmbiguousAlternation = true;
         }
         groupHistory.push(group);
@@ -304,6 +340,30 @@ export class SafetyEvaluator implements Evaluator {
       }
     }
     return -1;
+  }
+
+  private hasFollowingAtomInCurrentAlternative(
+    pattern: string,
+    start: number,
+  ): boolean {
+    let depth = 0;
+    for (let i = start; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '\\' || char === '[') return true;
+      if (char === '(') {
+        if (depth === 0) return true;
+        depth += 1;
+        continue;
+      }
+      if (char === ')' && depth === 0) return false;
+      if (char === '|' && depth === 0) return false;
+      if (char === ')') {
+        depth -= 1;
+        continue;
+      }
+      if (char !== '^' && char !== '$') return true;
+    }
+    return false;
   }
 
   private regexAtomTokenAt(
@@ -586,18 +646,31 @@ export class SafetyEvaluator implements Evaluator {
       if (token === 'DIGIT') return false;
       if (token === 'WORD' || token === 'SPACE' || token === 'DOT') return true;
       if (token.startsWith('RANGE:')) return !this.rangeIsWithin(token, '0', '9');
+      if (token.startsWith('CLASS:')) {
+        return this.classBodyContainsOutsideToken(token, (char) => /^\d$/.test(char));
+      }
     }
 
     if (complementToken === 'NOT_WORD') {
       if (token === 'WORD' || token === 'DIGIT') return false;
       if (token === 'SPACE' || token === 'DOT') return true;
       if (token.startsWith('RANGE:')) return !this.rangeContainsOnlyWordCharacters(token);
+      if (token.startsWith('CLASS:')) {
+        return this.classBodyContainsOutsideToken(token, (char) =>
+          /^[A-Za-z0-9_]$/.test(char),
+        );
+      }
     }
 
     if (complementToken === 'NOT_SPACE') {
       if (token === 'SPACE') return false;
       if (token === 'WORD' || token === 'DIGIT' || token === 'DOT') return true;
       if (token.startsWith('RANGE:')) return !this.rangeContainsOnlyWhitespace(token);
+      if (token.startsWith('CLASS:')) {
+        return this.classBodyContainsOutsideToken(token, (char) =>
+          /^[\t\n\r\f\v ]$/.test(char),
+        );
+      }
     }
 
     return this.tokenMayMatchSample(complementToken, token);
@@ -621,6 +694,58 @@ export class SafetyEvaluator implements Evaluator {
 
   private rangeContainsOnlyWhitespace(rangeToken: string): boolean {
     return rangeToken === 'RANGE:\t-\r' || rangeToken === 'RANGE: - ';
+  }
+
+  private classBodyContainsOutsideToken(
+    classToken: string,
+    contains: (char: string) => boolean,
+  ): boolean {
+    const characterClass = classToken.slice('CLASS:'.length);
+    const body = characterClass.slice(1, -1);
+    if (body.startsWith('^')) return true;
+
+    for (let i = 0; i < body.length; i += 1) {
+      const char = body[i]!;
+      if (char === '\\') {
+        const escaped = body[i + 1];
+        if (escaped === undefined) continue;
+        const token = this.escapedAtomToken(escaped);
+        if (token.length === 1 && !contains(token)) return true;
+        if (token.startsWith('NOT_')) return true;
+        i += 1;
+        continue;
+      }
+
+      if (body[i + 1] === '-' && body[i + 2] !== undefined) {
+        const start = char;
+        const end = body[i + 2]!;
+        if (!this.sampleRangeCharacters(start, end).every(contains)) return true;
+        i += 2;
+        continue;
+      }
+
+      if (!contains(char)) return true;
+    }
+
+    return false;
+  }
+
+  private sampleRangeCharacters(start: string, end: string): string[] {
+    return [
+      start,
+      end,
+      '0',
+      '9',
+      'A',
+      'Z',
+      '_',
+      'a',
+      'z',
+      ' ',
+      '\t',
+      '\n',
+      'é',
+    ].filter((char) => char >= start && char <= end);
   }
 
   private tokenMayMatchSample(left: string, right: string): boolean {

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -228,11 +228,17 @@ export class SafetyEvaluator implements Evaluator {
             stack.at(-1)!.containsQuantifiedAtom = true;
           }
         }
-        if (
-          group.containsAmbiguousAlternation &&
-          !this.hasFollowingAtomInCurrentAlternative(pattern, i + 1)
-        ) {
-          stack.at(-1)!.containsAmbiguousAlternation = true;
+        if (group.containsAmbiguousAlternation) {
+          const groupContent = pattern.slice(group.startIndex + 1, i);
+          if (
+            !this.followingAtomDisambiguatesAlternation(
+              groupContent,
+              pattern,
+              i + 1,
+            )
+          ) {
+            stack.at(-1)!.containsAmbiguousAlternation = true;
+          }
         }
         groupHistory.push(group);
         previousToken = 'group';
@@ -376,10 +382,36 @@ export class SafetyEvaluator implements Evaluator {
     return -1;
   }
 
-  private hasFollowingAtomInCurrentAlternative(
+  private followingAtomDisambiguatesAlternation(
+    groupContent: string,
     pattern: string,
     start: number,
   ): boolean {
+    const followingToken = this.nextAtomTokenInCurrentAlternative(pattern, start);
+    if (followingToken === null) return false;
+
+    const alternatives = this.splitTopLevelAlternatives(
+      this.stripGroupPrefix(groupContent),
+    ).map((alternative) => {
+      const expansion = this.expandSimpleAlternativePrefix(alternative);
+      return {
+        tokens: [...expansion.tokens, followingToken.value],
+        truncated: expansion.truncated,
+      };
+    });
+
+    return !alternatives.some((left, leftIndex) =>
+      alternatives.some(
+        (right, rightIndex) =>
+          leftIndex !== rightIndex && this.tokenPrefixOverlaps(left, right),
+      ),
+    );
+  }
+
+  private nextAtomTokenInCurrentAlternative(
+    pattern: string,
+    start: number,
+  ): { value: string } | null {
     let depth = 0;
     for (let i = start; i < pattern.length; i += 1) {
       const char = pattern[i]!;
@@ -389,31 +421,29 @@ export class SafetyEvaluator implements Evaluator {
           i += 1;
           continue;
         }
-        return true;
       }
-      if (char === '[') return true;
+      if (char === '(' && depth === 0 && this.isZeroWidthAssertionGroup(pattern, i)) {
+        const close = this.findClosingGroup(pattern, i);
+        if (close === -1) return null;
+        i = close;
+        continue;
+      }
       if (char === '(') {
-        if (depth === 0) {
-          if (this.isZeroWidthAssertionGroup(pattern, i)) {
-            const close = this.findClosingGroup(pattern, i);
-            if (close === -1) return false;
-            i = close;
-            continue;
-          }
-          return true;
-        }
         depth += 1;
         continue;
       }
-      if (char === ')' && depth === 0) return false;
-      if (char === '|' && depth === 0) return false;
+      if (char === ')' && depth === 0) return null;
+      if (char === '|' && depth === 0) return null;
       if (char === ')') {
         depth -= 1;
         continue;
       }
-      if (char !== '^' && char !== '$') return true;
+      if (depth === 0 && char !== '^' && char !== '$') {
+        const token = this.regexAtomTokenAt(pattern, i);
+        return token === null ? null : { value: token.value };
+      }
     }
-    return false;
+    return null;
   }
 
   private isZeroWidthAssertionGroup(pattern: string, start: number): boolean {
@@ -472,6 +502,9 @@ export class SafetyEvaluator implements Evaluator {
     }
 
     const quantifier = this.quantifierAt(pattern, end + 1);
+    if (quantifier?.nullable) {
+      value = `ALT:${JSON.stringify([[EMPTY_ALTERNATIVE_TOKEN], [value]])}`;
+    }
     const repeatCount = quantifier?.fixedCount ?? 1;
     if (quantifier !== null) {
       end = quantifier.end;
@@ -1032,6 +1065,7 @@ export class SafetyEvaluator implements Evaluator {
     end: number;
     variable: boolean;
     repeatsGroup: boolean;
+    nullable: boolean;
     fixedCount?: number;
   } | null {
     const char = pattern[start];
@@ -1040,6 +1074,7 @@ export class SafetyEvaluator implements Evaluator {
         end: pattern[start + 1] === '?' ? start + 1 : start,
         variable: true,
         repeatsGroup: true,
+        nullable: char === '*',
       };
     }
     if (char === '?') {
@@ -1047,6 +1082,7 @@ export class SafetyEvaluator implements Evaluator {
         end: pattern[start + 1] === '?' ? start + 1 : start,
         variable: true,
         repeatsGroup: false,
+        nullable: true,
       };
     }
     if (char !== '{') return null;
@@ -1071,9 +1107,9 @@ export class SafetyEvaluator implements Evaluator {
     const end = pattern[close + 1] === '?' ? close + 1 : close;
 
     if (variable) {
-      return { end, variable, repeatsGroup };
+      return { end, variable, repeatsGroup, nullable: min === 0 };
     }
 
-    return { end, variable, repeatsGroup: min > 1, fixedCount: min };
+    return { end, variable, repeatsGroup: min > 1, fixedCount: min, nullable: min === 0 };
   }
 }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -117,10 +117,7 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private hasBackreference(pattern: string): boolean {
-    const namedGroups = new Set(
-      [...pattern.matchAll(/\(\?<([^=!][^>]*)>/g)].map((match) => match[1]!),
-    );
-    let captureCount = 0;
+    const { captureCount, namedGroups } = this.collectCapturingGroups(pattern);
 
     for (let i = 0; i < pattern.length; i += 1) {
       const char = pattern[i]!;
@@ -134,14 +131,37 @@ export class SafetyEvaluator implements Evaluator {
         const named = pattern.slice(i + 1).match(/^k<([^>]+)>/);
         if (named && namedGroups.has(named[1]!)) return true;
         i += 1;
-        continue;
-      }
-      if (char === '(' && this.isCapturingGroup(pattern, i)) {
-        captureCount += 1;
       }
     }
 
     return false;
+  }
+
+  private collectCapturingGroups(pattern: string): {
+    captureCount: number;
+    namedGroups: Set<string>;
+  } {
+    const namedGroups = new Set<string>();
+    let captureCount = 0;
+
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '[') {
+        i = this.skipCharacterClass(pattern, i);
+        continue;
+      }
+      if (char === '\\') {
+        i += 1;
+        continue;
+      }
+      if (char === '(' && this.isCapturingGroup(pattern, i)) {
+        captureCount += 1;
+        const named = pattern.slice(i).match(/^\(\?<([^>]+)>/);
+        if (named) namedGroups.add(named[1]!);
+      }
+    }
+
+    return { captureCount, namedGroups };
   }
 
   private isCapturingGroup(pattern: string, start: number): boolean {
@@ -349,9 +369,25 @@ export class SafetyEvaluator implements Evaluator {
     let depth = 0;
     for (let i = start; i < pattern.length; i += 1) {
       const char = pattern[i]!;
-      if (char === '\\' || char === '[') return true;
+      if (char === '\\') {
+        const escaped = pattern[i + 1];
+        if (escaped === 'b' || escaped === 'B') {
+          i += 1;
+          continue;
+        }
+        return true;
+      }
+      if (char === '[') return true;
       if (char === '(') {
-        if (depth === 0) return true;
+        if (depth === 0) {
+          if (this.isZeroWidthAssertionGroup(pattern, i)) {
+            const close = this.findClosingGroup(pattern, i);
+            if (close === -1) return false;
+            i = close;
+            continue;
+          }
+          return true;
+        }
         depth += 1;
         continue;
       }
@@ -364,6 +400,15 @@ export class SafetyEvaluator implements Evaluator {
       if (char !== '^' && char !== '$') return true;
     }
     return false;
+  }
+
+  private isZeroWidthAssertionGroup(pattern: string, start: number): boolean {
+    return (
+      pattern.startsWith('(?=', start) ||
+      pattern.startsWith('(?!', start) ||
+      pattern.startsWith('(?<=', start) ||
+      pattern.startsWith('(?<!', start)
+    );
   }
 
   private regexAtomTokenAt(

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -115,7 +115,7 @@ export class SafetyEvaluator implements Evaluator {
     return (
       this.hasBackreference(pattern) ||
       this.hasNestedQuantifiedExpression(pattern) ||
-      (pattern.includes('?s:') &&
+      (this.hasEnabledInlineModifier(pattern, 's') &&
         this.hasNestedQuantifiedExpression(this.expandDotAllLiterals(pattern)))
     );
   }
@@ -624,7 +624,9 @@ export class SafetyEvaluator implements Evaluator {
       left === 'SPACE' ||
       right === 'SPACE'
     ) {
-      return this.tokenMayMatchSample(left, right);
+      return left === 'SPACE'
+        ? this.spaceTokenOverlaps(right)
+        : this.spaceTokenOverlaps(left);
     }
     if (left === 'WORD') return this.wordTokenOverlaps(right);
     if (right === 'WORD') return this.wordTokenOverlaps(left);
@@ -748,7 +750,12 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private spaceTokenOverlaps(token: string): boolean {
-    return token === 'SPACE' || /^\s$/u.test(token);
+    if (token === 'SPACE') return true;
+    if (token.length === 1) return /^\s$/u.test(token);
+    if (token.startsWith('CLASS:')) return this.classTokenOverlaps(token, 'SPACE');
+    if (token.startsWith('RANGE:')) return !this.rangeContainsOnlyNonWhitespace(token);
+    if (token === 'DOT' || token.startsWith('NOT_')) return true;
+    return false;
   }
 
   private positiveClassBodyOverlaps(body: string, token: string): boolean {
@@ -825,6 +832,13 @@ export class SafetyEvaluator implements Evaluator {
     return rangeToken === 'RANGE:\t-\r' || rangeToken === 'RANGE: - ';
   }
 
+  private rangeContainsOnlyNonWhitespace(rangeToken: string): boolean {
+    const [, start, end] = rangeToken.match(/^RANGE:(.)-(.)$/) ?? [];
+    return start !== undefined && end !== undefined
+      ? !this.sampleRangeCharacters(start, end).some((char) => /^\s$/u.test(char))
+      : false;
+  }
+
   private classBodyContainsOutsideToken(
     classToken: string,
     contains: (char: string) => boolean,
@@ -872,6 +886,7 @@ export class SafetyEvaluator implements Evaluator {
       ' ',
       '\t',
       '\n',
+      '\u1680',
       'é',
     ].filter((char) => char >= start && char <= end);
   }
@@ -1011,10 +1026,10 @@ export class SafetyEvaluator implements Evaluator {
     const inlineModifier = groupContent.match(/^\?([A-Za-z-]+):/);
     if (inlineModifier) {
       let content = groupContent.slice(inlineModifier[0].length);
-      if (inlineModifier[1]?.includes('s')) {
+      if (this.modifierTextEnables(inlineModifier[1] ?? '', 's')) {
         content = this.expandDotAllLiterals(content);
       }
-      return inlineModifier[1]?.includes('i')
+      return this.modifierTextEnables(inlineModifier[1] ?? '', 'i')
         ? this.caseFoldRegexLiterals(content)
         : content;
     }
@@ -1023,6 +1038,19 @@ export class SafetyEvaluator implements Evaluator {
     if (namedCapture) return groupContent.slice(namedCapture[0].length);
 
     return groupContent;
+  }
+
+  private hasEnabledInlineModifier(pattern: string, flag: string): boolean {
+    const inlineModifiers = pattern.matchAll(/\(\?([A-Za-z-]+):/g);
+    for (const match of inlineModifiers) {
+      if (this.modifierTextEnables(match[1] ?? '', flag)) return true;
+    }
+    return false;
+  }
+
+  private modifierTextEnables(modifiers: string, flag: string): boolean {
+    const [enabled = '', disabled = ''] = modifiers.split('-', 2);
+    return enabled.includes(flag) && !disabled.includes(flag);
   }
 
   private expandDotAllLiterals(pattern: string): string {

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -224,12 +224,7 @@ export class SafetyEvaluator implements Evaluator {
           group.containsAmbiguousAlternation = true;
         }
         if (group.containsQuantifiedAtom) {
-          const groupContent = pattern.slice(group.startIndex + 1, i);
-          if (this.hasDeterministicTopLevelAlternation(groupContent)) {
-            group.containsQuantifiedAtom = false;
-          } else {
-            stack.at(-1)!.containsQuantifiedAtom = true;
-          }
+          stack.at(-1)!.containsQuantifiedAtom = true;
         }
         if (group.containsAmbiguousAlternation) {
           const groupContent = pattern.slice(group.startIndex + 1, i);
@@ -476,6 +471,7 @@ export class SafetyEvaluator implements Evaluator {
     } else if (char === '\\') {
       const escaped = pattern[start + 1];
       if (escaped === undefined) return null;
+      if (escaped === 'b' || escaped === 'B') return null;
       if (
         escaped === 'x' &&
         /^[0-9A-Fa-f]{2}$/.test(pattern.slice(start + 2, start + 4))
@@ -562,6 +558,8 @@ export class SafetyEvaluator implements Evaluator {
     if (escaped === '0' && !/^\d$/.test(body[start + 2] ?? '')) {
       return { value: '\0', end: start + 1 };
     }
+    if (escaped === 'b') return { value: '\b', end: start + 1 };
+    if (escaped === 'B') return { value: 'NOT_BACKSPACE', end: start + 1 };
     return { value: this.escapedAtomToken(escaped), end: start + 1 };
   }
 
@@ -763,7 +761,7 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private dotTokenOverlaps(token: string): boolean {
-    if (token.length === 1) return token !== '\n' && token !== '\r';
+    if (token.length === 1) return token !== '\n' && token !== '\r' && token !== '\u2028' && token !== '\u2029';
     if (token === 'SPACE') return true;
     if (token === 'NOT_SPACE') return true;
     if (token === 'NOT_DIGIT' || token === 'NOT_WORD') return true;
@@ -1041,9 +1039,21 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private hasEnabledInlineModifier(pattern: string, flag: string): boolean {
-    const inlineModifiers = pattern.matchAll(/\(\?([A-Za-z-]+):/g);
-    for (const match of inlineModifiers) {
-      if (this.modifierTextEnables(match[1] ?? '', flag)) return true;
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '\\') {
+        i += 1;
+        continue;
+      }
+      if (char === '[') {
+        i = this.skipCharacterClass(pattern, i);
+        continue;
+      }
+      if (char !== '(' || pattern[i + 1] !== '?') continue;
+      const modifierMatch = pattern.slice(i + 2).match(/^([A-Za-z-]+):/);
+      if (modifierMatch && this.modifierTextEnables(modifierMatch[1] ?? '', flag)) {
+        return true;
+      }
     }
     return false;
   }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -15,6 +15,11 @@ interface RegexGroupState {
   containsAmbiguousAlternation: boolean;
 }
 
+interface RegexPrefixExpansion {
+  tokens: string[];
+  truncated: boolean;
+}
+
 export class SafetyEvaluator implements Evaluator {
   readonly name = 'safety';
   readonly category = 'deterministic' as const;
@@ -206,15 +211,18 @@ export class SafetyEvaluator implements Evaluator {
       alternatives.some(
         (right, rightIndex) =>
           leftIndex !== rightIndex &&
-          left.length > 0 &&
-          right.length > 0 &&
+          left.tokens.length > 0 &&
+          right.tokens.length > 0 &&
           this.tokenPrefixOverlaps(left, right),
       ),
     );
   }
 
-  private expandSimpleAlternativePrefix(alternative: string): string[] {
+  private expandSimpleAlternativePrefix(
+    alternative: string,
+  ): RegexPrefixExpansion {
     const tokens: string[] = [];
+    let truncated = false;
 
     for (let i = 0; i < alternative.length; i += 1) {
       if (alternative[i] === '(') {
@@ -226,16 +234,29 @@ export class SafetyEvaluator implements Evaluator {
           .map((nestedAlternative) =>
             this.expandSimpleAlternativePrefix(nestedAlternative),
           )
-          .filter((prefix) => prefix.length > 0);
+          .filter((prefix) => prefix.tokens.length > 0);
         if (groupedPrefixes.length > 0) {
-          tokens.push(
-            `ALT:${groupedPrefixes
-              .map((prefix) => prefix[0])
-              .filter((token) => token !== undefined)
-              .join(',')}`,
-          );
+          truncated = truncated || groupedPrefixes.some((prefix) => prefix.truncated);
+          if (groupedPrefixes.length === 1) {
+            for (const token of groupedPrefixes[0]!.tokens) {
+              if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) {
+                truncated = true;
+                break;
+              }
+              tokens.push(token);
+            }
+          } else {
+            tokens.push(
+              `ALT:${groupedPrefixes
+                .map((prefix) => prefix.tokens.join('\u0000'))
+                .join(',')}`,
+            );
+          }
         }
-        if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) break;
+        if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) {
+          truncated = true;
+          break;
+        }
         i = close;
         continue;
       }
@@ -250,11 +271,14 @@ export class SafetyEvaluator implements Evaluator {
       ) {
         tokens.push(token.value);
       }
-      if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) break;
+      if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) {
+        truncated = token.repeatCount > tokens.length || token.end < alternative.length - 1;
+        break;
+      }
       i = token.end;
     }
 
-    return tokens;
+    return { tokens, truncated };
   }
 
   private findClosingGroup(pattern: string, start: number): number {
@@ -319,7 +343,7 @@ export class SafetyEvaluator implements Evaluator {
     } else if (char === '(') {
       return null;
     } else if (char === '.') {
-      value = 'ANY';
+      value = 'DOT';
     } else {
       value = char;
     }
@@ -337,8 +361,11 @@ export class SafetyEvaluator implements Evaluator {
     if (escaped === 'd') return 'DIGIT';
     if (escaped === 'w') return 'WORD';
     if (escaped === 's') return 'SPACE';
-    if (escaped === 't' || escaped === 'n' || escaped === 'r') return 'SPACE';
-    if (escaped === 'f' || escaped === 'v') return 'SPACE';
+    if (escaped === 't') return '\t';
+    if (escaped === 'n') return '\n';
+    if (escaped === 'r') return '\r';
+    if (escaped === 'f') return '\f';
+    if (escaped === 'v') return '\v';
     if (escaped === 'D') return 'NOT_DIGIT';
     if (escaped === 'W') return 'NOT_WORD';
     if (escaped === 'S') return 'NOT_SPACE';
@@ -371,29 +398,44 @@ export class SafetyEvaluator implements Evaluator {
     return `CLASS:${characterClass}`;
   }
 
-  private tokenPrefixOverlaps(left: string[], right: string[]): boolean {
-    const limit = Math.min(left.length, right.length);
+  private tokenPrefixOverlaps(
+    left: RegexPrefixExpansion,
+    right: RegexPrefixExpansion,
+  ): boolean {
+    const limit = Math.min(left.tokens.length, right.tokens.length);
     for (let i = 0; i < limit; i += 1) {
-      if (!this.regexTokensOverlap(left[i]!, right[i]!)) return false;
+      if (!this.regexTokensOverlap(left.tokens[i]!, right.tokens[i]!)) return false;
+    }
+    if (
+      left.truncated &&
+      right.truncated &&
+      left.tokens.length === limit &&
+      right.tokens.length === limit
+    ) {
+      return false;
     }
     return true;
   }
 
   private regexTokensOverlap(left: string, right: string): boolean {
     if (left === right) return true;
-    if (left === 'ANY' || right === 'ANY') return true;
+    if (left === 'DOT' || right === 'DOT') {
+      return this.tokenMayMatchSample(left, right);
+    }
     if (left.startsWith('ALT:')) return this.altTokenOverlaps(left, right);
     if (right.startsWith('ALT:')) return this.altTokenOverlaps(right, left);
+    if (
+      left === 'SPACE' ||
+      right === 'SPACE' ||
+      left.startsWith('NOT_') ||
+      right.startsWith('NOT_')
+    ) {
+      return this.tokenMayMatchSample(left, right);
+    }
     if (left === 'WORD') return this.wordTokenOverlaps(right);
     if (right === 'WORD') return this.wordTokenOverlaps(left);
     if (left === 'DIGIT') return this.digitTokenOverlaps(right);
     if (right === 'DIGIT') return this.digitTokenOverlaps(left);
-    if (left === 'NOT_DIGIT') return !this.digitTokenOverlaps(right);
-    if (right === 'NOT_DIGIT') return !this.digitTokenOverlaps(left);
-    if (left === 'NOT_WORD') return !this.wordTokenOverlaps(right);
-    if (right === 'NOT_WORD') return !this.wordTokenOverlaps(left);
-    if (left === 'NOT_SPACE') return !this.spaceTokenOverlaps(right);
-    if (right === 'NOT_SPACE') return !this.spaceTokenOverlaps(left);
     if (left.startsWith('RANGE:')) return this.rangeTokenOverlaps(left, right);
     if (right.startsWith('RANGE:')) return this.rangeTokenOverlaps(right, left);
     if (left.startsWith('CLASS:')) return this.classTokenOverlaps(left, right);
@@ -407,7 +449,9 @@ export class SafetyEvaluator implements Evaluator {
       .split(',')
       .some((alternativeToken) =>
         alternativeToken.length > 0
-          ? this.regexTokensOverlap(alternativeToken, token)
+          ? alternativeToken
+              .split('\u0000')
+              .some((nestedToken) => this.regexTokensOverlap(nestedToken, token))
           : false,
       );
   }
@@ -453,10 +497,12 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private classTokenOverlaps(classToken: string, token: string): boolean {
+    if (classToken.startsWith('CLASS:[^')) {
+      return this.tokenMayMatchSample(classToken, token);
+    }
+
     const characterClass = classToken.slice('CLASS:'.length);
     const body = characterClass.slice(1, -1);
-    if (body.startsWith('^')) return !this.positiveClassBodyOverlaps(body.slice(1), token);
-
     for (let i = 0; i < body.length; i += 1) {
       const char = body[i]!;
       if (char === '\\') {
@@ -488,6 +534,85 @@ export class SafetyEvaluator implements Evaluator {
 
   private positiveClassBodyOverlaps(body: string, token: string): boolean {
     return this.classTokenOverlaps(`CLASS:[${body}]`, token);
+  }
+
+  private tokenMayMatchSample(left: string, right: string): boolean {
+    const samples = [
+      'a',
+      'b',
+      'A',
+      'Z',
+      '0',
+      '5',
+      '9',
+      '_',
+      ' ',
+      '\t',
+      '\n',
+      '\r',
+      '!',
+      '-',
+      '.',
+      '/',
+    ];
+    return samples.some(
+      (sample) =>
+        this.tokenMatchesSample(left, sample) &&
+        this.tokenMatchesSample(right, sample),
+    );
+  }
+
+  private tokenMatchesSample(token: string, sample: string): boolean {
+    if (token.length === 1) return token === sample;
+    if (token === 'DOT') return sample !== '\n' && sample !== '\r';
+    if (token === 'WORD') return /^[A-Za-z0-9_]$/.test(sample);
+    if (token === 'DIGIT') return /^\d$/.test(sample);
+    if (token === 'SPACE') return /^[\t\n\r\f\v ]$/.test(sample);
+    if (token === 'NOT_DIGIT') return !/^\d$/.test(sample);
+    if (token === 'NOT_WORD') return !/^[A-Za-z0-9_]$/.test(sample);
+    if (token === 'NOT_SPACE') return !/^[\t\n\r\f\v ]$/.test(sample);
+    if (token.startsWith('RANGE:')) {
+      const [, start, end] = token.match(/^RANGE:(.)-(.)$/) ?? [];
+      return start !== undefined && end !== undefined
+        ? sample >= start && sample <= end
+        : false;
+    }
+    if (token.startsWith('CLASS:')) {
+      return this.classMatchesSample(token.slice('CLASS:'.length), sample);
+    }
+    return false;
+  }
+
+  private classMatchesSample(characterClass: string, sample: string): boolean {
+    const body = characterClass.slice(1, -1);
+    const negated = body.startsWith('^');
+    const positiveBody = negated ? body.slice(1) : body;
+    let matches = false;
+
+    for (let i = 0; i < positiveBody.length; i += 1) {
+      const char = positiveBody[i]!;
+      if (char === '\\') {
+        const escaped = positiveBody[i + 1];
+        if (escaped !== undefined) {
+          matches = this.tokenMatchesSample(this.escapedAtomToken(escaped), sample);
+          if (matches) break;
+          i += 1;
+        }
+        continue;
+      }
+
+      if (positiveBody[i + 1] === '-' && positiveBody[i + 2] !== undefined) {
+        matches = sample >= char && sample <= positiveBody[i + 2]!;
+        if (matches) break;
+        i += 2;
+        continue;
+      }
+
+      matches = char === sample;
+      if (matches) break;
+    }
+
+    return negated ? !matches : matches;
   }
 
   private rangeContainsWordCharacter(start: string, end: string): boolean {
@@ -598,10 +723,18 @@ export class SafetyEvaluator implements Evaluator {
   } | null {
     const char = pattern[start];
     if (char === '+' || char === '*') {
-      return { end: start, variable: true, repeatsGroup: true };
+      return {
+        end: pattern[start + 1] === '?' ? start + 1 : start,
+        variable: true,
+        repeatsGroup: true,
+      };
     }
     if (char === '?') {
-      return { end: start, variable: true, repeatsGroup: false };
+      return {
+        end: pattern[start + 1] === '?' ? start + 1 : start,
+        variable: true,
+        repeatsGroup: false,
+      };
     }
     if (char !== '{') return null;
 
@@ -622,10 +755,12 @@ export class SafetyEvaluator implements Evaluator {
     const variable = min !== max;
     const repeatsGroup = variable && max > 1;
 
+    const end = pattern[close + 1] === '?' ? close + 1 : close;
+
     if (variable) {
-      return { end: close, variable, repeatsGroup };
+      return { end, variable, repeatsGroup };
     }
 
-    return { end: close, variable, repeatsGroup: min > 1, fixedCount: min };
+    return { end, variable, repeatsGroup: min > 1, fixedCount: min };
   }
 }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -217,6 +217,25 @@ export class SafetyEvaluator implements Evaluator {
     const tokens: string[] = [];
 
     for (let i = 0; i < alternative.length; i += 1) {
+      if (alternative[i] === '(') {
+        const close = this.findClosingGroup(alternative, i);
+        if (close === -1) break;
+        const groupedPrefix = this.expandSimpleAlternativePrefix(
+          this.splitTopLevelAlternatives(
+            this.stripGroupPrefix(alternative.slice(i + 1, close)),
+          )[0] ?? '',
+        );
+        tokens.push(
+          ...groupedPrefix.slice(
+            0,
+            MAX_ALTERNATIVE_PREFIX_TOKENS - tokens.length,
+          ),
+        );
+        if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) break;
+        i = close;
+        continue;
+      }
+
       const token = this.regexAtomTokenAt(alternative, i);
       if (token === null) break;
 
@@ -232,6 +251,27 @@ export class SafetyEvaluator implements Evaluator {
     }
 
     return tokens;
+  }
+
+  private findClosingGroup(pattern: string, start: number): number {
+    let depth = 0;
+    for (let i = start; i < pattern.length; i += 1) {
+      const char = pattern[i];
+      if (char === '\\') {
+        i += 1;
+        continue;
+      }
+      if (char === '[') {
+        i = this.skipCharacterClass(pattern, i);
+        continue;
+      }
+      if (char === '(') depth += 1;
+      if (char === ')') {
+        depth -= 1;
+        if (depth === 0) return i;
+      }
+    }
+    return -1;
   }
 
   private regexAtomTokenAt(
@@ -314,15 +354,61 @@ export class SafetyEvaluator implements Evaluator {
       return String.fromCharCode(Number.parseInt(unicodeSingleton[1]!, 16));
     }
 
-    return characterClass;
+    const range = characterClass.match(/^\[([^\\\]])-([^\\\]])\]$/);
+    if (range) return `RANGE:${range[1]!}-${range[2]!}`;
+
+    return `CLASS:${characterClass}`;
   }
 
   private tokenPrefixOverlaps(left: string[], right: string[]): boolean {
     const limit = Math.min(left.length, right.length);
     for (let i = 0; i < limit; i += 1) {
-      if (left[i] !== right[i]) return false;
+      if (!this.regexTokensOverlap(left[i]!, right[i]!)) return false;
     }
     return true;
+  }
+
+  private regexTokensOverlap(left: string, right: string): boolean {
+    if (left === right) return true;
+    if (left === 'WORD') return this.wordTokenOverlaps(right);
+    if (right === 'WORD') return this.wordTokenOverlaps(left);
+    if (left === 'DIGIT') return this.digitTokenOverlaps(right);
+    if (right === 'DIGIT') return this.digitTokenOverlaps(left);
+    if (left.startsWith('RANGE:')) return this.rangeTokenOverlaps(left, right);
+    if (right.startsWith('RANGE:')) return this.rangeTokenOverlaps(right, left);
+    return false;
+  }
+
+  private wordTokenOverlaps(token: string): boolean {
+    return /^[A-Za-z0-9_]$/.test(token) || token === 'DIGIT';
+  }
+
+  private digitTokenOverlaps(token: string): boolean {
+    return /^\d$/.test(token) || token === 'WORD';
+  }
+
+  private rangeTokenOverlaps(rangeToken: string, token: string): boolean {
+    const [, start, end] = rangeToken.match(/^RANGE:(.)-(.)$/) ?? [];
+    if (start === undefined || end === undefined) return false;
+    if (token.length === 1) return token >= start && token <= end;
+    if (token === 'WORD') return this.rangeContainsWordCharacter(start, end);
+    if (token === 'DIGIT') return start <= '9' && end >= '0';
+    if (token.startsWith('RANGE:')) {
+      const [, otherStart, otherEnd] = token.match(/^RANGE:(.)-(.)$/) ?? [];
+      return otherStart !== undefined && otherEnd !== undefined
+        ? start <= otherEnd && otherStart <= end
+        : false;
+    }
+    return false;
+  }
+
+  private rangeContainsWordCharacter(start: string, end: string): boolean {
+    return (
+      (start <= 'z' && end >= 'a') ||
+      (start <= 'Z' && end >= 'A') ||
+      (start <= '9' && end >= '0') ||
+      (start <= '_' && end >= '_')
+    );
   }
 
   private stripGroupPrefix(groupContent: string): string {

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -7,7 +7,7 @@ import type {
 import type { GuardrailsPort } from '../types/contracts.js';
 
 const MAX_SAFETY_PATTERN_LENGTH = 1_000;
-const MAX_ALTERNATIVE_PREFIX_TOKENS = 256;
+const MAX_ALTERNATIVE_PREFIX_TOKENS = MAX_SAFETY_PATTERN_LENGTH;
 
 interface RegexGroupState {
   startIndex: number;
@@ -111,7 +111,13 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private hasUnsafeRegexShape(pattern: string): boolean {
-    return this.hasNestedQuantifiedExpression(pattern);
+    return (
+      this.hasBackreference(pattern) || this.hasNestedQuantifiedExpression(pattern)
+    );
+  }
+
+  private hasBackreference(pattern: string): boolean {
+    return /\\(?:[1-9]\d*|k<[^>]+>)/.test(pattern);
   }
 
   private hasNestedQuantifiedExpression(pattern: string): boolean {
@@ -247,9 +253,7 @@ export class SafetyEvaluator implements Evaluator {
             }
           } else {
             tokens.push(
-              `ALT:${groupedPrefixes
-                .map((prefix) => prefix.tokens.join('\u0000'))
-                .join(',')}`,
+              `ALT:${JSON.stringify(groupedPrefixes.map((prefix) => prefix.tokens))}`,
             );
           }
         }
@@ -412,7 +416,7 @@ export class SafetyEvaluator implements Evaluator {
       left.tokens.length === limit &&
       right.tokens.length === limit
     ) {
-      return false;
+      return true;
     }
     return true;
   }
@@ -420,15 +424,17 @@ export class SafetyEvaluator implements Evaluator {
   private regexTokensOverlap(left: string, right: string): boolean {
     if (left === right) return true;
     if (left === 'DOT' || right === 'DOT') {
-      return this.tokenMayMatchSample(left, right);
+      return left === 'DOT'
+        ? this.dotTokenOverlaps(right)
+        : this.dotTokenOverlaps(left);
     }
     if (left.startsWith('ALT:')) return this.altTokenOverlaps(left, right);
     if (right.startsWith('ALT:')) return this.altTokenOverlaps(right, left);
+    if (left.startsWith('NOT_')) return this.complementTokenOverlaps(left, right);
+    if (right.startsWith('NOT_')) return this.complementTokenOverlaps(right, left);
     if (
       left === 'SPACE' ||
-      right === 'SPACE' ||
-      left.startsWith('NOT_') ||
-      right.startsWith('NOT_')
+      right === 'SPACE'
     ) {
       return this.tokenMayMatchSample(left, right);
     }
@@ -444,16 +450,38 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private altTokenOverlaps(altToken: string, token: string): boolean {
-    return altToken
-      .slice('ALT:'.length)
-      .split(',')
-      .some((alternativeToken) =>
-        alternativeToken.length > 0
-          ? alternativeToken
-              .split('\u0000')
-              .some((nestedToken) => this.regexTokensOverlap(nestedToken, token))
-          : false,
-      );
+    const alternatives = this.parseAltToken(altToken);
+    const tokenAlternatives = token.startsWith('ALT:')
+      ? this.parseAltToken(token)
+      : [[token]];
+    return alternatives.some((alternative) =>
+      tokenAlternatives.some((tokenAlternative) =>
+        alternative.some((nestedToken) =>
+          tokenAlternative.some((otherToken) =>
+            this.regexTokensOverlap(nestedToken, otherToken),
+          ),
+        ),
+      ),
+    );
+  }
+
+  private parseAltToken(altToken: string): string[][] {
+    try {
+      const parsed: unknown = JSON.parse(altToken.slice('ALT:'.length));
+      if (
+        Array.isArray(parsed) &&
+        parsed.every(
+          (alternative) =>
+            Array.isArray(alternative) &&
+            alternative.every((token) => typeof token === 'string'),
+        )
+      ) {
+        return parsed;
+      }
+    } catch {
+      return [];
+    }
+    return [];
   }
 
   private wordTokenOverlaps(token: string): boolean {
@@ -498,6 +526,8 @@ export class SafetyEvaluator implements Evaluator {
 
   private classTokenOverlaps(classToken: string, token: string): boolean {
     if (classToken.startsWith('CLASS:[^')) {
+      const body = classToken.slice('CLASS:[^'.length, -1);
+      if (token.length === 1) return !this.positiveClassBodyOverlaps(body, token);
       return this.tokenMayMatchSample(classToken, token);
     }
 
@@ -534,6 +564,63 @@ export class SafetyEvaluator implements Evaluator {
 
   private positiveClassBodyOverlaps(body: string, token: string): boolean {
     return this.classTokenOverlaps(`CLASS:[${body}]`, token);
+  }
+
+  private dotTokenOverlaps(token: string): boolean {
+    if (token.length === 1) return token !== '\n' && token !== '\r';
+    if (token === 'SPACE') return true;
+    if (token === 'NOT_SPACE') return true;
+    if (token === 'NOT_DIGIT' || token === 'NOT_WORD') return true;
+    if (token === 'WORD' || token === 'DIGIT') return true;
+    if (token.startsWith('RANGE:') || token.startsWith('CLASS:')) {
+      return this.tokenMayMatchSample('DOT', token);
+    }
+    return false;
+  }
+
+  private complementTokenOverlaps(complementToken: string, token: string): boolean {
+    if (token.length === 1) return this.tokenMatchesSample(complementToken, token);
+    if (token.startsWith('NOT_')) return true;
+
+    if (complementToken === 'NOT_DIGIT') {
+      if (token === 'DIGIT') return false;
+      if (token === 'WORD' || token === 'SPACE' || token === 'DOT') return true;
+      if (token.startsWith('RANGE:')) return !this.rangeIsWithin(token, '0', '9');
+    }
+
+    if (complementToken === 'NOT_WORD') {
+      if (token === 'WORD' || token === 'DIGIT') return false;
+      if (token === 'SPACE' || token === 'DOT') return true;
+      if (token.startsWith('RANGE:')) return !this.rangeContainsOnlyWordCharacters(token);
+    }
+
+    if (complementToken === 'NOT_SPACE') {
+      if (token === 'SPACE') return false;
+      if (token === 'WORD' || token === 'DIGIT' || token === 'DOT') return true;
+      if (token.startsWith('RANGE:')) return !this.rangeContainsOnlyWhitespace(token);
+    }
+
+    return this.tokenMayMatchSample(complementToken, token);
+  }
+
+  private rangeIsWithin(rangeToken: string, start: string, end: string): boolean {
+    const [, rangeStart, rangeEnd] = rangeToken.match(/^RANGE:(.)-(.)$/) ?? [];
+    return rangeStart !== undefined && rangeEnd !== undefined
+      ? rangeStart >= start && rangeEnd <= end
+      : false;
+  }
+
+  private rangeContainsOnlyWordCharacters(rangeToken: string): boolean {
+    return (
+      this.rangeIsWithin(rangeToken, 'a', 'z') ||
+      this.rangeIsWithin(rangeToken, 'A', 'Z') ||
+      this.rangeIsWithin(rangeToken, '0', '9') ||
+      rangeToken === 'RANGE:_-_'
+    );
+  }
+
+  private rangeContainsOnlyWhitespace(rangeToken: string): boolean {
+    return rangeToken === 'RANGE:\t-\r' || rangeToken === 'RANGE: - ';
   }
 
   private tokenMayMatchSample(left: string, right: string): boolean {
@@ -629,7 +716,27 @@ export class SafetyEvaluator implements Evaluator {
     for (let i = 0; i < pattern.length; i += 1) {
       const char = pattern[i]!;
       if (char === '\\') {
-        result += pattern.slice(i, i + 2);
+        if (
+          pattern[i + 1] === 'x' &&
+          /^[0-9A-Fa-f]{2}$/.test(pattern.slice(i + 2, i + 4))
+        ) {
+          result += String.fromCharCode(
+            Number.parseInt(pattern.slice(i + 2, i + 4), 16),
+          ).toLowerCase();
+          i += 3;
+          continue;
+        }
+        if (
+          pattern[i + 1] === 'u' &&
+          /^[0-9A-Fa-f]{4}$/.test(pattern.slice(i + 2, i + 6))
+        ) {
+          result += String.fromCharCode(
+            Number.parseInt(pattern.slice(i + 2, i + 6), 16),
+          ).toLowerCase();
+          i += 5;
+          continue;
+        }
+        result += `${char}${pattern[i + 1]?.toLowerCase() ?? ''}`;
         i += 1;
         continue;
       }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -493,12 +493,15 @@ export class SafetyEvaluator implements Evaluator {
       } else if (escaped === 'c' && /^[A-Za-z]$/.test(pattern[start + 2] ?? '')) {
         end = start + 2;
         value = String.fromCharCode(pattern.charCodeAt(start + 2) & 31);
-      } else if (escaped === '0' && !/^\d$/.test(pattern[start + 2] ?? '')) {
-        end = start + 1;
-        value = '\0';
       } else {
-        end = start + 1;
-        value = this.escapedAtomToken(escaped);
+        const octal = this.legacyOctalEscapeAt(pattern, start);
+        if (octal !== null) {
+          end = octal.end;
+          value = octal.value;
+        } else {
+          end = start + 1;
+          value = this.escapedAtomToken(escaped);
+        }
       }
     } else if (char === '(') {
       return null;
@@ -532,8 +535,31 @@ export class SafetyEvaluator implements Evaluator {
     if (escaped === 'D') return 'NOT_DIGIT';
     if (escaped === 'W') return 'NOT_WORD';
     if (escaped === 'S') return 'NOT_SPACE';
-    if (escaped === 'x') return '\\x';
     return escaped;
+  }
+
+  private legacyOctalEscapeAt(
+    pattern: string,
+    start: number,
+  ): { value: string; end: number } | null {
+    const escaped = pattern[start + 1];
+    if (escaped === undefined || !/^[0-7]$/.test(escaped)) return null;
+
+    let end = start + 1;
+    let octalDigits = escaped;
+    const maxLength = escaped <= '3' ? 3 : 2;
+    while (
+      octalDigits.length < maxLength &&
+      /^[0-7]$/.test(pattern[end + 1] ?? '')
+    ) {
+      end += 1;
+      octalDigits += pattern[end]!;
+    }
+
+    return {
+      value: String.fromCharCode(Number.parseInt(octalDigits, 8)),
+      end,
+    };
   }
 
   private classEscapedTokenAt(
@@ -557,9 +583,8 @@ export class SafetyEvaluator implements Evaluator {
     if (escaped === 'c' && /^[A-Za-z]$/.test(body[start + 2] ?? '')) {
       return { value: String.fromCharCode(body.charCodeAt(start + 2) & 31), end: start + 2 };
     }
-    if (escaped === '0' && !/^\d$/.test(body[start + 2] ?? '')) {
-      return { value: '\0', end: start + 1 };
-    }
+    const octal = this.legacyOctalEscapeAt(body, start);
+    if (octal !== null) return octal;
     if (escaped === 'b') return { value: '\b', end: start + 1 };
     if (escaped === 'B') return { value: 'NOT_BACKSPACE', end: start + 1 };
     return { value: this.escapedAtomToken(escaped), end: start + 1 };

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -580,13 +580,12 @@ export class SafetyEvaluator implements Evaluator {
         end: start + 5,
       };
     }
-    if (escaped === 'c' && /^[A-Za-z]$/.test(body[start + 2] ?? '')) {
+    if (escaped === 'c' && /^[A-Za-z0-9_]$/.test(body[start + 2] ?? '')) {
       return { value: String.fromCharCode(body.charCodeAt(start + 2) & 31), end: start + 2 };
     }
     const octal = this.legacyOctalEscapeAt(body, start);
     if (octal !== null) return octal;
     if (escaped === 'b') return { value: '\b', end: start + 1 };
-    if (escaped === 'B') return { value: 'NOT_BACKSPACE', end: start + 1 };
     return { value: this.escapedAtomToken(escaped), end: start + 1 };
   }
 
@@ -986,7 +985,14 @@ export class SafetyEvaluator implements Evaluator {
 
   private tokenMatchesSample(token: string, sample: string): boolean {
     if (token.length === 1) return token === sample;
-    if (token === 'DOT') return sample !== '\n' && sample !== '\r';
+    if (token === 'DOT') {
+      return (
+        sample !== '\n' &&
+        sample !== '\r' &&
+        sample !== '\u2028' &&
+        sample !== '\u2029'
+      );
+    }
     if (token === 'WORD') return /^[A-Za-z0-9_]$/.test(sample);
     if (token === 'DIGIT') return /^\d$/.test(sample);
     if (token === 'SPACE') return /^\s$/u.test(sample);

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -116,7 +116,9 @@ export class SafetyEvaluator implements Evaluator {
       this.hasBackreference(pattern) ||
       this.hasNestedQuantifiedExpression(pattern) ||
       (this.hasEnabledInlineModifier(pattern, 's') &&
-        this.hasNestedQuantifiedExpression(this.expandDotAllLiterals(pattern)))
+        this.hasNestedQuantifiedExpression(
+          this.expandScopedDotAllLiterals(pattern),
+        ))
     );
   }
 
@@ -890,7 +892,7 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private tokenMayMatchSample(left: string, right: string): boolean {
-    const samples = [
+    const samples = new Set([
       'a',
       'b',
       'A',
@@ -908,12 +910,53 @@ export class SafetyEvaluator implements Evaluator {
       '.',
       '/',
       '\u00A0',
-    ];
-    return samples.some(
+      ...this.tokenProbeSamples(left),
+      ...this.tokenProbeSamples(right),
+    ]);
+    return [...samples].some(
       (sample) =>
         this.tokenMatchesSample(left, sample) &&
         this.tokenMatchesSample(right, sample),
     );
+  }
+
+  private tokenProbeSamples(token: string): string[] {
+    if (token.startsWith('RANGE:')) {
+      const [, start, end] = token.match(/^RANGE:(.)-(.)$/) ?? [];
+      return start !== undefined && end !== undefined
+        ? this.sampleRangeCharacters(start, end)
+        : [];
+    }
+    if (!token.startsWith('CLASS:')) return [];
+
+    const characterClass = token.slice('CLASS:'.length);
+    const body = characterClass.slice(1, -1);
+    const positiveBody = body.startsWith('^') ? body.slice(1) : body;
+    const samples: string[] = [];
+
+    for (let i = 0; i < positiveBody.length; i += 1) {
+      const char = positiveBody[i]!;
+      if (char === '\\') {
+        const escapedToken = this.classEscapedTokenAt(positiveBody, i);
+        if (escapedToken !== null) {
+          if (escapedToken.value.length === 1) samples.push(escapedToken.value);
+          i = escapedToken.end;
+        }
+        continue;
+      }
+
+      if (positiveBody[i + 1] === '-' && positiveBody[i + 2] !== undefined) {
+        samples.push(
+          ...this.sampleRangeCharacters(char, positiveBody[i + 2]!),
+        );
+        i += 2;
+        continue;
+      }
+
+      samples.push(char);
+    }
+
+    return samples;
   }
 
   private tokenMatchesSample(token: string, sample: string): boolean {
@@ -1003,7 +1046,7 @@ export class SafetyEvaluator implements Evaluator {
           i += 5;
           continue;
         }
-        result += `${char}${pattern[i + 1]?.toLowerCase() ?? ''}`;
+        result += `${char}${pattern[i + 1] ?? ''}`;
         i += 1;
         continue;
       }
@@ -1081,6 +1124,71 @@ export class SafetyEvaluator implements Evaluator {
       result += char === '.' ? '[\\s\\S]' : char;
     }
     return result;
+  }
+
+  private expandScopedDotAllLiterals(pattern: string, dotAll = false): string {
+    let result = '';
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '\\') {
+        result += pattern.slice(i, i + 2);
+        i += 1;
+        continue;
+      }
+      if (char === '[') {
+        const end = this.skipCharacterClass(pattern, i);
+        result += pattern.slice(i, end + 1);
+        i = end;
+        continue;
+      }
+      if (char === '(' && pattern[i + 1] === '?') {
+        const modifierMatch = pattern.slice(i + 2).match(/^([A-Za-z-]+):/);
+        if (modifierMatch) {
+          const groupEnd = this.findGroupEnd(pattern, i);
+          if (groupEnd !== null) {
+            const modifiers = modifierMatch[1] ?? '';
+            const contentStart = i + 2 + modifierMatch[0].length;
+            const scopedDotAll = this.modifierTextEnables(modifiers, 's')
+              ? true
+              : modifiers.includes('-s')
+                ? false
+                : dotAll;
+            result += `(?:${this.expandScopedDotAllLiterals(
+              pattern.slice(contentStart, groupEnd),
+              scopedDotAll,
+            )})`;
+            i = groupEnd;
+            continue;
+          }
+        }
+      }
+      result += char === '.' && dotAll ? '[\\s\\S]' : char;
+    }
+    return result;
+  }
+
+  private findGroupEnd(pattern: string, start: number): number | null {
+    let depth = 0;
+    for (let i = start; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '\\') {
+        i += 1;
+        continue;
+      }
+      if (char === '[') {
+        i = this.skipCharacterClass(pattern, i);
+        continue;
+      }
+      if (char === '(') {
+        depth += 1;
+        continue;
+      }
+      if (char === ')') {
+        depth -= 1;
+        if (depth === 0) return i;
+      }
+    }
+    return null;
   }
 
   private splitTopLevelAlternatives(groupContent: string): string[] {

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -7,6 +7,7 @@ import type {
 import type { GuardrailsPort } from '../types/contracts.js';
 
 const MAX_SAFETY_PATTERN_LENGTH = 1_000;
+const MAX_ALTERNATIVE_PREFIX_TOKENS = 32;
 
 interface RegexGroupState {
   startIndex: number;
@@ -219,9 +220,14 @@ export class SafetyEvaluator implements Evaluator {
       const token = this.regexAtomTokenAt(alternative, i);
       if (token === null) break;
 
-      for (let count = 0; count < token.repeatCount; count += 1) {
+      for (
+        let count = 0;
+        count < token.repeatCount && tokens.length < MAX_ALTERNATIVE_PREFIX_TOKENS;
+        count += 1
+      ) {
         tokens.push(token.value);
       }
+      if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) break;
       i = token.end;
     }
 
@@ -303,6 +309,9 @@ export class SafetyEvaluator implements Evaluator {
     if (groupContent.startsWith('?<=') || groupContent.startsWith('?<!')) {
       return groupContent.slice(3);
     }
+
+    const inlineModifier = groupContent.match(/^\?[A-Za-z-]+:/);
+    if (inlineModifier) return groupContent.slice(inlineModifier[0].length);
 
     const namedCapture = groupContent.match(/^\?<[^>]+>/);
     if (namedCapture) return groupContent.slice(namedCapture[0].length);
@@ -400,6 +409,6 @@ export class SafetyEvaluator implements Evaluator {
       return { end: close, variable, repeatsGroup };
     }
 
-    return { end: close, variable, repeatsGroup, fixedCount: min };
+    return { end: close, variable, repeatsGroup: min > 1, fixedCount: min };
   }
 }

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -220,17 +220,21 @@ export class SafetyEvaluator implements Evaluator {
       if (alternative[i] === '(') {
         const close = this.findClosingGroup(alternative, i);
         if (close === -1) break;
-        const groupedPrefix = this.expandSimpleAlternativePrefix(
-          this.splitTopLevelAlternatives(
-            this.stripGroupPrefix(alternative.slice(i + 1, close)),
-          )[0] ?? '',
-        );
-        tokens.push(
-          ...groupedPrefix.slice(
-            0,
-            MAX_ALTERNATIVE_PREFIX_TOKENS - tokens.length,
-          ),
-        );
+        const groupedPrefixes = this.splitTopLevelAlternatives(
+          this.stripGroupPrefix(alternative.slice(i + 1, close)),
+        )
+          .map((nestedAlternative) =>
+            this.expandSimpleAlternativePrefix(nestedAlternative),
+          )
+          .filter((prefix) => prefix.length > 0);
+        if (groupedPrefixes.length > 0) {
+          tokens.push(
+            `ALT:${groupedPrefixes
+              .map((prefix) => prefix[0])
+              .filter((token) => token !== undefined)
+              .join(',')}`,
+          );
+        }
         if (tokens.length >= MAX_ALTERNATIVE_PREFIX_TOKENS) break;
         i = close;
         continue;
@@ -314,6 +318,8 @@ export class SafetyEvaluator implements Evaluator {
       }
     } else if (char === '(') {
       return null;
+    } else if (char === '.') {
+      value = 'ANY';
     } else {
       value = char;
     }
@@ -331,6 +337,9 @@ export class SafetyEvaluator implements Evaluator {
     if (escaped === 'd') return 'DIGIT';
     if (escaped === 'w') return 'WORD';
     if (escaped === 's') return 'SPACE';
+    if (escaped === 'D') return 'NOT_DIGIT';
+    if (escaped === 'W') return 'NOT_WORD';
+    if (escaped === 'S') return 'NOT_SPACE';
     if (escaped === 'x') return '\\x';
     return escaped;
   }
@@ -370,13 +379,35 @@ export class SafetyEvaluator implements Evaluator {
 
   private regexTokensOverlap(left: string, right: string): boolean {
     if (left === right) return true;
+    if (left === 'ANY' || right === 'ANY') return true;
+    if (left.startsWith('ALT:')) return this.altTokenOverlaps(left, right);
+    if (right.startsWith('ALT:')) return this.altTokenOverlaps(right, left);
     if (left === 'WORD') return this.wordTokenOverlaps(right);
     if (right === 'WORD') return this.wordTokenOverlaps(left);
     if (left === 'DIGIT') return this.digitTokenOverlaps(right);
     if (right === 'DIGIT') return this.digitTokenOverlaps(left);
+    if (left === 'NOT_DIGIT') return !this.digitTokenOverlaps(right);
+    if (right === 'NOT_DIGIT') return !this.digitTokenOverlaps(left);
+    if (left === 'NOT_WORD') return !this.wordTokenOverlaps(right);
+    if (right === 'NOT_WORD') return !this.wordTokenOverlaps(left);
+    if (left === 'NOT_SPACE') return right !== 'SPACE';
+    if (right === 'NOT_SPACE') return left !== 'SPACE';
     if (left.startsWith('RANGE:')) return this.rangeTokenOverlaps(left, right);
     if (right.startsWith('RANGE:')) return this.rangeTokenOverlaps(right, left);
+    if (left.startsWith('CLASS:')) return this.classTokenOverlaps(left, right);
+    if (right.startsWith('CLASS:')) return this.classTokenOverlaps(right, left);
     return false;
+  }
+
+  private altTokenOverlaps(altToken: string, token: string): boolean {
+    return altToken
+      .slice('ALT:'.length)
+      .split(',')
+      .some((alternativeToken) =>
+        alternativeToken.length > 0
+          ? this.regexTokensOverlap(alternativeToken, token)
+          : false,
+      );
   }
 
   private wordTokenOverlaps(token: string): boolean {
@@ -399,6 +430,37 @@ export class SafetyEvaluator implements Evaluator {
         ? start <= otherEnd && otherStart <= end
         : false;
     }
+    if (token.startsWith('CLASS:')) return this.classTokenOverlaps(token, rangeToken);
+    return false;
+  }
+
+  private classTokenOverlaps(classToken: string, token: string): boolean {
+    const characterClass = classToken.slice('CLASS:'.length);
+    const body = characterClass.slice(1, -1);
+    if (body.startsWith('^')) return true;
+
+    for (let i = 0; i < body.length; i += 1) {
+      const char = body[i]!;
+      if (char === '\\') {
+        const escaped = body[i + 1];
+        if (escaped === undefined) continue;
+        const escapedToken = this.escapedAtomToken(escaped);
+        if (this.regexTokensOverlap(escapedToken, token)) return true;
+        i += 1;
+        continue;
+      }
+
+      if (body[i + 1] === '-' && body[i + 2] !== undefined) {
+        if (this.rangeTokenOverlaps(`RANGE:${char}-${body[i + 2]!}`, token)) {
+          return true;
+        }
+        i += 2;
+        continue;
+      }
+
+      if (this.regexTokensOverlap(char, token)) return true;
+    }
+
     return false;
   }
 

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -7,7 +7,7 @@ import type {
 import type { GuardrailsPort } from '../types/contracts.js';
 
 const MAX_SAFETY_PATTERN_LENGTH = 1_000;
-const MAX_ALTERNATIVE_PREFIX_TOKENS = 32;
+const MAX_ALTERNATIVE_PREFIX_TOKENS = 256;
 
 interface RegexGroupState {
   startIndex: number;
@@ -337,6 +337,8 @@ export class SafetyEvaluator implements Evaluator {
     if (escaped === 'd') return 'DIGIT';
     if (escaped === 'w') return 'WORD';
     if (escaped === 's') return 'SPACE';
+    if (escaped === 't' || escaped === 'n' || escaped === 'r') return 'SPACE';
+    if (escaped === 'f' || escaped === 'v') return 'SPACE';
     if (escaped === 'D') return 'NOT_DIGIT';
     if (escaped === 'W') return 'NOT_WORD';
     if (escaped === 'S') return 'NOT_SPACE';
@@ -390,8 +392,8 @@ export class SafetyEvaluator implements Evaluator {
     if (right === 'NOT_DIGIT') return !this.digitTokenOverlaps(left);
     if (left === 'NOT_WORD') return !this.wordTokenOverlaps(right);
     if (right === 'NOT_WORD') return !this.wordTokenOverlaps(left);
-    if (left === 'NOT_SPACE') return right !== 'SPACE';
-    if (right === 'NOT_SPACE') return left !== 'SPACE';
+    if (left === 'NOT_SPACE') return !this.spaceTokenOverlaps(right);
+    if (right === 'NOT_SPACE') return !this.spaceTokenOverlaps(left);
     if (left.startsWith('RANGE:')) return this.rangeTokenOverlaps(left, right);
     if (right.startsWith('RANGE:')) return this.rangeTokenOverlaps(right, left);
     if (left.startsWith('CLASS:')) return this.classTokenOverlaps(left, right);
@@ -411,11 +413,27 @@ export class SafetyEvaluator implements Evaluator {
   }
 
   private wordTokenOverlaps(token: string): boolean {
-    return /^[A-Za-z0-9_]$/.test(token) || token === 'DIGIT';
+    if (/^[A-Za-z0-9_]$/.test(token) || token === 'DIGIT') return true;
+    if (token.startsWith('RANGE:')) {
+      const [, start, end] = token.match(/^RANGE:(.)-(.)$/) ?? [];
+      return start !== undefined && end !== undefined
+        ? this.rangeContainsWordCharacter(start, end)
+        : false;
+    }
+    if (token.startsWith('CLASS:')) return this.classTokenOverlaps(token, 'WORD');
+    return false;
   }
 
   private digitTokenOverlaps(token: string): boolean {
-    return /^\d$/.test(token) || token === 'WORD';
+    if (/^\d$/.test(token) || token === 'WORD') return true;
+    if (token.startsWith('RANGE:')) {
+      const [, start, end] = token.match(/^RANGE:(.)-(.)$/) ?? [];
+      return start !== undefined && end !== undefined
+        ? start <= '9' && end >= '0'
+        : false;
+    }
+    if (token.startsWith('CLASS:')) return this.classTokenOverlaps(token, 'DIGIT');
+    return false;
   }
 
   private rangeTokenOverlaps(rangeToken: string, token: string): boolean {
@@ -437,7 +455,7 @@ export class SafetyEvaluator implements Evaluator {
   private classTokenOverlaps(classToken: string, token: string): boolean {
     const characterClass = classToken.slice('CLASS:'.length);
     const body = characterClass.slice(1, -1);
-    if (body.startsWith('^')) return true;
+    if (body.startsWith('^')) return !this.positiveClassBodyOverlaps(body.slice(1), token);
 
     for (let i = 0; i < body.length; i += 1) {
       const char = body[i]!;
@@ -464,6 +482,14 @@ export class SafetyEvaluator implements Evaluator {
     return false;
   }
 
+  private spaceTokenOverlaps(token: string): boolean {
+    return token === 'SPACE' || /^[\t\n\r\f\v ]$/.test(token);
+  }
+
+  private positiveClassBodyOverlaps(body: string, token: string): boolean {
+    return this.classTokenOverlaps(`CLASS:[${body}]`, token);
+  }
+
   private rangeContainsWordCharacter(start: string, end: string): boolean {
     return (
       (start <= 'z' && end >= 'a') ||
@@ -471,6 +497,20 @@ export class SafetyEvaluator implements Evaluator {
       (start <= '9' && end >= '0') ||
       (start <= '_' && end >= '_')
     );
+  }
+
+  private caseFoldRegexLiterals(pattern: string): string {
+    let result = '';
+    for (let i = 0; i < pattern.length; i += 1) {
+      const char = pattern[i]!;
+      if (char === '\\') {
+        result += pattern.slice(i, i + 2);
+        i += 1;
+        continue;
+      }
+      result += char.toLowerCase();
+    }
+    return result;
   }
 
   private stripGroupPrefix(groupContent: string): string {
@@ -485,7 +525,9 @@ export class SafetyEvaluator implements Evaluator {
     const inlineModifier = groupContent.match(/^\?([A-Za-z-]+):/);
     if (inlineModifier) {
       const content = groupContent.slice(inlineModifier[0].length);
-      return inlineModifier[1]?.includes('i') ? content.toLowerCase() : content;
+      return inlineModifier[1]?.includes('i')
+        ? this.caseFoldRegexLiterals(content)
+        : content;
     }
 
     const namedCapture = groupContent.match(/^\?<[^>]+>/);

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -563,6 +563,18 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
+        id: 'redos-class-word-boundary-identity-escape',
+        description: 'class word boundary identity escape pattern',
+        pattern: '^(?:[\\B]|BB)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-class-nonletter-control-escape',
+        description: 'class non-letter control escape pattern',
+        pattern: '^(?:[\\c0]|\\x10\\x10)+$',
+        severity: 'block',
+      },
+      {
         id: 'redos-comma-alt-serialization',
         description: 'comma alternative serialization pattern',
         pattern: '^(?:(?:,a)|(?:,b)|,)+$',
@@ -581,9 +593,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(39);
+    expect(result.findings).toHaveLength(41);
     expect(result.findings).toEqual(
-      Array.from({ length: 39 }, () =>
+      Array.from({ length: 41 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );
@@ -655,6 +667,12 @@ describe('SafetyEvaluator', () => {
         id: 'dot-line-separator-disjoint',
         description: 'dot line separator disjoint',
         pattern: '^(?:.|\\u2028)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'dot-all-line-terminators-disjoint',
+        description: 'dot all line terminators disjoint',
+        pattern: '^(?:.|[\\u2028\\u2029])+!$',
         severity: 'block',
       },
       {

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -627,6 +627,12 @@ describe('SafetyEvaluator', () => {
         pattern: '^(a+b+|c+d+)+y$',
         severity: 'block',
       },
+      {
+        id: 'disabled-case-fold-alternation',
+        description: 'disabled case fold alternation',
+        pattern: '^(?-i:A|a)+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -704,6 +710,18 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?s:(.|\\n\\n))+!$',
         severity: 'block',
       },
+      {
+        id: 'redos-unicode-space-alternation',
+        description: 'unicode space alternation pattern',
+        pattern: '^(?:\\s|\\u1680\\u1680)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-combined-dotall-alternation',
+        description: 'combined dotall alternation pattern',
+        pattern: '^(?is:(.|\\n\\n))+!$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -711,9 +729,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(11);
+    expect(result.findings).toHaveLength(13);
     expect(result.findings).toEqual(
-      Array.from({ length: 11 }, () =>
+      Array.from({ length: 13 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -635,4 +635,39 @@ describe('SafetyEvaluator', () => {
     expect(result.verdict).toBe('pass');
     expect(result.findings).toHaveLength(0);
   });
+
+  it('rejects nullable and variable-quantified alternation bypass patterns', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'redos-empty-branch-alternation',
+        description: 'empty branch alternation pattern',
+        pattern: '^(a(?:|a))+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-variable-quantifier-alternation',
+        description: 'variable quantifier alternation pattern',
+        pattern: '^(?:aa|a?)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-nullable-nested-alternation',
+        description: 'nullable nested alternation pattern',
+        pattern: '^(?:a(?:|a))+$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(createInput('safe content'));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.score).toBe(0);
+    expect(result.findings).toHaveLength(3);
+    expect(result.findings).toEqual(
+      Array.from({ length: 3 }, () =>
+        expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      ),
+    );
+  });
 });

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -509,6 +509,12 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
+        id: 'redos-forward-backreference-alternation',
+        description: 'forward backreference alternation pattern',
+        pattern: '^(?:\\1a|a)+(a)$',
+        severity: 'block',
+      },
+      {
         id: 'redos-case-folded-escaped-alternation',
         description: 'case folded escaped alternation pattern',
         pattern: '(?i:\\x41|aa)+$',
@@ -520,6 +526,12 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:(?:,a)|(?:,b)|,)+$',
         severity: 'block',
       },
+      {
+        id: 'redos-zero-width-suffix-alternation',
+        description: 'zero-width suffix alternation pattern',
+        pattern: '^((a|aa)(?=a))+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -527,9 +539,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(30);
+    expect(result.findings).toHaveLength(32);
     expect(result.findings).toEqual(
-      Array.from({ length: 30 }, () =>
+      Array.from({ length: 32 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );
@@ -583,6 +595,12 @@ describe('SafetyEvaluator', () => {
         id: 'unknown-named-escape-not-backreference',
         description: 'unknown named escape is not backreference',
         pattern: '^\\k<missing>$',
+        severity: 'block',
+      },
+      {
+        id: 'class-text-not-named-group',
+        description: 'class text is not named group',
+        pattern: '^[((?<x>)]\\k<x>$',
         severity: 'block',
       },
       {

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -514,12 +514,6 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
-        id: 'inline-negated-disjoint',
-        description: 'inline negated disjoint',
-        pattern: '^(?i:\\D|\\d)+!$',
-        severity: 'block',
-      },
-      {
         id: 'long-prefix-disjoint',
         description: 'long prefix disjoint',
         pattern: '^(?:a{33}b|a{33}c)+$',

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -484,6 +484,36 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:\\s|[ ])+!$',
         severity: 'block',
       },
+      {
+        id: 'redos-truncated-prefix-overlap',
+        description: 'truncated prefix overlap pattern',
+        pattern: '^(?:a{1001}|a{1001}a)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-not-word-unicode-alternation',
+        description: 'not word unicode alternation pattern',
+        pattern: '^(?:\\W|é)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-backreference-alternation',
+        description: 'backreference alternation pattern',
+        pattern: '^([a-z]+)(?:\\1|a)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-case-folded-escaped-alternation',
+        description: 'case folded escaped alternation pattern',
+        pattern: '(?i:\\x41|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-comma-alt-serialization',
+        description: 'comma alternative serialization pattern',
+        pattern: '^(?:(?:,a)|(?:,b)|,)+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -491,33 +521,12 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(24);
-    expect(result.findings).toEqual([
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
-    ]);
+    expect(result.findings).toHaveLength(29);
+    expect(result.findings).toEqual(
+      Array.from({ length: 29 }, () =>
+        expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      ),
+    );
   });
 
   it('allows disjoint and deterministic repeated alternatives', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -34,7 +34,12 @@ describe('SafetyEvaluator', () => {
 
   it('passes when no safety rules are violated', async () => {
     const port = createMockGuardrailsPort([
-      { id: 'r1', description: 'no eval', pattern: 'eval\\(', severity: 'block' },
+      {
+        id: 'r1',
+        description: 'no eval',
+        pattern: 'eval\\(',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -47,7 +52,12 @@ describe('SafetyEvaluator', () => {
 
   it('fails when a blocking rule is violated', async () => {
     const port = createMockGuardrailsPort([
-      { id: 'r1', description: 'no eval', pattern: 'eval\\(', severity: 'block' },
+      {
+        id: 'r1',
+        description: 'no eval',
+        pattern: 'eval\\(',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -62,11 +72,18 @@ describe('SafetyEvaluator', () => {
 
   it('warns but passes on warning-severity rules', async () => {
     const port = createMockGuardrailsPort([
-      { id: 'r1', description: 'avoid console.log', pattern: 'console\\.log', severity: 'warn' },
+      {
+        id: 'r1',
+        description: 'avoid console.log',
+        pattern: 'console\\.log',
+        severity: 'warn',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
-    const result = await evaluator.evaluate(createInput('console.log("debug")'));
+    const result = await evaluator.evaluate(
+      createInput('console.log("debug")'),
+    );
 
     expect(result.verdict).toBe('pass');
     expect(result.score).toBeLessThan(1);
@@ -74,14 +91,68 @@ describe('SafetyEvaluator', () => {
     expect(result.findings[0]!.severity).toBe('warning');
   });
 
-  it('detects multiple rule violations', async () => {
+  it('allows non-overlapping quantified alternation safety rules', async () => {
     const port = createMockGuardrailsPort([
-      { id: 'r1', description: 'no eval', pattern: 'eval\\(', severity: 'block' },
-      { id: 'r2', description: 'no exec', pattern: 'exec\\(', severity: 'block' },
+      {
+        id: 'safe-alternation',
+        description: 'safe alternation',
+        pattern: '(?:cat|dog)+',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
-    const result = await evaluator.evaluate(createInput('eval("x"); exec("y")'));
+    const result = await evaluator.evaluate(createInput('bird'));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.score).toBe(1);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('allows repeated groups with fixed inner quantifiers', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'fixed-digits',
+        description: 'fixed digits',
+        pattern: '(?:\\d{2})+',
+        severity: 'block',
+      },
+      {
+        id: 'fixed-letter',
+        description: 'fixed letter',
+        pattern: '(ab{3})+',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(createInput('safe content'));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.score).toBe(1);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('detects multiple rule violations', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'r1',
+        description: 'no eval',
+        pattern: 'eval\\(',
+        severity: 'block',
+      },
+      {
+        id: 'r2',
+        description: 'no exec',
+        pattern: 'exec\\(',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(
+      createInput('eval("x"); exec("y")'),
+    );
 
     expect(result.verdict).toBe('fail');
     expect(result.findings).toHaveLength(2);
@@ -96,5 +167,186 @@ describe('SafetyEvaluator', () => {
     expect(result.verdict).toBe('pass');
     expect(result.score).toBe(1);
     expect(result.findings).toHaveLength(0);
+  });
+
+  it('reports malformed safety rule regexes instead of throwing', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'bad-regex',
+        description: 'bad regex',
+        pattern: 'eval(',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    await expect(
+      evaluator.evaluate(createInput('const x = 1;')),
+    ).resolves.toMatchObject({
+      verdict: 'fail',
+      score: 0,
+      findings: [
+        expect.objectContaining({
+          message: expect.stringContaining('Invalid safety rule regex'),
+          severity: 'critical',
+        }),
+      ],
+    });
+  });
+
+  it('rejects nested quantifier patterns before evaluating content', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'redos',
+        description: 'redos pattern',
+        pattern: '(a+)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-optional',
+        description: 'redos optional pattern',
+        pattern: '(a?)+$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(
+      createInput('safe content without matching input'),
+    );
+
+    expect(result.verdict).toBe('fail');
+    expect(result.score).toBe(0);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Unsafe safety rule regex'),
+        severity: 'critical',
+      }),
+      expect.objectContaining({
+        message: expect.stringContaining('Unsafe safety rule regex'),
+        severity: 'critical',
+      }),
+    ]);
+  });
+
+  it('rejects nested brace quantifier patterns before evaluating content', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'redos-brace',
+        description: 'redos brace pattern',
+        pattern: '(a{1,})+$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(
+      createInput('safe content without matching input'),
+    );
+
+    expect(result.verdict).toBe('fail');
+    expect(result.score).toBe(0);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Unsafe safety rule regex'),
+        severity: 'critical',
+      }),
+    ]);
+  });
+
+  it('rejects grouped nested quantifier bypass patterns', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'redos-grouped-plus',
+        description: 'grouped plus pattern',
+        pattern: '((a)+)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-grouped-brace',
+        description: 'grouped brace pattern',
+        pattern: '((a{1,})){1,}$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(
+      createInput('safe content without matching input'),
+    );
+
+    expect(result.verdict).toBe('fail');
+    expect(result.score).toBe(0);
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+    ]);
+  });
+
+  it('does not echo invalid safety rule patterns in findings', async () => {
+    const secretPattern = 'secret_token_abc(';
+    const port = createMockGuardrailsPort([
+      {
+        id: 'secret-regex',
+        description: 'secret regex',
+        pattern: secretPattern,
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(createInput('safe content'));
+
+    expect(JSON.stringify(result.findings)).not.toContain(secretPattern);
+  });
+
+  it('rejects grouped overlapping alternation bypass patterns', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'redos-alternation',
+        description: 'grouped alternation pattern',
+        pattern: '((a|aa))+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-noncapturing-alternation',
+        description: 'grouped noncapturing alternation pattern',
+        pattern: '(?:(a|aa))+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-direct-alternation',
+        description: 'direct alternation pattern',
+        pattern: '(a|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-direct-noncapturing-alternation',
+        description: 'direct noncapturing alternation pattern',
+        pattern: '(?:a|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-named-capture-alternation',
+        description: 'named capture alternation pattern',
+        pattern: '(?<x>a|aa)+$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(createInput('safe content'));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.score).toBe(0);
+    expect(result.findings).toHaveLength(5);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+    ]);
   });
 });

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -394,6 +394,24 @@ describe('SafetyEvaluator', () => {
         pattern: '(?:a|a{1000000000})+$',
         severity: 'block',
       },
+      {
+        id: 'redos-unicode-alternation',
+        description: 'unicode alternation pattern',
+        pattern: '(?:\\u0061|a{2})+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-singleton-class-alternation',
+        description: 'singleton class alternation pattern',
+        pattern: '(?:a|[a]a)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-case-folded-alternation',
+        description: 'case folded alternation pattern',
+        pattern: '(?i:a|Aa)+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -401,8 +419,11 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(9);
+    expect(result.findings).toHaveLength(12);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -533,6 +533,18 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
+        id: 'redos-case-folded-preserves-negated-escape',
+        description: 'case folded negated escape pattern',
+        pattern: '^(?i:\\D|a)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-nonascii-negated-class-range-overlap',
+        description: 'non-ascii negated class range overlap pattern',
+        pattern: '^(?:[^a]|[Ω-Ϋ][Ω-Ϋ])+$',
+        severity: 'block',
+      },
+      {
         id: 'redos-comma-alt-serialization',
         description: 'comma alternative serialization pattern',
         pattern: '^(?:(?:,a)|(?:,b)|,)+$',
@@ -551,9 +563,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(34);
+    expect(result.findings).toHaveLength(36);
     expect(result.findings).toEqual(
-      Array.from({ length: 34 }, () =>
+      Array.from({ length: 36 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );
@@ -637,6 +649,12 @@ describe('SafetyEvaluator', () => {
         id: 'inline-modifier-text-in-class',
         description: 'inline modifier text in class',
         pattern: '^(?:.|\\n\\n)+[(?s:]$',
+        severity: 'block',
+      },
+      {
+        id: 'scoped-dotall-leaves-outer-dot-unchanged',
+        description: 'scoped dotAll leaves outer dot unchanged',
+        pattern: '^(?s:a)(?:.|\\n)+!$',
         severity: 'block',
       },
     ]);

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -497,6 +497,12 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
+        id: 'redos-not-word-unicode-class-alternation',
+        description: 'not word unicode class alternation pattern',
+        pattern: '^(?:\\W|[éê])+a$',
+        severity: 'block',
+      },
+      {
         id: 'redos-backreference-alternation',
         description: 'backreference alternation pattern',
         pattern: '^([a-z]+)(?:\\1|a)+$',
@@ -521,9 +527,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(29);
+    expect(result.findings).toHaveLength(30);
     expect(result.findings).toEqual(
-      Array.from({ length: 29 }, () =>
+      Array.from({ length: 30 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );
@@ -565,6 +571,24 @@ describe('SafetyEvaluator', () => {
         id: 'dot-newline-disjoint',
         description: 'dot newline disjoint',
         pattern: '^(?:.|\\n)+$',
+        severity: 'block',
+      },
+      {
+        id: 'character-class-escape-not-backreference',
+        description: 'character class escape is not backreference',
+        pattern: '^[\\1]+$',
+        severity: 'block',
+      },
+      {
+        id: 'unknown-named-escape-not-backreference',
+        description: 'unknown named escape is not backreference',
+        pattern: '^\\k<missing>$',
+        severity: 'block',
+      },
+      {
+        id: 'deterministic-suffix-after-inner-alternation',
+        description: 'deterministic suffix after inner alternation',
+        pattern: '^((a|aa)b)+$',
         severity: 'block',
       },
     ]);

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -123,10 +123,40 @@ describe('SafetyEvaluator', () => {
         pattern: '(ab{3})+',
         severity: 'block',
       },
+      {
+        id: 'exact-range-letter',
+        description: 'exact range letter',
+        pattern: '(?:a{2,2})+',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
     const result = await evaluator.evaluate(createInput('safe content'));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.score).toBe(1);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('allows optional outer groups with variable inner quantifiers', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'optional-plus',
+        description: 'optional plus',
+        pattern: '^(a+)?$',
+        severity: 'block',
+      },
+      {
+        id: 'optional-range',
+        description: 'optional range',
+        pattern: '^(a+){0,1}$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(createInput('bbb'));
 
     expect(result.verdict).toBe('pass');
     expect(result.score).toBe(1);
@@ -333,6 +363,18 @@ describe('SafetyEvaluator', () => {
         pattern: '(?<x>a|aa)+$',
         severity: 'block',
       },
+      {
+        id: 'redos-digit-class-alternation',
+        description: 'digit class alternation pattern',
+        pattern: '(?:[0-9]|\\d\\d)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-hex-alternation',
+        description: 'hex alternation pattern',
+        pattern: '(?:\\x61|a{2})+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -340,8 +382,10 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(5);
+    expect(result.findings).toHaveLength(7);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -627,12 +627,6 @@ describe('SafetyEvaluator', () => {
         pattern: '^(a+b+|c+d+)+y$',
         severity: 'block',
       },
-      {
-        id: 'disabled-case-fold-alternation',
-        description: 'disabled case fold alternation',
-        pattern: '^(?-i:A|a)+$',
-        severity: 'block',
-      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -485,6 +485,18 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
+        id: 'redos-hex-class-alternation',
+        description: 'hex class alternation pattern',
+        pattern: '^(?:[\\x61b]|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-nbsp-space-alternation',
+        description: 'nbsp space alternation pattern',
+        pattern: '^(?:\\s|\\u00A0\\s)+!$',
+        severity: 'block',
+      },
+      {
         id: 'redos-truncated-prefix-overlap',
         description: 'truncated prefix overlap pattern',
         pattern: '^(?:a{1001}|a{1001}a)+$',
@@ -539,9 +551,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(32);
+    expect(result.findings).toHaveLength(34);
     expect(result.findings).toEqual(
-      Array.from({ length: 32 }, () =>
+      Array.from({ length: 34 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );
@@ -607,6 +619,12 @@ describe('SafetyEvaluator', () => {
         id: 'deterministic-suffix-after-inner-alternation',
         description: 'deterministic suffix after inner alternation',
         pattern: '^((a|aa)b)+$',
+        severity: 'block',
+      },
+      {
+        id: 'deterministic-quantified-alternation',
+        description: 'deterministic quantified alternation',
+        pattern: '^(a+b+|c+d+)+y$',
         severity: 'block',
       },
     ]);

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -656,6 +656,24 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:a(?:|a))+$',
         severity: 'block',
       },
+      {
+        id: 'redos-nondisambiguating-suffix',
+        description: 'nondisambiguating suffix pattern',
+        pattern: '^((a|aa)a)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-nullable-prefix-alternation',
+        description: 'nullable prefix alternation pattern',
+        pattern: '^(?:a?b|b)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-star-prefix-alternation',
+        description: 'star prefix alternation pattern',
+        pattern: '^(?:a*b|b)+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -663,9 +681,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(3);
+    expect(result.findings).toHaveLength(6);
     expect(result.findings).toEqual(
-      Array.from({ length: 3 }, () =>
+      Array.from({ length: 6 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -454,6 +454,18 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:\\D|a)+\\d$',
         severity: 'block',
       },
+      {
+        id: 'redos-word-range-alternation',
+        description: 'word range alternation pattern',
+        pattern: '^(?:\\w|[a-z]a)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-whitespace-tab-alternation',
+        description: 'whitespace tab alternation pattern',
+        pattern: '^(?:\\s|\\t)+!$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -461,7 +473,7 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(19);
+    expect(result.findings).toHaveLength(21);
     expect(result.findings).toEqual([
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
@@ -482,6 +494,43 @@ describe('SafetyEvaluator', () => {
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
     ]);
+  });
+
+  it('allows disjoint negated class and whitespace alternatives', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'negated-class-disjoint',
+        description: 'negated class disjoint',
+        pattern: '^(?:[^a]|a)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'not-space-disjoint',
+        description: 'not space disjoint',
+        pattern: '^(?:\\S| )+!$',
+        severity: 'block',
+      },
+      {
+        id: 'inline-negated-disjoint',
+        description: 'inline negated disjoint',
+        pattern: '^(?i:\\D|\\d)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'long-prefix-disjoint',
+        description: 'long prefix disjoint',
+        pattern: '^(?:a{33}b|a{33}c)+$',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+
+    const result = await evaluator.evaluate(createInput(''));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
   });
 });

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -651,12 +651,6 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:.|\\n\\n)+[(?s:]$',
         severity: 'block',
       },
-      {
-        id: 'scoped-dotall-leaves-outer-dot-unchanged',
-        description: 'scoped dotAll leaves outer dot unchanged',
-        pattern: '^(?s:a)(?:.|\\n)+!$',
-        severity: 'block',
-      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -664,6 +658,15 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('pass');
     expect(result.findings).toHaveLength(0);
+  });
+
+  it('limits inline dotAll rewriting to the modifier group scope', () => {
+    const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
+      hasUnsafeRegexShape(pattern: string): boolean;
+    };
+
+    expect(evaluator.hasUnsafeRegexShape('^(?s:a)(?:.|\\n)+!$')).toBe(false);
+    expect(evaluator.hasUnsafeRegexShape('^(?s:(.|\\n\\n))+!$')).toBe(true);
   });
 
   it('rejects nullable and variable-quantified alternation bypass patterns', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -298,6 +298,12 @@ describe('SafetyEvaluator', () => {
         pattern: '((a{1,})){1,}$',
         severity: 'block',
       },
+      {
+        id: 'redos-fixed-outer-repeat',
+        description: 'fixed outer repeat pattern',
+        pattern: '(a+){10}$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -307,8 +313,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(2);
+    expect(result.findings).toHaveLength(3);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
     ]);
@@ -375,6 +382,18 @@ describe('SafetyEvaluator', () => {
         pattern: '(?:\\x61|a{2})+$',
         severity: 'block',
       },
+      {
+        id: 'redos-inline-modifier-alternation',
+        description: 'inline modifier alternation pattern',
+        pattern: '(?i:a|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-large-fixed-alternation',
+        description: 'large fixed alternation pattern',
+        pattern: '(?:a|a{1000000000})+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -382,8 +401,10 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(7);
+    expect(result.findings).toHaveLength(9);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -430,6 +430,30 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:\\w|a)+!$',
         severity: 'block',
       },
+      {
+        id: 'redos-later-nested-alternative',
+        description: 'later nested alternative pattern',
+        pattern: '(?:(?:a|b)|b)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-class-literal-alternation',
+        description: 'class literal alternation pattern',
+        pattern: '(?:(?:[ab]|b))+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-wildcard-literal-alternation',
+        description: 'wildcard literal alternation pattern',
+        pattern: '^(?:.|a)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-negated-escape-alternation',
+        description: 'negated escape alternation pattern',
+        pattern: '^(?:\\D|a)+\\d$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -437,8 +461,12 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(15);
+    expect(result.findings).toHaveLength(19);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -466,6 +466,24 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:\\s|\\t)+!$',
         severity: 'block',
       },
+      {
+        id: 'redos-not-digit-word-alternation',
+        description: 'not digit word alternation pattern',
+        pattern: '^(?:\\D|\\w)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-negated-class-word-alternation',
+        description: 'negated class word alternation pattern',
+        pattern: '^(?:[^a]|\\w)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-space-class-alternation',
+        description: 'space class alternation pattern',
+        pattern: '^(?:\\s|[ ])+!$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -473,8 +491,11 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(21);
+    expect(result.findings).toHaveLength(24);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
@@ -499,7 +520,7 @@ describe('SafetyEvaluator', () => {
     ]);
   });
 
-  it('allows disjoint negated class and whitespace alternatives', async () => {
+  it('allows disjoint and deterministic repeated alternatives', async () => {
     const port = createMockGuardrailsPort([
       {
         id: 'negated-class-disjoint',
@@ -516,7 +537,25 @@ describe('SafetyEvaluator', () => {
       {
         id: 'long-prefix-disjoint',
         description: 'long prefix disjoint',
-        pattern: '^(?:a{33}b|a{33}c)+$',
+        pattern: '^(?:a{257}b|a{257}c)+$',
+        severity: 'block',
+      },
+      {
+        id: 'nested-group-prefix-disjoint',
+        description: 'nested group prefix disjoint',
+        pattern: '^(?:(?:ab)|(?:ac))+$',
+        severity: 'block',
+      },
+      {
+        id: 'lazy-exact-count',
+        description: 'lazy exact counted quantifier',
+        pattern: '^(?:a{2}?)+$',
+        severity: 'block',
+      },
+      {
+        id: 'dot-newline-disjoint',
+        description: 'dot newline disjoint',
+        pattern: '^(?:.|\\n)+$',
         severity: 'block',
       },
     ]);

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -622,9 +622,21 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
-        id: 'deterministic-quantified-alternation',
-        description: 'deterministic quantified alternation',
-        pattern: '^(a+b+|c+d+)+y$',
+        id: 'dot-line-separator-disjoint',
+        description: 'dot line separator disjoint',
+        pattern: '^(?:.|\\u2028)+!$',
+        severity: 'block',
+      },
+      {
+        id: 'backspace-class-disjoint',
+        description: 'backspace class disjoint',
+        pattern: '^(?:[\\b]|b)+$',
+        severity: 'block',
+      },
+      {
+        id: 'inline-modifier-text-in-class',
+        description: 'inline modifier text in class',
+        pattern: '^(?:.|\\n\\n)+[(?s:]$',
         severity: 'block',
       },
     ]);
@@ -716,6 +728,12 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?is:(.|\\n\\n))+!$',
         severity: 'block',
       },
+      {
+        id: 'redos-disjoint-quantified-branch',
+        description: 'disjoint quantified branch pattern',
+        pattern: '^(?:a+|\\d)+$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -723,9 +741,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(13);
+    expect(result.findings).toHaveLength(14);
     expect(result.findings).toEqual(
-      Array.from({ length: 13 }, () =>
+      Array.from({ length: 14 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -412,6 +412,24 @@ describe('SafetyEvaluator', () => {
         pattern: '(?i:a|Aa)+$',
         severity: 'block',
       },
+      {
+        id: 'redos-case-folded-class-alternation',
+        description: 'case folded class alternation pattern',
+        pattern: '(?i:[A-Z]|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-grouped-alternative',
+        description: 'grouped alternative pattern',
+        pattern: '(?:a|(?:aa))+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-word-literal-alternation',
+        description: 'word literal alternation pattern',
+        pattern: '^(?:\\w|a)+!$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -419,8 +437,11 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(12);
+    expect(result.findings).toHaveLength(15);
     expect(result.findings).toEqual([
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
+      expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       expect.objectContaining({ message: expect.stringContaining('Unsafe') }),

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -545,6 +545,24 @@ describe('SafetyEvaluator', () => {
         severity: 'block',
       },
       {
+        id: 'redos-octal-escape-alternation',
+        description: 'octal escape alternation pattern',
+        pattern: '^(?:\\141|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-octal-class-escape-alternation',
+        description: 'octal class escape alternation pattern',
+        pattern: '^(?:[\\141]|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-legacy-incomplete-hex-escape-alternation',
+        description: 'legacy incomplete hex escape alternation pattern',
+        pattern: '^(?:\\x|xx)+$',
+        severity: 'block',
+      },
+      {
         id: 'redos-comma-alt-serialization',
         description: 'comma alternative serialization pattern',
         pattern: '^(?:(?:,a)|(?:,b)|,)+$',
@@ -563,9 +581,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(36);
+    expect(result.findings).toHaveLength(39);
     expect(result.findings).toEqual(
-      Array.from({ length: 36 }, () =>
+      Array.from({ length: 39 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -674,6 +674,36 @@ describe('SafetyEvaluator', () => {
         pattern: '^(?:a*b|b)+$',
         severity: 'block',
       },
+      {
+        id: 'redos-lookahead-branch-alternation',
+        description: 'lookahead branch alternation pattern',
+        pattern: '^(?:(?!b)a|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-lookbehind-branch-alternation',
+        description: 'lookbehind branch alternation pattern',
+        pattern: '^(?:(?<!b)a|aa)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-control-escape-alternation',
+        description: 'control escape alternation pattern',
+        pattern: '^(?:\\cJ|\\n\\n)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-nul-escape-alternation',
+        description: 'nul escape alternation pattern',
+        pattern: '^(?:\\0|\\x00\\x00)+$',
+        severity: 'block',
+      },
+      {
+        id: 'redos-dotall-alternation',
+        description: 'dotall alternation pattern',
+        pattern: '^(?s:(.|\\n\\n))+!$',
+        severity: 'block',
+      },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
@@ -681,9 +711,9 @@ describe('SafetyEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
-    expect(result.findings).toHaveLength(6);
+    expect(result.findings).toHaveLength(11);
     expect(result.findings).toEqual(
-      Array.from({ length: 6 }, () =>
+      Array.from({ length: 11 }, () =>
         expect.objectContaining({ message: expect.stringContaining('Unsafe') }),
       ),
     );

--- a/tasks/security-safety-redos-progress.md
+++ b/tasks/security-safety-redos-progress.md
@@ -1,0 +1,26 @@
+# Security SafetyEvaluator ReDoS Progress
+
+- [x] Inventory open GitHub security issues and select highest-priority actionable patch.
+- [x] Isolate work in a clean worktree on `fix/security-safety-evaluator-redos` from `origin/main`.
+- [x] Reproduce issue #49 with failing tests for invalid and malicious regex patterns.
+- [x] Implement regex validation/error handling and safe evaluation behavior.
+- [x] Run targeted tests and package-level verification.
+- [x] Commit the fix with a conventional commit message.
+- [x] Update/triage GitHub issue #49 with implementation status.
+
+## Notes
+
+- Selected #49 first because it is an open `security` issue with HIGH severity and direct code-level exploitability (user-supplied regex -> ReDoS/syntax errors).
+- Other open security issues to revisit afterward: #44, #48, #65, #76, #83, #84.
+- RED verification: `npm test --workspace @franken/critique -- --run tests/unit/evaluators/safety.test.ts` failed for malformed regex throwing and nested quantifier pattern passing unflagged.
+- Implementation rejects unsafe rule patterns before evaluation, handles invalid regexes as findings instead of throwing, and avoids echoing raw safety rule patterns in findings.
+- Independent review initially found bypasses for brace quantifiers, grouped nested quantifiers, grouped alternation, and named capture alternation; follow-up patches added scanner propagation plus regression coverage for those cases.
+- Codex review on first pushed commit flagged broad alternation false positives and missing `?` quantifier detection; local patch narrowed alternation rejection to overlapping alternatives, added `?` support, and added safe alternation regression coverage.
+- Codex review on current commit flagged fixed-inner-quantifier false positives; local patch now treats exact `{n}` quantifiers as fixed while preserving variable `{m,}` / `{m,n}` rejection, with regression coverage for `(?:\\d{2})+` and `(ab{3})+`.
+- GREEN verification:
+  - `npm test --workspace @franken/critique -- --run tests/unit/evaluators/safety.test.ts` (14 passed)
+  - `npm run build --workspace @franken/critique`
+  - `npm run lint --workspace @franken/critique`
+  - `npm test --workspace @franken/critique` (123 passed)
+  - Independent focused review passed with no security concerns or logic errors.
+- PR opened: https://github.com/djm204/frankenbeast/pull/302. Latest local changes need amended force-with-lease push and another Codex pass.


### PR DESCRIPTION
## Summary
- Fixes SafetyEvaluator handling of user-supplied safety rule regexes for issue #49.
- Adds validation findings for malformed regexes instead of throwing out of evaluation.
- Rejects unsafe regex shapes before evaluation, including nested/ambiguous quantifier patterns associated with ReDoS.
- Adds regression coverage for invalid regex and nested-quantifier ReDoS patterns.

## Test Plan
- [x] `npm test --workspace @franken/critique -- --run tests/unit/evaluators/safety.test.ts`
- [x] `npm run build --workspace @franken/critique`
- [x] `npm test --workspace @franken/critique`
- [x] `npm run typecheck -- --filter=@franken/critique`

Fixes #49
