### PR TITLE
fix(observer): escape trace viewer template metacharacters

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -1,3 +1,4 @@
+import { createContext, Script } from 'node:vm'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { TraceServer } from './TraceServer.js'
 import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
@@ -59,6 +60,20 @@ describe('TraceServer', () => {
       const html = await fetch(server.url + '/').then(r => r.text())
       expect(html).not.toMatch(/<script\s+src=/i)
       expect(html).not.toMatch(/<link\s[^>]*rel=["']stylesheet["']/i)
+    })
+
+    it('escapes template-literal metacharacters in trace text before writing innerHTML', async () => {
+      const html = await fetch(server.url + '/').then(r => r.text())
+      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+      expect(script).toBeDefined()
+
+      const context = createContext({ document: { getElementById: () => ({}) } }) as { esc?: (s: string) => string }
+      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+
+      const escaped = context.esc!('goal`);globalThis.__xss=1;//${alert(1)}<img src=x onerror=alert(2)>')
+      expect(escaped).not.toContain('`')
+      expect(escaped).not.toContain('${')
+      expect(escaped).toContain('&lt;img src=x onerror=alert(2)&gt;')
     })
   })
 

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -164,7 +164,13 @@ const sidebar = document.getElementById('sidebar')
 const panel   = document.getElementById('panel')
 
 function esc(s){
-  return String(s??'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')
+  return String(s??'')
+    .replace(/&/g,'&amp;')
+    .replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;')
+    .replace(/\`/g,'&#96;')
+    .replace(/\\$/g,'&#36;')
 }
 function badge(status){
   const cls = status==='completed'?'ok':status==='error'?'err':'act'

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -170,7 +170,7 @@ function esc(s){
     .replace(/>/g,'&gt;')
     .replace(/"/g,'&quot;')
     .replace(/\`/g,'&#96;')
-    .replace(/\\$/g,'&#36;')
+    .split('$').join('&#36;')
 }
 function badge(status){
   const cls = status==='completed'?'ok':status==='error'?'err':'act'


### PR DESCRIPTION
## Summary
- Escapes backticks and dollar signs in the TraceServer HTML viewer esc() helper before trace text is written via innerHTML
- Adds a regression test that executes the embedded viewer script helper and verifies template-literal XSS metacharacters are neutralized alongside HTML escaping

## Test Plan
- npm test -- --run src/ui/TraceServer.test.ts -t "escapes template-literal"
- npm test -- --run src/ui/TraceServer.test.ts
- npm run typecheck
- npm test

Fixes #65
