### PR TITLE
fix(mcp): enforce advertised tool schemas

### DIFF
--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -19,7 +19,7 @@ export function createMemoryServer(deps: MemoryServerDeps): FbeastMcpServer {
         type: 'object',
         properties: {
           query: { type: 'string', description: 'Search query (substring match on key and value)' },
-          type: { type: 'string', description: 'Filter by type: working, episodic, recovery' },
+          type: { type: 'string', description: 'Filter by type: working, episodic, recovery', enum: ['working', 'episodic', 'recovery'] },
           limit: { type: 'string', description: 'Max results (default 20)' },
         },
         required: ['query'],
@@ -48,7 +48,7 @@ export function createMemoryServer(deps: MemoryServerDeps): FbeastMcpServer {
         properties: {
           key: { type: 'string', description: 'Unique key for this memory entry' },
           value: { type: 'string', description: 'Content to store' },
-          type: { type: 'string', description: 'Memory type: working, episodic, or recovery' },
+          type: { type: 'string', description: 'Memory type: working, episodic, or recovery', enum: ['working', 'episodic', 'recovery'] },
         },
         required: ['key', 'value', 'type'],
       },

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -9,7 +9,7 @@ vi.mock('../shared/tool-registry.js', () => ({
         name: 'test_tool',
         server: 'memory',
         description: 'A test tool',
-        inputSchema: { type: 'object', properties: {} },
+        inputSchema: { type: 'object', properties: { key: { type: 'string', description: 'Key' } }, required: ['key'] },
         makeHandler: vi.fn(),
       },
     ],
@@ -98,9 +98,21 @@ describe('proxy server', () => {
       const entry = mockRegistry.get('test_tool')!;
       vi.mocked(entry.makeHandler).mockReturnValue(fakeHandler);
 
-      const toolArgs = { foo: 'bar', count: 42 };
+      const toolArgs = { key: 'bar' };
       await executeToolDef.handler({ tool: 'test_tool', args: toolArgs });
       expect(fakeHandler).toHaveBeenCalledWith(toolArgs);
+    });
+
+    it('validates proxied target tool args before calling the target handler', async () => {
+      const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+      const entry = mockRegistry.get('test_tool')!;
+      vi.mocked(entry.makeHandler).mockReturnValue(fakeHandler);
+
+      const result = await executeToolDef.handler({ tool: 'test_tool', args: { key: 42 } }) as { isError: boolean; content: Array<{ text: string }> };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('property key must be string');
+      expect(fakeHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createMcpServer, type FbeastMcpServer, type ToolDef, type ToolResult } from '../shared/server-factory.js';
+import { createMcpServer, validateToolArguments, type FbeastMcpServer, type ToolDef, type ToolResult } from '../shared/server-factory.js';
 import { isMain } from '../shared/is-main.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
 import { parseArgs } from 'node:util';
@@ -52,9 +52,13 @@ export function createProxyServer(deps: { dbPath: string }): FbeastMcpServer {
             isError: true,
           };
         }
+        const validated = validateToolArguments(entry, toolArgs);
+        if (!validated.ok) {
+          return { content: [{ type: 'text', text: `Error: ${validated.message}` }], isError: true };
+        }
         const adapters = getAdapters();
         const handler = entry.makeHandler(adapters);
-        return handler(toolArgs) as Promise<ToolResult>;
+        return handler(validated.value) as Promise<ToolResult>;
       },
     },
   ];

--- a/packages/franken-mcp-suite/src/servers/skills.ts
+++ b/packages/franken-mcp-suite/src/servers/skills.ts
@@ -18,7 +18,7 @@ export function createSkillsServer(deps: SkillsServerDeps): FbeastMcpServer {
       inputSchema: {
         type: 'object',
         properties: {
-          enabled: { type: 'string', description: 'Filter: "true" for enabled only, "false" for disabled only' },
+          enabled: { type: 'string', description: 'Filter: "true" for enabled only, "false" for disabled only', enum: ['true', 'false'] },
         },
       },
       async handler(args) {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createMcpServer, type ToolDef } from './server-factory.js';
+import { createMcpServer, validateToolArguments, type ToolDef } from './server-factory.js';
 
 describe('createMcpServer', () => {
   it('creates server with name and version', () => {
@@ -108,6 +108,40 @@ describe('createMcpServer', () => {
     const res = await srv.callTool('cfg', { args: null });
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
+  });
+
+  it('rejects non-finite number arguments before invoking the handler', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'cost',
+      description: 'cost',
+      inputSchema: { type: 'object', properties: { costUsd: { type: 'number', description: 'cost' } }, required: ['costUsd'] },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    const res = await srv.callTool('cost', { costUsd: Infinity });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects enum values not advertised by the input schema', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'store',
+      description: 'store',
+      inputSchema: {
+        type: 'object',
+        properties: { type: { type: 'string', description: 'memory type', enum: ['working', 'episodic', 'recovery'] } },
+        required: ['type'],
+      },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    const res = await srv.callTool('store', { type: 'bogus' });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+
+    expect(validateToolArguments(tool, { type: 'working' }).ok).toBe(true);
   });
 
   it('handler returns correct format', async () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -17,14 +17,17 @@ export interface ToolResult {
 
 export interface ToolInputSchema {
   type: 'object';
-  properties: Record<string, { type: string; description: string }>;
+  properties: Record<string, { type: string; description: string; enum?: readonly unknown[] }>;
   required?: string[];
 }
 
-export interface ToolDef {
+export interface ToolSchemaDef {
   name: string;
-  description: string;
   inputSchema: ToolInputSchema;
+}
+
+export interface ToolDef extends ToolSchemaDef {
+  description: string;
   handler: (args: Record<string, unknown>) => Promise<ToolResult>;
 }
 
@@ -37,7 +40,7 @@ export interface FbeastMcpServer {
 }
 
 export function validateToolArguments(
-  tool: ToolDef,
+  tool: ToolSchemaDef,
   args: unknown,
 ): { ok: true; value: Record<string, unknown> } | { ok: false; message: string } {
   if (args === null || typeof args !== 'object' || Array.isArray(args)) {
@@ -58,6 +61,12 @@ export function validateToolArguments(
     const actual = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
     if (prop.type === 'integer' ? !Number.isInteger(value) : actual !== prop.type) {
       return { ok: false, message: `Tool ${tool.name} property ${key} must be ${prop.type}` };
+    }
+    if (prop.type === 'number' && !Number.isFinite(value)) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must be a finite number` };
+    }
+    if (prop.enum && !prop.enum.includes(value)) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must be one of: ${prop.enum.join(', ')}` };
     }
   }
   return { ok: true, value: obj };

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -5,6 +5,7 @@ import { createGovernorAdapter, type GovernorAdapter } from '../adapters/governo
 import { createObserverAdapter, type ObserverAdapter } from '../adapters/observer-adapter.js';
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
+import type { ToolInputSchema } from './server-factory.js';
 
 export type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 
@@ -25,7 +26,7 @@ interface ToolStub {
 }
 
 interface ToolFull extends ToolStub {
-  inputSchema: Record<string, unknown>;
+  inputSchema: ToolInputSchema;
   makeHandler: (adapters: AdapterSet) => (args: Record<string, unknown>) => Promise<ToolResult>;
 }
 
@@ -58,7 +59,7 @@ const TOOLS: ToolFull[] = [
       properties: {
         key: { type: 'string', description: 'Unique key for this memory entry' },
         value: { type: 'string', description: 'Content to store' },
-        type: { type: 'string', description: 'Memory type: working, episodic, or recovery' },
+        type: { type: 'string', description: 'Memory type: working, episodic, or recovery', enum: ['working', 'episodic', 'recovery'] },
       },
       required: ['key', 'value', 'type'],
     },
@@ -78,7 +79,7 @@ const TOOLS: ToolFull[] = [
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Search query (substring match on key and value)' },
-        type: { type: 'string', description: 'Filter by type: working, episodic, recovery' },
+        type: { type: 'string', description: 'Filter by type: working, episodic, recovery', enum: ['working', 'episodic', 'recovery'] },
         limit: { type: 'string', description: 'Max results (default 20)' },
       },
       required: ['query'],
@@ -431,7 +432,7 @@ const TOOLS: ToolFull[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        enabled: { type: 'string', description: 'Filter: "true" for enabled only, "false" for disabled only' },
+        enabled: { type: 'string', description: 'Filter: "true" for enabled only, "false" for disabled only', enum: ['true', 'false'] },
       },
     },
     makeHandler: ({ skills }) => async (args) => {

--- a/tasks/issue-427-mcp-schema-validation-progress.md
+++ b/tasks/issue-427-mcp-schema-validation-progress.md
@@ -1,0 +1,15 @@
+# Issue 427 MCP schema validation progress
+
+- [x] Inspect repository instructions and current MCP server factory/tests
+- [x] Implement central schema validation improvements (finite numbers, enums)
+- [x] Ensure execute_tool validates target tool args through same validator
+- [x] Add focused regression tests for direct calls and proxy path
+- [x] Run focused tests/typecheck and broader feasible verification
+  - [x] `npm test --workspace=@fbeast/mcp-suite -- --run src/shared/server-factory.test.ts src/servers/proxy.test.ts`
+  - [x] `npm run typecheck --workspace=@fbeast/mcp-suite`
+  - [x] `npm test --workspace=@fbeast/mcp-suite`
+  - [x] `npm run build --workspace=@fbeast/mcp-suite`
+  - [x] `npm run typecheck` attempted; fails in unrelated `franken-orchestrator` imports of missing `makeTokenSpend` from `@franken/types`
+- [ ] Commit intended files
+- [ ] Push branch and open PR with Closes #427
+- [ ] Run bounded Codex review loop and address real findings or report terminal state


### PR DESCRIPTION
## Summary
- Enforce advertised MCP input schemas centrally in `createMcpServer()` before handlers run.
- Reject missing required fields, wrong primitive types, undeclared properties, non-finite numbers, and schema enum violations.
- Validate `execute_tool` proxy target arguments with the same shared validator before dispatch.
- Advertise enum constraints for memory types and skills enabled filters.

## Tests
- `npm test --workspace=@fbeast/mcp-suite -- --run src/shared/server-factory.test.ts src/servers/proxy.test.ts`
- `npm run typecheck --workspace=@fbeast/mcp-suite`
- `npm test --workspace=@fbeast/mcp-suite`
- `npm run build --workspace=@fbeast/mcp-suite`

## Notes
- Broader `npm run typecheck` was attempted and still fails outside this change in `franken-orchestrator` because `makeTokenSpend` is imported from `@franken/types` but is not exported there.

Closes #427
