### PR TITLE
fix(observer): escape trace IDs in trace viewer to prevent XSS

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -193,6 +193,23 @@ describe('TraceServer', () => {
       const body = await res.json() as Record<string, unknown>
       expect(body).toHaveProperty('error')
     })
+
+    it('decodes percent-encoded trace ids so they round-trip encodeURIComponent', async () => {
+      const trace = makeTrace('Special id')
+      trace.id = 'run:42@host+a&b=c;d,e'
+      await adapter.flush(trace)
+      const res = await fetch(`${server.url}/api/traces/${encodeURIComponent(trace.id)}`)
+      expect(res.status).toBe(200)
+      const body = await res.json() as { id: string }
+      expect(body.id).toBe(trace.id)
+    })
+
+    it('returns 404 JSON (not 500) for malformed percent-encoding', async () => {
+      const res = await fetch(`${server.url}/api/traces/%E0%A4%A`)
+      expect(res.status).toBe(404)
+      const body = await res.json() as Record<string, unknown>
+      expect(body).toHaveProperty('error')
+    })
   })
 
   describe('GET /unknown-path', () => {

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -67,13 +67,58 @@ describe('TraceServer', () => {
       const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
       expect(script).toBeDefined()
 
-      const context = createContext({ document: { getElementById: () => ({}) } }) as { esc?: (s: string) => string }
+      const context = createContext({ document: { getElementById: () => ({ addEventListener: () => {} }) } }) as { esc?: (s: string) => string }
       new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
       const escaped = context.esc!('goal`);globalThis.__xss=1;//${alert(1)}<img src=x onerror=alert(2)>')
       expect(escaped).not.toContain('`')
       expect(escaped).not.toContain('${')
       expect(escaped).toContain('&lt;img src=x onerror=alert(2)&gt;')
+    })
+
+    it('escapes trace IDs when rendering sidebar and detail (XSS via t.id)', async () => {
+      const html = await fetch(server.url + '/').then(r => r.text())
+      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+      expect(script).toBeDefined()
+
+      const maliciousId = '"><img src=x onerror=alert(1)>'
+      const sidebar = { innerHTML: '', addEventListener: () => {} }
+      const panel = { innerHTML: '', addEventListener: () => {} }
+      const elements: Record<string, unknown> = { sidebar, panel }
+
+      const fetchMock = (url: string) => {
+        if (url.endsWith('/api/traces')) {
+          return Promise.resolve({
+            json: () => Promise.resolve({
+              traces: [{ id: maliciousId, goal: 'g', status: 'completed', spanCount: 0, startedAt: Date.now() }],
+            }),
+          })
+        }
+        return Promise.resolve({
+          json: () => Promise.resolve({ id: maliciousId, goal: 'g', status: 'completed', spans: [] }),
+        })
+      }
+
+      const context = createContext({
+        document: {
+          getElementById: (id: string) => elements[id],
+          querySelectorAll: () => [] as unknown[],
+        },
+        fetch: fetchMock,
+        Date,
+      }) as {
+        loadTraces?: () => Promise<void>
+        loadDetail?: (id: string) => Promise<void>
+      }
+      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+
+      await context.loadTraces!()
+      expect(sidebar.innerHTML).not.toContain('<img')
+      expect(sidebar.innerHTML).toContain('&lt;img')
+
+      await context.loadDetail!(maliciousId)
+      expect(panel.innerHTML).not.toContain('<img')
+      expect(panel.innerHTML).toContain('&lt;img')
     })
   })
 

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -182,7 +182,7 @@ async function loadTraces(){
   const {traces} = await fetch('/api/traces').then(r=>r.json())
   if(!traces.length){sidebar.innerHTML='<p class="empty" style="padding:1rem;font-size:.8rem">No traces yet.</p>';return}
   sidebar.innerHTML = traces.map(t=>\`
-    <div class="trace-item" data-id="\${t.id}" onclick="loadDetail('\${t.id}')">
+    <div class="trace-item" data-id="\${esc(t.id)}">
       <div class="trace-goal">\${esc(t.goal)}</div>
       <div class="trace-meta">
         \${badge(t.status)}
@@ -192,13 +192,18 @@ async function loadTraces(){
     </div>\`).join('')
 }
 
+sidebar.addEventListener('click', e=>{
+  const item = e.target.closest && e.target.closest('.trace-item')
+  if(item) loadDetail(item.dataset.id)
+})
+
 async function loadDetail(id){
   document.querySelectorAll('.trace-item').forEach(el=>el.classList.toggle('active',el.dataset.id===id))
-  const t = await fetch('/api/traces/'+id).then(r=>r.json())
+  const t = await fetch('/api/traces/'+encodeURIComponent(id)).then(r=>r.json())
   const totalTokens = t.spans.reduce((n,s)=>(n+(s.metadata.totalTokens??0)),0)
   panel.innerHTML = \`
     <h2>\${esc(t.goal)}</h2>
-    <div class="trace-id">\${t.id}</div>
+    <div class="trace-id">\${esc(t.id)}</div>
     <div style="display:flex;gap:2rem;font-size:.8rem;color:#666;margin-bottom:1rem">
       <span>Status: \${badge(t.status)}</span>
       <span>Spans: \${t.spans.length}</span>

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -93,7 +93,17 @@ export class TraceServer {
 
       const traceMatch = /^\/api\/traces\/([^/]+)$/.exec(path)
       if (traceMatch) {
-        const trace = await this.adapter.queryByTraceId(traceMatch[1])
+        // The client encodes the id with encodeURIComponent; pathname keeps it
+        // percent-encoded, so decode it back before lookup. Malformed encodings
+        // (e.g. a lone "%") throw URIError — treat those as "not found".
+        let traceId: string
+        try {
+          traceId = decodeURIComponent(traceMatch[1])
+        } catch {
+          json(res, 404, { error: 'trace not found' })
+          return
+        }
+        const trace = await this.adapter.queryByTraceId(traceId)
         if (!trace) { json(res, 404, { error: 'trace not found' }); return }
         json(res, 200, trace)
         return


### PR DESCRIPTION
Closes #353

## Root cause
The trace viewer's client-side renderer (`packages/franken-observer/src/ui/TraceServer.ts`) wrote `t.id` raw into a `data-id` attribute, an inline `onclick="loadDetail('...')"` handler, and the detail `trace-id` div — while sibling fields used the existing `esc()` helper. Trace IDs are part of the public trace model and may not be UUID-safe, so a malformed/malicious ID could inject HTML/JS into the local viewer.

## Fix
- Escape `t.id` via `esc()` in both the attribute and detail-text contexts.
- Remove the inline `onclick` (which interpolated an untrusted value into a JS string context) in favour of click event delegation on the sidebar using `dataset.id`.
- `encodeURIComponent` the id when building the detail fetch URL.

## Testing (TDD)
Added a VM-based test that renders a malicious trace ID (`"><img src=x onerror=alert(1)>`) and asserts no raw `<img` reaches sidebar/panel `innerHTML` (escaped to `&lt;img`). Verified the test fails before the fix and passes after.

## Verification (per-package)
`cd packages/franken-observer`
- `npm run build` — pass
- `npm test` — 445 passed (33 files)
- `npm run typecheck` — pass