### PR TITLE
fix(orchestrator): use argv subprocess calls for PR/git commands

### DIFF
--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -44,7 +44,6 @@ const REF_FORBIDDEN_SEQ_RE = /\.\.|@\{|\/{2,}|^[./]|[./]$|\/\.|\.lock(?:\/|$)/;
 
 function isSafeRef(value: string): boolean {
   if (value.length === 0 || value.length > 255) return false;
-  if (value === '@') return false; // git disallows the single-character ref `@`
   if (value.startsWith('-')) return false; // argument/option-injection guard
   if (REF_FORBIDDEN_CHAR_RE.test(value)) return false;
   if (REF_FORBIDDEN_SEQ_RE.test(value)) return false;

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -51,6 +51,23 @@ function isSafeRef(value: string): boolean {
   return true;
 }
 
+/**
+ * Validates a `git push` remote, which may be a named remote *or* a full
+ * repository URL (HTTPS/SSH). URLs legitimately contain `:` and `//`, so the
+ * branch-ref validator is too strict here. Argv execution already strips shell
+ * meaning, so we only reject control chars / whitespace and a leading `-`
+ * (argument/option-injection guard).
+ */
+// Control chars and whitespace only — URL punctuation (`:`, `/`, `@`, `~`) is fine.
+const REMOTE_FORBIDDEN_CHAR_RE = /[\x00-\x20\x7f]/;
+
+function isSafeRemote(value: string): boolean {
+  if (value.length === 0 || value.length > 2048) return false;
+  if (value.startsWith('-')) return false; // argument/option-injection guard
+  if (REMOTE_FORBIDDEN_CHAR_RE.test(value)) return false;
+  return true;
+}
+
 export class PrCreator {
   private readonly config: PrCreatorConfig;
   private readonly exec: ExecFn;
@@ -171,7 +188,7 @@ export class PrCreator {
       return null;
     }
 
-    if (!isSafeRef(this.config.remote)) {
+    if (!isSafeRemote(this.config.remote)) {
       logger?.error('PrCreator: unsafe remote name', { remote: this.config.remote });
       return null;
     }
@@ -270,7 +287,10 @@ export class PrCreator {
   }
 
   private pushBranch(branch: string, logger?: ILogger): boolean {
-    const args = ['push', this.config.remote, branch];
+    // Push a fully-qualified refspec so a branch literally named e.g. `+foo`
+    // is published verbatim rather than parsed as a `+`-prefixed (force) refspec.
+    const refspec = `refs/heads/${branch}:refs/heads/${branch}`;
+    const args = ['push', this.config.remote, refspec];
     try {
       this.exec('git', args);
       return true;

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -56,14 +56,24 @@ function isSafeRef(value: string): boolean {
  * branch-ref validator is too strict here. Argv execution already strips shell
  * meaning, so we only reject control chars / whitespace and a leading `-`
  * (argument/option-injection guard).
+ *
+ * We additionally reject git transport-helper remotes of the form
+ * `<transport>::<address>` (e.g. `ext::sh -c '<cmd>'`, `fd::<n>`). Git runs the
+ * named helper as a command for such remotes, so a config-derived value could
+ * execute arbitrary code even though no shell is involved. Legitimate URL
+ * remotes (`https://…`, `ssh://…`, scp-like `git@host:path`) never match this
+ * form: a scheme uses `://`, and scp-like syntax uses a single `:`, not `::`.
  */
 // Control chars and whitespace only — URL punctuation (`:`, `/`, `@`, `~`) is fine.
 const REMOTE_FORBIDDEN_CHAR_RE = /[\x00-\x20\x7f]/;
+// git transport-helper form: a bare scheme word immediately followed by `::`.
+const REMOTE_TRANSPORT_HELPER_RE = /^[A-Za-z][A-Za-z0-9+.-]*::/;
 
 function isSafeRemote(value: string): boolean {
   if (value.length === 0 || value.length > 2048) return false;
   if (value.startsWith('-')) return false; // argument/option-injection guard
   if (REMOTE_FORBIDDEN_CHAR_RE.test(value)) return false;
+  if (REMOTE_TRANSPORT_HELPER_RE.test(value)) return false; // ext::/fd:: helpers
   return true;
 }
 

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type { ILlmClient } from '@franken/types';
 import type { BeastResult, TaskOutcome } from '../types.js';
 import type { ILogger } from '../deps.js';
@@ -15,9 +15,26 @@ export interface PrCreateOptions {
   readonly issueNumber?: number | undefined;
 }
 
-type ExecFn = (cmd: string) => string;
+/**
+ * Executes a subprocess as a binary name plus a discrete argument array.
+ * Arguments are never concatenated into a shell string, so branch, remote and
+ * base values cannot be interpreted by a shell (no command injection).
+ */
+type ExecFn = (command: string, args: readonly string[]) => string;
 
-const defaultExec: ExecFn = (cmd: string) => execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' });
+const defaultExec: ExecFn = (command: string, args: readonly string[]) =>
+  execFileSync(command, [...args], { encoding: 'utf-8', stdio: 'pipe' });
+
+/**
+ * Safe git ref / remote pattern: alphanumerics plus `._/-`, no leading `-`
+ * (which would otherwise be parsed as a flag — argument injection). Rejects
+ * shell metacharacters, whitespace, and empty values.
+ */
+const SAFE_REF_RE = /^(?!-)[A-Za-z0-9._/-]+$/;
+
+function isSafeRef(value: string): boolean {
+  return value.length > 0 && value.length <= 255 && SAFE_REF_RE.test(value);
+}
 
 export class PrCreator {
   private readonly config: PrCreatorConfig;
@@ -139,9 +156,22 @@ export class PrCreator {
       return null;
     }
 
-    const branch = this.safeExec('git branch --show-current', logger)?.trim() ?? '';
+    if (!isSafeRef(this.config.remote)) {
+      logger?.error('PrCreator: unsafe remote name', { remote: this.config.remote });
+      return null;
+    }
+    if (!isSafeRef(this.config.targetBranch)) {
+      logger?.error('PrCreator: unsafe target branch', { targetBranch: this.config.targetBranch });
+      return null;
+    }
+
+    const branch = this.safeExec('git', ['branch', '--show-current'], logger)?.trim() ?? '';
     if (!branch) {
       logger?.error('PrCreator: unable to resolve current branch');
+      return null;
+    }
+    if (!isSafeRef(branch)) {
+      logger?.error('PrCreator: unsafe branch name', { branch });
       return null;
     }
 
@@ -192,9 +222,12 @@ export class PrCreator {
     }
 
     try {
-      const output = this.exec(
-        `gh pr create --base ${targetBranch} --title ${shellEscape(title)} --body ${shellEscape(body)}`,
-      );
+      const output = this.exec('gh', [
+        'pr', 'create',
+        '--base', targetBranch,
+        '--title', title,
+        '--body', body,
+      ]);
       const url = output.trim();
       if (!url) {
         logger?.warn('PrCreator: PR created but no URL returned');
@@ -212,28 +245,30 @@ export class PrCreator {
     }
   }
 
-  private safeExec(cmd: string, logger?: ILogger): string | null {
+  private safeExec(command: string, args: readonly string[], logger?: ILogger): string | null {
     try {
-      return this.exec(cmd);
+      return this.exec(command, args);
     } catch (error) {
-      logger?.error('PrCreator: command failed', this.commandFailure('git', cmd, error));
+      logger?.error('PrCreator: command failed', this.commandFailure('git', formatCommand(command, args), error));
       return null;
     }
   }
 
   private pushBranch(branch: string, logger?: ILogger): boolean {
+    const args = ['push', this.config.remote, branch];
     try {
-      this.exec(`git push ${this.config.remote} ${branch}`);
+      this.exec('git', args);
       return true;
     } catch (error) {
-      logger?.error('PrCreator: failed to push branch', this.commandFailure('git', `git push ${this.config.remote} ${branch}`, error, { branch }));
+      logger?.error('PrCreator: failed to push branch', this.commandFailure('git', formatCommand('git', args), error, { branch }));
       return false;
     }
   }
 
   private findExistingPr(branch: string, logger?: ILogger): Array<{ url?: string }> | null {
+    const args = ['pr', 'list', '--head', branch, '--json', 'url', '--limit', '1'];
     try {
-      const output = this.exec(`gh pr list --head ${branch} --json url --limit 1`);
+      const output = this.exec('gh', args);
       const parsed = JSON.parse(output) as Array<{ url?: string }>;
       return Array.isArray(parsed) ? parsed : [];
     } catch (error) {
@@ -242,7 +277,7 @@ export class PrCreator {
         return null;
       }
       logger?.error('PrCreator: failed to list PRs', this.commandFailure('gh', 'gh pr list', error, {
-        rawCommand: `gh pr list --head ${branch} --json url --limit 1`,
+        rawCommand: formatCommand('gh', args),
       }));
       return null;
     }
@@ -271,11 +306,13 @@ export class PrCreator {
     if (!this.llm) return null;
     try {
       const commitLog = this.safeExec(
-        `git log ${this.config.targetBranch}..HEAD --oneline`,
+        'git',
+        ['log', `${this.config.targetBranch}..HEAD`, '--oneline'],
         logger,
       ) ?? '';
       const diffStat = this.safeExec(
-        `git diff --stat ${this.config.targetBranch}..HEAD`,
+        'git',
+        ['diff', '--stat', `${this.config.targetBranch}..HEAD`],
         logger,
       ) ?? '';
       return await this.generatePrDescription(
@@ -291,12 +328,13 @@ export class PrCreator {
   }
 
   private gatherGitContext(targetBranch: string, logger?: ILogger): GitContext {
-    const diffStat = this.safeExec(`git diff --stat ${targetBranch}...HEAD`, logger) ?? '';
+    const diffStat = this.safeExec('git', ['diff', '--stat', `${targetBranch}...HEAD`], logger) ?? '';
     const logOutput = this.safeExec(
-      `git log --oneline ${targetBranch}...HEAD`,
+      'git',
+      ['log', '--oneline', `${targetBranch}...HEAD`],
       logger,
     ) ?? '';
-    const shortstat = this.safeExec(`git diff --shortstat ${targetBranch}...HEAD`, logger) ?? '';
+    const shortstat = this.safeExec('git', ['diff', '--shortstat', `${targetBranch}...HEAD`], logger) ?? '';
 
     return { diffStat, logOutput, shortstat: shortstat.trim() };
   }
@@ -520,8 +558,9 @@ function formatTokenCount(tokens: number): string {
   return `${(tokens / 1_000_000).toFixed(2)}M`;
 }
 
-function shellEscape(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
+/** Human-readable rendering of an argv command for logs/diagnostics only. */
+function formatCommand(command: string, args: readonly string[]): string {
+  return [command, ...args].join(' ');
 }
 
 function isGhMissing(error: unknown): boolean {

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -26,14 +26,29 @@ const defaultExec: ExecFn = (command: string, args: readonly string[]) =>
   execFileSync(command, [...args], { encoding: 'utf-8', stdio: 'pipe' });
 
 /**
- * Safe git ref / remote pattern: alphanumerics plus `._/-`, no leading `-`
- * (which would otherwise be parsed as a flag — argument injection). Rejects
- * shell metacharacters, whitespace, and empty values.
+ * Validates a git ref / remote name for safe argv execution.
+ *
+ * Subprocesses are spawned with a discrete argument array (never a shell string),
+ * so shell metacharacters carry no special meaning and need not be rejected.
+ * Instead we enforce git's own ref-format rules — so legitimate names like
+ * `feature/foo+bar`, `release/issue#123` or `user@host` are accepted — while
+ * separately rejecting a leading `-` to prevent argument/option injection.
+ *
+ * Mirrors `git check-ref-format` (https://git-scm.com/docs/git-check-ref-format).
  */
-const SAFE_REF_RE = /^(?!-)[A-Za-z0-9._/-]+$/;
+// Control chars, space, and the metacharacters git forbids in refs.
+const REF_FORBIDDEN_CHAR_RE = /[\x00-\x20\x7f~^:?*[\\]/;
+// Sequences git forbids: `..`, `@{`, leading/trailing `.` or `/`, consecutive
+// slashes, a component beginning with `.`, or a component ending with `.lock`.
+const REF_FORBIDDEN_SEQ_RE = /\.\.|@\{|\/{2,}|^[./]|[./]$|\/\.|\.lock(?:\/|$)/;
 
 function isSafeRef(value: string): boolean {
-  return value.length > 0 && value.length <= 255 && SAFE_REF_RE.test(value);
+  if (value.length === 0 || value.length > 255) return false;
+  if (value === '@') return false; // git disallows the single-character ref `@`
+  if (value.startsWith('-')) return false; // argument/option-injection guard
+  if (REF_FORBIDDEN_CHAR_RE.test(value)) return false;
+  if (REF_FORBIDDEN_SEQ_RE.test(value)) return false;
+  return true;
 }
 
 export class PrCreator {

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -141,6 +141,25 @@ describe('PrCreator argv subprocess safety', () => {
     expect(push!.args).not.toContain('+foo');
   });
 
+  // Codex round-3 P3: a branch literally named `@` is a valid git ref
+  // (`git check-ref-format --branch '@'` exits 0) and pushBranch already
+  // qualifies it as `refs/heads/@`, so it must not be special-cased away.
+  it('creates a PR for a branch literally named @', async () => {
+    const { exec, calls } = makeExecRecorder('@');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
+    expect(push!.args).toEqual([
+      'push', 'origin', 'refs/heads/@:refs/heads/@',
+    ]);
+  });
+
   // Codex round-2 P3: a remote may be a repository URL, which legitimately
   // contains ':' and '//'. These must be accepted (argv removes shell meaning).
   it.each([

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -94,4 +94,67 @@ describe('PrCreator argv subprocess safety', () => {
     expect(result).toBeNull();
     expect(calls.some(c => c.args.includes('push'))).toBe(false);
   });
+
+  // Codex P2: the previous whitelist rejected valid git refs (e.g. `+`, `@`,
+  // `#`), silently aborting PR creation for legitimately-named branches. Because
+  // execution is argv-based, these characters carry no shell meaning.
+  it.each([
+    'feature/foo+bar',
+    'feature/foo@bar',
+    'release/issue#123',
+    'feat/=value',
+  ])('creates a PR for valid git ref %s', async (branch) => {
+    const { exec, calls } = makeExecRecorder(branch);
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
+    expect(push!.args).toEqual(['push', 'origin', branch]);
+  });
+
+  it('accepts a base branch containing valid ref characters', async () => {
+    const { exec, calls } = makeExecRecorder('feature/work');
+    const creator = new PrCreator(
+      { targetBranch: 'release/v1.0+stable', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const create = calls.find(c => c.command === 'gh' && c.args.includes('create'));
+    expect(create!.args.slice(0, 4)).toEqual(['pr', 'create', '--base', 'release/v1.0+stable']);
+  });
+
+  // Argument-injection and invalid-ref guards must still hold.
+  it.each([
+    '-evil',
+    'foo..bar',
+    'foo~1',
+    'foo^bar',
+    'foo:bar',
+    'foo bar',
+    'foo@{0}',
+    'foo/',
+    '/foo',
+    'foo//bar',
+    'foo.lock',
+  ])('refuses to run for invalid/unsafe ref %s', async (branch) => {
+    const { exec, calls } = makeExecRecorder(branch);
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toBeNull();
+    expect(calls.some(c => c.args.includes('push'))).toBe(false);
+    expect(calls.some(c => c.command === 'gh')).toBe(false);
+  });
 });

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -51,7 +51,9 @@ describe('PrCreator argv subprocess safety', () => {
 
     const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
     expect(push).toBeDefined();
-    expect(push!.args).toEqual(['push', 'origin', 'feature/foo']);
+    expect(push!.args).toEqual([
+      'push', 'origin', 'refs/heads/feature/foo:refs/heads/feature/foo',
+    ]);
 
     const list = calls.find(c => c.command === 'gh' && c.args.includes('list'));
     expect(list).toBeDefined();
@@ -114,7 +116,64 @@ describe('PrCreator argv subprocess safety', () => {
 
     expect(result).toEqual({ url: 'https://example.com/pr/1' });
     const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
-    expect(push!.args).toEqual(['push', 'origin', branch]);
+    expect(push!.args).toEqual([
+      'push', 'origin', `refs/heads/${branch}:refs/heads/${branch}`,
+    ]);
+  });
+
+  // Codex round-2 P2: a branch literally named `+foo` must be published as that
+  // branch, not parsed as a `+`-prefixed (force) push refspec.
+  it('pushes a plus-prefixed branch by full refspec (never as a force refspec)', async () => {
+    const { exec, calls } = makeExecRecorder('+foo');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
+    expect(push!.args).toEqual([
+      'push', 'origin', 'refs/heads/+foo:refs/heads/+foo',
+    ]);
+    // The bare `+foo` (force refspec) form must never be passed.
+    expect(push!.args).not.toContain('+foo');
+  });
+
+  // Codex round-2 P3: a remote may be a repository URL, which legitimately
+  // contains ':' and '//'. These must be accepted (argv removes shell meaning).
+  it.each([
+    'git@github.com:djm204/frankenbeast.git',
+    'https://github.com/djm204/frankenbeast.git',
+    'ssh://git@example.com:22/repo.git',
+  ])('accepts repository URL %s as a push remote', async (remote) => {
+    const { exec, calls } = makeExecRecorder('feature/foo');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
+    expect(push!.args).toEqual([
+      'push', remote, 'refs/heads/feature/foo:refs/heads/feature/foo',
+    ]);
+  });
+
+  it('still rejects an option-injecting remote', async () => {
+    const { exec, calls } = makeExecRecorder('feature/foo');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: '--upload-pack=evil' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toBeNull();
+    expect(calls.some(c => c.args.includes('push'))).toBe(false);
   });
 
   it('accepts a base branch containing valid ref characters', async () => {

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -182,6 +182,27 @@ describe('PrCreator argv subprocess safety', () => {
     ]);
   });
 
+  // Codex round-4 P2: git runs a transport-helper command for remotes of the
+  // form `<transport>::<address>` (e.g. `ext::`, `fd::`). A config-derived value
+  // of this shape is a command-injection vector and must be rejected, while
+  // legitimate URL/named remotes (no `::`) keep working.
+  it.each([
+    "ext::sh -c 'touch pwned'",
+    'ext::git-upload-pack /evil',
+    'fd::17',
+  ])('refuses to run for a transport-helper remote %s', async (remote) => {
+    const { exec, calls } = makeExecRecorder('feature/foo');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toBeNull();
+    expect(calls.some(c => c.args.includes('push'))).toBe(false);
+  });
+
   it('still rejects an option-injecting remote', async () => {
     const { exec, calls } = makeExecRecorder('feature/foo');
     const creator = new PrCreator(

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { PrCreator } from '../../src/closure/pr-creator.js';
+import type { BeastResult, TaskOutcome } from '../../src/types.js';
+
+interface ExecCall {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+function makeResult(overrides: Partial<BeastResult> = {}): BeastResult {
+  return {
+    projectId: 'test-project',
+    status: 'completed',
+    durationMs: 60000,
+    tokenSpend: { totalTokens: 5000, estimatedCostUsd: 0.1 },
+    taskResults: [
+      { taskId: 'impl:01_setup', status: 'success', output: {} },
+    ] as TaskOutcome[],
+    ...overrides,
+  };
+}
+
+/**
+ * Records every exec invocation as (command, argv[]). The new contract is that
+ * PrCreator never builds a shell string — it passes the binary name and a
+ * discrete argument array, so values can never be interpreted by a shell.
+ */
+function makeExecRecorder(branch: string) {
+  const calls: ExecCall[] = [];
+  const exec = (command: string, args: readonly string[] = []): string => {
+    calls.push({ command, args });
+    if (args.includes('--show-current')) return `${branch}\n`;
+    if (command === 'gh' && args.includes('list')) return '[]';
+    if (command === 'gh' && args.includes('create')) return 'https://example.com/pr/1\n';
+    return '';
+  };
+  return { exec, calls };
+}
+
+describe('PrCreator argv subprocess safety', () => {
+  it('passes branch, remote and base as discrete argv elements (no shell string)', async () => {
+    const { exec, calls } = makeExecRecorder('feature/foo');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+
+    const push = calls.find(c => c.command === 'git' && c.args.includes('push'));
+    expect(push).toBeDefined();
+    expect(push!.args).toEqual(['push', 'origin', 'feature/foo']);
+
+    const list = calls.find(c => c.command === 'gh' && c.args.includes('list'));
+    expect(list).toBeDefined();
+    // The branch must appear as a standalone argv element, never concatenated.
+    expect(list!.args).toContain('feature/foo');
+    expect(list!.args.some(a => a.includes(' '))).toBe(false);
+
+    const create = calls.find(c => c.command === 'gh' && c.args.includes('create'));
+    expect(create).toBeDefined();
+    expect(create!.args.slice(0, 4)).toEqual(['pr', 'create', '--base', 'main']);
+    // No argv element should be a packed shell command.
+    expect(create!.args).toContain('--title');
+    expect(create!.args).toContain('--body');
+  });
+
+  it('refuses to run any subprocess when the branch contains shell metacharacters', async () => {
+    const { exec, calls } = makeExecRecorder('evil$(touch pwned)');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toBeNull();
+    // git branch --show-current may run, but nothing that consumes the unsafe ref.
+    expect(calls.some(c => c.args.includes('push'))).toBe(false);
+    expect(calls.some(c => c.command === 'gh')).toBe(false);
+  });
+
+  it('refuses to run when the configured remote is unsafe', async () => {
+    const { exec, calls } = makeExecRecorder('feature/foo');
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: '--upload-pack=evil' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult());
+
+    expect(result).toBeNull();
+    expect(calls.some(c => c.args.includes('push'))).toBe(false);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/closure/pr-creator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/pr-creator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PrCreator } from '../../../src/closure/pr-creator.js';
-import type { BeastResult, TaskOutcome } from '../../../src/types.js';
+import type { BeastResult } from '../../../src/types.js';
 
 const baseResult: BeastResult = {
   sessionId: 'issue-42',
@@ -28,8 +28,19 @@ function makeLogger() {
   };
 }
 
+/** Renders a recorded (command, argv[]) exec call back into a single string. */
+function joinCall(call: unknown[]): string {
+  const [command, args] = call as [string, readonly string[] | undefined];
+  return [command, ...(args ?? [])].join(' ');
+}
+
+function findCommand(exec: ReturnType<typeof vi.fn>, prefix: string): string {
+  return exec.mock.calls.map(joinCall).find(c => c.startsWith(prefix)) ?? '';
+}
+
 function mockExec(overrides?: Partial<Record<string, string | Error>>): ReturnType<typeof vi.fn> {
-  return vi.fn((cmd: string) => {
+  return vi.fn((command: string, args: readonly string[] = []) => {
+    const cmd = [command, ...args].join(' ');
     for (const [prefix, value] of Object.entries(overrides ?? {})) {
       if (cmd.startsWith(prefix)) {
         if (value instanceof Error) throw value;
@@ -180,7 +191,7 @@ describe('PrCreator issue reference integration', () => {
 
       await creator.create(baseResult, makeLogger(), { issueNumber: 42 });
 
-      const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+      const createCmd = findCommand(exec, 'gh pr create');
       expect(createCmd).toContain('Fixes #42');
     });
 
@@ -190,11 +201,10 @@ describe('PrCreator issue reference integration', () => {
 
       await creator.create(baseResult, makeLogger(), { issueNumber: 42 });
 
-      const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
-      // Extract the body from the gh pr create command
-      const bodyMatch = createCmd.match(/--body\s+'([\s\S]*?)'\s*$/);
-      expect(bodyMatch).toBeTruthy();
-      const body = bodyMatch![1] as string;
+      // Read the body argv element directly (it is the last argument).
+      const createCall = exec.mock.calls.find(c => c[0] === 'gh' && (c[1] as string[]).includes('create'));
+      const args = (createCall?.[1] as string[]) ?? [];
+      const body = args[args.indexOf('--body') + 1] ?? '';
       // Fixes #42 must appear on its own line (preceded by newline or start of string)
       expect(body).toMatch(/(?:^|\n)Fixes #42(?:\n|$)/);
     });
@@ -205,7 +215,7 @@ describe('PrCreator issue reference integration', () => {
 
       await creator.create(baseResult, makeLogger());
 
-      const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+      const createCmd = findCommand(exec, 'gh pr create');
       expect(createCmd).not.toMatch(/Fixes #\d+/);
     });
 
@@ -222,7 +232,7 @@ describe('PrCreator issue reference integration', () => {
 
       await creator.create(baseResult, makeLogger(), { issueNumber: 42 });
 
-      const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+      const createCmd = findCommand(exec, 'gh pr create');
       expect(createCmd).toContain('Fixes #42');
     });
 
@@ -241,37 +251,28 @@ describe('PrCreator issue reference integration', () => {
 
       await creator.create(baseResult, makeLogger(), { issueNumber: 42 });
 
-      const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+      const createCmd = findCommand(exec, 'gh pr create');
       // Count occurrences of "Fixes #42" — should be exactly 1
       const matches = createCmd.match(/Fixes #42/g);
       expect(matches).toHaveLength(1);
     });
 
     it('does not change PR title when issueNumber is provided', async () => {
-      const exec = mockExec();
-      const creator = new PrCreator({ targetBranch: 'main', disabled: false, remote: 'origin' }, exec);
+      const titleOf = (exec: ReturnType<typeof vi.fn>): string | undefined => {
+        const call = exec.mock.calls.find(c => c[0] === 'gh' && (c[1] as string[]).includes('create'));
+        const args = (call?.[1] as string[]) ?? [];
+        return args[args.indexOf('--title') + 1];
+      };
 
-      // Create without issue number
-      await creator.create(baseResult, makeLogger());
-      const cmdWithout = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
-      const titleWithout = cmdWithout.match(/--title\s+'([^']*?)'/)?.[1];
+      const execWithout = mockExec();
+      const creatorWithout = new PrCreator({ targetBranch: 'main', disabled: false, remote: 'origin' }, execWithout);
+      await creatorWithout.create(baseResult, makeLogger());
+      const titleWithout = titleOf(execWithout);
 
-      // Reset and create with issue number
-      exec.mockClear();
-      exec.mockImplementation((cmd: string) => {
-        if (cmd.startsWith('git branch --show-current')) return 'fix/issue-42\n';
-        if (cmd.startsWith('git push')) return '';
-        if (cmd.startsWith('gh pr list')) return '[]';
-        if (cmd.startsWith('gh pr create')) return 'https://example.com/pr/42\n';
-        if (cmd.startsWith('git diff --stat')) return ' src/auth.ts | 10 ++++\n 1 file changed, 10 insertions(+)\n';
-        if (cmd.startsWith('git diff --shortstat')) return ' 1 file changed, 10 insertions(+)';
-        if (cmd.startsWith('git log --oneline')) return 'abc1234 fix(auth): patch null check\n';
-        return '';
-      });
-
-      await creator.create(baseResult, makeLogger(), { issueNumber: 42 });
-      const cmdWith = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
-      const titleWith = cmdWith.match(/--title\s+'([^']*?)'/)?.[1];
+      const execWith = mockExec();
+      const creatorWith = new PrCreator({ targetBranch: 'main', disabled: false, remote: 'origin' }, execWith);
+      await creatorWith.create(baseResult, makeLogger(), { issueNumber: 42 });
+      const titleWith = titleOf(execWith);
 
       expect(titleWith).toBe(titleWithout);
     });
@@ -317,7 +318,7 @@ describe('PrCreator issue reference integration', () => {
 
       await creator.create(baseResult, makeLogger());
 
-      const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+      const createCmd = findCommand(exec, 'gh pr create');
       expect(createCmd).toContain('--base main');
     });
 
@@ -346,10 +347,11 @@ describe('PrCreator issue reference integration', () => {
       await creator.create(baseResult, makeLogger());
 
       // git diff/log commands should reference main, not feat/my-feature
-      const diffCalls = exec.mock.calls.filter((c: string[]) => c[0].startsWith('git diff --stat'));
-      const logCalls = exec.mock.calls.filter((c: string[]) => c[0].startsWith('git log --oneline'));
+      const joined = exec.mock.calls.map(joinCall);
+      const diffCalls = joined.filter(c => c.startsWith('git diff --stat'));
+      const logCalls = joined.filter(c => c.startsWith('git log --oneline'));
       for (const call of [...diffCalls, ...logCalls]) {
-        expect(call[0]).toContain('main');
+        expect(call).toContain('main');
       }
     });
   });

--- a/packages/franken-orchestrator/tests/unit/pr-creator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/pr-creator.test.ts
@@ -137,7 +137,9 @@ describe('PrCreator', () => {
     await creator.create(baseResult, makeLogger());
 
     const pushCall = exec.mock.calls.find(c => c[0] === 'git' && (c[1] as string[]).includes('push'));
-    expect(pushCall?.[1]).toEqual(['push', 'origin', 'feature/branch']);
+    expect(pushCall?.[1]).toEqual([
+      'push', 'origin', 'refs/heads/feature/branch:refs/heads/feature/branch',
+    ]);
   });
 
   it('trims PR title to stay under 70 characters', async () => {

--- a/packages/franken-orchestrator/tests/unit/pr-creator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/pr-creator.test.ts
@@ -29,8 +29,26 @@ function makeLogger() {
   };
 }
 
+/** Renders a recorded (command, argv[]) exec call back into a single string. */
+function joinCall(call: unknown[]): string {
+  const [command, args] = call as [string, readonly string[] | undefined];
+  return [command, ...(args ?? [])].join(' ');
+}
+
+function findCommand(exec: ReturnType<typeof vi.fn>, prefix: string): string {
+  return exec.mock.calls.map(joinCall).find(c => c.startsWith(prefix)) ?? '';
+}
+
+function argFor(exec: ReturnType<typeof vi.fn>, command: string, sub: string, flag: string): string | undefined {
+  const call = exec.mock.calls.find(c => c[0] === command && (c[1] as string[]).includes(sub));
+  const args = (call?.[1] as string[]) ?? [];
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
 function mockExec(overrides?: Partial<Record<string, string | Error>>): ReturnType<typeof vi.fn> {
-  return vi.fn((cmd: string) => {
+  return vi.fn((command: string, args: readonly string[] = []) => {
+    const cmd = [command, ...args].join(' ');
     for (const [prefix, value] of Object.entries(overrides ?? {})) {
       if (cmd.startsWith(prefix)) {
         if (value instanceof Error) throw value;
@@ -89,7 +107,7 @@ describe('PrCreator', () => {
 
     expect(result?.url).toBe('https://example.com/pr/1');
 
-    const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
 
     // Body should include What Changed section with chunk descriptions
     expect(createCmd).toContain('## What Changed');
@@ -112,6 +130,16 @@ describe('PrCreator', () => {
     expect(createCmd).toContain('impl:01_checkpoint_store');
   });
 
+  it('passes branch and remote as discrete argv elements', async () => {
+    const exec = mockExec();
+    const creator = new PrCreator({ targetBranch: 'main', disabled: false, remote: 'origin' }, exec);
+
+    await creator.create(baseResult, makeLogger());
+
+    const pushCall = exec.mock.calls.find(c => c[0] === 'git' && (c[1] as string[]).includes('push'));
+    expect(pushCall?.[1]).toEqual(['push', 'origin', 'feature/branch']);
+  });
+
   it('trims PR title to stay under 70 characters', async () => {
     const exec = mockExec();
     const creator = new PrCreator({ targetBranch: 'main', disabled: false, remote: 'origin' }, exec);
@@ -130,12 +158,9 @@ describe('PrCreator', () => {
 
     await creator.create(longResult, makeLogger());
 
-    const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create')) ?? [''];
-    const titleMatch = (createCmd[0] as string).match(/--title\s+('.*?'|".*?")/);
-    expect(titleMatch).toBeTruthy();
-    const rawTitle = titleMatch?.[1] ?? '';
-    const title = rawTitle.slice(1, -1);
-    expect(title.length).toBeLessThanOrEqual(70);
+    const title = argFor(exec, 'gh', 'create', '--title');
+    expect(title).toBeTruthy();
+    expect(title!.length).toBeLessThanOrEqual(70);
   });
 
   it('uses chunk names in title when 3 or fewer chunks', async () => {
@@ -144,7 +169,7 @@ describe('PrCreator', () => {
 
     await creator.create(baseResult, makeLogger());
 
-    const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
     // Should use chunk name not project ID for small PRs
     expect(createCmd).toContain('01_checkpoint_store');
   });
@@ -164,8 +189,10 @@ describe('PrCreator', () => {
       expect.objectContaining({ branch: 'main' }),
     );
     // Should not attempt to push or create PR
-    expect(exec).not.toHaveBeenCalledWith(expect.stringContaining('git push'), expect.anything());
-    expect(exec).not.toHaveBeenCalledWith(expect.stringContaining('gh pr create'), expect.anything());
+    const pushed = exec.mock.calls.some(c => c[0] === 'git' && (c[1] as string[]).includes('push'));
+    const created = exec.mock.calls.some(c => c[0] === 'gh' && (c[1] as string[]).includes('create'));
+    expect(pushed).toBe(false);
+    expect(created).toBe(false);
   });
 
   it('skips when PR already exists', async () => {
@@ -203,6 +230,26 @@ describe('PrCreator', () => {
 
     expect(result).toBeNull();
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('rejects unsafe branch names without running push or gh', async () => {
+    const exec = mockExec({
+      'git branch --show-current': 'evil$(touch pwned)\n',
+    });
+    const creator = new PrCreator({ targetBranch: 'main', disabled: false, remote: 'origin' }, exec);
+    const logger = makeLogger();
+
+    const result = await creator.create(baseResult, logger);
+
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      'PrCreator: unsafe branch name',
+      expect.objectContaining({ branch: expect.stringContaining('evil') }),
+    );
+    const pushed = exec.mock.calls.some(c => c[0] === 'git' && (c[1] as string[]).includes('push'));
+    const usedGh = exec.mock.calls.some(c => c[0] === 'gh');
+    expect(pushed).toBe(false);
+    expect(usedGh).toBe(false);
   });
 
   describe('generatePrDescription()', () => {
@@ -344,7 +391,7 @@ describe('PrCreator', () => {
 
     await creator.create(resultWithIterations, makeLogger());
 
-    const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
     expect(createCmd).toContain('| impl:01_checkpoint_store | pass | 3 |');
   });
 
@@ -354,7 +401,7 @@ describe('PrCreator', () => {
 
     await creator.create(baseResult, makeLogger());
 
-    const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
     expect(createCmd).toContain('Commit Log');
     expect(createCmd).toContain('abc1234');
   });
@@ -370,12 +417,13 @@ describe('PrCreator', () => {
 
     await creator.create(longRun, makeLogger());
 
-    const createCmd = exec.mock.calls.find((c: string[]) => c[0].startsWith('gh pr create'))?.[0] ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
     expect(createCmd).toContain('1h 2m');
   });
 
   it('gracefully handles missing git context', async () => {
-    const exec = vi.fn((cmd: string) => {
+    const exec = vi.fn((command: string, args: readonly string[] = []) => {
+      const cmd = [command, ...args].join(' ');
       if (cmd.startsWith('git branch --show-current')) return 'feature/branch\n';
       if (cmd.startsWith('git push')) return '';
       if (cmd.startsWith('gh pr list')) return '[]';
@@ -402,9 +450,8 @@ describe('PrCreator', () => {
       '- `src/skills/cli-skill-executor.ts`',
     ].join('\n');
     const llm = { complete: vi.fn().mockResolvedValue(llmResponse) };
-    const calls: string[] = [];
-    const exec = vi.fn((cmd: string) => {
-      calls.push(cmd);
+    const exec = vi.fn((command: string, args: readonly string[] = []) => {
+      const cmd = [command, ...args].join(' ');
       if (cmd.startsWith('git branch --show-current')) return 'feature/branch\n';
       if (cmd.startsWith('git push')) return '';
       if (cmd.startsWith('gh pr list')) return '[]';
@@ -418,15 +465,14 @@ describe('PrCreator', () => {
     const result = await creator.create(baseResult, makeLogger());
 
     expect(result?.url).toBe('https://example.com/pr/5');
-    const createCmd = calls.find(c => c.startsWith('gh pr create')) ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
     expect(createCmd).toContain('feat(cli): implement Martin loop execution pipeline');
   });
 
   it('falls back to static title/body when LLM generation fails', async () => {
     const llm = { complete: vi.fn().mockRejectedValue(new Error('rate limited')) };
-    const calls: string[] = [];
-    const exec = vi.fn((cmd: string) => {
-      calls.push(cmd);
+    const exec = vi.fn((command: string, args: readonly string[] = []) => {
+      const cmd = [command, ...args].join(' ');
       if (cmd.startsWith('git branch --show-current')) return 'feature/branch\n';
       if (cmd.startsWith('git push')) return '';
       if (cmd.startsWith('gh pr list')) return '[]';
@@ -440,7 +486,7 @@ describe('PrCreator', () => {
     const result = await creator.create(baseResult, makeLogger());
 
     expect(result?.url).toBe('https://example.com/pr/6');
-    const createCmd = calls.find(c => c.startsWith('gh pr create')) ?? '';
+    const createCmd = findCommand(exec, 'gh pr create');
     // Falls back to static buildTitle (uses chunk names for small PRs)
     expect(createCmd).toContain('feat: 01_checkpoint_store');
   });


### PR DESCRIPTION
Closes #346

## Problem
`PrCreator` built `gh pr create`, `git push`, and `gh pr list` (plus the git context `log`/`diff` commands) as **shell strings**, interpolating `branch`, `remote`, and `targetBranch` without escaping. Repo- or config-derived refs containing shell metacharacters could execute arbitrary commands.

## Fix
- Changed the exec contract from `(cmd: string)` to `(command: string, args: readonly string[])`, backed by `execFileSync` — no value is ever passed through a shell, eliminating command injection. This matches the existing `execFileSync('git', [...])` convention already used in `git-branch-isolator.ts` and `base-branch.ts`.
- Converted every subprocess call site to discrete argv arrays.
- Added a safe git-ref validator (`SAFE_REF_RE`) applied to `remote`, `branch`, and `targetBranch` before any subprocess runs, blocking argument injection (e.g. a leading `-` being parsed as a flag). Unsafe values abort the PR flow with a logged error.
- Removed the now-unused `shellEscape` helper.

## Tests (TDD)
- New `test/closure/pr-creator-argv.test.ts` proves values are passed as discrete argv elements and that unsafe branch/remote names abort before any subprocess runs (failing first against the shell-string code).
- Updated the two existing `pr-creator` unit suites to the argv exec signature.

## Verification (per-package, franken-orchestrator)
- `npm run build` — pass (tsc)
- `npm run typecheck` — pass
- `npm test` — 2202 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)