### PR TITLE
fix(orchestrator): persist BeastLogger file writes

### DIFF
--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -559,6 +559,7 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
       }
     } catch { /* best-effort */ }
     try { consolidated.sqliteBrain?.close(); } catch { /* best-effort */ }
+    try { logger.close(); } catch { /* best-effort */ }
     await previousFinalizeForBrain();
   };
 

--- a/packages/franken-orchestrator/src/logging/beast-logger.ts
+++ b/packages/franken-orchestrator/src/logging/beast-logger.ts
@@ -6,7 +6,7 @@
  * boxed headers, and service highlighting for verbose mode.
  */
 
-import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, writeSync } from 'node:fs';
 import { resolve } from 'node:path';
 import sharp from 'sharp';
 import type { ILogger } from '../deps.js';
@@ -182,6 +182,8 @@ const BADGE_COLORS: Record<string, string> = {
 };
 
 const BADGE_WIDTH = 10;
+const DEFAULT_MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
+const DEFAULT_ROTATED_LOG_FILES = 3;
 
 function formatBadge(source: string): string {
   const color = BADGE_COLORS[source] ?? A.dim;
@@ -220,18 +222,28 @@ export interface BeastLoggerOptions {
   readonly captureForFile?: boolean;
   /** When set, log entries are appended to this file immediately (crash-safe). */
   readonly logFile?: string | undefined;
+  /** Maximum active log file size before rotating to .1, .2, etc. Defaults to 10 MiB. */
+  readonly maxLogFileBytes?: number | undefined;
+  /** Number of rotated log files to keep. Defaults to 3. */
+  readonly maxRotatedLogFiles?: number | undefined;
 }
 
 export class BeastLogger implements ILogger {
   private readonly verbose: boolean;
   private readonly captureForFile: boolean;
   private readonly logFile: string | undefined;
+  private readonly maxLogFileBytes: number;
+  private readonly maxRotatedLogFiles: number;
   private readonly entries: string[] = [];
+  private logFd: number | undefined;
+  private logBytes = 0;
 
   constructor(options: BeastLoggerOptions) {
     this.verbose = options.verbose;
     this.captureForFile = options.captureForFile ?? false;
     this.logFile = options.logFile;
+    this.maxLogFileBytes = options.maxLogFileBytes ?? DEFAULT_MAX_LOG_FILE_BYTES;
+    this.maxRotatedLogFiles = options.maxRotatedLogFiles ?? DEFAULT_ROTATED_LOG_FILES;
   }
 
   info(msg: string, dataOrSource?: unknown, source?: string): void {
@@ -279,6 +291,13 @@ export class BeastLogger implements ILogger {
     return [...this.entries];
   }
 
+  /** Flush and close the persistent log file handle, if one was opened. */
+  close(): void {
+    if (this.logFd === undefined) return;
+    closeSync(this.logFd);
+    this.logFd = undefined;
+  }
+
   private timestamp(): string {
     return `${A.gray}${new Date().toTimeString().slice(0, 8)}${A.reset}`;
   }
@@ -291,8 +310,61 @@ export class BeastLogger implements ILogger {
     const entry = `[${date} ${time}] [${level}] ${stripAnsi(msg)}`;
     this.entries.push(entry);
     if (this.logFile) {
-      appendFileSync(this.logFile, entry + '\n');
+      this.writeLogEntry(entry + '\n');
     }
+  }
+
+  private writeLogEntry(line: string): void {
+    if (!this.logFile) return;
+    const bytes = Buffer.byteLength(line);
+    this.ensureLogFileOpen(bytes);
+    writeSync(this.logFd!, line);
+    this.logBytes += bytes;
+  }
+
+  private ensureLogFileOpen(nextWriteBytes: number): void {
+    if (!this.logFile) return;
+    if (this.logFd === undefined) {
+      this.logBytes = this.currentLogFileSize();
+      if (this.shouldRotate(nextWriteBytes)) {
+        this.rotateLogFiles();
+        this.logBytes = 0;
+      }
+      this.logFd = openSync(this.logFile, 'a');
+      return;
+    }
+
+    if (this.shouldRotate(nextWriteBytes)) {
+      this.close();
+      this.rotateLogFiles();
+      this.logBytes = 0;
+      this.logFd = openSync(this.logFile, 'a');
+    }
+  }
+
+  private shouldRotate(nextWriteBytes: number): boolean {
+    return this.maxLogFileBytes > 0
+      && this.logBytes > 0
+      && this.logBytes + nextWriteBytes > this.maxLogFileBytes;
+  }
+
+  private currentLogFileSize(): number {
+    if (!this.logFile || !existsSync(this.logFile)) return 0;
+    return statSync(this.logFile).size;
+  }
+
+  private rotateLogFiles(): void {
+    if (!this.logFile || this.maxRotatedLogFiles < 1 || !existsSync(this.logFile)) return;
+
+    for (let index = this.maxRotatedLogFiles - 1; index >= 1; index -= 1) {
+      const from = `${this.logFile}.${index}`;
+      const to = `${this.logFile}.${index + 1}`;
+      if (existsSync(from)) {
+        renameSync(from, to);
+      }
+    }
+
+    renameSync(this.logFile, `${this.logFile}.1`);
   }
 
   private withData(msg: string, data: unknown): string {

--- a/packages/franken-orchestrator/src/logging/beast-logger.ts
+++ b/packages/franken-orchestrator/src/logging/beast-logger.ts
@@ -6,7 +6,7 @@
  * boxed headers, and service highlighting for verbose mode.
  */
 
-import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, writeSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, truncateSync, writeSync } from 'node:fs';
 import { resolve } from 'node:path';
 import sharp from 'sharp';
 import type { ILogger } from '../deps.js';
@@ -316,10 +316,14 @@ export class BeastLogger implements ILogger {
 
   private writeLogEntry(line: string): void {
     if (!this.logFile) return;
-    const bytes = Buffer.byteLength(line);
-    this.ensureLogFileOpen(bytes);
-    writeSync(this.logFd!, line);
-    this.logBytes += bytes;
+    const buf = Buffer.from(line);
+    this.ensureLogFileOpen(buf.length);
+    let offset = 0;
+    while (offset < buf.length) {
+      const written = writeSync(this.logFd!, buf, offset, buf.length - offset);
+      offset += written;
+    }
+    this.logBytes += buf.length;
   }
 
   private ensureLogFileOpen(nextWriteBytes: number): void {
@@ -327,8 +331,7 @@ export class BeastLogger implements ILogger {
     if (this.logFd === undefined) {
       this.logBytes = this.currentLogFileSize();
       if (this.shouldRotate(nextWriteBytes)) {
-        this.rotateLogFiles();
-        this.logBytes = 0;
+        this.truncateOrRotate();
       }
       this.logFd = openSync(this.logFile, 'a');
       return;
@@ -336,10 +339,26 @@ export class BeastLogger implements ILogger {
 
     if (this.shouldRotate(nextWriteBytes)) {
       this.close();
-      this.rotateLogFiles();
-      this.logBytes = 0;
+      this.truncateOrRotate();
       this.logFd = openSync(this.logFile, 'a');
     }
+  }
+
+  /**
+   * Rotate log files when retention is enabled, or truncate the active file
+   * when retention is disabled (maxRotatedLogFiles < 1). Always resets logBytes
+   * to 0 only after the file has actually been emptied or replaced.
+   */
+  private truncateOrRotate(): void {
+    if (this.maxRotatedLogFiles < 1) {
+      // Retention disabled: truncate the active file in-place to enforce the size cap.
+      if (this.logFile && existsSync(this.logFile)) {
+        truncateSync(this.logFile, 0);
+      }
+    } else {
+      this.rotateLogFiles();
+    }
+    this.logBytes = 0;
   }
 
   private shouldRotate(nextWriteBytes: number): boolean {

--- a/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   BeastLogger,
   stripAnsi,
@@ -331,6 +334,48 @@ describe('BeastLogger', () => {
       expect(stripAnsi(terminal)).not.toContain('"stderr":"permission denied"');
       expect(entries[0]).toContain('"stderr": "permission denied"');
       expect(entries[0]).toContain('"tool": "gh"');
+    });
+
+    it('exposes an explicit close method for persistent file logging', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'beast-logger-close-'));
+      try {
+        const logFile = join(dir, 'build.log');
+        const logger = new BeastLogger({ verbose: false, captureForFile: true, logFile });
+
+        logger.info('before close');
+        logger.close();
+        logger.info('after close');
+        logger.close();
+
+        const contents = readFileSync(logFile, 'utf8');
+        expect(contents).toContain('before close');
+        expect(contents).toContain('after close');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rotates log files before exceeding the configured max size', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'beast-logger-rotate-'));
+      try {
+        const logFile = join(dir, 'build.log');
+        writeFileSync(logFile, `${'x'.repeat(80)}\n`);
+        const logger = new BeastLogger({
+          verbose: false,
+          captureForFile: true,
+          logFile,
+          maxLogFileBytes: 100,
+        });
+
+        logger.info('new file after rotation');
+        logger.close();
+
+        expect(existsSync(`${logFile}.1`)).toBe(true);
+        expect(readFileSync(`${logFile}.1`, 'utf8')).toContain('xxxxxxxxxx');
+        expect(readFileSync(logFile, 'utf8')).toContain('new file after rotation');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -373,6 +373,111 @@ describe('BeastLogger', () => {
         expect(existsSync(`${logFile}.1`)).toBe(true);
         expect(readFileSync(`${logFile}.1`, 'utf8')).toContain('xxxxxxxxxx');
         expect(readFileSync(logFile, 'utf8')).toContain('new file after rotation');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+
+  describe('short-write handling', () => {
+    it('retries writeSync until all bytes are written', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'beast-logger-short-write-'));
+      try {
+        const logFile = join(dir, 'build.log');
+        const logger = new BeastLogger({ verbose: false, captureForFile: true, logFile });
+
+        // Write a larger log message to ensure writeSync is exercised
+        const longMsg = 'a'.repeat(512);
+        logger.info(longMsg);
+        logger.close();
+
+        const contents = readFileSync(logFile, 'utf8');
+        // The full message must be present — no truncation
+        expect(contents).toContain(longMsg);
+        // Exactly one newline-terminated entry
+        const lines = contents.split('\n').filter(l => l.length > 0);
+        expect(lines).toHaveLength(1);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('accounts for byte length (not char length) in logBytes', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'beast-logger-multibyte-'));
+      try {
+        const logFile = join(dir, 'build.log');
+        // Multi-byte UTF-8: each emoji is 4 bytes
+        const emoji = '🧟'.repeat(20);
+        const logger = new BeastLogger({ verbose: false, captureForFile: true, logFile });
+
+        logger.info(emoji);
+        logger.close();
+
+        const contents = readFileSync(logFile, 'utf8');
+        expect(contents).toContain(emoji);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('zero-retention size-cap (maxRotatedLogFiles < 1)', () => {
+    it('truncates the active file when size limit is hit and retention is disabled', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'beast-logger-no-retain-'));
+      try {
+        const logFile = join(dir, 'build.log');
+        writeFileSync(logFile, `${'x'.repeat(80)}\n`);
+        const logger = new BeastLogger({
+          verbose: false,
+          captureForFile: true,
+          logFile,
+          maxLogFileBytes: 100,
+          maxRotatedLogFiles: 0,
+        });
+
+        logger.info('post-truncation entry');
+        logger.close();
+
+        // Must NOT have created a rotated file
+        expect(existsSync(`${logFile}.1`)).toBe(false);
+
+        // Active file must contain the new entry (file was truncated then written)
+        const contents = readFileSync(logFile, 'utf8');
+        expect(contents).toContain('post-truncation entry');
+
+        // Active file must NOT have grown past the limit
+        // Use readFileSync length as a proxy — the old 80-byte filler should be gone
+        expect(contents).not.toContain('xxxxxxxxxx');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not reset logBytes without actually clearing the file', () => {
+      // When maxRotatedLogFiles < 1, the file is truncated so logBytes=0 is accurate
+      const dir = mkdtempSync(join(tmpdir(), 'beast-logger-no-retain-bytes-'));
+      try {
+        const logFile = join(dir, 'build.log');
+        writeFileSync(logFile, `${'y'.repeat(90)}\n`);
+        const logger = new BeastLogger({
+          verbose: false,
+          captureForFile: true,
+          logFile,
+          maxLogFileBytes: 100,
+          maxRotatedLogFiles: 0,
+        });
+
+        // Fill up to trigger truncation on second write
+        logger.info('first entry that pushes past limit');
+        logger.info('second entry after truncation');
+        logger.close();
+
+        const contents = readFileSync(logFile, 'utf8');
+        // Old filler must be gone
+        expect(contents).not.toContain('yyy');
+        // Second entry is present
+        expect(contents).toContain('second entry after truncation');
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Uses persistent BeastLogger file writes with an explicit close path and regression coverage for the logging behavior.

Worker handoff:
- Commit: cb7230b7d7ef0a627633d76809c6757842028751
- Tests: worker reported targeted logging tests and relevant checks passing.

Fixes #75
