### PR TITLE
fix(security): mask common secrets in PII middleware

### DIFF
--- a/packages/franken-orchestrator/src/middleware/pii-masking.ts
+++ b/packages/franken-orchestrator/src/middleware/pii-masking.ts
@@ -2,7 +2,8 @@ import type { LlmRequest } from '@franken/types';
 import type { LlmMiddleware, LlmResponse } from './llm-middleware.js';
 
 /**
- * PII patterns from the original frankenfirewall (v0.pre-consolidation).
+ * PII patterns from the original frankenfirewall (v0.pre-consolidation), plus
+ * narrowly scoped secret patterns that commonly appear in prompts and logs.
  * Credit card regex validates Visa/MC/Amex/Discover prefixes.
  * SSN regex excludes invalid prefixes (000, 666, 9xx).
  */
@@ -11,6 +12,18 @@ const PII_RULES: Array<{
   pattern: RegExp;
   replacement: string;
 }> = [
+  {
+    name: 'database-connection-string',
+    pattern:
+      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/[^\s'"`<>]+/gi,
+    replacement: '[CONNECTION_STRING]',
+  },
+  {
+    name: 'api-key-or-token',
+    pattern:
+      /\b(?:sk-[A-Za-z0-9_-]{16,}|(?:ghp|gho)_[A-Za-z0-9_]{20,}|xoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{20,}|Bearer\s+[A-Za-z0-9._~+/=-]{20,})\b/g,
+    replacement: '[API_KEY]',
+  },
   {
     name: 'email',
     pattern: /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g,

--- a/packages/franken-orchestrator/src/middleware/pii-masking.ts
+++ b/packages/franken-orchestrator/src/middleware/pii-masking.ts
@@ -15,13 +15,32 @@ const PII_RULES: Array<{
   {
     name: 'database-connection-string',
     pattern:
-      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/[^\s'"`<>]+/gi,
+      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/[^\s'"`<>,)\]}]+/gi,
     replacement: '[CONNECTION_STRING]',
   },
   {
-    name: 'api-key-or-token',
-    pattern:
-      /\b(?:sk-[A-Za-z0-9_-]{16,}|(?:gh[opusr])_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}_[A-Za-z0-9]{40,}|xoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{20,}|bearer\s+[A-Za-z0-9._~+/=-]{20,})(?![A-Za-z0-9._~+/=-])/gi,
+    name: 'openai-api-key',
+    pattern: /\bsk-[A-Za-z0-9_-]{15,}[A-Za-z0-9_-]/g,
+    replacement: '[API_KEY]',
+  },
+  {
+    name: 'github-token',
+    pattern: /\b(?:gh[opusr])_[A-Za-z0-9_]{19,}[A-Za-z0-9_]/gi,
+    replacement: '[API_KEY]',
+  },
+  {
+    name: 'github-fine-grained-pat',
+    pattern: /\bgithub_pat_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}_[A-Za-z0-9]{40,}/gi,
+    replacement: '[API_KEY]',
+  },
+  {
+    name: 'slack-bot-token',
+    pattern: /\bxoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{19,}[A-Za-z0-9]/gi,
+    replacement: '[API_KEY]',
+  },
+  {
+    name: 'bearer-token',
+    pattern: /\bbearer\s+[A-Za-z0-9._~+/=-]{19,}[A-Za-z0-9_=/-]/gi,
     replacement: '[API_KEY]',
   },
   {

--- a/packages/franken-orchestrator/src/middleware/pii-masking.ts
+++ b/packages/franken-orchestrator/src/middleware/pii-masking.ts
@@ -15,7 +15,7 @@ const PII_RULES: Array<{
   {
     name: 'database-connection-string',
     pattern:
-      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/[^\s'"`<>,)}]+(?:,[A-Za-z0-9.-]+:\d+[^\s'"`<>,)}]*)*/gi,
+      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/(?:[^\s'"`<>()@,]+@)?(?:\[[^\]\s'"`<>()]+\]|[A-Za-z0-9.-]+)(?::\d+)?(?:,(?:\[[^\]\s'"`<>()]+\]|[A-Za-z0-9.-]+)(?::\d+)?)*(?:\/[^\s'"`<>,)}]*)?(?:\?[^\s'"`<>,)}]*)?/gi,
     replacement: (match) => {
       const trailingDelimiter = match.match(/[.;:]+$/)?.[0] ?? '';
       return `[CONNECTION_STRING]${trailingDelimiter}`;
@@ -28,8 +28,11 @@ const PII_RULES: Array<{
   },
   {
     name: 'github-token',
-    pattern: /\b(?:gh[opusr])_[A-Za-z0-9_.]{19,}[A-Za-z0-9_]/gi,
-    replacement: '[API_KEY]',
+    pattern: /\b(?:gh[opusr])_[A-Za-z0-9_.-]{20,}/gi,
+    replacement: (match) => {
+      const trailingDelimiter = match.match(/[.;:]+$/)?.[0] ?? '';
+      return `[API_KEY]${trailingDelimiter}`;
+    },
   },
   {
     name: 'github-fine-grained-pat',

--- a/packages/franken-orchestrator/src/middleware/pii-masking.ts
+++ b/packages/franken-orchestrator/src/middleware/pii-masking.ts
@@ -21,7 +21,7 @@ const PII_RULES: Array<{
   {
     name: 'api-key-or-token',
     pattern:
-      /\b(?:sk-[A-Za-z0-9_-]{16,}|(?:ghp|gho)_[A-Za-z0-9_]{20,}|xoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{20,}|Bearer\s+[A-Za-z0-9._~+/=-]{20,})\b/g,
+      /\b(?:sk-[A-Za-z0-9_-]{16,}|(?:gh[opusr])_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}_[A-Za-z0-9]{40,}|xoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{20,}|bearer\s+[A-Za-z0-9._~+/=-]{20,})(?![A-Za-z0-9._~+/=-])/gi,
     replacement: '[API_KEY]',
   },
   {

--- a/packages/franken-orchestrator/src/middleware/pii-masking.ts
+++ b/packages/franken-orchestrator/src/middleware/pii-masking.ts
@@ -40,7 +40,7 @@ const PII_RULES: Array<{
   },
   {
     name: 'bearer-token',
-    pattern: /\bbearer\s+[A-Za-z0-9._~+/=-]{19,}[A-Za-z0-9_=/-]/gi,
+    pattern: /\bbearer\s+[A-Za-z0-9._~+/=-]{19,}[A-Za-z0-9_=\/+~-]/gi,
     replacement: '[API_KEY]',
   },
   {

--- a/packages/franken-orchestrator/src/middleware/pii-masking.ts
+++ b/packages/franken-orchestrator/src/middleware/pii-masking.ts
@@ -10,13 +10,16 @@ import type { LlmMiddleware, LlmResponse } from './llm-middleware.js';
 const PII_RULES: Array<{
   name: string;
   pattern: RegExp;
-  replacement: string;
+  replacement: string | ((match: string) => string);
 }> = [
   {
     name: 'database-connection-string',
     pattern:
-      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/[^\s'"`<>,)\]}]+/gi,
-    replacement: '[CONNECTION_STRING]',
+      /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss):\/\/[^\s'"`<>,)}]+(?:,[A-Za-z0-9.-]+:\d+[^\s'"`<>,)}]*)*/gi,
+    replacement: (match) => {
+      const trailingDelimiter = match.match(/[.;:]+$/)?.[0] ?? '';
+      return `[CONNECTION_STRING]${trailingDelimiter}`;
+    },
   },
   {
     name: 'openai-api-key',
@@ -25,7 +28,7 @@ const PII_RULES: Array<{
   },
   {
     name: 'github-token',
-    pattern: /\b(?:gh[opusr])_[A-Za-z0-9_]{19,}[A-Za-z0-9_]/gi,
+    pattern: /\b(?:gh[opusr])_[A-Za-z0-9_.]{19,}[A-Za-z0-9_]/gi,
     replacement: '[API_KEY]',
   },
   {
@@ -75,7 +78,10 @@ const PII_RULES: Array<{
 function mask(text: string): string {
   let result = text;
   for (const rule of PII_RULES) {
-    result = result.replace(rule.pattern, rule.replacement);
+    const { pattern, replacement } = rule;
+    result = typeof replacement === 'function'
+      ? result.replace(pattern, replacement)
+      : result.replace(pattern, replacement);
   }
   return result;
 }

--- a/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
@@ -95,17 +95,25 @@ describe('PiiMaskingMiddleware', () => {
     const openAiKey = `sk-${'abcdef1234567890'.repeat(2)}`;
     const githubToken = `ghp_${'abcdef1234567890'.repeat(2)}123456`;
     const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
+    const plusBearerToken = `Bearer ${'opaqueToken'.repeat(3)}+`;
+    const tildeBearerToken = `Bearer ${'opaqueToken'.repeat(3)}~`;
     const result = mw.beforeRequest(
       makeRequest(
-        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. dbs=(postgres://user:secret@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done`,
+        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. plus=${plusBearerToken} tilde=${tildeBearerToken} dbs=(postgres://user:secret@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done`,
       ),
     );
     const content = result.messages[0]!.content as string;
     expect(content).toContain('tokens: [API_KEY]. [API_KEY]. Authorization: [API_KEY].');
+    expect(content).toContain('plus=[API_KEY]');
+    expect(content).toContain('tilde=[API_KEY]');
+    expect(content).not.toContain('plus=[API_KEY]+');
+    expect(content).not.toContain('tilde=[API_KEY]~');
     expect(content).toContain('dbs=([CONNECTION_STRING]),[CONNECTION_STRING],done');
     expect(content).not.toContain(openAiKey);
     expect(content).not.toContain(githubToken);
     expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
+    expect(content).not.toContain(plusBearerToken.replace('Bearer ', ''));
+    expect(content).not.toContain(tildeBearerToken.replace('Bearer ', ''));
     expect(content).not.toContain('postgres://user:secret@db.example.com:5432/app');
     expect(content).not.toContain('redis://:cachepass@localhost:6379/0');
   });

--- a/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
@@ -43,6 +43,43 @@ describe('PiiMaskingMiddleware', () => {
     expect((result.messages[0]!.content as string)).toContain('[IP]');
   });
 
+  it('masks common API keys and bearer tokens', () => {
+    const openAiKey = `sk-${'1234567890abcdef'.repeat(2)}`;
+    const githubToken = `ghp_${'1234567890abcdef'.repeat(2)}123456`;
+    const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
+    const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
+
+    const result = mw.beforeRequest(
+      makeRequest(
+        `openai=${openAiKey} github=${githubToken} slack=${slackToken} bearer=${bearerToken}`,
+      ),
+    );
+    const content = result.messages[0]!.content as string;
+    expect(content).toContain('openai=[API_KEY]');
+    expect(content).toContain('github=[API_KEY]');
+    expect(content).toContain('slack=[API_KEY]');
+    expect(content).toContain('bearer=[API_KEY]');
+    expect(content).not.toContain(openAiKey);
+    expect(content).not.toContain(githubToken);
+    expect(content).not.toContain(slackToken);
+    expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
+  });
+
+  it('masks database connection strings', () => {
+    const result = mw.beforeRequest(
+      makeRequest(
+        'primary=postgres://user:secret@db.example.com:5432/app replica=mongodb+srv://admin:p4ss@cluster.example.com/db cache=redis://:cachepass@localhost:6379/0',
+      ),
+    );
+    const content = result.messages[0]!.content as string;
+    expect(content).toContain('primary=[CONNECTION_STRING]');
+    expect(content).toContain('replica=[CONNECTION_STRING]');
+    expect(content).toContain('cache=[CONNECTION_STRING]');
+    expect(content).not.toContain('postgres://user:secret@db.example.com:5432/app');
+    expect(content).not.toContain('mongodb+srv://admin:p4ss@cluster.example.com/db');
+    expect(content).not.toContain('redis://:cachepass@localhost:6379/0');
+  });
+
   it('masks PII in response (afterResponse)', () => {
     const result = mw.afterResponse(makeResponse('Email: user@test.com'));
     expect(result.content).toContain('[EMAIL]');

--- a/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
@@ -46,23 +46,34 @@ describe('PiiMaskingMiddleware', () => {
   it('masks common API keys and bearer tokens', () => {
     const openAiKey = `sk-${'1234567890abcdef'.repeat(2)}`;
     const githubToken = `ghp_${'1234567890abcdef'.repeat(2)}123456`;
+    const githubFineGrainedToken = ['github', 'pat', '11AAAAAAA'].join('_')
+      + `_${'b'.repeat(22)}_${'c'.repeat(59)}`;
+    const githubAppToken = `ghs_${'1234567890abcdef'.repeat(2)}123456`;
     const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
     const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
+    const lowercaseBearerToken = `bearer ${'base64token'.repeat(3)}==`;
 
     const result = mw.beforeRequest(
       makeRequest(
-        `openai=${openAiKey} github=${githubToken} slack=${slackToken} bearer=${bearerToken}`,
+        `openai=${openAiKey} github=${githubToken} github_pat=${githubFineGrainedToken} github_app=${githubAppToken} slack=${slackToken} bearer=${bearerToken} auth=${lowercaseBearerToken}`,
       ),
     );
     const content = result.messages[0]!.content as string;
     expect(content).toContain('openai=[API_KEY]');
     expect(content).toContain('github=[API_KEY]');
+    expect(content).toContain('github_pat=[API_KEY]');
+    expect(content).toContain('github_app=[API_KEY]');
     expect(content).toContain('slack=[API_KEY]');
     expect(content).toContain('bearer=[API_KEY]');
+    expect(content).toContain('auth=[API_KEY]');
     expect(content).not.toContain(openAiKey);
     expect(content).not.toContain(githubToken);
+    expect(content).not.toContain(githubFineGrainedToken);
+    expect(content).not.toContain(githubAppToken);
     expect(content).not.toContain(slackToken);
     expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
+    expect(content).not.toContain(lowercaseBearerToken.replace('bearer ', ''));
+    expect(content).not.toContain('==');
   });
 
   it('masks database connection strings', () => {

--- a/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
@@ -50,13 +50,14 @@ describe('PiiMaskingMiddleware', () => {
       + `_${'b'.repeat(22)}_${'c'.repeat(59)}`;
     const githubAppToken = `ghs_${'1234567890abcdef'.repeat(2)}123456`;
     const githubAppJwtToken = `ghs_${['appHeader', 'appPayload'.repeat(3), 'appSignature'].join('.')}`;
+    const githubAppJwtTokenWithHyphens = `ghs_${['app-header', 'app-payload'.repeat(3), 'app-signature'].join('.')}`;
     const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
     const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
     const lowercaseBearerToken = `bearer ${'base64token'.repeat(3)}==`;
 
     const result = mw.beforeRequest(
       makeRequest(
-        `openai=${openAiKey} github=${githubToken} github_pat=${githubFineGrainedToken} github_app=${githubAppToken} github_app_jwt=${githubAppJwtToken} slack=${slackToken} bearer=${bearerToken} auth=${lowercaseBearerToken}`,
+        `openai=${openAiKey} github=${githubToken} github_pat=${githubFineGrainedToken} github_app=${githubAppToken} github_app_jwt=${githubAppJwtToken} github_app_jwt_hyphen=${githubAppJwtTokenWithHyphens} slack=${slackToken} bearer=${bearerToken} auth=${lowercaseBearerToken}`,
       ),
     );
     const content = result.messages[0]!.content as string;
@@ -65,6 +66,7 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).toContain('github_pat=[API_KEY]');
     expect(content).toContain('github_app=[API_KEY]');
     expect(content).toContain('github_app_jwt=[API_KEY]');
+    expect(content).toContain('github_app_jwt_hyphen=[API_KEY]');
     expect(content).toContain('slack=[API_KEY]');
     expect(content).toContain('bearer=[API_KEY]');
     expect(content).toContain('auth=[API_KEY]');
@@ -73,6 +75,7 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).not.toContain(githubFineGrainedToken);
     expect(content).not.toContain(githubAppToken);
     expect(content).not.toContain(githubAppJwtToken);
+    expect(content).not.toContain(githubAppJwtTokenWithHyphens);
     expect(content).not.toContain(slackToken);
     expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
     expect(content).not.toContain(lowercaseBearerToken.replace('bearer ', ''));
@@ -100,11 +103,12 @@ describe('PiiMaskingMiddleware', () => {
     const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
     const plusBearerToken = `Bearer ${'opaqueToken'.repeat(3)}+`;
     const tildeBearerToken = `Bearer ${'opaqueToken'.repeat(3)}~`;
-    const ipv6Connection = 'postgres://user:secret@[2001:db8::1]:5432/app?sslmode=require';
-    const multiHostConnection = 'postgresql://user:secret@host1:5432,host2:5432/app?sslmode=require';
+    const ipv6Connection = 'postgres://user:***@[2001:db8::1]:5432/app?sslmode=require';
+    const multiHostConnection = 'postgresql://user:***@host1:5432,host2:5432/app?sslmode=require';
+    const multiHostIpv6Connection = 'postgresql://user:***@[2001:db8::1]:5432,[2001:db8::2]:5432/app?sslmode=require';
     const result = mw.beforeRequest(
       makeRequest(
-        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. plus=${plusBearerToken} tilde=${tildeBearerToken} dbs=(postgres://user:secret@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done ipv6=${ipv6Connection}. cluster=${multiHostConnection}.`,
+        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. plus=${plusBearerToken} tilde=${tildeBearerToken} dbs=(postgres://user:***@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done ipv6=${ipv6Connection}. cluster=${multiHostConnection}. cluster6=${multiHostIpv6Connection}.`,
       ),
     );
     const content = result.messages[0]!.content as string;
@@ -116,6 +120,7 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).toContain('dbs=([CONNECTION_STRING]),[CONNECTION_STRING],done');
     expect(content).toContain('ipv6=[CONNECTION_STRING].');
     expect(content).toContain('cluster=[CONNECTION_STRING].');
+    expect(content).toContain('cluster6=[CONNECTION_STRING].');
     expect(content).not.toContain(openAiKey);
     expect(content).not.toContain(githubToken);
     expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
@@ -125,6 +130,7 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).not.toContain('redis://:cachepass@localhost:6379/0');
     expect(content).not.toContain(ipv6Connection);
     expect(content).not.toContain(multiHostConnection);
+    expect(content).not.toContain(multiHostIpv6Connection);
   });
 
   it('masks PII in response (afterResponse)', () => {

--- a/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
@@ -91,6 +91,25 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).not.toContain('redis://:cachepass@localhost:6379/0');
   });
 
+  it('preserves delimiters around masked secrets', () => {
+    const openAiKey = `sk-${'abcdef1234567890'.repeat(2)}`;
+    const githubToken = `ghp_${'abcdef1234567890'.repeat(2)}123456`;
+    const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
+    const result = mw.beforeRequest(
+      makeRequest(
+        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. dbs=(postgres://user:secret@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done`,
+      ),
+    );
+    const content = result.messages[0]!.content as string;
+    expect(content).toContain('tokens: [API_KEY]. [API_KEY]. Authorization: [API_KEY].');
+    expect(content).toContain('dbs=([CONNECTION_STRING]),[CONNECTION_STRING],done');
+    expect(content).not.toContain(openAiKey);
+    expect(content).not.toContain(githubToken);
+    expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
+    expect(content).not.toContain('postgres://user:secret@db.example.com:5432/app');
+    expect(content).not.toContain('redis://:cachepass@localhost:6379/0');
+  });
+
   it('masks PII in response (afterResponse)', () => {
     const result = mw.afterResponse(makeResponse('Email: user@test.com'));
     expect(result.content).toContain('[EMAIL]');

--- a/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/pii-masking.test.ts
@@ -49,13 +49,14 @@ describe('PiiMaskingMiddleware', () => {
     const githubFineGrainedToken = ['github', 'pat', '11AAAAAAA'].join('_')
       + `_${'b'.repeat(22)}_${'c'.repeat(59)}`;
     const githubAppToken = `ghs_${'1234567890abcdef'.repeat(2)}123456`;
+    const githubAppJwtToken = `ghs_${['appHeader', 'appPayload'.repeat(3), 'appSignature'].join('.')}`;
     const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
     const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
     const lowercaseBearerToken = `bearer ${'base64token'.repeat(3)}==`;
 
     const result = mw.beforeRequest(
       makeRequest(
-        `openai=${openAiKey} github=${githubToken} github_pat=${githubFineGrainedToken} github_app=${githubAppToken} slack=${slackToken} bearer=${bearerToken} auth=${lowercaseBearerToken}`,
+        `openai=${openAiKey} github=${githubToken} github_pat=${githubFineGrainedToken} github_app=${githubAppToken} github_app_jwt=${githubAppJwtToken} slack=${slackToken} bearer=${bearerToken} auth=${lowercaseBearerToken}`,
       ),
     );
     const content = result.messages[0]!.content as string;
@@ -63,6 +64,7 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).toContain('github=[API_KEY]');
     expect(content).toContain('github_pat=[API_KEY]');
     expect(content).toContain('github_app=[API_KEY]');
+    expect(content).toContain('github_app_jwt=[API_KEY]');
     expect(content).toContain('slack=[API_KEY]');
     expect(content).toContain('bearer=[API_KEY]');
     expect(content).toContain('auth=[API_KEY]');
@@ -70,6 +72,7 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).not.toContain(githubToken);
     expect(content).not.toContain(githubFineGrainedToken);
     expect(content).not.toContain(githubAppToken);
+    expect(content).not.toContain(githubAppJwtToken);
     expect(content).not.toContain(slackToken);
     expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
     expect(content).not.toContain(lowercaseBearerToken.replace('bearer ', ''));
@@ -97,9 +100,11 @@ describe('PiiMaskingMiddleware', () => {
     const bearerToken = `Bearer ${['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'payload', 'signature'].join('.')}`;
     const plusBearerToken = `Bearer ${'opaqueToken'.repeat(3)}+`;
     const tildeBearerToken = `Bearer ${'opaqueToken'.repeat(3)}~`;
+    const ipv6Connection = 'postgres://user:secret@[2001:db8::1]:5432/app?sslmode=require';
+    const multiHostConnection = 'postgresql://user:secret@host1:5432,host2:5432/app?sslmode=require';
     const result = mw.beforeRequest(
       makeRequest(
-        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. plus=${plusBearerToken} tilde=${tildeBearerToken} dbs=(postgres://user:secret@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done`,
+        `tokens: ${openAiKey}. ${githubToken}. Authorization: ${bearerToken}. plus=${plusBearerToken} tilde=${tildeBearerToken} dbs=(postgres://user:secret@db.example.com:5432/app),redis://:cachepass@localhost:6379/0,done ipv6=${ipv6Connection}. cluster=${multiHostConnection}.`,
       ),
     );
     const content = result.messages[0]!.content as string;
@@ -109,13 +114,17 @@ describe('PiiMaskingMiddleware', () => {
     expect(content).not.toContain('plus=[API_KEY]+');
     expect(content).not.toContain('tilde=[API_KEY]~');
     expect(content).toContain('dbs=([CONNECTION_STRING]),[CONNECTION_STRING],done');
+    expect(content).toContain('ipv6=[CONNECTION_STRING].');
+    expect(content).toContain('cluster=[CONNECTION_STRING].');
     expect(content).not.toContain(openAiKey);
     expect(content).not.toContain(githubToken);
     expect(content).not.toContain(bearerToken.replace('Bearer ', ''));
     expect(content).not.toContain(plusBearerToken.replace('Bearer ', ''));
     expect(content).not.toContain(tildeBearerToken.replace('Bearer ', ''));
-    expect(content).not.toContain('postgres://user:secret@db.example.com:5432/app');
+    expect(content).not.toContain('postgres://user:***@db.example.com:5432/app');
     expect(content).not.toContain('redis://:cachepass@localhost:6379/0');
+    expect(content).not.toContain(ipv6Connection);
+    expect(content).not.toContain(multiHostConnection);
   });
 
   it('masks PII in response (afterResponse)', () => {


### PR DESCRIPTION
## Summary
- Add PII masking rules for common API keys/tokens (`sk-`, `ghp_`, `gho_`, `xoxb-`, and `Bearer ...`).
- Add masking for common database connection strings (`postgres`, `mysql`, `mariadb`, `mongodb`, `redis`).
- Cover the new secret classes with unit tests while constructing fake tokens at runtime to avoid GitHub push-protection false positives.

## Test Plan
- `npm test -- --run tests/unit/middleware/pii-masking.test.ts` (RED: failed before implementation for new API-key/token and connection-string cases)
- `npm test -- --run tests/unit/middleware/pii-masking.test.ts` (GREEN: 11/11 passed)
- `npm run typecheck && npm test` in `packages/franken-orchestrator` (typecheck passed; 2127 tests passed, 1 skipped)

Fixes #84
