### PR TITLE
fix(mcp-suite): namespace Codex MCP server names

### DIFF
--- a/packages/franken-mcp-suite/src/cli/codex-server-names.ts
+++ b/packages/franken-mcp-suite/src/cli/codex-server-names.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { FbeastServer } from '../shared/config.js';
@@ -9,20 +9,21 @@ const CODEX_PROJECT_ID_FILE = join('.fbeast', 'codex-project-id');
 /**
  * Codex MCP server names are global, so fbeast registrations must be scoped to
  * the project root they serve. Keep the human-readable server prefix while
- * suffixing a stable root hash to avoid cross-repository collisions.
+ * suffixing a persisted project id to avoid cross-repository collisions and keep
+ * uninstall stable if the repository is moved or opened via another path.
  */
 export function codexProjectId(root: string): string {
   const persisted = readPersistedCodexProjectId(root);
   if (persisted) return persisted;
 
-  return codexProjectIdForPath(root);
+  return legacyCodexProjectIdForPath(root);
 }
 
 export function ensureCodexProjectId(root: string): string {
   const existing = readPersistedCodexProjectId(root);
   if (existing) return existing;
 
-  const projectId = codexProjectIdForPath(root);
+  const projectId = randomBytes(CODEX_NAME_HASH_LENGTH / 2).toString('hex');
   const fbeastDir = join(root, '.fbeast');
   mkdirSync(fbeastDir, { recursive: true });
   writeFileSync(join(root, CODEX_PROJECT_ID_FILE), `${projectId}\n`);
@@ -33,11 +34,13 @@ export function codexProjectIds(root: string): string[] {
   const ids = new Set<string>();
   const persisted = readPersistedCodexProjectId(root);
   if (persisted) ids.add(persisted);
-  ids.add(codexProjectIdForPath(root));
+  // Backward-compatible cleanup for prerelease registrations whose names were
+  // derived from the current root path before project ids were persisted.
+  ids.add(legacyCodexProjectIdForPath(root));
   return [...ids];
 }
 
-function codexProjectIdForPath(root: string): string {
+function legacyCodexProjectIdForPath(root: string): string {
   return createHash('sha256')
     .update(resolve(root))
     .digest('hex')

--- a/packages/franken-mcp-suite/src/cli/codex-server-names.ts
+++ b/packages/franken-mcp-suite/src/cli/codex-server-names.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+import type { FbeastServer } from '../shared/config.js';
+
+const CODEX_NAME_HASH_LENGTH = 12;
+
+/**
+ * Codex MCP server names are global, so fbeast registrations must be scoped to
+ * the project root they serve. Keep the human-readable server prefix while
+ * suffixing a stable root hash to avoid cross-repository collisions.
+ */
+export function codexProjectId(root: string): string {
+  return createHash('sha256')
+    .update(resolve(root))
+    .digest('hex')
+    .slice(0, CODEX_NAME_HASH_LENGTH);
+}
+
+export function codexServerName(root: string, server: FbeastServer | 'proxy'): string {
+  return `fbeast-${server}-${codexProjectId(root)}`;
+}
+
+export function codexServerNames(root: string, servers: readonly FbeastServer[], mode: 'standard' | 'proxy'): string[] {
+  if (mode === 'proxy') {
+    return [codexServerName(root, 'proxy')];
+  }
+
+  return servers.map((server) => codexServerName(root, server));
+}

--- a/packages/franken-mcp-suite/src/cli/codex-server-names.ts
+++ b/packages/franken-mcp-suite/src/cli/codex-server-names.ts
@@ -1,8 +1,10 @@
 import { createHash } from 'node:crypto';
-import { resolve } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import type { FbeastServer } from '../shared/config.js';
 
 const CODEX_NAME_HASH_LENGTH = 12;
+const CODEX_PROJECT_ID_FILE = join('.fbeast', 'codex-project-id');
 
 /**
  * Codex MCP server names are global, so fbeast registrations must be scoped to
@@ -10,14 +12,56 @@ const CODEX_NAME_HASH_LENGTH = 12;
  * suffixing a stable root hash to avoid cross-repository collisions.
  */
 export function codexProjectId(root: string): string {
+  const persisted = readPersistedCodexProjectId(root);
+  if (persisted) return persisted;
+
+  return codexProjectIdForPath(root);
+}
+
+export function ensureCodexProjectId(root: string): string {
+  const existing = readPersistedCodexProjectId(root);
+  if (existing) return existing;
+
+  const projectId = codexProjectIdForPath(root);
+  const fbeastDir = join(root, '.fbeast');
+  mkdirSync(fbeastDir, { recursive: true });
+  writeFileSync(join(root, CODEX_PROJECT_ID_FILE), `${projectId}\n`);
+  return projectId;
+}
+
+export function codexProjectIds(root: string): string[] {
+  const ids = new Set<string>();
+  const persisted = readPersistedCodexProjectId(root);
+  if (persisted) ids.add(persisted);
+  ids.add(codexProjectIdForPath(root));
+  return [...ids];
+}
+
+function codexProjectIdForPath(root: string): string {
   return createHash('sha256')
     .update(resolve(root))
     .digest('hex')
     .slice(0, CODEX_NAME_HASH_LENGTH);
 }
 
+function readPersistedCodexProjectId(root: string): string | null {
+  const path = join(root, CODEX_PROJECT_ID_FILE);
+  if (!existsSync(path)) return null;
+
+  try {
+    const value = readFileSync(path, 'utf-8').trim();
+    return /^[0-9a-f]{12}$/.test(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function codexServerNameForProjectId(projectId: string, server: FbeastServer | 'proxy'): string {
+  return `fbeast-${server}-${projectId}`;
+}
+
 export function codexServerName(root: string, server: FbeastServer | 'proxy'): string {
-  return `fbeast-${server}-${codexProjectId(root)}`;
+  return codexServerNameForProjectId(codexProjectId(root), server);
 }
 
 export function codexServerNames(root: string, servers: readonly FbeastServer[], mode: 'standard' | 'proxy'): string[] {
@@ -26,4 +70,13 @@ export function codexServerNames(root: string, servers: readonly FbeastServer[],
   }
 
   return servers.map((server) => codexServerName(root, server));
+}
+
+export function codexServerNamesForProjectIds(
+  projectIds: readonly string[],
+  servers: readonly FbeastServer[],
+  mode: 'standard' | 'proxy',
+): string[] {
+  const serverList: Array<FbeastServer | 'proxy'> = mode === 'proxy' ? ['proxy'] : [...servers];
+  return projectIds.flatMap((projectId) => serverList.map((server) => codexServerNameForProjectId(projectId, server)));
 }

--- a/packages/franken-mcp-suite/src/cli/codex-server-names.ts
+++ b/packages/franken-mcp-suite/src/cli/codex-server-names.ts
@@ -1,6 +1,6 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import type { FbeastServer } from '../shared/config.js';
 
 const CODEX_NAME_HASH_LENGTH = 12;
@@ -13,10 +13,7 @@ const CODEX_PROJECT_ID_FILE = join('.fbeast', 'codex-project-id');
  * uninstall stable if the repository is moved or opened via another path.
  */
 export function codexProjectId(root: string): string {
-  const persisted = readPersistedCodexProjectId(root);
-  if (persisted) return persisted;
-
-  return legacyCodexProjectIdForPath(root);
+  return ensureCodexProjectId(root);
 }
 
 export function ensureCodexProjectId(root: string): string {
@@ -34,17 +31,7 @@ export function codexProjectIds(root: string): string[] {
   const ids = new Set<string>();
   const persisted = readPersistedCodexProjectId(root);
   if (persisted) ids.add(persisted);
-  // Backward-compatible cleanup for prerelease registrations whose names were
-  // derived from the current root path before project ids were persisted.
-  ids.add(legacyCodexProjectIdForPath(root));
   return [...ids];
-}
-
-function legacyCodexProjectIdForPath(root: string): string {
-  return createHash('sha256')
-    .update(resolve(root))
-    .digest('hex')
-    .slice(0, CODEX_NAME_HASH_LENGTH);
 }
 
 function readPersistedCodexProjectId(root: string): string | null {

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -253,74 +253,102 @@ describe('fbeast init', () => {
     expect(content.split('<!-- fbeast-start -->').length).toBe(2); // exactly one
   });
 
-  it('registers Codex MCP servers via spawn when --client=codex', () => {
+  it('writes Codex MCP servers to project-scoped config when --client=codex', () => {
     const root = tmpDir();
     dirs.push(root);
     const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
     const mockSpawn = (cmd: string, args: string[]) => {
       spawnCalls.push({ cmd, args });
-      return { status: 0 };
+      return { status: 1, stderr: Buffer.from('not found') };
     };
 
     runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn });
 
-    // One spawn call per server
-    expect(spawnCalls.length).toBe(7);
+    expect(spawnCalls.length).toBe(8);
     expect(spawnCalls.every((c) => c.cmd === 'codex')).toBe(true);
-    expect(spawnCalls.every((c) => c.args[0] === 'mcp' && c.args[1] === 'add')).toBe(true);
-    const names = spawnCalls.map((c) => c.args[2]);
-    expect(names).toContain(codexServerName(root, 'memory'));
-    expect(names).toContain(codexServerName(root, 'governor'));
-    expect(names).not.toContain('fbeast-memory');
-    expect(names.every((name) => name.endsWith(codexServerName(root, 'memory').slice(-12)))).toBe(true);
+    expect(spawnCalls.every((c) => c.args[0] === 'mcp' && c.args[1] === 'get')).toBe(true);
+    expect(spawnCalls.map((c) => c.args[2])).toContain('fbeast-memory');
+    expect(spawnCalls.map((c) => c.args[2])).toContain('fbeast-proxy');
+
+    const config = readFileSync(join(root, '.codex', 'config.toml'), 'utf-8');
+    const names = config.match(/^\[mcp_servers\.[^\]]+]/gm) ?? [];
+    expect(names.length).toBe(7);
+    expect(config).toContain(`[mcp_servers.${codexServerName(root, 'memory')}]`);
+    expect(config).toContain(`[mcp_servers.${codexServerName(root, 'governor')}]`);
+    expect(config).not.toContain('[mcp_servers.fbeast-memory]');
+    expect(config).toContain(`args = ["--db", "${join(root, '.fbeast', 'beast.db')}"]`);
   });
 
   it('uses distinct Codex MCP server names for distinct project roots', () => {
     const rootA = tmpDir();
     const rootB = tmpDir();
     dirs.push(rootA, rootB);
-    const spawnCallsA: Array<{ cmd: string; args: string[] }> = [];
-    const spawnCallsB: Array<{ cmd: string; args: string[] }> = [];
 
     runInit({
       root: rootA,
       claudeDir: join(rootA, '.codex'),
       hooks: false,
       client: 'codex',
-      spawn: (cmd, args) => {
-        spawnCallsA.push({ cmd, args });
-        return { status: 0 };
-      },
+      spawn: () => ({ status: 1 }),
     });
     runInit({
       root: rootB,
       claudeDir: join(rootB, '.codex'),
       hooks: false,
       client: 'codex',
-      spawn: (cmd, args) => {
-        spawnCallsB.push({ cmd, args });
-        return { status: 0 };
-      },
+      spawn: () => ({ status: 1 }),
     });
 
-    const namesA = spawnCallsA.map((c) => c.args[2]);
-    const namesB = spawnCallsB.map((c) => c.args[2]);
-    expect(namesA).toContain(codexServerName(rootA, 'memory'));
-    expect(namesB).toContain(codexServerName(rootB, 'memory'));
-    expect(new Set([...namesA, ...namesB]).size).toBe(namesA.length + namesB.length);
+    const configA = readFileSync(join(rootA, '.codex', 'config.toml'), 'utf-8');
+    const configB = readFileSync(join(rootB, '.codex', 'config.toml'), 'utf-8');
+    expect(configA).toContain(`[mcp_servers.${codexServerName(rootA, 'memory')}]`);
+    expect(configB).toContain(`[mcp_servers.${codexServerName(rootB, 'memory')}]`);
+    expect(codexServerName(rootA, 'memory')).not.toBe(codexServerName(rootB, 'memory'));
+    expect(configA).not.toContain(codexServerName(rootB, 'memory'));
+    expect(configB).not.toContain(codexServerName(rootA, 'memory'));
   });
 
-  it('throws when codex mcp add fails for any server', () => {
+  it('removes legacy global Codex entries only when they target the current root', () => {
     const root = tmpDir();
     dirs.push(root);
-    const mockSpawn = (_cmd: string, args: string[]) => ({
-      status: args[2] === codexServerName(root, 'memory') ? 1 : 0,
-      stderr: Buffer.from('command not found'),
-    });
+    const dbPath = join(root, '.fbeast', 'beast.db');
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const mockSpawn = (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      if (args[1] === 'get' && args[2] === 'fbeast-memory') return { status: 0, stdout: Buffer.from(`command = "fbeast-memory"\nargs = ["--db", "${dbPath}"]`) };
+      if (args[1] === 'get' && args[2] === 'fbeast-planner') return { status: 0, stdout: Buffer.from('args = ["--db", "/other/project/.fbeast/beast.db"]') };
+      if (args[1] === 'remove' && args[2] === 'fbeast-memory') return { status: 0 };
+      return { status: 1 };
+    };
+
+    runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn });
+
+    expect(calls.filter((c) => c.args[1] === 'get').map((c) => c.args[2])).toEqual([
+      'fbeast-memory',
+      'fbeast-planner',
+      'fbeast-critique',
+      'fbeast-firewall',
+      'fbeast-observer',
+      'fbeast-governor',
+      'fbeast-skills',
+      'fbeast-proxy',
+    ]);
+    expect(calls.filter((c) => c.args[1] === 'remove').map((c) => c.args[2])).toEqual(['fbeast-memory']);
+  });
+
+  it('throws when legacy Codex removal fails', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const dbPath = join(root, '.fbeast', 'beast.db');
+    const mockSpawn = (_cmd: string, args: string[]) => {
+      if (args[1] === 'get' && args[2] === 'fbeast-memory') return { status: 0, stdout: Buffer.from(dbPath) };
+      if (args[1] === 'remove' && args[2] === 'fbeast-memory') return { status: 1, stderr: Buffer.from('permission denied') };
+      return { status: 1 };
+    };
 
     expect(() =>
       runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn }),
-    ).toThrow('failed to register 1 server');
+    ).toThrow('failed to remove legacy Codex MCP server fbeast-memory');
   });
 
   it('proxy mode writes single fbeast-proxy entry (not 7) for claude client', () => {
@@ -362,32 +390,23 @@ describe('fbeast init', () => {
     expect(settings.mcpServers['fbeast-proxy']).toBeUndefined();
   });
 
-  it('proxy mode for codex calls spawnFn once with fbeast-proxy (not 7 times)', () => {
+  it('proxy mode for codex writes only the project-scoped fbeast-proxy entry', () => {
     const root = tmpDir();
     dirs.push(root);
     const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
     const mockSpawn = (cmd: string, args: string[]) => {
       spawnCalls.push({ cmd, args });
-      return { status: 0 };
+      return { status: 1 };
     };
 
     runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn, mode: 'proxy' });
 
-    expect(spawnCalls.length).toBe(1);
-    expect(spawnCalls[0].cmd).toBe('codex');
-    expect(spawnCalls[0].args[0]).toBe('mcp');
-    expect(spawnCalls[0].args[1]).toBe('add');
-    expect(spawnCalls[0].args[2]).toBe(codexServerName(root, 'proxy'));
-  });
-
-  it('proxy mode for codex throws when fbeast-proxy registration fails', () => {
-    const root = tmpDir();
-    dirs.push(root);
-    const mockSpawn = () => ({ status: 1, stderr: Buffer.from('command not found') });
-
-    expect(() =>
-      runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn, mode: 'proxy' }),
-    ).toThrow(`failed to register ${codexServerName(root, 'proxy')} with codex`);
+    expect(spawnCalls.length).toBe(8);
+    expect(spawnCalls.every((c) => c.args[0] === 'mcp' && c.args[1] === 'get')).toBe(true);
+    const config = readFileSync(join(root, '.codex', 'config.toml'), 'utf-8');
+    expect(config.match(/^\[mcp_servers\.[^\]]+]/gm)).toEqual([`[mcp_servers.${codexServerName(root, 'proxy')}]`]);
+    expect(config).toContain('command = "fbeast-proxy"');
+    expect(config).not.toContain('fbeast-memory');
   });
 
   it('writes Codex hooks.json when --client=codex --hooks', () => {

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -409,6 +409,33 @@ describe('fbeast init', () => {
     expect(config).not.toContain('fbeast-memory');
   });
 
+  it('codex re-init removes fbeast MCP subtables without deleting TOML array sections', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const mockSpawn = () => ({ status: 1 });
+
+    runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn });
+    const oldMemoryName = codexServerName(root, 'memory');
+    const configPath = join(root, '.codex', 'config.toml');
+    writeFileSync(configPath, `${readFileSync(configPath, 'utf-8')}\n` + [
+      `[mcp_servers.${oldMemoryName}.tools.fbeast_memory_store]`,
+      'enabled = true',
+      '',
+      '[[hooks.PreToolUse]]',
+      'command = "keep-me"',
+      '',
+    ].join('\n'));
+
+    runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn, mode: 'proxy' });
+
+    const config = readFileSync(configPath, 'utf-8');
+    expect(config).toContain(`[mcp_servers.${codexServerName(root, 'proxy')}]`);
+    expect(config).toContain('[[hooks.PreToolUse]]');
+    expect(config).toContain('command = "keep-me"');
+    expect(config).not.toContain(oldMemoryName);
+    expect(config).not.toContain('fbeast_memory_store');
+  });
+
   it('writes Codex hooks.json when --client=codex --hooks', () => {
     const root = tmpDir();
     dirs.push(root);

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { runInit } from './init.js';
 import { resolveClientConfigDir } from './mcp-client-paths.js';
+import { codexServerName } from './codex-server-names.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -268,15 +269,52 @@ describe('fbeast init', () => {
     expect(spawnCalls.every((c) => c.cmd === 'codex')).toBe(true);
     expect(spawnCalls.every((c) => c.args[0] === 'mcp' && c.args[1] === 'add')).toBe(true);
     const names = spawnCalls.map((c) => c.args[2]);
-    expect(names).toContain('fbeast-memory');
-    expect(names).toContain('fbeast-governor');
+    expect(names).toContain(codexServerName(root, 'memory'));
+    expect(names).toContain(codexServerName(root, 'governor'));
+    expect(names).not.toContain('fbeast-memory');
+    expect(names.every((name) => name.endsWith(codexServerName(root, 'memory').slice(-12)))).toBe(true);
+  });
+
+  it('uses distinct Codex MCP server names for distinct project roots', () => {
+    const rootA = tmpDir();
+    const rootB = tmpDir();
+    dirs.push(rootA, rootB);
+    const spawnCallsA: Array<{ cmd: string; args: string[] }> = [];
+    const spawnCallsB: Array<{ cmd: string; args: string[] }> = [];
+
+    runInit({
+      root: rootA,
+      claudeDir: join(rootA, '.codex'),
+      hooks: false,
+      client: 'codex',
+      spawn: (cmd, args) => {
+        spawnCallsA.push({ cmd, args });
+        return { status: 0 };
+      },
+    });
+    runInit({
+      root: rootB,
+      claudeDir: join(rootB, '.codex'),
+      hooks: false,
+      client: 'codex',
+      spawn: (cmd, args) => {
+        spawnCallsB.push({ cmd, args });
+        return { status: 0 };
+      },
+    });
+
+    const namesA = spawnCallsA.map((c) => c.args[2]);
+    const namesB = spawnCallsB.map((c) => c.args[2]);
+    expect(namesA).toContain(codexServerName(rootA, 'memory'));
+    expect(namesB).toContain(codexServerName(rootB, 'memory'));
+    expect(new Set([...namesA, ...namesB]).size).toBe(namesA.length + namesB.length);
   });
 
   it('throws when codex mcp add fails for any server', () => {
     const root = tmpDir();
     dirs.push(root);
     const mockSpawn = (_cmd: string, args: string[]) => ({
-      status: args[2] === 'fbeast-memory' ? 1 : 0,
+      status: args[2] === codexServerName(root, 'memory') ? 1 : 0,
       stderr: Buffer.from('command not found'),
     });
 
@@ -339,7 +377,7 @@ describe('fbeast init', () => {
     expect(spawnCalls[0].cmd).toBe('codex');
     expect(spawnCalls[0].args[0]).toBe('mcp');
     expect(spawnCalls[0].args[1]).toBe('add');
-    expect(spawnCalls[0].args[2]).toBe('fbeast-proxy');
+    expect(spawnCalls[0].args[2]).toBe(codexServerName(root, 'proxy'));
   });
 
   it('proxy mode for codex throws when fbeast-proxy registration fails', () => {
@@ -349,7 +387,7 @@ describe('fbeast init', () => {
 
     expect(() =>
       runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn, mode: 'proxy' }),
-    ).toThrow('failed to register fbeast-proxy with codex');
+    ).toThrow(`failed to register ${codexServerName(root, 'proxy')} with codex`);
   });
 
   it('writes Codex hooks.json when --client=codex --hooks', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { writeHookScripts } from './hook-scripts.js';
-import { codexServerName } from './codex-server-names.js';
+import { codexServerName, ensureCodexProjectId } from './codex-server-names.js';
 
 const ALL_SERVERS: FbeastServer[] = [
   'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
@@ -137,6 +137,7 @@ function initCodex(options: {
   mode: 'standard' | 'proxy';
 }): void {
   const { root, servers, hooks, config, spawnFn, mode } = options;
+  ensureCodexProjectId(root);
   const dbPath = join(root, '.fbeast', 'beast.db');
 
   // Register MCP servers via codex mcp add

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -32,7 +32,7 @@ export interface InitOptions {
   client?: McpClient;
   mode?: 'standard' | 'proxy';
   /** Inject spawn for testing the codex path. */
-  spawn?: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string };
+  spawn?: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string; stdout?: Buffer | string };
 }
 
 export function runInit(options: InitOptions): void {
@@ -133,35 +133,15 @@ function initCodex(options: {
   servers: FbeastServer[];
   hooks: boolean;
   config: FbeastConfig;
-  spawnFn: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string };
+  spawnFn: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string; stdout?: Buffer | string };
   mode: 'standard' | 'proxy';
 }): void {
   const { root, servers, hooks, config, spawnFn, mode } = options;
   ensureCodexProjectId(root);
   const dbPath = join(root, '.fbeast', 'beast.db');
 
-  // Register MCP servers via codex mcp add
-  if (mode === 'proxy') {
-    const name = codexServerName(root, 'proxy');
-    const result = spawnFn('codex', ['mcp', 'add', name, '--', 'fbeast-proxy', '--db', dbPath]);
-    if (result.status !== 0) {
-      throw new Error(`fbeast init: failed to register ${name} with codex: ${result.stderr?.toString().trim() ?? 'unknown error'}`);
-    }
-  } else {
-    const failed: string[] = [];
-    for (const srv of servers) {
-      const name = codexServerName(root, srv);
-      const result = spawnFn('codex', ['mcp', 'add', name, '--', SERVER_BIN_MAP[srv], '--db', dbPath]);
-      if (result.status !== 0) {
-        failed.push(name);
-        console.error(`  ✗ Failed to register ${name}: ${result.stderr?.toString().trim() ?? 'unknown error'}`);
-      }
-    }
-
-    if (failed.length > 0) {
-      throw new Error(`fbeast init: failed to register ${failed.length} server(s) with codex: ${failed.join(', ')}`);
-    }
-  }
+  migrateLegacyCodexServers(root, spawnFn);
+  writeCodexProjectConfig(root, servers, mode, dbPath);
 
   // Drop instructions into AGENTS.md
   writeAgentsMd(root);
@@ -178,8 +158,73 @@ function initCodex(options: {
   console.log(`  Config:   ${config.configPath}`);
   console.log(`  Database: ${config.dbPath}`);
   console.log(`  AGENTS.md: ${join(root, 'AGENTS.md')}`);
-  console.log(`  Servers:  ${mode === 'proxy' ? `${codexServerName(root, 'proxy')} (proxy mode, registered via codex mcp add)` : `${servers.map((srv) => codexServerName(root, srv)).join(', ')} (registered via codex mcp add)`}`);
+  console.log(`  MCP config: ${join(root, '.codex', 'config.toml')}`);
+  console.log(`  Servers:  ${mode === 'proxy' ? `${codexServerName(root, 'proxy')} (proxy mode, project-scoped)` : `${servers.map((srv) => codexServerName(root, srv)).join(', ')} (project-scoped)`}`);
   if (hooks) console.log(`  Hooks:    enabled (codex hooks.json)`);
+}
+
+function migrateLegacyCodexServers(
+  root: string,
+  spawnFn: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string; stdout?: Buffer | string },
+): void {
+  const dbPath = join(root, '.fbeast', 'beast.db');
+  const legacyNames = [...ALL_SERVERS.map((srv) => `fbeast-${srv}`), 'fbeast-proxy'];
+
+  for (const name of legacyNames) {
+    const getResult = spawnFn('codex', ['mcp', 'get', name]);
+    if (getResult.status !== 0) continue;
+
+    const output = `${getResult.stdout?.toString() ?? ''}\n${getResult.stderr?.toString() ?? ''}`;
+    if (!output.includes(dbPath)) continue;
+
+    const removeResult = spawnFn('codex', ['mcp', 'remove', name]);
+    if (removeResult.status !== 0) {
+      throw new Error(`fbeast init: failed to remove legacy Codex MCP server ${name}: ${removeResult.stderr?.toString().trim() ?? 'unknown error'}`);
+    }
+  }
+}
+
+function writeCodexProjectConfig(
+  root: string,
+  servers: readonly FbeastServer[],
+  mode: 'standard' | 'proxy',
+  dbPath: string,
+): void {
+  const codexDir = join(root, '.codex');
+  mkdirSync(codexDir, { recursive: true });
+  const configPath = join(codexDir, 'config.toml');
+  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
+  const cleaned = removeFbeastMcpServerTables(existing).trimEnd();
+  const serverEntries = mode === 'proxy'
+    ? [{ name: codexServerName(root, 'proxy'), command: 'fbeast-proxy' }]
+    : servers.map((srv) => ({ name: codexServerName(root, srv), command: SERVER_BIN_MAP[srv] }));
+  const fbeastConfig = serverEntries.map(({ name, command }) => [
+    `[mcp_servers.${name}]`,
+    `command = ${tomlString(command)}`,
+    `args = ["--db", ${tomlString(dbPath)}]`,
+  ].join('\n')).join('\n\n');
+  const content = [cleaned, fbeastConfig].filter(Boolean).join('\n\n') + '\n';
+  writeFileSync(configPath, content);
+}
+
+function removeFbeastMcpServerTables(toml: string): string {
+  const lines = toml.split(/\r?\n/);
+  const kept: string[] = [];
+  let dropping = false;
+
+  for (const line of lines) {
+    const header = line.match(/^\s*\[([^\]]+)]\s*$/);
+    if (header?.[1]) {
+      dropping = /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)$/.test(header[1]);
+    }
+    if (!dropping) kept.push(line);
+  }
+
+  return kept.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
 }
 
 // ─── Hook config builders ─────────────────────────────────────────────────────

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { writeHookScripts } from './hook-scripts.js';
+import { codexServerName } from './codex-server-names.js';
 
 const ALL_SERVERS: FbeastServer[] = [
   'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
@@ -140,14 +141,15 @@ function initCodex(options: {
 
   // Register MCP servers via codex mcp add
   if (mode === 'proxy') {
-    const result = spawnFn('codex', ['mcp', 'add', 'fbeast-proxy', '--', 'fbeast-proxy', '--db', dbPath]);
+    const name = codexServerName(root, 'proxy');
+    const result = spawnFn('codex', ['mcp', 'add', name, '--', 'fbeast-proxy', '--db', dbPath]);
     if (result.status !== 0) {
-      throw new Error(`fbeast init: failed to register fbeast-proxy with codex: ${result.stderr?.toString().trim() ?? 'unknown error'}`);
+      throw new Error(`fbeast init: failed to register ${name} with codex: ${result.stderr?.toString().trim() ?? 'unknown error'}`);
     }
   } else {
     const failed: string[] = [];
     for (const srv of servers) {
-      const name = `fbeast-${srv}`;
+      const name = codexServerName(root, srv);
       const result = spawnFn('codex', ['mcp', 'add', name, '--', SERVER_BIN_MAP[srv], '--db', dbPath]);
       if (result.status !== 0) {
         failed.push(name);
@@ -175,7 +177,7 @@ function initCodex(options: {
   console.log(`  Config:   ${config.configPath}`);
   console.log(`  Database: ${config.dbPath}`);
   console.log(`  AGENTS.md: ${join(root, 'AGENTS.md')}`);
-  console.log(`  Servers:  ${mode === 'proxy' ? 'fbeast-proxy (proxy mode, registered via codex mcp add)' : `${servers.join(', ')} (registered via codex mcp add)`}`);
+  console.log(`  Servers:  ${mode === 'proxy' ? `${codexServerName(root, 'proxy')} (proxy mode, registered via codex mcp add)` : `${servers.map((srv) => codexServerName(root, srv)).join(', ')} (registered via codex mcp add)`}`);
   if (hooks) console.log(`  Hooks:    enabled (codex hooks.json)`);
 }
 

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -213,14 +213,18 @@ function removeFbeastMcpServerTables(toml: string): string {
   let dropping = false;
 
   for (const line of lines) {
-    const header = line.match(/^\s*\[([^\]]+)]\s*$/);
+    const header = line.match(/^\s*\[\[?([^\]]+)]\]?\s*$/);
     if (header?.[1]) {
-      dropping = /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)$/.test(header[1]);
+      dropping = isFbeastMcpServerSection(header[1]);
     }
     if (!dropping) kept.push(line);
   }
 
   return kept.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+function isFbeastMcpServerSection(section: string): boolean {
+  return /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)(?:\.|$)/.test(section);
 }
 
 function tomlString(value: string): string {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { runUninstall } from './uninstall.js';
 import { runInit } from './init.js';
 import { confirmYesNo } from './prompt.js';
+import { codexServerName, codexServerNames } from './codex-server-names.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -241,9 +242,13 @@ describe('fbeast uninstall', () => {
 
     await runUninstall({ root, claudeDir: join(root, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
 
-    // Each server gets a remove call (7 individual + fbeast-proxy = 8)
+    // Each namespaced server gets a remove call (7 individual + project proxy = 8)
     expect(spawnCalls.length).toBe(8);
     expect(spawnCalls.every((c) => c.args[1] === 'remove')).toBe(true);
+    expect(spawnCalls.map((c) => c.args[2])).toEqual([
+      ...codexServerNames(root, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
+      codexServerName(root, 'proxy'),
+    ]);
 
     // hooks.json has no fbeast entries left
     const hooksPath = join(root, '.codex', 'hooks.json');
@@ -283,7 +288,7 @@ describe('fbeast uninstall', () => {
     expect(existsSync(legacyPostScript)).toBe(false);
   });
 
-  it('codex uninstall runs codex mcp remove fbeast-proxy', async () => {
+  it('codex uninstall runs codex mcp remove for the project namespaced fbeast-proxy', async () => {
     const root = tmpDir();
     dirs.push(root);
     const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
@@ -297,7 +302,37 @@ describe('fbeast uninstall', () => {
     const removedNames = spawnCalls
       .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
       .map((c) => c.args[2]);
-    expect(removedNames).toContain('fbeast-proxy');
+    expect(removedNames).toContain(codexServerName(root, 'proxy'));
+    expect(removedNames).not.toContain('fbeast-proxy');
+  });
+
+  it('codex uninstall removes only this project names and does not target another project', async () => {
+    const rootA = tmpDir();
+    const rootB = tmpDir();
+    dirs.push(rootA, rootB);
+    const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+    const mockSpawn = (cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      return { status: 0 };
+    };
+
+    await runUninstall({ root: rootA, claudeDir: join(rootA, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
+
+    const removedNames = spawnCalls
+      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
+      .map((c) => c.args[2]);
+    const projectANames = [
+      ...codexServerNames(rootA, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
+      codexServerName(rootA, 'proxy'),
+    ];
+    const projectBNames = [
+      ...codexServerNames(rootB, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
+      codexServerName(rootB, 'proxy'),
+    ];
+
+    expect(removedNames).toEqual(projectANames);
+    expect(removedNames.some((name) => projectBNames.includes(name))).toBe(false);
+    expect(removedNames).not.toContain('fbeast-memory');
   });
 
   it('preserves non-fbeast hooks sharing a Claude matcher entry on uninstall', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -242,11 +242,12 @@ describe('fbeast uninstall', () => {
 
     await runUninstall({ root, claudeDir: join(root, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
 
-    // Uninstall removes the persisted project-id names plus the legacy current-path
-    // fallback names for older path-derived registrations.
+    // Uninstall removes the persisted project-id names. Older path-derived
+    // registrations are discovered from local config or `codex mcp list --json`,
+    // not by deriving another path hash.
     const removeCalls = spawnCalls.filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove');
     const removedNames = removeCalls.map((c) => c.args[2]);
-    expect(removeCalls.length).toBe(16);
+    expect(removeCalls.length).toBe(8);
     expect(removedNames).toEqual(expect.arrayContaining([
       ...codexServerNames(root, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
       codexServerName(root, 'proxy'),
@@ -299,6 +300,9 @@ describe('fbeast uninstall', () => {
       return { status: 0 };
     };
 
+    runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', mode: 'proxy', spawn: mockSpawn });
+    spawnCalls.length = 0;
+
     await runUninstall({ root, claudeDir: join(root, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
 
     const removedNames = spawnCalls
@@ -317,12 +321,6 @@ describe('fbeast uninstall', () => {
       spawnCalls.push({ cmd, args });
       return { status: 0 };
     };
-
-    await runUninstall({ root: rootA, claudeDir: join(rootA, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
-
-    const removedNames = spawnCalls
-      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
-      .map((c) => c.args[2]);
     const projectANames = [
       ...codexServerNames(rootA, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
       codexServerName(rootA, 'proxy'),
@@ -331,6 +329,12 @@ describe('fbeast uninstall', () => {
       ...codexServerNames(rootB, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
       codexServerName(rootB, 'proxy'),
     ];
+
+    await runUninstall({ root: rootA, claudeDir: join(rootA, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
+
+    const removedNames = spawnCalls
+      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
+      .map((c) => c.args[2]);
 
     expect(removedNames).toEqual(projectANames);
     expect(removedNames.some((name) => projectBNames.includes(name))).toBe(false);
@@ -438,6 +442,41 @@ describe('fbeast uninstall', () => {
     expect(remainingConfig).toContain('command = "keep-me"');
     expect(remainingConfig).not.toContain(oldCodexName);
     expect(remainingConfig).not.toContain('fbeast_memory_store');
+  });
+
+  it('codex uninstall removes moved pre-persistence registrations by DB path from local config', async () => {
+    const oldRoot = tmpDir();
+    const movedRoot = tmpDir();
+    dirs.push(oldRoot, movedRoot);
+    const oldDbPath = join(oldRoot, '.fbeast', 'beast.db');
+    const oldName = 'fbeast-memory-deadbeefcafe';
+
+    mkdirSync(join(movedRoot, '.codex'), { recursive: true });
+    writeFileSync(join(movedRoot, '.codex', 'config.toml'), [
+      `[mcp_servers.${oldName}]`,
+      'command = "fbeast-memory"',
+      `args = ["--db", "${oldDbPath}"]`,
+      '',
+    ].join('\n'));
+
+    const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+    const mockSpawn = (cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      return args[0] === 'mcp' && args[1] === 'list'
+        ? { status: 0, stdout: JSON.stringify([
+          { name: oldName, transport: { type: 'stdio', command: 'fbeast-memory', args: ['--db', oldDbPath] } },
+          { name: 'fbeast-memory-other', transport: { type: 'stdio', command: 'fbeast-memory', args: ['--db', join(tmpDir(), '.fbeast', 'beast.db')] } },
+        ]) }
+        : { status: 0 };
+    };
+
+    await runUninstall({ root: movedRoot, claudeDir: join(movedRoot, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
+
+    const removedNames = spawnCalls
+      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
+      .map((c) => c.args[2]);
+    expect(removedNames).toContain(oldName);
+    expect(removedNames).not.toContain('fbeast-memory-other');
   });
 
   it('preserves non-fbeast hooks sharing a Claude matcher entry on uninstall', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -410,6 +410,12 @@ describe('fbeast uninstall', () => {
       'command = "fbeast-memory"',
       `args = ["--db", "${join(oldRoot, '.fbeast', 'beast.db')}"]`,
       '',
+      `[mcp_servers.${oldCodexName}.tools.fbeast_memory_store]`,
+      'enabled = true',
+      '',
+      '[[hooks.PreToolUse]]',
+      'command = "keep-me"',
+      '',
     ].join('\n'));
 
     const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
@@ -428,7 +434,10 @@ describe('fbeast uninstall', () => {
     expect(removedNames).toContain(oldCodexName);
     const remainingConfig = readFileSync(join(movedRoot, '.codex', 'config.toml'), 'utf-8');
     expect(remainingConfig).toContain('[mcp_servers.github]');
+    expect(remainingConfig).toContain('[[hooks.PreToolUse]]');
+    expect(remainingConfig).toContain('command = "keep-me"');
     expect(remainingConfig).not.toContain(oldCodexName);
+    expect(remainingConfig).not.toContain('fbeast_memory_store');
   });
 
   it('preserves non-fbeast hooks sharing a Claude matcher entry on uninstall', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -243,9 +243,9 @@ describe('fbeast uninstall', () => {
     await runUninstall({ root, claudeDir: join(root, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
 
     // Each namespaced server gets a remove call (7 individual + project proxy = 8)
-    expect(spawnCalls.length).toBe(8);
-    expect(spawnCalls.every((c) => c.args[1] === 'remove')).toBe(true);
-    expect(spawnCalls.map((c) => c.args[2])).toEqual([
+    const removeCalls = spawnCalls.filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove');
+    expect(removeCalls.length).toBe(8);
+    expect(removeCalls.map((c) => c.args[2])).toEqual([
       ...codexServerNames(root, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
       codexServerName(root, 'proxy'),
     ]);
@@ -333,6 +333,64 @@ describe('fbeast uninstall', () => {
     expect(removedNames).toEqual(projectANames);
     expect(removedNames.some((name) => projectBNames.includes(name))).toBe(false);
     expect(removedNames).not.toContain('fbeast-memory');
+  });
+
+  it('codex uninstall removes legacy fixed names only when they target this root', async () => {
+    const root = tmpDir();
+    const otherRoot = tmpDir();
+    dirs.push(root, otherRoot);
+    const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+    const mockSpawn = (cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      if (args[0] === 'mcp' && args[1] === 'list') {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            { name: 'fbeast-memory', transport: { type: 'stdio', command: 'fbeast-memory', args: ['--db', join(root, '.fbeast', 'beast.db')] } },
+            { name: 'fbeast-planner', transport: { type: 'stdio', command: 'fbeast-planner', args: ['--db', join(otherRoot, '.fbeast', 'beast.db')] } },
+            { name: 'github', transport: { type: 'streamable_http', url: 'https://example.invalid/mcp' } },
+          ]),
+        };
+      }
+      return { status: 0 };
+    };
+
+    await runUninstall({ root, claudeDir: join(root, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
+
+    const removedNames = spawnCalls
+      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
+      .map((c) => c.args[2]);
+    expect(removedNames).toContain('fbeast-memory');
+    expect(removedNames).not.toContain('fbeast-planner');
+    expect(removedNames).not.toContain('github');
+  });
+
+  it('codex uninstall removes persisted project-id names after a project move', async () => {
+    const oldRoot = tmpDir();
+    const movedRoot = tmpDir();
+    dirs.push(oldRoot, movedRoot);
+    const initSpawn = () => ({ status: 0 });
+
+    runInit({ root: oldRoot, claudeDir: join(oldRoot, '.codex'), hooks: false, client: 'codex', spawn: initSpawn });
+    const oldProjectId = readFileSync(join(oldRoot, '.fbeast', 'codex-project-id'), 'utf-8').trim();
+    mkdirSync(join(movedRoot, '.fbeast'), { recursive: true });
+    writeFileSync(join(movedRoot, '.fbeast', 'codex-project-id'), `${oldProjectId}\n`);
+
+    const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+    const mockSpawn = (cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      return args[0] === 'mcp' && args[1] === 'list'
+        ? { status: 0, stdout: '[]' }
+        : { status: 0 };
+    };
+
+    await runUninstall({ root: movedRoot, claudeDir: join(movedRoot, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
+
+    const removedNames = spawnCalls
+      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
+      .map((c) => c.args[2]);
+    expect(removedNames).toContain(`fbeast-memory-${oldProjectId}`);
+    expect(removedNames).toContain(codexServerName(movedRoot, 'memory'));
   });
 
   it('preserves non-fbeast hooks sharing a Claude matcher entry on uninstall', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -242,13 +242,15 @@ describe('fbeast uninstall', () => {
 
     await runUninstall({ root, claudeDir: join(root, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
 
-    // Each namespaced server gets a remove call (7 individual + project proxy = 8)
+    // Uninstall removes the persisted project-id names plus the legacy current-path
+    // fallback names for older path-derived registrations.
     const removeCalls = spawnCalls.filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove');
-    expect(removeCalls.length).toBe(8);
-    expect(removeCalls.map((c) => c.args[2])).toEqual([
+    const removedNames = removeCalls.map((c) => c.args[2]);
+    expect(removeCalls.length).toBe(16);
+    expect(removedNames).toEqual(expect.arrayContaining([
       ...codexServerNames(root, ['memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills'], 'standard'),
       codexServerName(root, 'proxy'),
-    ]);
+    ]));
 
     // hooks.json has no fbeast entries left
     const hooksPath = join(root, '.codex', 'hooks.json');
@@ -391,6 +393,42 @@ describe('fbeast uninstall', () => {
       .map((c) => c.args[2]);
     expect(removedNames).toContain(`fbeast-memory-${oldProjectId}`);
     expect(removedNames).toContain(codexServerName(movedRoot, 'memory'));
+  });
+
+  it('codex uninstall removes project-scoped names from moved local config', async () => {
+    const oldRoot = tmpDir();
+    const movedRoot = tmpDir();
+    dirs.push(oldRoot, movedRoot);
+    const oldCodexName = codexServerName(oldRoot, 'memory');
+
+    mkdirSync(join(movedRoot, '.codex'), { recursive: true });
+    writeFileSync(join(movedRoot, '.codex', 'config.toml'), [
+      '[mcp_servers.github]',
+      'command = "github-mcp"',
+      '',
+      `[mcp_servers.${oldCodexName}]`,
+      'command = "fbeast-memory"',
+      `args = ["--db", "${join(oldRoot, '.fbeast', 'beast.db')}"]`,
+      '',
+    ].join('\n'));
+
+    const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+    const mockSpawn = (cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      return args[0] === 'mcp' && args[1] === 'list'
+        ? { status: 0, stdout: '[]' }
+        : { status: 0 };
+    };
+
+    await runUninstall({ root: movedRoot, claudeDir: join(movedRoot, '.codex'), client: 'codex', purge: false, spawn: mockSpawn });
+
+    const removedNames = spawnCalls
+      .filter((c) => c.args[0] === 'mcp' && c.args[1] === 'remove')
+      .map((c) => c.args[2]);
+    expect(removedNames).toContain(oldCodexName);
+    const remainingConfig = readFileSync(join(movedRoot, '.codex', 'config.toml'), 'utf-8');
+    expect(remainingConfig).toContain('[mcp_servers.github]');
+    expect(remainingConfig).not.toContain(oldCodexName);
   });
 
   it('preserves non-fbeast hooks sharing a Claude matcher entry on uninstall', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -122,6 +122,7 @@ function uninstallCodex(options: {
   const namesToRemove = new Set([
     ...codexServerNamesForProjectIds(projectIds, ALL_SERVERS, 'standard'),
     ...codexServerNamesForProjectIds(projectIds, ALL_SERVERS, 'proxy'),
+    ...codexServerNamesFromLocalConfig(root),
     ...legacyCodexServerNamesForRoot(root, spawnFn),
   ]);
 
@@ -170,7 +171,50 @@ function uninstallCodex(options: {
     } catch { /* ignore parse errors */ }
   }
 
+  removeCodexProjectConfigEntries(root);
+
   removeGeneratedHookScripts(root, 'codex');
+}
+
+function codexServerNamesFromLocalConfig(root: string): string[] {
+  const configPath = join(root, '.codex', 'config.toml');
+  if (!existsSync(configPath)) return [];
+
+  const toml = readFileSync(configPath, 'utf-8');
+  return toml.split(/\r?\n/).flatMap((line) => {
+    const header = line.match(/^\s*\[mcp_servers\.(?:"([^"]+)"|([^\]]+))]\s*$/);
+    const name = header?.[1] ?? header?.[2];
+    return typeof name === 'string' && name.startsWith('fbeast-') ? [name] : [];
+  });
+}
+
+function removeCodexProjectConfigEntries(root: string): void {
+  const configPath = join(root, '.codex', 'config.toml');
+  if (!existsSync(configPath)) return;
+
+  const existing = readFileSync(configPath, 'utf-8');
+  const cleaned = removeFbeastMcpServerTables(existing).trimEnd();
+  if (cleaned.length === 0) {
+    unlinkSync(configPath);
+  } else {
+    writeFileSync(configPath, `${cleaned}\n`);
+  }
+}
+
+function removeFbeastMcpServerTables(toml: string): string {
+  const lines = toml.split(/\r?\n/);
+  const kept: string[] = [];
+  let dropping = false;
+
+  for (const line of lines) {
+    const header = line.match(/^\s*\[([^\]]+)]\s*$/);
+    if (header?.[1]) {
+      dropping = /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)$/.test(header[1]);
+    }
+    if (!dropping) kept.push(line);
+  }
+
+  return kept.join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
 function legacyCodexServerNamesForRoot(

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { confirmYesNo } from './prompt.js';
+import { codexServerNames } from './codex-server-names.js';
+import type { FbeastServer } from '../shared/config.js';
 
 export interface UninstallOptions {
   root: string;
@@ -103,9 +105,8 @@ function uninstallJsonClient(options: { root: string; claudeDir: string; client:
 
 // ─── Codex ────────────────────────────────────────────────────────────────────
 
-const ALL_SERVER_NAMES = [
-  'fbeast-memory', 'fbeast-planner', 'fbeast-critique', 'fbeast-firewall',
-  'fbeast-observer', 'fbeast-governor', 'fbeast-skills', 'fbeast-proxy',
+const ALL_SERVERS: FbeastServer[] = [
+  'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
 ];
 
 const AGENTS_MD_START = '<!-- fbeast-start -->';
@@ -117,8 +118,10 @@ function uninstallCodex(options: {
 }): void {
   const { root, spawnFn } = options;
 
-  // Remove MCP servers via codex mcp remove
-  for (const name of ALL_SERVER_NAMES) {
+  // Remove only this project's namespaced MCP servers. Codex MCP server names
+  // are global, so fixed legacy names such as `fbeast-memory` may belong to a
+  // different checkout and must not be blindly removed.
+  for (const name of [...codexServerNames(root, ALL_SERVERS, 'standard'), ...codexServerNames(root, ALL_SERVERS, 'proxy')]) {
     spawnFn('codex', ['mcp', 'remove', name]);
   }
 

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -207,14 +207,18 @@ function removeFbeastMcpServerTables(toml: string): string {
   let dropping = false;
 
   for (const line of lines) {
-    const header = line.match(/^\s*\[([^\]]+)]\s*$/);
+    const header = line.match(/^\s*\[\[?([^\]]+)]\]?\s*$/);
     if (header?.[1]) {
-      dropping = /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)$/.test(header[1]);
+      dropping = isFbeastMcpServerSection(header[1]);
     }
     if (!dropping) kept.push(line);
   }
 
   return kept.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+function isFbeastMcpServerSection(section: string): boolean {
+  return /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)(?:\.|$)/.test(section);
 }
 
 function legacyCodexServerNamesForRoot(

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -123,13 +123,13 @@ function uninstallCodex(options: {
     ...codexServerNamesForProjectIds(projectIds, ALL_SERVERS, 'standard'),
     ...codexServerNamesForProjectIds(projectIds, ALL_SERVERS, 'proxy'),
     ...codexServerNamesFromLocalConfig(root),
-    ...legacyCodexServerNamesForRoot(root, spawnFn),
+    ...codexServerNamesFromRegisteredDbPaths(root, spawnFn),
   ]);
 
   // Remove only this project's MCP servers. Namespaced entries are scoped by a
-  // persisted project id (plus the current path hash as a defensive fallback).
-  // Legacy fixed names are removed only when `codex mcp list --json` proves that
-  // they target this root's .fbeast database.
+  // persisted project id. Pre-persistence entries are removed only when local
+  // config or `codex mcp list --json` ties a fbeast registration to this root's
+  // database (including a moved repo's old database path from .codex/config.toml).
   for (const name of namesToRemove) {
     spawnFn('codex', ['mcp', 'remove', name]);
   }
@@ -188,6 +188,24 @@ function codexServerNamesFromLocalConfig(root: string): string[] {
   });
 }
 
+function codexDbPathsFromLocalConfig(root: string): string[] {
+  const configPath = join(root, '.codex', 'config.toml');
+  if (!existsSync(configPath)) return [];
+
+  const paths = new Set<string>();
+  const toml = readFileSync(configPath, 'utf-8');
+  for (const line of toml.split(/\r?\n/)) {
+    const args = line.match(/^\s*args\s*=\s*\[(.*)]\s*$/)?.[1];
+    if (!args) continue;
+    const strings = [...args.matchAll(/"((?:[^"\\]|\\.)*)"/g)].map((match) => match[1]?.replace(/\\"/g, '"') ?? '');
+    for (let index = 0; index < strings.length - 1; index += 1) {
+      const dbPath = strings[index + 1];
+      if (strings[index] === '--db' && dbPath) paths.add(resolve(dbPath));
+    }
+  }
+  return [...paths];
+}
+
 function removeCodexProjectConfigEntries(root: string): void {
   const configPath = join(root, '.codex', 'config.toml');
   if (!existsSync(configPath)) return;
@@ -221,7 +239,7 @@ function isFbeastMcpServerSection(section: string): boolean {
   return /^mcp_servers\.(?:"fbeast-[^"]+"|fbeast-[A-Za-z0-9_-]+)(?:\.|$)/.test(section);
 }
 
-function legacyCodexServerNamesForRoot(
+function codexServerNamesFromRegisteredDbPaths(
   root: string,
   spawnFn: (cmd: string, args: string[]) => { status: number | null; stdout?: Buffer | string; stderr?: Buffer | string },
 ): string[] {
@@ -236,24 +254,26 @@ function legacyCodexServerNamesForRoot(
   }
   if (!Array.isArray(entries)) return [];
 
-  const legacyNames = new Set([...ALL_SERVERS.map((server) => `fbeast-${server}`), 'fbeast-proxy']);
+  const dbPaths = new Set([
+    resolve(root, '.fbeast', 'beast.db'),
+    ...codexDbPathsFromLocalConfig(root),
+  ]);
   return entries.flatMap((entry) => {
     if (!isObjectRecord(entry)) return [];
     const name = entry['name'];
-    if (typeof name !== 'string' || !legacyNames.has(name)) return [];
-    return codexEntryTargetsRootDb(entry, root) ? [name] : [];
+    if (typeof name !== 'string' || !name.startsWith('fbeast-')) return [];
+    return codexEntryTargetsAnyDbPath(entry, dbPaths) ? [name] : [];
   });
 }
 
-function codexEntryTargetsRootDb(entry: Record<string, unknown>, root: string): boolean {
-  const dbPath = resolve(root, '.fbeast', 'beast.db');
+function codexEntryTargetsAnyDbPath(entry: Record<string, unknown>, dbPaths: ReadonlySet<string>): boolean {
   const candidates = [entry, isObjectRecord(entry['transport']) ? entry['transport'] : undefined]
     .filter((value): value is Record<string, unknown> => value !== undefined);
 
   return candidates.some((candidate) => {
     const args = candidate['args'];
     if (!Array.isArray(args)) return false;
-    return args.some((arg) => typeof arg === 'string' && resolve(arg) === dbPath);
+    return args.some((arg) => typeof arg === 'string' && dbPaths.has(resolve(arg)));
   });
 }
 

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, writeFileSync, rmSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { confirmYesNo } from './prompt.js';
-import { codexServerNames } from './codex-server-names.js';
+import { codexProjectIds, codexServerNamesForProjectIds } from './codex-server-names.js';
 import type { FbeastServer } from '../shared/config.js';
 
 export interface UninstallOptions {
@@ -15,7 +15,7 @@ export interface UninstallOptions {
   purge?: boolean | undefined;
   ask?: (question: string) => Promise<string>;
   /** Injectable spawn for testing the codex path. */
-  spawn?: (cmd: string, args: string[]) => { status: number | null };
+  spawn?: (cmd: string, args: string[]) => { status: number | null; stdout?: Buffer | string; stderr?: Buffer | string };
 }
 
 export async function runUninstall(options: UninstallOptions): Promise<void> {
@@ -114,14 +114,22 @@ const AGENTS_MD_END = '<!-- fbeast-end -->';
 
 function uninstallCodex(options: {
   root: string;
-  spawnFn: (cmd: string, args: string[]) => { status: number | null };
+  spawnFn: (cmd: string, args: string[]) => { status: number | null; stdout?: Buffer | string; stderr?: Buffer | string };
 }): void {
   const { root, spawnFn } = options;
 
-  // Remove only this project's namespaced MCP servers. Codex MCP server names
-  // are global, so fixed legacy names such as `fbeast-memory` may belong to a
-  // different checkout and must not be blindly removed.
-  for (const name of [...codexServerNames(root, ALL_SERVERS, 'standard'), ...codexServerNames(root, ALL_SERVERS, 'proxy')]) {
+  const projectIds = codexProjectIds(root);
+  const namesToRemove = new Set([
+    ...codexServerNamesForProjectIds(projectIds, ALL_SERVERS, 'standard'),
+    ...codexServerNamesForProjectIds(projectIds, ALL_SERVERS, 'proxy'),
+    ...legacyCodexServerNamesForRoot(root, spawnFn),
+  ]);
+
+  // Remove only this project's MCP servers. Namespaced entries are scoped by a
+  // persisted project id (plus the current path hash as a defensive fallback).
+  // Legacy fixed names are removed only when `codex mcp list --json` proves that
+  // they target this root's .fbeast database.
+  for (const name of namesToRemove) {
     spawnFn('codex', ['mcp', 'remove', name]);
   }
 
@@ -163,6 +171,46 @@ function uninstallCodex(options: {
   }
 
   removeGeneratedHookScripts(root, 'codex');
+}
+
+function legacyCodexServerNamesForRoot(
+  root: string,
+  spawnFn: (cmd: string, args: string[]) => { status: number | null; stdout?: Buffer | string; stderr?: Buffer | string },
+): string[] {
+  const result = spawnFn('codex', ['mcp', 'list', '--json']);
+  if (result.status !== 0 || result.stdout === undefined) return [];
+
+  let entries: unknown;
+  try {
+    entries = JSON.parse(result.stdout.toString());
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(entries)) return [];
+
+  const legacyNames = new Set([...ALL_SERVERS.map((server) => `fbeast-${server}`), 'fbeast-proxy']);
+  return entries.flatMap((entry) => {
+    if (!isObjectRecord(entry)) return [];
+    const name = entry['name'];
+    if (typeof name !== 'string' || !legacyNames.has(name)) return [];
+    return codexEntryTargetsRootDb(entry, root) ? [name] : [];
+  });
+}
+
+function codexEntryTargetsRootDb(entry: Record<string, unknown>, root: string): boolean {
+  const dbPath = resolve(root, '.fbeast', 'beast.db');
+  const candidates = [entry, isObjectRecord(entry['transport']) ? entry['transport'] : undefined]
+    .filter((value): value is Record<string, unknown> => value !== undefined);
+
+  return candidates.some((candidate) => {
+    const args = candidate['args'];
+    if (!Array.isArray(args)) return false;
+    return args.some((arg) => typeof arg === 'string' && resolve(arg) === dbPath);
+  });
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function removeGeneratedHookScripts(root: string, client: 'claude' | 'gemini' | 'codex'): void {


### PR DESCRIPTION
Closes #371

## Summary
- add a shared Codex MCP naming helper that suffixes fbeast server names with a stable project-root hash
- register Codex MCP servers using namespaced names in both standard and proxy modes
- uninstall only the current project's namespaced Codex MCP entries, avoiding fixed global fbeast-* removals
- add regression coverage for multi-project install/uninstall behavior

## Test plan
- npm --workspace @fbeast/mcp-suite run typecheck
- npm --workspace @fbeast/mcp-suite test -- --run src/cli/init.test.ts src/cli/uninstall.test.ts
- npm run build
- npm --workspace @fbeast/mcp-suite test

Note: an initial full mcp-suite test run before building workspace packages failed because local workspace dist entries were missing; after `npm run build`, the full mcp-suite suite passed.