### PR TITLE
docs: refresh issue 86 status docs

### DIFF
--- a/docs/CONTRACT_MATRIX.md
+++ b/docs/CONTRACT_MATRIX.md
@@ -9,11 +9,11 @@
 | `IAdapter` | MOD-01 firewall | Orchestrator | Yes |
 | `ISkillRegistry` | MOD-02 skills | MOD-04 planner (via `SkillsModule`) | Needs adapter |
 | `ILlmClient` (brain) | MOD-03 brain | MOD-03 internal | Yes |
-| `ILlmClient` (heartbeat) | MOD-08 heartbeat | MOD-08 internal | Different return type |
+| `ILlmClient` (heartbeat) | MOD-08 heartbeat | MOD-08 internal | Resolved via `IResultLlmClient` projection |
 | `GuardrailsModule` | MOD-04 planner | MOD-01 firewall impl | Yes |
 | `SkillsModule` | MOD-04 planner | MOD-02 skills impl | Needs adapter |
 | `MemoryModule` | MOD-04 planner | MOD-03 brain impl | Needs adapter |
-| `SelfCritiqueModule` | MOD-04 planner | MOD-07 governor impl | Structural match (minus branded TaskId) |
+| `SelfCritiqueModule` | MOD-04 planner | MOD-07 governor impl | Resolved for shared `TaskId` via `@franken/types`; still adapter-shaped |
 | `GuardrailsPort` | MOD-06 critique | MOD-01 firewall impl | Needs adapter |
 | `MemoryPort` | MOD-06 critique | MOD-03 brain impl | Needs adapter |
 | `ObservabilityPort` | MOD-06 critique | MOD-05 observer impl | Needs adapter |
@@ -26,38 +26,41 @@
 | `ICritiqueModule` | MOD-08 heartbeat | MOD-06 critique impl | Needs adapter |
 | `IHitlGateway` | MOD-08 heartbeat | MOD-07 governor impl | Needs adapter |
 
-## Type Mismatches Requiring Resolution
+## Resolved Type Mismatches
+
+These items were previously listed under “Type Mismatches Requiring Resolution”, but the live source now resolves them through `@franken/types` shared exports.
 
 ### 1. TaskId Branding
-- **Planner** (`franken-planner/src/core/types.ts:6`): `TaskId = string & { readonly __brand: 'TaskId' }`
-- **Critique** (`franken-critique/src/types/common.ts:17`): `TaskId = string`
-- **Governor** (`franken-governor/src/gateway/governor-critique-adapter.ts:9`): `taskId: string`
-- **Resolution**: Adopt branded `TaskId` in `@franken/types`. Critique and governor import from shared.
+- **Former mismatch**: Planner used branded `TaskId`; critique/governor used plain `string` values in cross-module contracts.
+- **Canonical source**: `packages/franken-types/src/ids.ts` exports branded `TaskId` and `createTaskId()`.
+- **Adopters**: Critique, governor, and planner import or re-export the shared type where their current cross-module contracts require it.
+- **Status**: Resolved.
 
 ### 2. Severity Scale Divergence
-- **Critique** (`franken-critique/src/types/common.ts:2`): `'critical' | 'warning' | 'info'`
-- **Governor** (`franken-governor/src/core/types.ts:3`): `'low' | 'medium' | 'high' | 'critical'`
-- **Heartbeat** (`franken-heartbeat/src/core/types.ts:6`): `'low' | 'medium' | 'high'`
-- **Resolution**: Superset `Severity` in `@franken/types` with module-specific subsets.
+- **Former mismatch**: Critique, governor, and heartbeat used overlapping but incompatible severity unions.
+- **Canonical source**: `packages/franken-types/src/severity.ts` exports the `Severity` superset plus module-specific `CritiqueSeverity`, `TriggerSeverity`, and `FlagSeverity` subsets.
+- **Status**: Resolved.
 
 ### 3. RationaleBlock Duplication
-- **Canonical** (`franken-planner/src/core/types.ts:81-91`)
-- **Local copy** (`franken-governor/src/gateway/governor-critique-adapter.ts:8-18`)
-- **Resolution**: Single definition in `@franken/types`, both import from there.
+- **Former mismatch**: Planner and governor carried separate `RationaleBlock`/verification shapes.
+- **Canonical source**: `packages/franken-types/src/rationale.ts` exports `RationaleBlock` and `VerificationResult`.
+- **Status**: Resolved.
 
 ### 4. ILlmClient Return Type Divergence
-- **Brain** (`franken-brain/src/compression/llm-client-interface.ts`): `Promise<string>`
-- **Heartbeat** (`franken-heartbeat/src/reflection/types.ts`): `Promise<Result<string>>`
-- **Resolution**: Two interfaces in `@franken/types`: `ILlmClient` (string) and `IResultLlmClient` (Result).
+- **Former mismatch**: Brain-style LLM clients returned `Promise<string>` while heartbeat-style clients returned `Promise<Result<string>>`.
+- **Canonical source**: `packages/franken-types/src/llm.ts` exports both `ILlmClient` and `IResultLlmClient` so the two call shapes are explicit instead of conflicting.
+- **Status**: Resolved.
 
-### 5. EpisodicTrace Quadruple-Definition
+## Remaining Type Mismatches Requiring Resolution or Adapter Boundaries
+
+### 1. EpisodicTrace Quadruple-Definition
 - **Brain** (`franken-brain/src/types/memory.ts:46-54`): Zod-backed, `input`/`output` fields
 - **Critique** (`franken-critique/src/types/contracts.ts:28-33`): `summary`/`outcome` fields
 - **Governor** (`franken-governor/src/audit/governor-memory-port.ts:1-12`): `toolName`/`tags` fields
 - **Heartbeat** (`franken-heartbeat/src/modules/memory.ts:5-11`): `summary`/`timestamp` fields
 - **Resolution**: Each module keeps its own projection (different shapes serve different purposes). Document that these are intentional views, not duplicates.
 
-### 6. Zod Version Split
+### 2. Zod Version Split
 - **Heartbeat**: `zod/v4` (Zod 4.x import path)
 - **Critique**: `zod` 3.24.x
 - **Resolution**: `@franken/types` uses Zod 4. Critique continues with Zod 3 internally. Shared types avoid Zod runtime validation at the boundary (use TypeScript types only for cross-module contracts).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -168,7 +168,7 @@ All 8 modules implemented with 971+ tests passing. 52 root-level integration tes
 ## Test Counts
 
 > Phase 7 baseline was 1,572 tests. Phases 8–11 and later consolidation work added orchestrator, web, MCP-suite, live-bench, and root integration tests.
-> Current tracked total was verified from the live workspace on 2026-05-26 with `npm test`, targeted package `vitest --reporter=json` runs, and `npm run test:root -- tests/docs-issue-86.test.ts` for this documentation guard.
+> Current tracked total was verified from the live workspace on 2026-06-07 with `npm test`, targeted package `vitest --reporter=json` runs, and `npm run test:root -- tests/docs-issue-86.test.ts` for this documentation guard (the guard test was added in the 2026-06-07 commit, so this provenance reflects that run rather than the earlier 2026-05-26 baseline).
 > Known stale/failing-module caveat: issues #27, #30, and #31 recorded historical red typecheck/build paths behind the old all-green claim. Those specific deleted-package paths are no longer in the current package set, but this table no longer treats historical package counts as proof of global health.
 
 | Module | Tests | Files | Status |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -167,21 +167,24 @@ All 8 modules implemented with 971+ tests passing. 52 root-level integration tes
 
 ## Test Counts
 
-> Phase 7 baseline was 1,572 tests. Phases 8–11 added orchestrator, web, and root integration tests.
-> Architecture consolidation (Phase 1) removed 5 packages and ~760 tests (package deletion + audit).
+> Phase 7 baseline was 1,572 tests. Phases 8–11 and later consolidation work added orchestrator, web, MCP-suite, live-bench, and root integration tests.
+> Current tracked total was verified from the live workspace on 2026-05-26 with `npm test`, targeted package `vitest --reporter=json` runs, and `npm run test:root -- tests/docs-issue-86.test.ts` for this documentation guard.
+> Known stale/failing-module caveat: issues #27, #30, and #31 recorded historical red typecheck/build paths behind the old all-green claim. Those specific deleted-package paths are no longer in the current package set, but this table no longer treats historical package counts as proof of global health.
 
 | Module | Tests | Files | Status |
 |--------|-------|-------|--------|
-| franken-types | 0 | 0 | PASS (no test files) |
-| franken-brain | 123 | 13 | PASS |
+| @fbeast/live-bench | 31 | 3 | PASS |
+| @fbeast/mcp-suite | 163 | 26 | PASS |
+| franken-brain | 41 | 2 | PASS |
+| franken-critique | 129 | 17 | PASS |
+| franken-governor | 113 | 17 | PASS |
+| franken-observer | 412 | 32 | PASS |
+| franken-orchestrator | 2,129 | 219 | PASS (1 skipped) |
 | franken-planner | 187 | 17 | PASS |
-| franken-observer | 377 | 27 | PASS |
-| franken-critique | 107 | 16 | PASS |
-| franken-governor | 111 | 17 | PASS |
-| franken-orchestrator | 1,674 | 180 | PASS (1 skipped) |
-| franken-web | 145 | 38 | PASS |
-| Root integration | 132 | 10 | PASS |
-| **Total** | **2,856** | **318** | **ALL PASS** |
+| franken-types | 61 | 3 | PASS |
+| franken-web | 193 | 47 | FAIL (1 dashboard EventSource constructor test fails when run directly) |
+| Root integration/docs guard | 135 | 11 | PASS for `tests/docs-issue-86.test.ts`; broader root suite not re-counted in this update |
+| **Current tracked total** | **3,594** | **394** | **NOT ALL GREEN — see franken-web caveat** |
 
 ## Phase 8: CLI Gap Closure
 

--- a/docs/adr/007-cli-skill-execution-type.md
+++ b/docs/adr/007-cli-skill-execution-type.md
@@ -4,7 +4,7 @@
 Accepted
 
 Supersedes: None
-Superseded by: ADR-010
+Superseded by: None (ADR-010 changes only CLI provider selection; the skill execution primitives defined here remain the active design reference, per ADR-008 and docs/ARCHITECTURE.md)
 
 ## Context
 The RALPH loop workflow (chunk decomposition → CLI-spawned AI loops → git branch isolation → observer tracing) was implemented as an ad-hoc build runner script (`plan-2026-03-05/build-runner.ts`). This script duplicates concerns that `franken-observer` (tracing, cost tracking, circuit breakers), `franken-planner` (task ordering via PlanGraph), and `franken-orchestrator` (the execution pipeline) already handle.

--- a/docs/adr/007-cli-skill-execution-type.md
+++ b/docs/adr/007-cli-skill-execution-type.md
@@ -3,6 +3,9 @@
 ## Status
 Accepted
 
+Supersedes: None
+Superseded by: ADR-010
+
 ## Context
 The RALPH loop workflow (chunk decomposition → CLI-spawned AI loops → git branch isolation → observer tracing) was implemented as an ad-hoc build runner script (`plan-2026-03-05/build-runner.ts`). This script duplicates concerns that `franken-observer` (tracing, cost tracking, circuit breakers), `franken-planner` (task ordering via PlanGraph), and `franken-orchestrator` (the execution pipeline) already handle.
 

--- a/docs/adr/010-pluggable-cli-providers.md
+++ b/docs/adr/010-pluggable-cli-providers.md
@@ -4,7 +4,7 @@
 
 Accepted
 
-Supersedes: ADR-007
+Supersedes: ADR-009 (partial — only the deferred-CLI-provider consequence; ADR-007's CLI skill execution primitives remain the active design reference)
 
 ## Context
 

--- a/docs/adr/010-pluggable-cli-providers.md
+++ b/docs/adr/010-pluggable-cli-providers.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+Supersedes: ADR-007
+
 ## Context
 
 The orchestrator hardcoded CLI agent support as a `'claude' | 'codex'` union type with if/else dispatch scattered across `martin-loop.ts`, `cli-llm-adapter.ts`, `args.ts`, `dep-factory.ts`, and `session.ts`. Adding a new provider (e.g., Gemini CLI, Aider) required touching 5+ files with no isolation or testability. Rate-limit handling, env-var filtering, and output normalization were inlined per provider.

--- a/packages/franken-governor/src/core/types.ts
+++ b/packages/franken-governor/src/core/types.ts
@@ -1,6 +1,11 @@
+import type { TriggerSeverity } from '@franken/types';
+
 export type ResponseCode = 'APPROVE' | 'REGEN' | 'ABORT' | 'DEBUG';
 
-export type TriggerSeverity = 'low' | 'medium' | 'high' | 'critical';
+// Canonicalized: the governor severity scale is the shared `@franken/types`
+// `TriggerSeverity` (see docs/CONTRACT_MATRIX.md §2), re-exported here so the
+// boundary is no longer a duplicated local union.
+export type { TriggerSeverity };
 
 export interface TriggerResult {
   readonly triggered: boolean;

--- a/tests/docs-issue-86.test.ts
+++ b/tests/docs-issue-86.test.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const ROOT = resolve(import.meta.dirname, '..');
+// `import.meta.dirname` is only available in Node >= 20.11, but the repo's
+// engines allow >= 20.0.0; use the portable fileURLToPath pattern instead.
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
 
 describe('issue #86 documentation accuracy', () => {
@@ -26,9 +29,12 @@ describe('issue #86 documentation accuracy', () => {
     const adr007 = readDoc('docs/adr/007-cli-skill-execution-type.md');
     const adr010 = readDoc('docs/adr/010-pluggable-cli-providers.md');
 
+    // ADR-007 (CLI skill execution primitives) is still the active design
+    // reference; ADR-010 only changes provider selection and partially
+    // supersedes ADR-009's deferred-provider consequence — not ADR-007.
     expect(adr007).toMatch(/^Supersedes: None$/m);
-    expect(adr007).toMatch(/^Superseded by: ADR-010$/m);
-    expect(adr010).toMatch(/^Supersedes: ADR-007$/m);
+    expect(adr007).toMatch(/^Superseded by: None/m);
+    expect(adr010).toMatch(/^Supersedes: ADR-009/m);
   });
 
   it('does not claim the stale Phase 7 baseline is the current all-pass test status', () => {

--- a/tests/docs-issue-86.test.ts
+++ b/tests/docs-issue-86.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+describe('issue #86 documentation accuracy', () => {
+  it('marks shared @franken/types mismatches as resolved in the contract matrix', () => {
+    const matrix = readDoc('docs/CONTRACT_MATRIX.md');
+
+    expect(matrix).toContain('## Resolved Type Mismatches');
+    for (const resolvedType of [
+      'TaskId Branding',
+      'Severity Scale Divergence',
+      'RationaleBlock Duplication',
+      'ILlmClient Return Type Divergence',
+    ]) {
+      expect(matrix).toMatch(
+        new RegExp(`### \\d+\\. ${resolvedType}[\\s\\S]*\\*\\*Status\\*\\*: Resolved`),
+      );
+    }
+  });
+
+  it('records explicit ADR supersession metadata for ADR-007 and ADR-010', () => {
+    const adr007 = readDoc('docs/adr/007-cli-skill-execution-type.md');
+    const adr010 = readDoc('docs/adr/010-pluggable-cli-providers.md');
+
+    expect(adr007).toMatch(/^Supersedes: None$/m);
+    expect(adr007).toMatch(/^Superseded by: ADR-010$/m);
+    expect(adr010).toMatch(/^Supersedes: ADR-007$/m);
+  });
+
+  it('does not claim the stale Phase 7 baseline is the current all-pass test status', () => {
+    const progress = readDoc('docs/PROGRESS.md');
+
+    expect(progress).not.toContain('**ALL PASS**');
+    expect(progress).toContain('Current tracked total');
+    expect(progress).toContain('Known stale/failing-module caveat');
+    expect(progress).toContain('#27');
+    expect(progress).toContain('#30');
+    expect(progress).toContain('#31');
+  });
+});

--- a/tests/docs-issue-86.test.ts
+++ b/tests/docs-issue-86.test.ts
@@ -17,7 +17,7 @@ describe('issue #86 documentation accuracy', () => {
       'ILlmClient Return Type Divergence',
     ]) {
       expect(matrix).toMatch(
-        new RegExp(`### \\d+\\. ${resolvedType}[\\s\\S]*\\*\\*Status\\*\\*: Resolved`),
+        new RegExp(`### \\d+\\. ${resolvedType}(?:(?!###)[\\s\\S])*?\\*\\*Status\\*\\*: Resolved`),
       );
     }
   });


### PR DESCRIPTION
Refreshes stale documentation for CONTRACT_MATRIX, ADR supersession state, and PROGRESS test counts, with docs regression coverage.

Worker handoff:
- Commit: 1d1f8e9e4eb0
- Tests: docs issue test passed; full npm test/turbo pass reported, with documented direct franken-web EventSource limitation.

Fixes #86
