### PR TITLE
fix(governor): verify approval signatures over raw body

### DIFF
--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -23,6 +23,49 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
+const GOVERNOR_SIGNATURE_PREFIX = 'sha256=';
+const SHA256_HEX_LENGTH = 64;
+
+type GovernorSignatureVerificationResult =
+  | { ok: true }
+  | { ok: false; reason: 'missing' | 'malformed' | 'invalid' };
+
+function normalizeGovernorSignature(signature: string): Buffer | null {
+  const trimmed = signature.trim();
+  if (!trimmed.toLowerCase().startsWith(GOVERNOR_SIGNATURE_PREFIX)) {
+    return null;
+  }
+
+  const hex = trimmed.slice(GOVERNOR_SIGNATURE_PREFIX.length);
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length !== SHA256_HEX_LENGTH) {
+    return null;
+  }
+
+  return Buffer.from(hex.toLowerCase(), 'hex');
+}
+
+function verifyGovernorSignature(
+  signature: string | undefined,
+  rawBody: Buffer,
+  signingSecret: string,
+): GovernorSignatureVerificationResult {
+  if (!signature) {
+    return { ok: false, reason: 'missing' };
+  }
+
+  const provided = normalizeGovernorSignature(signature);
+  if (!provided) {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  const expected = createHmac('sha256', signingSecret).update(rawBody).digest();
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    return { ok: false, reason: 'invalid' };
+  }
+
+  return { ok: true };
+}
+
 /**
  * Map a raw Slack action_id into a domain decision (ResponseCode).
  * Returns `null` for unrecognized actions so the caller can reject the
@@ -89,7 +132,13 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
   // POST /v1/approval/respond — respond to an approval request
   app.post('/v1/approval/respond', async (c) => {
-    const body = await c.req.json();
+    const rawBody = Buffer.from(await c.req.arrayBuffer());
+    let body: { requestId?: string; decision?: string };
+    try {
+      body = rawBody.length > 0 ? JSON.parse(rawBody.toString('utf8')) : {};
+    } catch {
+      return c.json({ error: { message: 'Malformed JSON body' } }, 400);
+    }
 
     // Fail closed: unsigned approval responses are rejected unless a signing
     // secret is configured (then verified) or an explicit test flag is set.
@@ -98,17 +147,18 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
         return c.json({ error: { message: 'Signing secret required for approval responses' } }, 401);
       }
     } else {
-      const signature = c.req.header('x-governor-signature');
-      if (!signature) {
+      const verification = verifyGovernorSignature(
+        c.req.header('x-governor-signature'),
+        rawBody,
+        options.signingSecret,
+      );
+      if (!verification.ok && verification.reason === 'missing') {
         return c.json({ error: { message: 'Missing signature' } }, 401);
       }
-
-      const rawBody = JSON.stringify(body);
-      const expected = createHmac('sha256', options.signingSecret)
-        .update(rawBody)
-        .digest('hex');
-
-      if (signature !== `sha256=${expected}`) {
+      if (!verification.ok && verification.reason === 'malformed') {
+        return c.json({ error: { message: 'Malformed signature' } }, 401);
+      }
+      if (!verification.ok) {
         return c.json({ error: { message: 'Invalid signature' } }, 401);
       }
     }

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -45,6 +45,22 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/approval/respond', () => {
+    function governorSignature(rawBody: string, secret: string): string {
+      return `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+    }
+
+    async function seedResponseApproval(app: ReturnType<typeof createGovernorApp>, requestId: string) {
+      await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requestId,
+          taskId: 'task-1',
+          summary: 'Deploy',
+        }),
+      });
+    }
+
     it('resolves a pending approval', async () => {
       const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
 
@@ -137,13 +153,12 @@ describe('Governor Hono Server', () => {
 
       // Respond with valid signature
       const payload = JSON.stringify({ requestId: 'req-2', decision: 'APPROVE' });
-      const signature = createHmac('sha256', secret).update(payload).digest('hex');
 
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-governor-signature': `sha256=${signature}`,
+          'x-governor-signature': governorSignature(payload, secret),
         },
         body: payload,
       });
@@ -151,7 +166,70 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(200);
     });
 
-    it('rejects invalid signature', async () => {
+    it('verifies approval HMAC over raw body bytes including whitespace', async () => {
+      const secret = 'test-secret';
+      const app = createGovernorApp({ signingSecret: secret });
+      await seedResponseApproval(app, 'req-raw-spacing');
+
+      const payload = '{\n  "requestId" : "req-raw-spacing",\n  "decision" : "APPROVE"\n}';
+
+      const res = await app.request('/v1/approval/respond', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': governorSignature(payload, secret),
+        },
+        body: payload,
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('resolved');
+    });
+
+    it('requires signatures to match the exact raw body instead of parsed key ordering', async () => {
+      const secret = 'test-secret';
+      const app = createGovernorApp({ signingSecret: secret });
+      await seedResponseApproval(app, 'req-key-order');
+
+      const payload = '{"decision":"APPROVE","requestId":"req-key-order"}';
+      const canonicalButDifferentOrder = JSON.stringify({ requestId: 'req-key-order', decision: 'APPROVE' });
+
+      const res = await app.request('/v1/approval/respond', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': governorSignature(canonicalButDifferentOrder, secret),
+        },
+        body: payload,
+      });
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.message).toBe('Invalid signature');
+    });
+
+    it('accepts normalized sha256 hex signatures through the timing-safe compare path', async () => {
+      const secret = 'test-secret';
+      const app = createGovernorApp({ signingSecret: secret });
+      await seedResponseApproval(app, 'req-upper-hex');
+
+      const payload = JSON.stringify({ requestId: 'req-upper-hex', decision: 'APPROVE' });
+      const signature = governorSignature(payload, secret).toUpperCase();
+
+      const res = await app.request('/v1/approval/respond', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': signature,
+        },
+        body: payload,
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects invalid signature using timing-safe hex comparison', async () => {
       const app = createGovernorApp({ signingSecret: 'secret' });
 
       await app.request('/v1/approval/request', {
@@ -168,12 +246,30 @@ describe('Governor Hono Server', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-governor-signature': 'sha256=invalid',
+          'x-governor-signature': `sha256=${'0'.repeat(64)}`,
         },
         body: JSON.stringify({ requestId: 'req-3', decision: 'APPROVE' }),
       });
 
       expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.message).toBe('Invalid signature');
+    });
+
+    it('returns a clear 401 for a malformed signature', async () => {
+      const app = createGovernorApp({ signingSecret: 'secret' });
+      const res = await app.request('/v1/approval/respond', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': 'sha256=not-hex',
+        },
+        body: JSON.stringify({ requestId: 'req-malformed', decision: 'APPROVE' }),
+      });
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.message).toBe('Malformed signature');
     });
 
     it('rejects unsigned approval responses when no signing secret is configured', async () => {
@@ -195,6 +291,8 @@ describe('Governor Hono Server', () => {
       });
 
       expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.message).toBe('Missing signature');
     });
   });
 


### PR DESCRIPTION
Closes #429

## Summary
- verify governor approval response HMACs over the exact raw request body bytes
- normalize `sha256=<hex>` signatures and compare digest bytes with `timingSafeEqual`
- return distinct 401 messages for missing, malformed, and invalid signatures
- add regression tests for raw spacing/key ordering and timing-safe hex compare paths

## Test plan
- `npm test --workspace @franken/governor -- tests/unit/server/app.test.ts`
- `npm run typecheck --workspace @franken/governor`
- `npm test --workspace @franken/governor`
- `npm run typecheck` (known unrelated failure: `franken-orchestrator` imports missing `makeTokenSpend` from `@franken/types`)
