### PR TITLE
fix(observer,types): guard token counters against overflow & bad input

### DIFF
--- a/packages/franken-observer/src/core/SpanLifecycle.test.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.test.ts
@@ -100,6 +100,18 @@ describe('SpanLifecycle', () => {
         SpanLifecycle.recordTokenUsage(span, { promptTokens: 50, completionTokens: 25 }),
       ).not.toThrow()
     })
+
+    it('rejects an ended span before touching the counter (no poisoned totals)', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'llm-call' })
+      const counter = new TokenCounter()
+      TraceContext.endSpan(span, { status: 'completed' })
+      expect(() =>
+        SpanLifecycle.recordTokenUsage(span, { promptTokens: 100, completionTokens: 50, model: 'gpt-4o' }, counter),
+      ).toThrow(/ended|completed|error/i)
+      // The inactive span must not have contributed to spend.
+      expect(counter.totalsFor('gpt-4o').totalTokens).toBe(0)
+    })
   })
 
   describe('endSpan() + LoopDetector integration', () => {

--- a/packages/franken-observer/src/core/SpanLifecycle.test.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.test.ts
@@ -81,6 +81,18 @@ describe('SpanLifecycle', () => {
       expect(counter.totalsFor('claude-sonnet-4-6').totalTokens).toBe(400)
     })
 
+    it('rejects atomically: a counter validation throw leaves the span unmutated', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'llm-call' })
+      const counter = new TokenCounter()
+      expect(() =>
+        SpanLifecycle.recordTokenUsage(span, { promptTokens: -1, completionTokens: 0, model: 'gpt-4o' }, counter),
+      ).toThrow(RangeError)
+      // Span metadata must not carry the rejected token values.
+      expect(span.metadata['promptTokens']).toBeUndefined()
+      expect(span.metadata['totalTokens']).toBeUndefined()
+    })
+
     it('does not require a TokenCounter — existing behaviour is unchanged', () => {
       const trace = TraceContext.createTrace('goal')
       const span = TraceContext.startSpan(trace, { name: 'llm-call' })

--- a/packages/franken-observer/src/core/SpanLifecycle.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.ts
@@ -23,6 +23,16 @@ export const SpanLifecycle = {
   },
 
   recordTokenUsage(span: Span, usage: TokenUsage, counter?: TokenCounter): void {
+    // Record to the counter first: it validates the token counts and may throw
+    // on bad/overflowing input. Doing it before mutating the span keeps the
+    // rejection atomic — a rejected record leaves the span untouched.
+    if (counter !== undefined && usage.model !== undefined) {
+      counter.record({
+        model: usage.model,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+      })
+    }
     const data: Record<string, unknown> = {
       promptTokens: usage.promptTokens,
       completionTokens: usage.completionTokens,
@@ -32,12 +42,5 @@ export const SpanLifecycle = {
       data['model'] = usage.model
     }
     SpanLifecycle.setMetadata(span, data)
-    if (counter !== undefined && usage.model !== undefined) {
-      counter.record({
-        model: usage.model,
-        promptTokens: usage.promptTokens,
-        completionTokens: usage.completionTokens,
-      })
-    }
   },
 }

--- a/packages/franken-observer/src/core/SpanLifecycle.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.ts
@@ -23,7 +23,13 @@ export const SpanLifecycle = {
   },
 
   recordTokenUsage(span: Span, usage: TokenUsage, counter?: TokenCounter): void {
-    // Record to the counter first: it validates the token counts and may throw
+    // Guard span state up front: an ended/error span must not contribute to
+    // spend. Checking before touching the counter prevents inactive spans from
+    // poisoning totals even though their metadata write would be rejected.
+    if (span.status !== 'active') {
+      throw new Error(`Cannot record token usage on a ${span.status} span (id: ${span.id})`)
+    }
+    // Record to the counter next: it validates the token counts and may throw
     // on bad/overflowing input. Doing it before mutating the span keeps the
     // rejection atomic — a rejected record leaves the span untouched.
     if (counter !== undefined && usage.model !== undefined) {

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -76,4 +76,35 @@ describe('TokenCounter', () => {
       expect(counter.allModels()).toHaveLength(0)
     })
   })
+
+  describe('overflow & validation (issue #58)', () => {
+    it('accepts a zero-token record (no false positive)', () => {
+      expect(() => counter.record({ model: 'm', promptTokens: 0, completionTokens: 0 })).not.toThrow()
+    })
+
+    it('throws on negative promptTokens', () => {
+      expect(() => counter.record({ model: 'm', promptTokens: -1, completionTokens: 0 })).toThrow(
+        RangeError,
+      )
+    })
+
+    it('throws on non-integer completionTokens', () => {
+      expect(() => counter.record({ model: 'm', promptTokens: 0, completionTokens: 1.5 })).toThrow(
+        RangeError,
+      )
+    })
+
+    it('throws when a cumulative sum would cross the safe-integer boundary', () => {
+      counter.record({ model: 'm', promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 0 })
+      expect(() => counter.record({ model: 'm', promptTokens: 1, completionTokens: 0 })).toThrow(
+        RangeError,
+      )
+    })
+
+    it('throws from totalsFor() when prompt + completion would overflow', () => {
+      // Each field is individually safe; only their sum overflows.
+      counter.record({ model: 'm', promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 1 })
+      expect(() => counter.totalsFor('m')).toThrow(RangeError)
+    })
+  })
 })

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -101,10 +101,18 @@ describe('TokenCounter', () => {
       )
     })
 
-    it('throws from totalsFor() when prompt + completion would overflow', () => {
-      // Each field is individually safe; only their sum overflows.
-      counter.record({ model: 'm', promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 1 })
-      expect(() => counter.totalsFor('m')).toThrow(RangeError)
+    it('rejects a record whose prompt + completion would overflow, atomically', () => {
+      // Each field is individually safe; only their combined total overflows.
+      // record() must reject at ingestion rather than store and poison later reads.
+      expect(() =>
+        counter.record({ model: 'm', promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 1 }),
+      ).toThrow(RangeError)
+      // The rejected record left the counter untouched: subsequent reads succeed.
+      expect(counter.totalsFor('m')).toEqual({
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      })
     })
   })
 })

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -114,5 +114,20 @@ describe('TokenCounter', () => {
         totalTokens: 0,
       })
     })
+
+    it('rejects a record that would overflow the global total across models, atomically', () => {
+      // Each per-model total is safe, but together they overflow grandTotal().
+      counter.record({ model: 'a', promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 0 })
+      expect(() =>
+        counter.record({ model: 'b', promptTokens: 0, completionTokens: 1 }),
+      ).toThrow(RangeError)
+      // The rejected record was not stored; grandTotal() still reads cleanly.
+      expect(counter.allModels()).toEqual(['a'])
+      expect(counter.grandTotal()).toEqual({
+        promptTokens: Number.MAX_SAFE_INTEGER,
+        completionTokens: 0,
+        totalTokens: Number.MAX_SAFE_INTEGER,
+      })
+    })
   })
 })

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -13,11 +13,33 @@ export interface TokenTotals {
 export class TokenCounter {
   private readonly counts = new Map<string, { prompt: number; completion: number }>()
 
+  /** A token delta must be a non-negative safe integer. */
+  private static assertValidDelta(value: number, label: string): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(
+        `TokenCounter: ${label} must be a non-negative safe integer, received ${value}`,
+      )
+    }
+  }
+
+  /** Add two token counts, throwing if the result would leave the safe-integer range. */
+  private static safeAdd(a: number, b: number): number {
+    const sum = a + b
+    if (!Number.isSafeInteger(sum)) {
+      throw new RangeError(
+        `TokenCounter: token total ${sum} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+      )
+    }
+    return sum
+  }
+
   record(entry: TokenRecord): void {
+    TokenCounter.assertValidDelta(entry.promptTokens, 'promptTokens')
+    TokenCounter.assertValidDelta(entry.completionTokens, 'completionTokens')
     const existing = this.counts.get(entry.model) ?? { prompt: 0, completion: 0 }
     this.counts.set(entry.model, {
-      prompt: existing.prompt + entry.promptTokens,
-      completion: existing.completion + entry.completionTokens,
+      prompt: TokenCounter.safeAdd(existing.prompt, entry.promptTokens),
+      completion: TokenCounter.safeAdd(existing.completion, entry.completionTokens),
     })
   }
 
@@ -26,7 +48,7 @@ export class TokenCounter {
     return {
       promptTokens: entry.prompt,
       completionTokens: entry.completion,
-      totalTokens: entry.prompt + entry.completion,
+      totalTokens: TokenCounter.safeAdd(entry.prompt, entry.completion),
     }
   }
 
@@ -34,10 +56,14 @@ export class TokenCounter {
     let prompt = 0
     let completion = 0
     for (const entry of this.counts.values()) {
-      prompt += entry.prompt
-      completion += entry.completion
+      prompt = TokenCounter.safeAdd(prompt, entry.prompt)
+      completion = TokenCounter.safeAdd(completion, entry.completion)
     }
-    return { promptTokens: prompt, completionTokens: completion, totalTokens: prompt + completion }
+    return {
+      promptTokens: prompt,
+      completionTokens: completion,
+      totalTokens: TokenCounter.safeAdd(prompt, completion),
+    }
   }
 
   allModels(): string[] {

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -37,10 +37,13 @@ export class TokenCounter {
     TokenCounter.assertValidDelta(entry.promptTokens, 'promptTokens')
     TokenCounter.assertValidDelta(entry.completionTokens, 'completionTokens')
     const existing = this.counts.get(entry.model) ?? { prompt: 0, completion: 0 }
-    this.counts.set(entry.model, {
-      prompt: TokenCounter.safeAdd(existing.prompt, entry.promptTokens),
-      completion: TokenCounter.safeAdd(existing.completion, entry.completionTokens),
-    })
+    const prompt = TokenCounter.safeAdd(existing.prompt, entry.promptTokens)
+    const completion = TokenCounter.safeAdd(existing.completion, entry.completionTokens)
+    // Validate the combined total up-front so a record whose prompt+completion
+    // overflows the safe-integer range is rejected here, atomically, instead of
+    // being stored and poisoning later totalsFor()/grandTotal() reads.
+    TokenCounter.safeAdd(prompt, completion)
+    this.counts.set(entry.model, { prompt, completion })
   }
 
   totalsFor(model: string): TokenTotals {

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -39,10 +39,18 @@ export class TokenCounter {
     const existing = this.counts.get(entry.model) ?? { prompt: 0, completion: 0 }
     const prompt = TokenCounter.safeAdd(existing.prompt, entry.promptTokens)
     const completion = TokenCounter.safeAdd(existing.completion, entry.completionTokens)
-    // Validate the combined total up-front so a record whose prompt+completion
-    // overflows the safe-integer range is rejected here, atomically, instead of
-    // being stored and poisoning later totalsFor()/grandTotal() reads.
+    // Validate the combined per-model total up-front so a record whose
+    // prompt+completion overflows the safe-integer range is rejected here,
+    // atomically, instead of poisoning later totalsFor() reads.
     TokenCounter.safeAdd(prompt, completion)
+    // Also validate the new global totals: a second model could otherwise push
+    // grandTotal() past the safe-integer range even when every per-model total
+    // is safe (e.g. model A with MAX_SAFE_INTEGER prompt, model B with 1). The
+    // current stored state is always valid, so grandTotal() will not throw here.
+    const global = this.grandTotal()
+    const globalPrompt = TokenCounter.safeAdd(global.promptTokens, entry.promptTokens)
+    const globalCompletion = TokenCounter.safeAdd(global.completionTokens, entry.completionTokens)
+    TokenCounter.safeAdd(globalPrompt, globalCompletion)
     this.counts.set(entry.model, { prompt, completion })
   }
 

--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -8,6 +8,7 @@ import {
   SpanLifecycle,
 } from '@frankenbeast/observer';
 import type { Trace, Span } from '@frankenbeast/observer';
+import { makeTokenSpend } from '@franken/types';
 import type { IObserverModule, SpanHandle, TokenSpendData } from '../deps.js';
 import type { ContextWindowUsage, ObserverDeps } from '../skills/cli-skill-executor.js';
 import type { ReplayContentStoreLike, ReplayRecord, ReplayRecordKind } from '../replay/replay-content-store.js';
@@ -73,12 +74,9 @@ export class CliObserverBridge implements IObserverModule {
       return { model: m, promptTokens: t.promptTokens, completionTokens: t.completionTokens };
     });
     const estimatedCostUsd = this.costCalc.totalCost(entries);
-    return {
-      inputTokens: totals.promptTokens,
-      outputTokens: totals.completionTokens,
-      totalTokens: totals.totalTokens,
-      estimatedCostUsd,
-    };
+    // Route through the validating factory so the orchestrator boundary rejects
+    // negative/unsafe totals instead of forwarding poisoned spend downstream.
+    return makeTokenSpend(totals.promptTokens, totals.completionTokens, estimatedCostUsd);
   }
 
   estimateContextWindow(input: {

--- a/packages/franken-orchestrator/src/adapters/observer-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/observer-adapter.ts
@@ -103,8 +103,12 @@ export class ObserverPortAdapter implements IObserverModule {
     let estimatedCostUsd = 0;
 
     for (const span of trace.spans) {
-      const promptTokens = numberFromMetadata(span.metadata.promptTokens);
-      const completionTokens = numberFromMetadata(span.metadata.completionTokens);
+      // Validate each span's token counts before aggregating. A negative or
+      // unsafe per-span value would otherwise cancel against other spans and
+      // slip past makeTokenSpend's aggregate check, reporting inconsistent
+      // tokens/cost. Missing/non-numeric metadata is treated as zero.
+      const promptTokens = tokenCountFromMetadata(span.metadata.promptTokens, 'promptTokens', span.id);
+      const completionTokens = tokenCountFromMetadata(span.metadata.completionTokens, 'completionTokens', span.id);
       inputTokens += promptTokens;
       outputTokens += completionTokens;
 
@@ -124,8 +128,17 @@ export class ObserverPortAdapter implements IObserverModule {
   }
 }
 
-function numberFromMetadata(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+function tokenCountFromMetadata(value: unknown, label: string, spanId: string): number {
+  // Absent or non-numeric metadata means "no tokens recorded" → zero.
+  if (typeof value !== 'number') return 0;
+  // A numeric token count must be a non-negative safe integer; anything else is
+  // corrupt span metadata and is surfaced loudly rather than silently coerced.
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(
+      `ObserverPortAdapter: span ${spanId} has invalid ${label} metadata: ${value}`,
+    );
+  }
+  return value;
 }
 
 function splitEndOptions(metadata?: Record<string, unknown>): {

--- a/packages/franken-orchestrator/src/adapters/observer-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/observer-adapter.ts
@@ -1,3 +1,4 @@
+import { makeTokenSpend } from '@franken/types';
 import type { IObserverModule, SpanHandle, TokenSpendData } from '../deps.js';
 
 export interface TraceContextPort<Trace = TracePort, Span = SpanPort> {
@@ -117,12 +118,9 @@ export class ObserverPortAdapter implements IObserverModule {
       }
     }
 
-    return {
-      inputTokens,
-      outputTokens,
-      totalTokens: inputTokens + outputTokens,
-      estimatedCostUsd,
-    };
+    // Route through the validating factory so corrupt/overflowing span metadata
+    // surfaces loudly at the boundary instead of forwarding poisoned spend.
+    return makeTokenSpend(inputTokens, outputTokens, estimatedCostUsd);
   }
 }
 

--- a/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
@@ -83,6 +83,32 @@ describe('ObserverPortAdapter', () => {
     });
   });
 
+  it('rejects a span with negative token metadata instead of letting it cancel', async () => {
+    const trace = makeTrace();
+    const traceContext = {
+      createTrace: vi.fn().mockReturnValue(trace),
+      startSpan: vi.fn().mockImplementation((_trace: any, options: any) => {
+        const span = makeSpan(trace.id, options.name);
+        trace.spans.push(span);
+        return span;
+      }),
+      endSpan: vi.fn(),
+    };
+
+    const adapter = new ObserverPortAdapter({
+      traceContext,
+      costCalculator: { calculate: vi.fn().mockReturnValue(0) },
+    });
+    adapter.startTrace('session-1');
+
+    // One span with -10 prompt tokens and a later span with +20 would aggregate
+    // to a valid 10 and slip past makeTokenSpend — the negative span must throw.
+    adapter.startSpan('task:1').end({ promptTokens: -10, completionTokens: 0, model: 'gpt-4o' });
+    adapter.startSpan('task:2').end({ promptTokens: 20, completionTokens: 0, model: 'gpt-4o' });
+
+    await expect(adapter.getTokenSpend('session-1')).rejects.toThrow(RangeError);
+  });
+
   it('wraps trace errors', () => {
     const traceContext = {
       createTrace: vi.fn().mockReturnValue(makeTrace()),

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -38,6 +38,7 @@ export type { ILlmClient, IResultLlmClient } from './llm.js';
 
 // Token
 export type { TokenSpend } from './token.js';
+export { makeTokenSpend } from './token.js';
 
 // Context
 export type { FrankenContext } from './context.js';

--- a/packages/franken-types/src/token.test.ts
+++ b/packages/franken-types/src/token.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { makeTokenSpend } from './token.js';
+
+describe('makeTokenSpend (issue #58)', () => {
+  it('computes totalTokens from the parts rather than trusting a supplied total', () => {
+    const spend = makeTokenSpend(100, 50, 0.01);
+    expect(spend).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      estimatedCostUsd: 0.01,
+    });
+  });
+
+  it('accepts zero tokens and zero cost', () => {
+    expect(() => makeTokenSpend(0, 0, 0)).not.toThrow();
+  });
+
+  it('throws on negative inputTokens', () => {
+    expect(() => makeTokenSpend(-1, 0, 0)).toThrow(RangeError);
+  });
+
+  it('throws on negative outputTokens', () => {
+    expect(() => makeTokenSpend(0, -5, 0)).toThrow(RangeError);
+  });
+
+  it('throws on non-integer token counts', () => {
+    expect(() => makeTokenSpend(1.5, 0, 0)).toThrow(RangeError);
+  });
+
+  it('throws on negative cost', () => {
+    expect(() => makeTokenSpend(1, 1, -0.01)).toThrow(RangeError);
+  });
+
+  it('throws on non-finite cost (NaN / Infinity)', () => {
+    expect(() => makeTokenSpend(1, 1, Number.NaN)).toThrow(RangeError);
+    expect(() => makeTokenSpend(1, 1, Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
+  it('throws when inputTokens + outputTokens would exceed the safe-integer range', () => {
+    expect(() => makeTokenSpend(Number.MAX_SAFE_INTEGER, 1, 0)).toThrow(RangeError);
+  });
+});

--- a/packages/franken-types/src/token.ts
+++ b/packages/franken-types/src/token.ts
@@ -7,3 +7,38 @@ export interface TokenSpend {
   totalTokens: number;
   estimatedCostUsd: number;
 }
+
+/**
+ * Construct a validated {@link TokenSpend}. Enforces non-negative safe-integer
+ * token counts, computes the `totalTokens = inputTokens + outputTokens`
+ * invariant (rather than trusting a caller-supplied total), and requires a
+ * non-negative finite cost. Throws {@link RangeError} on any violation, so
+ * overflow or corrupt input surfaces loudly instead of silently mis-billing.
+ */
+export function makeTokenSpend(
+  inputTokens: number,
+  outputTokens: number,
+  estimatedCostUsd: number,
+): TokenSpend {
+  const assertCount = (value: number, label: string): void => {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(
+        `TokenSpend: ${label} must be a non-negative safe integer, received ${value}`,
+      );
+    }
+  };
+  assertCount(inputTokens, 'inputTokens');
+  assertCount(outputTokens, 'outputTokens');
+  const totalTokens = inputTokens + outputTokens;
+  if (!Number.isSafeInteger(totalTokens)) {
+    throw new RangeError(
+      `TokenSpend: totalTokens ${totalTokens} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+    );
+  }
+  if (!Number.isFinite(estimatedCostUsd) || estimatedCostUsd < 0) {
+    throw new RangeError(
+      `TokenSpend: estimatedCostUsd must be a non-negative finite number, received ${estimatedCostUsd}`,
+    );
+  }
+  return { inputTokens, outputTokens, totalTokens, estimatedCostUsd };
+}

--- a/packages/franken-types/tests/token.test.ts
+++ b/packages/franken-types/tests/token.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { makeTokenSpend } from './token.js';
+import { makeTokenSpend } from '../src/token.js';
 
 describe('makeTokenSpend (issue #58)', () => {
   it('computes totalTokens from the parts rather than trusting a supplied total', () => {


### PR DESCRIPTION
Closes #58.

## Summary
`TokenCounter` accumulated with bare `+` and no validation, so token sums could silently lose precision past `Number.MAX_SAFE_INTEGER` and negative/NaN inputs corrupted billing. `TokenSpend` had no runtime construction guard.

- `TokenCounter.record()` validates each delta (non-negative safe integer) and adds via `safeAdd()`, which throws `RangeError` if a sum would exceed the safe range. `totalsFor()`/`grandTotal()` guard the total line too.
- New `makeTokenSpend()` in `@franken/types` enforces the same invariants, computes `totalTokens` from the parts, and requires a finite non-negative cost. Exported from the entrypoint.
- BigInt was rejected as it would break the `number`-typed public API; explicit `Number.isSafeInteger` guards match how the repo handles this elsewhere (franken-brain working memory).

## Acceptance criteria
- [x] explicit overflow check (safe-integer guard)
- [x] reject negative / non-integer token counts
- [x] runtime validation for TokenSpend construction

## Testing
`franken-observer` + `franken-types` build/typecheck/test green; new overflow+validation cases on TokenCounter and a new `token.test.ts` for `makeTokenSpend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)