### PR TITLE
fix(observer): detect varied loop patterns

### DIFF
--- a/packages/franken-observer/src/incident/LoopDetector.test.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.test.ts
@@ -70,6 +70,40 @@ describe('LoopDetector', () => {
     })
   })
 
+  describe('varied repetition patterns', () => {
+    it('detects fuzzy span-name repetitions with volatile metadata differences', () => {
+      const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 3 })
+
+      for (const name of [
+        'tool:search duration=101ms',
+        'tool:execute tokens=504',
+        'tool:search duration=117ms',
+        'tool:execute tokens=512',
+        'tool:search duration=124ms',
+      ]) {
+        expect(detector.check(name).detected).toBe(false)
+      }
+
+      const result = detector.check('tool:execute tokens=521')
+      expect(result.detected).toBe(true)
+      expect(result.detectedPattern).toEqual(['tool:search duration=101ms', 'tool:execute tokens=504'])
+      expect(result.repetitions).toBe(3)
+    })
+
+    it('detects repeated patterns separated by small gaps in history', () => {
+      const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 3 })
+
+      for (const name of ['plan', 'execute', 'heartbeat', 'plan', 'execute', 'retry-wait', 'plan']) {
+        expect(detector.check(name).detected).toBe(false)
+      }
+
+      const result = detector.check('execute')
+      expect(result.detected).toBe(true)
+      expect(result.detectedPattern).toEqual(['plan', 'execute'])
+      expect(result.repetitions).toBe(3)
+    })
+  })
+
   describe('event emission', () => {
     it('emits a loop-detected event when a loop is found', () => {
       const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 2 })

--- a/packages/franken-observer/src/incident/LoopDetector.test.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.test.ts
@@ -104,6 +104,43 @@ describe('LoopDetector', () => {
     })
   })
 
+  describe('ordinal progressions are not loops', () => {
+    it('does not flag a normal incrementing iteration counter as a loop', () => {
+      // Mirrors the CLI executor span naming cli:<chunk>:iter-<n> over a normal
+      // 9-iteration run under the default detector.
+      const detector = new LoopDetector()
+      let detected = false
+      for (let i = 1; i <= 9; i += 1) {
+        detected = detector.check(`cli:chunk-a:iter-${i}`).detected || detected
+      }
+      expect(detected).toBe(false)
+    })
+
+    it('does not collapse hyphenated ordinal step names', () => {
+      const detector = new LoopDetector({ windowSize: 1, repeatThreshold: 3 })
+      for (const n of ['step-1', 'step-2']) {
+        expect(detector.check(n).detected).toBe(false)
+      }
+      expect(detector.check('step-3').detected).toBe(false)
+    })
+  })
+
+  describe('history retention for large windows', () => {
+    it('still detects loops when windowSize × repeatThreshold exceeds the default historyLimit', () => {
+      const detector = new LoopDetector({ windowSize: 50, repeatThreshold: 3 })
+      const pattern = Array.from({ length: 50 }, (_, i) => `span-${i}-fixed`)
+      let result = { detected: false } as ReturnType<typeof detector.check>
+      // Feed the 50-span pattern three times (150 spans > default 100 limit).
+      for (let rep = 0; rep < 3; rep += 1) {
+        for (const name of pattern) {
+          result = detector.check(name)
+        }
+      }
+      expect(result.detected).toBe(true)
+      expect(result.repetitions).toBe(3)
+    })
+  })
+
   describe('event emission', () => {
     it('emits a loop-detected event when a loop is found', () => {
       const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 2 })

--- a/packages/franken-observer/src/incident/LoopDetector.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.ts
@@ -37,7 +37,13 @@ export class LoopDetector {
     this.repeatThreshold = options.repeatThreshold ?? 3
     this.similarityThreshold = options.similarityThreshold ?? 0.85
     this.maxGapBetweenRepetitions = options.maxGapBetweenRepetitions ?? 1
-    this.historyLimit = options.historyLimit ?? 100
+    // Never retain fewer spans than a full detection span needs, otherwise
+    // check() would trim history below detectLoop()'s minLength gate and no
+    // loop could ever be reported for larger window/threshold configurations.
+    const spanNeededForDetection =
+      this.windowSize * this.repeatThreshold +
+      Math.max(0, this.repeatThreshold - 1) * this.maxGapBetweenRepetitions
+    this.historyLimit = Math.max(options.historyLimit ?? 100, spanNeededForDetection)
   }
 
   check(spanName: string): LoopDetectionResult {
@@ -121,6 +127,14 @@ export class LoopDetector {
       return true
     }
 
+    // Names that differ only by ordinal counters (e.g. `step-1` vs `step-2`,
+    // `iter-1` vs `iter-9`) represent normal progression, not a loop. Without
+    // this guard the fuzzy match below would also collapse them into a fake
+    // loop because the edit distance is tiny.
+    if (LoopDetector.maskDigits(normalizedLeft) === LoopDetector.maskDigits(normalizedRight)) {
+      return false
+    }
+
     if (normalizedLeft.length < 6 || normalizedRight.length < 6) {
       return false
     }
@@ -128,12 +142,22 @@ export class LoopDetector {
     return LoopDetector.similarity(normalizedLeft, normalizedRight) >= this.similarityThreshold
   }
 
+  private static maskDigits(value: string): string {
+    return value.replace(/\d+/g, '#')
+  }
+
   private static normalizeSpanName(spanName: string): string {
     return spanName
       .toLowerCase()
       .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/g, '#')
       .replace(/\b0x[0-9a-f]+\b/g, '#')
-      .replace(/\b\d+(?:\.\d+)?\s*(?:ms|s|sec|secs|seconds|tokens?|bytes?|kb|mb)?\b/g, '#')
+      .replace(/\b\d+(?:\.\d+)?\s*(?:ms|s|sec|secs|seconds|tokens?|bytes?|kb|mb)\b/g, '#')
+      // Collapse volatile metadata values written as `key=value`
+      // (e.g. `tokens=504`) so changing counts don't defeat loop detection.
+      // Bare ordinal suffixes like `iter-1` are intentionally left intact and
+      // handled by the digit-mask guard in spanNamesMatch(). `:` is the span
+      // namespace separator here, so it is deliberately excluded.
+      .replace(/=\s*\d+(?:\.\d+)?\b/g, '=#')
       .replace(/\s+/g, ' ')
       .trim()
   }

--- a/packages/franken-observer/src/incident/LoopDetector.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.ts
@@ -7,8 +7,14 @@ export interface LoopDetectionResult {
 export interface LoopDetectorOptions {
   /** Number of spans in a single repeating window. Default: 3. */
   windowSize?: number
-  /** How many consecutive repetitions trigger detection. Default: 3. */
+  /** How many repetitions trigger detection. Default: 3. */
   repeatThreshold?: number
+  /** Minimum normalized string similarity for fuzzy span-name matches. Default: 0.85. */
+  similarityThreshold?: number
+  /** Number of unrelated spans allowed between repeated pattern windows. Default: 1. */
+  maxGapBetweenRepetitions?: number
+  /** Maximum span names retained for loop detection. Default: 100. */
+  historyLimit?: number
 }
 
 type LoopHandler = (result: LoopDetectionResult) => void
@@ -20,38 +26,29 @@ type LoopHandler = (result: LoopDetectionResult) => void
 export class LoopDetector {
   private readonly windowSize: number
   private readonly repeatThreshold: number
+  private readonly similarityThreshold: number
+  private readonly maxGapBetweenRepetitions: number
+  private readonly historyLimit: number
   private readonly handlers = new Set<LoopHandler>()
   private history: string[] = []
 
   constructor(options: LoopDetectorOptions = {}) {
     this.windowSize = options.windowSize ?? 3
     this.repeatThreshold = options.repeatThreshold ?? 3
+    this.similarityThreshold = options.similarityThreshold ?? 0.85
+    this.maxGapBetweenRepetitions = options.maxGapBetweenRepetitions ?? 1
+    this.historyLimit = options.historyLimit ?? 100
   }
 
   check(spanName: string): LoopDetectionResult {
     this.history.push(spanName)
-
-    const minLength = this.windowSize * this.repeatThreshold
-    if (this.history.length < minLength) {
-      return { detected: false, detectedPattern: [], repetitions: 0 }
+    if (this.history.length > this.historyLimit) {
+      this.history = this.history.slice(-this.historyLimit)
     }
 
-    // Examine the most recent minLength entries
-    const tail = this.history.slice(-minLength)
-    const pattern = tail.slice(0, this.windowSize)
-
-    const allMatch = Array.from({ length: this.repeatThreshold }, (_, i) =>
-      pattern.every((p, j) => p === tail[i * this.windowSize + j]),
-    ).every(Boolean)
-
-    if (!allMatch) {
-      return { detected: false, detectedPattern: [], repetitions: 0 }
-    }
-
-    const result: LoopDetectionResult = {
-      detected: true,
-      detectedPattern: pattern,
-      repetitions: this.repeatThreshold,
+    const result = this.detectLoop()
+    if (!result.detected) {
+      return result
     }
 
     for (const handler of this.handlers) {
@@ -59,6 +56,113 @@ export class LoopDetector {
     }
 
     return result
+  }
+
+  private detectLoop(): LoopDetectionResult {
+    const minLength = this.windowSize * this.repeatThreshold
+    if (this.history.length < minLength) {
+      return { detected: false, detectedPattern: [], repetitions: 0 }
+    }
+
+    const latestPatternStart = this.history.length - this.windowSize
+
+    for (let start = 0; start <= latestPatternStart; start += 1) {
+      const pattern = this.history.slice(start, start + this.windowSize)
+      let repetitions = 1
+      let cursor = start + this.windowSize
+
+      while (repetitions < this.repeatThreshold) {
+        const nextStart = this.findNextPatternStart(pattern, cursor)
+        if (nextStart === undefined) {
+          break
+        }
+
+        repetitions += 1
+        cursor = nextStart + this.windowSize
+      }
+
+      if (repetitions >= this.repeatThreshold && cursor === this.history.length) {
+        return {
+          detected: true,
+          detectedPattern: pattern,
+          repetitions,
+        }
+      }
+    }
+
+    return { detected: false, detectedPattern: [], repetitions: 0 }
+  }
+
+  private findNextPatternStart(pattern: string[], searchStart: number): number | undefined {
+    const latestPatternStart = this.history.length - this.windowSize
+    const latestAllowedStart = Math.min(
+      latestPatternStart,
+      searchStart + this.maxGapBetweenRepetitions,
+    )
+
+    for (let candidate = searchStart; candidate <= latestAllowedStart; candidate += 1) {
+      if (this.windowMatches(pattern, candidate)) {
+        return candidate
+      }
+    }
+
+    return undefined
+  }
+
+  private windowMatches(pattern: string[], start: number): boolean {
+    return pattern.every((spanName, index) => this.spanNamesMatch(spanName, this.history[start + index]))
+  }
+
+  private spanNamesMatch(left: string, right: string): boolean {
+    const normalizedLeft = LoopDetector.normalizeSpanName(left)
+    const normalizedRight = LoopDetector.normalizeSpanName(right)
+
+    if (normalizedLeft === normalizedRight) {
+      return true
+    }
+
+    if (normalizedLeft.length < 6 || normalizedRight.length < 6) {
+      return false
+    }
+
+    return LoopDetector.similarity(normalizedLeft, normalizedRight) >= this.similarityThreshold
+  }
+
+  private static normalizeSpanName(spanName: string): string {
+    return spanName
+      .toLowerCase()
+      .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/g, '#')
+      .replace(/\b0x[0-9a-f]+\b/g, '#')
+      .replace(/\b\d+(?:\.\d+)?\s*(?:ms|s|sec|secs|seconds|tokens?|bytes?|kb|mb)?\b/g, '#')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+
+  private static similarity(left: string, right: string): number {
+    const maxLength = Math.max(left.length, right.length)
+    if (maxLength === 0) {
+      return 1
+    }
+
+    return 1 - LoopDetector.levenshteinDistance(left, right) / maxLength
+  }
+
+  private static levenshteinDistance(left: string, right: string): number {
+    const previous = Array.from({ length: right.length + 1 }, (_, index) => index)
+
+    for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+      let upperLeft = previous[0]
+      previous[0] = leftIndex + 1
+
+      for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+        const upper = previous[rightIndex + 1]
+        const cost = left[leftIndex] === right[rightIndex] ? 0 : 1
+        previous[rightIndex + 1] = Math.min(previous[rightIndex + 1] + 1, previous[rightIndex] + 1, upperLeft + cost)
+        upperLeft = upper
+      }
+    }
+
+    return previous[right.length]
   }
 
   on(event: 'loop-detected', handler: LoopHandler): void {


### PR DESCRIPTION
Improves LoopDetector by normalizing volatile span-name tokens, adding fuzzy matching, and detecting repeated windows with gaps instead of exact tail-only repetition.

Worker handoff:
- Commit: a2c75876612920e260c8198cd40f51d1c45811ca
- Tests: LoopDetector targeted tests passed; broader observer checks reported by worker.

Fixes #78
