### PR TITLE
fix(franken-observer): handle PostMortemGenerator file write errors gracefully

### DIFF
--- a/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { TraceContext } from '../core/TraceContext.js'
 import { SpanLifecycle } from '../core/SpanLifecycle.js'
@@ -131,7 +131,53 @@ describe('PostMortemGenerator', () => {
       const gen = new PostMortemGenerator({ outputDir: nested })
       const trace = makeTrace()
       const filePath = await gen.generate(trace, makeSignal(trace.id))
-      expect(existsSync(filePath)).toBe(true)
+      expect(existsSync(filePath!)).toBe(true)
+    })
+  })
+
+  describe('generate() error handling (disk full / read-only)', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('does not throw and returns null when the directory cannot be created', async () => {
+      // Make the parent of outputDir a regular file, so recursive mkdir fails
+      // with ENOTDIR — the same unrecoverable class as a read-only filesystem.
+      const blocker = join(tmpdir(), `pm-block-${randomUUID()}`)
+      writeFileSync(blocker, 'not a directory')
+      const gen = new PostMortemGenerator({ outputDir: join(blocker, 'reports') })
+      const trace = makeTrace()
+
+      let result: string | null
+      try {
+        result = await gen.generate(trace, makeSignal(trace.id))
+      } finally {
+        rmSync(blocker, { force: true })
+      }
+
+      expect(result).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+    })
+
+    it('does not throw and returns null when the file cannot be written', async () => {
+      // Pre-create a *directory* at the exact target file path so writeFile
+      // fails with EISDIR — mimics a disk-full / unwritable target without mocks.
+      const trace = makeTrace()
+      const sig = makeSignal(trace.id)
+      const filename = `post-mortem-${trace.id}-${sig.timestamp}.md`
+      mkdirSync(join(outputDir, filename), { recursive: true })
+
+      const gen = new PostMortemGenerator({ outputDir })
+      const result = await gen.generate(trace, sig)
+
+      expect(result).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
     })
   })
 

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -1,4 +1,4 @@
-import { writeFile, mkdir } from 'node:fs/promises'
+import * as fs from 'node:fs/promises'
 import { join } from 'node:path'
 import type { Trace } from '../core/types.js'
 import type { InterruptSignal } from './InterruptEmitter.js'
@@ -11,7 +11,9 @@ export interface PostMortemOptions {
 /**
  * Generates a markdown post-mortem report when an agent loop is detected.
  * generateContent() builds the markdown string (pure, no I/O).
- * generate() writes it to disk and returns the file path.
+ * generate() writes it to disk and returns the file path, or `null` if the
+ * write failed (e.g. disk full or read-only directory). A write failure is
+ * logged and degraded gracefully so it never crashes the agent loop.
  */
 export class PostMortemGenerator {
   private readonly outputDir: string
@@ -69,13 +71,29 @@ without reaching a terminal condition. Possible causes:
 `
   }
 
-  async generate(trace: Trace, signal: InterruptSignal): Promise<string> {
-    await mkdir(this.outputDir, { recursive: true })
+  /**
+   * Writes the post-mortem to disk. Returns the file path on success, or
+   * `null` if the directory could not be created or the file could not be
+   * written (e.g. ENOSPC disk full, EACCES/EROFS read-only). Failures are
+   * logged rather than thrown so a reporting failure never crashes the loop
+   * the post-mortem was meant to diagnose.
+   */
+  async generate(trace: Trace, signal: InterruptSignal): Promise<string | null> {
     const timestamp = signal.timestamp
     const filename = `post-mortem-${trace.id}-${timestamp}.md`
     const filePath = join(this.outputDir, filename)
     const content = this.generateContent(trace, signal)
-    await writeFile(filePath, content, 'utf-8')
-    return filePath
+
+    try {
+      await fs.mkdir(this.outputDir, { recursive: true })
+      await fs.writeFile(filePath, content, 'utf-8')
+      return filePath
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      console.warn(
+        `[PostMortemGenerator] Failed to write post-mortem for trace ${trace.id} to ${filePath}: ${reason}. Continuing without persisting the report.`,
+      )
+      return null
+    }
   }
 }


### PR DESCRIPTION
Closes #72

## Problem
`PostMortemGenerator.generate()` called `mkdir()` and `writeFile()` without a try-catch (`PostMortemGenerator.ts:72-80`). A read-only output directory or a full disk produced an unhandled promise rejection that crashed the very agent loop the post-mortem was meant to diagnose.

## Fix
- Wrapped directory creation and file write in a try-catch.
- On failure, the error is logged via `console.warn` (matching the package's `[Tag]` convention) and `generate()` returns `null` — degrading gracefully rather than propagating the crash.
- Return type is now `Promise<string | null>`. No external caller consumes the value as a non-null string.

## Tests (TDD)
Added two tests that trigger real filesystem failures (no fragile ESM mocking):
- mkdir failure via a file-as-parent (`ENOTDIR`)
- writeFile failure via a directory pre-created at the target path (`EISDIR`)

Both assert `generate()` does not throw, returns `null`, and logs a warning.

## Verification (per-package, in worktree)
- `npm run build` — pass
- `npm test` — 446 passed (33 files)
- `npm run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)