### PR TITLE
fix(observer): validate audit trail run IDs before filesystem access

### DIFF
--- a/packages/franken-observer/src/audit-trail-store.test.ts
+++ b/packages/franken-observer/src/audit-trail-store.test.ts
@@ -92,8 +92,11 @@ describe('AuditTrailStore', () => {
 
   it('rejects run IDs containing path traversal segments on save', () => {
     expect(() => store.save('../../etc/passwd', sampleTrail())).toThrow(/invalid run id/i);
-    // Confirm nothing escaped the audit directory.
-    expect(existsSync(join(tempDir, '..', '..', 'etc', 'passwd.json'))).toBe(false);
+    // Confirm nothing escaped the audit directory. A naive
+    // join(auditDir, '../../etc/passwd.json') would normalize to
+    // <tempDir>/etc/passwd.json, so assert against that hermetic target
+    // rather than a path that escapes tempDir into the real filesystem.
+    expect(existsSync(join(tempDir, 'etc', 'passwd.json'))).toBe(false);
   });
 
   it('rejects run IDs containing slashes or path separators', () => {

--- a/packages/franken-observer/src/audit-trail-store.test.ts
+++ b/packages/franken-observer/src/audit-trail-store.test.ts
@@ -90,6 +90,28 @@ describe('AuditTrailStore', () => {
     expect(() => store.load('missing')).toThrow('Audit trail not found');
   });
 
+  it('rejects run IDs containing path traversal segments on save', () => {
+    expect(() => store.save('../../etc/passwd', sampleTrail())).toThrow(/invalid run id/i);
+    // Confirm nothing escaped the audit directory.
+    expect(existsSync(join(tempDir, '..', '..', 'etc', 'passwd.json'))).toBe(false);
+  });
+
+  it('rejects run IDs containing slashes or path separators', () => {
+    expect(() => store.save('foo/bar', sampleTrail())).toThrow(/invalid run id/i);
+    expect(() => store.save('foo\\bar', sampleTrail())).toThrow(/invalid run id/i);
+  });
+
+  it('rejects empty and dot run IDs', () => {
+    expect(() => store.save('', sampleTrail())).toThrow(/invalid run id/i);
+    expect(() => store.save('.', sampleTrail())).toThrow(/invalid run id/i);
+    expect(() => store.save('..', sampleTrail())).toThrow(/invalid run id/i);
+  });
+
+  it('rejects invalid run IDs on load and exists without filesystem access', () => {
+    expect(() => store.load('../secret')).toThrow(/invalid run id/i);
+    expect(() => store.exists('../secret')).toThrow(/invalid run id/i);
+  });
+
   it('replayer can load and replay a persisted artifact', () => {
     store.save('run-1', sampleTrail());
     const loaded = store.load('run-1');

--- a/packages/franken-observer/src/audit-trail-store.ts
+++ b/packages/franken-observer/src/audit-trail-store.ts
@@ -11,6 +11,24 @@ export interface PersistedAuditTrail {
 }
 
 /**
+ * Allowed run ID characters. Restricting to a single safe filename segment
+ * prevents path traversal (`../`), absolute paths, and separator injection
+ * when a run ID is interpolated into a filesystem path.
+ */
+const SAFE_RUN_ID = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Validates a run ID as a safe single filename segment before it is used to
+ * build a filesystem path. Rejects empty values, `.`/`..`, and any value
+ * containing path separators or characters outside the safe set.
+ */
+function assertSafeRunId(runId: string): void {
+  if (typeof runId !== 'string' || runId === '.' || runId === '..' || !SAFE_RUN_ID.test(runId)) {
+    throw new Error(`Invalid run id: ${JSON.stringify(runId)}`);
+  }
+}
+
+/**
  * Persists audit trails as JSON files under .fbeast/audit/.
  * One file per run: <runId>.json.
  */
@@ -22,6 +40,7 @@ export class AuditTrailStore {
   }
 
   save(runId: string, trail: AuditTrail, manifest?: readonly ReplayRecord[]): string {
+    assertSafeRunId(runId);
     mkdirSync(this.auditDir, { recursive: true });
 
     const filePath = join(this.auditDir, `${runId}.json`);
@@ -39,6 +58,7 @@ export class AuditTrailStore {
   }
 
   load(runId: string): AuditTrail {
+    assertSafeRunId(runId);
     const filePath = join(this.auditDir, `${runId}.json`);
     if (!existsSync(filePath)) {
       throw new Error(`Audit trail not found: ${filePath}`);
@@ -48,6 +68,7 @@ export class AuditTrailStore {
   }
 
   exists(runId: string): boolean {
+    assertSafeRunId(runId);
     return existsSync(join(this.auditDir, `${runId}.json`));
   }
 }


### PR DESCRIPTION
Closes #349

## Problem
`AuditTrailStore` interpolated `runId` directly into filesystem paths under `.fbeast/audit` (`save`, `load`, `exists`). A run ID containing `../` (e.g. `../../etc/passwd`) caused path traversal — reading or overwriting files outside the audit directory.

## Fix
Added `assertSafeRunId()` which validates `runId` as a single safe filename segment (`/^[A-Za-z0-9._-]+$/`) with explicit rejection of empty, `.`, and `..`. Called at the top of `save`, `load`, and `exists` before any `node:fs` access.

## Tests (TDD)
Added failing-first tests in `audit-trail-store.test.ts` covering traversal segments, path separators (`/` and `\`), empty/dot IDs, and validation on `load`/`exists`.

## Verification (per-package, franken-observer)
- `npm run build` — pass (tsc)
- `npm test` — pass (33 files, 448 tests)
- `npm run typecheck` — pass