### PR TITLE
fix(governor): validate approval decision against allowed response codes

### DIFF
--- a/packages/franken-governor/src/core/types.ts
+++ b/packages/franken-governor/src/core/types.ts
@@ -1,6 +1,7 @@
 import type { TriggerSeverity } from '@franken/types';
 
-export type ResponseCode = 'APPROVE' | 'REGEN' | 'ABORT' | 'DEBUG';
+export const RESPONSE_CODES = ['APPROVE', 'REGEN', 'ABORT', 'DEBUG'] as const;
+export type ResponseCode = (typeof RESPONSE_CODES)[number];
 
 // Canonicalized: the governor severity scale is the shared `@franken/types`
 // `TriggerSeverity` (see docs/CONTRACT_MATRIX.md §2), re-exported here so the

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -1,5 +1,8 @@
 import { Hono } from 'hono';
 import { createHmac } from 'node:crypto';
+import { RESPONSE_CODES } from '../core/types.js';
+
+const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
 
 export interface GovernorAppOptions {
   signingSecret?: string;
@@ -77,6 +80,17 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     if (!body.requestId || !body.decision) {
       return c.json(
         { error: { message: 'Missing required fields: requestId, decision' } },
+        400,
+      );
+    }
+
+    if (!VALID_DECISIONS.has(body.decision)) {
+      return c.json(
+        {
+          error: {
+            message: `Invalid decision: must be one of ${RESPONSE_CODES.join(', ')}`,
+          },
+        },
         400,
       );
     }

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -72,6 +72,43 @@ describe('Governor Hono Server', () => {
       expect(body.status).toBe('resolved');
     });
 
+    it('returns 400 for an invalid decision value and preserves the pending request', async () => {
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+
+      // Create approval
+      await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requestId: 'req-invalid',
+          taskId: 'task-1',
+          summary: 'Deploy',
+        }),
+      });
+
+      // Respond with an impossible decision value
+      const res = await app.request('/v1/approval/respond', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: 'req-invalid', decision: 'YOLO' }),
+      });
+
+      expect(res.status).toBe(400);
+
+      // The pending request must NOT have been consumed by the invalid attempt.
+      const health = await app.request('/health');
+      const healthBody = await health.json();
+      expect(healthBody.pendingApprovals).toBe(1);
+
+      // A subsequent valid decision should still resolve it.
+      const valid = await app.request('/v1/approval/respond', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: 'req-invalid', decision: 'APPROVE' }),
+      });
+      expect(valid.status).toBe(200);
+    });
+
     it('returns 404 for unknown request', async () => {
       const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
       const res = await app.request('/v1/approval/respond', {


### PR DESCRIPTION
Closes #350

## Problem
`POST /v1/approval/respond` accepted any non-empty `decision` string, deleted the pending approval, and returned it as `resolved`. An impossible value (e.g. `YOLO`) could mark an approval resolved and corrupt downstream state, since the domain only allows `APPROVE`, `REGEN`, `ABORT`, `DEBUG`.

## Fix
- Added `RESPONSE_CODES` constant in `core/types.ts` as the single source of truth; `ResponseCode` is now derived from it.
- `app.ts` validates `body.decision` against `RESPONSE_CODES` before consuming the pending request, returning `400` for unknown values. The pending request is preserved on rejection.

## Tests
- New test asserts an invalid decision returns `400`, leaves the pending request intact (`pendingApprovals === 1`), and a subsequent valid decision still resolves it.

## Verification (per-package, `packages/franken-governor`)
- `npm run build` — pass
- `npm test` — pass (114 tests)
- `npm run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)