### PR TITLE
fix(observer): fire CircuitBreaker handler on rising edge; add reset()

### DIFF
--- a/packages/franken-observer/src/cost/CircuitBreaker.test.ts
+++ b/packages/franken-observer/src/cost/CircuitBreaker.test.ts
@@ -49,12 +49,34 @@ describe('CircuitBreaker', () => {
       expect(handler).not.toHaveBeenCalled()
     })
 
-    it('emits on every call that exceeds the limit (not just the first)', () => {
+    it('fires the handler only once while continuously tripped (no alert fatigue)', () => {
       const handler = vi.fn()
       breaker.on('limit-reached', handler)
       breaker.check(0.51)
       breaker.check(0.60)
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('re-arms and fires again after spend recovers below the limit', () => {
+      const handler = vi.fn()
+      breaker.on('limit-reached', handler)
+      breaker.check(0.51) // trips, fires
+      breaker.check(0.25) // recovers, re-arms
+      breaker.check(0.60) // trips again, fires
       expect(handler).toHaveBeenCalledTimes(2)
+    })
+
+    it('reset() re-arms so the next trip fires again', () => {
+      const handler = vi.fn()
+      breaker.on('limit-reached', handler)
+      breaker.check(0.51) // fires once
+      breaker.reset()
+      breaker.check(0.60) // fires again after acknowledge
+      expect(handler).toHaveBeenCalledTimes(2)
+    })
+
+    it('reset() does not throw when never tripped', () => {
+      expect(() => breaker.reset()).not.toThrow()
     })
 
     it('supports removing a listener with off()', () => {

--- a/packages/franken-observer/src/cost/CircuitBreaker.ts
+++ b/packages/franken-observer/src/cost/CircuitBreaker.ts
@@ -17,6 +17,7 @@ type LimitReachedHandler = (result: CircuitBreakerResult) => void
 export class CircuitBreaker {
   private readonly limitUsd: number
   private readonly handlers = new Set<LimitReachedHandler>()
+  private tripped = false
 
   constructor(options: CircuitBreakerOptions) {
     this.limitUsd = options.limitUsd
@@ -29,11 +30,27 @@ export class CircuitBreaker {
       spendUsd,
     }
     if (result.tripped) {
-      for (const handler of this.handlers) {
-        handler(result)
+      // Fire handlers only on the rising edge to avoid alert fatigue / repeated
+      // HITL escalation while spend stays over the limit.
+      if (!this.tripped) {
+        this.tripped = true
+        for (const handler of this.handlers) {
+          handler(result)
+        }
       }
+    } else {
+      // Spend recovered at/below the limit — re-arm so a future trip alerts again.
+      this.tripped = false
     }
     return result
+  }
+
+  /**
+   * Re-arm the breaker so the next trip fires handlers again. Use after a
+   * HITL operator has acknowledged and remediated the overage.
+   */
+  reset(): void {
+    this.tripped = false
   }
 
   on(event: 'limit-reached', handler: LimitReachedHandler): void {


### PR DESCRIPTION
Closes #59.

## Summary
`CircuitBreaker.check()` fired its `limit-reached` handlers on **every** over-limit call, with no `reset()`/acknowledge path — causing alert fatigue and repeated HITL escalation while spend stayed over the limit.

- Handlers now fire only on the **rising edge** (transition into tripped).
- Auto re-arms when spend recovers at/below the limit.
- New `reset()` re-arms after a HITL operator acknowledges an overage.
- `result.tripped` still reflects current spend on every call, so orchestrator control flow (`cli-skill-executor.ts`) is unchanged.

## Acceptance criteria
- [x] reset()/acknowledge method
- [x] already-alerted guard (no repeated firing)
- [ ] persistence — deferred (in-process state; no store wired)

## Testing
`franken-observer` build + typecheck + test green; updated the test that encoded the old every-call behavior, added rising-edge / recovery / reset cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)