### PR TITLE
Fix MCP skill execution fail-closed path

### DIFF
--- a/packages/franken-orchestrator/src/adapters/mcp-sdk-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/mcp-sdk-adapter.ts
@@ -2,9 +2,8 @@ import type { IMcpModule, McpToolCallResult, McpToolInfo } from '../deps.js';
 
 /**
  * Adapts MCP SDK clients to the IMcpModule port.
- * v1: placeholder that delegates to provider-native MCP support.
- * Real MCP SDK integration deferred until @modelcontextprotocol/sdk
- * is used directly.
+ * Direct SDK-based MCP calls are not wired here yet; this adapter intentionally
+ * fails closed instead of reporting synthetic success.
  */
 export class McpSdkAdapter implements IMcpModule {
   private readonly tools: McpToolInfo[];
@@ -14,13 +13,11 @@ export class McpSdkAdapter implements IMcpModule {
   }
 
   async callTool(name: string, args: unknown): Promise<McpToolCallResult> {
-    // In v1, MCP tool calls go through the CLI provider's native MCP support
-    // (--mcp-config for Claude, codex mcp add for Codex, settings.json for Gemini).
-    // Direct SDK-based MCP calls are a future enhancement.
-    return {
-      content: `MCP tool ${name} called with args: ${JSON.stringify(args)}`,
-      isError: false,
-    };
+    void args;
+    throw new Error(
+      `MCP tool '${name}' is not reachable through McpSdkAdapter: no MCP SDK client/server transport is configured. ` +
+        'Configure an IMcpModule implementation with a live MCP client, or route this skill through a CLI/provider path that supports MCP.',
+    );
   }
 
   getAvailableTools(): readonly McpToolInfo[] {

--- a/packages/franken-orchestrator/src/adapters/mcp-sdk-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/mcp-sdk-adapter.ts
@@ -12,8 +12,9 @@ export class McpSdkAdapter implements IMcpModule {
     this.tools = tools;
   }
 
-  async callTool(name: string, args: unknown): Promise<McpToolCallResult> {
+  async callTool(name: string, args: unknown, serverId?: string | undefined): Promise<McpToolCallResult> {
     void args;
+    void serverId;
     throw new Error(
       `MCP tool '${name}' is not reachable through McpSdkAdapter: no MCP SDK client/server transport is configured. ` +
         'Configure an IMcpModule implementation with a live MCP client, or route this skill through a CLI/provider path that supports MCP.',

--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -13,16 +13,31 @@ export class SkillManagerAdapter implements ISkillsModule {
   constructor(private readonly manager: SkillManager) {}
 
   hasSkill(skillId: string): boolean {
-    return this.manager.getEnabledSkills().includes(skillId);
+    return this.manager.getEnabledSkills().some((enabledSkill) => (
+      enabledSkill === skillId || this.manager.readTools(enabledSkill).some(tool => tool.name === skillId)
+    ));
   }
 
   getAvailableSkills(): readonly SkillDescriptor[] {
-    return this.manager.getEnabledSkills().map((name) => ({
-      id: name,
-      name,
-      requiresHitl: false,
-      executionType: 'mcp' as const,
-    }));
+    return this.manager.getEnabledSkills().flatMap((name) => {
+      const tools = this.manager.readTools(name);
+
+      if (tools.length > 1) {
+        return tools.map((tool) => ({
+          id: tool.name,
+          name: tool.name,
+          requiresHitl: false,
+          executionType: 'mcp' as const,
+        }));
+      }
+
+      return [{
+        id: name,
+        name,
+        requiresHitl: false,
+        executionType: 'mcp' as const,
+      }];
+    });
   }
 
   async execute(skillId: string, input: SkillInput): Promise<SkillResult> {

--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -26,12 +26,11 @@ export class SkillManagerAdapter implements ISkillsModule {
   }
 
   async execute(skillId: string, input: SkillInput): Promise<SkillResult> {
-    // SkillManager manages directory config, not direct execution.
-    // Skill execution happens through CliSkillExecutor or MCP SDK.
-    // This adapter provides the metadata layer; execution is delegated.
-    return {
-      output: `Skill ${skillId} executed for: ${input.objective}`,
-      tokensUsed: 0,
-    };
+    void input;
+    throw new Error(
+      `MCP skill '${skillId}' cannot be executed by SkillManagerAdapter directly. ` +
+        'Provide an IMcpModule to runExecution so executionType=mcp skills can be dispatched to a real MCP tool/server, ' +
+        'or configure the skill as executionType=cli/function/llm with an executor that implements that path.',
+    );
   }
 }

--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -17,7 +17,7 @@ export class SkillManagerAdapter implements ISkillsModule {
       const tools = this.manager.readTools(enabledSkill);
       return (
         (enabledSkill === skillId && isServerAliasExecutable(enabledSkill, tools)) ||
-        tools.some(tool => tool.name === skillId)
+        tools.some(tool => tool.name === skillId || namespacedToolId(enabledSkill, tool.name) === skillId)
       );
     });
   }
@@ -28,23 +28,14 @@ export class SkillManagerAdapter implements ISkillsModule {
       const descriptors: SkillDescriptor[] = [];
 
       if (isServerAliasExecutable(name, tools)) {
-        descriptors.push({
-          id: name,
-          name,
-          requiresHitl: false,
-          executionType: 'mcp' as const,
-        });
+        descriptors.push(createDescriptor(name, name));
       }
 
       for (const tool of tools) {
         if (tool.name !== name) {
-          descriptors.push({
-            id: tool.name,
-            name: tool.name,
-            requiresHitl: false,
-            executionType: 'mcp' as const,
-          });
+          descriptors.push(createDescriptor(tool.name, tool.name, name));
         }
+        descriptors.push(createDescriptor(namespacedToolId(name, tool.name), tool.name, name));
       }
 
       return descriptors;
@@ -61,9 +52,23 @@ export class SkillManagerAdapter implements ISkillsModule {
   }
 }
 
+function createDescriptor(id: string, name: string, parentSkillId?: string): SkillDescriptor {
+  return {
+    id,
+    name,
+    ...(parentSkillId ? { parentSkillId } : {}),
+    requiresHitl: false,
+    executionType: 'mcp',
+  };
+}
+
+function namespacedToolId(skillName: string, toolName: string): string {
+  return `${skillName}/${toolName}`;
+}
+
 function isServerAliasExecutable(
   skillName: string,
   tools: ReturnType<SkillManager['readTools']>,
 ): boolean {
-  return tools.length === 1 || tools.some(tool => tool.name === skillName);
+  return tools.length === 0 || tools.length === 1 || tools.some(tool => tool.name === skillName);
 }

--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -21,22 +21,25 @@ export class SkillManagerAdapter implements ISkillsModule {
   getAvailableSkills(): readonly SkillDescriptor[] {
     return this.manager.getEnabledSkills().flatMap((name) => {
       const tools = this.manager.readTools(name);
-
-      if (tools.length > 1) {
-        return tools.map((tool) => ({
-          id: tool.name,
-          name: tool.name,
-          requiresHitl: false,
-          executionType: 'mcp' as const,
-        }));
-      }
-
-      return [{
+      const descriptors: SkillDescriptor[] = [{
         id: name,
         name,
         requiresHitl: false,
         executionType: 'mcp' as const,
       }];
+
+      for (const tool of tools) {
+        if (tool.name !== name) {
+          descriptors.push({
+            id: tool.name,
+            name: tool.name,
+            requiresHitl: false,
+            executionType: 'mcp' as const,
+          });
+        }
+      }
+
+      return descriptors;
     });
   }
 

--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -13,20 +13,28 @@ export class SkillManagerAdapter implements ISkillsModule {
   constructor(private readonly manager: SkillManager) {}
 
   hasSkill(skillId: string): boolean {
-    return this.manager.getEnabledSkills().some((enabledSkill) => (
-      enabledSkill === skillId || this.manager.readTools(enabledSkill).some(tool => tool.name === skillId)
-    ));
+    return this.manager.getEnabledSkills().some((enabledSkill) => {
+      const tools = this.manager.readTools(enabledSkill);
+      return (
+        (enabledSkill === skillId && isServerAliasExecutable(enabledSkill, tools)) ||
+        tools.some(tool => tool.name === skillId)
+      );
+    });
   }
 
   getAvailableSkills(): readonly SkillDescriptor[] {
     return this.manager.getEnabledSkills().flatMap((name) => {
       const tools = this.manager.readTools(name);
-      const descriptors: SkillDescriptor[] = [{
-        id: name,
-        name,
-        requiresHitl: false,
-        executionType: 'mcp' as const,
-      }];
+      const descriptors: SkillDescriptor[] = [];
+
+      if (isServerAliasExecutable(name, tools)) {
+        descriptors.push({
+          id: name,
+          name,
+          requiresHitl: false,
+          executionType: 'mcp' as const,
+        });
+      }
 
       for (const tool of tools) {
         if (tool.name !== name) {
@@ -51,4 +59,11 @@ export class SkillManagerAdapter implements ISkillsModule {
         'or configure the skill as executionType=cli/function/llm with an executor that implements that path.',
     );
   }
+}
+
+function isServerAliasExecutable(
+  skillName: string,
+  tools: ReturnType<SkillManager['readTools']>,
+): boolean {
+  return tools.length === 1 || tools.some(tool => tool.name === skillName);
 }

--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -34,7 +34,7 @@ import { AnthropicApiAdapter } from '../providers/anthropic-api-adapter.js';
 import { OpenAiApiAdapter } from '../providers/openai-api-adapter.js';
 import { GeminiApiAdapter } from '../providers/gemini-api-adapter.js';
 
-import type { BeastLoopDeps, IObserverModule } from '../deps.js';
+import type { BeastLoopDeps, IObserverModule, McpToolInfo } from '../deps.js';
 import type { ILlmProvider } from '@franken/types';
 import type { AggregatedTokenUsage } from '../providers/token-aggregator.js';
 
@@ -182,7 +182,7 @@ export function createBeastDeps(
     'unknown',
     replayStore,
   );
-  const mcp = new McpSdkAdapter();
+  const mcp = new McpSdkAdapter(collectEnabledMcpTools(skillManager));
 
   return {
     firewall,
@@ -227,6 +227,22 @@ export function createBeastDeps(
     ...(existingDeps.refreshPlanTasks ? { refreshPlanTasks: existingDeps.refreshPlanTasks } : {}),
     ...(existingDeps.runConfigOverrides ? { runConfigOverrides: existingDeps.runConfigOverrides } : {}),
   } as ConsolidatedDeps;
+}
+
+function collectEnabledMcpTools(skillManager: SkillManager): McpToolInfo[] {
+  return skillManager.getEnabledSkills().flatMap((skillName) => {
+    const tools = skillManager.readTools(skillName);
+    const mcpConfig = skillManager.readMcpConfig(skillName);
+    const serverIds = mcpConfig ? Object.keys(mcpConfig.mcpServers) : [];
+    const serverId = serverIds.length === 1 ? serverIds[0]! : skillName;
+
+    return tools.map((tool) => ({
+      name: tool.name,
+      serverId,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
+  });
 }
 
 function buildProviderList(

--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -81,6 +81,7 @@ export interface ExistingDeps {
   graphBuilder?: BeastLoopDeps['graphBuilder'];
   prCreator?: BeastLoopDeps['prCreator'];
   cliExecutor?: BeastLoopDeps['cliExecutor'];
+  mcp?: BeastLoopDeps['mcp'];
   checkpoint?: BeastLoopDeps['checkpoint'];
   refreshPlanTasks?: BeastLoopDeps['refreshPlanTasks'];
   runConfigOverrides?: BeastLoopDeps['runConfigOverrides'];
@@ -182,7 +183,7 @@ export function createBeastDeps(
     'unknown',
     replayStore,
   );
-  const mcp = new McpSdkAdapter(collectEnabledMcpTools(skillManager));
+  const mcp = existingDeps.mcp ?? new McpSdkAdapter(collectEnabledMcpTools(skillManager));
 
   return {
     firewall,
@@ -232,13 +233,9 @@ export function createBeastDeps(
 function collectEnabledMcpTools(skillManager: SkillManager): McpToolInfo[] {
   return skillManager.getEnabledSkills().flatMap((skillName) => {
     const tools = skillManager.readTools(skillName);
-    const mcpConfig = skillManager.readMcpConfig(skillName);
-    const serverIds = mcpConfig ? Object.keys(mcpConfig.mcpServers) : [];
-    const serverId = serverIds.length === 1 ? serverIds[0]! : skillName;
-
     return tools.map((tool) => ({
       name: tool.name,
-      serverId,
+      serverId: skillName,
       description: tool.description,
       inputSchema: tool.inputSchema,
     }));

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -640,8 +640,12 @@ function createSkillDeps(consolidated: ConsolidatedDeps, allowedSkills?: string[
   const cliSkillCompat = (id: string) => id.startsWith('cli:');
   return allowedSkills?.length
     ? {
-        hasSkill: (id: string) => cliSkillCompat(id) || (allowedSkills.includes(id) && baseSkills.hasSkill(id)),
-        getAvailableSkills: () => baseSkills.getAvailableSkills().filter((s) => allowedSkills.includes(s.id)),
+        hasSkill: (id: string) => cliSkillCompat(id) || baseSkills.getAvailableSkills().some((s) => (
+          s.id === id && (allowedSkills.includes(s.id) || Boolean(s.parentSkillId && allowedSkills.includes(s.parentSkillId)))
+        )),
+        getAvailableSkills: () => baseSkills.getAvailableSkills().filter((s) => (
+          allowedSkills.includes(s.id) || Boolean(s.parentSkillId && allowedSkills.includes(s.parentSkillId))
+        )),
         execute: baseSkills.execute,
       }
     : {

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -44,6 +44,7 @@ export interface SkillDescriptor {
   readonly name: string;
   readonly requiresHitl: boolean;
   readonly executionType: 'llm' | 'function' | 'mcp' | 'cli';
+  readonly parentSkillId?: string | undefined;
 }
 
 export interface SkillInput {
@@ -182,7 +183,7 @@ export interface HeartbeatPulseResult {
 }
 
 export interface IMcpModule {
-  callTool(name: string, args: unknown): Promise<McpToolCallResult>;
+  callTool(name: string, args: unknown, serverId?: string | undefined): Promise<McpToolCallResult>;
   getAvailableTools(): readonly McpToolInfo[];
 }
 

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -195,6 +195,7 @@ export interface McpToolInfo {
   readonly name: string;
   readonly serverId: string;
   readonly description: string;
+  readonly inputSchema?: Record<string, unknown> | undefined;
 }
 
 /** Checkpoint persistence for crash recovery. */

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -7,6 +7,7 @@ import type {
   PlanTask,
   SkillInput,
   IMcpModule,
+  McpToolInfo,
   MemoryContext,
   ILogger,
   ICheckpointStore,
@@ -366,7 +367,7 @@ async function executeMcpSkill(
 function resolveMcpTool(
   skillId: string,
   tools: ReturnType<IMcpModule['getAvailableTools']>,
-): { name: string; serverId: string } {
+): McpToolInfo {
   const byName = tools.filter(tool => tool.name === skillId);
   const byServer = tools.filter(tool => tool.serverId === skillId);
 
@@ -389,7 +390,17 @@ function resolveMcpTool(
   }
 
   if (exactTool) return exactTool;
-  if (byServer.length === 1) return byServer[0]!;
+  if (byServer.length === 1) {
+    const serverTool = byServer[0]!;
+    const duplicateNames = tools.filter(tool => tool.name === serverTool.name && tool.serverId !== serverTool.serverId);
+    if (duplicateNames.length > 0) {
+      throw new Error(
+        `MCP skill '${skillId}' resolves to tool '${serverTool.name}', but that tool name is also exposed by ` +
+          `other MCP servers (${duplicateNames.map(tool => tool.serverId).join(', ')}). Use an unambiguous tool id.`,
+      );
+    }
+    return serverTool;
+  }
 
   if (byServer.length > 1) {
     throw new Error(

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -355,7 +355,7 @@ async function executeMcpSkill(
   }
 
   const tool = resolveMcpTool(skillId, mcp.getAvailableTools());
-  const result = await mcp.callTool(tool.name, serializeMcpSkillInput(input, tool.inputSchema));
+  const result = await mcp.callTool(tool.name, serializeMcpSkillInput(input, tool.inputSchema), tool.serverId);
 
   if (result.isError) {
     throw new Error(`MCP skill '${skillId}' failed via tool '${tool.name}': ${String(result.content)}`);
@@ -368,6 +368,15 @@ function resolveMcpTool(
   skillId: string,
   tools: ReturnType<IMcpModule['getAvailableTools']>,
 ): McpToolInfo {
+  const namespaced = parseNamespacedToolId(skillId);
+  if (namespaced) {
+    const matches = tools.filter(tool => tool.serverId === namespaced.serverId && tool.name === namespaced.toolName);
+    if (matches.length === 1) return matches[0]!;
+    if (matches.length > 1) {
+      throw new Error(`MCP skill '${skillId}' is ambiguous: multiple MCP tools match that namespaced id.`);
+    }
+  }
+
   const byName = tools.filter(tool => tool.name === skillId);
   const byServer = tools.filter(tool => tool.serverId === skillId);
 
@@ -390,17 +399,7 @@ function resolveMcpTool(
   }
 
   if (exactTool) return exactTool;
-  if (byServer.length === 1) {
-    const serverTool = byServer[0]!;
-    const duplicateNames = tools.filter(tool => tool.name === serverTool.name && tool.serverId !== serverTool.serverId);
-    if (duplicateNames.length > 0) {
-      throw new Error(
-        `MCP skill '${skillId}' resolves to tool '${serverTool.name}', but that tool name is also exposed by ` +
-          `other MCP servers (${duplicateNames.map(tool => tool.serverId).join(', ')}). Use an unambiguous tool id.`,
-      );
-    }
-    return serverTool;
-  }
+  if (byServer.length === 1) return byServer[0]!;
 
   if (byServer.length > 1) {
     throw new Error(
@@ -415,6 +414,15 @@ function resolveMcpTool(
       `Expected a tool named '${skillId}' or exactly one tool from server '${skillId}'. Available MCP tools: ${available}. ` +
       'Start/configure the MCP server or disable the skill.',
   );
+}
+
+function parseNamespacedToolId(skillId: string): { serverId: string; toolName: string } | undefined {
+  const separator = skillId.indexOf('/');
+  if (separator <= 0 || separator === skillId.length - 1) return undefined;
+  return {
+    serverId: skillId.slice(0, separator),
+    toolName: skillId.slice(separator + 1),
+  };
 }
 
 function serializeMcpSkillInput(input: SkillInput, inputSchema?: Record<string, unknown>): Record<string, unknown> {
@@ -444,6 +452,9 @@ function serializeMcpSkillInput(input: SkillInput, inputSchema?: Record<string, 
   }
   if ('input' in properties && !('input' in schemaInput)) {
     schemaInput.input = input.objective;
+  }
+  if ('content' in properties && !('content' in schemaInput)) {
+    schemaInput.content = input.objective;
   }
 
   return schemaInput;

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -354,7 +354,7 @@ async function executeMcpSkill(
   }
 
   const tool = resolveMcpTool(skillId, mcp.getAvailableTools());
-  const result = await mcp.callTool(tool.name, serializeMcpSkillInput(input));
+  const result = await mcp.callTool(tool.name, serializeMcpSkillInput(input, tool.inputSchema));
 
   if (result.isError) {
     throw new Error(`MCP skill '${skillId}' failed via tool '${tool.name}': ${String(result.content)}`);
@@ -367,18 +367,28 @@ function resolveMcpTool(
   skillId: string,
   tools: ReturnType<IMcpModule['getAvailableTools']>,
 ): { name: string; serverId: string } {
-  const byName = tools.find(tool => tool.name === skillId);
+  const byName = tools.filter(tool => tool.name === skillId);
   const byServer = tools.filter(tool => tool.serverId === skillId);
 
-  if (byName && byServer.some(tool => tool !== byName)) {
+  if (byName.length > 1) {
     throw new Error(
-      `MCP skill '${skillId}' is ambiguous: it matches tool '${byName.name}' from server '${byName.serverId}' ` +
+      `MCP skill '${skillId}' is ambiguous: multiple MCP servers expose a tool named '${skillId}' ` +
+        `(${byName.map(tool => tool.serverId).join(', ')}). Use an unambiguous server/tool id.`,
+    );
+  }
+
+  const exactTool = byName[0];
+  if (exactTool && exactTool.serverId === skillId) return exactTool;
+
+  if (exactTool && byServer.length > 0) {
+    throw new Error(
+      `MCP skill '${skillId}' is ambiguous: it matches tool '${exactTool.name}' from server '${exactTool.serverId}' ` +
         `and server '${skillId}' tools (${byServer.map(tool => tool.name).join(', ')}). ` +
         'Use an unambiguous tool id or server id.',
     );
   }
 
-  if (byName) return byName;
+  if (exactTool) return exactTool;
   if (byServer.length === 1) return byServer[0]!;
 
   if (byServer.length > 1) {
@@ -396,14 +406,44 @@ function resolveMcpTool(
   );
 }
 
-function serializeMcpSkillInput(input: SkillInput): Record<string, unknown> {
-  return {
+function serializeMcpSkillInput(input: SkillInput, inputSchema?: Record<string, unknown>): Record<string, unknown> {
+  const genericInput = {
     objective: input.objective,
     context: input.context,
     dependencyOutputs: Object.fromEntries(input.dependencyOutputs),
     sessionId: input.sessionId,
     projectId: input.projectId,
   };
+
+  const properties = getSchemaProperties(inputSchema);
+  if (!properties) return genericInput;
+
+  const schemaInput: Record<string, unknown> = {};
+  for (const key of Object.keys(properties)) {
+    if (key in genericInput) {
+      schemaInput[key] = genericInput[key as keyof typeof genericInput];
+    }
+  }
+
+  if ('query' in properties && !('query' in schemaInput)) {
+    schemaInput.query = input.objective;
+  }
+  if ('prompt' in properties && !('prompt' in schemaInput)) {
+    schemaInput.prompt = input.objective;
+  }
+  if ('input' in properties && !('input' in schemaInput)) {
+    schemaInput.input = input.objective;
+  }
+
+  return schemaInput;
+}
+
+function getSchemaProperties(inputSchema: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  const properties = inputSchema?.properties;
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+    return undefined;
+  }
+  return properties as Record<string, unknown>;
 }
 
 function resolveMemoryContext(

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -158,7 +158,7 @@ async function executeTask(
   observer: IObserverModule,
   ctx: BeastContext,
   completedOutputs: ReadonlyMap<string, unknown>,
-  _mcp?: IMcpModule,
+  mcp?: IMcpModule,
   logger: ILogger = new NullLogger(),
   cliExecutor?: CliSkillExecutor,
   checkpoint?: ICheckpointStore,
@@ -211,7 +211,7 @@ async function executeTask(
       }
     }
 
-    // Execute (placeholder — real execution calls skill registry)
+    // Execute through the concrete path declared by each skill descriptor.
     ctx.addAudit('executor', 'task:start', { taskId: task.id, objective: task.objective });
 
     const dependencyOutputs = new Map<string, unknown>();
@@ -278,6 +278,7 @@ async function executeTask(
     for (const skillId of task.requiredSkills) {
       const descriptor = availableSkills.find(sk => sk.id === skillId);
       const isCli = descriptor?.executionType === 'cli';
+      const isMcp = descriptor?.executionType === 'mcp';
 
       let result;
       if (isCli) {
@@ -285,6 +286,8 @@ async function executeTask(
           throw new Error(`CLI skill '${skillId}' requires a CliSkillExecutor but none was provided`);
         }
         result = await cliExecutor.execute(skillId, baseInput, {} as never, checkpoint, task.id);
+      } else if (isMcp) {
+        result = await executeMcpSkill(skillId, baseInput, mcp);
       } else {
         result = await skills.execute(skillId, baseInput);
       }
@@ -336,6 +339,63 @@ async function executeTask(
   } finally {
     span.end({ taskId: task.id });
   }
+}
+
+async function executeMcpSkill(
+  skillId: string,
+  input: SkillInput,
+  mcp?: IMcpModule,
+): Promise<{ output: unknown; tokensUsed: number }> {
+  if (!mcp) {
+    throw new Error(
+      `MCP skill '${skillId}' requires an IMcpModule but none was provided. ` +
+        'Wire a live MCP module into runExecution/createBeastDeps or disable the MCP skill.',
+    );
+  }
+
+  const tool = resolveMcpTool(skillId, mcp.getAvailableTools());
+  const result = await mcp.callTool(tool.name, serializeMcpSkillInput(input));
+
+  if (result.isError) {
+    throw new Error(`MCP skill '${skillId}' failed via tool '${tool.name}': ${String(result.content)}`);
+  }
+
+  return { output: result.content, tokensUsed: 0 };
+}
+
+function resolveMcpTool(
+  skillId: string,
+  tools: ReturnType<IMcpModule['getAvailableTools']>,
+): { name: string; serverId: string } {
+  const byName = tools.find(tool => tool.name === skillId);
+  if (byName) return byName;
+
+  const byServer = tools.filter(tool => tool.serverId === skillId);
+  if (byServer.length === 1) return byServer[0]!;
+
+  if (byServer.length > 1) {
+    throw new Error(
+      `MCP skill '${skillId}' maps to multiple MCP tools (${byServer.map(tool => tool.name).join(', ')}). ` +
+        'Use a required skill id that matches the intended MCP tool name, or expose exactly one tool for this skill server.',
+    );
+  }
+
+  const available = tools.map(tool => `${tool.serverId}/${tool.name}`).join(', ') || 'none';
+  throw new Error(
+    `MCP skill '${skillId}' is enabled but no matching MCP tool/server is available. ` +
+      `Expected a tool named '${skillId}' or exactly one tool from server '${skillId}'. Available MCP tools: ${available}. ` +
+      'Start/configure the MCP server or disable the skill.',
+  );
+}
+
+function serializeMcpSkillInput(input: SkillInput): Record<string, unknown> {
+  return {
+    objective: input.objective,
+    context: input.context,
+    dependencyOutputs: Object.fromEntries(input.dependencyOutputs),
+    sessionId: input.sessionId,
+    projectId: input.projectId,
+  };
 }
 
 function resolveMemoryContext(

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -277,7 +277,7 @@ async function executeTask(
 
     for (const skillId of task.requiredSkills) {
       const descriptor = availableSkills.find(sk => sk.id === skillId);
-      const isCli = descriptor?.executionType === 'cli';
+      const isCli = descriptor?.executionType === 'cli' || (!descriptor && skillId.startsWith('cli:'));
       const isMcp = descriptor?.executionType === 'mcp';
 
       let result;
@@ -368,9 +368,17 @@ function resolveMcpTool(
   tools: ReturnType<IMcpModule['getAvailableTools']>,
 ): { name: string; serverId: string } {
   const byName = tools.find(tool => tool.name === skillId);
-  if (byName) return byName;
-
   const byServer = tools.filter(tool => tool.serverId === skillId);
+
+  if (byName && byServer.some(tool => tool !== byName)) {
+    throw new Error(
+      `MCP skill '${skillId}' is ambiguous: it matches tool '${byName.name}' from server '${byName.serverId}' ` +
+        `and server '${skillId}' tools (${byServer.map(tool => tool.name).join(', ')}). ` +
+        'Use an unambiguous tool id or server id.',
+    );
+  }
+
+  if (byName) return byName;
   if (byServer.length === 1) return byServer[0]!;
 
   if (byServer.length > 1) {

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillManagerAdapter } from '../../../src/adapters/skill-manager-adapter.js';
+import { McpSdkAdapter } from '../../../src/adapters/mcp-sdk-adapter.js';
+import { SkillManager } from '../../../src/skills/skill-manager.js';
+
+describe('MCP execution adapters', () => {
+  it('SkillManagerAdapter fails closed instead of returning placeholder success', async () => {
+    const skillsDir = mkdtempSync(join(tmpdir(), 'franken-skills-'));
+    mkdirSync(join(skillsDir, 'search'));
+    writeFileSync(join(skillsDir, 'search', 'mcp.json'), JSON.stringify({ mcpServers: { search: { command: 'search' } } }));
+    const manager = new SkillManager(skillsDir, new Set(['search']));
+    const adapter = new SkillManagerAdapter(manager);
+
+    await expect(adapter.execute('search', {
+      objective: 'look this up',
+      context: { adrs: [], knownErrors: [], rules: [] },
+      dependencyOutputs: new Map(),
+      sessionId: 'sess',
+      projectId: 'proj',
+    })).rejects.toThrow('cannot be executed by SkillManagerAdapter directly');
+  });
+
+  it('McpSdkAdapter fails closed when no live MCP transport is configured', async () => {
+    const adapter = new McpSdkAdapter([{ name: 'search', serverId: 'search', description: 'Search' }]);
+
+    await expect(adapter.callTool('search', { objective: 'look this up' }))
+      .rejects.toThrow('no MCP SDK client/server transport is configured');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -37,7 +37,9 @@ describe('MCP execution adapters', () => {
     expect(adapter.hasSkill('query')).toBe(true);
     expect(adapter.hasSkill('summarize')).toBe(true);
     expect(adapter.hasSkill('search')).toBe(false);
-    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['query', 'summarize']);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['query', 'search/query', 'summarize', 'search/summarize']);
+    expect(adapter.getAvailableSkills().filter(skill => skill.parentSkillId === 'search').map(skill => skill.id))
+      .toEqual(['query', 'search/query', 'summarize', 'search/summarize']);
   });
 
   it('SkillManagerAdapter keeps server aliases only when they resolve to one tool', () => {
@@ -52,7 +54,18 @@ describe('MCP execution adapters', () => {
 
     expect(adapter.hasSkill('memory')).toBe(true);
     expect(adapter.hasSkill('query')).toBe(true);
-    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['memory', 'query']);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['memory', 'query', 'memory/query']);
+  });
+
+  it('SkillManagerAdapter preserves mcp.json-only skill aliases for runtime discovery', () => {
+    const skillsDir = mkdtempSync(join(tmpdir(), 'franken-skills-'));
+    mkdirSync(join(skillsDir, 'dynamic'));
+    writeFileSync(join(skillsDir, 'dynamic', 'mcp.json'), JSON.stringify({ mcpServers: { dynamic: { command: 'dynamic' } } }));
+    const manager = new SkillManager(skillsDir, new Set(['dynamic']));
+    const adapter = new SkillManagerAdapter(manager);
+
+    expect(adapter.hasSkill('dynamic')).toBe(true);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['dynamic']);
   });
 
   it('McpSdkAdapter fails closed when no live MCP transport is configured', async () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -36,7 +36,23 @@ describe('MCP execution adapters', () => {
 
     expect(adapter.hasSkill('query')).toBe(true);
     expect(adapter.hasSkill('summarize')).toBe(true);
-    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['search', 'query', 'summarize']);
+    expect(adapter.hasSkill('search')).toBe(false);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['query', 'summarize']);
+  });
+
+  it('SkillManagerAdapter keeps server aliases only when they resolve to one tool', () => {
+    const skillsDir = mkdtempSync(join(tmpdir(), 'franken-skills-'));
+    mkdirSync(join(skillsDir, 'memory'));
+    writeFileSync(join(skillsDir, 'memory', 'mcp.json'), JSON.stringify({ mcpServers: { memory: { command: 'memory' } } }));
+    writeFileSync(join(skillsDir, 'memory', 'tools.json'), JSON.stringify([
+      { name: 'query', description: 'Query', inputSchema: {} },
+    ]));
+    const manager = new SkillManager(skillsDir, new Set(['memory']));
+    const adapter = new SkillManagerAdapter(manager);
+
+    expect(adapter.hasSkill('memory')).toBe(true);
+    expect(adapter.hasSkill('query')).toBe(true);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['memory', 'query']);
   });
 
   it('McpSdkAdapter fails closed when no live MCP transport is configured', async () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -23,6 +23,22 @@ describe('MCP execution adapters', () => {
     })).rejects.toThrow('cannot be executed by SkillManagerAdapter directly');
   });
 
+  it('SkillManagerAdapter exposes tool-level descriptors for multi-tool MCP skills', () => {
+    const skillsDir = mkdtempSync(join(tmpdir(), 'franken-skills-'));
+    mkdirSync(join(skillsDir, 'search'));
+    writeFileSync(join(skillsDir, 'search', 'mcp.json'), JSON.stringify({ mcpServers: { search: { command: 'search' } } }));
+    writeFileSync(join(skillsDir, 'search', 'tools.json'), JSON.stringify([
+      { name: 'query', description: 'Query', inputSchema: {} },
+      { name: 'summarize', description: 'Summarize', inputSchema: {} },
+    ]));
+    const manager = new SkillManager(skillsDir, new Set(['search']));
+    const adapter = new SkillManagerAdapter(manager);
+
+    expect(adapter.hasSkill('query')).toBe(true);
+    expect(adapter.hasSkill('summarize')).toBe(true);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['query', 'summarize']);
+  });
+
   it('McpSdkAdapter fails closed when no live MCP transport is configured', async () => {
     const adapter = new McpSdkAdapter([{ name: 'search', serverId: 'search', description: 'Search' }]);
 

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -36,7 +36,7 @@ describe('MCP execution adapters', () => {
 
     expect(adapter.hasSkill('query')).toBe(true);
     expect(adapter.hasSkill('summarize')).toBe(true);
-    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['query', 'summarize']);
+    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['search', 'query', 'summarize']);
   });
 
   it('McpSdkAdapter fails closed when no live MCP transport is configured', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
@@ -1,177 +1,52 @@
-import { describe, it, expect, vi } from 'vitest';
-import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { createBeastDeps, type BeastDepsConfig, type ExistingDeps } from '../../../src/cli/create-beast-deps.js';
-import { MiddlewareChainFirewallAdapter } from '../../../src/adapters/middleware-firewall-adapter.js';
-import { SqliteBrainMemoryAdapter } from '../../../src/adapters/brain-memory-adapter.js';
-import { ReflectionHeartbeatAdapter } from '../../../src/adapters/reflection-heartbeat-adapter.js';
-import { SkillManagerAdapter } from '../../../src/adapters/skill-manager-adapter.js';
-import { AuditTrailObserverAdapter } from '../../../src/adapters/audit-observer-adapter.js';
+import { createBeastDeps } from '../../../src/cli/create-beast-deps.js';
+import { makeCritique, makeGovernor, makeLogger, makeObserver, makePlanner } from '../../helpers/stubs.js';
 
-function mockExistingDeps(): ExistingDeps {
-  return {
-    planner: { createPlan: vi.fn().mockResolvedValue({ tasks: [] }) },
-    critique: { reviewPlan: vi.fn().mockResolvedValue({ verdict: 'pass', findings: [], score: 1 }) },
-    governor: { requestApproval: vi.fn().mockResolvedValue({ decision: 'approved' }) },
-    observer: {
-      startTrace: vi.fn(),
-      startSpan: vi.fn(() => ({ end: vi.fn() })),
-      getTokenSpend: vi.fn().mockResolvedValue({ inputTokens: 0, outputTokens: 0, totalTokens: 0, estimatedCostUsd: 0 }),
-    },
-    logger: {
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    },
-  };
-}
+describe('createBeastDeps', () => {
+  it('populates the MCP adapter catalog from enabled skill tool manifests', () => {
+    const root = mkdtempSync(join(tmpdir(), 'franken-create-deps-'));
+    const skillsDir = join(root, 'skills');
+    const configDir = join(root, '.fbeast');
+    const skillDir = join(skillsDir, 'memory');
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ skills: { enabled: ['memory'] } }));
+    writeFileSync(join(skillDir, 'mcp.json'), JSON.stringify({ mcpServers: { memory: { command: 'memory-server' } } }));
+    writeFileSync(join(skillDir, 'tools.json'), JSON.stringify([
+      {
+        name: 'fbeast_memory_query',
+        description: 'Query memory',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+      },
+    ]));
 
-const minimalConfig: BeastDepsConfig = {
-  providers: [{ name: 'claude', type: 'claude-cli' }],
-};
+    const deps = createBeastDeps(
+      {
+        providers: [{ name: 'claude', type: 'claude-cli' }],
+        skillsDir,
+        configDir,
+        reflection: false,
+      },
+      {
+        planner: makePlanner(),
+        critique: makeCritique(),
+        governor: makeGovernor(),
+        observer: makeObserver(),
+        logger: makeLogger(),
+        clock: vi.fn(() => new Date('2026-01-01T00:00:00Z')),
+      },
+    );
 
-describe('createBeastDeps()', () => {
-  it('returns valid BeastLoopDeps with all required fields', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.firewall).toBeDefined();
-    expect(deps.skills).toBeDefined();
-    expect(deps.memory).toBeDefined();
-    expect(deps.planner).toBeDefined();
-    expect(deps.observer).toBeDefined();
-    expect(deps.critique).toBeDefined();
-    expect(deps.governor).toBeDefined();
-    expect(deps.heartbeat).toBeDefined();
-    expect(deps.logger).toBeDefined();
-    expect(deps.clock).toBeDefined();
-  });
-
-  it('adapts firewall to MiddlewareChainFirewallAdapter', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.firewall).toBeInstanceOf(MiddlewareChainFirewallAdapter);
-  });
-
-  it('adapts memory to SqliteBrainMemoryAdapter', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.memory).toBeInstanceOf(SqliteBrainMemoryAdapter);
-  });
-
-  it('adapts heartbeat to ReflectionHeartbeatAdapter', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.heartbeat).toBeInstanceOf(ReflectionHeartbeatAdapter);
-  });
-
-  it('adapts skills to SkillManagerAdapter', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.skills).toBeInstanceOf(SkillManagerAdapter);
-  });
-
-  it('wraps observer with AuditTrailObserverAdapter', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.observer).toBeInstanceOf(AuditTrailObserverAdapter);
-  });
-
-  it('provides direct access to new components', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.providerRegistry).toBeDefined();
-    expect(deps.sqliteBrain).toBeDefined();
-    expect(deps.auditTrail).toBeDefined();
-    expect(deps.middlewareChain).toBeDefined();
-    expect(deps.skillManager).toBeDefined();
-  });
-
-  it('builds multiple providers from config', () => {
-    const deps = createBeastDeps({
-      providers: [
-        { name: 'primary', type: 'claude-cli' },
-        { name: 'fallback', type: 'anthropic-api', apiKey: 'sk-test' },
-      ],
-    }, mockExistingDeps());
-    expect(deps.providerRegistry!.getProviders()).toHaveLength(2);
-  });
-
-  it('throws helpful error when no providers configured', () => {
-    expect(() =>
-      createBeastDeps({ providers: [] }, mockExistingDeps()),
-    ).toThrow(/frankenbeast provider add/);
-  });
-
-  it('passes through existing deps unchanged', () => {
-    const existing = mockExistingDeps();
-    const deps = createBeastDeps(minimalConfig, existing);
-    expect(deps.planner).toBe(existing.planner);
-    expect(deps.critique).toBe(existing.critique);
-    expect(deps.governor).toBe(existing.governor);
-    expect(deps.logger).toBe(existing.logger);
-  });
-
-  it('creates SqliteBrain with default :memory:', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.sqliteBrain).toBeDefined();
-    deps.sqliteBrain!.close();
-  });
-
-  it('creates AuditTrail', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.auditTrail!.getAll()).toHaveLength(0);
-  });
-
-  it('creates SkillManager with default directory', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.skillManager).toBeDefined();
-  });
-
-  it('exposes getTokenUsage that delegates to ProviderRegistry', () => {
-    const deps = createBeastDeps(minimalConfig, mockExistingDeps());
-    expect(deps.getTokenUsage).toBeTypeOf('function');
-
-    const usage = deps.getTokenUsage!();
-    expect(usage).toEqual(expect.objectContaining({
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalTokens: 0,
-    }));
-    // Should be the same reference as registry.getTokenUsage()
-    const registryUsage = deps.providerRegistry!.getTokenUsage();
-    expect(usage).toEqual(registryUsage);
-  });
-
-  it('persists replay manifests captured by the wrapped observer', () => {
-    const root = mkdtempSync(join(tmpdir(), 'create-beast-deps-replay-'));
-    const deps = createBeastDeps({ ...minimalConfig, configDir: root }, mockExistingDeps());
-
-    deps.observer.recordReplay!({
-      kind: 'tool.result',
-      runId: 'run-1',
-      toolName: 'cli:01',
-      content: JSON.stringify({ ok: true }),
-    });
-    deps.persistAuditTrail!('run-1');
-
-    const manifest = JSON.parse(readFileSync(join(root, '.fbeast', 'audit', 'run-1.replay.json'), 'utf8'));
-    expect(manifest).toHaveLength(1);
-    expect(manifest[0]).toMatchObject({ kind: 'tool.result', runId: 'run-1', toolName: 'cli:01' });
-    expect(manifest[0].contentRef).toMatch(/^[a-f0-9]{64}$/);
-  });
-
-  it('does not double-nest .fbeast when configDir already points to metadata', () => {
-    const root = mkdtempSync(join(tmpdir(), 'create-beast-deps-metadata-'));
-    const metadataDir = join(root, '.fbeast');
-    const deps = createBeastDeps({ ...minimalConfig, configDir: metadataDir }, mockExistingDeps());
-
-    deps.observer.recordReplay!({
-      kind: 'tool.result',
-      runId: 'run-1',
-      toolName: 'cli:01',
-      content: JSON.stringify({ ok: true }),
-    });
-    deps.persistAuditTrail!('run-1');
-
-    const manifest = JSON.parse(readFileSync(join(metadataDir, 'audit', 'run-1.replay.json'), 'utf8'));
-    expect(manifest).toHaveLength(1);
-    expect(existsSync(join(metadataDir, 'audit', 'run-1.json'))).toBe(true);
-    expect(existsSync(join(metadataDir, '.fbeast', 'audit', 'run-1.json'))).toBe(false);
-    expect(existsSync(join(metadataDir, '.fbeast', 'audit', 'run-1.replay.json'))).toBe(false);
+    expect(deps.mcp.getAvailableTools()).toEqual([
+      {
+        name: 'fbeast_memory_query',
+        serverId: 'memory',
+        description: 'Query memory',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+      },
+    ]);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
@@ -23,24 +23,9 @@ describe('createBeastDeps', () => {
       },
     ]));
 
-    const deps = createBeastDeps(
-      {
-        providers: [{ name: 'claude', type: 'claude-cli' }],
-        skillsDir,
-        configDir,
-        reflection: false,
-      },
-      {
-        planner: makePlanner(),
-        critique: makeCritique(),
-        governor: makeGovernor(),
-        observer: makeObserver(),
-        logger: makeLogger(),
-        clock: vi.fn(() => new Date('2026-01-01T00:00:00Z')),
-      },
-    );
+    const deps = createDeps(skillsDir, configDir);
 
-    expect(deps.mcp.getAvailableTools()).toEqual([
+    expect(deps.mcp!.getAvailableTools()).toEqual([
       {
         name: 'fbeast_memory_query',
         serverId: 'memory',
@@ -49,4 +34,64 @@ describe('createBeastDeps', () => {
       },
     ]);
   });
+
+  it('preserves the skill-name alias when the mcp server key is renamed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'franken-create-deps-'));
+    const skillsDir = join(root, 'skills');
+    const configDir = join(root, '.fbeast');
+    const skillDir = join(skillsDir, 'memory-skill');
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ skills: { enabled: ['memory-skill'] } }));
+    writeFileSync(join(skillDir, 'mcp.json'), JSON.stringify({ mcpServers: { actualMemoryServer: { command: 'memory-server' } } }));
+    writeFileSync(join(skillDir, 'tools.json'), JSON.stringify([
+      { name: 'query', description: 'Query', inputSchema: {} },
+    ]));
+
+    const deps = createDeps(skillsDir, configDir);
+
+    expect(deps.mcp!.getAvailableTools()).toEqual([
+      { name: 'query', serverId: 'memory-skill', description: 'Query', inputSchema: {} },
+    ]);
+  });
+
+  it('uses an injected live MCP module when provided', () => {
+    const root = mkdtempSync(join(tmpdir(), 'franken-create-deps-'));
+    const skillsDir = join(root, 'skills');
+    const configDir = join(root, '.fbeast');
+    mkdirSync(skillsDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    const liveMcp = {
+      callTool: vi.fn(async () => ({ content: 'ok', isError: false })),
+      getAvailableTools: vi.fn(() => [{ name: 'runtime', serverId: 'live', description: 'Runtime tool' }]),
+    };
+
+    const deps = createDeps(skillsDir, configDir, { mcp: liveMcp });
+
+    expect(deps.mcp).toBe(liveMcp);
+  });
 });
+
+function createDeps(
+  skillsDir: string,
+  configDir: string,
+  overrides: Partial<Parameters<typeof createBeastDeps>[1]> = {},
+) {
+  return createBeastDeps(
+    {
+      providers: [{ name: 'claude', type: 'claude-cli' }],
+      skillsDir,
+      configDir,
+      reflection: false,
+    },
+    {
+      planner: makePlanner(),
+      critique: makeCritique(),
+      governor: makeGovernor(),
+      observer: makeObserver(),
+      logger: makeLogger(),
+      clock: vi.fn(() => new Date('2026-01-01T00:00:00Z')),
+      ...overrides,
+    },
+  );
+}

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -589,6 +589,32 @@ describe('runExecution', () => {
     expect(outcomes[0]!.error).toContain('multiple MCP servers expose a tool named');
   });
 
+  it('fails closed when a server-id match resolves to a duplicated tool name', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'serverA', name: 'Server A', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'search', serverId: 'serverA', description: 'A search' },
+        { name: 'search', serverId: 'serverB', description: 'B search' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'should not run', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['serverA'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).not.toHaveBeenCalled();
+    expect(outcomes[0]!.status).toBe('failure');
+    expect(outcomes[0]!.error).toContain("resolves to tool 'search'");
+  });
+
   it('prefers an exact same-server MCP tool match over sibling server tools', async () => {
     const skills = makeSkills({
       hasSkill: vi.fn(() => true),

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -3,7 +3,7 @@ import { runExecution } from '../../../src/phases/execution.js';
 import { BeastContext } from '../../../src/context/franken-context.js';
 import { makeSkills, makeGovernor, makeMemory, makeObserver, makeLogger } from '../../helpers/stubs.js';
 import type { CliSkillExecutor } from '../../../src/skills/cli-skill-executor.js';
-import type { SkillInput, SkillResult } from '../../../src/deps.js';
+import type { IMcpModule, SkillInput, SkillResult } from '../../../src/deps.js';
 
 function ctx(tasks = [{ id: 't1', objective: 'do it', requiredSkills: [] as string[], dependsOn: [] as string[] }]): BeastContext {
   const c = new BeastContext('proj', 'sess', 'input');
@@ -400,6 +400,86 @@ describe('runExecution', () => {
     expect(skills.execute).not.toHaveBeenCalled();
     expect(outcomes[0]!.status).toBe('success');
     expect(outcomes[0]!.output).toBe('cli-output');
+  });
+
+  it('routes mcp executionType skills through IMcpModule and uses tool output', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'search', name: 'Search', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'search', serverId: 'search-server', description: 'Search tool' },
+      ]),
+      callTool: vi.fn(async () => ({ content: { answer: 'real mcp output' }, isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).toHaveBeenCalledWith(
+      'search',
+      expect.objectContaining({
+        objective: 'look this up',
+        projectId: 'proj',
+        sessionId: 'sess',
+        dependencyOutputs: {},
+      }),
+    );
+    expect(skills.execute).not.toHaveBeenCalled();
+    expect(outcomes[0]!.status).toBe('success');
+    expect(outcomes[0]!.output).toEqual({ answer: 'real mcp output' });
+  });
+
+  it('fails closed for mcp skills when no IMcpModule is provided', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'search', name: 'Search', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver());
+
+    expect(skills.execute).not.toHaveBeenCalled();
+    expect(outcomes[0]!.status).toBe('failure');
+    expect(outcomes[0]!.error).toContain("MCP skill 'search' requires an IMcpModule");
+  });
+
+  it('fails closed for mcp skills when the matching server/tool is unavailable', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'search', name: 'Search', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'other', serverId: 'other-server', description: 'Other tool' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'should not run', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).not.toHaveBeenCalled();
+    expect(skills.execute).not.toHaveBeenCalled();
+    expect(outcomes[0]!.status).toBe('failure');
+    expect(outcomes[0]!.error).toContain("MCP skill 'search' is enabled but no matching MCP tool/server is available");
+    expect(outcomes[0]!.error).toContain('Start/configure the MCP server or disable the skill');
   });
 
   it('routes llm executionType skills through skills.execute (regression)', async () => {

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -482,6 +482,58 @@ describe('runExecution', () => {
     expect(outcomes[0]!.error).toContain('Start/configure the MCP server or disable the skill');
   });
 
+  it('fails closed for ambiguous MCP tool and server-id matches', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'search', name: 'Search', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'search', serverId: 'other-server', description: 'Search tool' },
+        { name: 'query', serverId: 'search', description: 'Query tool' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'should not run', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).not.toHaveBeenCalled();
+    expect(outcomes[0]!.status).toBe('failure');
+    expect(outcomes[0]!.error).toContain("MCP skill 'search' is ambiguous");
+  });
+
+  it('executes exact MCP tool ids exposed from multi-tool servers', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn((skillId: string) => skillId === 'query'),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'query', name: 'Query', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'query', serverId: 'search', description: 'Query tool' },
+        { name: 'summarize', serverId: 'search', description: 'Summarize tool' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'query output', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['query'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).toHaveBeenCalledWith('query', expect.objectContaining({ objective: 'look this up' }));
+    expect(outcomes[0]!.status).toBe('success');
+    expect(outcomes[0]!.output).toBe('query output');
+  });
+
   it('routes llm executionType skills through skills.execute (regression)', async () => {
     const cliExec = makeCliExecutor();
     const skills = makeSkills({
@@ -540,6 +592,24 @@ describe('runExecution', () => {
 
     expect(outcomes[0]!.status).toBe('failure');
     expect(outcomes[0]!.error).toContain("CLI skill 'build' requires a CliSkillExecutor but none was provided");
+  });
+
+  it('routes cli-prefixed skills through cliExecutor even without descriptors', async () => {
+    const cliExec = makeCliExecutor();
+    const skills = makeSkills({
+      hasSkill: vi.fn((skillId: string) => skillId.startsWith('cli:')),
+      getAvailableSkills: vi.fn(() => []),
+      execute: vi.fn(async () => ({ output: 'fallback-output', tokensUsed: 1 })),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'implement chunk', requiredSkills: ['cli:chunk-1'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), undefined, undefined, cliExec);
+
+    expect(cliExec.execute).toHaveBeenCalledWith('cli:chunk-1', expect.objectContaining({ objective: 'implement chunk' }), expect.anything(), undefined, 't1');
+    expect(skills.execute).not.toHaveBeenCalled();
+    expect(outcomes[0]!.output).toBe('cli-output');
   });
 
   it('falls through to skills.execute when skill not found in available skills list', async () => {

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -430,6 +430,7 @@ describe('runExecution', () => {
         sessionId: 'sess',
         dependencyOutputs: {},
       }),
+      'search-server',
     );
     expect(skills.execute).not.toHaveBeenCalled();
     expect(outcomes[0]!.status).toBe('success');
@@ -529,7 +530,7 @@ describe('runExecution', () => {
 
     const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
 
-    expect(mcp.callTool).toHaveBeenCalledWith('query', expect.objectContaining({ objective: 'look this up' }));
+    expect(mcp.callTool).toHaveBeenCalledWith('query', expect.objectContaining({ objective: 'look this up' }), 'search');
     expect(outcomes[0]!.status).toBe('success');
     expect(outcomes[0]!.output).toBe('query output');
   });
@@ -559,7 +560,36 @@ describe('runExecution', () => {
 
     const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
 
-    expect(mcp.callTool).toHaveBeenCalledWith('fbeast_memory_query', { query: 'what do we know about MCP?' });
+    expect(mcp.callTool).toHaveBeenCalledWith('fbeast_memory_query', { query: 'what do we know about MCP?' }, 'memory');
+    expect(outcomes[0]!.status).toBe('success');
+  });
+
+  it('maps objective to content for content-based MCP tool schemas', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'fbeast_critique_evaluate', name: 'Critique', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        {
+          name: 'fbeast_critique_evaluate',
+          serverId: 'fbeast',
+          description: 'Evaluate content',
+          inputSchema: { type: 'object', properties: { content: { type: 'string' } }, required: ['content'] },
+        },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'critique output', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'review this work', requiredSkills: ['fbeast_critique_evaluate'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).toHaveBeenCalledWith('fbeast_critique_evaluate', { content: 'review this work' }, 'fbeast');
     expect(outcomes[0]!.status).toBe('success');
   });
 
@@ -589,7 +619,33 @@ describe('runExecution', () => {
     expect(outcomes[0]!.error).toContain('multiple MCP servers expose a tool named');
   });
 
-  it('fails closed when a server-id match resolves to a duplicated tool name', async () => {
+  it('routes namespaced MCP tool ids when tool names collide', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'memory/search', name: 'Search', parentSkillId: 'memory', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'search', serverId: 'memory', description: 'Memory search' },
+        { name: 'search', serverId: 'web', description: 'Web search' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'memory result', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['memory/search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).toHaveBeenCalledWith('search', expect.objectContaining({ objective: 'look this up' }), 'memory');
+    expect(outcomes[0]!.status).toBe('success');
+    expect(outcomes[0]!.output).toBe('memory result');
+  });
+
+  it('passes server identity when a server-id match resolves to a duplicated tool name', async () => {
     const skills = makeSkills({
       hasSkill: vi.fn(() => true),
       getAvailableSkills: vi.fn(() => [
@@ -610,9 +666,8 @@ describe('runExecution', () => {
 
     const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
 
-    expect(mcp.callTool).not.toHaveBeenCalled();
-    expect(outcomes[0]!.status).toBe('failure');
-    expect(outcomes[0]!.error).toContain("resolves to tool 'search'");
+    expect(mcp.callTool).toHaveBeenCalledWith('search', expect.objectContaining({ objective: 'look this up' }), 'serverA');
+    expect(outcomes[0]!.status).toBe('success');
   });
 
   it('prefers an exact same-server MCP tool match over sibling server tools', async () => {
@@ -636,7 +691,7 @@ describe('runExecution', () => {
 
     const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
 
-    expect(mcp.callTool).toHaveBeenCalledWith('search', expect.objectContaining({ objective: 'look this up' }));
+    expect(mcp.callTool).toHaveBeenCalledWith('search', expect.objectContaining({ objective: 'look this up' }), 'search');
     expect(outcomes[0]!.status).toBe('success');
   });
 

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -534,6 +534,86 @@ describe('runExecution', () => {
     expect(outcomes[0]!.output).toBe('query output');
   });
 
+  it('passes schema-compatible MCP arguments when a tool declares an input schema', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'fbeast_memory_query', name: 'Memory Query', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        {
+          name: 'fbeast_memory_query',
+          serverId: 'memory',
+          description: 'Query memory',
+          inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+        },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'memory output', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'what do we know about MCP?', requiredSkills: ['fbeast_memory_query'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).toHaveBeenCalledWith('fbeast_memory_query', { query: 'what do we know about MCP?' });
+    expect(outcomes[0]!.status).toBe('success');
+  });
+
+  it('fails closed for duplicate MCP tool-name matches', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'search', name: 'Search', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'search', serverId: 'memory', description: 'Memory search' },
+        { name: 'search', serverId: 'web', description: 'Web search' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'should not run', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).not.toHaveBeenCalled();
+    expect(outcomes[0]!.status).toBe('failure');
+    expect(outcomes[0]!.error).toContain('multiple MCP servers expose a tool named');
+  });
+
+  it('prefers an exact same-server MCP tool match over sibling server tools', async () => {
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'search', name: 'Search', requiresHitl: false, executionType: 'mcp' as const },
+      ]),
+      execute: vi.fn(async () => ({ output: 'placeholder', tokensUsed: 1 })),
+    });
+    const mcp: IMcpModule = {
+      getAvailableTools: vi.fn(() => [
+        { name: 'search', serverId: 'search', description: 'Exact search' },
+        { name: 'query', serverId: 'search', description: 'Sibling query' },
+      ]),
+      callTool: vi.fn(async () => ({ content: 'search output', isError: false })),
+    };
+    const c = ctx([
+      { id: 't1', objective: 'look this up', requiredSkills: ['search'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), mcp);
+
+    expect(mcp.callTool).toHaveBeenCalledWith('search', expect.objectContaining({ objective: 'look this up' }));
+    expect(outcomes[0]!.status).toBe('success');
+  });
+
   it('routes llm executionType skills through skills.execute (regression)', async () => {
     const cliExec = makeCliExecutor();
     const skills = makeSkills({

--- a/tasks/issue-417-skills-mcp-execution-progress.md
+++ b/tasks/issue-417-skills-mcp-execution-progress.md
@@ -1,0 +1,11 @@
+# Issue 417 MCP skill execution progress
+
+- [x] Inspect AGENTS/CLAUDE guidance and current skill/MCP execution paths
+- [x] Implement fail-closed SkillManagerAdapter execute behavior
+- [x] Route `executionType: 'mcp'` skills through `IMcpModule` in `runExecution`
+- [x] Remove placeholder MCP adapter success behavior
+- [x] Add regression and negative tests
+- [x] Run targeted verification/typecheck
+- [ ] Commit and push branch
+- [ ] Open PR with `Closes #417`
+- [ ] Run bounded Codex review loop and address actionable findings or report terminal state


### PR DESCRIPTION
Closes #417

## Summary
- route executionType=mcp skills through IMcpModule in runExecution
- remove placeholder success from SkillManagerAdapter and McpSdkAdapter by failing closed with actionable errors
- add regression coverage for real MCP handler output and negative coverage for missing/unavailable MCP server/tool

## Verification
- npm exec vitest run tests/unit/phases/execution.test.ts tests/unit/adapters/mcp-execution-adapters.test.ts (pass)
- npm run typecheck -- --filter=franken-orchestrator (fails pre-existing: @franken/types does not export makeTokenSpend used by observer adapters)
- npm test in packages/franken-orchestrator (fails pre-existing makeTokenSpend runtime failures in observer adapter tests; new MCP tests pass)
