### PR TITLE
fix(orchestrator): harden CLI adapter timeout handling

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -338,7 +338,17 @@ export class CliLlmAdapter implements IAdapter {
       let stdout = '';
       let stderr = '';
       let settled = false;
+      let timedOut = false;
+      let hardKillTimer: ReturnType<typeof setTimeout> | undefined;
       let lineBuffer = '';
+
+      const clearTimers = (): void => {
+        clearTimeout(timer);
+        if (hardKillTimer) {
+          clearTimeout(hardKillTimer);
+          hardKillTimer = undefined;
+        }
+      };
 
       const settle = (fn: () => void): void => {
         if (settled) return;
@@ -367,24 +377,26 @@ export class CliLlmAdapter implements IAdapter {
       });
 
       const timer = setTimeout(() => {
+        timedOut = true;
         child.kill('SIGTERM');
-        const killTimer = setTimeout(() => {
+        hardKillTimer = setTimeout(() => {
           try { child.kill('SIGKILL'); } catch {}
         }, 5_000);
-        killTimer.unref();
         settle(() => reject(new Error(`CLI timeout after ${this.opts.timeoutMs}ms`)));
       }, this.opts.timeoutMs);
 
       child.on('close', (code) => {
-        clearTimeout(timer);
+        clearTimers();
         if (this.opts.onStreamLine && lineBuffer.trim().length > 0) {
           this.opts.onStreamLine(lineBuffer);
         }
+        if (timedOut) return;
         settle(() => resolve({ stdout, stderr, exitCode: code ?? 1 }));
       });
 
       child.on('error', (err) => {
-        clearTimeout(timer);
+        clearTimers();
+        if (timedOut) return;
         settle(() => reject(err));
       });
     });

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -382,6 +382,9 @@ export class CliLlmAdapter implements IAdapter {
         hardKillTimer = setTimeout(() => {
           try { child.kill('SIGKILL'); } catch {}
         }, 5_000);
+        // Don't keep the event loop alive waiting on the hard-kill fallback;
+        // short-lived invocations should exit promptly after a timeout reject.
+        hardKillTimer.unref();
         settle(() => reject(new Error(`CLI timeout after ${this.opts.timeoutMs}ms`)));
       }, this.opts.timeoutMs);
 
@@ -395,8 +398,14 @@ export class CliLlmAdapter implements IAdapter {
       });
 
       child.on('error', (err) => {
+        if (timedOut) {
+          // An 'error' here can mean the process couldn't be killed; keep the
+          // scheduled hard-kill (SIGKILL) so a process that ignored SIGTERM is
+          // still terminated. Only cancel the original deadline timer.
+          clearTimeout(timer);
+          return;
+        }
         clearTimers();
-        if (timedOut) return;
         settle(() => reject(err));
       });
     });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -403,6 +403,53 @@ describe('CliLlmAdapter', () => {
           .rejects.toThrow(/timeout/i);
       });
 
+      it('settles the timeout path once when the child closes before hard kill', async () => {
+        vi.useFakeTimers();
+        const killSignals: NodeJS.Signals[] = [];
+        const rejections: Error[] = [];
+
+        try {
+          const spawnFn = (): ChildProcess => {
+            const proc = new EventEmitter() as ChildProcess;
+            Object.defineProperty(proc, 'stdin', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'stdout', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'stderr', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'kill', {
+              value: vi.fn((signal?: NodeJS.Signals | number) => {
+                if (typeof signal === 'string') killSignals.push(signal);
+                if (signal === 'SIGTERM') {
+                  setTimeout(() => proc.emit('close', null), 1);
+                }
+                return true;
+              }),
+              writable: false,
+            });
+            return proc;
+          };
+          const adapter = new CliLlmAdapter(
+            claudeProvider,
+            { ...baseOpts, timeoutMs: 50 },
+            spawnFn,
+          );
+
+          const result = adapter.execute({ prompt: 'test', maxTurns: 1 }).catch((error: Error) => {
+            rejections.push(error);
+            throw error;
+          });
+          const assertion = expect(result).rejects.toThrow('CLI timeout after 50ms');
+
+          await vi.advanceTimersByTimeAsync(50);
+          await vi.advanceTimersByTimeAsync(1);
+          await assertion;
+          await vi.advanceTimersByTimeAsync(5_000);
+
+          expect(rejections).toHaveLength(1);
+          expect(killSignals).toEqual(['SIGTERM']);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it('sets cwd to opts.workingDir', async () => {
         const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
         const adapter = new CliLlmAdapter(


### PR DESCRIPTION
Hardens CliLlmAdapter timeout handling to avoid duplicate settlement and late hard-kill behavior after a graceful timeout close.

Worker handoff:
- Commit: f2d22daf982d6f42555542decc3fbcb3086eacde
- Tests: timeout regression test red/green; cli-llm-adapter targeted tests, typecheck, and adapter tests reported passing.

Fixes #81
