### PR TITLE
fix(governor): authenticate Slack callbacks and resolve pending approvals

### DIFF
--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -1,13 +1,45 @@
 import { Hono } from 'hono';
-import { createHmac } from 'node:crypto';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import { RESPONSE_CODES } from '../core/types.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
 
 export interface GovernorAppOptions {
   signingSecret?: string;
+  /** Slack signing secret used to verify `X-Slack-Signature` on inbound callbacks. */
+  slackSigningSecret?: string;
   slackWebhookUrl?: string;
   allowUnsignedApprovalsForTests?: boolean;
+}
+
+/** Maximum age (seconds) for a Slack request timestamp before it is rejected as a replay. */
+const SLACK_MAX_TIMESTAMP_SKEW_SECONDS = 60 * 5;
+
+/** Timing-safe comparison of two equal-purpose strings. */
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/** Map a raw Slack action_id into a domain decision (ResponseCode). */
+function normalizeSlackDecision(actionId: unknown): string {
+  switch (String(actionId).toLowerCase()) {
+    case 'approve':
+      return 'APPROVE';
+    case 'reject':
+    case 'deny':
+    case 'abort':
+      return 'ABORT';
+    case 'regen':
+    case 'regenerate':
+      return 'REGEN';
+    case 'debug':
+      return 'DEBUG';
+    default:
+      return String(actionId).toUpperCase();
+  }
 }
 
 export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
@@ -111,21 +143,85 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
   // POST /v1/webhook/slack — Slack interactive message callback
   app.post('/v1/webhook/slack', async (c) => {
-    const body = await c.req.json();
+    // Read the raw body once: signature verification must run over the exact
+    // bytes Slack signed, and the parsed payload is derived from the same text.
+    const rawBody = await c.req.text();
 
-    const action = body.actions?.[0];
+    // Authenticate the callback. Fail closed: without a configured Slack signing
+    // secret we cannot trust any inbound callback, so reject it.
+    if (!options.slackSigningSecret) {
+      return c.json(
+        { error: { message: 'Slack signing secret required for callbacks' } },
+        401,
+      );
+    }
+
+    const timestamp = c.req.header('x-slack-request-timestamp');
+    const signature = c.req.header('x-slack-signature');
+    if (!timestamp || !signature) {
+      return c.json({ error: { message: 'Missing Slack signature headers' } }, 401);
+    }
+
+    // Reject stale timestamps to mitigate replay attacks.
+    const tsSeconds = Number(timestamp);
+    if (
+      !Number.isFinite(tsSeconds) ||
+      Math.abs(Date.now() / 1000 - tsSeconds) > SLACK_MAX_TIMESTAMP_SKEW_SECONDS
+    ) {
+      return c.json({ error: { message: 'Stale or invalid Slack timestamp' } }, 401);
+    }
+
+    const baseString = `v0:${timestamp}:${rawBody}`;
+    const expected = `v0=${createHmac('sha256', options.slackSigningSecret)
+      .update(baseString)
+      .digest('hex')}`;
+    if (!safeEqual(expected, signature)) {
+      return c.json({ error: { message: 'Invalid Slack signature' } }, 401);
+    }
+
+    // Parse the payload. Slack delivers interactive callbacks as
+    // `application/x-www-form-urlencoded` with a JSON `payload` field; we also
+    // accept raw JSON bodies for direct/test integrations.
+    let payload: { actions?: Array<{ action_id?: string; value?: string }> };
+    try {
+      const contentType = c.req.header('content-type') ?? '';
+      if (contentType.includes('application/x-www-form-urlencoded')) {
+        const payloadStr = new URLSearchParams(rawBody).get('payload');
+        payload = payloadStr ? JSON.parse(payloadStr) : {};
+      } else {
+        payload = rawBody ? JSON.parse(rawBody) : {};
+      }
+    } catch {
+      return c.json({ error: { message: 'Malformed Slack payload' } }, 400);
+    }
+
+    const action = payload.actions?.[0];
     if (!action) {
       return c.json({ error: { message: 'No action found in payload' } }, 400);
     }
 
     const requestId = action.value;
-    const decision = action.action_id; // 'approve' or 'reject'
+    const decision = normalizeSlackDecision(action.action_id);
+
+    if (!requestId) {
+      return c.json({ error: { message: 'Missing request identifier in action' } }, 400);
+    }
+
+    // Look up the pending approval; unknown requests are rejected.
+    const pending = pendingApprovals.get(requestId);
+    if (!pending) {
+      return c.json({ error: { message: 'Approval request not found' } }, 404);
+    }
+
+    // Resolve and clear the pending approval exactly once.
+    pendingApprovals.delete(requestId);
+    pending.resolve(decision);
 
     return c.json({
       requestId,
       decision,
       source: 'slack',
-      status: 'processed',
+      status: 'resolved',
     });
   });
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { RESPONSE_CODES } from '../core/types.js';
+import { RESPONSE_CODES, type ResponseCode } from '../core/types.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
 
@@ -23,8 +23,12 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
-/** Map a raw Slack action_id into a domain decision (ResponseCode). */
-function normalizeSlackDecision(actionId: unknown): string {
+/**
+ * Map a raw Slack action_id into a domain decision (ResponseCode).
+ * Returns `null` for unrecognized actions so the caller can reject the
+ * callback instead of consuming the pending approval with a bogus decision.
+ */
+function normalizeSlackDecision(actionId: unknown): ResponseCode | null {
   switch (String(actionId).toLowerCase()) {
     case 'approve':
       return 'APPROVE';
@@ -38,7 +42,7 @@ function normalizeSlackDecision(actionId: unknown): string {
     case 'debug':
       return 'DEBUG';
     default:
-      return String(actionId).toUpperCase();
+      return null;
   }
 }
 
@@ -201,10 +205,16 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     }
 
     const requestId = action.value;
-    const decision = normalizeSlackDecision(action.action_id);
 
     if (!requestId) {
       return c.json({ error: { message: 'Missing request identifier in action' } }, 400);
+    }
+
+    // Reject unknown action IDs before touching the pending approval so a typo
+    // or renamed button cannot consume the request with a bogus decision.
+    const decision = normalizeSlackDecision(action.action_id);
+    if (decision === null) {
+      return c.json({ error: { message: 'Unknown Slack action' } }, 400);
     }
 
     // Look up the pending approval; unknown requests are rejected.

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -199,31 +199,157 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/webhook/slack', () => {
-    it('processes Slack interactive action', async () => {
+    const SLACK_SECRET = 'slack-signing-secret';
+
+    function slackHeaders(rawBody: string, secret = SLACK_SECRET, timestamp?: string) {
+      const ts = timestamp ?? Math.floor(Date.now() / 1000).toString();
+      const base = `v0:${ts}:${rawBody}`;
+      const sig = `v0=${createHmac('sha256', secret).update(base).digest('hex')}`;
+      return {
+        'Content-Type': 'application/json',
+        'X-Slack-Request-Timestamp': ts,
+        'X-Slack-Signature': sig,
+      };
+    }
+
+    async function seedApproval(app: ReturnType<typeof createGovernorApp>, requestId: string) {
+      await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId, taskId: 'task-1', summary: 'Deploy' }),
+      });
+    }
+
+    it('rejects an unauthenticated (unsigned) Slack callback', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      await seedApproval(app, 'req-1');
+
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] }),
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a forged Slack callback with an invalid signature', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      await seedApproval(app, 'req-1');
+
+      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: {
+          ...slackHeaders(rawBody, 'wrong-secret'),
+        },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a stale Slack timestamp (replay protection)', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      await seedApproval(app, 'req-1');
+
+      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
+      const staleTs = (Math.floor(Date.now() / 1000) - 60 * 10).toString();
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody, SLACK_SECRET, staleTs) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('fails closed when no Slack signing secret is configured', async () => {
       const app = createGovernorApp();
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          actions: [{ action_id: 'approve', value: 'req-1' }],
-        }),
+        body: JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] }),
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('resolves the pending approval on a valid signed callback', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      await seedApproval(app, 'req-1');
+
+      // Health shows one pending approval before the callback
+      const before = await (await app.request('/health')).json();
+      expect(before.pendingApprovals).toBe(1);
+
+      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
       });
 
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.source).toBe('slack');
-      expect(body.decision).toBe('approve');
+      expect(body.decision).toBe('APPROVE');
+      expect(body.status).toBe('resolved');
+
+      // Pending approval is cleared after resolution
+      const after = await (await app.request('/health')).json();
+      expect(after.pendingApprovals).toBe(0);
     });
 
-    it('returns 400 for missing actions', async () => {
-      const app = createGovernorApp();
+    it('returns 404 for a signed callback referencing an unknown request', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+
+      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'nope' }] });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actions: [] }),
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for missing actions on a signed request', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const rawBody = JSON.stringify({ actions: [] });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
       });
 
       expect(res.status).toBe(400);
+    });
+
+    it('parses Slack form-encoded payloads and normalizes reject', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      await seedApproval(app, 'req-9');
+
+      const payloadJson = JSON.stringify({ actions: [{ action_id: 'reject', value: 'req-9' }] });
+      const rawBody = `payload=${encodeURIComponent(payloadJson)}`;
+      const ts = Math.floor(Date.now() / 1000).toString();
+      const base = `v0:${ts}:${rawBody}`;
+      const sig = `v0=${createHmac('sha256', SLACK_SECRET).update(base).digest('hex')}`;
+
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-Slack-Request-Timestamp': ts,
+          'X-Slack-Signature': sig,
+        },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.decision).toBe('ABORT');
+      expect(body.status).toBe('resolved');
     });
   });
 });

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -326,6 +326,26 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(400);
     });
 
+    it('rejects an unknown action_id without consuming the pending approval', async () => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      await seedApproval(app, 'req-unknown');
+
+      const rawBody = JSON.stringify({
+        actions: [{ action_id: 'launch_nukes', value: 'req-unknown' }],
+      });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(400);
+
+      // Pending approval must survive an unknown action so a valid callback can still resolve it.
+      const after = await (await app.request('/health')).json();
+      expect(after.pendingApprovals).toBe(1);
+    });
+
     it('parses Slack form-encoded payloads and normalizes reject', async () => {
       const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
       await seedApproval(app, 'req-9');


### PR DESCRIPTION
Closes #351

## Problem
`packages/franken-governor/src/server/app.ts` exposed `/v1/webhook/slack` with no authentication. It parsed JSON, read `body.actions[0]`, and returned `status: "processed"` without verifying Slack signatures or touching approval state. A spoofed POST appeared successful while real Slack interactions never resolved the pending approval.

## Fix
- Verify `X-Slack-Signature` (HMAC-SHA256 over `v0:{timestamp}:{rawBody}`) using a configured `slackSigningSecret`; **fail closed** with 401 when the secret is absent or the signature/headers are missing/invalid.
- Reject stale `X-Slack-Request-Timestamp` (> 5 min skew) to mitigate replay attacks.
- Support both Slack form-encoded `payload` bodies and raw JSON.
- Normalize Slack `action_id` into domain `ResponseCode` values (approve→APPROVE, reject→ABORT, etc.).
- Look up the pending approval, delete it, and call its stored resolver; return **404** for unknown request IDs.

## Tests (TDD)
Added failing-first tests in `tests/unit/server/app.test.ts` covering: unsigned/forged callbacks rejected (401), stale timestamp rejected, fail-closed when no secret, valid signed callback resolves + clears the pending approval (health goes 1→0), 404 for unknown request, 400 for missing actions, and form-encoded payload parsing/normalization.

## Verification (per-package)
- `npm run build` — pass
- `npm test` — 119 passed
- `npm run typecheck` — pass