### PR TITLE
fix(cli): persist network config sets

### DIFF
--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -76,10 +76,17 @@ function fromCli(args: CliArgs): Partial<OrchestratorConfig> {
  * Loads and merges config from all sources.
  * Priority: CLI > env > file > defaults
  */
-export async function loadConfig(args: CliArgs): Promise<OrchestratorConfig> {
+export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Promise<OrchestratorConfig> {
   let fileConfig: Partial<OrchestratorConfig> = {};
-  if (args.config) {
-    fileConfig = await fromFile(args.config);
+  const configPath = args.config ?? defaultConfigPath;
+  if (configPath) {
+    try {
+      fileConfig = await fromFile(configPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT' || args.config) {
+        throw error;
+      }
+    }
   }
 
   const envConfig = fromEnv();

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -102,11 +102,11 @@ export function resolvePhases(args: Pick<CliArgs, 'subcommand' | 'designDoc' | '
  * Validates config path and loads config from all sources.
  * Exported for testability.
  */
-export async function resolveConfig(args: CliArgs): Promise<OrchestratorConfig> {
+export async function resolveConfig(args: CliArgs, defaultConfigPath?: string): Promise<OrchestratorConfig> {
   if (args.config && !existsSync(args.config)) {
     throw new Error(`Config file not found: ${args.config}`);
   }
-  return loadConfig(args);
+  return loadConfig(args, defaultConfigPath);
 }
 
 interface ChatSurfaceDeps {
@@ -240,7 +240,10 @@ export async function main(): Promise<void> {
     console.log(await renderBanner(root));
   }
 
-  const config = await resolveConfig(args);
+  // Resolve project root — scope plans by name unless --plan-dir overrides
+  const planName = args.planDir ? undefined : (args.planName ?? generatePlanName(args.designDoc));
+  const paths = getProjectPaths(root, planName);
+  const config = await resolveConfig(args, paths.configFile);
 
   const logger = new BeastLogger({ verbose: args.verbose });
   if (args.config) {
@@ -253,9 +256,6 @@ export async function main(): Promise<void> {
     console.log('Config:', JSON.stringify(config, null, 2));
   }
 
-  // Resolve project root — scope plans by name unless --plan-dir overrides
-  const planName = args.planDir ? undefined : (args.planName ?? generatePlanName(args.designDoc));
-  const paths = getProjectPaths(root, planName);
   scaffoldFrankenbeast(paths);
 
   if (args.subcommand === 'network') {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { open, readFile } from 'node:fs/promises';
+import { mkdir, open, readFile, writeFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 import { existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
@@ -27,7 +27,7 @@ import { createCliDeps } from './dep-factory.js';
 import { createDefaultRegistry } from '../skills/providers/cli-provider.js';
 import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
 import { CliLlmAdapter } from '../adapters/cli-llm-adapter.js';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { startChatServer } from '../http/chat-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
@@ -40,6 +40,8 @@ import { NetworkStateStore } from '../network/network-state-store.js';
 import { NetworkLogStore } from '../network/network-logs.js';
 import { NetworkSupervisor } from '../network/network-supervisor.js';
 import { renderNetworkHelp } from '../network/network-help.js';
+import { applyNetworkConfigSets } from '../network/network-config-paths.js';
+import { OrchestratorConfigSchema } from '../config/orchestrator-config.js';
 import { resolveManagedChatAttachment, runManagedChatRepl } from '../network/chat-attach.js';
 import {
   healthcheckNetworkService,
@@ -510,7 +512,7 @@ export async function main(): Promise<void> {
   }
 }
 
-type NetworkPaths = Pick<ReturnType<typeof getProjectPaths>, 'frankenbeastDir'>;
+type NetworkPaths = Pick<ReturnType<typeof getProjectPaths>, 'frankenbeastDir' | 'configFile'>;
 
 export interface NetworkCommandSupervisorLike {
   up(options: {
@@ -532,6 +534,26 @@ export interface NetworkCommandDeps {
   printError: (message: string) => void;
   renderHelp: () => string;
   waitForShutdown: () => Promise<void>;
+}
+
+async function persistNetworkConfigSets(args: CliArgs, paths: NetworkPaths): Promise<string> {
+  const configFile = args.config ?? paths.configFile;
+  let fileConfig: Partial<OrchestratorConfig> = {};
+
+  try {
+    fileConfig = JSON.parse(await readFile(configFile, 'utf-8')) as Partial<OrchestratorConfig>;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const updatedFileConfig = applyNetworkConfigSets(fileConfig, args.networkSet ?? []);
+  OrchestratorConfigSchema.parse(updatedFileConfig);
+
+  await mkdir(dirname(configFile), { recursive: true });
+  await writeFile(configFile, JSON.stringify(updatedFileConfig, null, 2) + '\n', 'utf-8');
+  return configFile;
 }
 
 function createDefaultNetworkDeps(root: string): NetworkCommandDeps {
@@ -602,6 +624,10 @@ export async function runNetworkCommand(
   }
 
   if (action === 'config') {
+    if (args.networkSet && args.networkSet.length > 0) {
+      const configFile = await persistNetworkConfigSets(args, paths);
+      deps.print(`Saved network config to ${configFile}.`);
+    }
     deps.print(JSON.stringify({
       network: config.network,
       chat: config.chat,

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -57,6 +57,22 @@ describe('Config loader', () => {
     expect(config.maxCritiqueIterations).toBe(5);
   });
 
+  it('loads the default operator config file when --config is omitted', async () => {
+    const filePath = join(tmpdir(), `beast-default-config-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({ chat: { model: 'persisted-model' } }));
+
+    const config = await loadConfig(makeArgs(), filePath);
+    expect(config.chat.model).toBe('persisted-model');
+  });
+
+  it('ignores a missing default operator config file', async () => {
+    const filePath = join(tmpdir(), `missing-beast-default-config-${Date.now()}.json`);
+
+    const config = await loadConfig(makeArgs(), filePath);
+    expect(config.chat.model).toBe('claude-sonnet-4-6');
+  });
+
   it('deep merges nested network config from file', async () => {
     const filePath = join(tmpdir(), `beast-network-config-${Date.now()}.json`);
     tmpFiles.push(filePath);

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { CliArgs } from '../../../src/cli/args.js';
 import { runNetworkCommand } from '../../../src/cli/run.js';
@@ -41,6 +44,14 @@ function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
   };
 }
 
+function makePaths(root = '/repo/frankenbeast'): { frankenbeastDir: string; configFile: string } {
+  const frankenbeastDir = join(root, '.fbeast');
+  return {
+    frankenbeastDir,
+    configFile: join(frankenbeastDir, 'config.json'),
+  };
+}
+
 function makeService(id: ResolvedNetworkService['id']): ResolvedNetworkService {
   return {
     id,
@@ -75,9 +86,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'up', networkDetached: true }),
       defaultConfig(),
       '/repo/frankenbeast',
-      {
-        frankenbeastDir: '/repo/frankenbeast/.fbeast',
-      },
+      makePaths(),
       {
         resolveServices: vi.fn(() => services),
         createSupervisor: vi.fn(() => ({
@@ -110,7 +119,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'up', networkDetached: true }),
       defaultConfig(),
       '/repo/frankenbeast',
-      { frankenbeastDir: '/repo/frankenbeast/.fbeast' },
+      makePaths(),
       {
         resolveServices: vi.fn(() => services),
         createSupervisor: vi.fn(() => ({
@@ -145,7 +154,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'up', networkDetached: true }),
       defaultConfig(),
       '/repo/frankenbeast',
-      { frankenbeastDir: '/repo/frankenbeast/.fbeast' },
+      makePaths(),
       {
         resolveServices: vi.fn(() => [makeService('chat-server')]),
         createSupervisor: vi.fn(() => ({
@@ -174,9 +183,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'down' }),
       defaultConfig(),
       '/repo/frankenbeast',
-      {
-        frankenbeastDir: '/repo/frankenbeast/.fbeast',
-      },
+      makePaths(),
       {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(() => ({
@@ -208,9 +215,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'status' }),
       defaultConfig(),
       '/repo/frankenbeast',
-      {
-        frankenbeastDir: '/repo/frankenbeast/.fbeast',
-      },
+      makePaths(),
       {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(() => ({
@@ -261,21 +266,21 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'start', networkTarget: 'dashboard-web', networkDetached: true }),
       defaultConfig(),
       '/repo/frankenbeast',
-      { frankenbeastDir: '/repo/frankenbeast/.fbeast' },
+      makePaths(),
       deps,
     );
     await runNetworkCommand(
       makeArgs({ networkAction: 'stop', networkTarget: 'dashboard-web' }),
       defaultConfig(),
       '/repo/frankenbeast',
-      { frankenbeastDir: '/repo/frankenbeast/.fbeast' },
+      makePaths(),
       deps,
     );
     await runNetworkCommand(
       makeArgs({ networkAction: 'restart', networkTarget: 'all', networkDetached: true }),
       defaultConfig(),
       '/repo/frankenbeast',
-      { frankenbeastDir: '/repo/frankenbeast/.fbeast' },
+      makePaths(),
       deps,
     );
 
@@ -292,9 +297,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'logs', networkTarget: 'chat-server' }),
       defaultConfig(),
       '/repo/frankenbeast',
-      {
-        frankenbeastDir: '/repo/frankenbeast/.fbeast',
-      },
+      makePaths(),
       {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(() => ({
@@ -315,6 +318,57 @@ describe('runNetworkCommand', () => {
     expect(print).toHaveBeenCalledWith(expect.stringContaining('/tmp/chat-server.log'));
   });
 
+  it('persists config --set changes to the operator config file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'frankenbeast-network-config-'));
+    const configFile = join(root, 'custom-config.json');
+    try {
+      await writeFile(configFile, JSON.stringify({
+        chat: { model: 'old-model' },
+        dashboard: { port: 5173 },
+      }, null, 2) + '\n', 'utf-8');
+
+      const config = defaultConfig();
+      config.chat.model = 'new-model';
+      config.dashboard.port = 6000;
+      const print = vi.fn();
+
+      await runNetworkCommand(
+        makeArgs({
+          networkAction: 'config',
+          networkSet: ['chat.model=new-model', 'dashboard.port=6000'],
+          config: configFile,
+        }),
+        config,
+        root,
+        makePaths(root),
+        {
+          resolveServices: vi.fn(() => []),
+          createSupervisor: vi.fn(() => ({
+            up: vi.fn(),
+            down: vi.fn(),
+            status: vi.fn(),
+            stop: vi.fn(),
+            logs: vi.fn(),
+          })),
+          print,
+          printError: vi.fn(),
+          renderHelp: () => 'network help',
+          waitForShutdown: vi.fn(async () => undefined),
+        },
+      );
+
+      const saved = JSON.parse(await readFile(configFile, 'utf-8')) as {
+        chat: { model: string };
+        dashboard: { port: number };
+      };
+      expect(saved.chat.model).toBe('new-model');
+      expect(saved.dashboard.port).toBe(6000);
+      expect(print).toHaveBeenCalledWith(`Saved network config to ${configFile}.`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('help prints a man-style command reference', async () => {
     const print = vi.fn();
 
@@ -322,9 +376,7 @@ describe('runNetworkCommand', () => {
       makeArgs({ networkAction: 'help' }),
       defaultConfig(),
       '/repo/frankenbeast',
-      {
-        frankenbeastDir: '/repo/frankenbeast/.fbeast',
-      },
+      makePaths(),
       {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(),

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -369,6 +369,48 @@ describe('runNetworkCommand', () => {
     }
   });
 
+  it('persists config --set changes to the default operator config file when --config is omitted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'frankenbeast-network-default-config-'));
+    const paths = makePaths(root);
+    try {
+      const config = defaultConfig();
+      config.dashboard.port = 6000;
+      const print = vi.fn();
+
+      await runNetworkCommand(
+        makeArgs({
+          networkAction: 'config',
+          networkSet: ['dashboard.port=6000'],
+        }),
+        config,
+        root,
+        paths,
+        {
+          resolveServices: vi.fn(() => []),
+          createSupervisor: vi.fn(() => ({
+            up: vi.fn(),
+            down: vi.fn(),
+            status: vi.fn(),
+            stop: vi.fn(),
+            logs: vi.fn(),
+          })),
+          print,
+          printError: vi.fn(),
+          renderHelp: () => 'network help',
+          waitForShutdown: vi.fn(async () => undefined),
+        },
+      );
+
+      const saved = JSON.parse(await readFile(paths.configFile, 'utf-8')) as {
+        dashboard: { port: number };
+      };
+      expect(saved.dashboard.port).toBe(6000);
+      expect(print).toHaveBeenCalledWith(`Saved network config to ${paths.configFile}.`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('help prints a man-style command reference', async () => {
     const print = vi.fn();
 


### PR DESCRIPTION
## Summary
- Persist `network config --set` assignments to the configured JSON config file (`--config` or .fbeast/config.json).
- Preserve existing config file contents while validating the updated config before writing.
- Add a regression test for persisted network config assignments.

Closes #399

## Test plan
- `npm --workspace packages/franken-orchestrator test -- tests/unit/cli/network-run.test.ts` ✅
- `npm --workspace packages/franken-orchestrator run typecheck` ❌ existing unrelated `@franken/types` export error: `makeTokenSpend` not exported
- `npm --workspace packages/franken-orchestrator test` ❌ existing unrelated observer adapter failures due `makeTokenSpend is not a function`