### PR TITLE
fix(web): share Beast wizard launch config

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-review.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-review.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import { useBeastStore } from '../../../stores/beast-store';
-
-const SECTION_LABELS = ['Identity', 'Workflow', 'LLM Targets', 'Modules', 'Skills', 'Prompts', 'Git'];
+import { buildWizardLaunchConfig } from '../wizard-launch-config';
 
 interface StepReviewProps {
   onLaunch: (config: Record<string, unknown>) => void;
@@ -11,13 +10,7 @@ export function StepReview({ onLaunch }: StepReviewProps) {
   const { stepValues, setWizardStep } = useBeastStore();
 
   function handleLaunch() {
-    const config: Record<string, unknown> = {};
-    for (let i = 0; i < SECTION_LABELS.length; i++) {
-      if (stepValues[i]) {
-        config[SECTION_LABELS[i]!.toLowerCase().replace(/ /g, '_')] = stepValues[i];
-      }
-    }
-    onLaunch(config);
+    onLaunch(buildWizardLaunchConfig(stepValues));
   }
 
   const identity = stepValues[0] as { name?: string; description?: string } | undefined;

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -39,16 +39,29 @@ export function StepWorkflow() {
       )}
 
       {values.workflowType === 'chunk-plan' && (
-        <div>
-          <label htmlFor="wf-file" className="block text-sm font-medium text-beast-text mb-1.5">Design Doc Path</label>
-          <input
-            id="wf-file"
-            type="text"
-            value={(values.docPath as string) ?? ''}
-            onChange={(e) => updateField('docPath', e.target.value)}
-            placeholder="/path/to/design-doc.md"
-            className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-          />
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="wf-file" className="block text-sm font-medium text-beast-text mb-1.5">Design Doc Path</label>
+            <input
+              id="wf-file"
+              type="text"
+              value={(values.docPath as string) ?? ''}
+              onChange={(e) => updateField('docPath', e.target.value)}
+              placeholder="/path/to/design-doc.md"
+              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
+            />
+          </div>
+          <div>
+            <label htmlFor="wf-output-dir" className="block text-sm font-medium text-beast-text mb-1.5">Output Directory</label>
+            <input
+              id="wf-output-dir"
+              type="text"
+              value={(values.outputDir as string) ?? ''}
+              onChange={(e) => updateField('outputDir', e.target.value)}
+              placeholder="/path/to/chunks"
+              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
+            />
+          </div>
         </div>
       )}
 

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -10,9 +10,9 @@ import { StepSkills } from './steps/step-skills';
 import { StepPrompts } from './steps/step-prompts';
 import { StepGit } from './steps/step-git';
 import { StepReview } from './steps/step-review';
+import { buildWizardLaunchConfig } from './wizard-launch-config';
 
 const STEP_LABELS = ['Identity', 'Workflow', 'LLM Targets', 'Modules', 'Skills', 'Prompts', 'Git', 'Review'];
-const SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 'skills', 'prompts', 'git', 'review'];
 
 interface WizardDialogProps {
   isOpen: boolean;
@@ -30,11 +30,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, launching, launchError
   const isFirstStep = wizardStep === 0;
 
   function buildAndLaunch() {
-    const config: Record<string, unknown> = {};
-    for (let i = 0; i < STEP_LABELS.length; i++) {
-      if (stepValues[i]) config[SECTION_KEYS[i]!] = stepValues[i];
-    }
-    onLaunch(config);
+    onLaunch(buildWizardLaunchConfig(stepValues));
   }
 
   function handleNext() {

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -1,0 +1,15 @@
+export const WIZARD_SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 'skills', 'prompts', 'git'] as const;
+
+type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
+
+export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+
+  for (let i = 0; i < WIZARD_SECTION_KEYS.length; i += 1) {
+    if (stepValues[i]) {
+      config[WIZARD_SECTION_KEYS[i]!] = stepValues[i];
+    }
+  }
+
+  return config;
+}

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -11,5 +11,14 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
     }
   }
 
+  const workflow = config.workflow as Record<string, unknown> | undefined;
+  if (workflow?.workflowType === 'chunk-plan' && typeof workflow.docPath === 'string') {
+    config.designDocPath = workflow.docPath;
+  }
+
+  if (workflow?.workflowType === 'chunk-plan' && typeof workflow.outputDir === 'string') {
+    config.outputDir = workflow.outputDir;
+  }
+
   return config;
 }

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -27,10 +27,16 @@ describe('StepReview', () => {
     expect(useBeastStore.getState().wizardStep).toBe(0);
   });
 
-  it('has Launch button that calls onLaunch', () => {
+  it('launches with the shared wizard config shape for non-default workflows', () => {
     const onLaunch = vi.fn();
+    useBeastStore.getState().setStepValues(2, { defaultProvider: 'codex', defaultModel: 'gpt-5.1' });
     render(<StepReview onLaunch={onLaunch} />);
     fireEvent.click(screen.getByText('Launch'));
-    expect(onLaunch).toHaveBeenCalled();
+    expect(onLaunch).toHaveBeenCalledWith({
+      identity: { name: 'Test Agent', description: 'A test agent' },
+      workflow: { workflowType: 'design-interview' },
+      llm: { defaultProvider: 'codex', defaultModel: 'gpt-5.1' },
+    });
+    expect(onLaunch.mock.calls[0]?.[0]).not.toHaveProperty('workflow_type');
   });
 });

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -29,12 +29,14 @@ describe('StepReview', () => {
 
   it('launches with the shared wizard config shape for non-default workflows', () => {
     const onLaunch = vi.fn();
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md' });
     useBeastStore.getState().setStepValues(2, { defaultProvider: 'codex', defaultModel: 'gpt-5.1' });
     render(<StepReview onLaunch={onLaunch} />);
     fireEvent.click(screen.getByText('Launch'));
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Test Agent', description: 'A test agent' },
-      workflow: { workflowType: 'design-interview' },
+      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md' },
+      designDocPath: 'docs/design.md',
       llm: { defaultProvider: 'codex', defaultModel: 'gpt-5.1' },
     });
     expect(onLaunch.mock.calls[0]?.[0]).not.toHaveProperty('workflow_type');

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -29,14 +29,15 @@ describe('StepReview', () => {
 
   it('launches with the shared wizard config shape for non-default workflows', () => {
     const onLaunch = vi.fn();
-    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md' });
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' });
     useBeastStore.getState().setStepValues(2, { defaultProvider: 'codex', defaultModel: 'gpt-5.1' });
     render(<StepReview onLaunch={onLaunch} />);
     fireEvent.click(screen.getByText('Launch'));
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Test Agent', description: 'A test agent' },
-      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md' },
+      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
       designDocPath: 'docs/design.md',
+      outputDir: 'tasks/chunks',
       llm: { defaultProvider: 'codex', defaultModel: 'gpt-5.1' },
     });
     expect(onLaunch.mock.calls[0]?.[0]).not.toHaveProperty('workflow_type');

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -29,4 +29,18 @@ describe('StepWorkflow', () => {
     render(<StepWorkflow />);
     expect(screen.getByPlaceholderText(/topic|context/i)).toBeTruthy();
   });
+
+  it('collects both required chunk-plan launch fields', () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan' });
+    render(<StepWorkflow />);
+
+    fireEvent.change(screen.getByLabelText('Design Doc Path'), { target: { value: 'docs/design.md' } });
+    fireEvent.change(screen.getByLabelText('Output Directory'), { target: { value: 'tasks/chunks' } });
+
+    expect(useBeastStore.getState().stepValues[1]).toEqual({
+      workflowType: 'chunk-plan',
+      docPath: 'docs/design.md',
+      outputDir: 'tasks/chunks',
+    });
+  });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -29,4 +29,19 @@ describe('WizardDialog', () => {
     const toggle = screen.getByText(/form view/i) || screen.getByText(/form/i);
     expect(toggle).toBeTruthy();
   });
+
+  it('footer launch uses the shared config shape for non-default workflows', () => {
+    const onLaunch = vi.fn();
+    useBeastStore.getState().setStepValues(0, { name: 'Footer Agent' });
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md' });
+    useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
+
+    render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={onLaunch} />);
+    fireEvent.click(screen.getByText('Launch Agent'));
+
+    expect(onLaunch).toHaveBeenCalledWith({
+      identity: { name: 'Footer Agent' },
+      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md' },
+    });
+  });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -33,7 +33,7 @@ describe('WizardDialog', () => {
   it('footer launch uses the shared config shape for non-default workflows', () => {
     const onLaunch = vi.fn();
     useBeastStore.getState().setStepValues(0, { name: 'Footer Agent' });
-    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md' });
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' });
     useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
 
     render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={onLaunch} />);
@@ -41,8 +41,9 @@ describe('WizardDialog', () => {
 
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Footer Agent' },
-      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md' },
+      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
       designDocPath: 'docs/design.md',
+      outputDir: 'tasks/chunks',
     });
   });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -42,6 +42,7 @@ describe('WizardDialog', () => {
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Footer Agent' },
       workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md' },
+      designDocPath: 'docs/design.md',
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add a shared Beast wizard launch config builder used by both the footer launch and review-step launch.
- Preserve `config.workflow.workflowType` for selected workflows so ChatShell maps to the selected definitionId instead of silently falling back.
- Add tests for review-step and footer launches with non-default workflow selections.

## Tests
- `npm --workspace @frankenbeast/web test -- tests/components/beasts/steps/step-review.test.tsx tests/components/beasts/wizard-dialog.test.tsx`
- `npm --workspace @frankenbeast/web run typecheck`
- `npm --workspace @frankenbeast/web test` (fails in pre-existing `src/lib/dashboard-api.test.ts > DashboardApiClient > subscribeToDashboard > creates EventSource and returns unsubscribe function`: mocked EventSource is not a constructor)

Closes #426