### PR TITLE
fix(governor): bind approval response to active request ID

### DIFF
--- a/packages/franken-governor/src/errors/approval-mismatch-error.ts
+++ b/packages/franken-governor/src/errors/approval-mismatch-error.ts
@@ -1,0 +1,14 @@
+import { GovernorError } from './governor-error.js';
+
+export class ApprovalMismatchError extends GovernorError {
+  constructor(
+    public readonly expectedRequestId: string,
+    public readonly actualRequestId: string,
+  ) {
+    super(
+      `Approval response is bound to request '${actualRequestId}' but the active request is '${expectedRequestId}'`,
+    );
+    this.name = 'ApprovalMismatchError';
+    Object.setPrototypeOf(this, ApprovalMismatchError.prototype);
+  }
+}

--- a/packages/franken-governor/src/errors/index.ts
+++ b/packages/franken-governor/src/errors/index.ts
@@ -2,4 +2,5 @@ export { GovernorError } from './governor-error.js';
 export { ApprovalTimeoutError } from './approval-timeout-error.js';
 export { ChannelUnavailableError } from './channel-unavailable-error.js';
 export { SignatureVerificationError } from './signature-verification-error.js';
+export { ApprovalMismatchError } from './approval-mismatch-error.js';
 export { TriggerEvaluationError } from './trigger-evaluation-error.js';

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -4,7 +4,11 @@ import type { ApprovalChannel } from './approval-channel.js';
 import type { SignatureVerifier } from '../security/signature-verifier.js';
 import type { SessionTokenStore } from '../security/session-token-store.js';
 import { createSessionToken } from '../security/session-token.js';
-import { ApprovalTimeoutError, SignatureVerificationError } from '../errors/index.js';
+import {
+  ApprovalTimeoutError,
+  SignatureVerificationError,
+  ApprovalMismatchError,
+} from '../errors/index.js';
 
 export interface AuditRecorder {
   record(request: ApprovalRequest, response: ApprovalResponse): Promise<void>;
@@ -42,6 +46,13 @@ export class ApprovalGateway {
       this.channel.requestApproval(request),
       request.requestId,
     );
+
+    // Bind the response to the active request: a stale, replayed, or misrouted
+    // response for a different request must never resolve this one, even if it is
+    // validly signed for its own requestId.
+    if (response.requestId !== request.requestId) {
+      throw new ApprovalMismatchError(request.requestId, response.requestId);
+    }
 
     if (this.config.requireSignedApprovals && this.signatureVerifier) {
       this.verifySignature(response);

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -18,6 +18,7 @@ export {
   ApprovalTimeoutError,
   ChannelUnavailableError,
   SignatureVerificationError,
+  ApprovalMismatchError,
   TriggerEvaluationError,
 } from './errors/index.js';
 

--- a/packages/franken-governor/tests/integration/full-approval-flow.test.ts
+++ b/packages/franken-governor/tests/integration/full-approval-flow.test.ts
@@ -18,13 +18,15 @@ function makeFakeMemoryPort(): GovernorMemoryPort & { traces: EpisodicTraceRecor
 function makeFakeChannel(decision: ApprovalResponse['decision'], feedback?: string): ApprovalChannel {
   return {
     channelId: 'fake',
-    requestApproval: vi.fn<[ApprovalRequest], Promise<ApprovalResponse>>().mockResolvedValue({
-      requestId: 'req-001',
-      decision,
-      feedback,
-      respondedBy: 'human',
-      respondedAt: new Date(),
-    }),
+    requestApproval: vi
+      .fn<[ApprovalRequest], Promise<ApprovalResponse>>()
+      .mockImplementation(async (request: ApprovalRequest) => ({
+        requestId: request.requestId,
+        decision,
+        feedback,
+        respondedBy: 'human',
+        respondedAt: new Date(),
+      })),
   };
 }
 

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -5,7 +5,7 @@ import type { ApprovalRequest, ApprovalResponse } from '../../../src/core/types.
 import { defaultConfig } from '../../../src/core/config.js';
 import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
 import { SessionTokenStore } from '../../../src/security/session-token-store.js';
-import { SignatureVerificationError } from '../../../src/errors/index.js';
+import { SignatureVerificationError, ApprovalMismatchError } from '../../../src/errors/index.js';
 
 function makeRequest(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
   return {
@@ -20,16 +20,20 @@ function makeRequest(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest 
 }
 
 function makeFakeChannel(response: Partial<ApprovalResponse> = {}): ApprovalChannel {
-  const base: ApprovalResponse = {
-    requestId: 'req-001',
-    decision: 'APPROVE',
-    respondedBy: 'human',
-    respondedAt: new Date(),
-    ...response,
-  };
   return {
     channelId: 'fake',
-    requestApproval: vi.fn<[ApprovalRequest], Promise<ApprovalResponse>>().mockResolvedValue(base),
+    // By default a channel echoes the active request's id (a well-behaved
+    // responder). Tests can override `response.requestId` to simulate a
+    // stale/misrouted response bound to a different request.
+    requestApproval: vi
+      .fn<[ApprovalRequest], Promise<ApprovalResponse>>()
+      .mockImplementation(async (request: ApprovalRequest) => ({
+        requestId: request.requestId,
+        decision: 'APPROVE',
+        respondedBy: 'human',
+        respondedAt: new Date(),
+        ...response,
+      })),
   };
 }
 
@@ -107,6 +111,55 @@ describe('ApprovalGateway — security integration', () => {
       config: { ...defaultConfig(), requireSignedApprovals: true },
       // no signatureVerifier
     })).toThrow(/signed approvals.*verifier/i);
+  });
+
+  it('rejects an unsigned response whose requestId does not match the active request', async () => {
+    // Response is for a different (stale/misrouted) request than the one in flight.
+    const channel = makeFakeChannel({ requestId: 'req-OTHER', decision: 'APPROVE' });
+    const auditRecorder = makeFakeAuditRecorder();
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder,
+      config: defaultConfig(),
+    });
+
+    await expect(
+      gateway.requestApproval(makeRequest({ requestId: 'req-ACTIVE' })),
+    ).rejects.toThrow(ApprovalMismatchError);
+    // A mismatched response must not be audited.
+    expect(auditRecorder.record).not.toHaveBeenCalled();
+  });
+
+  it('rejects a validly-signed response whose requestId does not match the active request', async () => {
+    // Attacker replays a genuinely-signed approval for request A against active request B.
+    const verifier = new SignatureVerifier('secret');
+    const signedForOther = verifier.sign(
+      JSON.stringify({ requestId: 'req-OTHER', decision: 'APPROVE' }),
+    );
+    const channel = makeFakeChannel({ requestId: 'req-OTHER', signature: signedForOther });
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+      signatureVerifier: verifier,
+    });
+
+    await expect(
+      gateway.requestApproval(makeRequest({ requestId: 'req-ACTIVE' })),
+    ).rejects.toThrow(ApprovalMismatchError);
+  });
+
+  it('accepts a response whose requestId matches the active request', async () => {
+    const channel = makeFakeChannel({ requestId: 'req-ACTIVE', decision: 'APPROVE' });
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config: defaultConfig(),
+    });
+
+    const outcome = await gateway.requestApproval(makeRequest({ requestId: 'req-ACTIVE' }));
+    expect(outcome.decision).toBe('APPROVE');
   });
 
   it('does not return SessionToken for non-APPROVE decisions', async () => {

--- a/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
@@ -27,13 +27,13 @@ function makeRationale(overrides: Partial<RationaleBlock> = {}): RationaleBlock 
 function makeFakeChannel(decision: ApprovalOutcome['decision'] = 'APPROVE'): ApprovalChannel {
   return {
     channelId: 'fake',
-    requestApproval: vi.fn().mockResolvedValue({
-      requestId: 'req-001',
+    requestApproval: vi.fn().mockImplementation(async (request: ApprovalRequest) => ({
+      requestId: request.requestId,
       decision,
       feedback: decision === 'REGEN' ? 'Try another approach' : undefined,
       respondedBy: 'human',
       respondedAt: new Date(),
-    }),
+    })),
   };
 }
 

--- a/packages/franken-governor/tests/unit/public-api.test.ts
+++ b/packages/franken-governor/tests/unit/public-api.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import * as publicApi from '../../src/index.js';
+import { ApprovalMismatchError as InternalApprovalMismatchError } from '../../src/errors/index.js';
+
+describe('public API exports', () => {
+  it('re-exports ApprovalMismatchError from the package root', () => {
+    expect(publicApi.ApprovalMismatchError).toBeDefined();
+    expect(publicApi.ApprovalMismatchError).toBe(InternalApprovalMismatchError);
+  });
+
+  it('re-exports the other governor error classes from the package root', () => {
+    expect(publicApi.GovernorError).toBeDefined();
+    expect(publicApi.ApprovalTimeoutError).toBeDefined();
+    expect(publicApi.ChannelUnavailableError).toBeDefined();
+    expect(publicApi.SignatureVerificationError).toBeDefined();
+    expect(publicApi.TriggerEvaluationError).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #348

## Problem
`ApprovalGateway` applied a channel response without verifying it belonged to the active request. A stale, replayed, or misrouted approval for request A could resolve request B. Signature verification only proves the response object was signed for its *own* requestId — not that it matches the in-flight request (confused-deputy / race).

## Fix
In `requestApproval`, reject any response whose `requestId` differs from the active `request.requestId` **before** signature verification, auditing, or session-token creation. Throws a new `ApprovalMismatchError`.

## Tests (TDD, red-first)
- Unsigned mismatched response is rejected and never audited.
- Validly-signed response for a *different* requestId is rejected (replay).
- Matching-id response resolves normally.
- Pre-existing fakes updated to echo the active request id (well-behaved responder).

## Verification (per-package)
`npm run build`, `npm test` (124 passing), `npm run typecheck` — all green.