### PR TITLE
fix(observer): tolerate corrupt JSON columns in SQLiteAdapter reads

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { unlinkSync, existsSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
+import Database from 'better-sqlite3'
 import { TraceContext } from '../../core/TraceContext.js'
 import { SpanLifecycle } from '../../core/SpanLifecycle.js'
 import { SQLiteAdapter } from './SQLiteAdapter.js'
@@ -100,6 +101,66 @@ describe('SQLiteAdapter', () => {
 
       const result = await adapter.queryByTraceId(trace.id)
       expect(result!.goal).toBe('updated')
+    })
+  })
+
+  describe('corrupt JSON resilience (issue #67)', () => {
+    // flush() always writes valid JSON, so corruption is injected via a raw
+    // second connection to the same file.
+    function corruptColumn(column: 'metadata' | 'thoughtBlocks', spanId: string, value: string) {
+      const raw = new Database(dbPath)
+      raw.prepare(`UPDATE spans SET ${column} = ? WHERE id = ?`).run(value, spanId)
+      raw.close()
+    }
+
+    it('does not crash the query when metadata JSON is corrupt', async () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'step' })
+      SpanLifecycle.setMetadata(span, { foo: 'bar' })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+      await adapter.flush(trace)
+
+      corruptColumn('metadata', span.id, '{not valid json')
+
+      const result = await adapter.queryByTraceId(trace.id)
+      expect(result).not.toBeNull()
+      expect(result!.spans).toHaveLength(1)
+      expect(result!.spans[0]!.metadata).toEqual({})
+    })
+
+    it('does not crash the query when thoughtBlocks JSON is corrupt', async () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'step' })
+      SpanLifecycle.addThoughtBlock(span, 'thinking')
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+      await adapter.flush(trace)
+
+      corruptColumn('thoughtBlocks', span.id, 'definitely[ not json')
+
+      const result = await adapter.queryByTraceId(trace.id)
+      expect(result).not.toBeNull()
+      expect(result!.spans[0]!.thoughtBlocks).toEqual([])
+    })
+
+    it('corruption in one span does not poison sibling spans', async () => {
+      const trace = TraceContext.createTrace('goal')
+      const bad = TraceContext.startSpan(trace, { name: 'bad' })
+      SpanLifecycle.setMetadata(bad, { x: 1 })
+      TraceContext.endSpan(bad)
+      const good = TraceContext.startSpan(trace, { name: 'good' })
+      SpanLifecycle.setMetadata(good, { healthy: true })
+      TraceContext.endSpan(good)
+      TraceContext.endTrace(trace)
+      await adapter.flush(trace)
+
+      corruptColumn('metadata', bad.id, '<<<garbage')
+
+      const result = await adapter.queryByTraceId(trace.id)
+      expect(result!.spans).toHaveLength(2)
+      expect(result!.spans.find(s => s.name === 'bad')!.metadata).toEqual({})
+      expect(result!.spans.find(s => s.name === 'good')!.metadata['healthy']).toBe(true)
     })
   })
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -32,6 +32,20 @@ interface SpanRow {
   thoughtBlocks: string
 }
 
+/**
+ * Parse a JSON column, returning a fallback instead of throwing when the
+ * stored value is corrupt. A single bad row must not poison the whole trace
+ * query — the span is still returned, just with empty metadata/thoughtBlocks.
+ */
+function safeParse<T>(raw: string, fallback: T, context: string): T {
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    console.warn(`[SQLiteAdapter] Skipping corrupt JSON in ${context}; using fallback`)
+    return fallback
+  }
+}
+
 function rowToSpan(row: SpanRow): Span {
   return {
     id: row.id,
@@ -43,8 +57,8 @@ function rowToSpan(row: SpanRow): Span {
     endedAt: row.endedAt ?? undefined,
     durationMs: row.durationMs ?? undefined,
     errorMessage: row.errorMessage ?? undefined,
-    metadata: JSON.parse(row.metadata) as Record<string, unknown>,
-    thoughtBlocks: JSON.parse(row.thoughtBlocks) as string[],
+    metadata: safeParse<Record<string, unknown>>(row.metadata, {}, `span ${row.id} metadata`),
+    thoughtBlocks: safeParse<string[]>(row.thoughtBlocks, [], `span ${row.id} thoughtBlocks`),
   }
 }
 


### PR DESCRIPTION
Closes #67.

## Summary
`rowToSpan()` called bare `JSON.parse` on the `metadata` and `thoughtBlocks` columns, so one corrupt row threw and aborted the entire `queryByTraceId` via `.map(rowToSpan)` — a whole trace became permanently unreadable.

- Added `safeParse()` that returns an empty-object/array fallback and logs a warning instead of throwing.
- Corrupt spans still appear (with empty metadata/thoughtBlocks) rather than nulling the trace.

## Acceptance criteria
- [x] try/catch with empty fallback
- [x] logs the corrupt row
- [x] never throws on read
- [x] test proving a corrupt row doesn't break the query or sibling spans

## Testing
`franken-observer` build + typecheck + test green; 3 new corruption-resilience tests injecting malformed JSON via a raw connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)