### PR TITLE
fix(cli): make beasts catalog exit cleanly

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -27,6 +27,7 @@ export interface BeastServiceBundle {
   metrics: PrometheusBeastMetrics;
   eventBus: BeastEventBus;
   ticketStore: SseConnectionTicketStore;
+  dispose(): void;
 }
 
 export function createBeastServices(paths: BeastServicePaths): BeastServiceBundle {
@@ -69,5 +70,9 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     metrics,
     eventBus,
     ticketStore,
+    dispose: () => {
+      ticketStore.destroy();
+      repository.close();
+    },
   };
 }

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -5,19 +5,33 @@ import { collectBeastConfig } from './beast-prompts.js';
 import type { ProjectPaths } from './project-root.js';
 import { createBeastControlClient } from './beast-control-client.js';
 
+type BeastControlClient = Omit<ReturnType<typeof createBeastControlClient>, 'dispose'> & {
+  dispose?: () => void;
+};
+
 interface BeastCommandDeps {
   args: CliArgs;
   io: InterviewIO;
   paths: ProjectPaths;
   print(message: string): void;
-  control?: ReturnType<typeof createBeastControlClient>;
+  control?: BeastControlClient;
 }
 
 export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> {
   const { args, io, paths, print } = deps;
   const services = createBeastServices(paths);
-  const control = deps.control ?? createBeastControlClient(paths);
+  let control = deps.control;
+  let ownsControl = false;
+  const getControl = (): BeastControlClient => {
+    if (!control) {
+      control = createBeastControlClient(paths);
+      ownsControl = true;
+    }
+    const activeControl = control;
+    return activeControl;
+  };
   const actor = process.env.USER ?? 'operator';
+  let keepServicesAlive = false;
 
   try {
     switch (args.beastAction) {
@@ -47,6 +61,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           startNow: true,
           ...(args.moduleConfig ? { moduleConfig: args.moduleConfig } : {}),
         });
+        keepServicesAlive = true;
         print(`Spawned ${run.definitionId} as ${run.id}`);
         return;
       }
@@ -96,13 +111,13 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
       }
       case 'resume': {
         if (!args.beastTarget) throw new Error('beasts resume requires an agent id');
-        const run = await control.resumeAgent(args.beastTarget, actor);
+        const run = await getControl().resumeAgent(args.beastTarget, actor);
         print(`Resumed ${run.id}`);
         return;
       }
       case 'delete': {
         if (!args.beastTarget) throw new Error('beasts delete requires an agent id');
-        await control.deleteAgent(args.beastTarget);
+        await getControl().deleteAgent(args.beastTarget);
         print(`Deleted ${args.beastTarget}`);
         return;
       }
@@ -110,6 +125,11 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
         throw new Error('Unknown beasts command');
     }
   } finally {
-    services.dispose();
+    if (!keepServicesAlive) {
+      services.dispose();
+    }
+    if (ownsControl) {
+      control?.dispose();
+    }
   }
 }

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -4,10 +4,22 @@ import { createBeastServices } from '../beasts/create-beast-services.js';
 import { collectBeastConfig } from './beast-prompts.js';
 import type { ProjectPaths } from './project-root.js';
 import { createBeastControlClient } from './beast-control-client.js';
+import type { BeastRun } from '../beasts/types.js';
 
 type BeastControlClient = Omit<ReturnType<typeof createBeastControlClient>, 'dispose'> & {
   dispose?: () => void;
 };
+
+const liveRunStatuses = new Set<BeastRun['status']>([
+  'queued',
+  'interviewing',
+  'running',
+  'pending_approval',
+]);
+
+function shouldKeepServicesAliveForRun(run: Pick<BeastRun, 'status' | 'currentAttemptId'>): boolean {
+  return Boolean(run.currentAttemptId && liveRunStatuses.has(run.status));
+}
 
 interface BeastCommandDeps {
   args: CliArgs;
@@ -61,7 +73,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           startNow: true,
           ...(args.moduleConfig ? { moduleConfig: args.moduleConfig } : {}),
         });
-        keepServicesAlive = true;
+        keepServicesAlive = shouldKeepServicesAliveForRun(run);
         print(`Spawned ${run.definitionId} as ${run.id}`);
         return;
       }
@@ -106,13 +118,14 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           throw new Error('beasts restart requires a run id');
         }
         const run = await services.runs.restart(args.beastTarget, actor);
-        keepServicesAlive = true;
+        keepServicesAlive = shouldKeepServicesAliveForRun(run);
         print(`Restarted ${run.id}`);
         return;
       }
       case 'resume': {
         if (!args.beastTarget) throw new Error('beasts resume requires an agent id');
         const run = await getControl().resumeAgent(args.beastTarget, actor);
+        keepServicesAlive = shouldKeepServicesAliveForRun(run);
         print(`Resumed ${run.id}`);
         return;
       }
@@ -129,7 +142,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
     if (!keepServicesAlive) {
       services.dispose();
     }
-    if (ownsControl) {
+    if (ownsControl && !keepServicesAlive) {
       control?.dispose?.();
     }
   }

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -19,93 +19,97 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
   const control = deps.control ?? createBeastControlClient(paths);
   const actor = process.env.USER ?? 'operator';
 
-  switch (args.beastAction) {
-    case 'catalog': {
-      const catalog = services.catalog.listDefinitions()
-        .map((definition) => `${definition.id}: ${definition.description}`)
-        .join('\n');
-      print(catalog);
-      return;
-    }
-    case 'create':
-    case 'spawn': {
-      if (!args.beastTarget) {
-        throw new Error('beasts spawn requires a definition id');
+  try {
+    switch (args.beastAction) {
+      case 'catalog': {
+        const catalog = services.catalog.listDefinitions()
+          .map((definition) => `${definition.id}: ${definition.description}`)
+          .join('\n');
+        print(catalog);
+        return;
       }
-      const definition = services.catalog.getDefinition(args.beastTarget);
-      if (!definition) {
-        throw new Error(`Unknown Beast definition: ${args.beastTarget}`);
+      case 'create':
+      case 'spawn': {
+        if (!args.beastTarget) {
+          throw new Error('beasts spawn requires a definition id');
+        }
+        const definition = services.catalog.getDefinition(args.beastTarget);
+        if (!definition) {
+          throw new Error(`Unknown Beast definition: ${args.beastTarget}`);
+        }
+        const config = await collectBeastConfig(io, definition);
+        const run = await services.dispatch.createRun({
+          definitionId: definition.id,
+          config,
+          dispatchedBy: 'cli',
+          dispatchedByUser: actor,
+          executionMode: 'process',
+          startNow: true,
+          ...(args.moduleConfig ? { moduleConfig: args.moduleConfig } : {}),
+        });
+        print(`Spawned ${run.definitionId} as ${run.id}`);
+        return;
       }
-      const config = await collectBeastConfig(io, definition);
-      const run = await services.dispatch.createRun({
-        definitionId: definition.id,
-        config,
-        dispatchedBy: 'cli',
-        dispatchedByUser: actor,
-        executionMode: 'process',
-        startNow: true,
-        ...(args.moduleConfig ? { moduleConfig: args.moduleConfig } : {}),
-      });
-      print(`Spawned ${run.definitionId} as ${run.id}`);
-      return;
-    }
-    case 'list': {
-      const runs = services.runs.listRuns();
-      print(JSON.stringify(runs, null, 2));
-      return;
-    }
-    case 'status': {
-      if (!args.beastTarget) {
-        throw new Error('beasts status requires a run id');
+      case 'list': {
+        const runs = services.runs.listRuns();
+        print(JSON.stringify(runs, null, 2));
+        return;
       }
-      print(JSON.stringify(services.runs.getRun(args.beastTarget), null, 2));
-      return;
-    }
-    case 'logs': {
-      if (!args.beastTarget) {
-        throw new Error('beasts logs requires a run id');
+      case 'status': {
+        if (!args.beastTarget) {
+          throw new Error('beasts status requires a run id');
+        }
+        print(JSON.stringify(services.runs.getRun(args.beastTarget), null, 2));
+        return;
       }
-      const logs = await services.runs.readLogs(args.beastTarget);
-      print(logs.join('\n'));
-      return;
-    }
-    case 'stop': {
-      if (!args.beastTarget) {
-        throw new Error('beasts stop requires a run id');
+      case 'logs': {
+        if (!args.beastTarget) {
+          throw new Error('beasts logs requires a run id');
+        }
+        const logs = await services.runs.readLogs(args.beastTarget);
+        print(logs.join('\n'));
+        return;
       }
-      const run = await services.runs.stop(args.beastTarget, actor);
-      print(`Stopped ${run.id}`);
-      return;
-    }
-    case 'kill': {
-      if (!args.beastTarget) {
-        throw new Error('beasts kill requires a run id');
+      case 'stop': {
+        if (!args.beastTarget) {
+          throw new Error('beasts stop requires a run id');
+        }
+        const run = await services.runs.stop(args.beastTarget, actor);
+        print(`Stopped ${run.id}`);
+        return;
       }
-      const run = await services.runs.kill(args.beastTarget, actor);
-      print(`Killed ${run.id}`);
-      return;
-    }
-    case 'restart': {
-      if (!args.beastTarget) {
-        throw new Error('beasts restart requires a run id');
+      case 'kill': {
+        if (!args.beastTarget) {
+          throw new Error('beasts kill requires a run id');
+        }
+        const run = await services.runs.kill(args.beastTarget, actor);
+        print(`Killed ${run.id}`);
+        return;
       }
-      const run = await services.runs.restart(args.beastTarget, actor);
-      print(`Restarted ${run.id}`);
-      return;
+      case 'restart': {
+        if (!args.beastTarget) {
+          throw new Error('beasts restart requires a run id');
+        }
+        const run = await services.runs.restart(args.beastTarget, actor);
+        print(`Restarted ${run.id}`);
+        return;
+      }
+      case 'resume': {
+        if (!args.beastTarget) throw new Error('beasts resume requires an agent id');
+        const run = await control.resumeAgent(args.beastTarget, actor);
+        print(`Resumed ${run.id}`);
+        return;
+      }
+      case 'delete': {
+        if (!args.beastTarget) throw new Error('beasts delete requires an agent id');
+        await control.deleteAgent(args.beastTarget);
+        print(`Deleted ${args.beastTarget}`);
+        return;
+      }
+      default:
+        throw new Error('Unknown beasts command');
     }
-    case 'resume': {
-      if (!args.beastTarget) throw new Error('beasts resume requires an agent id');
-      const run = await control.resumeAgent(args.beastTarget, actor);
-      print(`Resumed ${run.id}`);
-      return;
-    }
-    case 'delete': {
-      if (!args.beastTarget) throw new Error('beasts delete requires an agent id');
-      await control.deleteAgent(args.beastTarget);
-      print(`Deleted ${args.beastTarget}`);
-      return;
-    }
-    default:
-      throw new Error('Unknown beasts command');
+  } finally {
+    services.dispose();
   }
 }

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -106,6 +106,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           throw new Error('beasts restart requires a run id');
         }
         const run = await services.runs.restart(args.beastTarget, actor);
+        keepServicesAlive = true;
         print(`Restarted ${run.id}`);
         return;
       }
@@ -129,7 +130,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
       services.dispose();
     }
     if (ownsControl) {
-      control?.dispose();
+      control?.dispose?.();
     }
   }
 }

--- a/packages/franken-orchestrator/src/cli/beast-control-client.ts
+++ b/packages/franken-orchestrator/src/cli/beast-control-client.ts
@@ -34,5 +34,6 @@ export function createBeastControlClient(paths: ProjectPaths) {
     },
     createRun: (input: Parameters<typeof services.dispatch.createRun>[0]) =>
       services.dispatch.createRun(input),
+    dispose: () => services.dispose(),
   };
 }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -53,12 +53,16 @@ import { resolveSecurityConfig } from '../middleware/security-profiles.js';
 /**
  * Creates an InterviewIO backed by stdin/stdout.
  */
-export function createStdinIO(): InterviewIO {
+export function createStdinIO(): InterviewIO & { close(): void } {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   return {
     ask: (question: string) =>
       new Promise<string>((resolve) => rl.question(`${question}\n> `, resolve)),
     display: (message: string) => console.log(message),
+    close: () => {
+      rl.close();
+      process.stdin.pause();
+    },
   };
 }
 
@@ -262,24 +266,34 @@ export async function main(): Promise<void> {
   }
 
   if (args.subcommand === 'beasts') {
-    await handleBeastCommand({
-      args,
-      io: createStdinIO(),
-      paths,
-      print: console.log,
-      control: createBeastControlClient(paths),
-    });
+    const io = createStdinIO();
+    try {
+      await handleBeastCommand({
+        args,
+        io,
+        paths,
+        print: console.log,
+        control: createBeastControlClient(paths),
+      });
+    } finally {
+      io.close();
+    }
     return;
   }
 
   if (args.subcommand === 'init') {
-    await handleInitCommand({
-      args,
-      config,
-      io: createStdinIO(),
-      paths,
-      print: console.log,
-    });
+    const io = createStdinIO();
+    try {
+      await handleInitCommand({
+        args,
+        config,
+        io,
+        paths,
+        print: console.log,
+      });
+    } finally {
+      io.close();
+    }
     return;
   }
 
@@ -686,8 +700,12 @@ import { realpathSync } from 'node:fs';
 const self = fileURLToPath(import.meta.url);
 const caller = process.argv[1];
 if (caller && realpathSync(caller) === realpathSync(self)) {
-  main().catch((error) => {
-    console.error('Fatal:', error instanceof Error ? error.message : error);
-    process.exit(1);
-  });
+  main()
+    .then(() => {
+      process.exit(process.exitCode ?? 0);
+    })
+    .catch((error) => {
+      console.error('Fatal:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    });
 }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -701,7 +701,13 @@ const self = fileURLToPath(import.meta.url);
 const caller = process.argv[1];
 
 export function shouldForceDirectCliExit(argv: readonly string[] = process.argv): boolean {
-  return argv[2] !== 'chat-server';
+  if (argv[2] === 'chat-server') {
+    return false;
+  }
+  if (argv[2] === 'beasts' && ['create', 'spawn', 'restart'].includes(argv[3] ?? '')) {
+    return false;
+  }
+  return true;
 }
 
 export function runDirectCli(
@@ -712,7 +718,13 @@ export function runDirectCli(
   void entrypoint()
     .then(() => {
       if (shouldExitOnSuccess()) {
-        exit(process.exitCode ?? 0);
+        let exitCode = 0;
+        if (typeof process.exitCode === 'number') {
+          exitCode = process.exitCode;
+        } else if (typeof process.exitCode === 'string') {
+          exitCode = Number(process.exitCode);
+        }
+        exit(exitCode);
       }
     })
     .catch((error) => {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -7,7 +7,6 @@ import { spawn } from 'node:child_process';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
 import { handleBeastCommand } from './beast-cli.js';
-import { createBeastControlClient } from './beast-control-client.js';
 import { handleInitCommand } from './init-command.js';
 import { handleSkillCommand } from './skill-cli.js';
 import { handleSecurityCommand } from './security-cli.js';
@@ -273,7 +272,6 @@ export async function main(): Promise<void> {
         io,
         paths,
         print: console.log,
-        control: createBeastControlClient(paths),
       });
     } finally {
       io.close();
@@ -701,13 +699,8 @@ const self = fileURLToPath(import.meta.url);
 const caller = process.argv[1];
 
 export function shouldForceDirectCliExit(argv: readonly string[] = process.argv): boolean {
-  if (argv[2] === 'chat-server') {
-    return false;
-  }
-  if (argv[2] === 'beasts' && ['create', 'spawn', 'restart'].includes(argv[3] ?? '')) {
-    return false;
-  }
-  return true;
+  void argv;
+  return false;
 }
 
 export function runDirectCli(
@@ -718,13 +711,9 @@ export function runDirectCli(
   void entrypoint()
     .then(() => {
       if (shouldExitOnSuccess()) {
-        let exitCode = 0;
-        if (typeof process.exitCode === 'number') {
-          exitCode = process.exitCode;
-        } else if (typeof process.exitCode === 'string') {
-          exitCode = Number(process.exitCode);
-        }
-        exit(exitCode);
+        // Successful direct CLI invocations exit naturally after command-specific
+        // cleanup disposes blocking handles. Avoid process.exit(0), which can
+        // truncate asynchronous stdout writes for short commands like beasts logs.
       }
     })
     .catch((error) => {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -699,13 +699,28 @@ import { realpathSync } from 'node:fs';
 
 const self = fileURLToPath(import.meta.url);
 const caller = process.argv[1];
-if (caller && realpathSync(caller) === realpathSync(self)) {
-  main()
+
+export function shouldForceDirectCliExit(argv: readonly string[] = process.argv): boolean {
+  return argv[2] !== 'chat-server';
+}
+
+export function runDirectCli(
+  entrypoint: () => Promise<void> = main,
+  exit: (code?: number) => never = process.exit,
+  shouldExitOnSuccess: () => boolean = shouldForceDirectCliExit,
+): void {
+  void entrypoint()
     .then(() => {
-      process.exit(process.exitCode ?? 0);
+      if (shouldExitOnSuccess()) {
+        exit(process.exitCode ?? 0);
+      }
     })
     .catch((error) => {
       console.error('Fatal:', error instanceof Error ? error.message : error);
-      process.exit(1);
+      exit(1);
     });
+}
+
+if (caller && realpathSync(caller) === realpathSync(self)) {
+  runDirectCli();
 }

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -42,7 +42,7 @@ function makeDeps(overrides: Partial<Parameters<typeof handleBeastCommand>[0]> =
       readLogs: vi.fn(),
       stopRun: vi.fn(),
       restartRun: vi.fn(),
-      resumeAgent: vi.fn().mockResolvedValue({ id: 'run-42' }),
+      resumeAgent: vi.fn().mockResolvedValue({ id: 'run-42', status: 'running', currentAttemptId: 'attempt-42' }),
       deleteAgent: vi.fn().mockResolvedValue({ id: 'agent-1' }),
       createRun: vi.fn(),
       dispose: vi.fn(),
@@ -80,7 +80,12 @@ describe('handleBeastCommand() spawn', () => {
       interviewPrompts: [],
       configSchema: { parse: vi.fn(() => ({})) },
     });
-    mockServices.dispatch.createRun.mockResolvedValue({ id: 'run-1', definitionId: 'design-interview' });
+    mockServices.dispatch.createRun.mockResolvedValue({
+      id: 'run-1',
+      definitionId: 'design-interview',
+      status: 'running',
+      currentAttemptId: 'attempt-1',
+    });
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'spawn', beastTarget: 'design-interview' } as CliArgs,
     });
@@ -105,11 +110,34 @@ describe('handleBeastCommand() spawn', () => {
     await expect(handleBeastCommand(deps)).rejects.toThrow('Unknown Beast definition: missing');
     expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
+
+  it('disposes services if spawn returns a failed run after executor start fails', async () => {
+    mockServices.catalog.getDefinition.mockReturnValue({
+      id: 'design-interview',
+      description: 'Design interview',
+      interviewPrompts: [],
+      configSchema: { parse: vi.fn(() => ({})) },
+    });
+    mockServices.dispatch.createRun.mockResolvedValue({
+      id: 'run-1',
+      definitionId: 'design-interview',
+      status: 'failed',
+      currentAttemptId: undefined,
+    });
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'spawn', beastTarget: 'design-interview' } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(deps.print).toHaveBeenCalledWith('Spawned design-interview as run-1');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('handleBeastCommand() restart', () => {
   it('leaves services alive after restarting an in-process executor', async () => {
-    mockServices.runs.restart.mockResolvedValue({ id: 'run-1' });
+    mockServices.runs.restart.mockResolvedValue({ id: 'run-1', status: 'running', currentAttemptId: 'attempt-1' });
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'restart', beastTarget: 'run-1' } as CliArgs,
     });
@@ -133,7 +161,7 @@ describe('handleBeastCommand() restart', () => {
 });
 
 describe('handleBeastCommand() resume', () => {
-  it('calls control.resumeAgent with agent id, prints result, and disposes services', async () => {
+  it('calls control.resumeAgent with agent id, prints result, and leaves services alive for a live run', async () => {
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'resume', beastTarget: 'agent-1' } as CliArgs,
     });
@@ -141,6 +169,20 @@ describe('handleBeastCommand() resume', () => {
     await handleBeastCommand(deps);
 
     expect(deps.control.resumeAgent).toHaveBeenCalledWith('agent-1', expect.any(String));
+    expect(deps.print).toHaveBeenCalledWith('Resumed run-42');
+    expect(mockServices.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes services if resume returns a non-live run', async () => {
+    const control = makeDeps().control;
+    control.resumeAgent = vi.fn().mockResolvedValue({ id: 'run-42', status: 'failed' });
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'resume', beastTarget: 'agent-1' } as CliArgs,
+      control,
+    });
+
+    await handleBeastCommand(deps);
+
     expect(deps.print).toHaveBeenCalledWith('Resumed run-42');
     expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -1,10 +1,29 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { handleBeastCommand } from '../../../src/cli/beast-cli.js';
 import type { CliArgs } from '../../../src/cli/args.js';
 import type { ProjectPaths } from '../../../src/cli/project-root.js';
 
+const mockServices = vi.hoisted(() => ({
+  catalog: {
+    listDefinitions: vi.fn(),
+    getDefinition: vi.fn(),
+  },
+  dispatch: {
+    createRun: vi.fn(),
+  },
+  runs: {
+    listRuns: vi.fn(),
+    getRun: vi.fn(),
+    readLogs: vi.fn(),
+    stop: vi.fn(),
+    kill: vi.fn(),
+    restart: vi.fn(),
+  },
+  dispose: vi.fn(),
+}));
+
 vi.mock('../../../src/beasts/create-beast-services.js', () => ({
-  createBeastServices: () => ({}),
+  createBeastServices: () => mockServices,
 }));
 
 vi.mock('../../../src/cli/beast-control-client.js', () => ({
@@ -15,7 +34,7 @@ function makeDeps(overrides: Partial<Parameters<typeof handleBeastCommand>[0]> =
   return {
     args: { subcommand: 'beasts' as const, beastAction: undefined, networkDetached: false, baseDir: '/tmp', budget: 10, provider: 'claude', noPr: false, verbose: false, reset: false, resume: false, cleanup: false, help: false, initVerify: false, initRepair: false, initNonInteractive: false } as CliArgs,
     io: { ask: vi.fn(), confirm: vi.fn(), choose: vi.fn(), print: vi.fn() } as any,
-    paths: { root: '/tmp', fbeast: '/tmp/.fbeast' } as ProjectPaths,
+    paths: { root: '/tmp', fbeast: '/tmp/.fbeast' } as unknown as ProjectPaths,
     print: vi.fn(),
     control: {
       listRuns: vi.fn(),
@@ -31,8 +50,29 @@ function makeDeps(overrides: Partial<Parameters<typeof handleBeastCommand>[0]> =
   };
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('handleBeastCommand() catalog', () => {
+  it('prints fixed Beast definitions and disposes services so the CLI can exit', async () => {
+    mockServices.catalog.listDefinitions.mockReturnValue([
+      { id: 'design-interview', description: 'Design interview' },
+      { id: 'chunk-plan', description: 'Chunk plan' },
+    ]);
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'catalog' } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(deps.print).toHaveBeenCalledWith('design-interview: Design interview\nchunk-plan: Chunk plan');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('handleBeastCommand() resume', () => {
-  it('calls control.resumeAgent with agent id and prints result', async () => {
+  it('calls control.resumeAgent with agent id, prints result, and disposes services', async () => {
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'resume', beastTarget: 'agent-1' } as CliArgs,
     });
@@ -41,19 +81,21 @@ describe('handleBeastCommand() resume', () => {
 
     expect(deps.control.resumeAgent).toHaveBeenCalledWith('agent-1', expect.any(String));
     expect(deps.print).toHaveBeenCalledWith('Resumed run-42');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it('throws if no beastTarget provided', async () => {
+  it('throws if no beastTarget provided and still disposes services', async () => {
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'resume' } as CliArgs,
     });
 
     await expect(handleBeastCommand(deps)).rejects.toThrow('beasts resume requires an agent id');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('handleBeastCommand() delete', () => {
-  it('calls control.deleteAgent with agent id and prints result', async () => {
+  it('calls control.deleteAgent with agent id, prints result, and disposes services', async () => {
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'delete', beastTarget: 'agent-1' } as CliArgs,
     });
@@ -62,13 +104,15 @@ describe('handleBeastCommand() delete', () => {
 
     expect(deps.control.deleteAgent).toHaveBeenCalledWith('agent-1');
     expect(deps.print).toHaveBeenCalledWith('Deleted agent-1');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it('throws if no beastTarget provided', async () => {
+  it('throws if no beastTarget provided and still disposes services', async () => {
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'delete' } as CliArgs,
     });
 
     await expect(handleBeastCommand(deps)).rejects.toThrow('beasts delete requires an agent id');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -107,6 +107,31 @@ describe('handleBeastCommand() spawn', () => {
   });
 });
 
+describe('handleBeastCommand() restart', () => {
+  it('leaves services alive after restarting an in-process executor', async () => {
+    mockServices.runs.restart.mockResolvedValue({ id: 'run-1' });
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'restart', beastTarget: 'run-1' } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(mockServices.runs.restart).toHaveBeenCalledWith('run-1', expect.any(String));
+    expect(deps.print).toHaveBeenCalledWith('Restarted run-1');
+    expect(mockServices.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes services if restart fails before a run is started', async () => {
+    mockServices.runs.restart.mockRejectedValue(new Error('missing run'));
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'restart', beastTarget: 'missing' } as CliArgs,
+    });
+
+    await expect(handleBeastCommand(deps)).rejects.toThrow('missing run');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('handleBeastCommand() resume', () => {
   it('calls control.resumeAgent with agent id, prints result, and disposes services', async () => {
     const deps = makeDeps({

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -45,6 +45,7 @@ function makeDeps(overrides: Partial<Parameters<typeof handleBeastCommand>[0]> =
       resumeAgent: vi.fn().mockResolvedValue({ id: 'run-42' }),
       deleteAgent: vi.fn().mockResolvedValue({ id: 'agent-1' }),
       createRun: vi.fn(),
+      dispose: vi.fn(),
     },
     ...overrides,
   };
@@ -67,6 +68,41 @@ describe('handleBeastCommand() catalog', () => {
     await handleBeastCommand(deps);
 
     expect(deps.print).toHaveBeenCalledWith('design-interview: Design interview\nchunk-plan: Chunk plan');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleBeastCommand() spawn', () => {
+  it('leaves services alive after starting an in-process executor', async () => {
+    mockServices.catalog.getDefinition.mockReturnValue({
+      id: 'design-interview',
+      description: 'Design interview',
+      interviewPrompts: [],
+      configSchema: { parse: vi.fn(() => ({})) },
+    });
+    mockServices.dispatch.createRun.mockResolvedValue({ id: 'run-1', definitionId: 'design-interview' });
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'spawn', beastTarget: 'design-interview' } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(mockServices.dispatch.createRun).toHaveBeenCalledWith(expect.objectContaining({
+      definitionId: 'design-interview',
+      executionMode: 'process',
+      startNow: true,
+    }));
+    expect(deps.print).toHaveBeenCalledWith('Spawned design-interview as run-1');
+    expect(mockServices.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes services if spawn fails before a run is started', async () => {
+    mockServices.catalog.getDefinition.mockReturnValue(undefined);
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'spawn', beastTarget: 'missing' } as CliArgs,
+    });
+
+    await expect(handleBeastCommand(deps)).rejects.toThrow('Unknown Beast definition: missing');
     expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -312,8 +312,11 @@ describe('runDirectCli', () => {
     expect(exit).toHaveBeenCalledWith(0);
   });
 
-  it('classifies chat-server as long-running and catalog as short-lived', () => {
+  it('classifies long-running commands and short-lived catalog commands', () => {
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'chat-server'])).toBe(false);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'spawn'])).toBe(false);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'create'])).toBe(false);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'restart'])).toBe(false);
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'catalog'])).toBe(true);
   });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -203,6 +203,7 @@ vi.mock('node:readline', () => ({
 import { resolvePhases, createStdinIO, main } from '../../../src/cli/run.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
+import { createInterface } from 'node:readline';
 
 // ── Tests ──
 
@@ -274,6 +275,18 @@ describe('createStdinIO', () => {
     const io = createStdinIO();
     const answer = await io.ask('What?');
     expect(answer).toBe('mock-answer');
+  });
+
+  it('close closes readline and pauses stdin so read-only commands can terminate', () => {
+    const pauseSpy = vi.spyOn(process.stdin, 'pause').mockImplementation(() => process.stdin);
+    const io = createStdinIO();
+    const readline = vi.mocked(createInterface).mock.results.at(-1)?.value;
+
+    io.close();
+
+    expect(readline.close).toHaveBeenCalled();
+    expect(pauseSpy).toHaveBeenCalled();
+    pauseSpy.mockRestore();
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -302,22 +302,24 @@ describe('runDirectCli', () => {
     expect(exit).not.toHaveBeenCalled();
   });
 
-  it('forces process.exit after successful short-lived direct commands', async () => {
+  it('lets successful direct commands exit naturally so stdout can drain', async () => {
     const entrypoint = vi.fn(async () => undefined);
     const exit = vi.fn() as unknown as (code?: number) => never;
 
     runDirectCli(entrypoint, exit, () => true);
     await Promise.resolve();
 
-    expect(exit).toHaveBeenCalledWith(0);
+    expect(exit).not.toHaveBeenCalled();
   });
 
-  it('classifies long-running commands and short-lived catalog commands', () => {
+  it('does not force successful direct CLI exits, including catalog and option-shifted beast actions', () => {
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'chat-server'])).toBe(false);
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'spawn'])).toBe(false);
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'create'])).toBe(false);
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'restart'])).toBe(false);
-    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'catalog'])).toBe(true);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'resume'])).toBe(false);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', '--base-dir', '/tmp', 'spawn'])).toBe(false);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'catalog'])).toBe(false);
   });
 
   it('exits nonzero when the direct CLI entrypoint rejects', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -200,7 +200,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, runDirectCli, shouldForceDirectCliExit } from '../../../src/cli/run.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
 import { createInterface } from 'node:readline';
@@ -287,6 +287,50 @@ describe('createStdinIO', () => {
     expect(readline.close).toHaveBeenCalled();
     expect(pauseSpy).toHaveBeenCalled();
     pauseSpy.mockRestore();
+  });
+});
+
+describe('runDirectCli', () => {
+  it('does not force process.exit after successful long-running chat-server startup', async () => {
+    const entrypoint = vi.fn(async () => undefined);
+    const exit = vi.fn() as unknown as (code?: number) => never;
+
+    runDirectCli(entrypoint, exit, () => false);
+    await Promise.resolve();
+
+    expect(entrypoint).toHaveBeenCalledTimes(1);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('forces process.exit after successful short-lived direct commands', async () => {
+    const entrypoint = vi.fn(async () => undefined);
+    const exit = vi.fn() as unknown as (code?: number) => never;
+
+    runDirectCli(entrypoint, exit, () => true);
+    await Promise.resolve();
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('classifies chat-server as long-running and catalog as short-lived', () => {
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'chat-server'])).toBe(false);
+    expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'catalog'])).toBe(true);
+  });
+
+  it('exits nonzero when the direct CLI entrypoint rejects', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const entrypoint = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const exit = vi.fn() as unknown as (code?: number) => never;
+
+    runDirectCli(entrypoint, exit);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith('Fatal:', 'boom');
+    errorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- dispose Beast service resources after CLI beast commands complete
- close stdin readline handles after beasts/init command dispatch
- add coverage for catalog output, service disposal, and stdin IO close behavior

Closes #401

## Test plan
- `git diff --check`
- `npx vitest run tests/unit/cli/beast-cli.test.ts tests/unit/cli/run.test.ts` from `packages/franken-orchestrator` (2 files passed, 31 tests passed)
- `timeout 8s npx tsx packages/franken-orchestrator/src/cli/run.ts beasts catalog; echo EXIT:$?` (printed catalog and EXIT:0)

## Known unrelated broad checks
- Handoff reported `npm --workspace packages/franken-orchestrator run typecheck` currently fails on pre-existing unrelated `makeTokenSpend` export errors.
- Handoff reported full orchestrator tests currently fail on broader workspace/package resolution and `makeTokenSpend` issues.