### PR TITLE
fix(planner): reject trivial error patterns

### DIFF
--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -3,11 +3,15 @@ import type { KnownError } from '../core/types.js';
 const MIN_PATTERN_LENGTH = 6;
 const WORD_CHAR_CLASS = String.raw`\p{L}\p{N}_`;
 /**
- * Canonical OS/CLI error codes (e.g. `EPERM`, `EPIPE`, `SIGKILL`) are short but
- * highly specific, so they are exempt from the minimum-length trivial-pattern
- * gate. Matches an uppercase, underscore-or-digit token of at least 3 chars.
+ * Canonical OS/CLI error codes are short but highly specific, so they are exempt
+ * from the minimum-length trivial-pattern gate. The exemption is restricted to
+ * recognized code shapes — errno (`EPERM`, `EPIPE`, `ENOENT`), Node error codes
+ * (`ERR_MODULE_NOT_FOUND`), and signals (`SIGKILL`, `SIGTERM`) — so arbitrary
+ * short uppercase words like `THE`/`AND` are NOT exempted (which would otherwise
+ * reintroduce broad false positives). Matched case-insensitively to mirror the
+ * `iu` matcher, so a lowercase stored code such as `eperm` is still accepted.
  */
-const CANONICAL_ERROR_CODE = /^[A-Z][A-Z0-9_]{2,}$/;
+const CANONICAL_ERROR_CODE = /^(?:E[A-Z]{2,}|ERR_[A-Z0-9_]+|SIG[A-Z]+)$/i;
 
 export type ErrorClassification =
   | { type: 'known'; knownError: KnownError }

--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -1,20 +1,49 @@
 import type { KnownError } from '../core/types.js';
 
+const MIN_PATTERN_LENGTH = 6;
+const WORD_CHAR_CLASS = String.raw`\p{L}\p{N}_`;
+
 export type ErrorClassification =
   | { type: 'known'; knownError: KnownError }
   | { type: 'unknown' };
 
 /**
  * Classifies a task error against a list of known error patterns from MOD-03.
- * Matching is case-insensitive substring search on the error message.
+ * Patterns are validated before matching, then matched case-insensitively as
+ * literal text bounded by non-word characters to avoid broad substring hits.
  */
 export class ErrorIngester {
   classify(error: Error, knownErrors: KnownError[]): ErrorClassification {
-    const msg = error.message.toLowerCase();
-    const match = knownErrors.find((ke) => msg.includes(ke.pattern.toLowerCase()));
+    const match = knownErrors.find((ke) => patternMatches(error.message, ke.pattern));
     if (match !== undefined) {
       return { type: 'known', knownError: match };
     }
     return { type: 'unknown' };
   }
+}
+
+function patternMatches(message: string, pattern: string): boolean {
+  const normalizedPattern = validatePattern(pattern);
+  const escapedPattern = escapeRegex(normalizedPattern).replace(/\s+/g, String.raw`\s+`);
+  const matcher = new RegExp(
+    String.raw`(?<![${WORD_CHAR_CLASS}])${escapedPattern}(?![${WORD_CHAR_CLASS}])`,
+    'iu',
+  );
+
+  return matcher.test(message);
+}
+
+function validatePattern(pattern: string): string {
+  const normalizedPattern = pattern.trim();
+  if (normalizedPattern.length < MIN_PATTERN_LENGTH) {
+    throw new RangeError(
+      `Known error patterns must be at least ${MIN_PATTERN_LENGTH} characters long`,
+    );
+  }
+
+  return normalizedPattern;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -23,7 +23,21 @@ export class ErrorIngester {
 }
 
 function patternMatches(message: string, pattern: string): boolean {
-  const normalizedPattern = validatePattern(pattern);
+  let normalizedPattern: string;
+  try {
+    normalizedPattern = validatePattern(pattern);
+  } catch (err) {
+    // A single malformed/stale stored pattern (e.g. an empty or trivially
+    // short memory entry) must not abort the whole classification loop and
+    // mask valid later patterns. Skip it so matching falls through to the
+    // remaining knownErrors and, ultimately, the unknown-error path.
+    console.warn(
+      `[ErrorIngester] skipping invalid known error pattern ${JSON.stringify(pattern)}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return false;
+  }
   const escapedPattern = escapeRegex(normalizedPattern).replace(/\s+/g, String.raw`\s+`);
   const matcher = new RegExp(
     String.raw`(?<![${WORD_CHAR_CLASS}])${escapedPattern}(?![${WORD_CHAR_CLASS}])`,

--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -3,15 +3,29 @@ import type { KnownError } from '../core/types.js';
 const MIN_PATTERN_LENGTH = 6;
 const WORD_CHAR_CLASS = String.raw`\p{L}\p{N}_`;
 /**
- * Canonical OS/CLI error codes are short but highly specific, so they are exempt
- * from the minimum-length trivial-pattern gate. The exemption is restricted to
- * recognized code shapes — errno (`EPERM`, `EPIPE`, `ENOENT`), Node error codes
- * (`ERR_MODULE_NOT_FOUND`), and signals (`SIGKILL`, `SIGTERM`) — so arbitrary
- * short uppercase words like `THE`/`AND` are NOT exempted (which would otherwise
- * reintroduce broad false positives). Matched case-insensitively to mirror the
- * `iu` matcher, so a lowercase stored code such as `eperm` is still accepted.
+ * Short errno-style codes that are highly specific and worth keeping even though
+ * they fall under the minimum-length trivial-pattern gate. A curated allowlist is
+ * used (rather than a shape like `E[A-Z]+`) because a shape would also exempt
+ * ordinary E-words such as `error`/`end`, reintroducing the broad false positives
+ * this gate exists to prevent. Longer codes (most signals, all `ERR_*` Node codes)
+ * already clear the length gate on their own.
  */
-const CANONICAL_ERROR_CODE = /^(?:E[A-Z]{2,}|ERR_[A-Z0-9_]+|SIG[A-Z]+)$/i;
+const CANONICAL_ERRNO_CODES = new Set([
+  'EPERM', 'ENOENT', 'ESRCH', 'EINTR', 'EIO', 'ENXIO', 'EBADF', 'EAGAIN',
+  'ENOMEM', 'EACCES', 'EFAULT', 'EBUSY', 'EEXIST', 'EXDEV', 'ENODEV', 'ENOTDIR',
+  'EISDIR', 'EINVAL', 'ENFILE', 'EMFILE', 'ENOTTY', 'EFBIG', 'ENOSPC', 'ESPIPE',
+  'EROFS', 'EMLINK', 'EPIPE', 'ELOOP', 'EPROTO', 'EHOSTDOWN',
+]);
+
+/**
+ * True when a sub-minimum-length pattern is a recognized canonical error code
+ * (a known errno code or a Node `ERR_*` code). Matched case-insensitively to
+ * mirror the `iu` matcher, so a lowercase stored code like `eperm` is accepted.
+ */
+function isCanonicalErrorCode(pattern: string): boolean {
+  const upper = pattern.toUpperCase();
+  return CANONICAL_ERRNO_CODES.has(upper) || /^ERR_[A-Z0-9_]+$/.test(upper);
+}
 
 export type ErrorClassification =
   | { type: 'known'; knownError: KnownError }
@@ -61,7 +75,7 @@ function validatePattern(pattern: string): string {
   const normalizedPattern = pattern.trim();
   if (
     normalizedPattern.length < MIN_PATTERN_LENGTH &&
-    !CANONICAL_ERROR_CODE.test(normalizedPattern)
+    !isCanonicalErrorCode(normalizedPattern)
   ) {
     throw new RangeError(
       `Known error patterns must be at least ${MIN_PATTERN_LENGTH} characters long`,

--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -2,6 +2,12 @@ import type { KnownError } from '../core/types.js';
 
 const MIN_PATTERN_LENGTH = 6;
 const WORD_CHAR_CLASS = String.raw`\p{L}\p{N}_`;
+/**
+ * Canonical OS/CLI error codes (e.g. `EPERM`, `EPIPE`, `SIGKILL`) are short but
+ * highly specific, so they are exempt from the minimum-length trivial-pattern
+ * gate. Matches an uppercase, underscore-or-digit token of at least 3 chars.
+ */
+const CANONICAL_ERROR_CODE = /^[A-Z][A-Z0-9_]{2,}$/;
 
 export type ErrorClassification =
   | { type: 'known'; knownError: KnownError }
@@ -49,7 +55,10 @@ function patternMatches(message: string, pattern: string): boolean {
 
 function validatePattern(pattern: string): string {
   const normalizedPattern = pattern.trim();
-  if (normalizedPattern.length < MIN_PATTERN_LENGTH) {
+  if (
+    normalizedPattern.length < MIN_PATTERN_LENGTH &&
+    !CANONICAL_ERROR_CODE.test(normalizedPattern)
+  ) {
     throw new RangeError(
       `Known error patterns must be at least ${MIN_PATTERN_LENGTH} characters long`,
     );

--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -1,30 +1,31 @@
+import { constants } from 'node:os';
 import type { KnownError } from '../core/types.js';
 
 const MIN_PATTERN_LENGTH = 6;
 const WORD_CHAR_CLASS = String.raw`\p{L}\p{N}_`;
+const WORD_CHAR_RE = /[\p{L}\p{N}_]/u;
+
 /**
- * Short errno-style codes that are highly specific and worth keeping even though
- * they fall under the minimum-length trivial-pattern gate. A curated allowlist is
- * used (rather than a shape like `E[A-Z]+`) because a shape would also exempt
- * ordinary E-words such as `error`/`end`, reintroducing the broad false positives
- * this gate exists to prevent. Longer codes (most signals, all `ERR_*` Node codes)
- * already clear the length gate on their own.
+ * Recognized canonical error/signal codes that are highly specific and worth
+ * keeping even when shorter than the trivial-pattern gate (e.g. `E2BIG`, `EDOM`,
+ * `SIGIO`). Derived from Node's own `os.constants` so the full errno/signal set
+ * is covered exactly, rather than a hand-curated list. This is deliberately not a
+ * shape like `E[A-Z]+`, which would also exempt ordinary words such as
+ * `error`/`end` and reintroduce the broad false positives the gate prevents.
  */
-const CANONICAL_ERRNO_CODES = new Set([
-  'EPERM', 'ENOENT', 'ESRCH', 'EINTR', 'EIO', 'ENXIO', 'EBADF', 'EAGAIN',
-  'ENOMEM', 'EACCES', 'EFAULT', 'EBUSY', 'EEXIST', 'EXDEV', 'ENODEV', 'ENOTDIR',
-  'EISDIR', 'EINVAL', 'ENFILE', 'EMFILE', 'ENOTTY', 'EFBIG', 'ENOSPC', 'ESPIPE',
-  'EROFS', 'EMLINK', 'EPIPE', 'ELOOP', 'EPROTO', 'EHOSTDOWN',
+const CANONICAL_CODES = new Set<string>([
+  ...Object.keys(constants.errno ?? {}),
+  ...Object.keys(constants.signals ?? {}),
 ]);
 
 /**
- * True when a sub-minimum-length pattern is a recognized canonical error code
- * (a known errno code or a Node `ERR_*` code). Matched case-insensitively to
- * mirror the `iu` matcher, so a lowercase stored code like `eperm` is accepted.
+ * True when a sub-minimum-length pattern is a recognized canonical code (a Node
+ * errno/signal code or a Node `ERR_*` code). Matched case-insensitively to mirror
+ * the `iu` matcher, so a lowercase stored code like `eperm` is accepted.
  */
 function isCanonicalErrorCode(pattern: string): boolean {
   const upper = pattern.toUpperCase();
-  return CANONICAL_ERRNO_CODES.has(upper) || /^ERR_[A-Z0-9_]+$/.test(upper);
+  return CANONICAL_CODES.has(upper) || /^ERR_[A-Z0-9_]+$/.test(upper);
 }
 
 export type ErrorClassification =
@@ -63,10 +64,17 @@ function patternMatches(message: string, pattern: string): boolean {
     return false;
   }
   const escapedPattern = escapeRegex(normalizedPattern).replace(/\s+/g, String.raw`\s+`);
-  const matcher = new RegExp(
-    String.raw`(?<![${WORD_CHAR_CLASS}])${escapedPattern}(?![${WORD_CHAR_CLASS}])`,
-    'iu',
-  );
+  // Only guard an edge with a word boundary when the pattern actually starts/ends
+  // with a word character. Applying the lookarounds unconditionally would drop
+  // legitimate partial patterns ending (or starting) in punctuation — e.g.
+  // `failed:` or `Cannot find module '` — when adjacent error text is a word.
+  const leadingBoundary = WORD_CHAR_RE.test(normalizedPattern[0] ?? '')
+    ? String.raw`(?<![${WORD_CHAR_CLASS}])`
+    : '';
+  const trailingBoundary = WORD_CHAR_RE.test(normalizedPattern[normalizedPattern.length - 1] ?? '')
+    ? String.raw`(?![${WORD_CHAR_CLASS}])`
+    : '';
+  const matcher = new RegExp(`${leadingBoundary}${escapedPattern}${trailingBoundary}`, 'iu');
 
   return matcher.test(message);
 }

--- a/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
+++ b/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
@@ -61,6 +61,13 @@ describe('ErrorIngester', () => {
     expect(result.type).toBe('unknown');
   });
 
+  it('matches short canonical error codes despite the length gate', () => {
+    const result = new ErrorIngester().classify(new Error('spawnSync git EPERM'), [
+      makeKnownError('EPERM'),
+    ]);
+    expect(result.type).toBe('known');
+  });
+
   it('still matches valid patterns that follow an invalid stored pattern', () => {
     const trivial = makeKnownError('error');
     const valid = makeKnownError('disk full');

--- a/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
+++ b/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
@@ -47,16 +47,26 @@ describe('ErrorIngester', () => {
     expect(result.type).toBe('known');
   });
 
-  it('rejects empty known error patterns before matching', () => {
-    expect(() =>
-      new ErrorIngester().classify(new Error('unrelated failure'), [makeKnownError('')]),
-    ).toThrow(/at least 6 characters/);
+  it('skips empty known error patterns without aborting classification', () => {
+    const result = new ErrorIngester().classify(new Error('unrelated failure'), [
+      makeKnownError(''),
+    ]);
+    expect(result.type).toBe('unknown');
   });
 
-  it('rejects trivial known error patterns before matching', () => {
-    expect(() =>
-      new ErrorIngester().classify(new Error('any error message'), [makeKnownError('error')]),
-    ).toThrow(/at least 6 characters/);
+  it('skips trivial known error patterns without aborting classification', () => {
+    const result = new ErrorIngester().classify(new Error('any error message'), [
+      makeKnownError('error'),
+    ]);
+    expect(result.type).toBe('unknown');
+  });
+
+  it('still matches valid patterns that follow an invalid stored pattern', () => {
+    const trivial = makeKnownError('error');
+    const valid = makeKnownError('disk full');
+    const result = new ErrorIngester().classify(new Error('disk full error'), [trivial, valid]);
+    expect(result.type).toBe('known');
+    expect(result).toMatchObject({ knownError: valid });
   });
 
   it('does not match literal patterns inside larger words', () => {

--- a/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
+++ b/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
@@ -82,6 +82,32 @@ describe('ErrorIngester', () => {
     expect(sig.type).toBe('known');
   });
 
+  it('matches short errno codes from os.constants (e.g. E2BIG)', () => {
+    const result = new ErrorIngester().classify(new Error('spawn E2BIG'), [
+      makeKnownError('E2BIG'),
+    ]);
+    expect(result.type).toBe('known');
+  });
+
+  it('matches short signal codes from os.constants (e.g. SIGIO)', () => {
+    const result = new ErrorIngester().classify(new Error('process got signal SIGIO'), [
+      makeKnownError('SIGIO'),
+    ]);
+    expect(result.type).toBe('known');
+  });
+
+  it('matches partial patterns ending in punctuation', () => {
+    const colon = new ErrorIngester().classify(new Error('failed:foo'), [
+      makeKnownError('failed:'),
+    ]);
+    expect(colon.type).toBe('known');
+
+    const quote = new ErrorIngester().classify(new Error("Cannot find module 'foo'"), [
+      makeKnownError("Cannot find module '"),
+    ]);
+    expect(quote.type).toBe('known');
+  });
+
   it('does not exempt short uppercase common words from the length gate', () => {
     // `THE` is not a recognized code shape, so it stays gated as trivial and is
     // skipped rather than matching common words in error text.

--- a/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
+++ b/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
@@ -46,4 +46,22 @@ describe('ErrorIngester', () => {
     const result = new ErrorIngester().classify(new Error('connection timeout after 30s'), [ke]);
     expect(result.type).toBe('known');
   });
+
+  it('rejects empty known error patterns before matching', () => {
+    expect(() =>
+      new ErrorIngester().classify(new Error('unrelated failure'), [makeKnownError('')]),
+    ).toThrow(/at least 6 characters/);
+  });
+
+  it('rejects trivial known error patterns before matching', () => {
+    expect(() =>
+      new ErrorIngester().classify(new Error('any error message'), [makeKnownError('error')]),
+    ).toThrow(/at least 6 characters/);
+  });
+
+  it('does not match literal patterns inside larger words', () => {
+    const ke = makeKnownError('timeout');
+    const result = new ErrorIngester().classify(new Error('operation timedout unexpectedly'), [ke]);
+    expect(result.type).toBe('unknown');
+  });
 });

--- a/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
+++ b/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
@@ -68,6 +68,29 @@ describe('ErrorIngester', () => {
     expect(result.type).toBe('known');
   });
 
+  it('matches a lowercase canonical code (case-insensitive exemption)', () => {
+    const result = new ErrorIngester().classify(new Error('spawnSync git EPERM'), [
+      makeKnownError('eperm'),
+    ]);
+    expect(result.type).toBe('known');
+  });
+
+  it('exempts ERR_/SIG code shapes from the length gate', () => {
+    const sig = new ErrorIngester().classify(new Error('child killed by SIGKILL'), [
+      makeKnownError('SIGKILL'),
+    ]);
+    expect(sig.type).toBe('known');
+  });
+
+  it('does not exempt short uppercase common words from the length gate', () => {
+    // `THE` is not a recognized code shape, so it stays gated as trivial and is
+    // skipped rather than matching common words in error text.
+    const result = new ErrorIngester().classify(new Error('THE build failed'), [
+      makeKnownError('THE'),
+    ]);
+    expect(result.type).toBe('unknown');
+  });
+
   it('still matches valid patterns that follow an invalid stored pattern', () => {
     const trivial = makeKnownError('error');
     const valid = makeKnownError('disk full');


### PR DESCRIPTION
Validates trimmed recovery error patterns before matching, rejects empty/trivial patterns, and switches from broad substring matching to escaped case-insensitive literal matching with non-word boundaries.

Worker handoff:
- Commit: 2e76cd08239082313dc691e8c2f394da47aa78b1
- Tests: error-ingester targeted tests passed; franken-planner typecheck and tests reported passing.

Fixes #77
