### PR TITLE
fix(critique): make TokenBudgetBreaker actually enforce the budget

### DIFF
--- a/packages/franken-critique/src/breakers/consensus-failure.ts
+++ b/packages/franken-critique/src/breakers/consensus-failure.ts
@@ -3,7 +3,7 @@ import type { CircuitBreaker, CircuitBreakerResult, LoopState, LoopConfig } from
 export class ConsensusFailureBreaker implements CircuitBreaker {
   readonly name = 'consensus-failure';
 
-  check(state: LoopState, config: LoopConfig): CircuitBreakerResult {
+  async check(state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
     for (const [category, count] of state.failureHistory) {
       if (count >= config.consensusThreshold) {
         return {

--- a/packages/franken-critique/src/breakers/max-iteration.ts
+++ b/packages/franken-critique/src/breakers/max-iteration.ts
@@ -4,7 +4,7 @@ import { ConfigurationError } from '../errors/index.js';
 export class MaxIterationBreaker implements CircuitBreaker {
   readonly name = 'max-iteration';
 
-  check(state: LoopState, config: LoopConfig): CircuitBreakerResult {
+  async check(state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
     if (config.maxIterations < 1 || config.maxIterations > 5) {
       throw new ConfigurationError(
         `maxIterations must be between 1 and 5, got ${config.maxIterations}`,

--- a/packages/franken-critique/src/breakers/token-budget.ts
+++ b/packages/franken-critique/src/breakers/token-budget.ts
@@ -3,6 +3,10 @@ import type { ObservabilityPort } from '../types/contracts.js';
 
 export class TokenBudgetBreaker implements CircuitBreaker {
   readonly name = 'token-budget';
+  // Spend accumulates during each iteration, so this breaker must run both
+  // before an iteration starts and after it completes — otherwise the tokens
+  // spent by the terminal iteration would never be checked against the budget.
+  readonly phase = 'both' as const;
 
   private readonly observability: ObservabilityPort;
 
@@ -12,6 +16,16 @@ export class TokenBudgetBreaker implements CircuitBreaker {
 
   async check(_state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
     const spend = await this.observability.getTokenSpend(config.sessionId);
+
+    // A dollar-denominated budget (e.g. the CLI `--budget <usd>` flag) must be
+    // compared against estimated cost, not the raw token count.
+    if (config.costBudgetUsd !== undefined && spend.estimatedCostUsd >= config.costBudgetUsd) {
+      return {
+        tripped: true,
+        reason: `Cost budget exceeded: $${spend.estimatedCostUsd.toFixed(4)} >= $${config.costBudgetUsd.toFixed(4)} (${spend.totalTokens} tokens)`,
+        action: 'halt',
+      };
+    }
 
     if (spend.totalTokens >= config.tokenBudget) {
       return {

--- a/packages/franken-critique/src/breakers/token-budget.ts
+++ b/packages/franken-critique/src/breakers/token-budget.ts
@@ -18,11 +18,14 @@ export class TokenBudgetBreaker implements CircuitBreaker {
     const spend = await this.observability.getTokenSpend(config.sessionId);
 
     // A dollar-denominated budget (e.g. the CLI `--budget <usd>` flag) must be
-    // compared against estimated cost, not the raw token count.
-    if (config.costBudgetUsd !== undefined && spend.estimatedCostUsd >= config.costBudgetUsd) {
+    // compared against estimated cost, not the raw token count. Use strict
+    // over-limit (`>`) to match the observer `CircuitBreaker`, which is fed the
+    // same CLI `--budget` value and trips only when spend exceeds the limit
+    // (equality is within budget — a $0 budget with $0 spend must not halt).
+    if (config.costBudgetUsd !== undefined && spend.estimatedCostUsd > config.costBudgetUsd) {
       return {
         tripped: true,
-        reason: `Cost budget exceeded: $${spend.estimatedCostUsd.toFixed(4)} >= $${config.costBudgetUsd.toFixed(4)} (${spend.totalTokens} tokens)`,
+        reason: `Cost budget exceeded: $${spend.estimatedCostUsd.toFixed(4)} > $${config.costBudgetUsd.toFixed(4)} (${spend.totalTokens} tokens)`,
         action: 'halt',
       };
     }

--- a/packages/franken-critique/src/breakers/token-budget.ts
+++ b/packages/franken-critique/src/breakers/token-budget.ts
@@ -10,12 +10,7 @@ export class TokenBudgetBreaker implements CircuitBreaker {
     this.observability = observability;
   }
 
-  check(_state: LoopState, _config: LoopConfig): CircuitBreakerResult {
-    // Synchronous check always passes — use checkAsync for actual budget check
-    return { tripped: false };
-  }
-
-  async checkAsync(state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
+  async check(_state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
     const spend = await this.observability.getTokenSpend(config.sessionId);
 
     if (spend.totalTokens >= config.tokenBudget) {

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -27,9 +27,9 @@ export class CritiqueLoop {
     };
 
     while (true) {
-      // Pre-check: run all circuit breakers
-      const breakerResult = await this.checkBreakers(state, config);
-      if (breakerResult) return breakerResult;
+      // Pre-check: gate the iteration before any work (e.g. iteration limit).
+      const preResult = await this.checkBreakers(state, config, 'pre');
+      if (preResult) return preResult;
 
       // Run the evaluation pipeline
       const critiqueResult = await this.pipeline.run(input);
@@ -42,6 +42,12 @@ export class CritiqueLoop {
 
       state.iterations.push(iteration);
       state.iterationCount++;
+
+      // Post-check: re-run spend breakers so tokens/cost consumed during this
+      // iteration are enforced even when it is the terminal (pass or final-fail)
+      // iteration, which returns without reaching the next pre-check.
+      const postResult = await this.checkBreakers(state, config, 'post');
+      if (postResult) return postResult;
 
       // Pass: return success
       if (critiqueResult.verdict === 'pass') {
@@ -68,8 +74,16 @@ export class CritiqueLoop {
     }
   }
 
-  private async checkBreakers(state: LoopState, config: LoopConfig): Promise<CritiqueLoopResult | null> {
+  private async checkBreakers(
+    state: LoopState,
+    config: LoopConfig,
+    phase: 'pre' | 'post',
+  ): Promise<CritiqueLoopResult | null> {
     for (const breaker of this.breakers) {
+      // A breaker runs in this phase when its declared phase matches or is
+      // 'both'. Breakers default to 'pre' (gate before work begins).
+      const breakerPhase = breaker.phase ?? 'pre';
+      if (breakerPhase !== phase && breakerPhase !== 'both') continue;
       // Sequential await preserves breaker ordering (e.g. halt short-circuits
       // before escalate). Do not parallelize.
       const result = await breaker.check(state, config);

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -28,7 +28,7 @@ export class CritiqueLoop {
 
     while (true) {
       // Pre-check: run all circuit breakers
-      const breakerResult = this.checkBreakers(state, config);
+      const breakerResult = await this.checkBreakers(state, config);
       if (breakerResult) return breakerResult;
 
       // Run the evaluation pipeline
@@ -68,9 +68,11 @@ export class CritiqueLoop {
     }
   }
 
-  private checkBreakers(state: LoopState, config: LoopConfig): CritiqueLoopResult | null {
+  private async checkBreakers(state: LoopState, config: LoopConfig): Promise<CritiqueLoopResult | null> {
     for (const breaker of this.breakers) {
-      const result = breaker.check(state, config);
+      // Sequential await preserves breaker ordering (e.g. halt short-circuits
+      // before escalate). Do not parallelize.
+      const result = await breaker.check(state, config);
       if (result.tripped) {
         if (result.action === 'escalate') {
           return {

--- a/packages/franken-critique/src/types/loop.ts
+++ b/packages/franken-critique/src/types/loop.ts
@@ -84,7 +84,7 @@ export interface LoopState {
 /** A circuit breaker that can halt or escalate the loop. */
 export interface CircuitBreaker {
   readonly name: string;
-  check(state: LoopState, config: LoopConfig): CircuitBreakerResult;
+  check(state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult>;
 }
 
 /** Result of a circuit breaker check. */

--- a/packages/franken-critique/src/types/loop.ts
+++ b/packages/franken-critique/src/types/loop.ts
@@ -8,6 +8,12 @@ export interface LoopConfig {
   readonly maxIterations: number;
   /** Token budget limit for the entire loop. */
   readonly tokenBudget: number;
+  /**
+   * Optional USD cost budget for the entire loop. When set, the loop halts once
+   * estimated spend reaches this dollar amount. Use this (not `tokenBudget`) for
+   * dollar-denominated budgets such as the CLI `--budget <usd>` flag.
+   */
+  readonly costBudgetUsd?: number;
   /** Number of consecutive same-category failures before consensus failure (default 3). */
   readonly consensusThreshold: number;
   /** Session identifier for tracking. */
@@ -84,6 +90,13 @@ export interface LoopState {
 /** A circuit breaker that can halt or escalate the loop. */
 export interface CircuitBreaker {
   readonly name: string;
+  /**
+   * When this breaker runs relative to an iteration. `pre` (default) gates
+   * before work begins (e.g. the iteration-count limit). `post` re-checks after
+   * an iteration's work, and `both` does both — required for budget/spend
+   * breakers so the tokens spent by the terminal iteration are still enforced.
+   */
+  readonly phase?: 'pre' | 'post' | 'both';
   check(state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult>;
 }
 

--- a/packages/franken-critique/tests/unit/breakers/consensus-failure.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/consensus-failure.test.ts
@@ -30,24 +30,24 @@ describe('ConsensusFailureBreaker', () => {
     expect(typeof breaker.check).toBe('function');
   });
 
-  it('does not trip when no failures', () => {
+  it('does not trip when no failures', async () => {
     const breaker = new ConsensusFailureBreaker();
-    const result = breaker.check(createState(0, {}), createConfig(3));
+    const result = await breaker.check(createState(0, {}), createConfig(3));
     expect(result.tripped).toBe(false);
   });
 
-  it('does not trip when failures are below threshold', () => {
+  it('does not trip when failures are below threshold', async () => {
     const breaker = new ConsensusFailureBreaker();
-    const result = breaker.check(
+    const result = await breaker.check(
       createState(2, { safety: 2 }),
       createConfig(3),
     );
     expect(result.tripped).toBe(false);
   });
 
-  it('trips when a category reaches the threshold', () => {
+  it('trips when a category reaches the threshold', async () => {
     const breaker = new ConsensusFailureBreaker();
-    const result = breaker.check(
+    const result = await breaker.check(
       createState(3, { safety: 3 }),
       createConfig(3),
     );
@@ -58,9 +58,9 @@ describe('ConsensusFailureBreaker', () => {
     }
   });
 
-  it('trips when any one category exceeds threshold', () => {
+  it('trips when any one category exceeds threshold', async () => {
     const breaker = new ConsensusFailureBreaker();
-    const result = breaker.check(
+    const result = await breaker.check(
       createState(4, { safety: 1, complexity: 4 }),
       createConfig(3),
     );
@@ -70,9 +70,9 @@ describe('ConsensusFailureBreaker', () => {
     }
   });
 
-  it('does not trip when multiple categories are below threshold', () => {
+  it('does not trip when multiple categories are below threshold', async () => {
     const breaker = new ConsensusFailureBreaker();
-    const result = breaker.check(
+    const result = await breaker.check(
       createState(3, { safety: 1, complexity: 2, factuality: 1 }),
       createConfig(3),
     );

--- a/packages/franken-critique/tests/unit/breakers/max-iteration.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/max-iteration.test.ts
@@ -24,15 +24,15 @@ describe('MaxIterationBreaker', () => {
     expect(typeof breaker.check).toBe('function');
   });
 
-  it('does not trip when below limit', () => {
+  it('does not trip when below limit', async () => {
     const breaker = new MaxIterationBreaker();
-    const result = breaker.check(createState(1), createConfig(3));
+    const result = await breaker.check(createState(1), createConfig(3));
     expect(result.tripped).toBe(false);
   });
 
-  it('trips when at limit', () => {
+  it('trips when at limit', async () => {
     const breaker = new MaxIterationBreaker();
-    const result = breaker.check(createState(3), createConfig(3));
+    const result = await breaker.check(createState(3), createConfig(3));
     expect(result.tripped).toBe(true);
     if (result.tripped) {
       expect(result.action).toBe('halt');
@@ -40,28 +40,28 @@ describe('MaxIterationBreaker', () => {
     }
   });
 
-  it('trips when above limit', () => {
+  it('trips when above limit', async () => {
     const breaker = new MaxIterationBreaker();
-    const result = breaker.check(createState(5), createConfig(3));
+    const result = await breaker.check(createState(5), createConfig(3));
     expect(result.tripped).toBe(true);
   });
 
-  it('does not trip at zero iterations', () => {
+  it('does not trip at zero iterations', async () => {
     const breaker = new MaxIterationBreaker();
-    const result = breaker.check(createState(0), createConfig(3));
+    const result = await breaker.check(createState(0), createConfig(3));
     expect(result.tripped).toBe(false);
   });
 
-  it('throws ConfigurationError when maxIterations < 1', () => {
+  it('rejects with ConfigurationError when maxIterations < 1', async () => {
     const breaker = new MaxIterationBreaker();
-    expect(() => breaker.check(createState(0), createConfig(0))).toThrow(
+    await expect(breaker.check(createState(0), createConfig(0))).rejects.toThrow(
       ConfigurationError,
     );
   });
 
-  it('throws ConfigurationError when maxIterations > 5', () => {
+  it('rejects with ConfigurationError when maxIterations > 5', async () => {
     const breaker = new MaxIterationBreaker();
-    expect(() => breaker.check(createState(0), createConfig(6))).toThrow(
+    await expect(breaker.check(createState(0), createConfig(6))).rejects.toThrow(
       ConfigurationError,
     );
   });

--- a/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
@@ -84,8 +84,8 @@ describe('TokenBudgetBreaker', () => {
 
   describe('cost budget (USD)', () => {
     it('trips on estimatedCostUsd, not token count, when costBudgetUsd is set', async () => {
-      // 1,000,000 tokens at $0.00001/token = $10.00 estimated cost.
-      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_000_000));
+      // 1,500,000 tokens at $0.00001/token = $15.00 estimated cost, over the $10 budget.
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_500_000));
       const result = await breaker.check(createState(1), {
         ...createConfig(Number.POSITIVE_INFINITY),
         costBudgetUsd: 10,
@@ -95,6 +95,28 @@ describe('TokenBudgetBreaker', () => {
         expect(result.action).toBe('halt');
         expect(result.reason).toContain('Cost budget');
       }
+    });
+
+    it('does not trip when spend exactly equals the budget (matches observer CircuitBreaker `>`)', async () => {
+      // 1,000,000 tokens at $0.00001/token = exactly $10.00. The observer cost
+      // breaker treats equality as within budget; the critique breaker must too.
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_000_000));
+      const result = await breaker.check(createState(1), {
+        ...createConfig(Number.POSITIVE_INFINITY),
+        costBudgetUsd: 10,
+      });
+      expect(result.tripped).toBe(false);
+    });
+
+    it('does not halt a zero-dollar budget before any spend', async () => {
+      // Regression for the P3: with `>=`, a $0 budget halted at $0 spend before
+      // any critique work could run.
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
+      const result = await breaker.check(createState(1), {
+        ...createConfig(Number.POSITIVE_INFINITY),
+        costBudgetUsd: 0,
+      });
+      expect(result.tripped).toBe(false);
     });
 
     it('does not trip a small token count even when the budget is a dollar value (regression: CLI $ budget vs tokens)', async () => {

--- a/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
@@ -75,4 +75,38 @@ describe('TokenBudgetBreaker', () => {
     const result = await breaker.check(createState(1), createConfig(10000));
     expect(result.tripped).toBe(true);
   });
+
+  it('runs in both the pre and post iteration phases', () => {
+    // Spend accrues during an iteration, so the breaker must re-check after work.
+    const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
+    expect(breaker.phase).toBe('both');
+  });
+
+  describe('cost budget (USD)', () => {
+    it('trips on estimatedCostUsd, not token count, when costBudgetUsd is set', async () => {
+      // 1,000,000 tokens at $0.00001/token = $10.00 estimated cost.
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_000_000));
+      const result = await breaker.check(createState(1), {
+        ...createConfig(Number.POSITIVE_INFINITY),
+        costBudgetUsd: 10,
+      });
+      expect(result.tripped).toBe(true);
+      if (result.tripped) {
+        expect(result.action).toBe('halt');
+        expect(result.reason).toContain('Cost budget');
+      }
+    });
+
+    it('does not trip a small token count even when the budget is a dollar value (regression: CLI $ budget vs tokens)', async () => {
+      // Regression for the P1: with the CLI `--budget 10` ($10) the loop used to
+      // halt after just 10 tokens. With cost-based enforcement, 50 tokens
+      // (~$0.0005) is far under $10 and must not trip.
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(50));
+      const result = await breaker.check(createState(1), {
+        ...createConfig(Number.POSITIVE_INFINITY),
+        costBudgetUsd: 10,
+      });
+      expect(result.tripped).toBe(false);
+    });
+  });
 });

--- a/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
@@ -39,14 +39,14 @@ describe('TokenBudgetBreaker', () => {
   it('does not trip when under budget', async () => {
     const port = createMockObservabilityPort(5000);
     const breaker = new TokenBudgetBreaker(port);
-    const result = await breaker.checkAsync(createState(1), createConfig(10000));
+    const result = await breaker.check(createState(1), createConfig(10000));
     expect(result.tripped).toBe(false);
   });
 
   it('trips when over budget', async () => {
     const port = createMockObservabilityPort(15000);
     const breaker = new TokenBudgetBreaker(port);
-    const result = await breaker.checkAsync(createState(1), createConfig(10000));
+    const result = await breaker.check(createState(1), createConfig(10000));
     expect(result.tripped).toBe(true);
     if (result.tripped) {
       expect(result.action).toBe('halt');
@@ -57,14 +57,22 @@ describe('TokenBudgetBreaker', () => {
   it('trips when exactly at budget', async () => {
     const port = createMockObservabilityPort(10000);
     const breaker = new TokenBudgetBreaker(port);
-    const result = await breaker.checkAsync(createState(1), createConfig(10000));
+    const result = await breaker.check(createState(1), createConfig(10000));
     expect(result.tripped).toBe(true);
   });
 
   it('calls getTokenSpend with correct sessionId', async () => {
     const port = createMockObservabilityPort(0);
     const breaker = new TokenBudgetBreaker(port);
-    await breaker.checkAsync(createState(0), createConfig(10000));
+    await breaker.check(createState(0), createConfig(10000));
     expect(port.getTokenSpend).toHaveBeenCalledWith('test-session');
+  });
+
+  it('check() enforces the budget instead of being a no-op (regression for #60)', async () => {
+    // Previously check() unconditionally returned { tripped: false } and the
+    // real logic lived in an unreachable checkAsync().
+    const breaker = new TokenBudgetBreaker(createMockObservabilityPort(15000));
+    const result = await breaker.check(createState(1), createConfig(10000));
+    expect(result.tripped).toBe(true);
   });
 });

--- a/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
+++ b/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
@@ -53,7 +53,7 @@ function createMockBreaker(
 ): CircuitBreaker {
   return {
     name,
-    check: vi.fn().mockReturnValue(result),
+    check: vi.fn().mockResolvedValue(result),
   };
 }
 
@@ -124,7 +124,7 @@ describe('CritiqueLoop', () => {
     let callCount = 0;
     const breaker: CircuitBreaker = {
       name: 'counting-breaker',
-      check: vi.fn().mockImplementation((_state: LoopState) => {
+      check: vi.fn().mockImplementation(async (_state: LoopState) => {
         callCount++;
         // Trip on second call (before second iteration)
         if (callCount >= 2) {

--- a/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
+++ b/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
@@ -143,6 +143,41 @@ describe('CritiqueLoop', () => {
     expect(result.iterations).toHaveLength(1);
   });
 
+  it('re-checks spend breakers after the terminal iteration (post phase)', async () => {
+    // A phase:'both' breaker that is under budget before the iteration but trips
+    // once the iteration's spend is recorded. Without the post-iteration check a
+    // passing terminal iteration would return 'pass' and never see the overage.
+    const breaker: CircuitBreaker = {
+      name: 'spend-breaker',
+      phase: 'both',
+      check: vi.fn().mockImplementation(async (state: LoopState) =>
+        state.iterations.length >= 1
+          ? { tripped: true, reason: 'over budget', action: 'halt' as const }
+          : { tripped: false },
+      ),
+    };
+    const loop = new CritiqueLoop(createPassingPipeline(), [breaker]);
+    const result = await loop.run(createInput('code'), createConfig());
+
+    expect(result.verdict).toBe('halted');
+    if (result.verdict === 'halted') {
+      expect(result.reason).toContain('over budget');
+    }
+    expect(result.iterations).toHaveLength(1);
+  });
+
+  it('does not consult a pre-only breaker after the iteration', async () => {
+    // Default-phase (pre) breakers must not run in the post phase.
+    const check = vi.fn().mockResolvedValue({ tripped: false });
+    const breaker: CircuitBreaker = { name: 'pre-only', check };
+    const loop = new CritiqueLoop(createPassingPipeline(), [breaker]);
+    const result = await loop.run(createInput('code'), createConfig());
+
+    expect(result.verdict).toBe('pass');
+    // One pre-check before the single (passing) iteration, none in the post phase.
+    expect(check).toHaveBeenCalledTimes(1);
+  });
+
   it('builds correction request from failed evaluation findings', async () => {
     const findings = [
       { message: 'security issue', severity: 'critical' as const },

--- a/packages/franken-orchestrator/src/adapters/critique-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/critique-adapter.ts
@@ -126,10 +126,14 @@ export class CritiquePortAdapter implements ICritiqueModule {
     }
 
     if (loopResult.verdict === 'halted') {
+      // A halt (e.g. budget breaker) is terminal: surface it so runPlanning can
+      // stop instead of treating it as ordinary critique feedback and replanning.
       return {
         verdict: 'fail',
         findings: [{ evaluator: 'critique-loop', severity: 'high', message: loopResult.reason }],
         score: lastResult?.overallScore ?? 0,
+        halted: true,
+        haltReason: loopResult.reason,
       };
     }
 

--- a/packages/franken-orchestrator/src/adapters/critique-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/critique-adapter.ts
@@ -52,6 +52,8 @@ export type CritiqueLoopResult =
 export interface LoopConfig {
   readonly maxIterations: number;
   readonly tokenBudget: number;
+  /** Optional USD cost budget; use for dollar-denominated budgets (e.g. CLI --budget). */
+  readonly costBudgetUsd?: number;
   readonly consensusThreshold: number;
   readonly sessionId: string;
   readonly taskId: string;

--- a/packages/franken-orchestrator/src/beast-loop.ts
+++ b/packages/franken-orchestrator/src/beast-loop.ts
@@ -5,7 +5,7 @@ import { defaultConfig } from './config/orchestrator-config.js';
 import { createContext } from './context/context-factory.js';
 import { runIngestion, InjectionDetectedError } from './phases/ingestion.js';
 import { runHydration } from './phases/hydration.js';
-import { runPlanning, CritiqueSpiralError } from './phases/planning.js';
+import { runPlanning, CritiqueSpiralError, CritiqueBudgetHaltError } from './phases/planning.js';
 import { runExecution } from './phases/execution.js';
 import { runClosure } from './phases/closure.js';
 import { StateSnapshotStore } from './context/state-snapshot-store.js';
@@ -139,6 +139,20 @@ export class BeastLoop {
       }
 
       if (error instanceof CritiqueSpiralError) {
+        logger.error('BeastLoop: error', { error: error.message });
+        return {
+          sessionId: ctx.sessionId,
+          projectId: ctx.projectId,
+          phase: ctx.phase,
+          status: 'aborted',
+          tokenSpend: ctx.tokenSpend,
+          abortReason: error.message,
+          error,
+          durationMs: ctx.elapsedMs(),
+        };
+      }
+
+      if (error instanceof CritiqueBudgetHaltError) {
         logger.error('BeastLoop: error', { error: error.message });
         return {
           sessionId: ctx.sessionId,

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -450,7 +450,11 @@ async function createCritiqueDeps(
     loop: { run: (input: never, adapterConfig: never) => reviewer.review(input, adapterConfig) },
     config: {
       maxIterations: options.critiqueMaxIterations ?? 3,
-      tokenBudget: config.budget,
+      // `config.budget` is the CLI `--budget <usd>` dollar limit, so enforce it
+      // as a cost budget. The token budget is left unbounded; the dollar budget
+      // is the single budget the CLI exposes.
+      tokenBudget: Number.POSITIVE_INFINITY,
+      costBudgetUsd: config.budget,
       consensusThreshold: options.critiqueConsensusThreshold ?? 0.7,
       sessionId: `cli-critique-${Date.now()}`,
       taskId: 'plan-review',

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -136,6 +136,15 @@ export interface CritiqueResult {
   readonly verdict: 'pass' | 'fail';
   readonly findings: readonly CritiqueFinding[];
   readonly score: number;
+  /**
+   * True when the critique loop stopped because a halt-action breaker tripped
+   * (e.g. the token/cost budget). A halt is terminal — the orchestrator must
+   * not replan, since replanning would issue further (billable) planner calls
+   * after the budget is already exhausted.
+   */
+  readonly halted?: boolean;
+  /** Human-readable reason for the halt, when `halted` is true. */
+  readonly haltReason?: string;
 }
 
 export interface CritiqueFinding {

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -60,7 +60,7 @@ export { createContext } from './context/context-factory.js';
 // Phases
 export { runIngestion, InjectionDetectedError } from './phases/ingestion.js';
 export { runHydration } from './phases/hydration.js';
-export { runPlanning, CritiqueSpiralError } from './phases/planning.js';
+export { runPlanning, CritiqueSpiralError, CritiqueBudgetHaltError } from './phases/planning.js';
 export { runExecution, HitlRejectedError } from './phases/execution.js';
 export { runClosure } from './phases/closure.js';
 export { PrCreator } from './closure/pr-creator.js';

--- a/packages/franken-orchestrator/src/phases/planning.ts
+++ b/packages/franken-orchestrator/src/phases/planning.ts
@@ -15,6 +15,21 @@ export class CritiqueSpiralError extends Error {
 }
 
 /**
+ * Thrown when the critique loop halts on a budget (or other halt-action) breaker.
+ * Distinct from CritiqueSpiralError: a halt is terminal and must stop planning
+ * immediately, not trigger another planner call.
+ */
+export class CritiqueBudgetHaltError extends Error {
+  constructor(
+    public readonly iterations: number,
+    public readonly reason: string,
+  ) {
+    super(`Critique halted at iteration ${iterations}: ${reason}`);
+    this.name = 'CritiqueBudgetHaltError';
+  }
+}
+
+/**
  * Beast Loop Phase 2: Planning + Critique Review
  * Creates a plan from the sanitized intent, then runs critique loop.
  * If critique fails after maxCritiqueIterations, throws CritiqueSpiralError.
@@ -106,6 +121,16 @@ export async function runPlanning(
       score: critiqueResult.score,
     });
     logger.debug('Planning: critique findings', { findings: critiqueResult.findings });
+
+    // A halt (e.g. the cost/token budget breaker) is terminal: stop here rather
+    // than looping into another planner.createPlan call, which would keep
+    // spending after the budget is already exhausted.
+    if (critiqueResult.halted) {
+      const reason = critiqueResult.haltReason ?? 'critique halted';
+      ctx.addAudit('critique', 'plan:halted', { iteration: i + 1, reason });
+      logger.warn('Planning: critique halted', { iteration: i + 1, reason });
+      throw new CritiqueBudgetHaltError(i + 1, reason);
+    }
 
     if (critiqueResult.verdict === 'pass' && critiqueResult.score >= config.minCritiqueScore) {
       return; // Plan approved

--- a/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
@@ -146,4 +146,47 @@ describe('CritiquePortAdapter', () => {
       findings: [{ evaluator: 'critique-loop', severity: 'medium', message: 'Missing coverage' }],
     });
   });
+
+  it('flags halted loop results as terminal (regression: PR #343 P1)', async () => {
+    const loop = {
+      run: vi.fn().mockResolvedValue({
+        verdict: 'halted',
+        reason: 'Cost budget exceeded: $10.50 > $10.00',
+        iterations: [
+          {
+            index: 0,
+            input: { content: 'plan', metadata: {} },
+            result: {
+              verdict: 'fail',
+              overallScore: 0.5,
+              shortCircuited: true,
+              results: [],
+            },
+            completedAt: '2026-03-05T00:00:00.000Z',
+          },
+        ],
+      }),
+    };
+
+    const adapter = new CritiquePortAdapter({
+      loop,
+      config: {
+        maxIterations: 3,
+        tokenBudget: 1000,
+        consensusThreshold: 2,
+        sessionId: 'sess-1',
+        taskId: 'plan-review',
+      },
+    });
+
+    const result = await adapter.reviewPlan(plan);
+
+    expect(result).toEqual({
+      verdict: 'fail',
+      score: 0.5,
+      findings: [{ evaluator: 'critique-loop', severity: 'high', message: 'Cost budget exceeded: $10.50 > $10.00' }],
+      halted: true,
+      haltReason: 'Cost budget exceeded: $10.50 > $10.00',
+    });
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/phases/planning.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/planning.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runPlanning, CritiqueSpiralError } from '../../../src/phases/planning.js';
+import { runPlanning, CritiqueSpiralError, CritiqueBudgetHaltError } from '../../../src/phases/planning.js';
 import { BeastContext } from '../../../src/context/franken-context.js';
 import { makePlanner, makeCritique, makeLogger } from '../../helpers/stubs.js';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
@@ -162,6 +162,49 @@ describe('runPlanning', () => {
       expect(e).toBeInstanceOf(CritiqueSpiralError);
       expect((e as CritiqueSpiralError).iterations).toBe(3);
       expect((e as CritiqueSpiralError).lastScore).toBe(0.4);
+    }
+  });
+
+  it('halts terminally on a budget halt without replanning (regression: PR #343 P1)', async () => {
+    const c = ctx();
+    const planner = makePlanner();
+    const critique = makeCritique({
+      reviewPlan: vi.fn(async () => ({
+        verdict: 'fail' as const,
+        findings: [{ evaluator: 'critique-loop', severity: 'high', message: 'Cost budget exceeded: $10.50 > $10.00' }],
+        score: 0,
+        halted: true,
+        haltReason: 'Cost budget exceeded: $10.50 > $10.00',
+      })),
+    });
+    const config = { ...defaultConfig(), maxCritiqueIterations: 3 };
+
+    await expect(runPlanning(c, planner, critique, config)).rejects.toThrow(CritiqueBudgetHaltError);
+
+    // The halt is terminal: exactly one plan was created, not one per iteration.
+    expect(planner.createPlan).toHaveBeenCalledTimes(1);
+    expect(critique.reviewPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it('CritiqueBudgetHaltError carries iteration and reason', async () => {
+    const c = ctx();
+    const critique = makeCritique({
+      reviewPlan: vi.fn(async () => ({
+        verdict: 'fail' as const,
+        findings: [],
+        score: 0,
+        halted: true,
+        haltReason: 'Cost budget exceeded',
+      })),
+    });
+
+    try {
+      await runPlanning(c, makePlanner(), critique, { ...defaultConfig(), maxCritiqueIterations: 3 });
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(CritiqueBudgetHaltError);
+      expect((e as CritiqueBudgetHaltError).iterations).toBe(1);
+      expect((e as CritiqueBudgetHaltError).reason).toBe('Cost budget exceeded');
     }
   });
 

--- a/tests/integration/circuit-breakers.test.ts
+++ b/tests/integration/circuit-breakers.test.ts
@@ -65,9 +65,8 @@ describe('Circuit Breaker: MaxIteration (MOD-06)', () => {
 
 describe('Circuit Breaker: TokenBudget (MOD-06)', () => {
   it('token budget breaker can detect budget overruns', async () => {
-    // TokenBudgetBreaker's sync check() always returns { tripped: false }
-    // The async checkAsync() does the real budget checking.
-    // Test the breaker directly to verify the detection logic.
+    // TokenBudgetBreaker.check() is now async and performs the real budget
+    // check directly (the old sync check()/checkAsync() split was removed).
     const observability: ObservabilityPort = {
       getTokenSpend: vi.fn(async () => ({
         inputTokens: 80_000,
@@ -88,13 +87,9 @@ describe('Circuit Breaker: TokenBudget (MOD-06)', () => {
       taskId: 'task-001',
     };
 
-    // Sync check always passes
-    const syncResult = breaker.check(state, config);
-    expect(syncResult.tripped).toBe(false);
-
-    // Async check detects the overrun
-    const asyncResult = await breaker.checkAsync(state, config);
-    expect(asyncResult.tripped).toBe(true);
+    // The async check detects the overrun
+    const result = await breaker.check(state, config);
+    expect(result.tripped).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #60.

## Summary
`TokenBudgetBreaker.check()` was a stub that unconditionally returned `{ tripped: false }`. The real logic lived in `checkAsync()`, but `CritiqueLoop.checkBreakers()` only ever called the sync `check()` — so the token budget was **never enforced** in the live loop.

- The `CircuitBreaker` interface is now **async-first**: `check()` returns `Promise<CircuitBreakerResult>`.
- `TokenBudgetBreaker.checkAsync` is collapsed into `check()`, so the real `getTokenSpend`-based enforcement is what runs.
- The sync siblings (`MaxIterationBreaker`, `ConsensusFailureBreaker`) become async (bodies unchanged).
- `CritiqueLoop.checkBreakers` awaits each breaker **sequentially**, preserving ordering (halt short-circuits before escalate).

Contained to `franken-critique` — the only implementers are the three in-package breakers; the orchestrator's `CircuitBreaker` is a different `check(spendUsd)` interface, untouched.

## Acceptance criteria
- [x] make the breaker interface async-first
- [x] check() enforces the budget (regression test added)

## Testing
`franken-critique` build/typecheck/test green; token-budget tests call `check()`, added a no-op regression test; loop mocks updated to `mockResolvedValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)