### PR TITLE
fix(planner): escape markdown in plan exports

### DIFF
--- a/packages/franken-planner/src/hitl/plan-exporter.ts
+++ b/packages/franken-planner/src/hitl/plan-exporter.ts
@@ -1,5 +1,9 @@
 import type { PlanGraph } from '../core/dag.js';
 
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_{}\[\]()#+.!|>])/g, '\\$1');
+}
+
 /**
  * Renders a PlanGraph as a Markdown checklist for HITL review (ADR-006).
  * Output is deterministic: tasks appear in topological order.
@@ -16,9 +20,12 @@ export class PlanExporter {
 
     for (const task of tasks) {
       const deps = graph.getDependencies(task.id);
+      const escapedDeps = deps.map((dep) => escapeMarkdownText(dep));
       const depsAnnotation =
-        deps.length > 0 ? ` _(depends on: ${deps.join(', ')})_` : '';
-      lines.push(`- [ ] **${task.id}**: ${task.objective}${depsAnnotation}`);
+        escapedDeps.length > 0 ? ` _(depends on: ${escapedDeps.join(', ')})_` : '';
+      lines.push(
+        `- [ ] **${escapeMarkdownText(task.id)}**: ${escapeMarkdownText(task.objective)}${depsAnnotation}`
+      );
     }
 
     lines.push('');

--- a/packages/franken-planner/tests/unit/hitl/plan-exporter.test.ts
+++ b/packages/franken-planner/tests/unit/hitl/plan-exporter.test.ts
@@ -59,6 +59,25 @@ describe('PlanExporter.toMarkdown', () => {
     expect(md).toContain('a');
   });
 
+  it('escapes markdown syntax in task ids and objectives', () => {
+    const task: Task = {
+      id: createTaskId('task**[spoof](https://evil.example)'),
+      objective: 'Ship **approved** [payload](https://evil.example)',
+      requiredSkills: [],
+      dependsOn: [],
+      status: 'pending',
+    };
+    const graph = PlanGraph.empty().addTask(task);
+
+    const md = new PlanExporter().toMarkdown(graph);
+
+    expect(md).toContain(
+      '- [ ] **task\\*\\*\\[spoof\\]\\(https://evil\\.example\\)**: Ship \\*\\*approved\\*\\* \\[payload\\]\\(https://evil\\.example\\)'
+    );
+    expect(md).not.toContain('task**[spoof](https://evil.example)');
+    expect(md).not.toContain('Ship **approved** [payload](https://evil.example)');
+  });
+
   it('lists tasks in topological order', () => {
     const graph = PlanGraph.empty()
       .addTask(makeTask('a'))


### PR DESCRIPTION
Escapes Markdown special characters in exported task IDs and objectives and adds regression coverage for Markdown injection in plan export display.

Worker handoff:
- Commit: fc705182d4bf77cbbaf7f12d5407b9e293c2dd5d
- Tests: franken-planner plan-exporter targeted tests passed.

Fixes #76
