### PR TITLE
fix(critique): token-aware loop detection (closes #69)

### DIFF
--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -19,14 +19,62 @@ const LOOP_EXIT_KEYWORDS = ['break', 'return', 'throw', 'await', 'yield'];
  * keyword detection operates on real code, not on prose or data. Without this,
  * `// break down the problem` or `"break the ice"` would be mistaken for a real
  * `break` statement.
+ *
+ * Implemented as a single left-to-right scan so that whichever construct opens
+ * first wins. A naive replace-comments-then-strings ordering would treat the
+ * `//` inside `log("http://x"); break;` as a line comment and delete the real
+ * `break`, producing a false infinite-loop finding.
  */
 function stripCommentsAndStrings(code: string): string {
-  return code
-    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
-    .replace(/\/\/[^\n]*/g, ' ') // line comments
-    .replace(/`(?:\\.|[^`\\])*`/g, ' ') // template literals
-    .replace(/"(?:\\.|[^"\\])*"/g, ' ') // double-quoted strings
-    .replace(/'(?:\\.|[^'\\])*'/g, ' '); // single-quoted strings
+  let out = '';
+  let i = 0;
+  const n = code.length;
+
+  while (i < n) {
+    const c = code[i];
+    const next = code[i + 1];
+
+    // Line comment: skip to end of line.
+    if (c === '/' && next === '/') {
+      i += 2;
+      while (i < n && code[i] !== '\n') i++;
+      out += ' ';
+      continue;
+    }
+
+    // Block comment: skip to closing */.
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(code[i] === '*' && code[i + 1] === '/')) i++;
+      i += 2;
+      out += ' ';
+      continue;
+    }
+
+    // String / template literal: skip to matching unescaped quote.
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < n) {
+        if (code[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (code[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      out += ' ';
+      continue;
+    }
+
+    out += c;
+    i++;
+  }
+
+  return out;
 }
 
 /**
@@ -35,6 +83,60 @@ function stripCommentsAndStrings(code: string): string {
  */
 function hasKeyword(code: string, keyword: string): boolean {
   return new RegExp(`\\b${keyword}\\b`).test(code);
+}
+
+/**
+ * Detects whether a loop body contains a real loop-level exit/suspend keyword.
+ *
+ * A bare keyword match anywhere in the body is not enough: `await`/`yield`/etc.
+ * only suspend or exit the *outer* loop when they execute as part of its direct
+ * control flow. This scan rejects matches that are:
+ *   - member accesses (`timer.await()` — `await` is a method name),
+ *   - the concise body of a nested arrow function (`() => await work()` — the
+ *     keyword runs when the function is called, not by the loop), or
+ *   - nested inside another block such as a nested function (brace depth > 0).
+ *
+ * The body is assumed to already have comments and strings stripped.
+ */
+function hasLoopExit(body: string, keywords: ReadonlyArray<string>): boolean {
+  const keywordSet = new Set(keywords);
+  // Tokens we care about: braces, arrow, member access (`.name`), identifiers.
+  const tokenPattern = /=>|[{}]|\.\s*[A-Za-z_$][\w$]*|[A-Za-z_$][\w$]*/g;
+  let braceDepth = 0;
+  let prevWasArrow = false;
+
+  for (const match of body.matchAll(tokenPattern)) {
+    const token = match[0];
+
+    if (token === '{') {
+      braceDepth++;
+      prevWasArrow = false;
+      continue;
+    }
+    if (token === '}') {
+      if (braceDepth > 0) braceDepth--;
+      prevWasArrow = false;
+      continue;
+    }
+    if (token === '=>') {
+      prevWasArrow = true;
+      continue;
+    }
+
+    const isMemberAccess = token.startsWith('.');
+    if (
+      !isMemberAccess &&
+      braceDepth === 0 &&
+      !prevWasArrow &&
+      keywordSet.has(token)
+    ) {
+      return true;
+    }
+
+    prevWasArrow = false;
+  }
+
+  return false;
 }
 
 export class LogicLoopEvaluator implements Evaluator {
@@ -61,7 +163,7 @@ export class LogicLoopEvaluator implements Evaluator {
     for (const pattern of INFINITE_LOOP_PATTERNS) {
       for (const match of content.matchAll(pattern)) {
         const body = stripCommentsAndStrings(match[1] ?? '');
-        const hasExit = LOOP_EXIT_KEYWORDS.some((kw) => hasKeyword(body, kw));
+        const hasExit = hasLoopExit(body, LOOP_EXIT_KEYWORDS);
         if (!hasExit) {
           findings.push({
             message: 'Potential infinite loop detected: loop has no break or return statement',

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -1,37 +1,57 @@
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
 
-// Matches while(true){...} or for(;;){...} — captures the loop body
-const INFINITE_LOOP_PATTERNS = [
-  /while\s*\(\s*true\s*\)\s*\{([^}]*)\}/g,
-  /for\s*\(\s*;;\s*\)\s*\{([^}]*)\}/g,
+// Loop headers we treat as unconditional: while(true){ and for(;;){.
+// We only match up to the opening brace; the body is extracted with a
+// brace-balanced scan so nested `{ ... }` blocks (if/try/switch) are preserved.
+const INFINITE_LOOP_HEADERS = [
+  /while\s*\(\s*true\s*\)\s*\{/g,
+  /for\s*\(\s*;;\s*\)\s*\{/g,
 ];
 
-// Matches function name() { ... name() ... } where the call has no preceding if/return/?
+// Matches function name() { ... } — body captured lazily; recursion detection
+// works on the sanitized body (comments/strings removed, interpolations kept).
 const SELF_RECURSION_PATTERN =
   /function\s+(\w+)\s*\([^)]*\)\s*\{([\s\S]*?)\}/g;
 
 // Keywords that legitimately exit (or suspend) a loop. `await`/`yield` cover
 // intentional async event loops such as `while (true) { await queue.next(); }`.
-const LOOP_EXIT_KEYWORDS = ['break', 'return', 'throw', 'await', 'yield'];
+const LOOP_EXIT_KEYWORDS = new Set(['break', 'return', 'throw', 'await', 'yield']);
+
+// Keywords that open a nested loop or switch. A `break` inside one of these is
+// captured by it, not by the outer loop, so it does not count as an outer exit.
+const LOOP_OR_SWITCH_KEYWORDS = new Set(['for', 'while', 'do', 'switch']);
 
 /**
- * Removes comments and string/template literals from a code snippet so that
- * keyword detection operates on real code, not on prose or data. Without this,
- * `// break down the problem` or `"break the ice"` would be mistaken for a real
- * `break` statement.
- *
- * Implemented as a single left-to-right scan so that whichever construct opens
- * first wins. A naive replace-comments-then-strings ordering would treat the
- * `//` inside `log("http://x"); break;` as a line comment and delete the real
- * `break`, producing a false infinite-loop finding.
+ * Returns true if a `/` at this position can legally start a regex literal,
+ * based on the previous significant character. A `/` after a value (identifier,
+ * number, closing bracket, or string) is division; anywhere an expression is
+ * expected it begins a regex. This is the standard JS lexer heuristic.
  */
-function stripCommentsAndStrings(code: string): string {
+function regexCanStart(prevSignificant: string): boolean {
+  if (prevSignificant === '') return true;
+  return !/[A-Za-z0-9_$)\]}'"`]/.test(prevSignificant);
+}
+
+/**
+ * Removes comments, string literals, and regex literals from a code snippet so
+ * that keyword detection operates on real code, not on prose or data. Template
+ * literals are special-cased: the literal text is dropped but the code inside
+ * `${ ... }` interpolations is preserved (and recursively sanitized) so that
+ * real expressions like `` `${loop()}` `` remain visible to recursion detection.
+ *
+ * Implemented as a single left-to-right scan so whichever construct opens first
+ * wins. A naive replace-comments-then-strings ordering would treat the `//`
+ * inside `log("http://x"); break;` or `/\/\//.test(x); break;` as a line comment
+ * and delete the real `break`, producing a false infinite-loop finding.
+ */
+function sanitize(code: string): string {
   let out = '';
   let i = 0;
   const n = code.length;
+  let prevSignificant = '';
 
   while (i < n) {
-    const c = code[i];
+    const c = code[i]!;
     const next = code[i + 1];
 
     // Line comment: skip to end of line.
@@ -51,8 +71,8 @@ function stripCommentsAndStrings(code: string): string {
       continue;
     }
 
-    // String / template literal: skip to matching unescaped quote.
-    if (c === '"' || c === "'" || c === '`') {
+    // String literal: skip to matching unescaped quote.
+    if (c === '"' || c === "'") {
       const quote = c;
       i++;
       while (i < n) {
@@ -67,14 +87,107 @@ function stripCommentsAndStrings(code: string): string {
         i++;
       }
       out += ' ';
+      prevSignificant = ')';
+      continue;
+    }
+
+    // Template literal: drop literal text, keep & sanitize ${...} code.
+    if (c === '`') {
+      i++;
+      out += ' ';
+      while (i < n) {
+        if (code[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (code[i] === '`') {
+          i++;
+          break;
+        }
+        if (code[i] === '$' && code[i + 1] === '{') {
+          i += 2;
+          let depth = 1;
+          let inner = '';
+          while (i < n && depth > 0) {
+            const cc = code[i];
+            if (cc === '{') depth++;
+            else if (cc === '}') {
+              depth--;
+              if (depth === 0) {
+                i++;
+                break;
+              }
+            }
+            inner += cc;
+            i++;
+          }
+          out += ` ${sanitize(inner)} `;
+          continue;
+        }
+        i++;
+      }
+      prevSignificant = ')';
+      continue;
+    }
+
+    // Regex literal: skip to closing unescaped `/` (respecting char classes).
+    if (c === '/' && regexCanStart(prevSignificant)) {
+      i++;
+      let inClass = false;
+      let terminated = false;
+      while (i < n) {
+        const ch = code[i];
+        if (ch === '\\') {
+          i += 2;
+          continue;
+        }
+        if (ch === '\n') break; // unterminated — not a regex, bail
+        if (ch === '[') inClass = true;
+        else if (ch === ']') inClass = false;
+        else if (ch === '/' && !inClass) {
+          i++;
+          terminated = true;
+          break;
+        }
+        i++;
+      }
+      if (terminated) {
+        out += ' ';
+        prevSignificant = ')';
+        continue;
+      }
+      // Not a regex after all: fall through and treat `/` as a normal char.
+      out += c;
+      prevSignificant = c;
+      i++;
       continue;
     }
 
     out += c;
+    if (!/\s/.test(c)) prevSignificant = c;
     i++;
   }
 
   return out;
+}
+
+/**
+ * Extracts the brace-balanced block starting at `openBraceIdx` (which must point
+ * at a `{`). Returns the content between the outer braces. If the block is never
+ * closed (truncated input), returns everything after the opening brace.
+ * Assumes the code has already been sanitized so all braces are real.
+ */
+function extractBlock(code: string, openBraceIdx: number): string {
+  let depth = 0;
+  for (let i = openBraceIdx; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return code.slice(openBraceIdx + 1, i);
+    }
+  }
+  return code.slice(openBraceIdx + 1);
 }
 
 /**
@@ -86,54 +199,112 @@ function hasKeyword(code: string, keyword: string): boolean {
 }
 
 /**
- * Detects whether a loop body contains a real loop-level exit/suspend keyword.
+ * Detects whether a (sanitized, brace-balanced) loop body contains a real
+ * loop-level exit/suspend keyword.
  *
- * A bare keyword match anywhere in the body is not enough: `await`/`yield`/etc.
- * only suspend or exit the *outer* loop when they execute as part of its direct
- * control flow. This scan rejects matches that are:
+ * A bare keyword match anywhere in the body is not enough. An exit counts only
+ * when it executes as part of the loop's own control flow, so this scan rejects:
  *   - member accesses (`timer.await()` — `await` is a method name),
- *   - the concise body of a nested arrow function (`() => await work()` — the
- *     keyword runs when the function is called, not by the loop), or
- *   - nested inside another block such as a nested function (brace depth > 0).
+ *   - keywords inside a nested function (braced `() => { return; }` or concise
+ *     `() => await work(...)` arrow bodies, and `function` declarations), and
+ *   - a `break` captured by a nested loop or `switch` rather than the outer loop.
  *
- * The body is assumed to already have comments and strings stripped.
+ * `return`/`throw`/`await`/`yield` inside plain blocks (`if`/`try`) still count,
+ * which is why brace-balanced extraction matters: an exit inside `if (x) { ... }`
+ * is a legitimate loop exit.
  */
-function hasLoopExit(body: string, keywords: ReadonlyArray<string>): boolean {
-  const keywordSet = new Set(keywords);
-  // Tokens we care about: braces, arrow, member access (`.name`), identifiers.
-  const tokenPattern = /=>|[{}]|\.\s*[A-Za-z_$][\w$]*|[A-Za-z_$][\w$]*/g;
-  let braceDepth = 0;
-  let prevWasArrow = false;
+function hasLoopExit(body: string): boolean {
+  const tokenPattern = /=>|function\b|[{}()[\];,]|\.\s*[A-Za-z_$][\w$]*|[A-Za-z_$][\w$]*/g;
+
+  // Semantic stack of `{ ... }` frames; brackets ()[]{} all bump `bracketDepth`,
+  // which positions concise-arrow markers.
+  const braceStack: Array<{ isFunc: boolean; loopOrSwitch: boolean }> = [];
+  const conciseMarkers: number[] = []; // bracketDepth at each open concise arrow
+  let bracketDepth = 0;
+  let pendingFunc = false; // next `{` opens a function body
+  let pendingLoopOrSwitch = false; // next `{` opens a loop/switch body
+  let arrowPending = false; // we just saw `=>`, awaiting its body
+
+  const insideFunction = (): boolean =>
+    conciseMarkers.length > 0 || braceStack.some((f) => f.isFunc);
+  const insideNestedLoopOrSwitch = (): boolean =>
+    braceStack.some((f) => f.loopOrSwitch);
 
   for (const match of body.matchAll(tokenPattern)) {
     const token = match[0];
 
+    // Resolve a concise-vs-braced arrow body the moment we see the next token.
+    if (arrowPending) {
+      arrowPending = false;
+      if (token === '{') {
+        pendingFunc = true; // braced arrow body; fall through to `{` handling
+      } else {
+        conciseMarkers.push(bracketDepth); // concise body; keep scanning token
+      }
+    }
+
     if (token === '{') {
-      braceDepth++;
-      prevWasArrow = false;
+      braceStack.push({
+        isFunc: pendingFunc,
+        loopOrSwitch: !pendingFunc && pendingLoopOrSwitch,
+      });
+      bracketDepth++;
+      pendingFunc = false;
+      pendingLoopOrSwitch = false;
+      continue;
+    }
+    if (token === '(' || token === '[') {
+      bracketDepth++;
       continue;
     }
     if (token === '}') {
-      if (braceDepth > 0) braceDepth--;
-      prevWasArrow = false;
+      braceStack.pop();
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      while (conciseMarkers.length && conciseMarkers[conciseMarkers.length - 1]! > bracketDepth) {
+        conciseMarkers.pop();
+      }
+      pendingLoopOrSwitch = false;
+      pendingFunc = false;
+      continue;
+    }
+    if (token === ')' || token === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      while (conciseMarkers.length && conciseMarkers[conciseMarkers.length - 1]! > bracketDepth) {
+        conciseMarkers.pop();
+      }
+      continue;
+    }
+    if (token === ';' || token === ',') {
+      // A statement/argument boundary at the arrow's own depth ends a concise body.
+      while (conciseMarkers.length && conciseMarkers[conciseMarkers.length - 1]! >= bracketDepth) {
+        conciseMarkers.pop();
+      }
+      pendingLoopOrSwitch = false;
+      pendingFunc = false;
       continue;
     }
     if (token === '=>') {
-      prevWasArrow = true;
+      arrowPending = true;
+      continue;
+    }
+    if (token === 'function') {
+      pendingFunc = true;
+      continue;
+    }
+    if (token.startsWith('.')) {
+      continue; // member access — never a loop keyword
+    }
+
+    if (LOOP_OR_SWITCH_KEYWORDS.has(token)) {
+      pendingLoopOrSwitch = true;
       continue;
     }
 
-    const isMemberAccess = token.startsWith('.');
-    if (
-      !isMemberAccess &&
-      braceDepth === 0 &&
-      !prevWasArrow &&
-      keywordSet.has(token)
-    ) {
+    if (LOOP_EXIT_KEYWORDS.has(token)) {
+      if (insideFunction()) continue;
+      if (token === 'break' && insideNestedLoopOrSwitch()) continue;
       return true;
     }
-
-    prevWasArrow = false;
   }
 
   return false;
@@ -145,9 +316,10 @@ export class LogicLoopEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     const findings: EvaluationFinding[] = [];
+    const sanitized = sanitize(input.content);
 
-    this.checkInfiniteLoops(input.content, findings);
-    this.checkUnguardedRecursion(input.content, findings);
+    this.checkInfiniteLoops(sanitized, findings);
+    this.checkUnguardedRecursion(sanitized, findings);
 
     const score = findings.length === 0 ? 1 : 0;
 
@@ -159,12 +331,12 @@ export class LogicLoopEvaluator implements Evaluator {
     };
   }
 
-  private checkInfiniteLoops(content: string, findings: EvaluationFinding[]): void {
-    for (const pattern of INFINITE_LOOP_PATTERNS) {
-      for (const match of content.matchAll(pattern)) {
-        const body = stripCommentsAndStrings(match[1] ?? '');
-        const hasExit = hasLoopExit(body, LOOP_EXIT_KEYWORDS);
-        if (!hasExit) {
+  private checkInfiniteLoops(sanitized: string, findings: EvaluationFinding[]): void {
+    for (const header of INFINITE_LOOP_HEADERS) {
+      for (const match of sanitized.matchAll(header)) {
+        const braceIdx = match.index! + match[0].length - 1; // position of `{`
+        const body = extractBlock(sanitized, braceIdx);
+        if (!hasLoopExit(body)) {
           findings.push({
             message: 'Potential infinite loop detected: loop has no break or return statement',
             severity: 'critical',
@@ -175,22 +347,20 @@ export class LogicLoopEvaluator implements Evaluator {
     }
   }
 
-  private checkUnguardedRecursion(content: string, findings: EvaluationFinding[]): void {
-    for (const match of content.matchAll(SELF_RECURSION_PATTERN)) {
+  private checkUnguardedRecursion(sanitized: string, findings: EvaluationFinding[]): void {
+    for (const match of sanitized.matchAll(SELF_RECURSION_PATTERN)) {
       const fnName = match[1];
-      const rawBody = match[2] ?? '';
+      const body = match[2] ?? '';
 
       if (!fnName) continue;
 
-      const body = stripCommentsAndStrings(rawBody);
-
-      // Check if the function calls itself
+      // Check if the function calls itself.
       const callPattern = new RegExp(`\\b${fnName}\\s*\\(`, 'g');
       if (!callPattern.test(body)) continue;
 
-      // Check if there's a guard: a conditional, or a return before the
-      // recursive call. Word-boundary matching avoids treating identifiers like
-      // `notify` or `returnValue` as guards.
+      // Check for a guard: a conditional, or a return before the recursive call.
+      // Word-boundary matching avoids treating identifiers like `notify` or
+      // `returnValue` as guards.
       const returnIdx = body.search(/\breturn\b/);
       const recursiveCallIdx = body.search(new RegExp(`\\b${fnName}\\s*\\(`));
       const hasGuard =

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -10,6 +10,33 @@ const INFINITE_LOOP_PATTERNS = [
 const SELF_RECURSION_PATTERN =
   /function\s+(\w+)\s*\([^)]*\)\s*\{([\s\S]*?)\}/g;
 
+// Keywords that legitimately exit (or suspend) a loop. `await`/`yield` cover
+// intentional async event loops such as `while (true) { await queue.next(); }`.
+const LOOP_EXIT_KEYWORDS = ['break', 'return', 'throw', 'await', 'yield'];
+
+/**
+ * Removes comments and string/template literals from a code snippet so that
+ * keyword detection operates on real code, not on prose or data. Without this,
+ * `// break down the problem` or `"break the ice"` would be mistaken for a real
+ * `break` statement.
+ */
+function stripCommentsAndStrings(code: string): string {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+    .replace(/\/\/[^\n]*/g, ' ') // line comments
+    .replace(/`(?:\\.|[^`\\])*`/g, ' ') // template literals
+    .replace(/"(?:\\.|[^"\\])*"/g, ' ') // double-quoted strings
+    .replace(/'(?:\\.|[^'\\])*'/g, ' '); // single-quoted strings
+}
+
+/**
+ * Word-boundary keyword check. Matches `break` but not `breakPoint`, and
+ * `return` but not `returnValue`, eliminating identifier-based false matches.
+ */
+function hasKeyword(code: string, keyword: string): boolean {
+  return new RegExp(`\\b${keyword}\\b`).test(code);
+}
+
 export class LogicLoopEvaluator implements Evaluator {
   readonly name = 'logic-loop';
   readonly category = 'deterministic' as const;
@@ -33,8 +60,9 @@ export class LogicLoopEvaluator implements Evaluator {
   private checkInfiniteLoops(content: string, findings: EvaluationFinding[]): void {
     for (const pattern of INFINITE_LOOP_PATTERNS) {
       for (const match of content.matchAll(pattern)) {
-        const body = match[1] ?? '';
-        if (!body.includes('break') && !body.includes('return')) {
+        const body = stripCommentsAndStrings(match[1] ?? '');
+        const hasExit = LOOP_EXIT_KEYWORDS.some((kw) => hasKeyword(body, kw));
+        if (!hasExit) {
           findings.push({
             message: 'Potential infinite loop detected: loop has no break or return statement',
             severity: 'critical',
@@ -48,17 +76,24 @@ export class LogicLoopEvaluator implements Evaluator {
   private checkUnguardedRecursion(content: string, findings: EvaluationFinding[]): void {
     for (const match of content.matchAll(SELF_RECURSION_PATTERN)) {
       const fnName = match[1];
-      const body = match[2] ?? '';
+      const rawBody = match[2] ?? '';
 
       if (!fnName) continue;
+
+      const body = stripCommentsAndStrings(rawBody);
 
       // Check if the function calls itself
       const callPattern = new RegExp(`\\b${fnName}\\s*\\(`, 'g');
       if (!callPattern.test(body)) continue;
 
-      // Check if there's a guard (if/return before the recursive call)
+      // Check if there's a guard: a conditional, or a return before the
+      // recursive call. Word-boundary matching avoids treating identifiers like
+      // `notify` or `returnValue` as guards.
+      const returnIdx = body.search(/\breturn\b/);
+      const recursiveCallIdx = body.search(new RegExp(`\\b${fnName}\\s*\\(`));
       const hasGuard =
-        body.includes('if') || body.includes('return') && body.indexOf('return') < body.indexOf(`${fnName}(`);
+        hasKeyword(body, 'if') ||
+        (returnIdx !== -1 && recursiveCallIdx !== -1 && returnIdx < recursiveCallIdx);
 
       if (!hasGuard) {
         findings.push({

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -124,6 +124,45 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  // Regression for PR #385 (Codex): a `//` inside a string literal must not be
+  // treated as a line comment that swallows a real exit on the same line.
+  it('does not flag a loop whose break follows a URL-like string on one line', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { log("http://x"); break; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  // Regression for PR #385 (Codex): exit/suspend keywords must apply to the
+  // loop itself, not to nested functions or member names.
+  it('flags an infinite loop whose only await is inside a nested arrow function', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { const f = async () => await work(); doWork(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('flags an infinite loop whose only await is a member/method name', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { timer.await(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('flags an infinite loop whose only return is inside a nested callback', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { items.forEach(() => { return; }); doWork(); `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('does not treat a "returnValue" identifier as a recursion base case', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `function loop() { const returnValue = 1; loop(); }`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -172,6 +172,82 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('recursion');
   });
 
+  // Regression for PR #385 round 2 (Codex F3): an exit inside a braced
+  // conditional/try block is a real loop exit and must not be flagged.
+  it('passes a loop whose break sits inside a braced if block', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { if (done) { break; } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('passes a loop whose return sits inside a braced try block', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `for (;;) { try { return compute(); } catch (e) { log(e); } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('still flags an infinite loop whose only break is inside a NESTED loop', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { for (const x of xs) { break; } doWork(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('still flags an infinite loop whose only break is inside a switch', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { switch (k) { case 1: break; } doWork(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  // Regression for PR #385 round 2 (Codex F4): an await that is not the first
+  // token of a concise arrow body still belongs to that nested function.
+  it('flags an infinite loop whose await is buried in a concise arrow body', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { const f = async () => work(await job); doWork(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  // Regression for PR #385 round 2 (Codex F5): a `//` inside a regex literal
+  // must not be treated as a comment that swallows a real exit.
+  it('does not flag a loop whose break follows a regex literal containing slashes', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { if (/\\/\\//.test(url)) break; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('still treats division as division, not a regex literal', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { const r = a / b / c; if (r > 1) break; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  // Regression for PR #385 round 2 (Codex F6): real code inside a template
+  // interpolation must remain visible to recursion detection.
+  it('detects recursion that occurs inside a template interpolation', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop() { const s = `${loop()}`; }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('handles empty content', async () => {
     const evaluator = new LogicLoopEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -77,6 +77,62 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  // Regression tests for issue #69: substring matching produced false matches.
+  it('flags infinite loop whose only "break" is inside a comment', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while(true) {
+      // break down the problem into steps
+      doWork();
+    }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('flags infinite loop whose only "break" is inside a string literal', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while(true) { log("break the ice"); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('flags infinite loop where "break"/"return" appear only inside identifiers', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while(true) { breakPoint = computeReturnValue(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('does not flag a real break that is preceded by a break-like identifier', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while(true) { breakPoint = 1; if (done) break; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('treats await-based event loops as intentional (no finding)', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { const msg = await queue.next(); handle(msg); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('does not treat a "returnValue" identifier as a recursion base case', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { const returnValue = 1; loop(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('handles empty content', async () => {
     const evaluator = new LogicLoopEvaluator();
     const result = await evaluator.evaluate(createInput(''));


### PR DESCRIPTION
Closes #69

## Problem
`LogicLoopEvaluator` used substring matching (`body.includes('break')` / `body.includes('return')`) to detect whether a `while(true)`/`for(;;)` loop or recursive function had an exit/guard. This matched comments, string literals, and identifiers — e.g. `// break down the problem`, `"break the ice"`, `breakPoint`, `returnValue` — making the evaluator unreliable.

## Fix
- Strip comments and string/template literals from the loop/function body before keyword detection.
- Match keywords with word boundaries (`\bbreak\b`), so identifiers like `breakPoint`/`returnValue` no longer count.
- Treat `await`/`yield` as loop exits so intentional async event loops (`while(true){ await queue.next(); }`) are not flagged.
- Applied the same token-aware matching to the recursion base-case guard.

## Acceptance criteria
- [x] Word-boundary regex instead of substring matching
- [x] Handle intentional `while(true)` event loops (await/yield)
- [x] Tests proving comments, strings, and identifiers don't trigger false matches

## Verification (per-package)
`cd packages/franken-critique && npm run build && npm test` — 150 tests pass (15 logic-loop, including 6 new regression tests). No `typecheck` script in this package; `npm run build` runs `tsc`.