### PR TITLE
fix(orchestrator): resolve review action item hardening

### DIFF
--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -1,3 +1,4 @@
+import { Worker } from 'node:worker_threads';
 import type {
   Evaluator,
   EvaluationInput,
@@ -8,6 +9,9 @@ import type { GuardrailsPort } from '../types/contracts.js';
 
 const MAX_SAFETY_PATTERN_LENGTH = 1_000;
 const MAX_ALTERNATIVE_PREFIX_TOKENS = MAX_SAFETY_PATTERN_LENGTH;
+const REGEX_EVALUATION_BASE_TIMEOUT_MS = 2_000;
+const REGEX_EVALUATION_MAX_TIMEOUT_MS = 10_000;
+const REGEX_EVALUATION_BYTES_PER_EXTRA_MS = 32 * 1024;
 const EMPTY_ALTERNATIVE_TOKEN = 'EMPTY_ALTERNATIVE';
 
 interface RegexGroupState {
@@ -44,8 +48,21 @@ export class SafetyEvaluator implements Evaluator {
         continue;
       }
 
-      const regex = new RegExp(rule.pattern, 'g');
-      if (regex.test(input.content)) {
+      const matchResult = await this.regexMatchesWithTimeout(
+        rule.pattern,
+        input.content,
+      );
+      if (matchResult === 'timeout') {
+        findings.push({
+          message: `Safety rule regex evaluation timed out: ${rule.description}`,
+          severity: 'warning',
+          suggestion:
+            'Review this validated pattern or narrow the input scope; evaluation exceeded the regex safety timeout and was skipped to keep critique responsive.',
+        });
+        continue;
+      }
+
+      if (matchResult) {
         const isBlock = rule.severity === 'block';
         if (isBlock) hasBlock = true;
 
@@ -72,6 +89,81 @@ export class SafetyEvaluator implements Evaluator {
       score,
       findings,
     };
+  }
+
+  private async regexMatchesWithTimeout(
+    pattern: string,
+    content: string,
+  ): Promise<boolean | 'timeout'> {
+    const worker = new Worker(
+      `
+        import { parentPort, workerData } from 'node:worker_threads';
+        try {
+          const regex = new RegExp(workerData.pattern, 'g');
+          parentPort.postMessage({ matches: regex.test(workerData.content) });
+        } catch (error) {
+          parentPort.postMessage({ error: error instanceof Error ? error.message : String(error) });
+        }
+      `,
+      { eval: true, workerData: { pattern, content } },
+    );
+
+    return new Promise<boolean | 'timeout'>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        void worker.terminate();
+        resolve('timeout');
+      }, this.regexEvaluationTimeoutMs(content.length));
+
+      worker.once('message', (message: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        void worker.terminate();
+
+        if (
+          typeof message === 'object' &&
+          message !== null &&
+          'matches' in message &&
+          typeof message.matches === 'boolean'
+        ) {
+          resolve(message.matches);
+          return;
+        }
+
+        if (
+          typeof message === 'object' &&
+          message !== null &&
+          'error' in message &&
+          typeof message.error === 'string'
+        ) {
+          reject(new Error(message.error));
+          return;
+        }
+
+        reject(new Error('Regex worker returned an invalid response'));
+      });
+
+      worker.once('error', (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        void worker.terminate();
+        reject(error);
+      });
+    });
+  }
+
+  private regexEvaluationTimeoutMs(contentLength: number): number {
+    const sizeAllowance = Math.ceil(
+      contentLength / REGEX_EVALUATION_BYTES_PER_EXTRA_MS,
+    );
+    return Math.min(
+      REGEX_EVALUATION_MAX_TIMEOUT_MS,
+      REGEX_EVALUATION_BASE_TIMEOUT_MS + sizeAllowance,
+    );
   }
 
   private validateRulePattern(rule: {

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -91,6 +91,76 @@ describe('SafetyEvaluator', () => {
     expect(result.findings[0]!.severity).toBe('warning');
   });
 
+  it('preserves warning severity when runtime regex evaluation times out', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'slow-warn',
+        description: 'slow warning rule',
+        pattern: 'slow-pattern',
+        severity: 'warn',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+    vi.spyOn(
+      evaluator as unknown as {
+        regexMatchesWithTimeout(pattern: string, content: string): Promise<boolean | 'timeout'>;
+      },
+      'regexMatchesWithTimeout',
+    ).mockResolvedValue('timeout');
+
+    const result = await evaluator.evaluate(createInput('large review payload'));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.score).toBeLessThan(1);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Safety rule regex evaluation timed out'),
+        severity: 'warning',
+      }),
+    ]);
+  });
+
+  it('does not fail closed when a validated block rule times out at runtime', async () => {
+    const port = createMockGuardrailsPort([
+      {
+        id: 'slow-block',
+        description: 'slow block rule',
+        pattern: 'slow-pattern',
+        severity: 'block',
+      },
+    ]);
+    const evaluator = new SafetyEvaluator(port);
+    vi.spyOn(
+      evaluator as unknown as {
+        regexMatchesWithTimeout(pattern: string, content: string): Promise<boolean | 'timeout'>;
+      },
+      'regexMatchesWithTimeout',
+    ).mockResolvedValue('timeout');
+
+    const result = await evaluator.evaluate(createInput('large review payload'));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Safety rule regex evaluation timed out'),
+        severity: 'warning',
+      }),
+    ]);
+  });
+
+  it('scales runtime regex timeout budget with input size', () => {
+    const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
+      regexEvaluationTimeoutMs(contentLength: number): number;
+    };
+
+    const smallBudget = evaluator.regexEvaluationTimeoutMs(10);
+    const largeBudget = evaluator.regexEvaluationTimeoutMs(10 * 1024 * 1024);
+
+    expect(smallBudget).toBeGreaterThanOrEqual(2_000);
+    expect(largeBudget).toBeGreaterThan(smallBudget);
+    expect(largeBudget).toBeLessThanOrEqual(10_000);
+  });
+
   it('allows non-overlapping quantified alternation safety rules', async () => {
     const port = createMockGuardrailsPort([
       {
@@ -886,6 +956,16 @@ describe('SafetyEvaluator', () => {
         severity: 'warning',
       }),
     ]);
+  });
+
+  it('terminates catastrophic regex evaluation that reaches the runtime matcher', async () => {
+    const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
+      regexMatchesWithTimeout(pattern: string, content: string): Promise<boolean | 'timeout'>;
+    };
+
+    await expect(
+      evaluator.regexMatchesWithTimeout('(a+)+$', `${'a'.repeat(100)}!`),
+    ).resolves.toBe('timeout');
   });
 
   it('rejects genuinely unsafe nested quantifiers without catastrophic backtracking', async () => {

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -156,217 +156,405 @@ function discoverWorkspacePackages(root: string): string[] {
   } catch { return []; }
 }
 
-export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
-  // Apply RunConfig overrides (config file takes precedence for spawned agents)
-  const effectiveProvider =
-    options.runConfig?.llmConfig?.default?.provider
-    ?? options.runConfig?.provider
-    ?? options.provider;
-  const effectiveModel =
-    options.runConfig?.llmConfig?.default?.model
-    ?? options.runConfig?.model;
-  const effectiveBranch = options.runConfig?.gitConfig?.baseBranch ?? options.baseBranch;
-  const effectiveBudget = options.budget;
-  const effectiveBranchPattern = options.runConfig?.gitConfig?.branchPattern ?? 'feat/';
-  const effectivePrCreation = options.runConfig?.gitConfig?.prCreation;
-  const effectiveMergeStrategy = options.runConfig?.gitConfig?.mergeStrategy;
-  const effectiveSkills = options.runConfig?.skills;
-
-  const { paths, verbose, noPr, reset } = options;
-  const baseBranch = effectiveBranch;
-  const budget = effectiveBudget;
-
-  // Resolve per-agent module toggles (runConfig > options > env vars > default enabled)
-  const effectiveModules = options.runConfig?.modules ?? options.enabledModules;
-  const modules = {
-    memory: effectiveModules?.memory ?? (process.env.FRANKENBEAST_MODULE_MEMORY !== 'false'),
-    planner: effectiveModules?.planner ?? (process.env.FRANKENBEAST_MODULE_PLANNER !== 'false'),
-    critique: effectiveModules?.critique ?? (process.env.FRANKENBEAST_MODULE_CRITIQUE !== 'false'),
-    governor: effectiveModules?.governor ?? (process.env.FRANKENBEAST_MODULE_GOVERNOR !== 'false'),
+interface EffectiveCliConfig {
+  provider: string;
+  model?: string | undefined;
+  baseBranch: string;
+  budget: number;
+  branchPattern: string;
+  prCreation?: 'auto' | 'manual' | 'disabled' | undefined;
+  mergeStrategy?: 'merge' | 'squash' | 'rebase' | undefined;
+  skills?: string[] | undefined;
+  modules: {
+    memory: boolean;
+    planner: boolean;
+    critique: boolean;
+    governor: boolean;
   };
+}
 
-  // Derive plan name for plan-specific build artifacts
+interface SessionArtifacts {
+  planName: string;
+  checkpointFile: string;
+  logFile: string;
+}
+
+interface ObserverDepsBundle {
+  logger: BeastLogger;
+  observerBridge: CliObserverBridge;
+  replayAuditRoot: string;
+  runSessionId: string;
+  traceViewerHandle: TraceViewerHandle | null;
+}
+
+interface ExecutionStackDeps {
+  checkpoint: FileCheckpointStore;
+  chunkSessionStore: FileChunkSessionStore;
+  chunkSessionSnapshotStore: FileChunkSessionSnapshotStore;
+  chunkSessionRenderer: ChunkSessionRenderer;
+  registry: ReturnType<typeof createDefaultRegistry>;
+  martin: MartinLoop;
+  gitIso: GitBranchIsolator;
+}
+
+interface LlmDeps {
+  cliLlmAdapter: CliLlmAdapter;
+  cachedLlm: CachedCliLlmClient;
+}
+
+interface CliExecutorDeps {
+  cliExecutor: CliSkillExecutor;
+  prCreator?: PrCreator | undefined;
+}
+
+function resolveEffectiveConfig(options: CliDepOptions): EffectiveCliConfig {
+  const effectiveModules = options.runConfig?.modules ?? options.enabledModules;
+  return {
+    provider: options.runConfig?.llmConfig?.default?.provider
+      ?? options.runConfig?.provider
+      ?? options.provider,
+    model: options.runConfig?.llmConfig?.default?.model
+      ?? options.runConfig?.model,
+    baseBranch: options.runConfig?.gitConfig?.baseBranch ?? options.baseBranch,
+    budget: options.budget,
+    branchPattern: options.runConfig?.gitConfig?.branchPattern ?? 'feat/',
+    prCreation: options.runConfig?.gitConfig?.prCreation,
+    mergeStrategy: options.runConfig?.gitConfig?.mergeStrategy,
+    skills: options.runConfig?.skills,
+    modules: {
+      memory: effectiveModules?.memory ?? (process.env.FRANKENBEAST_MODULE_MEMORY !== 'false'),
+      planner: effectiveModules?.planner ?? (process.env.FRANKENBEAST_MODULE_PLANNER !== 'false'),
+      critique: effectiveModules?.critique ?? (process.env.FRANKENBEAST_MODULE_CRITIQUE !== 'false'),
+      governor: effectiveModules?.governor ?? (process.env.FRANKENBEAST_MODULE_GOVERNOR !== 'false'),
+    },
+  };
+}
+
+function createSessionArtifacts(options: CliDepOptions): SessionArtifacts {
+  const { paths } = options;
   const planName = options.planDirOverride
     ? basename(options.planDirOverride).replace(/\/$/, '')
     : basename(paths.plansDir) === 'plans' ? 'session' : basename(paths.plansDir);
   const checkpointFile = resolve(paths.buildDir, `${planName}.checkpoint`);
+  const now = new Date();
+  const ts = now.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return {
+    planName,
+    checkpointFile,
+    logFile: resolve(paths.buildDir, `${planName}-${ts}-build.log`),
+  };
+}
 
-  // Reset if requested
-  if (reset) {
+function clearSessionArtifacts(options: CliDepOptions, artifacts: SessionArtifacts): void {
+  const { paths } = options;
+  if (options.reset) {
     const memoryDbPath = resolve(paths.buildDir, 'memory.db');
-    for (const f of [checkpointFile, paths.tracesDb, memoryDbPath]) {
+    for (const f of [artifacts.checkpointFile, paths.tracesDb, memoryDbPath]) {
       try { if (existsSync(f)) unlinkSync(f); } catch {}
     }
     for (const dir of [resolve(paths.buildDir, 'issues'), paths.chunkSessionsDir, paths.chunkSessionSnapshotsDir]) {
       try { if (existsSync(dir)) rmSync(dir, { recursive: true, force: true }); } catch {}
     }
   } else if (!options.resume) {
-    for (const f of [checkpointFile]) {
-      try { if (existsSync(f)) unlinkSync(f); } catch {}
-    }
+    try { if (existsSync(artifacts.checkpointFile)) unlinkSync(artifacts.checkpointFile); } catch {}
     for (const dir of [paths.chunkSessionsDir, paths.chunkSessionSnapshotsDir]) {
       try { if (existsSync(dir)) rmSync(dir, { recursive: true, force: true }); } catch {}
     }
   }
+}
 
-  // Build timestamped log file: .build/<plan-name>-<datetime>-build.log
-  const now = new Date();
-  const ts = now.toISOString().replace(/[:.]/g, '-').slice(0, 19); // 2026-03-08T20-12-05
-  const logFile = resolve(paths.buildDir, `${planName}-${ts}-build.log`);
-  mkdirSync(paths.buildDir, { recursive: true });
-
-  const logger = new BeastLogger({ verbose, captureForFile: true, logFile });
-
-  // Observer
-  const replayAuditRoot = resolve(paths.root, '.fbeast', 'audit');
+async function createObserverDeps(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  artifacts: SessionArtifacts,
+): Promise<ObserverDepsBundle> {
+  mkdirSync(options.paths.buildDir, { recursive: true });
+  const logger = new BeastLogger({
+    verbose: options.verbose,
+    captureForFile: true,
+    logFile: artifacts.logFile,
+  });
+  const replayAuditRoot = resolve(options.paths.root, '.fbeast', 'audit');
   const replayStore = new ReplayContentStore(replayAuditRoot);
-  const observerBridge = new CliObserverBridge({ budgetLimitUsd: budget, replayStore });
+  const observerBridge = new CliObserverBridge({ budgetLimitUsd: config.budget, replayStore });
   const runSessionId = options.runSessionId ?? `cli-session-${Date.now()}`;
   observerBridge.startTrace(runSessionId);
+  const traceViewerHandle = options.verbose
+    ? await setupTraceViewer(options.paths.tracesDb, logger)
+    : null;
 
-  // Trace viewer (verbose mode only)
-  let traceViewerHandle: TraceViewerHandle | null = null;
-  if (verbose) {
-    traceViewerHandle = await setupTraceViewer(paths.tracesDb, logger);
-  }
+  return { logger, observerBridge, replayAuditRoot, runSessionId, traceViewerHandle };
+}
 
-  // CLI execution stack
-  const checkpoint = new FileCheckpointStore(checkpointFile);
-  const chunkSessionStore = new FileChunkSessionStore(paths.chunkSessionsDir);
-  const chunkSessionSnapshotStore = new FileChunkSessionSnapshotStore(paths.chunkSessionSnapshotsDir);
+function createExecutionStack(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  artifacts: SessionArtifacts,
+): ExecutionStackDeps {
+  const checkpoint = new FileCheckpointStore(artifacts.checkpointFile);
+  const chunkSessionStore = new FileChunkSessionStore(options.paths.chunkSessionsDir);
+  const chunkSessionSnapshotStore = new FileChunkSessionSnapshotStore(options.paths.chunkSessionSnapshotsDir);
   const chunkSessionRenderer = new ChunkSessionRenderer();
   const chunkSessionGc = new ChunkSessionGc({
-    sessionRoot: paths.chunkSessionsDir,
-    snapshotRoot: paths.chunkSessionSnapshotsDir,
+    sessionRoot: options.paths.chunkSessionsDir,
+    snapshotRoot: options.paths.chunkSessionSnapshotsDir,
     completedTtlMs: 24 * 60 * 60 * 1000,
     failedTtlMs: 72 * 60 * 60 * 1000,
   });
   chunkSessionGc.collect();
+
   const registry = createDefaultRegistry();
   const martin = new MartinLoop(registry);
   const gitIso = new GitBranchIsolator({
-    baseBranch,
-    branchPrefix: effectiveBranchPattern,
+    baseBranch: config.baseBranch,
+    branchPrefix: config.branchPattern,
     autoCommit: true,
-    workingDir: paths.root,
-    ...(effectiveMergeStrategy ? { mergeStrategy: effectiveMergeStrategy as 'merge' | 'squash' | 'rebase' } : {}),
+    workingDir: options.paths.root,
+    ...(config.mergeStrategy ? { mergeStrategy: config.mergeStrategy as 'merge' | 'squash' | 'rebase' } : {}),
   });
-  const resolvedProvider = registry.get(effectiveProvider);
-  const override = options.providersConfig?.[effectiveProvider];
+
+  return {
+    checkpoint,
+    chunkSessionStore,
+    chunkSessionSnapshotStore,
+    chunkSessionRenderer,
+    registry,
+    martin,
+    gitIso,
+  };
+}
+
+function createLlmDeps(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  artifacts: SessionArtifacts,
+  observer: ObserverDepsBundle,
+  stack: ExecutionStackDeps,
+): LlmDeps {
+  const resolvedProvider = stack.registry.get(config.provider);
+  const override = options.providersConfig?.[config.provider];
   const cliLlmAdapter = new CliLlmAdapter(resolvedProvider, {
-    workingDir: options.adapterWorkingDir ?? paths.root,
+    workingDir: options.adapterWorkingDir ?? options.paths.root,
     ...(override?.command ? { commandOverride: override.command } : {}),
-    ...((effectiveModel ?? options.adapterModel) != null ? { model: (effectiveModel ?? options.adapterModel)! } : {}),
+    ...((config.model ?? options.adapterModel) != null ? { model: (config.model ?? options.adapterModel)! } : {}),
     ...(options.chatMode ? { chatMode: true } : {}),
     ...(options.onStreamLine ? { onStreamLine: options.onStreamLine } : {}),
-    replayRunId: () => observerBridge.getActiveSessionId() ?? runSessionId,
-    replayRecorder: (record) => observerBridge.recordReplay(record),
+    replayRunId: () => observer.observerBridge.getActiveSessionId() ?? observer.runSessionId,
+    replayRecorder: (record) => observer.observerBridge.recordReplay(record),
     ...(options.providers ? { providers: options.providers } : {}),
-    registry,
+    registry: stack.registry,
     ...(options.providersConfig ? { providerOverrides: options.providersConfig } : {}),
   });
 
-  const adapterLlm = new AdapterLlmClient(
+  new AdapterLlmClient(
     cliLlmAdapter,
-    observerBridge.observerDeps as never,
-    effectiveProvider,
+    observer.observerBridge.observerDeps as never,
+    config.provider,
   );
+
   const cachedLlm = new CachedCliLlmClient({
-    cacheRootDir: paths.llmCacheDir,
+    cacheRootDir: options.paths.llmCacheDir,
     cliAdapter: cliLlmAdapter,
-    projectId: paths.root,
-    provider: effectiveProvider,
-    model: override?.model ?? effectiveModel ?? options.adapterModel ?? effectiveProvider,
+    projectId: options.paths.root,
+    provider: config.provider,
+    model: override?.model ?? config.model ?? options.adapterModel ?? config.provider,
     operation: 'cli-session',
-    workId: `session:${planName}`,
+    workId: `session:${artifacts.planName}`,
     stablePrefix: 'surface:cli',
-    workPrefix: `plan:${planName}`,
-    observer: observerBridge.observerDeps as never,
+    workPrefix: `plan:${artifacts.planName}`,
+    observer: observer.observerBridge.observerDeps as never,
   });
 
-  // Critique (dynamic import — optional module)
-  let critique: ICritiqueModule = stubCritique;
-  if (modules.critique) {
-    try {
-      const critiqueModule = await import('@franken/critique');
-      const { createReviewer } = critiqueModule;
+  return { cliLlmAdapter, cachedLlm };
+}
 
-      const critiqueGuardrails = {
-        getSafetyRules: async () => [] as never[],
-        executeSandbox: async () => ({ success: true as const, output: '', exitCode: 0, timedOut: false }),
-      };
-      const critiqueMemory = {
-        searchADRs: async () => [] as never[],
-        searchEpisodic: async () => [] as never[],
-        recordLesson: async () => {},
-      };
-      const critiqueObservability = {
-        getTokenSpend: (sessionId: string) => observerBridge.getTokenSpend(sessionId),
-      };
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
-      const knownPackages = discoverWorkspacePackages(paths.root);
+function errorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  let current: unknown = error;
+  while (current !== undefined && current !== null) {
+    chain.push(current);
+    if (typeof current !== 'object' || !('cause' in current)) break;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return chain;
+}
 
-      const reviewer = createReviewer({
-        guardrails: critiqueGuardrails,
-        memory: critiqueMemory,
-        observability: critiqueObservability,
-        knownPackages,
-      });
+function errorDiagnostic(error: unknown): string {
+  return errorChain(error).map(errorMessage).join(': ');
+}
 
-      critique = new CritiquePortAdapter({
-        loop: { run: (input: never, config: never) => reviewer.review(input, config) },
-        config: {
-          maxIterations: options.critiqueMaxIterations ?? 3,
-          tokenBudget: budget,
-          consensusThreshold: options.critiqueConsensusThreshold ?? 0.7,
-          sessionId: `cli-critique-${Date.now()}`,
-          taskId: 'plan-review',
-        },
-      });
-    } catch (error) {
-      logger.warn(`Critique module unavailable, using stub: ${error instanceof Error ? error.message : String(error)}`, 'dep-factory');
+function isMissingOptionalModule(error: unknown, moduleName: string): boolean {
+  return errorChain(error).some((candidate) => {
+    if (typeof candidate !== 'object' || candidate === null) return false;
+    const code = 'code' in candidate ? String((candidate as { code?: unknown }).code) : undefined;
+    if (code !== 'ERR_MODULE_NOT_FOUND' && code !== 'MODULE_NOT_FOUND') return false;
+
+    const message = errorMessage(candidate);
+    return message.includes(`'${moduleName}'`)
+      || message.includes(`"${moduleName}"`)
+      || message.includes(`Cannot find module ${moduleName}`)
+      || message.includes(`Cannot find package ${moduleName}`);
+  });
+}
+
+async function importOptionalModule<T>(moduleName: string, logger: BeastLogger): Promise<T | undefined> {
+  try {
+    return await import(moduleName) as T;
+  } catch (error) {
+    if (isMissingOptionalModule(error, moduleName)) {
+      logger.warn(`${moduleName} unavailable, using stub: ${errorDiagnostic(error)}`, 'dep-factory');
+      return undefined;
     }
+    throw new Error(`Failed to load optional module ${moduleName}: ${errorDiagnostic(error)}`, { cause: error });
+  }
+}
+
+async function createCritiqueDeps(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  observer: ObserverDepsBundle,
+): Promise<ICritiqueModule> {
+  if (!config.modules.critique) return stubCritique;
+
+  const critiqueModule = await importOptionalModule<typeof import('@franken/critique')>(
+    '@franken/critique',
+    observer.logger,
+  );
+  if (!critiqueModule) return stubCritique;
+
+  const critiqueGuardrails = {
+    getSafetyRules: async () => [] as never[],
+    executeSandbox: async () => ({ success: true as const, output: '', exitCode: 0, timedOut: false }),
+  };
+  const critiqueMemory = {
+    searchADRs: async () => [] as never[],
+    searchEpisodic: async () => [] as never[],
+    recordLesson: async () => {},
+  };
+  const critiqueObservability = {
+    getTokenSpend: (sessionId: string) => observer.observerBridge.getTokenSpend(sessionId),
+  };
+
+  const reviewer = critiqueModule.createReviewer({
+    guardrails: critiqueGuardrails,
+    memory: critiqueMemory,
+    observability: critiqueObservability,
+    knownPackages: discoverWorkspacePackages(options.paths.root),
+  });
+
+  return new CritiquePortAdapter({
+    loop: { run: (input: never, adapterConfig: never) => reviewer.review(input, adapterConfig) },
+    config: {
+      maxIterations: options.critiqueMaxIterations ?? 3,
+      tokenBudget: config.budget,
+      consensusThreshold: options.critiqueConsensusThreshold ?? 0.7,
+      sessionId: `cli-critique-${Date.now()}`,
+      taskId: 'plan-review',
+    },
+  });
+}
+
+async function createGovernanceDeps(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  finalize: () => Promise<void>,
+  logger: BeastLogger,
+): Promise<{ governor: IGovernorModule; finalize: () => Promise<void> }> {
+  if (!config.modules.governor) return { governor: stubGovernor, finalize };
+
+  const governorModule = await importOptionalModule<typeof import('@franken/governor')>(
+    '@franken/governor',
+    logger,
+  );
+  if (!governorModule) return { governor: stubGovernor, finalize };
+
+  const { stdin, stdout } = await import('node:process');
+  if (!stdin.isTTY) {
+    return {
+      governor: new GovernorPortAdapter({
+        gateway: { requestApproval: async () => ({ decision: 'APPROVE' as const }) } as never,
+        projectId: basename(options.paths.root),
+        defaultDecision: process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL === '1'
+          ? ('approved' as const)
+          : ('rejected' as const),
+      }),
+      finalize,
+    };
   }
 
-  // PR creator (wrap adapter as ILlmClient for LLM-powered titles/descriptions)
-  const prDisabled = noPr || effectivePrCreation === 'disabled';
-  const prCreator = prDisabled ? undefined : new PrCreator(
-    { targetBranch: baseBranch, disabled: false, remote: 'origin' },
-    undefined,
-    cachedLlm,
-  );
+  const { createInterface } = await import('node:readline/promises');
+  const rl = createInterface({ input: stdin, output: stdout });
+  const cliChannel = new governorModule.CliChannel({
+    readline: { question: (prompt: string) => rl.question(prompt) },
+    operatorName: 'operator',
+  });
+  const gateway = new governorModule.ApprovalGateway({
+    channel: cliChannel,
+    auditRecorder: { record: async () => {} },
+    config: governorModule.defaultConfig(),
+  });
 
-  // Commit message generator — delegates to PrCreator's LLM prompt
+  return {
+    governor: new GovernorPortAdapter({
+      gateway: gateway as unknown as GovernorPortAdapterDeps['gateway'],
+      projectId: basename(options.paths.root),
+    }),
+    finalize: async () => {
+      rl.close();
+      await finalize();
+    },
+  };
+}
+
+function createCliExecutorDeps(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  artifacts: SessionArtifacts,
+  observer: ObserverDepsBundle,
+  stack: ExecutionStackDeps,
+  llm: LlmDeps,
+): CliExecutorDeps {
+  const prDisabled = options.noPr || config.prCreation === 'disabled';
+  const prCreator = prDisabled ? undefined : new PrCreator(
+    { targetBranch: config.baseBranch, disabled: false, remote: 'origin' },
+    undefined,
+    llm.cachedLlm,
+  );
   const commitMessageFn = prCreator
     ? (diffStat: string, objective: string) => prCreator.generateCommitMessage(diffStat, objective)
     : undefined;
 
-  // Recovery verify command — typecheck as a fast sanity check that
-  // dirty files from a crashed run don't break the build
-  const verifyCommand = 'npx tsc --noEmit';
-
+  const override = options.providersConfig?.[config.provider];
   const cliExecutor = new CliSkillExecutor(
-    martin, gitIso, observerBridge.observerDeps,
-    verifyCommand, commitMessageFn, logger,
+    stack.martin,
+    stack.gitIso,
+    observer.observerBridge.observerDeps,
+    'npx tsc --noEmit',
+    commitMessageFn,
+    observer.logger,
     {
-      provider: effectiveProvider,
-      planName,
-      sessionStore: chunkSessionStore,
-      snapshotStore: chunkSessionSnapshotStore,
-      renderer: chunkSessionRenderer,
+      provider: config.provider,
+      planName: artifacts.planName,
+      sessionStore: stack.chunkSessionStore,
+      snapshotStore: stack.chunkSessionSnapshotStore,
+      renderer: stack.chunkSessionRenderer,
       compactor: new ChunkSessionCompactor({
         summarize: async (prompt: string) => {
-          const response = await cachedLlm.complete(prompt, {
+          const response = await llm.cachedLlm.complete(prompt, {
             operation: 'chunk-session-compaction',
-            workId: `chunk-compactor:${planName}`,
+            workId: `chunk-compactor:${artifacts.planName}`,
             stablePrefix: 'surface:chunk-session-compactor',
-            workPrefix: `plan:${planName}`,
+            workPrefix: `plan:${artifacts.planName}`,
           });
           return response.trim();
         },
       }),
       contextUsage: (prompt: string, provider: string, maxTokens: number) =>
-        observerBridge.estimateContextWindow({
+        observer.observerBridge.estimateContextWindow({
           renderedPrompt: prompt,
           provider,
           maxTokens,
@@ -376,111 +564,52 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
     },
   );
 
-  let finalize = async () => {
-    if (traceViewerHandle) {
-      await traceViewerHandle.stop();
-    }
-    // Log entries are now written incrementally by BeastLogger (crash-safe).
-    // No batch write needed here.
-  };
+  return { cliExecutor, prCreator };
+}
 
-  // Governor (dynamic import — optional module)
-  let governor: IGovernorModule = stubGovernor;
-  if (modules.governor) {
-    try {
-      const { ApprovalGateway, CliChannel, defaultConfig } = await import('@franken/governor');
-      const { createInterface } = await import('node:readline/promises');
-      const { stdin, stdout } = await import('node:process');
-
-      if (!stdin.isTTY) {
-        // Non-interactive mode fails closed (denied) unless FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1 is explicitly set.
-        // defaultDecision short-circuits before gateway is called, so gateway is a no-op placeholder.
-        governor = new GovernorPortAdapter({
-          gateway: { requestApproval: async () => ({ decision: 'APPROVE' as const }) } as never,
-          projectId: basename(paths.root),
-          defaultDecision: process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL === '1'
-            ? ('approved' as const)
-            : ('rejected' as const),
-        });
-      } else {
-        const rl = createInterface({ input: stdin, output: stdout });
-
-        const cliChannel = new CliChannel({
-          readline: { question: (prompt: string) => rl.question(prompt) },
-          operatorName: 'operator',
-        });
-
-        // No-op audit recorder — audit persistence requires episodic store bridge (future)
-        const noopAuditRecorder = {
-          record: async () => {},
-        };
-
-        const gateway = new ApprovalGateway({
-          channel: cliChannel,
-          auditRecorder: noopAuditRecorder,
-          config: defaultConfig(),
-        });
-
-        governor = new GovernorPortAdapter({
-          gateway: gateway as unknown as GovernorPortAdapterDeps['gateway'],
-          projectId: basename(paths.root),
-        });
-
-        // Close readline on finalize to prevent dangling handles
-        const previousFinalize = finalize;
-        finalize = async () => {
-          rl.close();
-          await previousFinalize();
-        };
-      }
-    } catch (error) {
-      logger.warn(`Governor module unavailable, using stub: ${error instanceof Error ? error.message : String(error)}`, 'dep-factory');
-    }
-  }
-
-  // Build RunConfig overrides for downstream consumption by beast loop phases
-  // Note: mergeStrategy is wired directly via GitIsolationConfig, not through runConfigOverrides.
-  // llmOverrides and promptConfig are parsed by RunConfigSchema for forward compatibility
-  // but have no downstream consumer yet (per-phase LLM routing and prompt frontloading are future features).
+function createConsolidatedDeps(
+  options: CliDepOptions,
+  config: EffectiveCliConfig,
+  observer: ObserverDepsBundle,
+  stack: ExecutionStackDeps,
+  executor: CliExecutorDeps,
+  critique: ICritiqueModule,
+  governor: IGovernorModule,
+): ConsolidatedDeps {
   const runConfigOverrides: import('../deps.js').RunConfigOverrides | undefined =
-    effectiveSkills?.length
-      ? { allowedSkills: effectiveSkills }
+    config.skills?.length
+      ? { allowedSkills: config.skills }
       : undefined;
 
-  // Use the new consolidated component factory for module adapters
   const beastConfig = bridgeToBeastConfig(options, options.orchestratorConfig);
   const existingDeps = bridgeToExistingDeps({
     planner: stubPlanner,
     critique,
     governor,
-    observer: observerBridge,
-    logger,
-    cliExecutor,
-    checkpoint,
-    ...(prCreator ? { prCreator } : {}),
+    observer: observer.observerBridge,
+    logger: observer.logger,
+    cliExecutor: executor.cliExecutor,
+    checkpoint: stack.checkpoint,
+    ...(executor.prCreator ? { prCreator: executor.prCreator } : {}),
     ...(runConfigOverrides ? { runConfigOverrides } : {}),
   });
 
-  let consolidated: ConsolidatedDeps;
   try {
-    consolidated = createBeastDeps(beastConfig, existingDeps);
+    return createBeastDeps(beastConfig, existingDeps);
   } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    logger.warn(`createBeastDeps failed: ${reason}`, 'dep-factory');
+    const reason = errorMessage(error);
+    observer.logger.warn(`createBeastDeps failed: ${reason}`, 'dep-factory');
     throw new Error(`createBeastDeps failed: ${reason}`);
   }
+}
 
-  // Preserve CLI skill compatibility: ChunkFileGraphBuilder emits requiredSkills: ['cli:<chunk>']
-  // which the beast loop validates via hasSkill(). SkillManagerAdapter doesn't know about cli:*
-  // skills — they're a CLI-specific convention, not real skill directory entries.
+function createSkillDeps(consolidated: ConsolidatedDeps, allowedSkills?: string[] | undefined): BeastLoopDeps['skills'] {
   const baseSkills = consolidated.skills;
   const cliSkillCompat = (id: string) => id.startsWith('cli:');
-
-  // Apply RunConfig skills filter if present, always preserving cli:* compatibility
-  const skills = effectiveSkills?.length
+  return allowedSkills?.length
     ? {
-        hasSkill: (id: string) => cliSkillCompat(id) || (effectiveSkills.includes(id) && baseSkills.hasSkill(id)),
-        getAvailableSkills: () => baseSkills.getAvailableSkills().filter((s) => effectiveSkills.includes(s.id)),
+        hasSkill: (id: string) => cliSkillCompat(id) || (allowedSkills.includes(id) && baseSkills.hasSkill(id)),
+        getAvailableSkills: () => baseSkills.getAvailableSkills().filter((s) => allowedSkills.includes(s.id)),
         execute: baseSkills.execute,
       }
     : {
@@ -488,53 +617,57 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
         getAvailableSkills: () => baseSkills.getAvailableSkills(),
         execute: baseSkills.execute,
       };
+}
 
-  const deps: BeastLoopDeps = {
-    ...consolidated,
-    skills,
+function createIssueDeps(
+  options: CliDepOptions,
+  paths: ProjectPaths,
+  stack: ExecutionStackDeps,
+  executor: CliExecutorDeps,
+  llm: LlmDeps,
+): IssueCliDeps | undefined {
+  if (!options.issueIO) return undefined;
+
+  const completeFn = (
+    prompt: string,
+    hint?: {
+      operation?: string;
+      workId?: string;
+      stablePrefix?: string;
+      workPrefix?: string;
+    },
+  ) => llm.cachedLlm.complete(prompt, {
+    operation: hint?.operation ?? 'issues',
+    workId: hint?.workId,
+    stablePrefix: hint?.stablePrefix ?? 'surface:issues',
+    workPrefix: hint?.workPrefix,
+  });
+  return {
+    fetcher: new IssueFetcher(),
+    triage: new IssueTriage(completeFn),
+    graphBuilder: new IssueGraphBuilder(completeFn),
+    review: new IssueReview(options.issueIO, { dryRun: options.dryRun }),
+    runner: new IssueRunner(),
+    executor: executor.cliExecutor,
+    git: stack.gitIso,
+    prCreator: executor.prCreator,
+    checkpoint: stack.checkpoint,
+    issueRuntime: createIssueRuntimeSupport(paths),
   };
+}
 
-  // Issue pipeline deps (only created when issueIO is provided)
-  let issueDeps: IssueCliDeps | undefined;
-  if (options.issueIO) {
-    const completeFn = (
-      prompt: string,
-      hint?: {
-        operation?: string;
-        workId?: string;
-        stablePrefix?: string;
-        workPrefix?: string;
-      },
-    ) => cachedLlm.complete(prompt, {
-      operation: hint?.operation ?? 'issues',
-      workId: hint?.workId,
-      stablePrefix: hint?.stablePrefix ?? 'surface:issues',
-      workPrefix: hint?.workPrefix,
-    });
-    const issueRuntime = createIssueRuntimeSupport(paths);
-    issueDeps = {
-      fetcher: new IssueFetcher(),
-      triage: new IssueTriage(completeFn),
-      graphBuilder: new IssueGraphBuilder(completeFn),
-      review: new IssueReview(options.issueIO, { dryRun: options.dryRun }),
-      runner: new IssueRunner(),
-      executor: cliExecutor,
-      git: gitIso,
-      prCreator,
-      checkpoint,
-      issueRuntime,
-    };
-  }
-
-  // Augment finalize to persist audit trail and close SqliteBrain
-  const previousFinalizeForBrain = finalize;
-  finalize = async () => {
-    const runId = runSessionId;
+function appendAuditFinalize(
+  finalize: () => Promise<void>,
+  observer: ObserverDepsBundle,
+  consolidated: ConsolidatedDeps,
+): () => Promise<void> {
+  return async () => {
+    const runId = observer.runSessionId;
     try {
       consolidated.persistAuditTrail?.(runId);
-      const bridgeManifest = observerBridge.getReplayManifest();
+      const bridgeManifest = observer.observerBridge.getReplayManifest();
       if (bridgeManifest.length > 0) {
-        mkdirSync(replayAuditRoot, { recursive: true });
+        mkdirSync(observer.replayAuditRoot, { recursive: true });
         const manifestsByRunId = new Map<string, Array<(typeof bridgeManifest)[number]>>();
         for (const record of bridgeManifest) {
           const records = manifestsByRunId.get(record.runId) ?? [];
@@ -542,7 +675,7 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
           manifestsByRunId.set(record.runId, records);
         }
         for (const [manifestRunId, records] of manifestsByRunId) {
-          const replayManifestPath = join(replayAuditRoot, `${manifestRunId}.replay.json`);
+          const replayManifestPath = join(observer.replayAuditRoot, `${manifestRunId}.replay.json`);
           let existingManifest: unknown[] = [];
           if (existsSync(replayManifestPath)) {
             const parsed = JSON.parse(readFileSync(replayManifestPath, 'utf8')) as unknown;
@@ -559,19 +692,66 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
       }
     } catch { /* best-effort */ }
     try { consolidated.sqliteBrain?.close(); } catch { /* best-effort */ }
-    try { logger.close(); } catch { /* best-effort */ }
-    await previousFinalizeForBrain();
+    try { observer.logger.close(); } catch { /* best-effort */ }
+    await finalize();
   };
+}
 
-  return {
-    deps,
-    cliLlmAdapter,
-    observerBridge,
-    logger,
-    finalize,
-    issueDeps,
-    ...(consolidated.skillManager ? { skillManager: consolidated.skillManager } : {}),
-    ...(consolidated.providerRegistry ? { providerRegistry: consolidated.providerRegistry } : {}),
-    ...(consolidated.middlewareChain ? { middlewareChain: consolidated.middlewareChain } : {}),
+function createObserverFinalize(observer: ObserverDepsBundle): () => Promise<void> {
+  return async () => {
+    if (observer.traceViewerHandle) {
+      await observer.traceViewerHandle.stop();
+    }
   };
+}
+
+export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
+  const config = resolveEffectiveConfig(options);
+  const artifacts = createSessionArtifacts(options);
+  clearSessionArtifacts(options, artifacts);
+
+  const observer = await createObserverDeps(options, config, artifacts);
+  let finalize = createObserverFinalize(observer);
+
+  try {
+    const stack = createExecutionStack(options, config, artifacts);
+    const llm = createLlmDeps(options, config, artifacts, observer, stack);
+    const critique = await createCritiqueDeps(options, config, observer);
+
+    const governance = await createGovernanceDeps(options, config, finalize, observer.logger);
+    finalize = governance.finalize;
+
+    const executor = createCliExecutorDeps(options, config, artifacts, observer, stack, llm);
+    const consolidated = createConsolidatedDeps(
+      options,
+      config,
+      observer,
+      stack,
+      executor,
+      critique,
+      governance.governor,
+    );
+    const deps: BeastLoopDeps = {
+      ...consolidated,
+      skills: createSkillDeps(consolidated, config.skills),
+    };
+    const issueDeps = createIssueDeps(options, options.paths, stack, executor, llm);
+    finalize = appendAuditFinalize(finalize, observer, consolidated);
+
+    return {
+      deps,
+      cliLlmAdapter: llm.cliLlmAdapter,
+      observerBridge: observer.observerBridge,
+      logger: observer.logger,
+      finalize,
+      issueDeps,
+      ...(consolidated.skillManager ? { skillManager: consolidated.skillManager } : {}),
+      ...(consolidated.providerRegistry ? { providerRegistry: consolidated.providerRegistry } : {}),
+      ...(consolidated.middlewareChain ? { middlewareChain: consolidated.middlewareChain } : {}),
+    };
+  } catch (error) {
+    try { await finalize(); } catch { /* best-effort */ }
+    try { observer.logger.close(); } catch { /* best-effort */ }
+    throw error;
+  }
 }

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -233,7 +233,7 @@ export class CliSkillExecutor {
     return 'committed';
   }
 
-  async execute(skillId: string, input: SkillInput, config: CliSkillConfig, checkpoint?: ICheckpointStore, taskId?: string): Promise<SkillResult> {
+  async execute(skillId: string, input: SkillInput, config: Partial<CliSkillConfig>, checkpoint?: ICheckpointStore, taskId?: string): Promise<SkillResult> {
     if (!skillId || skillId.trim().length === 0) {
       throw new Error('skillId must not be empty');
     }

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -21,7 +21,20 @@ import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connect
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/agent-routes');
 
-function createBeastApp(opts?: { rateLimitMax?: number }) {
+type AgentEvent = { type: string };
+
+function expectEventsToIncludeTypes(events: AgentEvent[], requiredTypes: string[]) {
+  const actualTypes = new Set(events.map((event) => event.type));
+
+  for (const requiredType of requiredTypes) {
+    expect(actualTypes.has(requiredType), `expected agent events to include ${requiredType}`).toBe(true);
+  }
+}
+
+function createIntegratedBeastApp(opts?: { rateLimitMax?: number }) {
+  // Intentionally exercise the route with the real repository, dispatch service,
+  // run service, and event log graph. This file lives under tests/integration so
+  // circular service/linking behavior is covered here rather than hidden in unit tests.
   mkdirSync(TMP, { recursive: true });
   const repository = new SQLiteBeastRepository(join(TMP, 'beasts.db'));
   const logStore = new BeastLogStore(join(TMP, 'logs'));
@@ -119,13 +132,13 @@ function createStandaloneAgentApp() {
   return { app };
 }
 
-describe('agent routes', () => {
+describe('agent routes integration', () => {
   afterEach(() => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
   it('rejects unauthenticated access to tracked agent endpoints', async () => {
-    const { app } = createBeastApp();
+    const { app } = createIntegratedBeastApp();
 
     const listResponse = await app.request('/v1/beasts/agents');
 
@@ -141,7 +154,7 @@ describe('agent routes', () => {
   });
 
   it('returns validation errors for invalid tracked agent payloads', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
 
     const response = await app.request('/v1/beasts/agents', {
       method: 'POST',
@@ -163,7 +176,7 @@ describe('agent routes', () => {
   });
 
   it('returns malformed json errors for invalid tracked agent request bodies', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
 
     const response = await app.request('/v1/beasts/agents', {
       method: 'POST',
@@ -184,7 +197,7 @@ describe('agent routes', () => {
   });
 
   it('creates, dispatches, and lists tracked agents for authorized operators', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -232,7 +245,7 @@ describe('agent routes', () => {
   });
 
   it('dispatches chunk-plan tracked agents during creation when init config is complete', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -282,19 +295,19 @@ describe('agent routes', () => {
     const detail = await detailResponse.json() as {
       data: {
         agent: { dispatchRunId?: string; chatSessionId?: string; status: string };
-        events: Array<{ type: string }>;
+        events: AgentEvent[];
       };
     };
 
     expect(detail.data.agent.status).toBe('running');
     expect(detail.data.agent.chatSessionId).toBe(createdSession.data.id);
     expect(detail.data.agent.dispatchRunId).toBeTruthy();
-    expect(detail.data.events.map((event) => event.type)).toEqual(expect.arrayContaining([
+    expectEventsToIncludeTypes(detail.data.events, [
       'agent.created',
       'agent.chat.bound',
       'agent.command.sent',
       'agent.dispatch.linked',
-    ]));
+    ]);
 
     const runResponse = await app.request(`/v1/beasts/runs/${detail.data.agent.dispatchRunId}`, {
       headers: {
@@ -308,7 +321,7 @@ describe('agent routes', () => {
   });
 
   it('returns tracked agent detail including init metadata and linked run id', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -365,18 +378,18 @@ describe('agent routes', () => {
     const detailBody = await detailResponse.json() as {
       data: {
         agent: { id: string; dispatchRunId?: string; initAction: { kind: string } };
-        events: Array<{ type: string }>;
+        events: AgentEvent[];
       };
     };
 
     expect(detailBody.data.agent.id).toBe(createdAgent.data.id);
     expect(detailBody.data.agent.initAction.kind).toBe('martin-loop');
     expect(detailBody.data.agent.dispatchRunId).toBe(createdRun.data.id);
-    expect(detailBody.data.events.map((event) => event.type)).toContain('agent.created');
+    expectEventsToIncludeTypes(detailBody.data.events, ['agent.created']);
   });
 
   it('resumes a stopped tracked agent by creating a new run attempt on the linked run', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -491,15 +504,15 @@ describe('agent routes', () => {
     const detail = await detailResponse.json() as {
       data: {
         agent: { status: string };
-        events: Array<{ type: string }>;
+        events: AgentEvent[];
       };
     };
     expect(detail.data.agent.status).toBe('stopped');
-    expect(detail.data.events.map((event) => event.type)).toContain('agent.stop.requested');
+    expectEventsToIncludeTypes(detail.data.events, ['agent.stop.requested']);
   });
 
   it('starts and restarts stopped tracked agents through agent-specific endpoints', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -582,7 +595,7 @@ describe('agent routes', () => {
   });
 
   it('soft-deletes stopped tracked agents so they disappear from the dashboard list', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -637,7 +650,7 @@ describe('agent routes', () => {
   });
 
   it('returns 404 for unknown tracked agents', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
 
     const response = await app.request('/v1/beasts/agents/agent-missing', {
       headers: {
@@ -655,7 +668,7 @@ describe('agent routes', () => {
   });
 
   it('rate-limits agent creation requests', async () => {
-    const { app, operatorToken } = createBeastApp({ rateLimitMax: 2 });
+    const { app, operatorToken } = createIntegratedBeastApp({ rateLimitMax: 2 });
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -680,7 +693,7 @@ describe('agent routes', () => {
   });
 
   it('marks agent as failed when dispatch throws instead of leaving orphaned initializing agents', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',
@@ -716,15 +729,15 @@ describe('agent routes', () => {
     const detail = await detailResponse.json() as {
       data: {
         agent: { status: string };
-        events: Array<{ type: string }>;
+        events: AgentEvent[];
       };
     };
     expect(detail.data.agent.status).toBe('failed');
-    expect(detail.data.events.map((e) => e.type)).toContain('agent.dispatch.failed');
+    expectEventsToIncludeTypes(detail.data.events, ['agent.dispatch.failed']);
   });
 
   it('allows starting failed tracked agents via the start endpoint', async () => {
-    const { app, operatorToken } = createBeastApp();
+    const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
       'content-type': 'application/json',

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -33,17 +33,47 @@ function createSupervisorMock() {
   };
 }
 
+const tempDirs = new Set<string>();
+
+async function createTempWorkDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+  tempDirs.add(dir);
+  return dir;
+}
+
+async function cleanupTempDirs(): Promise<void> {
+  const dirs = [...tempDirs].reverse();
+  tempDirs.clear();
+
+  const failures: Error[] = [];
+  for (const dir of dirs) {
+    try {
+      await rm(dir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 50,
+      });
+    } catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to clean up test temp directories');
+  }
+}
+
 describe('ProcessBeastExecutor', () => {
   let workDir: string | undefined;
 
   afterEach(async () => {
-    if (workDir) {
-      await rm(workDir, { recursive: true, force: true });
-    }
+    workDir = undefined;
+    await cleanupTempDirs();
   });
 
   it('starts a tracked attempt and records a lifecycle event', async () => {
-    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+    workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = createSupervisorMock();
@@ -68,7 +98,7 @@ describe('ProcessBeastExecutor', () => {
   });
 
   it('stops the current attempt without deleting the run row', async () => {
-    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+    workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = {
@@ -118,7 +148,7 @@ describe('ProcessBeastExecutor', () => {
       expect(executor).toBeInstanceOf(ProcessBeastExecutor);
     });
 
-    it('works without onRunStatusChange (backward compat)', () => {
+    it('works without onRunStatusChange (legacy constructor contract; keep until the next major release)', () => {
       const repo = {} as SQLiteBeastRepository;
       const logs = {} as BeastLogStore;
       const supervisor = createSupervisorMock();
@@ -130,7 +160,7 @@ describe('ProcessBeastExecutor', () => {
 
   describe('ProcessCallbacks wiring', () => {
     it('passes ProcessCallbacks to supervisor.spawn()', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const supervisor = createSupervisorMock();
@@ -148,7 +178,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('logs stdout lines via logs.append()', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const appendSpy = vi.spyOn(logs, 'append');
@@ -177,7 +207,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('logs stderr lines via logs.append()', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const appendSpy = vi.spyOn(logs, 'append');
@@ -203,7 +233,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('publishes early buffered lines to eventBus after attempt creation', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const eventBus = new BeastEventBus();
@@ -247,7 +277,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('buffers early stdout lines received before attempt creation', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const appendSpy = vi.spyOn(logs, 'append');
@@ -280,7 +310,7 @@ describe('ProcessBeastExecutor', () => {
 
   describe('handleProcessExit', () => {
     it('marks attempt as completed on exit code 0', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const onRunStatusChange = vi.fn();
@@ -317,7 +347,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('marks attempt as failed on non-zero exit code', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const onRunStatusChange = vi.fn();
@@ -359,7 +389,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('marks attempt as failed on signal kill', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const supervisor = createSupervisorMock();
@@ -380,7 +410,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('calls onRunStatusChange after DB update', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const onRunStatusChange = vi.fn();
@@ -398,7 +428,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('handles process exit before attemptId is set (early exit)', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const onRunStatusChange = vi.fn();
@@ -438,7 +468,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('handles exit with null code and null signal', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const supervisor = createSupervisorMock();
@@ -459,7 +489,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('publishes run.status event via eventBus on process exit', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const eventBus = new BeastEventBus();
@@ -483,7 +513,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('publishes run.status event via eventBus on operator stop (finishAttempt)', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const eventBus = new BeastEventBus();
@@ -504,7 +534,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('publishes run.status event via eventBus on operator kill (finishAttempt)', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const eventBus = new BeastEventBus();
@@ -525,7 +555,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('publishes run.status event via eventBus on spawn failure', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const eventBus = new BeastEventBus();
@@ -549,7 +579,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('does not overwrite operator_stop status when SIGKILL exit fires after finishAttempt', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const eventBus = new BeastEventBus();
@@ -578,7 +608,7 @@ describe('ProcessBeastExecutor', () => {
 
   describe('spawn failure handling', () => {
     it('sets run to failed with spawn_failed stop reason', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const supervisor = {
@@ -600,7 +630,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('appends run.spawn_failed event with error details', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const supervisor = {
@@ -625,7 +655,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('calls onRunStatusChange on spawn failure', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const onRunStatusChange = vi.fn();
@@ -643,7 +673,7 @@ describe('ProcessBeastExecutor', () => {
     });
 
     it('cleans up config file on spawn failure', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const { existsSync } = await import('node:fs');
@@ -666,7 +696,7 @@ describe('ProcessBeastExecutor', () => {
 
   describe('stderr buffer', () => {
     it('maintains circular stderr buffer limited to 50 lines', async () => {
-      workDir = await mkdtemp(join(tmpdir(), 'franken-beast-executor-'));
+      workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
       const supervisor = createSupervisorMock();

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -8,6 +8,32 @@ import type { CliDepOptions } from '../../../src/cli/dep-factory.js';
 // ── Mock heavy dependencies to isolate provider wiring ──
 
 const mockBridgeReplayManifest: Array<{ version: 1; kind: 'llm.request' | 'llm.response' | 'tool.call' | 'tool.result'; runId: string; timestamp: string; contentRef: string }> = [];
+const optionalModuleMocks = vi.hoisted(() => {
+  const createReviewer = vi.fn(() => ({
+    review: vi.fn(async () => ({
+      verdict: 'pass',
+      iterations: [
+        {
+          result: {
+            overallScore: 1,
+            results: [],
+          },
+        },
+      ],
+    })),
+  }));
+  return {
+    critiqueError: undefined as unknown,
+    governorError: undefined as unknown,
+    createReviewer,
+    ApprovalGateway: vi.fn(function () {}),
+    CliChannel: vi.fn(function () {}),
+    defaultConfig: vi.fn(() => ({})),
+  };
+});
+const traceViewerMocks = vi.hoisted(() => ({
+  stop: vi.fn(async () => {}),
+}));
 
 vi.mock('../../../src/logging/beast-logger.js', () => ({
   BeastLogger: vi.fn(function (this: Record<string, unknown>) {
@@ -78,7 +104,7 @@ vi.mock('../../../src/skills/cli-skill-executor.js', () => ({
 }));
 
 vi.mock('../../../src/cli/trace-viewer.js', () => ({
-  setupTraceViewer: vi.fn(async () => ({ stop: vi.fn() })),
+  setupTraceViewer: vi.fn(async () => ({ stop: traceViewerMocks.stop })),
 }));
 
 vi.mock('../../../src/session/chunk-session-store.js', () => ({
@@ -163,21 +189,25 @@ vi.mock('franken-brain', () => ({
   WorkingMemoryStore: vi.fn(function () {}),
 }));
 
-vi.mock('@franken/critique', () => ({
-  createReviewer: vi.fn(() => ({
-    review: vi.fn(async () => ({
-      verdict: 'pass',
-      iterations: [
-        {
-          result: {
-            overallScore: 1,
-            results: [],
-          },
-        },
-      ],
-    })),
-  })),
-}));
+vi.mock('@franken/critique', () => {
+  if (optionalModuleMocks.critiqueError) {
+    throw optionalModuleMocks.critiqueError;
+  }
+  return {
+    createReviewer: optionalModuleMocks.createReviewer,
+  };
+});
+
+vi.mock('@franken/governor', () => {
+  if (optionalModuleMocks.governorError) {
+    throw optionalModuleMocks.governorError;
+  }
+  return {
+    ApprovalGateway: optionalModuleMocks.ApprovalGateway,
+    CliChannel: optionalModuleMocks.CliChannel,
+    defaultConfig: optionalModuleMocks.defaultConfig,
+  };
+});
 
 // ── Helpers ──
 
@@ -212,6 +242,9 @@ function makeOpts(overrides: Partial<CliDepOptions> = {}): CliDepOptions {
 describe('dep-factory provider wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    optionalModuleMocks.critiqueError = undefined;
+    optionalModuleMocks.governorError = undefined;
+    traceViewerMocks.stop.mockClear();
     mockBridgeReplayManifest.length = 0;
   });
 
@@ -426,5 +459,89 @@ describe('dep-factory provider wiring', () => {
 
     expect(existsSync(issueCheckpoint)).toBe(false);
     expect(existsSync(chunkSession)).toBe(false);
+  });
+
+  it('uses critique stub when the optional critique module is truly missing', async () => {
+    optionalModuleMocks.critiqueError = Object.assign(
+      new Error("Cannot find package '@franken/critique' imported from dep-factory.ts"),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+    vi.resetModules();
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    const result = await createCliDeps(makeOpts({
+      enabledModules: { critique: true, governor: false },
+    }));
+
+    await expect(result.deps.critique.reviewPlan({ tasks: [] })).resolves.toEqual({
+      verdict: 'pass',
+      findings: [],
+      score: 1.0,
+    });
+  });
+
+  it('fails loudly when the optional critique module exists but is broken', async () => {
+    optionalModuleMocks.critiqueError = new Error('critique init exploded');
+    vi.resetModules();
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    await expect(createCliDeps(makeOpts({
+      enabledModules: { critique: true, governor: false },
+    }))).rejects.toThrow(/@franken\/critique.*critique init exploded/);
+  });
+
+  it('stops verbose trace viewer when critique initialization fails after observer setup', async () => {
+    optionalModuleMocks.critiqueError = new Error('critique init exploded');
+    vi.resetModules();
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    await expect(createCliDeps(makeOpts({
+      verbose: true,
+      enabledModules: { critique: true, governor: false },
+    }))).rejects.toThrow(/@franken\/critique.*critique init exploded/);
+
+    expect(traceViewerMocks.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses governor stub when the optional governor module is truly missing', async () => {
+    optionalModuleMocks.governorError = Object.assign(
+      new Error("Cannot find package '@franken/governor' imported from dep-factory.ts"),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+    vi.resetModules();
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    const result = await createCliDeps(makeOpts({
+      enabledModules: { critique: false, governor: true },
+    }));
+
+    await expect(result.deps.governor.requestApproval({
+      taskId: 'test',
+      summary: 'test',
+      requiresHitl: true,
+    })).resolves.toEqual({ decision: 'approved' });
+  });
+
+  it('fails loudly when the optional governor module exists but is broken', async () => {
+    optionalModuleMocks.governorError = new Error('governor init exploded');
+    vi.resetModules();
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    await expect(createCliDeps(makeOpts({
+      enabledModules: { critique: false, governor: true },
+    }))).rejects.toThrow(/@franken\/governor.*governor init exploded/);
+  });
+
+  it('stops verbose trace viewer when governor initialization fails after observer setup', async () => {
+    optionalModuleMocks.governorError = new Error('governor init exploded');
+    vi.resetModules();
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    await expect(createCliDeps(makeOpts({
+      verbose: true,
+      enabledModules: { critique: false, governor: true },
+    }))).rejects.toThrow(/@franken\/governor.*governor init exploded/);
+
+    expect(traceViewerMocks.stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -6,9 +6,81 @@ import type { MartinLoopConfig, IterationResult, CliSkillConfig, GitIsolationCon
 import type { SkillInput, ICheckpointStore } from '../../../src/deps.js';
 import { makeLogger } from '../../helpers/stubs.js';
 import { FileChunkSessionStore } from '../../../src/session/chunk-session-store.js';
+import { FileChunkSessionSnapshotStore } from '../../../src/session/chunk-session-snapshot-store.js';
+import { ChunkSessionRenderer } from '../../../src/session/chunk-session-renderer.js';
+import { ChunkSessionCompactor } from '../../../src/session/chunk-session-compactor.js';
 import { createChunkSession } from '../../../src/session/chunk-session.js';
+import { CliSkillExecutor, type ObserverDeps } from '../../../src/skills/cli-skill-executor.js';
+import { MartinLoop } from '../../../src/skills/martin-loop.js';
+import { GitBranchIsolator } from '../../../src/skills/git-branch-isolator.js';
 
-// ── Factories ──
+// ── Typed test fixtures ──
+
+type MockMartin = MartinLoop & {
+  run: ReturnType<typeof vi.fn<MartinLoop['run']>>;
+};
+
+type MockGit = GitBranchIsolator & {
+  isolate: ReturnType<typeof vi.fn<GitBranchIsolator['isolate']>>;
+  merge: ReturnType<typeof vi.fn<GitBranchIsolator['merge']>>;
+  autoCommit: ReturnType<typeof vi.fn<GitBranchIsolator['autoCommit']>>;
+  hasMeaningfulChange: ReturnType<typeof vi.fn<GitBranchIsolator['hasMeaningfulChange']>>;
+  getCurrentHead: ReturnType<typeof vi.fn<GitBranchIsolator['getCurrentHead']>>;
+  getDiffStat: ReturnType<typeof vi.fn<GitBranchIsolator['getDiffStat']>>;
+  getWorkingDir: ReturnType<typeof vi.fn<GitBranchIsolator['getWorkingDir']>>;
+  getStatus: ReturnType<typeof vi.fn<GitBranchIsolator['getStatus']>>;
+  resetHard: ReturnType<typeof vi.fn<GitBranchIsolator['resetHard']>>;
+  getConflictedFiles: ReturnType<typeof vi.fn<GitBranchIsolator['getConflictedFiles']>>;
+  getConflictDiff: ReturnType<typeof vi.fn<GitBranchIsolator['getConflictDiff']>>;
+  completeMerge: ReturnType<typeof vi.fn<GitBranchIsolator['completeMerge']>>;
+  abortMerge: ReturnType<typeof vi.fn<GitBranchIsolator['abortMerge']>>;
+};
+
+type MockObserver = ObserverDeps & {
+  counter: {
+    grandTotal: ReturnType<typeof vi.fn<ObserverDeps['counter']['grandTotal']>>;
+    allModels: ReturnType<typeof vi.fn<ObserverDeps['counter']['allModels']>>;
+    totalsFor: ReturnType<typeof vi.fn<ObserverDeps['counter']['totalsFor']>>;
+  };
+  costCalc: {
+    totalCost: ReturnType<typeof vi.fn<ObserverDeps['costCalc']['totalCost']>>;
+  };
+  breaker: {
+    check: ReturnType<typeof vi.fn<ObserverDeps['breaker']['check']>>;
+  };
+  loopDetector: {
+    check: ReturnType<typeof vi.fn<ObserverDeps['loopDetector']['check']>>;
+  };
+  estimateContextWindow: ReturnType<typeof vi.fn<ObserverDeps['estimateContextWindow']>>;
+  startSpan: ReturnType<typeof vi.fn<ObserverDeps['startSpan']>>;
+  endSpan: ReturnType<typeof vi.fn<ObserverDeps['endSpan']>>;
+  recordTokenUsage: ReturnType<typeof vi.fn<ObserverDeps['recordTokenUsage']>>;
+  setMetadata: ReturnType<typeof vi.fn<ObserverDeps['setMetadata']>>;
+  recordReplay: ReturnType<typeof vi.fn<NonNullable<ObserverDeps['recordReplay']>>>;
+};
+
+type DefaultMartinConfig = NonNullable<ConstructorParameters<typeof CliSkillExecutor>[6]>;
+type CommitMessageFn = NonNullable<ConstructorParameters<typeof CliSkillExecutor>[4]>;
+type ExecutorLogger = ConstructorParameters<typeof CliSkillExecutor>[5];
+
+interface CliSkillHarness {
+  readonly martin: MockMartin;
+  readonly git: MockGit;
+  readonly observer: MockObserver;
+  executor(options?: {
+    verifyCommand?: string;
+    commitMessageFn?: CommitMessageFn;
+    logger?: ExecutorLogger;
+    defaultMartinConfig?: DefaultMartinConfig;
+  }): CliSkillExecutor;
+  execute(
+    skillId?: string,
+    input?: SkillInput,
+    config?: Partial<CliSkillConfig>,
+    checkpoint?: ICheckpointStore,
+    taskId?: string,
+  ): Promise<Awaited<ReturnType<CliSkillExecutor['execute']>>>;
+}
 
 function makeSkillInput(overrides?: Partial<SkillInput>): SkillInput {
   return {
@@ -28,8 +100,6 @@ function makeMartinConfig(overrides?: Partial<MartinLoopConfig>): MartinLoopConf
     maxIterations: 5,
     maxTurns: 10,
     provider: 'claude',
-    claudeCmd: 'claude',
-    codexCmd: 'codex',
     timeoutMs: 60000,
     ...overrides,
   };
@@ -60,6 +130,7 @@ function makeCliConfig(overrides?: {
 function makeIterResult(overrides?: Partial<IterationResult>): IterationResult {
   return {
     iteration: 1,
+    provider: 'claude',
     exitCode: 0,
     stdout: 'test output',
     stderr: '',
@@ -67,63 +138,140 @@ function makeIterResult(overrides?: Partial<IterationResult>): IterationResult {
     rateLimited: false,
     promiseDetected: false,
     tokensEstimated: 100,
+    sleepMs: 0,
     ...overrides,
   };
 }
 
-function makeMockMartin() {
-  return {
-    run: vi.fn().mockResolvedValue({
-      completed: true,
-      iterations: 1,
-      output: 'completed output',
-      tokensUsed: 100,
-    }),
-  };
+function makeMockMartin(): MockMartin {
+  const run = vi.fn<MartinLoop['run']>().mockResolvedValue({
+    completed: true,
+    iterations: 1,
+    output: 'completed output',
+    tokensUsed: 100,
+  });
+  return Object.assign(Object.create(MartinLoop.prototype) as MartinLoop, { run });
 }
 
-function makeMockGit() {
-  return {
-    isolate: vi.fn(),
-    merge: vi.fn().mockReturnValue({ merged: true, commits: 3 }),
-    autoCommit: vi.fn(),
-    hasMeaningfulChange: vi.fn(),
-    getCurrentHead: vi.fn(),
-    getDiffStat: vi.fn().mockReturnValue('src/foo.ts | 10 +++\n'),
-    getWorkingDir: vi.fn().mockReturnValue('/tmp/test-repo'),
-    getStatus: vi.fn().mockReturnValue(''),
-    resetHard: vi.fn(),
-    getConflictedFiles: vi.fn().mockReturnValue([]),
-    getConflictDiff: vi.fn().mockReturnValue(''),
-    completeMerge: vi.fn(),
-    abortMerge: vi.fn(),
-  };
+function makeMockGit(): MockGit {
+  return Object.assign(Object.create(GitBranchIsolator.prototype) as GitBranchIsolator, {
+    isolate: vi.fn<GitBranchIsolator['isolate']>(),
+    merge: vi.fn<GitBranchIsolator['merge']>().mockReturnValue({ merged: true, commits: 3 }),
+    autoCommit: vi.fn<GitBranchIsolator['autoCommit']>(),
+    hasMeaningfulChange: vi.fn<GitBranchIsolator['hasMeaningfulChange']>(),
+    getCurrentHead: vi.fn<GitBranchIsolator['getCurrentHead']>(),
+    getDiffStat: vi.fn<GitBranchIsolator['getDiffStat']>().mockReturnValue('src/foo.ts | 10 +++\n'),
+    getWorkingDir: vi.fn<GitBranchIsolator['getWorkingDir']>().mockReturnValue('/tmp/test-repo'),
+    getStatus: vi.fn<GitBranchIsolator['getStatus']>().mockReturnValue(''),
+    resetHard: vi.fn<GitBranchIsolator['resetHard']>(),
+    getConflictedFiles: vi.fn<GitBranchIsolator['getConflictedFiles']>().mockReturnValue([]),
+    getConflictDiff: vi.fn<GitBranchIsolator['getConflictDiff']>().mockReturnValue(''),
+    completeMerge: vi.fn<GitBranchIsolator['completeMerge']>(),
+    abortMerge: vi.fn<GitBranchIsolator['abortMerge']>(),
+  });
 }
 
-function makeMockObserver() {
+function makeMockObserver(): MockObserver {
   let spanCount = 0;
   return {
     trace: { id: 'trace-1' },
     counter: {
-      grandTotal: vi.fn().mockReturnValue({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
-      allModels: vi.fn().mockReturnValue([] as string[]),
-      totalsFor: vi.fn().mockReturnValue({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
+      grandTotal: vi.fn<ObserverDeps['counter']['grandTotal']>().mockReturnValue({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
+      allModels: vi.fn<ObserverDeps['counter']['allModels']>().mockReturnValue([]),
+      totalsFor: vi.fn<ObserverDeps['counter']['totalsFor']>().mockReturnValue({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
     },
     costCalc: {
-      totalCost: vi.fn().mockReturnValue(0),
+      totalCost: vi.fn<ObserverDeps['costCalc']['totalCost']>().mockReturnValue(0),
     },
     breaker: {
-      check: vi.fn().mockReturnValue({ tripped: false, limitUsd: 10, spendUsd: 0 }),
+      check: vi.fn<ObserverDeps['breaker']['check']>().mockReturnValue({ tripped: false, limitUsd: 10, spendUsd: 0 }),
     },
     loopDetector: {
-      check: vi.fn().mockReturnValue({ detected: false }),
+      check: vi.fn<ObserverDeps['loopDetector']['check']>().mockReturnValue({ detected: false }),
     },
-    startSpan: vi.fn().mockImplementation(() => ({ id: `span-${spanCount++}` })),
-    endSpan: vi.fn(),
-    recordTokenUsage: vi.fn(),
-    setMetadata: vi.fn(),
-    recordReplay: vi.fn(),
+    estimateContextWindow: vi.fn<ObserverDeps['estimateContextWindow']>().mockReturnValue({
+      usedTokens: 0,
+      maxTokens: 200000,
+      usageRatio: 0,
+      threshold: 0.8,
+      shouldCompact: false,
+    }),
+    startSpan: vi.fn<ObserverDeps['startSpan']>().mockImplementation(() => ({ id: `span-${spanCount++}` })),
+    endSpan: vi.fn<ObserverDeps['endSpan']>(),
+    recordTokenUsage: vi.fn<ObserverDeps['recordTokenUsage']>(),
+    setMetadata: vi.fn<ObserverDeps['setMetadata']>(),
+    recordReplay: vi.fn<NonNullable<ObserverDeps['recordReplay']>>(),
   };
+}
+
+function createHarness(): CliSkillHarness {
+  const martin = makeMockMartin();
+  const git = makeMockGit();
+  const observer = makeMockObserver();
+
+  return {
+    martin,
+    git,
+    observer,
+    executor(options = {}) {
+      return new CliSkillExecutor(
+        martin,
+        git,
+        observer,
+        options.verifyCommand,
+        options.commitMessageFn,
+        options.logger,
+        options.defaultMartinConfig,
+      );
+    },
+    execute(
+      skillId = 'cli:01_types',
+      input = makeSkillInput(),
+      config = makeCliConfig(),
+      checkpoint?: ICheckpointStore,
+      taskId?: string,
+    ) {
+      return this.executor().execute(skillId, input, config, checkpoint, taskId);
+    },
+  };
+}
+
+function makeStubSessionStore(): FileChunkSessionStore {
+  return Object.assign(Object.create(FileChunkSessionStore.prototype) as FileChunkSessionStore, {
+    save: vi.fn<FileChunkSessionStore['save']>(),
+    load: vi.fn<FileChunkSessionStore['load']>(),
+    delete: vi.fn<FileChunkSessionStore['delete']>(),
+    list: vi.fn<FileChunkSessionStore['list']>(),
+  });
+}
+
+function makeStubSnapshotStore(): FileChunkSessionSnapshotStore {
+  return Object.assign(Object.create(FileChunkSessionSnapshotStore.prototype) as FileChunkSessionSnapshotStore, {
+    writeSnapshot: vi.fn<FileChunkSessionSnapshotStore['writeSnapshot']>(),
+    list: vi.fn<FileChunkSessionSnapshotStore['list']>(),
+    restoreLatest: vi.fn<FileChunkSessionSnapshotStore['restoreLatest']>(),
+  });
+}
+
+function makeStubRenderer(): ChunkSessionRenderer {
+  return Object.assign(Object.create(ChunkSessionRenderer.prototype) as ChunkSessionRenderer, {
+    render: vi.fn<ChunkSessionRenderer['render']>(),
+  });
+}
+
+function makeStubCompactor(): ChunkSessionCompactor {
+  return Object.assign(Object.create(ChunkSessionCompactor.prototype) as ChunkSessionCompactor, {
+    compact: vi.fn<ChunkSessionCompactor['compact']>(),
+  });
+}
+
+type ReplayRecord = Parameters<NonNullable<ObserverDeps['recordReplay']>>[0];
+
+function replayRecord(observer: MockObserver, kind: 'tool.call' | 'tool.result'): ReplayRecord {
+  for (const [candidate] of observer.recordReplay.mock.calls) {
+    if (candidate.kind === kind) return candidate;
+  }
+  throw new Error(`Expected ${kind} replay record`);
 }
 
 function makeCheckpoint(overrides: Partial<ICheckpointStore> = {}): ICheckpointStore {
@@ -142,26 +290,24 @@ function makeCheckpoint(overrides: Partial<ICheckpointStore> = {}): ICheckpointS
 // ── Tests ──
 
 describe('CliSkillExecutor', () => {
-  let martin: ReturnType<typeof makeMockMartin>;
-  let git: ReturnType<typeof makeMockGit>;
-  let observer: ReturnType<typeof makeMockObserver>;
+  let harness: CliSkillHarness;
+  let martin: MockMartin;
+  let git: MockGit;
+  let observer: MockObserver;
 
   beforeEach(() => {
-    martin = makeMockMartin();
-    git = makeMockGit();
-    observer = makeMockObserver();
+    harness = createHarness();
+    ({ martin, git, observer } = harness);
   });
 
-  async function createAndExecute(
+  function createAndExecute(
     skillId = 'cli:01_types',
     input = makeSkillInput(),
     config = makeCliConfig(),
     checkpoint?: ICheckpointStore,
     taskId?: string,
   ) {
-    const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-    const executor = new CliSkillExecutor(martin as any, git as any, observer);
-    return executor.execute(skillId, input, config, checkpoint, taskId);
+    return harness.execute(skillId, input, config, checkpoint, taskId);
   }
 
   describe('successful execution (promise detected)', () => {
@@ -181,9 +327,7 @@ describe('CliSkillExecutor', () => {
         toolName: 'cli:01_types',
         content: expect.stringContaining('Replay this task'),
       }));
-      const toolCallRecord = observer.recordReplay.mock.calls.find(
-        ([record]: [{ kind: string; content: string }]) => record.kind === 'tool.call',
-      )?.[0];
+      const toolCallRecord = replayRecord(observer, 'tool.call');
       expect(JSON.parse(toolCallRecord.content).input.dependencyOutputs).toEqual([]);
       expect(observer.recordReplay).toHaveBeenCalledWith(expect.objectContaining({
         kind: 'tool.result',
@@ -202,15 +346,13 @@ describe('CliSkillExecutor', () => {
       });
 
       await createAndExecute('cli:01_types', makeSkillInput({
-        dependencyOutputs: new Map([
+        dependencyOutputs: new Map<string, unknown>([
           ['impl:00_bootstrap', 'bootstrap-output'],
           ['impl:00_types', { files: ['types.ts'] }],
         ]),
       }));
 
-      const toolCallRecord = observer.recordReplay.mock.calls.find(
-        ([record]: [{ kind: string; content: string }]) => record.kind === 'tool.call',
-      )?.[0];
+      const toolCallRecord = replayRecord(observer, 'tool.call');
       expect(JSON.parse(toolCallRecord.content).input.dependencyOutputs).toEqual([
         ['impl:00_bootstrap', 'bootstrap-output'],
         ['impl:00_types', { files: ['types.ts'] }],
@@ -233,22 +375,15 @@ describe('CliSkillExecutor', () => {
     });
 
     it('uses executor-level provider defaults when execution passes no martin config', async () => {
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(
-        martin as any,
-        git as any,
-        observer,
-        undefined,
-        undefined,
-        undefined,
-        {
+      const executor = harness.executor({
+        defaultMartinConfig: {
           provider: 'codex',
           providers: ['codex'],
           command: '/usr/local/bin/codex',
         },
-      );
+      });
 
-      await executor.execute('cli:01_types', makeSkillInput(), {} as never);
+      await executor.execute('cli:01_types', makeSkillInput(), {});
 
       expect(martin.run).toHaveBeenCalledWith(expect.objectContaining({
         provider: 'codex',
@@ -258,30 +393,23 @@ describe('CliSkillExecutor', () => {
     });
 
     it('passes chunk session services and task metadata into MartinLoop', async () => {
-      const sessionStore = { save: vi.fn(), load: vi.fn(), delete: vi.fn(), list: vi.fn() };
-      const snapshotStore = { writeSnapshot: vi.fn(), list: vi.fn(), restoreLatest: vi.fn() };
-      const renderer = { render: vi.fn() };
-      const compactor = { compact: vi.fn() };
-      const contextUsage = vi.fn();
+      const sessionStore = makeStubSessionStore();
+      const snapshotStore = makeStubSnapshotStore();
+      const renderer = makeStubRenderer();
+      const compactor = makeStubCompactor();
+      const contextUsage = vi.fn<NonNullable<MartinLoopConfig['contextUsage']>>();
 
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(
-        martin as any,
-        git as any,
-        observer,
-        undefined,
-        undefined,
-        undefined,
-        {
+      const executor = harness.executor({
+        defaultMartinConfig: {
           provider: 'claude',
           planName: 'demo-plan',
-          sessionStore: sessionStore as any,
-          snapshotStore: snapshotStore as any,
-          renderer: renderer as any,
-          compactor: compactor as any,
+          sessionStore,
+          snapshotStore,
+          renderer,
+          compactor,
           contextUsage,
-        } as any,
-      );
+        },
+      });
 
       await executor.execute('cli:01_types', makeSkillInput(), makeCliConfig(), undefined, 'impl:01_types');
 
@@ -453,20 +581,13 @@ describe('CliSkillExecutor', () => {
       git.getCurrentHead.mockReturnValue('abc123');
 
       const checkpoint = makeCheckpoint();
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(
-        martin as any,
-        git as any,
-        observer,
-        undefined,
-        undefined,
-        undefined,
-        {
+      const executor = harness.executor({
+        defaultMartinConfig: {
           provider: 'claude',
           planName: 'demo-plan',
           sessionStore,
-        } as any,
-      );
+        },
+      });
 
       await executor.recoverDirtyFiles('impl:11_rate_limit_resilience', 'impl', checkpoint, makeLogger());
 
@@ -526,7 +647,7 @@ describe('CliSkillExecutor', () => {
       // Should have called martin.run twice (impl + conflict resolution)
       expect(martin.run).toHaveBeenCalledTimes(2);
       // Second call should have a conflict resolution prompt
-      const resolveConfig = martin.run.mock.calls[1]![0] as MartinLoopConfig;
+      const resolveConfig = martin.run.mock.calls[1]![0];
       expect(resolveConfig.prompt).toContain('merge conflict');
       expect(resolveConfig.prompt).toContain('docs/ARCHITECTURE.md');
       expect(resolveConfig.maxIterations).toBeLessThanOrEqual(3);
@@ -605,10 +726,9 @@ describe('CliSkillExecutor', () => {
 
   describe('commit message generation before merge', () => {
     it('calls commitMessageFn before merge and passes result to merge()', async () => {
-      const commitMessageFn = vi.fn().mockResolvedValue('feat(types): add shared type definitions');
+      const commitMessageFn = vi.fn<CommitMessageFn>().mockResolvedValue('feat(types): add shared type definitions');
 
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(martin as any, git as any, observer, undefined, commitMessageFn);
+      const executor = harness.executor({ commitMessageFn });
       await executor.execute('cli:01_types', makeSkillInput(), makeCliConfig());
 
       expect(git.getDiffStat).toHaveBeenCalledWith('01_types');
@@ -617,28 +737,25 @@ describe('CliSkillExecutor', () => {
     });
 
     it('passes undefined to merge when commitMessageFn is not provided', async () => {
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(martin as any, git as any, observer);
+      const executor = harness.executor();
       await executor.execute('cli:01_types', makeSkillInput(), makeCliConfig());
 
       expect(git.merge).toHaveBeenCalledWith('01_types');
     });
 
     it('passes undefined to merge when commitMessageFn returns null', async () => {
-      const commitMessageFn = vi.fn().mockResolvedValue(null);
+      const commitMessageFn = vi.fn<CommitMessageFn>().mockResolvedValue(null);
 
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(martin as any, git as any, observer, undefined, commitMessageFn);
+      const executor = harness.executor({ commitMessageFn });
       await executor.execute('cli:01_types', makeSkillInput(), makeCliConfig());
 
       expect(git.merge).toHaveBeenCalledWith('01_types');
     });
 
     it('falls back to no message when commitMessageFn throws', async () => {
-      const commitMessageFn = vi.fn().mockRejectedValue(new Error('LLM down'));
+      const commitMessageFn = vi.fn<CommitMessageFn>().mockRejectedValue(new Error('LLM down'));
 
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(martin as any, git as any, observer, undefined, commitMessageFn);
+      const executor = harness.executor({ commitMessageFn });
       await executor.execute('cli:01_types', makeSkillInput(), makeCliConfig());
 
       // Should still merge, just without a message
@@ -655,8 +772,7 @@ describe('CliSkillExecutor', () => {
         return { completed: true, iterations: 1, output: 'done', tokensUsed: 100 };
       });
 
-      const { CliSkillExecutor } = await import('../../../src/skills/cli-skill-executor.js');
-      const executor = new CliSkillExecutor(martin as any, git as any, observer, undefined, undefined, logger);
+      const executor = harness.executor({ logger });
       await executor.execute('cli:01_types', makeSkillInput(), makeCliConfig());
 
       expect(logger.warn).toHaveBeenCalledWith(

--- a/packages/franken-orchestrator/tests/unit/skills/rate-limit-resilience.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/rate-limit-resilience.test.ts
@@ -55,6 +55,13 @@ function baseConfig(overrides?: Partial<MartinLoopConfig>): MartinLoopConfig {
   };
 }
 
+function restoreRealTimers(): void {
+  if (vi.isFakeTimers()) {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  }
+}
+
 describe('parseResetTime', () => {
   let parseResetTime: typeof import('../../../src/skills/martin-loop.js').parseResetTime;
 
@@ -170,6 +177,7 @@ describe('MartinLoop — Rate Limit Resilience', () => {
   });
 
   afterEach(() => {
+    restoreRealTimers();
     stdoutWriteSpy.mockRestore();
     vi.restoreAllMocks();
   });
@@ -570,7 +578,6 @@ describe('MartinLoop — Rate Limit Resilience', () => {
     abortController.abort();
 
     await expect(runPromise).rejects.toThrow(/abort/i);
-    vi.useRealTimers();
   });
 
   it('clears pending default sleep timer when abort signal is triggered', async () => {
@@ -592,7 +599,6 @@ describe('MartinLoop — Rate Limit Resilience', () => {
 
     await expect(runPromise).rejects.toThrow(/abort/i);
     expect(vi.getTimerCount()).toBe(0);
-    vi.useRealTimers();
   });
 
   // ── Timeout must NOT be confused with rate limiting ──
@@ -648,8 +654,6 @@ describe('MartinLoop — Rate Limit Resilience', () => {
 
     const firstIter = (onIteration.mock.calls[0] as [number, IterationResult]);
     expect(firstIter[1].rateLimited).toBe(false);
-
-    vi.useRealTimers();
   });
 
   it('falls back when the provider emits rate-limit details on stdout only', async () => {

--- a/tasks/review-action-items-p0-progress.md
+++ b/tasks/review-action-items-p0-progress.md
@@ -1,0 +1,57 @@
+# Review Action Items P0 Progress
+
+Worktree: `.worktrees/review-action-items-p0`
+Branch: `codex/review-action-items-p0`
+Issues: #325, #326
+
+## Checklist
+
+- [x] Inspect `packages/franken-orchestrator/src/cli/dep-factory.ts` and related tests.
+- [x] Refactor `createCliDeps()` into smaller focused domain factories while preserving public behavior.
+- [x] Keep `createCliDeps()` as a thin composition layer.
+- [x] Update/add focused tests for extracted factories where practical.
+- [x] Change optional dynamic import handling so true missing optional modules can stub, but broken installed modules fail loudly.
+- [x] Add tests for missing optional module vs broken optional module behavior.
+- [x] Run targeted tests for changed code.
+- [x] Run typecheck/build if feasible in this worktree.
+- [x] Commit changes on `codex/review-action-items-p0`.
+- [x] Run Codex review loop after implementation.
+- [x] Apply review fixes and re-run tests.
+- [x] Fix Codex review finding: clean up observer resources when post-observer optional critique/governor setup fails.
+- [x] Amend existing P0 commit after review fix.
+
+## Disk constraints
+
+- Avoid dependency installs unless required.
+- If dependencies must be installed, keep it to this single P0 worktree and report disk usage afterward.
+- Do not create additional worktrees during P0.
+
+## Plan
+
+- Add focused unit coverage in `packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts` for optional import semantics. Missing optional modules should preserve the existing stub fallback; broken module initialization should reject with a diagnostic that names the failed module.
+- Extract optional-module loading and domain-specific construction from `packages/franken-orchestrator/src/cli/dep-factory.ts`: effective config/module flags, reset/log/session paths, observer/checkpoint state, LLM/client stack, critique, governance, consolidated deps/skills, issues, and finalize handling.
+- Keep public behavior stable: `createCliDeps(options)` continues to return the same shape, module-disable flags still use stubs, issue deps remain conditional on `issueIO`, replay/audit finalization remains best-effort, and no dependency installation/worktree creation is planned.
+- Verify with targeted `vitest` for dep-factory tests, then run package typecheck if dependencies are already present.
+
+## Notes
+
+- fbeast MCP tools referenced by AGENTS.md are unavailable in this Codex toolset, so their memory/firewall/observer/critique calls cannot be executed directly.
+- Red test pass/fail check: `rtk npm test -- --run tests/unit/cli/dep-factory-providers.test.ts` failed as expected on the two broken-module cases because current code resolves with stubs instead of rejecting; true-missing stub tests passed.
+- Review-fix red check: `rtk npm test --workspace franken-orchestrator -- --run tests/unit/cli/dep-factory-providers.test.ts` failed as expected because verbose trace-viewer cleanup was not called when critique initialization rejected after observer setup.
+- Review fix wraps post-observer `createCliDeps()` setup in cleanup-on-error. The cleanup reuses the current finalize chain so trace viewer handles, and any later governor readline wrapper, are stopped/closed before the original error is rethrown.
+
+## Verification
+
+- `rtk npm test -- --run tests/unit/cli/dep-factory-providers.test.ts` passed (20 tests).
+- `rtk npm test -- --run tests/integration/cli/dep-factory-wiring.test.ts` passed (17 tests).
+- `rtk npm run typecheck` passed.
+- `rtk npm test --workspace franken-orchestrator -- --run tests/unit/cli/dep-factory-providers.test.ts` passed (22 tests).
+- `rtk npm test --workspace franken-orchestrator -- --run tests/integration/cli/dep-factory-wiring.test.ts` passed (17 tests).
+- `rtk npm run typecheck --workspace franken-orchestrator` passed.
+- No dependency install was needed.
+
+## Review
+
+- Independent review subagent reported no findings.
+- No review fixes were required after the final focused verification.
+- Codex review finding addressed locally; no push performed.

--- a/tasks/review-action-items-progress.md
+++ b/tasks/review-action-items-progress.md
@@ -1,0 +1,66 @@
+# Review Action Items Progress
+
+Started: 2026-06-11
+Final branch: `codex/review-action-items-all`
+
+## Disk-aware operating rules
+
+- [x] Ran disk preflight before creating any new worktree.
+- [x] Did not delete pre-existing worktrees without explicit user approval.
+- [x] Created one P0 worktree first, then limited later parallelism to two subagent lanes.
+- [x] Re-checked disk usage before later lanes.
+- [x] Avoided dependency installs; all work reused existing repo tooling/dependencies.
+- [x] Used task-local worktrees under `.worktrees/review-action-items-*` for predictable cleanup.
+- [ ] Remove task-created worktrees after PR is opened and branch is pushed.
+- [ ] Run `git worktree prune` after cleanup.
+
+## Preflight findings
+
+- Root filesystem at start: 99G total, 71G used, 24G available, 75% used.
+- Current project size at start: 4.4G.
+- Existing `.worktrees` size at start: 3.4G.
+- Existing `.claude` size at start: 467M.
+- Existing `node_modules` size at start: 320M.
+- Codex CLI available: `codex-cli 0.130.0`.
+- GitHub CLI available and authenticated.
+- Current checkout had pre-existing uncommitted task/progress files, so implementation used isolated worktrees from `origin/main`.
+
+## Implementation order
+
+1. P0 first:
+   - [x] #325 Refactor `createCliDeps` into focused dependency factories.
+   - [x] #326 Fail loudly for broken optional dynamic imports.
+   - [x] Ran Codex implementation loop in isolated P0 worktree.
+   - [x] Ran Codex review loop for P0 changes.
+   - [x] Fixed Codex review finding around cleanup-on-error for post-observer optional module failures.
+   - [x] Re-ran Codex review loop and targeted tests/typecheck.
+
+2. Limited parallel lanes after P0 and disk recheck:
+   - [x] #327, #328: typed CLI skill executor test fixtures and removed unsafe casts in touched tests.
+   - [x] #329, #332: clarified agent routes as integration tests and replaced brittle event assertions with semantic helpers.
+   - [x] Both parallel lanes ran targeted tests/typecheck and Codex review loops.
+
+3. Remaining reliability lane:
+   - [x] #330 Hardened temp directory cleanup in filesystem-backed tests.
+   - [x] #331 Normalized fake timer cleanup in rate-limit resilience tests.
+   - [x] #333 Added runtime timeout protection for regex safety evaluation.
+   - [x] #334 Added deprecation/sunset guidance to backward-compat tests.
+   - [x] Ran Codex review loop, fixed ESM worker body issue, fixed timeout severity/large-scan findings, and re-ran review until no findings.
+
+## Final verification
+
+- [x] `npm test --workspace franken-orchestrator -- --run tests/unit/cli/dep-factory-providers.test.ts tests/integration/cli/dep-factory-wiring.test.ts tests/unit/skills/cli-skill-executor.test.ts tests/integration/beasts/agent-routes.test.ts tests/unit/beasts/process-beast-executor.test.ts tests/unit/skills/rate-limit-resilience.test.ts` passed: 149 tests.
+- [x] `npm test --workspace @franken/critique -- --run tests/unit/evaluators/safety.test.ts` passed: 25 tests.
+- [x] `npm run typecheck --workspace franken-orchestrator` passed.
+- [x] `npm run build --workspace @franken/critique` passed.
+- [x] `git diff --check HEAD^..HEAD` passed.
+- [x] Final integrated `codex exec review --dangerously-bypass-approvals-and-sandbox --base origin/main` reported no actionable regressions.
+
+## Final acceptance
+
+- [x] All issue fixes implemented.
+- [x] Codex review loop triggered for every issue/group and final integrated branch.
+- [x] Tests/typecheck/build run with real output.
+- [ ] PR opened.
+- [ ] Task-created worktrees cleaned up after PR creation.
+- [ ] Final disk usage reported after cleanup.

--- a/tasks/review-action-items-reliability-progress.md
+++ b/tasks/review-action-items-reliability-progress.md
@@ -1,0 +1,49 @@
+# Review Action Items Reliability Progress
+
+Worktree: `.worktrees/review-action-items-reliability`
+Branch: `codex/review-action-items-reliability`
+Base: `codex/review-action-items-p0`
+Issues: #330, #331, #333, #334
+
+## Checklist
+
+- [x] Inspect filesystem temp-dir tests in `process-beast-executor.test.ts`.
+- [x] Harden temp directory cleanup where practical.
+- [x] Add deprecation/sunset guidance or rename permanent backward compatibility tests in `process-beast-executor.test.ts`.
+- [x] Inspect timer handling in `rate-limit-resilience.test.ts`.
+- [x] Normalize fake timer setup/cleanup.
+- [x] Inspect regex safety evaluator tests and implementation.
+- [x] Add timeout protection or library-backed validation for regex safety analysis.
+- [x] Run targeted tests for changed files.
+- [x] Run package typecheck if feasible.
+- [ ] Run Codex review loop and fix findings.
+- [ ] Commit changes referencing #330 #331 #333 #334.
+
+## Disk constraints
+
+- Do not install dependencies unless required.
+- Do not create additional worktrees.
+- No dependencies installed and no worktrees created.
+
+## Verification completed
+
+- `npm exec vitest run tests/unit/beasts/process-beast-executor.test.ts tests/unit/skills/rate-limit-resilience.test.ts` in `packages/franken-orchestrator`: 63 tests passed.
+- `npm exec vitest run tests/unit/evaluators/safety.test.ts` in `packages/franken-critique`: 22 tests passed.
+- `npm run typecheck` in `packages/franken-orchestrator`: passed.
+- `npm run build` in `packages/franken-critique`: passed.
+- ESM runtime smoke check of built `SafetyEvaluator.evaluate()` with a valid rule: returned `{"verdict":"fail","findings":1}`.
+
+## Codex review loop
+
+- Initial `codex exec review --dangerously-bypass-approvals-and-sandbox --commit HEAD` found a P1 ESM worker-body issue caused by CommonJS `require` in the eval worker.
+- Fixed worker body to use ESM `import { parentPort, workerData } from 'node:worker_threads';` and verified tests/build/runtime smoke.
+- Final Codex review found two P2 findings: preserve warn-only rule severity on regex runtime timeout and avoid false unsafe failures for large linear scans.
+- Addressed findings by preserving rule severity for timeout findings and scaling runtime regex timeout budget with input size, capped at 5 seconds.
+- Re-ran targeted tests/build/typecheck after the fix; pending amend and final Codex review rerun.
+
+## Notes
+
+- Temp directory tests now track all created temp roots in a set and remove them with retries, clearing state between tests.
+- Fake timers now have a shared cleanup helper that clears pending fake timers and restores real timers from `afterEach`.
+- Safety evaluator now executes rule matching in a worker with a timeout so a regex that bypasses static validation cannot hang the evaluator process.
+- Backward-compat constructor test now states the legacy contract sunset guidance.

--- a/tasks/review-action-items-routes-progress.md
+++ b/tasks/review-action-items-routes-progress.md
@@ -1,0 +1,28 @@
+# Review Action Items Routes Progress
+
+Worktree: `.worktrees/review-action-items-routes`
+Branch: `codex/review-action-items-routes`
+Base: `codex/review-action-items-p0`
+Issues: #329, #332
+
+## Checklist
+
+- [x] Inspect `packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts` and related route helpers.
+- [x] Clarify integration-test scope or isolate circular dependencies where appropriate.
+  - Kept the suite under `tests/integration`, renamed the suite to `agent routes integration`, and renamed the broad dependency helper to `createIntegratedBeastApp` with an explicit integration-scope comment.
+- [x] Make event assertions semantic rather than brittle/order-sensitive.
+  - Added `expectEventsToIncludeTypes` and replaced direct event-type array assertions in the agent route integration suite.
+- [x] Run targeted tests for changed files.
+  - `npm --workspace packages/franken-orchestrator exec vitest run tests/integration/beasts/agent-routes.test.ts` passed: 15 tests, 1 file.
+- [x] Run package typecheck if feasible.
+  - `npm --workspace packages/franken-orchestrator run typecheck` passed.
+- [x] Run Codex review loop and fix findings.
+  - `codex exec review --dangerously-bypass-approvals-and-sandbox --commit HEAD` passed with no actionable findings.
+- [x] Commit changes referencing #329 and #332.
+
+## Disk constraints
+
+- Do not install dependencies unless required.
+- Do not create additional worktrees.
+- No dependency install performed.
+- No additional worktrees created.

--- a/tasks/review-action-items-test-mocks-progress.md
+++ b/tasks/review-action-items-test-mocks-progress.md
@@ -1,0 +1,22 @@
+# Review Action Items Test Mocks Progress
+
+Worktree: `.worktrees/review-action-items-test-mocks`
+Branch: `codex/review-action-items-test-mocks`
+Base: `codex/review-action-items-p0`
+Issues: #327, #328
+
+## Checklist
+
+- [x] Inspect `packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts` and related types.
+- [x] Replace mock-factory sprawl with a typed test builder or fixture DSL.
+- [x] Remove unnecessary `as any` and suspicious unsafe casts in touched tests.
+- [x] Prefer `satisfies` or typed mocks to preserve compile-time compatibility.
+- [x] Run targeted tests for changed files.
+- [x] Run package typecheck if feasible.
+- [ ] Run Codex review loop and fix findings.
+- [ ] Commit changes referencing #327 and #328.
+
+## Disk constraints
+
+- Do not install dependencies unless required.
+- Do not create additional worktrees.


### PR DESCRIPTION
## Summary

Resolves the review action-item batch created from the TypeScript test/code review.

Closes #325
Closes #326
Closes #327
Closes #328
Closes #329
Closes #330
Closes #331
Closes #332
Closes #333
Closes #334

## What changed

- Refactored `createCliDeps()` into focused dependency factory helpers while keeping the public composition entry point.
- Hardened optional `@franken/critique` / `@franken/governor` dynamic import handling so true missing optional modules can stub, while broken installed modules fail loudly.
- Added cleanup-on-error for post-observer optional module failures.
- Reworked CLI skill executor tests around typed fixtures/builders and removed unsafe casts in touched tests.
- Clarified agent routes as integration tests and replaced brittle event assertions with semantic helpers.
- Hardened temp-directory cleanup and fake timer cleanup in tests.
- Added regex safety runtime timeout protection without turning validated slow scans into blocking false positives.
- Added deprecation/sunset guidance to backward compatibility tests.
- Added dated progress documents under `tasks/` documenting the autonomous workflow and verification.

## Verification

- `npm test --workspace franken-orchestrator -- --run tests/unit/cli/dep-factory-providers.test.ts tests/integration/cli/dep-factory-wiring.test.ts tests/unit/skills/cli-skill-executor.test.ts tests/integration/beasts/agent-routes.test.ts tests/unit/beasts/process-beast-executor.test.ts tests/unit/skills/rate-limit-resilience.test.ts`
  - Passed: 149 tests
- `npm test --workspace @franken/critique -- --run tests/unit/evaluators/safety.test.ts`
  - Passed: 25 tests
- `npm run typecheck --workspace franken-orchestrator`
  - Passed
- `npm run build --workspace @franken/critique`
  - Passed
- `git diff --check HEAD^..HEAD`
  - Passed
- Codex review loops:
  - P0 #325/#326 reviewed; fixed cleanup-on-error finding; re-reviewed clean.
  - #327/#328 reviewed clean.
  - #329/#332 reviewed clean.
  - #330/#331/#333/#334 reviewed; fixed ESM worker body and regex timeout semantics findings; re-reviewed clean.
  - Final integrated branch review against `origin/main` reported no actionable regressions.

## Disk-safety notes

- Started with 24G available on `/`.
- Used isolated worktrees, but limited fan-out: P0 first, then two parallel lanes, then one reliability lane.
- No dependency installs were performed.
- Worktrees were about 21-22M each.
- Task-created worktrees will be removed after PR creation.
