### PR TITLE
fix(orchestrator): reject stale Discord interaction signatures

### DIFF
--- a/packages/franken-orchestrator/src/comms/security/discord-signature.ts
+++ b/packages/franken-orchestrator/src/comms/security/discord-signature.ts
@@ -3,7 +3,16 @@ import type { Context, Next } from 'hono';
 
 export interface DiscordSignatureOptions {
   publicKey: string;
+  /**
+   * Maximum age (in seconds) an interaction timestamp may have, in either
+   * direction, before it is rejected as stale or excessively future-skewed.
+   * Defaults to 300 seconds (5 minutes).
+   */
+  toleranceSeconds?: number;
 }
+
+/** Default freshness window for Discord interaction timestamps (5 minutes). */
+const DEFAULT_TOLERANCE_SECONDS = 300;
 
 /**
  * Middleware for verifying Discord interaction signatures.
@@ -11,7 +20,7 @@ export interface DiscordSignatureOptions {
  * Follows: https://discord.com/developers/docs/interactions/receiving-and-responding#security-and-authorization
  */
 export function discordSignatureMiddleware(options: DiscordSignatureOptions) {
-  const { publicKey } = options;
+  const { publicKey, toleranceSeconds = DEFAULT_TOLERANCE_SECONDS } = options;
 
   // Prepare the public key object once (Discord public keys are 32-byte hex strings)
   let keyObject: KeyObject | undefined;
@@ -33,6 +42,17 @@ export function discordSignatureMiddleware(options: DiscordSignatureOptions) {
 
     if (!timestamp || !signature || !keyObject) {
       return c.json({ error: 'Missing security headers or invalid server config' }, 401);
+    }
+
+    // Reject stale or future-skewed timestamps to prevent replay of captured
+    // interactions. Discord sends X-Signature-Timestamp as seconds since epoch.
+    const timestampSeconds = Number(timestamp);
+    if (!Number.isFinite(timestampSeconds)) {
+      return c.json({ error: 'Invalid signature timestamp' }, 401);
+    }
+    const nowSeconds = Date.now() / 1000;
+    if (Math.abs(nowSeconds - timestampSeconds) > toleranceSeconds) {
+      return c.json({ error: 'Stale signature timestamp' }, 401);
     }
 
     try {

--- a/packages/franken-orchestrator/tests/unit/comms/security/discord-signature.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/security/discord-signature.test.ts
@@ -40,6 +40,80 @@ describe('discordSignatureMiddleware', () => {
     expect(res.status).toBe(200);
   });
 
+  it('rejects requests with a stale (expired) timestamp', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');
+
+    const localApp = new Hono();
+    localApp.use('/discord/*', discordSignatureMiddleware({ publicKey: rawPublicKey }));
+    localApp.post('/discord/interactions', (c) => c.json({ ok: true }));
+
+    // Timestamp 10 minutes in the past — outside the default 5 minute window.
+    const timestamp = (Math.floor(Date.now() / 1000) - 600).toString();
+    const body = JSON.stringify({ type: 1 });
+    const message = Buffer.from(timestamp + body);
+    const signature = sign(null, message, keys.privateKey).toString('hex');
+
+    const res = await localApp.request('/discord/interactions', {
+      method: 'POST',
+      headers: {
+        'X-Signature-Ed25519': signature,
+        'X-Signature-Timestamp': timestamp,
+      },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects requests with a timestamp too far in the future', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');
+
+    const localApp = new Hono();
+    localApp.use('/discord/*', discordSignatureMiddleware({ publicKey: rawPublicKey }));
+    localApp.post('/discord/interactions', (c) => c.json({ ok: true }));
+
+    // Timestamp 10 minutes in the future — excessive skew.
+    const timestamp = (Math.floor(Date.now() / 1000) + 600).toString();
+    const body = JSON.stringify({ type: 1 });
+    const message = Buffer.from(timestamp + body);
+    const signature = sign(null, message, keys.privateKey).toString('hex');
+
+    const res = await localApp.request('/discord/interactions', {
+      method: 'POST',
+      headers: {
+        'X-Signature-Ed25519': signature,
+        'X-Signature-Timestamp': timestamp,
+      },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects requests with a non-numeric timestamp', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');
+
+    const localApp = new Hono();
+    localApp.use('/discord/*', discordSignatureMiddleware({ publicKey: rawPublicKey }));
+    localApp.post('/discord/interactions', (c) => c.json({ ok: true }));
+
+    const timestamp = 'not-a-timestamp';
+    const body = JSON.stringify({ type: 1 });
+    const message = Buffer.from(timestamp + body);
+    const signature = sign(null, message, keys.privateKey).toString('hex');
+
+    const res = await localApp.request('/discord/interactions', {
+      method: 'POST',
+      headers: {
+        'X-Signature-Ed25519': signature,
+        'X-Signature-Timestamp': timestamp,
+      },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
   it('rejects requests with invalid signatures', async () => {
     const keys = generateKeyPairSync('ed25519');
     const rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');


### PR DESCRIPTION
Closes #352

## Root cause
`discordSignatureMiddleware` verified the Ed25519 signature over `timestamp + body` but never checked the timestamp's age, so a captured valid Discord interaction could be replayed indefinitely.

## Fix
- Parse `X-Signature-Timestamp` as seconds since epoch and reject requests outside a configurable freshness window (default 5 minutes), covering both stale (past) and excessive future skew.
- Reject non-numeric timestamps.
- Window is configurable via new `toleranceSeconds` option (defaults to 300s).

## Tests (TDD)
Added failing-first tests for expired, future-skewed, and malformed timestamps in `discord-signature.test.ts`.

## Verification (per-package, franken-orchestrator)
- `npm run build` — pass
- `npm test` — pass (2200 passed, 1 skipped)
- `npm run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)