### PR TITLE
fix(cli): correct provider setup guidance

### DIFF
--- a/docs/plans/consolidation/phase8-integration/01_dep-factory-rewiring.md
+++ b/docs/plans/consolidation/phase8-integration/01_dep-factory-rewiring.md
@@ -225,7 +225,7 @@ export function createBeastDeps(
 function buildProviderList(providerConfigs?: ProviderConfig[]): ILlmProvider[] {
   if (!providerConfigs || providerConfigs.length === 0) {
     throw new Error(
-      'No providers configured. Run \'frankenbeast provider add claude\' to get started.'
+      'No providers configured. Add a consolidatedProviders entry to your frankenbeast config.'
     );
   }
   return providerConfigs.map((pc) => {
@@ -354,7 +354,7 @@ describe('createBeastDeps()', () => {
     expect(() => createBeastDeps(
       { providers: [] },
       mockExistingDeps,
-    )).toThrow(/frankenbeast provider add/);
+    )).toThrow(/consolidatedProviders/);
   });
 
   it('wires onProviderSwitch callback to audit trail', () => {

--- a/docs/plans/consolidation/phase8-integration/04_cli-commands.md
+++ b/docs/plans/consolidation/phase8-integration/04_cli-commands.md
@@ -15,7 +15,7 @@ Add CLI commands for skill management, provider management, security configurati
 - **Verb-noun pattern**: `frankenbeast <noun> <verb>` (e.g., `skill add`, `provider list`)
 - **Smart defaults**: `frankenbeast run "task"` works with zero config if any provider CLI is logged in
 - **Progressive disclosure**: basic path needs no flags; power users get `--provider`, `--skills`, `--security`
-- **Helpful errors**: if no provider is configured, don't just fail — show `Run 'frankenbeast provider add claude' to get started`
+- **Helpful errors**: if no provider is configured, don't just fail — explain how to add `consolidatedProviders` to the frankenbeast config
 
 ## Implementation
 
@@ -269,8 +269,8 @@ export const HELPFUL_ERRORS = {
   noProviders: `No providers configured.
 
   Get started:
-    frankenbeast provider add claude     # if you have Claude CLI installed
-    frankenbeast provider add openai     # if you have an OpenAI API key
+    # Add providers in frankenbeast config, for example:
+    # {"consolidatedProviders":[{"name":"claude","type":"claude-cli"}]}
 
   Then run:
     frankenbeast run "your task here"`,
@@ -286,7 +286,7 @@ export const HELPFUL_ERRORS = {
   providerAuthFailed: (name: string) => `Provider '${name}' authentication failed.
 
   Options:
-    frankenbeast provider add ${name}    # reconfigure
+    # Update consolidatedProviders in frankenbeast config to reconfigure ${name}
     frankenbeast provider list           # check status`,
 };
 ```

--- a/docs/plans/consolidation/phase9-docs-cleanup/02_ramp-up-md.md
+++ b/docs/plans/consolidation/phase9-docs-cleanup/02_ramp-up-md.md
@@ -48,8 +48,8 @@ Deterministic guardrails framework for AI agents. Orchestrates multiple LLM prov
 frankenbeast run "fix the login bug"
 
 # Configure providers
-frankenbeast provider add claude
-frankenbeast provider add openai
+# Configure providers in frankenbeast config, for example:
+# {"consolidatedProviders":[{"name":"claude","type":"claude-cli"}]}
 
 # Install skills
 frankenbeast skill catalog

--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -247,7 +247,8 @@ function buildProviderList(
 ): ILlmProvider[] {
   if (!configs || configs.length === 0) {
     throw new Error(
-      "No providers configured. Run 'frankenbeast provider add claude' to get started.",
+      'No providers configured. Add a consolidatedProviders entry to your frankenbeast config, for example: '
+        + '{"consolidatedProviders":[{"name":"claude","type":"claude-cli"}]}',
     );
   }
   return configs.map((pc) => {

--- a/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
@@ -70,6 +70,26 @@ describe('createBeastDeps', () => {
 
     expect(deps.mcp).toBe(liveMcp);
   });
+
+  it('points missing-provider guidance at config instead of a nonexistent provider CLI', () => {
+    const createWithoutProviders = () => createBeastDeps(
+      {
+        providers: [],
+        reflection: false,
+      },
+      {
+        planner: makePlanner(),
+        critique: makeCritique(),
+        governor: makeGovernor(),
+        observer: makeObserver(),
+        logger: makeLogger(),
+        clock: vi.fn(() => new Date('2026-01-01T00:00:00Z')),
+      },
+    );
+
+    expect(createWithoutProviders).toThrow(/consolidatedProviders/);
+    expect(createWithoutProviders).not.toThrow(/frankenbeast provider add/);
+  });
 });
 
 function createDeps(


### PR DESCRIPTION
## Summary
- Replace missing-provider bootstrap guidance that referenced nonexistent `frankenbeast provider add` with config-based `consolidatedProviders` guidance.
- Add a regression test ensuring the error points at config and not the dead provider command.
- Update planning docs that still referenced the dead provider-add command.

Closes #400

## Test plan
- PASS: `npm test -- --run tests/unit/cli/create-beast-deps.test.ts` (packages/franken-orchestrator; 4 tests)
- FAIL (pre-existing unrelated): `npm run typecheck` (packages/franken-orchestrator) fails because `@franken/types` has no exported member `makeTokenSpend` used by `src/adapters/cli-observer-bridge.ts` and `src/adapters/observer-adapter.ts`.
- FAIL (pre-existing unrelated): `npm test` (packages/franken-orchestrator) fails 12 token-spend observer tests with `makeTokenSpend is not a function`; touched regression test passes within this run.