### PR TITLE
fix(governor): fail closed for signed approvals

### DIFF
--- a/packages/franken-governor/src/errors/approval-configuration-error.ts
+++ b/packages/franken-governor/src/errors/approval-configuration-error.ts
@@ -1,0 +1,9 @@
+import { GovernorError } from './governor-error.js';
+
+export class ApprovalConfigurationError extends GovernorError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApprovalConfigurationError';
+    Object.setPrototypeOf(this, ApprovalConfigurationError.prototype);
+  }
+}

--- a/packages/franken-governor/src/errors/index.ts
+++ b/packages/franken-governor/src/errors/index.ts
@@ -3,4 +3,5 @@ export { ApprovalTimeoutError } from './approval-timeout-error.js';
 export { ChannelUnavailableError } from './channel-unavailable-error.js';
 export { SignatureVerificationError } from './signature-verification-error.js';
 export { ApprovalMismatchError } from './approval-mismatch-error.js';
+export { ApprovalConfigurationError } from './approval-configuration-error.js';
 export { TriggerEvaluationError } from './trigger-evaluation-error.js';

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -1,13 +1,14 @@
 import type { ApprovalRequest, ApprovalResponse, ApprovalOutcome } from '../core/types.js';
 import type { GovernorConfig } from '../core/config.js';
 import type { ApprovalChannel } from './approval-channel.js';
-import type { SignatureVerifier } from '../security/signature-verifier.js';
+import { SignatureVerifier } from '../security/signature-verifier.js';
 import type { SessionTokenStore } from '../security/session-token-store.js';
 import { createSessionToken } from '../security/session-token.js';
 import {
   ApprovalTimeoutError,
   SignatureVerificationError,
   ApprovalMismatchError,
+  ApprovalConfigurationError,
 } from '../errors/index.js';
 
 export interface AuditRecorder {
@@ -33,15 +34,18 @@ export class ApprovalGateway {
     this.channel = deps.channel;
     this.auditRecorder = deps.auditRecorder;
     this.config = deps.config;
-    this.signatureVerifier = deps.signatureVerifier;
+    this.signatureVerifier = deps.signatureVerifier
+      ?? (deps.config.signingSecret ? new SignatureVerifier(deps.config.signingSecret) : undefined);
     this.sessionTokenStore = deps.sessionTokenStore;
-
-    if (deps.config.requireSignedApprovals && !deps.signatureVerifier) {
-      throw new Error('Signed approvals are required but no signatureVerifier was supplied');
-    }
   }
 
   async requestApproval(request: ApprovalRequest): Promise<ApprovalOutcome> {
+    if (this.config.requireSignedApprovals && !this.signatureVerifier) {
+      throw new ApprovalConfigurationError(
+        'Signed approvals are required but no signature verifier is configured. Provide config.signingSecret or ApprovalGatewayDeps.signatureVerifier.',
+      );
+    }
+
     const response = await this.withTimeout(
       this.channel.requestApproval(request),
       request.requestId,
@@ -54,7 +58,7 @@ export class ApprovalGateway {
       throw new ApprovalMismatchError(request.requestId, response.requestId);
     }
 
-    if (this.config.requireSignedApprovals && this.signatureVerifier) {
+    if (this.config.requireSignedApprovals) {
       this.verifySignature(response);
     }
 

--- a/packages/franken-governor/src/gateway/governor-critique-adapter.ts
+++ b/packages/franken-governor/src/gateway/governor-critique-adapter.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import type { ApprovalRequest, TriggerResult } from '../core/types.js';
-import { defaultConfig } from '../core/config.js';
+import { defaultConfig, type GovernorConfig } from '../core/config.js';
 import type { ApprovalChannel } from './approval-channel.js';
 import { ApprovalGateway, type AuditRecorder } from './approval-gateway.js';
+import type { SignatureVerifier } from '../security/signature-verifier.js';
 import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
 import type { RationaleBlock, VerificationResult } from '@franken/types';
 
@@ -11,6 +12,8 @@ export interface GovernorCritiqueAdapterDeps {
   readonly auditRecorder: AuditRecorder;
   readonly evaluators: ReadonlyArray<TriggerEvaluator>;
   readonly projectId: string;
+  readonly config?: GovernorConfig;
+  readonly signatureVerifier?: SignatureVerifier;
 }
 
 export class GovernorCritiqueAdapter {
@@ -22,7 +25,8 @@ export class GovernorCritiqueAdapter {
     this.gateway = new ApprovalGateway({
       channel: deps.channel,
       auditRecorder: deps.auditRecorder,
-      config: defaultConfig(),
+      config: deps.config ?? defaultConfig(),
+      ...(deps.signatureVerifier ? { signatureVerifier: deps.signatureVerifier } : {}),
     });
     this.evaluators = deps.evaluators;
     this.projectId = deps.projectId;

--- a/packages/franken-governor/src/gateway/governor-factory.ts
+++ b/packages/franken-governor/src/gateway/governor-factory.ts
@@ -3,7 +3,7 @@ import { GovernorAuditRecorder } from '../audit/audit-recorder.js';
 import { CliChannel, type ReadlineAdapter } from '../channels/cli-channel.js';
 import type { GovernorMemoryPort } from '../audit/governor-memory-port.js';
 import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
-import { defaultConfig } from '../core/config.js';
+import { defaultConfig, type GovernorConfig } from '../core/config.js';
 
 export interface CreateGovernorOptions {
   readonly readline: ReadlineAdapter;
@@ -11,10 +11,14 @@ export interface CreateGovernorOptions {
   readonly evaluators?: ReadonlyArray<TriggerEvaluator>;
   readonly projectId?: string;
   readonly operatorName?: string;
+  readonly config?: Partial<GovernorConfig>;
 }
 
 export function createGovernor(options: CreateGovernorOptions): GovernorCritiqueAdapter {
-  const config = defaultConfig();
+  const config: GovernorConfig = {
+    ...defaultConfig(),
+    ...options.config,
+  };
 
   const channel = new CliChannel({
     readline: options.readline,
@@ -28,5 +32,6 @@ export function createGovernor(options: CreateGovernorOptions): GovernorCritique
     auditRecorder,
     evaluators: options.evaluators ?? [],
     projectId: options.projectId ?? 'default',
+    config,
   });
 }

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -17,6 +17,7 @@ export {
   GovernorError,
   ApprovalTimeoutError,
   ChannelUnavailableError,
+  ApprovalConfigurationError,
   SignatureVerificationError,
   ApprovalMismatchError,
   TriggerEvaluationError,

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -5,7 +5,11 @@ import type { ApprovalRequest, ApprovalResponse } from '../../../src/core/types.
 import { defaultConfig } from '../../../src/core/config.js';
 import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
 import { SessionTokenStore } from '../../../src/security/session-token-store.js';
-import { SignatureVerificationError, ApprovalMismatchError } from '../../../src/errors/index.js';
+import {
+  SignatureVerificationError,
+  ApprovalMismatchError,
+  ApprovalConfigurationError,
+} from '../../../src/errors/index.js';
 
 function makeRequest(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
   return {
@@ -104,13 +108,34 @@ describe('ApprovalGateway — security integration', () => {
     }
   });
 
-  it('throws at construction when signed approvals are required without a verifier', () => {
-    expect(() => new ApprovalGateway({
-      channel: makeFakeChannel(),
-      auditRecorder: makeFakeAuditRecorder(),
+  it('rejects with a configuration error before contacting the channel when signed approvals require a verifier but none is configured', async () => {
+    const channel = makeFakeChannel();
+    const auditRecorder = makeFakeAuditRecorder();
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder,
       config: { ...defaultConfig(), requireSignedApprovals: true },
-      // no signatureVerifier
-    })).toThrow(/signed approvals.*verifier/i);
+      // no signatureVerifier and no config.signingSecret
+    });
+
+    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(ApprovalConfigurationError);
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+    expect(auditRecorder.record).not.toHaveBeenCalled();
+  });
+
+  it('constructs a verifier from config.signingSecret and accepts a valid signature', async () => {
+    const signingSecret = 'secret-from-config';
+    const verifier = new SignatureVerifier(signingSecret);
+    const validSig = verifier.sign(JSON.stringify({ requestId: 'req-001', decision: 'APPROVE' }));
+    const channel = makeFakeChannel({ signature: validSig });
+    const wiredGateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config: { ...defaultConfig(), requireSignedApprovals: true, signingSecret },
+    });
+
+    const outcome = await wiredGateway.requestApproval(makeRequest());
+    expect(outcome.decision).toBe('APPROVE');
   });
 
   it('rejects an unsigned response whose requestId does not match the active request', async () => {

--- a/packages/franken-governor/tests/unit/public-api.test.ts
+++ b/packages/franken-governor/tests/unit/public-api.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import * as publicApi from '../../src/index.js';
-import { ApprovalMismatchError as InternalApprovalMismatchError } from '../../src/errors/index.js';
+import {
+  ApprovalMismatchError as InternalApprovalMismatchError,
+  ApprovalConfigurationError as InternalApprovalConfigurationError,
+} from '../../src/errors/index.js';
 
 describe('public API exports', () => {
   it('re-exports ApprovalMismatchError from the package root', () => {
@@ -12,6 +15,7 @@ describe('public API exports', () => {
     expect(publicApi.GovernorError).toBeDefined();
     expect(publicApi.ApprovalTimeoutError).toBeDefined();
     expect(publicApi.ChannelUnavailableError).toBeDefined();
+    expect(publicApi.ApprovalConfigurationError).toBe(InternalApprovalConfigurationError);
     expect(publicApi.SignatureVerificationError).toBeDefined();
     expect(publicApi.TriggerEvaluationError).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- fail closed with an explicit ApprovalConfigurationError when signed approvals are required but no verifier/signing secret is configured
- construct ApprovalGateway signature verification from config.signingSecret and pass factory config through the critique adapter
- add coverage for missing verifier rejection, config-based valid signature acceptance, and public error export

## Tests
- npm test --workspace @franken/governor -- --run tests/unit/gateway/approval-gateway-security.test.ts tests/unit/public-api.test.ts tests/unit/gateway/governor-critique-adapter.test.ts
- npm run typecheck --workspace @franken/governor
- npm test --workspace @franken/governor
- npm run build --workspace @franken/governor

Closes #428