### PR TITLE
fix(franken-planner): error on cyclic sub-graph instead of silently dropping tasks

### DIFF
--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -1,4 +1,4 @@
-import { RecursionDepthExceededError } from '../core/errors.js';
+import { CyclicDependencyError, RecursionDepthExceededError } from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, TaskResult, Task } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
@@ -79,7 +79,15 @@ export class RecursivePlanner implements PlanningStrategy {
           remaining.splice(i, 1);
         }
       }
-      if (remaining.length === prevLen) break; // cycle guard — avoid infinite loop
+      if (remaining.length === prevLen) {
+        // No progress this pass: the remaining tasks have unresolvable
+        // dependencies (a cycle, or a dependency on a task not in this set).
+        // Surface a clear error instead of silently dropping the tasks.
+        const stuck = remaining.map((t) => t.id).join(', ');
+        throw new CyclicDependencyError(
+          `Cannot build sub-graph — ${remaining.length} task(s) have unresolvable dependencies (cycle): ${stuck}`
+        );
+      }
     }
 
     let graph = PlanGraph.empty();

--- a/packages/franken-planner/tests/unit/planners/recursive.test.ts
+++ b/packages/franken-planner/tests/unit/planners/recursive.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { RecursivePlanner } from '../../../src/planners/recursive';
-import { RecursionDepthExceededError } from '../../../src/core/errors';
+import { RecursionDepthExceededError, CyclicDependencyError } from '../../../src/core/errors';
 import { PlanGraph } from '../../../src/core/dag';
 import { createTaskId } from '../../../src/core/types';
 import type { Task, TaskResult } from '../../../src/core/types';
@@ -195,6 +195,40 @@ describe('RecursivePlanner — failure handling', () => {
     expect(result.status).toBe('failed');
     if (result.status !== 'failed') throw new Error('unexpected');
     expect(result.error.message).toBe('sub exploded');
+  });
+
+  it('throws CyclicDependencyError when expanded sub-tasks form a cycle (no silent drop)', async () => {
+    // sub-1 ↔ sub-2 form a dependency cycle; neither can ever be scheduled.
+    const sub1: Task = { ...makeTask('sub-1'), dependsOn: [createTaskId('sub-2')] };
+    const sub2: Task = { ...makeTask('sub-2'), dependsOn: [createTaskId('sub-1')] };
+    const parent = makeTask('parent');
+    const graph = PlanGraph.empty().addTask(parent);
+
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [sub1, sub2]))
+      .mockResolvedValue(success('sub-1'));
+
+    await expect(
+      new RecursivePlanner().execute(graph, { executor })
+    ).rejects.toThrowError(CyclicDependencyError);
+
+    // The cyclic sub-tasks must NOT be silently executed as a partial plan.
+    expect(executor).toHaveBeenCalledTimes(1); // only the parent
+  });
+
+  it('CyclicDependencyError names the unresolvable tasks in the cycle', async () => {
+    const sub1: Task = { ...makeTask('sub-1'), dependsOn: [createTaskId('sub-2')] };
+    const sub2: Task = { ...makeTask('sub-2'), dependsOn: [createTaskId('sub-1')] };
+    const parent = makeTask('parent');
+    const graph = PlanGraph.empty().addTask(parent);
+
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [sub1, sub2]))
+      .mockResolvedValue(success('sub-1'));
+
+    await expect(
+      new RecursivePlanner().execute(graph, { executor })
+    ).rejects.toThrowError(/sub-1|sub-2/);
   });
 
   it('throws RecursionDepthExceededError when maxDepth exceeded', async () => {


### PR DESCRIPTION
Closes #54

## Problem
`RecursivePlanner._buildSubGraph()` silently `break`ed out of its scheduling loop when remaining expanded tasks had unresolvable dependencies (a cycle). It then built a partial graph, dropping the cyclic tasks. The agent executed an incomplete plan with no error or warning — the caller had no way to know the plan was incomplete.

## Fix
When no progress is made in a scheduling pass, throw `CyclicDependencyError` naming the unresolvable tasks instead of silently breaking. This mirrors the existing cycle handling in `PlanGraph.topoSort()`.

## Tests (TDD)
Added two failing-first tests in `tests/unit/planners/recursive.test.ts`:
- Cyclic expanded sub-tasks now throw `CyclicDependencyError` (and are not silently executed as a partial plan — only the parent runs).
- The error message names the unresolvable tasks.

## Verification (per-package, franken-planner)
- `npm run build` — pass
- `npm test` — 201 passed
- `npm run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)