### PR TITLE
fix(planner): guard insertFixItTask against duplicate task IDs

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -116,6 +116,9 @@ export class PlanGraph {
     if (!this._nodes.has(failedTaskId)) {
       throw new TaskNotFoundError(failedTaskId);
     }
+    if (this._nodes.has(fixTask.id)) {
+      throw new DuplicateTaskError(fixTask.id);
+    }
     const failedDeps = this._edges.get(failedTaskId) ?? new Set<TaskId>();
 
     const newNodes = new Map(this._nodes);

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -221,6 +221,16 @@ describe('PlanGraph — insertFixItTask', () => {
     ).toThrowError(TaskNotFoundError);
   });
 
+  it('throws DuplicateTaskError when fix task id already exists', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+    // 'a' already exists — inserting a fix-it with the same id must not silently overwrite it.
+    expect(() => g.insertFixItTask(createTaskId('b'), makeTask('a'))).toThrowError(
+      DuplicateTaskError
+    );
+  });
+
   it('fix task result is sorted before the failed task', () => {
     const g = PlanGraph.empty()
       .addTask(makeTask('a'))


### PR DESCRIPTION
Closes #358

## Problem
`PlanGraph.insertFixItTask` inserted `fixTask` into the node/edge maps without checking whether its id already existed — unlike `addTask`, which throws `DuplicateTaskError`. A fix-it task reusing an existing id silently overwrote that task and its dependencies, corrupting the plan graph instead of failing fast.

## Fix
Added the same duplicate-ID guard used by `addTask` to `insertFixItTask`, throwing `DuplicateTaskError` when `fixTask.id` already exists.

## Tests
Added a regression test asserting `insertFixItTask` throws `DuplicateTaskError` for a colliding id. Per-package build, test (200 passing), and typecheck all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)