### PR TITLE
fix(orchestrator): prove and harden MartinLoop abort-listener cleanup

### DIFF
--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -28,7 +28,7 @@ export function parseResetTime(stderr: string, stdout: string): { sleepSeconds: 
   return parseResetTimeText(`${stderr}\n${stdout}`);
 }
 
-function defaultSleep(ms: number): Promise<void> {
+export function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
@@ -45,7 +45,8 @@ function abortError(): Error {
   return error;
 }
 
-function sleepWithAbort(
+/** Exported for tests: regression coverage that no abort listeners leak (issue #39). */
+export function sleepWithAbort(
   ms: number,
   sleepFn: (durationMs: number) => Promise<void>,
   signal?: AbortSignal,
@@ -311,15 +312,16 @@ function spawnIteration(
     });
 
     // Timeout: SIGTERM first, then SIGKILL after 5s
+    const escalationTimers: NodeJS.Timeout[] = [];
     const timer = setTimeout(() => {
       timedOut = true;
       config.onProviderTimeout?.(provider.name, config.timeoutMs);
       child.kill('SIGTERM');
-      setTimeout(() => {
+      escalationTimers.push(setTimeout(() => {
         try { child.kill('SIGKILL'); } catch { /* already dead */ }
-      }, 5_000);
+      }, 5_000));
       // Hard fail-safe: if process still hasn't closed, force resolution.
-      setTimeout(() => {
+      escalationTimers.push(setTimeout(() => {
         if (streamBuffer) {
           const remaining = streamBuffer.flush();
           for (const line of remaining) cleanParts.push(line);
@@ -331,11 +333,19 @@ function spawnIteration(
           timedOut: true,
           cleanStdout: cleanParts.join('\n'),
         });
-      }, 7_000);
+      }, 7_000));
     }, config.timeoutMs);
 
-    child.on('close', (code) => {
+    // Clear the timeout and any pending kill-escalation timers so a settled
+    // iteration does not keep the child and its buffers alive for up to 7s.
+    const clearTimers = (): void => {
       clearTimeout(timer);
+      for (const t of escalationTimers) clearTimeout(t);
+      escalationTimers.length = 0;
+    };
+
+    child.on('close', (code) => {
+      clearTimers();
       if (streamBuffer) {
         const remaining = streamBuffer.flush();
         for (const line of remaining) cleanParts.push(line);
@@ -344,7 +354,7 @@ function spawnIteration(
     });
 
     child.on('error', (err) => {
-      clearTimeout(timer);
+      clearTimers();
       reject(err);
     });
   });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop-abort-listeners.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop-abort-listeners.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getEventListeners } from 'node:events';
+import { sleepWithAbort, defaultSleep } from '../../../src/skills/martin-loop.js';
+
+const abortListenerCount = (signal: AbortSignal): number =>
+  getEventListeners(signal, 'abort').length;
+
+describe('sleepWithAbort listener hygiene (issue #39)', () => {
+  it('removes the abort listener after a normal default-sleep completion', async () => {
+    const ac = new AbortController();
+    await sleepWithAbort(1, defaultSleep, ac.signal);
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+
+  it('removes the abort listener after a normal custom-sleepFn completion', async () => {
+    const ac = new AbortController();
+    await sleepWithAbort(1, () => Promise.resolve(), ac.signal);
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+
+  it('removes the abort listener when the custom sleepFn rejects', async () => {
+    const ac = new AbortController();
+    await expect(
+      sleepWithAbort(1, () => Promise.reject(new Error('sleep broke')), ac.signal),
+    ).rejects.toThrow('sleep broke');
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+
+  it('removes the abort listener when aborted mid-sleep', async () => {
+    const ac = new AbortController();
+    const never = (): Promise<void> => new Promise(() => undefined);
+    const pending = sleepWithAbort(60_000, never, ac.signal);
+    ac.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+
+  it('does not accumulate listeners across many repeated sleeps on one signal', async () => {
+    const ac = new AbortController();
+    for (let i = 0; i < 100; i++) {
+      await sleepWithAbort(0, defaultSleep, ac.signal);
+      await sleepWithAbort(0, () => Promise.resolve(), ac.signal);
+    }
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+
+  it('does not accumulate listeners across repeated aborted sleeps', async () => {
+    const ac = new AbortController();
+    const never = (): Promise<void> => new Promise(() => undefined);
+
+    const first = sleepWithAbort(60_000, never, ac.signal);
+    ac.abort();
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+
+    // Once aborted, further sleeps must reject immediately without attaching anything.
+    for (let i = 0; i < 100; i++) {
+      await expect(sleepWithAbort(60_000, never, ac.signal)).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+    }
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    await expect(sleepWithAbort(1, defaultSleep, ac.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    expect(abortListenerCount(ac.signal)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #39.

## Summary
The specific leak in the issue (abort listener never removed when the hard fail-safe settles first) was already eliminated by an earlier refactor of `sleepWithAbort` — every settle path removes the listener, and registration uses `{ once: true }`. This PR closes the remaining gaps:

- **Regression tests** (the issue's unmet acceptance criterion): 7 tests using `node:events`' `getEventListeners()` proving listener count returns to 0 across default-sleep, custom-sleepFn, mid-sleep abort, sleep rejection, already-aborted, and 100-iteration repeated paths.
- **Timer hygiene on the timeout path**: after a timeout fired, the 5s SIGKILL and 7s hard-fail-safe timers were never cleared when the child closed, keeping the dead child and its output buffers reachable for up to 7s per timed-out iteration. They're now cleared on `close`/`error`.
- `sleepWithAbort`/`defaultSleep` exported for test access.

## Acceptance criteria from #39
- [x] Listeners cleaned on every settle path (verified present; covered by tests)
- [x] Test proving repeated timeouts don't accumulate listeners

## Testing
- Full `franken-orchestrator` suite: 219 files, 2165 tests passed (1 skipped)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)