### PR TITLE
fix(types): add recovery fields to FrankenContext

### DIFF
--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -3,29 +3,29 @@ import { dirname } from 'node:path';
 import type { ICheckpointStore } from '../deps.js';
 
 export class FileCheckpointStore implements ICheckpointStore {
-  constructor(private readonly filePath: string) {}
+  constructor(public readonly checkpointPath: string) {}
 
   has(key: string): boolean {
     return this.readAll().has(key);
   }
 
   write(key: string): void {
-    mkdirSync(dirname(this.filePath), { recursive: true });
-    appendFileSync(this.filePath, key + '\n');
+    mkdirSync(dirname(this.checkpointPath), { recursive: true });
+    appendFileSync(this.checkpointPath, key + '\n');
   }
 
   readAll(): Set<string> {
-    if (!existsSync(this.filePath)) {
+    if (!existsSync(this.checkpointPath)) {
       return new Set();
     }
-    const content = readFileSync(this.filePath, 'utf-8');
+    const content = readFileSync(this.checkpointPath, 'utf-8');
     const lines = content.split('\n').filter((line) => line.length > 0);
     return new Set(lines);
   }
 
   clear(): void {
-    if (existsSync(this.filePath)) {
-      writeFileSync(this.filePath, '');
+    if (existsSync(this.checkpointPath)) {
+      writeFileSync(this.checkpointPath, '');
     }
   }
 

--- a/packages/franken-orchestrator/src/context/franken-context.ts
+++ b/packages/franken-orchestrator/src/context/franken-context.ts
@@ -26,6 +26,12 @@ export class BeastContext {
   } | undefined;
 
   plan?: PlanGraph | undefined;
+  errorContext?: Error[] | undefined;
+  circuitBreakerTripped?: boolean | undefined;
+  critiqueFeedback?: string | undefined;
+  governorApproval?: boolean | undefined;
+  retryCount?: number | undefined;
+  checkpointPath?: string | undefined;
   phase: BeastPhase = 'ingestion';
 
   tokenSpend: TokenSpend = {

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -190,6 +190,7 @@ export interface McpToolInfo {
 
 /** Checkpoint persistence for crash recovery. */
 export interface ICheckpointStore {
+  readonly checkpointPath?: string | undefined;
   has(key: string): boolean;
   write(key: string): void;
   readAll(): Set<string>;

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -43,6 +43,7 @@ export async function runExecution(
   refreshPlanTasks?: () => Promise<readonly PlanTask[]>,
 ): Promise<readonly TaskOutcome[]> {
   ctx.phase = 'execution';
+  ctx.checkpointPath = checkpoint?.checkpointPath;
   ctx.addAudit('orchestrator', 'phase:start', { phase: 'execution' });
   logger.info('Execution: start', { phase: 'execution' });
 
@@ -88,6 +89,7 @@ export async function runExecution(
 
     if (readyIndex === -1) {
       // All remaining tasks have unmet dependencies — deadlock
+      ctx.circuitBreakerTripped = true;
       for (const task of pending) {
         outcomes.push({
           taskId: task.id,
@@ -159,6 +161,7 @@ async function executeTask(
   cliExecutor?: CliSkillExecutor,
   checkpoint?: ICheckpointStore,
 ): Promise<TaskOutcome> {
+  ctx.retryCount = (ctx.retryCount ?? 0) + 1;
   const startTime = Date.now();
   const span = observer.startSpan(`task:${task.id}`);
   logger.info('Execution: task start', {
@@ -193,8 +196,10 @@ async function executeTask(
         decision: approval.decision,
         reason: approval.reason,
       });
+      ctx.governorApproval = approval.decision === 'approved';
 
       if (approval.decision === 'rejected' || approval.decision === 'abort') {
+        ctx.circuitBreakerTripped = true;
         ctx.addAudit('governor', 'task:rejected', { taskId: task.id, reason: approval.reason });
         logger.warn('Execution: task rejected', {
           taskId: task.id,
@@ -308,7 +313,10 @@ async function executeTask(
     });
     return { taskId: task.id, status: 'success', output };
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
+    const errorObject = error instanceof Error ? error : new Error(String(error));
+    ctx.errorContext = [...(ctx.errorContext ?? []), errorObject];
+    ctx.circuitBreakerTripped = true;
+    const errorMsg = errorObject.message;
     ctx.addAudit('executor', 'task:failed', { taskId: task.id, error: errorMsg });
     logger.error('Execution: task failed', { taskId: task.id, error: errorMsg });
     await memory.recordTrace({

--- a/packages/franken-orchestrator/src/phases/planning.ts
+++ b/packages/franken-orchestrator/src/phases/planning.ts
@@ -1,5 +1,5 @@
 import type { BeastContext } from '../context/franken-context.js';
-import type { IPlannerModule, ICritiqueModule, ILogger } from '../deps.js';
+import type { IPlannerModule, ICritiqueModule, ILogger, PlanIntent } from '../deps.js';
 import type { GraphBuilder } from '../planning/chunk-file-graph-builder.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import { NullLogger } from '../logger.js';
@@ -60,12 +60,17 @@ export async function runPlanning(
     if (i > 0) {
       logger.info('Planning: replan', { iteration: i + 1 });
     }
-    // Create or re-create plan
-    const plan = await planner.createPlan({
+    // Create or re-create plan. On replans, carry the prior critique feedback
+    // into the planner request so the iteration can actually repair the plan
+    // instead of receiving identical input and repeating until CritiqueSpiralError.
+    const planIntent: PlanIntent = {
       goal: ctx.sanitizedIntent.goal,
       strategy: ctx.sanitizedIntent.strategy,
-      context: ctx.sanitizedIntent.context,
-    });
+      context: ctx.critiqueFeedback
+        ? { ...ctx.sanitizedIntent.context, critiqueFeedback: ctx.critiqueFeedback }
+        : ctx.sanitizedIntent.context,
+    };
+    const plan = await planner.createPlan(planIntent);
 
     ctx.plan = plan;
     ctx.addAudit('planner', 'plan:created', {
@@ -82,6 +87,11 @@ export async function runPlanning(
       ctx.critiqueFeedback = critiqueResult.findings
         .map(finding => `${finding.evaluator}: ${finding.message}`)
         .join('\n');
+    } else {
+      // A clean review supersedes any earlier findings; clear the stale text so
+      // downstream recovery/closure logic doesn't treat an approved plan as
+      // still needing the previous fixes.
+      ctx.critiqueFeedback = undefined;
     }
 
     ctx.addAudit('critique', 'plan:reviewed', {

--- a/packages/franken-orchestrator/src/phases/planning.ts
+++ b/packages/franken-orchestrator/src/phases/planning.ts
@@ -78,6 +78,11 @@ export async function runPlanning(
     // Critique the plan
     const critiqueResult = await critique.reviewPlan(plan);
     lastScore = critiqueResult.score;
+    if (critiqueResult.findings.length > 0) {
+      ctx.critiqueFeedback = critiqueResult.findings
+        .map(finding => `${finding.evaluator}: ${finding.message}`)
+        .join('\n');
+    }
 
     ctx.addAudit('critique', 'plan:reviewed', {
       iteration: i + 1,

--- a/packages/franken-orchestrator/src/resilience/context-serializer.ts
+++ b/packages/franken-orchestrator/src/resilience/context-serializer.ts
@@ -16,9 +16,22 @@ export interface ContextSnapshot {
     context?: Record<string, unknown> | undefined;
   } | undefined;
   readonly plan?: PlanGraph | undefined;
+  readonly errorContext?: ReadonlyArray<SerializedError> | undefined;
+  readonly circuitBreakerTripped?: boolean | undefined;
+  readonly critiqueFeedback?: string | undefined;
+  readonly governorApproval?: boolean | undefined;
+  readonly retryCount?: number | undefined;
+  readonly checkpointPath?: string | undefined;
   readonly tokenSpend: TokenSpend;
   readonly audit: readonly AuditEntry[];
   readonly savedAt: string;
+}
+
+/** JSON-safe representation of an Error retained in errorContext. */
+export interface SerializedError {
+  readonly name: string;
+  readonly message: string;
+  readonly stack?: string | undefined;
 }
 
 /** Serialize a BeastContext to a JSON snapshot. */
@@ -30,6 +43,16 @@ export function serializeContext(ctx: BeastContext): ContextSnapshot {
     phase: ctx.phase,
     sanitizedIntent: ctx.sanitizedIntent,
     plan: ctx.plan,
+    errorContext: ctx.errorContext?.map((err) => ({
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    })),
+    circuitBreakerTripped: ctx.circuitBreakerTripped,
+    critiqueFeedback: ctx.critiqueFeedback,
+    governorApproval: ctx.governorApproval,
+    retryCount: ctx.retryCount,
+    checkpointPath: ctx.checkpointPath,
     tokenSpend: ctx.tokenSpend,
     audit: ctx.audit,
     savedAt: new Date().toISOString(),
@@ -42,6 +65,21 @@ export function deserializeContext(snapshot: ContextSnapshot): BeastContext {
   ctx.phase = snapshot.phase;
   ctx.sanitizedIntent = snapshot.sanitizedIntent;
   ctx.plan = snapshot.plan;
+  if (snapshot.errorContext) {
+    ctx.errorContext = snapshot.errorContext.map((serialized) => {
+      const err = new Error(serialized.message);
+      err.name = serialized.name;
+      if (serialized.stack !== undefined) {
+        err.stack = serialized.stack;
+      }
+      return err;
+    });
+  }
+  ctx.circuitBreakerTripped = snapshot.circuitBreakerTripped;
+  ctx.critiqueFeedback = snapshot.critiqueFeedback;
+  ctx.governorApproval = snapshot.governorApproval;
+  ctx.retryCount = snapshot.retryCount;
+  ctx.checkpointPath = snapshot.checkpointPath;
   ctx.tokenSpend = snapshot.tokenSpend;
 
   for (const entry of snapshot.audit) {

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -78,6 +78,7 @@ describe('runExecution', () => {
     expect(governor.requestApproval).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 't1', requiresHitl: true }),
     );
+    expect(c.governorApproval).toBe(true);
   });
 
   it('skips task when governor rejects', async () => {
@@ -98,6 +99,29 @@ describe('runExecution', () => {
 
     const outcomes = await runExecution(c, skills, governor, makeMemory(), makeObserver());
     expect(outcomes[0]!.status).toBe('skipped');
+    expect(c.governorApproval).toBe(false);
+    expect(c.circuitBreakerTripped).toBe(true);
+  });
+
+  it('tracks retry count and checkpoint path for execution recovery', async () => {
+    const c = ctx([
+      { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },
+      { id: 't2', objective: 'second', requiredSkills: [], dependsOn: [] },
+    ]);
+    const checkpoint = {
+      checkpointPath: '/tmp/franken-checkpoint.txt',
+      has: vi.fn(() => false),
+      write: vi.fn(),
+      readAll: vi.fn(() => new Set<string>()),
+      clear: vi.fn(),
+      recordCommit: vi.fn(),
+      lastCommit: vi.fn(),
+    };
+
+    await runExecution(c, makeSkills(), makeGovernor(), makeMemory(), makeObserver(), undefined, undefined, undefined, checkpoint);
+
+    expect(c.retryCount).toBe(2);
+    expect(c.checkpointPath).toBe('/tmp/franken-checkpoint.txt');
   });
 
   it('throws if plan is missing', async () => {
@@ -314,6 +338,10 @@ describe('runExecution', () => {
     expect(memory.recordTrace).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 't1', outcome: 'failure' }),
     );
+    expect(c.errorContext).toHaveLength(1);
+    expect(c.errorContext![0]).toBeInstanceOf(Error);
+    expect(c.errorContext![0]!.message).toBe('boom');
+    expect(c.circuitBreakerTripped).toBe(true);
   });
 
   // ── CLI skill routing tests ──

--- a/packages/franken-orchestrator/tests/unit/phases/planning.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/planning.test.ts
@@ -53,6 +53,29 @@ describe('runPlanning', () => {
 
   it('stores critique feedback on context so replanning can recover from findings', async () => {
     const c = ctx();
+    const critique = makeCritique({
+      reviewPlan: vi.fn(async () => ({
+        verdict: 'fail' as const,
+        findings: [
+          { evaluator: 'safety', severity: 'critical', message: 'add a rollback step' },
+          { evaluator: 'quality', severity: 'warning', message: 'split deployment task' },
+        ],
+        score: 0.3,
+      })),
+    });
+    const config = { ...defaultConfig(), maxCritiqueIterations: 1 };
+
+    // When the run ends on findings, the feedback persists for downstream use.
+    await expect(runPlanning(c, makePlanner(), critique, config)).rejects.toThrow(
+      CritiqueSpiralError,
+    );
+
+    expect(c.critiqueFeedback).toBe('safety: add a rollback step\nquality: split deployment task');
+  });
+
+  it('propagates prior critique feedback into the replan request', async () => {
+    const c = ctx();
+    c.sanitizedIntent = { goal: 'ship it', strategy: 'safe', context: { repo: 'x' } };
     let callCount = 0;
     const critique = makeCritique({
       reviewPlan: vi.fn(async () => {
@@ -60,20 +83,51 @@ describe('runPlanning', () => {
         if (callCount === 1) {
           return {
             verdict: 'fail' as const,
-            findings: [
-              { evaluator: 'safety', severity: 'critical', message: 'add a rollback step' },
-              { evaluator: 'quality', severity: 'warning', message: 'split deployment task' },
-            ],
+            findings: [{ evaluator: 'safety', severity: 'critical', message: 'add a rollback step' }],
             score: 0.3,
           };
         }
         return { verdict: 'pass' as const, findings: [], score: 0.9 };
       }),
     });
+    const planner = makePlanner();
+
+    await runPlanning(c, planner, critique, defaultConfig());
+
+    // First call: no feedback yet (original context preserved).
+    expect(planner.createPlan).toHaveBeenNthCalledWith(1, {
+      goal: 'ship it',
+      strategy: 'safe',
+      context: { repo: 'x' },
+    });
+    // Second call (replan): feedback injected into context for plan repair.
+    expect(planner.createPlan).toHaveBeenNthCalledWith(2, {
+      goal: 'ship it',
+      strategy: 'safe',
+      context: { repo: 'x', critiqueFeedback: 'safety: add a rollback step' },
+    });
+  });
+
+  it('clears stale critique feedback after a later clean review', async () => {
+    const c = ctx();
+    let callCount = 0;
+    const critique = makeCritique({
+      reviewPlan: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            verdict: 'fail' as const,
+            findings: [{ evaluator: 'safety', severity: 'critical', message: 'fix this' }],
+            score: 0.3,
+          };
+        }
+        return { verdict: 'pass' as const, findings: [], score: 0.95 };
+      }),
+    });
 
     await runPlanning(c, makePlanner(), critique, defaultConfig());
 
-    expect(c.critiqueFeedback).toBe('safety: add a rollback step\nquality: split deployment task');
+    expect(c.critiqueFeedback).toBeUndefined();
   });
 
   it('throws CritiqueSpiralError after max iterations', async () => {

--- a/packages/franken-orchestrator/tests/unit/phases/planning.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/planning.test.ts
@@ -51,6 +51,31 @@ describe('runPlanning', () => {
     expect(critique.reviewPlan).toHaveBeenCalledTimes(2);
   });
 
+  it('stores critique feedback on context so replanning can recover from findings', async () => {
+    const c = ctx();
+    let callCount = 0;
+    const critique = makeCritique({
+      reviewPlan: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            verdict: 'fail' as const,
+            findings: [
+              { evaluator: 'safety', severity: 'critical', message: 'add a rollback step' },
+              { evaluator: 'quality', severity: 'warning', message: 'split deployment task' },
+            ],
+            score: 0.3,
+          };
+        }
+        return { verdict: 'pass' as const, findings: [], score: 0.9 };
+      }),
+    });
+
+    await runPlanning(c, makePlanner(), critique, defaultConfig());
+
+    expect(c.critiqueFeedback).toBe('safety: add a rollback step\nquality: split deployment task');
+  });
+
   it('throws CritiqueSpiralError after max iterations', async () => {
     const c = ctx();
     const critique = makeCritique({

--- a/packages/franken-orchestrator/tests/unit/resilience/context-serializer.test.ts
+++ b/packages/franken-orchestrator/tests/unit/resilience/context-serializer.test.ts
@@ -87,6 +87,30 @@ describe('ContextSerializer', () => {
     expect(restored.plan?.tasks).toEqual(ctx.plan?.tasks);
   });
 
+  it('round-trips recovery/error-handling fields', () => {
+    const ctx = makeContext();
+    ctx.errorContext = [new TypeError('boom')];
+    ctx.circuitBreakerTripped = true;
+    ctx.critiqueFeedback = 'safety: tighten validation';
+    ctx.governorApproval = false;
+    ctx.retryCount = 3;
+    ctx.checkpointPath = '/tmp/checkpoint.json';
+
+    const snapshot = serializeContext(ctx);
+    // Snapshot must be JSON-safe (errors serialized to plain objects).
+    const restored = deserializeContext(JSON.parse(JSON.stringify(snapshot)));
+
+    expect(restored.circuitBreakerTripped).toBe(true);
+    expect(restored.critiqueFeedback).toBe('safety: tighten validation');
+    expect(restored.governorApproval).toBe(false);
+    expect(restored.retryCount).toBe(3);
+    expect(restored.checkpointPath).toBe('/tmp/checkpoint.json');
+    expect(restored.errorContext).toHaveLength(1);
+    expect(restored.errorContext?.[0]).toBeInstanceOf(Error);
+    expect(restored.errorContext?.[0]?.name).toBe('TypeError');
+    expect(restored.errorContext?.[0]?.message).toBe('boom');
+  });
+
   it('handles context with no plan or sanitized intent', () => {
     const ctx = new BeastContext('proj-2', 'sess-2', 'Hello');
     const snapshot = serializeContext(ctx);

--- a/packages/franken-types/src/context.ts
+++ b/packages/franken-types/src/context.ts
@@ -14,6 +14,12 @@ export interface FrankenContext {
     context?: Record<string, unknown>;
   };
   plan?: unknown; // PlanGraph is module-specific
+  errorContext?: Error[];
+  circuitBreakerTripped?: boolean;
+  critiqueFeedback?: string;
+  governorApproval?: boolean;
+  retryCount?: number;
+  checkpointPath?: string;
   tokenSpend: TokenSpend;
   audit: Array<{
     timestamp: string;


### PR DESCRIPTION
Adds optional recovery/error-handling fields to FrankenContext and updates consuming modules to populate the new context fields.

Worker handoff:
- Commit: 185bdb696f23dac47e21ea14749f6c6952392177
- Tests: worker reported targeted verification passing.

Fixes #79
