### PR TITLE
fix(brain): bound working memory growth with configurable limits

### DIFF
--- a/packages/franken-brain/src/index.ts
+++ b/packages/franken-brain/src/index.ts
@@ -1,1 +1,6 @@
-export { SqliteBrain } from './sqlite-brain.js';
+export {
+  SqliteBrain,
+  WorkingMemoryLimitError,
+  DEFAULT_WORKING_MEMORY_LIMITS,
+  type WorkingMemoryLimits,
+} from './sqlite-brain.js';

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -63,15 +63,33 @@ class SqliteWorkingMemory implements IWorkingMemory {
     return this.store.get(key);
   }
 
-  set(key: string, value: unknown): void {
+  /**
+   * Serializes and size-checks one entry without mutating state.
+   * Returns the JSON round-tripped value so what we retain in memory is
+   * exactly the accounted (and SQLite-persisted) form — a Map or class
+   * instance cannot hide megabytes behind a tiny `{}` serialization.
+   */
+  private prepareEntry(key: string, value: unknown): { normalized: unknown; size: number } {
     const serialized = JSON.stringify(value);
-    const size = serialized === undefined ? 0 : Buffer.byteLength(serialized, 'utf8');
-
-    if (size > this.limits.maxValueBytes) {
+    if (serialized === undefined) {
       throw new WorkingMemoryLimitError(
-        `Working memory value for "${key}" is ${size} bytes, exceeding maxValueBytes (${this.limits.maxValueBytes})`,
+        `Working memory value for "${key}" is not JSON-serializable and could not be persisted`,
       );
     }
+    const valueBytes = Buffer.byteLength(serialized, 'utf8');
+    if (valueBytes > this.limits.maxValueBytes) {
+      throw new WorkingMemoryLimitError(
+        `Working memory value for "${key}" is ${valueBytes} bytes, exceeding maxValueBytes (${this.limits.maxValueBytes})`,
+      );
+    }
+    // Keys are retained by the Map and the SQLite table too — count them.
+    const size = Buffer.byteLength(key, 'utf8') + valueBytes;
+    return { normalized: JSON.parse(serialized) as unknown, size };
+  }
+
+  set(key: string, value: unknown): void {
+    const { normalized, size } = this.prepareEntry(key, value);
+
     if (!this.store.has(key) && this.store.size >= this.limits.maxEntries) {
       throw new WorkingMemoryLimitError(
         `Working memory is full: ${this.store.size} entries, maxEntries is ${this.limits.maxEntries}`,
@@ -84,7 +102,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       );
     }
 
-    this.store.set(key, value);
+    this.store.set(key, normalized);
     this.sizes.set(key, size);
     this.totalBytes = newTotal;
   }
@@ -117,10 +135,33 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   restore(snap: Record<string, unknown>): void {
-    this.clear();
-    for (const [key, value] of Object.entries(snap)) {
-      this.set(key, value);
+    // Validate the whole snapshot before mutating so a limit failure
+    // leaves the previous state intact instead of a half-restored one.
+    const entries = Object.entries(snap);
+    if (entries.length > this.limits.maxEntries) {
+      throw new WorkingMemoryLimitError(
+        `Snapshot has ${entries.length} entries, exceeding maxEntries (${this.limits.maxEntries})`,
+      );
     }
+    let total = 0;
+    const prepared: Array<[string, unknown, number]> = [];
+    for (const [key, value] of entries) {
+      const { normalized, size } = this.prepareEntry(key, value);
+      total += size;
+      prepared.push([key, normalized, size]);
+    }
+    if (!Number.isSafeInteger(total) || total > this.limits.maxTotalBytes) {
+      throw new WorkingMemoryLimitError(
+        `Snapshot is ${total} bytes, exceeding maxTotalBytes (${this.limits.maxTotalBytes})`,
+      );
+    }
+
+    this.clear();
+    for (const [key, normalized, size] of prepared) {
+      this.store.set(key, normalized);
+      this.sizes.set(key, size);
+    }
+    this.totalBytes = total;
   }
 
   clear(): void {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -372,8 +372,12 @@ export class SqliteBrain implements IBrain {
     };
   }
 
-  static hydrate(snapshot: BrainSnapshot, dbPath: string = ':memory:'): SqliteBrain {
-    const brain = new SqliteBrain(dbPath);
+  static hydrate(
+    snapshot: BrainSnapshot,
+    dbPath: string = ':memory:',
+    workingMemoryLimits?: Partial<WorkingMemoryLimits>,
+  ): SqliteBrain {
+    const brain = new SqliteBrain(dbPath, workingMemoryLimits);
     brain.working.restore(snapshot.working);
     for (const event of snapshot.episodic) {
       brain.episodic.record(event);

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -12,10 +12,37 @@ import type {
 
 // --- Working Memory ---
 
+export interface WorkingMemoryLimits {
+  /** Maximum number of keys held in working memory. */
+  maxEntries: number;
+  /** Maximum serialized size of a single value, in bytes. */
+  maxValueBytes: number;
+  /** Maximum total serialized size across all values, in bytes. */
+  maxTotalBytes: number;
+}
+
+export const DEFAULT_WORKING_MEMORY_LIMITS: WorkingMemoryLimits = {
+  maxEntries: 10_000,
+  maxValueBytes: 5 * 1024 * 1024,
+  maxTotalBytes: 64 * 1024 * 1024,
+};
+
+export class WorkingMemoryLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkingMemoryLimitError';
+  }
+}
+
 class SqliteWorkingMemory implements IWorkingMemory {
   private store = new Map<string, unknown>();
+  private sizes = new Map<string, number>();
+  private totalBytes = 0;
 
-  constructor(private db: Database.Database) {}
+  constructor(
+    private db: Database.Database,
+    private limits: WorkingMemoryLimits = DEFAULT_WORKING_MEMORY_LIMITS,
+  ) {}
 
   /** Flush in-memory Map to SQLite working_memory table (called on checkpoint). */
   flushToDb(): void {
@@ -37,11 +64,40 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   set(key: string, value: unknown): void {
+    const serialized = JSON.stringify(value);
+    const size = serialized === undefined ? 0 : Buffer.byteLength(serialized, 'utf8');
+
+    if (size > this.limits.maxValueBytes) {
+      throw new WorkingMemoryLimitError(
+        `Working memory value for "${key}" is ${size} bytes, exceeding maxValueBytes (${this.limits.maxValueBytes})`,
+      );
+    }
+    if (!this.store.has(key) && this.store.size >= this.limits.maxEntries) {
+      throw new WorkingMemoryLimitError(
+        `Working memory is full: ${this.store.size} entries, maxEntries is ${this.limits.maxEntries}`,
+      );
+    }
+    const newTotal = this.totalBytes - (this.sizes.get(key) ?? 0) + size;
+    if (!Number.isSafeInteger(newTotal) || newTotal > this.limits.maxTotalBytes) {
+      throw new WorkingMemoryLimitError(
+        `Working memory byte budget exceeded: ${newTotal} bytes, maxTotalBytes is ${this.limits.maxTotalBytes}`,
+      );
+    }
+
     this.store.set(key, value);
+    this.sizes.set(key, size);
+    this.totalBytes = newTotal;
   }
 
   delete(key: string): boolean {
+    this.totalBytes -= this.sizes.get(key) ?? 0;
+    this.sizes.delete(key);
     return this.store.delete(key);
+  }
+
+  /** Current occupancy, for callers that want to react before limits are hit. */
+  usage(): { entries: number; totalBytes: number; limits: WorkingMemoryLimits } {
+    return { entries: this.store.size, totalBytes: this.totalBytes, limits: { ...this.limits } };
   }
 
   has(key: string): boolean {
@@ -61,14 +117,16 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   restore(snap: Record<string, unknown>): void {
-    this.store.clear();
+    this.clear();
     for (const [key, value] of Object.entries(snap)) {
-      this.store.set(key, value);
+      this.set(key, value);
     }
   }
 
   clear(): void {
     this.store.clear();
+    this.sizes.clear();
+    this.totalBytes = 0;
   }
 }
 
@@ -215,12 +273,15 @@ export class SqliteBrain implements IBrain {
 
   private db: Database.Database;
 
-  constructor(dbPath: string = ':memory:') {
+  constructor(dbPath: string = ':memory:', workingMemoryLimits?: Partial<WorkingMemoryLimits>) {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');
     this.initSchema();
-    this.working = new SqliteWorkingMemory(this.db);
+    this.working = new SqliteWorkingMemory(this.db, {
+      ...DEFAULT_WORKING_MEMORY_LIMITS,
+      ...workingMemoryLimits,
+    });
     this.episodic = new SqliteEpisodicMemory(this.db);
     this.recovery = new SqliteRecoveryMemory(this.db, () => this.working.flushToDb());
   }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BrainSnapshotSchema } from '@franken/types';
 import type { EpisodicEvent, ExecutionState, BrainSnapshot } from '@franken/types';
-import { SqliteBrain } from '../../src/sqlite-brain.js';
+import {
+  SqliteBrain,
+  WorkingMemoryLimitError,
+  DEFAULT_WORKING_MEMORY_LIMITS,
+} from '../../src/sqlite-brain.js';
 
 describe('SqliteBrain', () => {
   let brain: SqliteBrain;
@@ -57,6 +61,77 @@ describe('SqliteBrain', () => {
 
     it('delete() returns false for non-existent key', () => {
       expect(brain.working.delete('nope')).toBe(false);
+    });
+  });
+
+  describe('working memory limits (issue #37)', () => {
+    it('applies generous default limits', () => {
+      const usage = brain.working.usage();
+      expect(usage.limits).toEqual(DEFAULT_WORKING_MEMORY_LIMITS);
+      expect(usage.entries).toBe(0);
+      expect(usage.totalBytes).toBe(0);
+    });
+
+    it('rejects new keys past maxEntries', () => {
+      const bounded = new SqliteBrain(':memory:', { maxEntries: 2 });
+      bounded.working.set('a', 1);
+      bounded.working.set('b', 2);
+      expect(() => bounded.working.set('c', 3)).toThrow(WorkingMemoryLimitError);
+      bounded.close();
+    });
+
+    it('allows overwriting an existing key at maxEntries', () => {
+      const bounded = new SqliteBrain(':memory:', { maxEntries: 2 });
+      bounded.working.set('a', 1);
+      bounded.working.set('b', 2);
+      expect(() => bounded.working.set('a', 'updated')).not.toThrow();
+      expect(bounded.working.get('a')).toBe('updated');
+      bounded.close();
+    });
+
+    it('rejects a single value larger than maxValueBytes', () => {
+      const bounded = new SqliteBrain(':memory:', { maxValueBytes: 16 });
+      expect(() => bounded.working.set('big', 'x'.repeat(100))).toThrow(WorkingMemoryLimitError);
+      bounded.close();
+    });
+
+    it('rejects writes that would exceed maxTotalBytes', () => {
+      const bounded = new SqliteBrain(':memory:', { maxTotalBytes: 30 });
+      bounded.working.set('a', 'x'.repeat(10));
+      expect(() => bounded.working.set('b', 'y'.repeat(20))).toThrow(WorkingMemoryLimitError);
+      bounded.close();
+    });
+
+    it('frees byte budget when keys are deleted or overwritten', () => {
+      const bounded = new SqliteBrain(':memory:', { maxTotalBytes: 30 });
+      bounded.working.set('a', 'x'.repeat(10));
+      bounded.working.delete('a');
+      expect(() => bounded.working.set('b', 'y'.repeat(20))).not.toThrow();
+      bounded.working.set('b', 'z');
+      expect(() => bounded.working.set('c', 'w'.repeat(20))).not.toThrow();
+      bounded.close();
+    });
+
+    it('resets accounting on clear()', () => {
+      const bounded = new SqliteBrain(':memory:', { maxTotalBytes: 30 });
+      bounded.working.set('a', 'x'.repeat(20));
+      bounded.working.clear();
+      expect(bounded.working.usage().totalBytes).toBe(0);
+      expect(() => bounded.working.set('b', 'y'.repeat(20))).not.toThrow();
+      bounded.close();
+    });
+
+    it('enforces limits on restore()', () => {
+      const bounded = new SqliteBrain(':memory:', { maxEntries: 1 });
+      expect(() => bounded.working.restore({ a: 1, b: 2 })).toThrow(WorkingMemoryLimitError);
+      bounded.close();
+    });
+
+    it('tracks usage as entries are added', () => {
+      brain.working.set('a', 'hello');
+      const usage = brain.working.usage();
+      expect(usage.entries).toBe(1);
+      expect(usage.totalBytes).toBe(JSON.stringify('hello').length);
     });
 
     it('handles complex objects (nested JSON)', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -155,6 +155,21 @@ describe('SqliteBrain', () => {
       expect(brain.working.get('m')).toEqual({});
     });
 
+    it('hydrate() honors custom working memory limits', () => {
+      const roomy = new SqliteBrain(':memory:', { maxEntries: 20_000 });
+      for (let i = 0; i < 15; i++) roomy.working.set(`k${i}`, i);
+      const snapshot = roomy.serialize();
+      roomy.close();
+
+      // Defaults would allow this, so prove the override flows through both ways.
+      expect(() => SqliteBrain.hydrate(snapshot, ':memory:', { maxEntries: 10 })).toThrow(
+        WorkingMemoryLimitError,
+      );
+      const hydrated = SqliteBrain.hydrate(snapshot, ':memory:', { maxEntries: 20_000 });
+      expect(hydrated.working.keys()).toHaveLength(15);
+      hydrated.close();
+    });
+
     it('keeps previous state when restore() exceeds limits', () => {
       const bounded = new SqliteBrain(':memory:', { maxEntries: 2 });
       bounded.working.set('keep', 'me');

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -127,11 +127,43 @@ describe('SqliteBrain', () => {
       bounded.close();
     });
 
-    it('tracks usage as entries are added', () => {
+    it('tracks usage as entries are added, counting key and value bytes', () => {
       brain.working.set('a', 'hello');
       const usage = brain.working.usage();
       expect(usage.entries).toBe(1);
-      expect(usage.totalBytes).toBe(JSON.stringify('hello').length);
+      expect(usage.totalBytes).toBe('a'.length + JSON.stringify('hello').length);
+    });
+
+    it('counts key bytes against the byte budget', () => {
+      const bounded = new SqliteBrain(':memory:', { maxTotalBytes: 30 });
+      expect(() => bounded.working.set('k'.repeat(40), 1)).toThrow(WorkingMemoryLimitError);
+      bounded.close();
+    });
+
+    it('rejects values that are not JSON-serializable', () => {
+      expect(() => brain.working.set('fn', () => 'hidden closure')).toThrow(
+        WorkingMemoryLimitError,
+      );
+    });
+
+    it('accounts for the serialized form, not a deceptive small JSON facade', () => {
+      // A Map stringifies to '{}' but would retain its full contents if stored
+      // by reference. The store normalizes to the JSON round-trip, so what is
+      // retained is exactly what was measured (and what flushToDb persists).
+      const big = new Map([['payload', 'x'.repeat(1000)]]);
+      brain.working.set('m', big);
+      expect(brain.working.get('m')).toEqual({});
+    });
+
+    it('keeps previous state when restore() exceeds limits', () => {
+      const bounded = new SqliteBrain(':memory:', { maxEntries: 2 });
+      bounded.working.set('keep', 'me');
+      expect(() => bounded.working.restore({ a: 1, b: 2, c: 3 })).toThrow(
+        WorkingMemoryLimitError,
+      );
+      expect(bounded.working.get('keep')).toBe('me');
+      expect(bounded.working.keys()).toEqual(['keep']);
+      bounded.close();
     });
 
     it('handles complex objects (nested JSON)', () => {


### PR DESCRIPTION
Closes #37.

## Summary
Issue #37 targeted the old turn-based `WorkingMemoryStore`, which was deleted in the SqliteBrain consolidation — but the unbounded-growth concern still applied to `SqliteWorkingMemory`: its backing `Map` accepted unlimited keys and arbitrarily large values, so a long-running agent could still exhaust process memory.

- `WorkingMemoryLimits` (`maxEntries`, `maxValueBytes`, `maxTotalBytes`) with generous defaults (10k entries, 5 MiB/value, 64 MiB total), overridable via the `SqliteBrain` constructor.
- Writes that exceed limits throw a typed `WorkingMemoryLimitError` instead of silently growing toward OOM.
- Per-key serialized sizes are tracked; `delete`/`clear`/overwrite free budget; `restore()` enforces the same limits.
- The byte accumulator is guarded with `Number.isSafeInteger` (overflow protection from the acceptance criteria).
- New `usage()` accessor gives callers early warning before limits are hit.

## Acceptance criteria from #37 (adapted to current store)
- [x] Configurable max entry count and max byte budget
- [x] Reject when limits are hit (typed error)
- [x] Overflow protection for the size accumulator

## Testing
- `franken-brain`: 50 tests pass (9 new limit tests), typecheck clean
- Full monorepo `turbo run test`: 20 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)