### PR TITLE
fix(orchestrator): improve CLI no-op UX

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -502,7 +502,10 @@ export async function main(): Promise<void> {
 
   const result = await session.start();
 
-  if (result && result.status !== 'completed') {
+  // `no-op` is a benign terminal status (empty or intentionally-skipped plan),
+  // so it must exit successfully alongside `completed` — otherwise CI/scripts
+  // invoking frankenbeast for no-change tasks would see a spurious nonzero exit.
+  if (result && result.status !== 'completed' && result.status !== 'no-op') {
     process.exit(1);
   }
 }

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -288,7 +288,13 @@ export class Session {
       // Load design doc
     let designContent: string;
     if (designDocPath) {
-      designContent = readFileSync(designDocPath, 'utf-8');
+      try {
+        designContent = readFileSync(designDocPath, 'utf-8');
+      } catch {
+        throw new Error(
+          `No design document found at ${designDocPath}. Check the path, run "frankenbeast interview" first, or provide --design-doc.`,
+        );
+      }
     } else {
       const stored = readDesignDoc(paths);
       if (!stored) {

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -489,7 +489,11 @@ export class Session {
     console.log(logHeader('BUILD SUMMARY'));
     console.log(`  ${A.dim}Duration:${A.reset}  ${(result.durationMs / 1000 / 60).toFixed(1)} min`);
     console.log(`  ${A.dim}Budget:${A.reset}    ${budgetBar(result.tokenSpend.estimatedCostUsd, this.config.budget)}`);
-    console.log(`  ${A.dim}Status:${A.reset}    ${statusBadge(result.status === 'completed')}`);
+    const statusDisplay =
+      result.status === 'no-op'
+        ? statusBadge('neutral')
+        : statusBadge(result.status === 'completed');
+    console.log(`  ${A.dim}Status:${A.reset}    ${statusDisplay}`);
     if (result.taskResults?.length) {
       console.log(`\n  ${A.dim}Chunks:${A.reset}`);
       for (const t of result.taskResults) {

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -290,10 +290,13 @@ export class Session {
     if (designDocPath) {
       try {
         designContent = readFileSync(designDocPath, 'utf-8');
-      } catch {
-        throw new Error(
-          `No design document found at ${designDocPath}. Check the path, run "frankenbeast interview" first, or provide --design-doc.`,
-        );
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(
+            `No design document found at ${designDocPath}. Check the path, run "frankenbeast interview" first, or provide --design-doc.`,
+          );
+        }
+        throw err;
       }
     } else {
       const stored = readDesignDoc(paths);

--- a/packages/franken-orchestrator/src/logging/beast-logger.ts
+++ b/packages/franken-orchestrator/src/logging/beast-logger.ts
@@ -51,7 +51,10 @@ export function budgetBar(spent: number, limit: number): string {
 }
 
 /** Status badge: ` PASS ` on green bg or ` FAIL ` on red bg. */
-export function statusBadge(pass: boolean): string {
+export function statusBadge(pass: boolean | 'neutral'): string {
+  if (pass === 'neutral') {
+    return `${A.yellow}${A.bold} NO-OP ${A.reset}`;
+  }
   return pass
     ? `${A.bgGreen}${A.bold} PASS ${A.reset}`
     : `${A.bgRed}${A.bold} FAIL ${A.reset}`;

--- a/packages/franken-orchestrator/src/phases/closure.ts
+++ b/packages/franken-orchestrator/src/phases/closure.ts
@@ -62,7 +62,7 @@ export async function runClosure(
   const allSucceeded = taskOutcomes.every(o => o.status === 'success');
   const allSkipped = taskOutcomes.length > 0 && taskOutcomes.every(o => o.status === 'skipped');
 
-  const status = allSkipped ? 'skipped' : allSucceeded ? 'completed' : 'failed';
+  const status = allSkipped ? 'no-op' : allSucceeded ? 'completed' : 'failed';
 
   const result: BeastResult = {
     sessionId: ctx.sessionId,

--- a/packages/franken-orchestrator/src/phases/closure.ts
+++ b/packages/franken-orchestrator/src/phases/closure.ts
@@ -61,8 +61,12 @@ export async function runClosure(
 
   const allSucceeded = taskOutcomes.every(o => o.status === 'success');
   const allSkipped = taskOutcomes.length > 0 && taskOutcomes.every(o => o.status === 'skipped');
+  // Only report no-op when every skipped outcome is a benign/intentional skip
+  // (no error reason attached). Skips caused by unmet dependencies or governor
+  // rejections always carry an error field and must not be silently labelled no-op.
+  const benignAllSkipped = allSkipped && taskOutcomes.every(o => !o.error);
 
-  const status = allSkipped ? 'no-op' : allSucceeded ? 'completed' : 'failed';
+  const status = benignAllSkipped ? 'no-op' : allSucceeded ? 'completed' : 'failed';
 
   const result: BeastResult = {
     sessionId: ctx.sessionId,

--- a/packages/franken-orchestrator/src/phases/closure.ts
+++ b/packages/franken-orchestrator/src/phases/closure.ts
@@ -59,14 +59,23 @@ export async function runClosure(
     }
   }
 
-  const allSucceeded = taskOutcomes.every(o => o.status === 'success');
-  const allSkipped = taskOutcomes.length > 0 && taskOutcomes.every(o => o.status === 'skipped');
-  // Only report no-op when every skipped outcome is a benign/intentional skip
-  // (no error reason attached). Skips caused by unmet dependencies or governor
-  // rejections always carry an error field and must not be silently labelled no-op.
-  const benignAllSkipped = allSkipped && taskOutcomes.every(o => !o.error);
+  const hasOutcomes = taskOutcomes.length > 0;
+  const allSucceeded = hasOutcomes && taskOutcomes.every(o => o.status === 'success');
+  const allSkipped = hasOutcomes && taskOutcomes.every(o => o.status === 'skipped');
+  // Only report no-op when every skipped outcome is a benign/intentional skip.
+  // Skips caused by unmet dependencies or governor rejections always attach an
+  // error field (possibly an empty reason), so test for its presence rather
+  // than truthiness — an empty rejection reason must still count as a failure.
+  const benignAllSkipped = allSkipped && taskOutcomes.every(o => o.error === undefined);
 
-  const status = benignAllSkipped ? 'no-op' : allSucceeded ? 'completed' : 'failed';
+  // An empty plan (e.g. a no-op design that produced no chunk files) yields no
+  // task outcomes; `[].every()` is vacuously true, so special-case it as no-op
+  // instead of letting it fall through to a misleading `completed`.
+  const status: BeastResult['status'] = !hasOutcomes || benignAllSkipped
+    ? 'no-op'
+    : allSucceeded
+      ? 'completed'
+      : 'failed';
 
   const result: BeastResult = {
     sessionId: ctx.sessionId,

--- a/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
@@ -30,19 +30,15 @@ export class CodexProvider implements ICliProvider {
       .filter((line) => line.length > 0);
 
     const extracted: string[] = [];
-    let parsedJsonLines = 0;
-
     for (const line of lines) {
       try {
         const parsed = JSON.parse(line) as unknown;
-        parsedJsonLines++;
         tryExtractTextFromNode(parsed, extracted);
       } catch {
         extracted.push(line);
       }
     }
 
-    if (parsedJsonLines > 0 && extracted.length === 0) return '';
     return extracted.join('\n').trim();
   }
 

--- a/packages/franken-orchestrator/src/types.ts
+++ b/packages/franken-orchestrator/src/types.ts
@@ -8,7 +8,7 @@ export interface BeastResult {
   readonly sessionId: string;
   readonly projectId: string;
   readonly phase: BeastPhase;
-  readonly status: 'completed' | 'failed' | 'aborted' | 'skipped';
+  readonly status: 'completed' | 'failed' | 'aborted' | 'skipped' | 'no-op';
   readonly tokenSpend: TokenSpend;
   readonly planSummary?: string | undefined;
   readonly taskResults?: readonly TaskOutcome[] | undefined;

--- a/packages/franken-orchestrator/tests/unit/build-runner-integration.test.ts
+++ b/packages/franken-orchestrator/tests/unit/build-runner-integration.test.ts
@@ -218,7 +218,9 @@ describe('build-runner integration — dep construction wiring', () => {
         const loop = new BeastLoop(deps);
         const result = await loop.run({ projectId: 'test', userInput: 'test' });
 
-        expect(result.status).toBe('completed');
+        // baseDeps' graphBuilder yields an empty plan, so a run with no task
+        // outcomes is a no-op (this test exercises wiring, not status).
+        expect(result.status).toBe('no-op');
         // Verify checkpoint is functional
         checkpoint.write('task-1:done');
         expect(checkpoint.has('task-1:done')).toBe(true);
@@ -236,7 +238,8 @@ describe('build-runner integration — dep construction wiring', () => {
       const loop = new BeastLoop(deps);
       const result = await loop.run({ projectId: 'test', userInput: 'test' });
 
-      expect(result.status).toBe('completed');
+      // Empty plan from baseDeps' graphBuilder ⇒ no-op run.
+      expect(result.status).toBe('no-op');
     });
 
     it('constructs ChunkFileGraphBuilder with plan directory', async () => {
@@ -332,7 +335,8 @@ describe('build-runner integration — dep construction wiring', () => {
         const loop = new BeastLoop(deps);
         const result = await loop.run({ projectId: 'test', userInput: 'test' });
 
-        expect(result.status).toBe('completed');
+        // Empty plan from baseDeps' graphBuilder ⇒ no-op run.
+        expect(result.status).toBe('no-op');
         // BeastLoop should have called logger.info at least once
         expect(spy).toHaveBeenCalled();
         const calls = spy.mock.calls.map(c => c[0] as string);

--- a/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
@@ -290,6 +290,20 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     expect(mockFinalize).toHaveBeenCalledTimes(1);
   });
 
+  it('runPlan() reports the searched design doc path when an explicit file is missing', async () => {
+    const { Session } = await import('../../../src/cli/session.js');
+    const missingDesignDoc = resolve(
+      tmpdir(),
+      `missing-design-${Date.now()}-${Math.random().toString(36).slice(2)}.md`,
+    );
+    const config = makeConfig({ designDocPath: missingDesignDoc });
+
+    await expect(new Session(config).start()).rejects.toThrow(
+      `No design document found at ${missingDesignDoc}`,
+    );
+    expect(mockFinalize).toHaveBeenCalledTimes(1);
+  });
+
   it('runPlan() passes LLM directly to LlmGraphBuilder (no ProgressLlmClient spinner)', async () => {
     const { Session } = await import('../../../src/cli/session.js');
     const config = makeConfig();

--- a/packages/franken-orchestrator/tests/unit/cli/session.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session.test.ts
@@ -371,6 +371,36 @@ describe('Session', () => {
       rmSync(testDir, { recursive: true, force: true });
     });
 
+    it('throws friendly ENOENT error when designDocPath file is missing', async () => {
+      const { Session } = await import('../../../src/cli/session.js');
+      const missingPath = resolve(tmpdir(), `nonexistent-design-${Date.now()}.md`);
+      const config = makeConfig({
+        entryPhase: 'plan',
+        exitAfter: 'plan',
+        designDocPath: missingPath,
+      });
+
+      await expect(new Session(config).start()).rejects.toThrow(
+        /No design document found.*Check the path/,
+      );
+    });
+
+    it('rethrows non-ENOENT errors from designDocPath (e.g. EISDIR)', async () => {
+      const { Session } = await import('../../../src/cli/session.js');
+      // Pass a directory path — readFileSync throws EISDIR, not ENOENT
+      const dirPath = tmpdir();
+      const config = makeConfig({
+        entryPhase: 'plan',
+        exitAfter: 'plan',
+        designDocPath: dirPath,
+      });
+
+      const err = await new Session(config).start().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      // Must NOT be the generic friendly message — the real error code survives
+      expect((err as Error).message).not.toMatch(/Check the path, run "frankenbeast interview"/);
+    });
+
     it('throws clear error when no design doc found', async () => {
       const { Session } = await import('../../../src/cli/session.js');
       mockReadDesignDoc.mockReturnValueOnce(undefined);

--- a/packages/franken-orchestrator/tests/unit/phases/closure.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/closure.test.ts
@@ -103,6 +103,35 @@ describe('runClosure', () => {
     expect(result.status).toBe('failed');
   });
 
+  it('returns failed status when all tasks skipped due to unmet dependencies', async () => {
+    const blockedByDeps: TaskOutcome[] = [
+      { taskId: 't1', status: 'skipped', error: 'Unmet dependencies' },
+      { taskId: 't2', status: 'skipped', error: 'Unmet dependencies' },
+    ];
+    const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), blockedByDeps);
+
+    expect(result.status).toBe('failed');
+    expect(result.taskResults).toHaveLength(2);
+  });
+
+  it('returns failed status when all tasks skipped due to governor rejection', async () => {
+    const governorRejected: TaskOutcome[] = [
+      { taskId: 't1', status: 'skipped', error: 'Rejected' },
+    ];
+    const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), governorRejected);
+
+    expect(result.status).toBe('failed');
+  });
+
+  it('returns no-op when all tasks are intentionally skipped with no error', async () => {
+    const intentionalSkips: TaskOutcome[] = [
+      { taskId: 't1', status: 'skipped' },
+    ];
+    const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), intentionalSkips);
+
+    expect(result.status).toBe('no-op');
+  });
+
   it('includes plan summary when plan exists', async () => {
     const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), successOutcomes);
     expect(result.planSummary).toBe('1 task(s) planned');

--- a/packages/franken-orchestrator/tests/unit/phases/closure.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/closure.test.ts
@@ -86,10 +86,10 @@ describe('runClosure', () => {
     expect(failAudit).toBeTruthy();
   });
 
-  it('returns skipped status when all tasks are skipped', async () => {
+  it('returns no-op status when all tasks are skipped', async () => {
     const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), allSkippedOutcomes);
 
-    expect(result.status).toBe('skipped');
+    expect(result.status).toBe('no-op');
     expect(result.taskResults).toHaveLength(2);
   });
 

--- a/packages/franken-orchestrator/tests/unit/phases/closure.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/closure.test.ts
@@ -132,6 +132,21 @@ describe('runClosure', () => {
     expect(result.status).toBe('no-op');
   });
 
+  it('returns no-op when there are no task outcomes (empty plan)', async () => {
+    const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), []);
+
+    expect(result.status).toBe('no-op');
+  });
+
+  it('returns failed when all tasks skipped with an empty rejection reason', async () => {
+    const emptyReasonSkips: TaskOutcome[] = [
+      { taskId: 't1', status: 'skipped', error: '' },
+    ];
+    const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), emptyReasonSkips);
+
+    expect(result.status).toBe('failed');
+  });
+
   it('includes plan summary when plan exists', async () => {
     const result = await runClosure(ctx(), makeObserver(), makeHeartbeat(), defaultConfig(), successOutcomes);
     expect(result.planSummary).toBe('1 task(s) planned');

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { CodexProvider } from '../../../../src/skills/providers/codex-provider.js';
 import type { ICliProvider } from '../../../../src/skills/providers/cli-provider.js';
 
@@ -116,6 +118,15 @@ describe('CodexProvider', () => {
       JSON.stringify({ type: 'message_stop' }),
     ].join('\n');
     expect(provider.normalizeOutput(raw)).toBe('');
+  });
+
+  it('normalizeOutput does not keep a redundant parsed-json empty-output branch', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, '../../../../src/skills/providers/codex-provider.ts'),
+      'utf-8',
+    );
+
+    expect(source).not.toContain('parsedJsonLines > 0 && extracted.length === 0');
   });
 
   it('normalizeOutput handles mixed JSON and plain text', () => {


### PR DESCRIPTION
Improves CLI UX for explicit design-doc read failures, adds a BeastResult no-op status for all-skipped task outcomes, and removes a redundant Codex provider branch.

Worker handoff:
- Commit: 10dccb3
- Tests: targeted no-op/session/provider tests passed; orchestrator typecheck and tests reported passing.

Fixes #87
