### PR TITLE
fix(orchestrator): bridge provider registries

### DIFF
--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -1,6 +1,10 @@
 import { SqliteBrain } from 'franken-brain';
 import { ProviderRegistry } from '../providers/provider-registry.js';
 import {
+  createLlmProvider,
+  type ProviderConfig,
+} from '../providers/provider-config.js';
+import {
   buildMiddlewareChain,
   resolveSecurityConfig,
   type SecurityProfile,
@@ -27,31 +31,13 @@ import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
 // fail-closed / config-disable / FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES
 // opt-out handling in dep-factory before it can run (issue #364, ADR-036).
 
-import { ClaudeCliAdapter } from '../providers/claude-cli-adapter.js';
-import { CodexCliAdapter } from '../providers/codex-cli-adapter.js';
-import { GeminiCliAdapter } from '../providers/gemini-cli-adapter.js';
-import { AnthropicApiAdapter } from '../providers/anthropic-api-adapter.js';
-import { OpenAiApiAdapter } from '../providers/openai-api-adapter.js';
-import { GeminiApiAdapter } from '../providers/gemini-api-adapter.js';
-
 import type { BeastLoopDeps, IObserverModule, McpToolInfo } from '../deps.js';
 import type { ILlmProvider } from '@franken/types';
 import type { AggregatedTokenUsage } from '../providers/token-aggregator.js';
 
-// --- Config types ---
+export type { ProviderConfig } from '../providers/provider-config.js';
 
-export interface ProviderConfig {
-  name: string;
-  type:
-    | 'claude-cli'
-    | 'codex-cli'
-    | 'gemini-cli'
-    | 'anthropic-api'
-    | 'openai-api'
-    | 'gemini-api';
-  apiKey?: string;
-  cliPath?: string;
-}
+// --- Config types ---
 
 export interface BeastDepsConfig {
   providers?: ProviderConfig[];
@@ -242,7 +228,7 @@ function collectEnabledMcpTools(skillManager: SkillManager): McpToolInfo[] {
   });
 }
 
-function buildProviderList(
+export function buildProviderList(
   configs?: ProviderConfig[],
 ): ILlmProvider[] {
   if (!configs || configs.length === 0) {
@@ -250,22 +236,5 @@ function buildProviderList(
       "No providers configured. Run 'frankenbeast provider add claude' to get started.",
     );
   }
-  return configs.map((pc) => {
-    switch (pc.type) {
-      case 'claude-cli':
-        return new ClaudeCliAdapter(pc.cliPath ? { binaryPath: pc.cliPath } : {});
-      case 'codex-cli':
-        return new CodexCliAdapter(pc.cliPath ? { binaryPath: pc.cliPath } : {});
-      case 'gemini-cli':
-        return new GeminiCliAdapter(pc.cliPath ? { binaryPath: pc.cliPath } : {});
-      case 'anthropic-api':
-        return new AnthropicApiAdapter(pc.apiKey ? { apiKey: pc.apiKey } : {});
-      case 'openai-api':
-        return new OpenAiApiAdapter(pc.apiKey ? { apiKey: pc.apiKey } : {});
-      case 'gemini-api':
-        return new GeminiApiAdapter(pc.apiKey ? { apiKey: pc.apiKey } : {});
-      default:
-        throw new Error(`Unknown provider type: ${(pc as { type: string }).type}`);
-    }
-  });
+  return configs.map((pc) => createLlmProvider(pc));
 }

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -33,6 +33,8 @@ const SECURITY_TIER_MAP: Record<string, SecurityProfile> = {
  * consolidatedProviders) take precedence over CLI-derived defaults.
  */
 export function bridgeToBeastConfig(options: CliDepOptions, config?: OrchestratorConfig): BeastDepsConfig {
+  const consolidatedProviders = config?.consolidatedProviders as ProviderConfig[] | undefined;
+
   // Resolve effective primary provider (runConfig overrides take precedence)
   const effectiveProvider =
     options.runConfig?.llmConfig?.default?.provider
@@ -51,7 +53,7 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
     }
   }
 
-  const providers: ProviderConfig[] = providerNames.map((name) => {
+  const providers: ProviderConfig[] = consolidatedProviders ?? providerNames.map((name) => {
     if (name === 'aider') {
       const override = options.providersConfig?.[name];
       return {
@@ -74,7 +76,7 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
   const dbPath = resolve(options.paths.frankenbeastDir, 'beast.db');
 
   return {
-    providers: (config?.consolidatedProviders as ProviderConfig[] | undefined) ?? providers,
+    providers,
     security: config?.security
       ? {
           profile: (config.security.profile as SecurityProfile) ?? securityProfile,

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -51,9 +51,20 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
     }
   }
 
-  const providers: ProviderConfig[] = providerNames.map((name) =>
-    buildProviderConfig(name, options.providersConfig?.[name]),
-  );
+  const providers: ProviderConfig[] = providerNames.map((name) => {
+    if (name === 'aider') {
+      const override = options.providersConfig?.[name];
+      return {
+        name,
+        type: 'claude-cli',
+        ...(override?.command ? { cliPath: override.command } : {}),
+        ...(override?.model ? { model: override.model } : {}),
+        ...(override?.extraArgs ? { extraArgs: override.extraArgs } : {}),
+      };
+    }
+
+    return buildProviderConfig(name, options.providersConfig?.[name]);
+  });
 
   // Security
   const securityProfile: SecurityProfile =

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -13,6 +13,7 @@ import type {
   ProviderConfig,
 } from './create-beast-deps.js';
 import { buildProviderConfig } from '../providers/provider-config.js';
+import type { ProviderOverrideConfig } from '../providers/provider-config.js';
 import type { SecurityProfile } from '../middleware/security-profiles.js';
 import type { BeastLoopDeps, IObserverModule } from '../deps.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
@@ -41,6 +42,19 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
       options.runConfig?.llmConfig?.default?.provider
       ?? options.runConfig?.provider
       ?? options.provider;
+    const effectiveModel =
+      options.runConfig?.llmConfig?.default?.model
+      ?? options.runConfig?.model;
+
+    const providerOverride = (name: string): ProviderOverrideConfig | undefined => {
+      const override = options.providersConfig?.[name];
+      if (name !== effectiveProvider || !effectiveModel) return override;
+
+      return {
+        ...override,
+        model: effectiveModel,
+      };
+    };
 
     // Build provider list: primary first, then additional (deduplicated)
     const providerNames: string[] = [];
@@ -56,7 +70,7 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
 
     return providerNames.map((name) => {
       if (name === 'aider') {
-        const override = options.providersConfig?.[name];
+        const override = providerOverride(name);
         return {
           name,
           type: 'claude-cli',
@@ -66,7 +80,7 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
         };
       }
 
-      return buildProviderConfig(name, options.providersConfig?.[name]);
+      return buildProviderConfig(name, providerOverride(name));
     });
   })();
 

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -12,23 +12,10 @@ import type {
   ExistingDeps,
   ProviderConfig,
 } from './create-beast-deps.js';
+import { buildProviderConfig } from '../providers/provider-config.js';
 import type { SecurityProfile } from '../middleware/security-profiles.js';
 import type { BeastLoopDeps, IObserverModule } from '../deps.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
-
-// ─── Provider name → type detection ───
-
-type ProviderType = ProviderConfig['type'];
-
-function detectProviderType(name: string): ProviderType {
-  const lower = name.toLowerCase();
-  if (lower.includes('claude')) return 'claude-cli';
-  if (lower.includes('codex')) return 'codex-cli';
-  if (lower.includes('gemini')) return 'gemini-cli';
-  if (lower.includes('anthropic')) return 'anthropic-api';
-  if (lower.includes('openai')) return 'openai-api';
-  return 'claude-cli'; // CLI default
-}
 
 // ─── Security tier mapping ───
 
@@ -64,20 +51,9 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
     }
   }
 
-  const providers: ProviderConfig[] = providerNames.map((name) => {
-    const config: ProviderConfig = {
-      name,
-      type: detectProviderType(name),
-    };
-
-    // Map providersConfig.command → cliPath
-    const override = options.providersConfig?.[name];
-    if (override?.command) {
-      return { ...config, cliPath: override.command };
-    }
-
-    return config;
-  });
+  const providers: ProviderConfig[] = providerNames.map((name) =>
+    buildProviderConfig(name, options.providersConfig?.[name]),
+  );
 
   // Security
   const securityProfile: SecurityProfile =

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -35,38 +35,40 @@ const SECURITY_TIER_MAP: Record<string, SecurityProfile> = {
 export function bridgeToBeastConfig(options: CliDepOptions, config?: OrchestratorConfig): BeastDepsConfig {
   const consolidatedProviders = config?.consolidatedProviders as ProviderConfig[] | undefined;
 
-  // Resolve effective primary provider (runConfig overrides take precedence)
-  const effectiveProvider =
-    options.runConfig?.llmConfig?.default?.provider
-    ?? options.runConfig?.provider
-    ?? options.provider;
+  const providers: ProviderConfig[] = consolidatedProviders ?? (() => {
+    // Resolve effective primary provider (runConfig overrides take precedence)
+    const effectiveProvider =
+      options.runConfig?.llmConfig?.default?.provider
+      ?? options.runConfig?.provider
+      ?? options.provider;
 
-  // Build provider list: primary first, then additional (deduplicated)
-  const providerNames: string[] = [];
-  providerNames.push(effectiveProvider);
+    // Build provider list: primary first, then additional (deduplicated)
+    const providerNames: string[] = [];
+    providerNames.push(effectiveProvider);
 
-  if (options.providers) {
-    for (const name of options.providers) {
-      if (!providerNames.includes(name)) {
-        providerNames.push(name);
+    if (options.providers) {
+      for (const name of options.providers) {
+        if (!providerNames.includes(name)) {
+          providerNames.push(name);
+        }
       }
     }
-  }
 
-  const providers: ProviderConfig[] = consolidatedProviders ?? providerNames.map((name) => {
-    if (name === 'aider') {
-      const override = options.providersConfig?.[name];
-      return {
-        name,
-        type: 'claude-cli',
-        ...(override?.command ? { cliPath: override.command } : {}),
-        ...(override?.model ? { model: override.model } : {}),
-        ...(override?.extraArgs ? { extraArgs: override.extraArgs } : {}),
-      };
-    }
+    return providerNames.map((name) => {
+      if (name === 'aider') {
+        const override = options.providersConfig?.[name];
+        return {
+          name,
+          type: 'claude-cli',
+          ...(override?.command ? { cliPath: override.command } : {}),
+          ...(override?.model ? { model: override.model } : {}),
+          ...(override?.extraArgs ? { extraArgs: override.extraArgs } : {}),
+        };
+      }
 
-    return buildProviderConfig(name, options.providersConfig?.[name]);
-  });
+      return buildProviderConfig(name, options.providersConfig?.[name]);
+    });
+  })();
 
   // Security
   const securityProfile: SecurityProfile =

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -15,6 +15,8 @@ export const ProviderConfigSchema = z.object({
   ]),
   apiKey: z.string().optional(),
   cliPath: z.string().optional(),
+  model: z.string().optional(),
+  extraArgs: z.array(z.string()).optional(),
 });
 
 export const SecurityConfigInputSchema = z.object({

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -18,6 +18,7 @@ export interface ClaudeCliOptions {
   maxBudgetUsd?: number;
   maxTurns?: number;
   tools?: string[];
+  extraArgs?: readonly string[];
 }
 
 export class ClaudeCliAdapter implements ILlmProvider {
@@ -118,6 +119,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
     }
     if (this.options.tools?.length) {
       args.push('--tools', this.options.tools.join(','));
+    }
+    if (this.options.extraArgs?.length) {
+      args.push(...this.options.extraArgs);
     }
     return args;
   }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -15,6 +15,7 @@ import { collectCliOutput, extractAuthFields } from './discover-skills-helpers.j
 
 export interface ClaudeCliOptions {
   binaryPath?: string;
+  model?: string;
   maxBudgetUsd?: number;
   maxTurns?: number;
   tools?: string[];
@@ -110,6 +111,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
     const args = ['-p', '--output-format', 'stream-json'];
     if (request.systemPrompt) {
       args.push('--append-system-prompt', request.systemPrompt);
+    }
+    if (this.options.model) {
+      args.push('--model', this.options.model);
     }
     if (this.options.maxBudgetUsd) {
       args.push('--max-budget-usd', String(this.options.maxBudgetUsd));

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -15,6 +15,7 @@ import { collectCliOutput, extractAuthFields } from './discover-skills-helpers.j
 
 export interface CodexCliOptions {
   binaryPath?: string;
+  model?: string;
   profile?: string;
   configOverrides?: Record<string, string>;
   extraArgs?: readonly string[];
@@ -108,6 +109,9 @@ export class CodexCliAdapter implements ILlmProvider {
     }
     if (this.options.profile) {
       args.push('-p', this.options.profile);
+    }
+    if (this.options.model && !this.options.configOverrides?.['model']) {
+      args.push('-c', `model=${this.options.model}`);
     }
     if (this.options.configOverrides) {
       for (const [key, value] of Object.entries(

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -17,6 +17,7 @@ export interface CodexCliOptions {
   binaryPath?: string;
   profile?: string;
   configOverrides?: Record<string, string>;
+  extraArgs?: readonly string[];
 }
 
 export class CodexCliAdapter implements ILlmProvider {
@@ -114,6 +115,9 @@ export class CodexCliAdapter implements ILlmProvider {
       )) {
         args.push('-c', `${key}=${value}`);
       }
+    }
+    if (this.options.extraArgs?.length) {
+      args.push(...this.options.extraArgs);
     }
     return args;
   }

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -23,6 +23,7 @@ export interface GeminiCliOptions {
   binaryPath?: string;
   model?: string;
   workingDir?: string;
+  extraArgs?: readonly string[];
 }
 
 export class GeminiCliAdapter implements ILlmProvider {
@@ -145,6 +146,9 @@ export class GeminiCliAdapter implements ILlmProvider {
     const args = ['-p', '--output-format', 'stream-json'];
     if (this.options.model) {
       args.push('-m', this.options.model);
+    }
+    if (this.options.extraArgs?.length) {
+      args.push(...this.options.extraArgs);
     }
     return args;
   }

--- a/packages/franken-orchestrator/src/providers/provider-config.ts
+++ b/packages/franken-orchestrator/src/providers/provider-config.ts
@@ -137,6 +137,7 @@ export function createLlmProvider(config: ProviderConfig): ILlmProvider {
     case 'claude-cli':
       return new ClaudeCliAdapter({
         ...(config.cliPath ? { binaryPath: config.cliPath } : {}),
+        ...(config.model ? { model: config.model } : {}),
         ...(config.extraArgs ? { extraArgs: config.extraArgs } : {}),
       });
     case 'codex-cli':

--- a/packages/franken-orchestrator/src/providers/provider-config.ts
+++ b/packages/franken-orchestrator/src/providers/provider-config.ts
@@ -1,0 +1,153 @@
+import type { ILlmProvider } from '@franken/types';
+import { ClaudeCliAdapter } from './claude-cli-adapter.js';
+import { CodexCliAdapter } from './codex-cli-adapter.js';
+import { GeminiCliAdapter } from './gemini-cli-adapter.js';
+import { AnthropicApiAdapter } from './anthropic-api-adapter.js';
+import { OpenAiApiAdapter } from './openai-api-adapter.js';
+import { GeminiApiAdapter } from './gemini-api-adapter.js';
+
+export const PROVIDER_TYPES = [
+  'claude-cli',
+  'codex-cli',
+  'gemini-cli',
+  'anthropic-api',
+  'openai-api',
+  'gemini-api',
+] as const;
+
+export type ProviderType = (typeof PROVIDER_TYPES)[number];
+
+export interface ProviderOverrideConfig {
+  readonly command?: string | undefined;
+  readonly model?: string | undefined;
+  readonly extraArgs?: readonly string[] | undefined;
+}
+
+export interface ProviderConfig {
+  readonly name: string;
+  readonly type: ProviderType;
+  readonly apiKey?: string | undefined;
+  readonly cliPath?: string | undefined;
+  readonly model?: string | undefined;
+  readonly extraArgs?: readonly string[] | undefined;
+}
+
+export interface ProviderCatalogEntry {
+  readonly name: string;
+  readonly type: ProviderType;
+  readonly cliRegistryName?: string | undefined;
+  readonly defaultCommand?: string | undefined;
+  readonly supportsCliRegistry: boolean;
+}
+
+const CATALOG: readonly ProviderCatalogEntry[] = [
+  {
+    name: 'claude',
+    type: 'claude-cli',
+    cliRegistryName: 'claude',
+    defaultCommand: 'claude',
+    supportsCliRegistry: true,
+  },
+  {
+    name: 'codex',
+    type: 'codex-cli',
+    cliRegistryName: 'codex',
+    defaultCommand: 'codex',
+    supportsCliRegistry: true,
+  },
+  {
+    name: 'gemini',
+    type: 'gemini-cli',
+    cliRegistryName: 'gemini',
+    defaultCommand: 'gemini',
+    supportsCliRegistry: true,
+  },
+  {
+    name: 'anthropic',
+    type: 'anthropic-api',
+    supportsCliRegistry: false,
+  },
+  {
+    name: 'openai',
+    type: 'openai-api',
+    supportsCliRegistry: false,
+  },
+  {
+    name: 'gemini-api',
+    type: 'gemini-api',
+    supportsCliRegistry: false,
+  },
+] as const;
+
+const TYPE_TO_ENTRY = new Map(CATALOG.map((entry) => [entry.type, entry]));
+const NAME_OR_TYPE_TO_ENTRY = new Map<string, ProviderCatalogEntry>();
+for (const entry of CATALOG) {
+  NAME_OR_TYPE_TO_ENTRY.set(entry.name, entry);
+  NAME_OR_TYPE_TO_ENTRY.set(entry.type, entry);
+  if (entry.cliRegistryName) {
+    NAME_OR_TYPE_TO_ENTRY.set(entry.cliRegistryName, entry);
+  }
+}
+
+export function providerCatalogEntries(): readonly ProviderCatalogEntry[] {
+  return CATALOG;
+}
+
+export function cliProviderCatalogEntries(): readonly ProviderCatalogEntry[] {
+  return CATALOG.filter((entry) => entry.supportsCliRegistry);
+}
+
+export function resolveProviderCatalogEntry(nameOrType: string): ProviderCatalogEntry {
+  const entry = NAME_OR_TYPE_TO_ENTRY.get(nameOrType);
+  if (entry) return entry;
+
+  const known = [...NAME_OR_TYPE_TO_ENTRY.keys()].sort().join(', ');
+  throw new Error(
+    `Unknown provider "${nameOrType}". Configure a typed consolidated provider or use one of: ${known}`,
+  );
+}
+
+export function resolveProviderType(nameOrType: string, explicitType?: ProviderType): ProviderType {
+  if (explicitType) {
+    if (!TYPE_TO_ENTRY.has(explicitType)) {
+      throw new Error(`Unknown provider type: ${explicitType}`);
+    }
+    return explicitType;
+  }
+  return resolveProviderCatalogEntry(nameOrType).type;
+}
+
+export function buildProviderConfig(
+  name: string,
+  override?: ProviderOverrideConfig,
+): ProviderConfig {
+  const entry = resolveProviderCatalogEntry(name);
+  return {
+    name,
+    type: entry.type,
+    ...(override?.command ? { cliPath: override.command } : {}),
+    ...(override?.model ? { model: override.model } : {}),
+    ...(override?.extraArgs ? { extraArgs: override.extraArgs } : {}),
+  };
+}
+
+export function createLlmProvider(config: ProviderConfig): ILlmProvider {
+  const type = resolveProviderType(config.name, config.type);
+  switch (type) {
+    case 'claude-cli':
+      return new ClaudeCliAdapter(config.cliPath ? { binaryPath: config.cliPath } : {});
+    case 'codex-cli':
+      return new CodexCliAdapter(config.cliPath ? { binaryPath: config.cliPath } : {});
+    case 'gemini-cli':
+      return new GeminiCliAdapter({
+        ...(config.cliPath ? { binaryPath: config.cliPath } : {}),
+        ...(config.model ? { model: config.model } : {}),
+      });
+    case 'anthropic-api':
+      return new AnthropicApiAdapter(config.apiKey ? { apiKey: config.apiKey } : {});
+    case 'openai-api':
+      return new OpenAiApiAdapter(config.apiKey ? { apiKey: config.apiKey } : {});
+    case 'gemini-api':
+      return new GeminiApiAdapter(config.apiKey ? { apiKey: config.apiKey } : {});
+  }
+}

--- a/packages/franken-orchestrator/src/providers/provider-config.ts
+++ b/packages/franken-orchestrator/src/providers/provider-config.ts
@@ -135,19 +135,35 @@ export function createLlmProvider(config: ProviderConfig): ILlmProvider {
   const type = resolveProviderType(config.name, config.type);
   switch (type) {
     case 'claude-cli':
-      return new ClaudeCliAdapter(config.cliPath ? { binaryPath: config.cliPath } : {});
+      return new ClaudeCliAdapter({
+        ...(config.cliPath ? { binaryPath: config.cliPath } : {}),
+        ...(config.extraArgs ? { extraArgs: config.extraArgs } : {}),
+      });
     case 'codex-cli':
-      return new CodexCliAdapter(config.cliPath ? { binaryPath: config.cliPath } : {});
+      return new CodexCliAdapter({
+        ...(config.cliPath ? { binaryPath: config.cliPath } : {}),
+        ...(config.extraArgs ? { extraArgs: config.extraArgs } : {}),
+      });
     case 'gemini-cli':
       return new GeminiCliAdapter({
         ...(config.cliPath ? { binaryPath: config.cliPath } : {}),
         ...(config.model ? { model: config.model } : {}),
+        ...(config.extraArgs ? { extraArgs: config.extraArgs } : {}),
       });
     case 'anthropic-api':
-      return new AnthropicApiAdapter(config.apiKey ? { apiKey: config.apiKey } : {});
+      return new AnthropicApiAdapter({
+        ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+        ...(config.model ? { model: config.model } : {}),
+      });
     case 'openai-api':
-      return new OpenAiApiAdapter(config.apiKey ? { apiKey: config.apiKey } : {});
+      return new OpenAiApiAdapter({
+        ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+        ...(config.model ? { model: config.model } : {}),
+      });
     case 'gemini-api':
-      return new GeminiApiAdapter(config.apiKey ? { apiKey: config.apiKey } : {});
+      return new GeminiApiAdapter({
+        ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+        ...(config.model ? { model: config.model } : {}),
+      });
   }
 }

--- a/packages/franken-orchestrator/src/providers/provider-config.ts
+++ b/packages/franken-orchestrator/src/providers/provider-config.ts
@@ -142,6 +142,7 @@ export function createLlmProvider(config: ProviderConfig): ILlmProvider {
     case 'codex-cli':
       return new CodexCliAdapter({
         ...(config.cliPath ? { binaryPath: config.cliPath } : {}),
+        ...(config.model ? { model: config.model } : {}),
         ...(config.extraArgs ? { extraArgs: config.extraArgs } : {}),
       });
     case 'gemini-cli':

--- a/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
@@ -11,6 +11,7 @@ import { ClaudeProvider } from './claude-provider.js';
 import { CodexProvider } from './codex-provider.js';
 import { GeminiProvider } from './gemini-provider.js';
 import { AiderProvider } from './aider-provider.js';
+import { cliProviderCatalogEntries } from '../../providers/provider-config.js';
 
 export interface ProviderOpts {
   readonly maxTurns?: number | undefined;
@@ -99,9 +100,23 @@ export class ProviderRegistry {
 
 export function createDefaultRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
-  registry.register(new ClaudeProvider());
-  registry.register(new CodexProvider());
-  registry.register(new GeminiProvider());
+  for (const entry of cliProviderCatalogEntries()) {
+    switch (entry.cliRegistryName) {
+      case 'claude':
+        registry.register(new ClaudeProvider());
+        break;
+      case 'codex':
+        registry.register(new CodexProvider());
+        break;
+      case 'gemini':
+        registry.register(new GeminiProvider());
+        break;
+    }
+  }
+
+  // Aider is only a legacy Martin-loop CLI provider today. It intentionally
+  // remains outside the consolidated LLM registry until an ILlmProvider adapter
+  // exists, so it cannot be selected by typed provider bridging accidentally.
   registry.register(new AiderProvider());
   return registry;
 }

--- a/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
@@ -2,10 +2,40 @@ import { describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { createBeastDeps } from '../../../src/cli/create-beast-deps.js';
+import { buildProviderList, createBeastDeps } from '../../../src/cli/create-beast-deps.js';
 import { makeCritique, makeGovernor, makeLogger, makeObserver, makePlanner } from '../../helpers/stubs.js';
 
 describe('createBeastDeps', () => {
+  it('builds consolidated CLI providers from the same typed provider config used by the CLI bridge', () => {
+    const providers = buildProviderList([
+      {
+        name: 'gemini',
+        type: 'gemini-cli',
+        cliPath: '/opt/bin/gemini',
+        model: 'gemini-2.5-pro',
+      },
+    ]);
+
+    expect(providers).toHaveLength(1);
+    const [provider] = providers;
+    expect(provider!.name).toBe('gemini-cli');
+    expect(provider!.type).toBe('gemini-cli');
+    expect(provider!.authMethod).toBe('cli-login');
+    expect(provider!.capabilities).toMatchObject({
+      streaming: true,
+      toolUse: true,
+      mcpSupport: true,
+      maxContextTokens: 1_000_000,
+    });
+    expect((provider as { buildArgs(request: unknown): string[] }).buildArgs({})).toEqual([
+      '-p',
+      '--output-format',
+      'stream-json',
+      '-m',
+      'gemini-2.5-pro',
+    ]);
+  });
+
   it('populates the MCP adapter catalog from enabled skill tool manifests', () => {
     const root = mkdtempSync(join(tmpdir(), 'franken-create-deps-'));
     const skillsDir = join(root, 'skills');

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -187,6 +187,57 @@ describe('bridgeToBeastConfig()', () => {
         expect.objectContaining({ name: 'anthropic', type: 'anthropic-api' }),
       );
     });
+
+    it('forwards runConfig.model into the effective bridged provider', () => {
+      const config = bridgeToBeastConfig(makeOptions({
+        provider: 'codex',
+        runConfig: { provider: 'gemini', model: 'gemini-2.5-pro' },
+        providers: ['codex', 'gemini'],
+      }));
+
+      expect(config.providers).toEqual([
+        { name: 'gemini', type: 'gemini-cli', model: 'gemini-2.5-pro' },
+        { name: 'codex', type: 'codex-cli' },
+      ]);
+    });
+
+    it('forwards runConfig.llmConfig.default.model into the effective bridged provider', () => {
+      const config = bridgeToBeastConfig(makeOptions({
+        provider: 'codex',
+        providersConfig: {
+          claude: { command: '/opt/bin/claude', extraArgs: ['--print'] },
+        },
+        runConfig: {
+          provider: 'gemini',
+          model: 'gemini-1.5-pro',
+          llmConfig: { default: { provider: 'claude', model: 'claude-sonnet-4-20250514' } },
+        },
+      }));
+
+      expect(config.providers).toEqual([
+        {
+          name: 'claude',
+          type: 'claude-cli',
+          cliPath: '/opt/bin/claude',
+          model: 'claude-sonnet-4-20250514',
+          extraArgs: ['--print'],
+        },
+      ]);
+    });
+
+    it('forwards runConfig.model through the legacy aider provider path', () => {
+      const config = bridgeToBeastConfig(makeOptions({
+        provider: 'aider',
+        providersConfig: {
+          aider: { command: '/opt/bin/aider' },
+        },
+        runConfig: { model: 'gpt-4o' },
+      }));
+
+      expect(config.providers).toEqual([
+        { name: 'aider', type: 'claude-cli', cliPath: '/opt/bin/aider', model: 'gpt-4o' },
+      ]);
+    });
   });
 
   describe('security tier mapping', () => {

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -77,11 +77,11 @@ describe('bridgeToBeastConfig()', () => {
       ]);
     });
 
-    it('defaults unknown provider to claude-cli', () => {
-      const config = bridgeToBeastConfig(makeOptions({ provider: 'some-custom' }));
-      expect(config.providers).toEqual([
-        { name: 'some-custom', type: 'claude-cli' },
-      ]);
+    it('rejects unknown providers instead of guessing by substring', () => {
+      expect(() => bridgeToBeastConfig(makeOptions({ provider: 'some-custom' })))
+        .toThrowError(/Unknown provider "some-custom"/);
+      expect(() => bridgeToBeastConfig(makeOptions({ provider: 'my-openai-wrapper' })))
+        .toThrowError(/Unknown provider "my-openai-wrapper"/);
     });
 
     it('maps multiple providers from options.providers', () => {
@@ -117,6 +117,28 @@ describe('bridgeToBeastConfig()', () => {
       }));
       expect(config.providers).toEqual([
         { name: 'claude', type: 'claude-cli', cliPath: '/usr/local/bin/claude' },
+      ]);
+    });
+
+    it('maps providersConfig command, model, and extraArgs through typed provider config', () => {
+      const config = bridgeToBeastConfig(makeOptions({
+        provider: 'gemini',
+        providersConfig: {
+          gemini: {
+            command: '/opt/bin/gemini',
+            model: 'gemini-2.5-pro',
+            extraArgs: ['--debug'],
+          },
+        },
+      }));
+      expect(config.providers).toEqual([
+        {
+          name: 'gemini',
+          type: 'gemini-cli',
+          cliPath: '/opt/bin/gemini',
+          model: 'gemini-2.5-pro',
+          extraArgs: ['--debug'],
+        },
       ]);
     });
 

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -63,6 +63,28 @@ describe('bridgeToBeastConfig()', () => {
       ]);
     });
 
+    it('preserves legacy "aider" CLI selection with the consolidated CLI fallback type', () => {
+      const config = bridgeToBeastConfig(makeOptions({
+        provider: 'aider',
+        providersConfig: {
+          aider: {
+            command: '/opt/bin/aider',
+            model: 'gpt-4o',
+            extraArgs: ['--yes-always'],
+          },
+        },
+      }));
+      expect(config.providers).toEqual([
+        {
+          name: 'aider',
+          type: 'claude-cli',
+          cliPath: '/opt/bin/aider',
+          model: 'gpt-4o',
+          extraArgs: ['--yes-always'],
+        },
+      ]);
+    });
+
     it('maps "anthropic" to anthropic-api type', () => {
       const config = bridgeToBeastConfig(makeOptions({ provider: 'anthropic' }));
       expect(config.providers).toEqual([

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -273,17 +273,20 @@ describe('bridgeToBeastConfig()', () => {
     it('uses config.consolidatedProviders before validating CLI-derived providers', () => {
       const orchestratorConfig = {
         consolidatedProviders: [
-          { name: 'custom-codex', type: 'codex-cli', model: 'o4-mini' },
+          { name: 'azure-openai', type: 'openai-api', model: 'gpt-4.1' },
         ],
       } as any;
 
       const config = bridgeToBeastConfig(
-        makeOptions({ provider: 'unknown-legacy-provider' }),
+        makeOptions({
+          provider: 'azure-openai',
+          providers: ['unknown-legacy-provider'],
+        }),
         orchestratorConfig,
       );
 
       expect(config.providers).toEqual([
-        { name: 'custom-codex', type: 'codex-cli', model: 'o4-mini' },
+        { name: 'azure-openai', type: 'openai-api', model: 'gpt-4.1' },
       ]);
     });
 

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -270,6 +270,23 @@ describe('bridgeToBeastConfig()', () => {
       ]);
     });
 
+    it('uses config.consolidatedProviders before validating CLI-derived providers', () => {
+      const orchestratorConfig = {
+        consolidatedProviders: [
+          { name: 'custom-codex', type: 'codex-cli', model: 'o4-mini' },
+        ],
+      } as any;
+
+      const config = bridgeToBeastConfig(
+        makeOptions({ provider: 'unknown-legacy-provider' }),
+        orchestratorConfig,
+      );
+
+      expect(config.providers).toEqual([
+        { name: 'custom-codex', type: 'codex-cli', model: 'o4-mini' },
+      ]);
+    });
+
     it('falls back to CLI-derived values when config fields are absent', () => {
       const orchestratorConfig = {} as any;
       const config = bridgeToBeastConfig(makeOptions({ provider: 'codex' }), orchestratorConfig);

--- a/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { AnthropicApiAdapter } from '../../../src/providers/anthropic-api-adapter.js';
+import { ClaudeCliAdapter } from '../../../src/providers/claude-cli-adapter.js';
+import { CodexCliAdapter } from '../../../src/providers/codex-cli-adapter.js';
+import { GeminiApiAdapter } from '../../../src/providers/gemini-api-adapter.js';
+import { GeminiCliAdapter } from '../../../src/providers/gemini-cli-adapter.js';
+import { OpenAiApiAdapter } from '../../../src/providers/openai-api-adapter.js';
+import { createLlmProvider, type ProviderConfig } from '../../../src/providers/provider-config.js';
+
+const request = {
+  messages: [],
+  systemPrompt: 'test',
+};
+
+function optionsOf<TOptions>(adapter: unknown): TOptions {
+  return (adapter as { options: TOptions }).options;
+}
+
+describe('createLlmProvider', () => {
+  it('forwards extraArgs to consolidated CLI adapters', () => {
+    const claude = createLlmProvider({
+      name: 'claude',
+      type: 'claude-cli',
+      extraArgs: ['--model', 'opus'],
+    });
+    const codex = createLlmProvider({
+      name: 'codex',
+      type: 'codex-cli',
+      extraArgs: ['--model', 'o3'],
+    });
+    const gemini = createLlmProvider({
+      name: 'gemini',
+      type: 'gemini-cli',
+      model: 'gemini-2.5-pro',
+      extraArgs: ['--debug'],
+    });
+
+    expect(claude).toBeInstanceOf(ClaudeCliAdapter);
+    expect((claude as ClaudeCliAdapter).buildArgs(request)).toContain('--model');
+    expect((claude as ClaudeCliAdapter).buildArgs(request)).toContain('opus');
+
+    expect(codex).toBeInstanceOf(CodexCliAdapter);
+    expect((codex as CodexCliAdapter).buildArgs(request)).toEqual([
+      'exec',
+      '--json',
+      '--ephemeral',
+      '-c',
+      'instructions=test',
+      '--model',
+      'o3',
+    ]);
+
+    expect(gemini).toBeInstanceOf(GeminiCliAdapter);
+    expect((gemini as GeminiCliAdapter).buildArgs(request)).toEqual([
+      '-p',
+      '--output-format',
+      'stream-json',
+      '-m',
+      'gemini-2.5-pro',
+      '--debug',
+    ]);
+  });
+
+  it('passes configured models into API adapters', () => {
+    const configs: ProviderConfig[] = [
+      { name: 'anthropic', type: 'anthropic-api', model: 'claude-opus-4' },
+      { name: 'openai', type: 'openai-api', model: 'gpt-4.1' },
+      { name: 'gemini-api', type: 'gemini-api', model: 'gemini-2.5-pro' },
+    ];
+
+    const [anthropic, openai, gemini] = configs.map(createLlmProvider);
+
+    expect(anthropic).toBeInstanceOf(AnthropicApiAdapter);
+    expect(optionsOf<{ model?: string }>(anthropic).model).toBe('claude-opus-4');
+
+    expect(openai).toBeInstanceOf(OpenAiApiAdapter);
+    expect(optionsOf<{ model?: string }>(openai).model).toBe('gpt-4.1');
+
+    expect(gemini).toBeInstanceOf(GeminiApiAdapter);
+    expect(optionsOf<{ model?: string }>(gemini).model).toBe('gemini-2.5-pro');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
@@ -35,7 +35,7 @@ describe('createLlmProvider', () => {
     const claude = createLlmProvider({
       name: 'claude',
       type: 'claude-cli',
-      extraArgs: ['--model', 'opus'],
+      extraArgs: ['--permission-mode', 'bypassPermissions'],
     });
     const codex = createLlmProvider({
       name: 'codex',
@@ -50,8 +50,8 @@ describe('createLlmProvider', () => {
     });
 
     expect(claude).toBeInstanceOf(ClaudeCliAdapter);
-    expect((claude as ClaudeCliAdapter).buildArgs(request)).toContain('--model');
-    expect((claude as ClaudeCliAdapter).buildArgs(request)).toContain('opus');
+    expect((claude as ClaudeCliAdapter).buildArgs(request)).toContain('--permission-mode');
+    expect((claude as ClaudeCliAdapter).buildArgs(request)).toContain('bypassPermissions');
 
     expect(codex).toBeInstanceOf(CodexCliAdapter);
     expect((codex as CodexCliAdapter).buildArgs(request)).toEqual([
@@ -91,6 +91,28 @@ describe('createLlmProvider', () => {
       'instructions=test',
       '-c',
       'model=o4-mini',
+    ]);
+  });
+
+  it('passes configured models into the Claude CLI adapter', () => {
+    const claude = createLlmProvider({
+      name: 'claude',
+      type: 'claude-cli',
+      model: 'claude-opus-4-1',
+      extraArgs: ['--permission-mode', 'bypassPermissions'],
+    });
+
+    expect(claude).toBeInstanceOf(ClaudeCliAdapter);
+    expect((claude as ClaudeCliAdapter).buildArgs(request)).toEqual([
+      '-p',
+      '--output-format',
+      'stream-json',
+      '--append-system-prompt',
+      'test',
+      '--model',
+      'claude-opus-4-1',
+      '--permission-mode',
+      'bypassPermissions',
     ]);
   });
 

--- a/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
@@ -5,7 +5,7 @@ import { CodexCliAdapter } from '../../../src/providers/codex-cli-adapter.js';
 import { GeminiApiAdapter } from '../../../src/providers/gemini-api-adapter.js';
 import { GeminiCliAdapter } from '../../../src/providers/gemini-cli-adapter.js';
 import { OpenAiApiAdapter } from '../../../src/providers/openai-api-adapter.js';
-import { createLlmProvider, type ProviderConfig } from '../../../src/providers/provider-config.js';
+import { buildProviderConfig, createLlmProvider, type ProviderConfig } from '../../../src/providers/provider-config.js';
 
 const request = {
   messages: [],
@@ -17,6 +17,20 @@ function optionsOf<TOptions>(adapter: unknown): TOptions {
 }
 
 describe('createLlmProvider', () => {
+  it('preserves legacy override fields while building consolidated provider configs', () => {
+    expect(buildProviderConfig('gemini', {
+      command: '/opt/bin/gemini',
+      model: 'gemini-2.5-pro',
+      extraArgs: ['--debug', '--yolo'],
+    })).toEqual({
+      name: 'gemini',
+      type: 'gemini-cli',
+      cliPath: '/opt/bin/gemini',
+      model: 'gemini-2.5-pro',
+      extraArgs: ['--debug', '--yolo'],
+    });
+  });
+
   it('forwards extraArgs to consolidated CLI adapters', () => {
     const claude = createLlmProvider({
       name: 'claude',

--- a/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
@@ -61,6 +61,25 @@ describe('createLlmProvider', () => {
     ]);
   });
 
+  it('passes configured models into the Codex CLI adapter', () => {
+    const codex = createLlmProvider({
+      name: 'codex',
+      type: 'codex-cli',
+      model: 'o4-mini',
+    });
+
+    expect(codex).toBeInstanceOf(CodexCliAdapter);
+    expect((codex as CodexCliAdapter).buildArgs(request)).toEqual([
+      'exec',
+      '--json',
+      '--ephemeral',
+      '-c',
+      'instructions=test',
+      '-c',
+      'model=o4-mini',
+    ]);
+  });
+
   it('passes configured models into API adapters', () => {
     const configs: ProviderConfig[] = [
       { name: 'anthropic', type: 'anthropic-api', model: 'claude-opus-4' },

--- a/packages/franken-orchestrator/tests/unit/skills/providers/cli-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/cli-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { ICliProvider, ProviderOpts } from '../../../../src/skills/providers/cli-provider.js';
 import { ProviderRegistry, createDefaultRegistry } from '../../../../src/skills/providers/cli-provider.js';
+import { cliProviderCatalogEntries } from '../../../../src/providers/provider-config.js';
 
 // ---------------------------------------------------------------------------
 // ICliProvider interface shape
@@ -243,6 +244,12 @@ describe('createDefaultRegistry', () => {
   it('has all 4 built-in providers registered in order', () => {
     const registry = createDefaultRegistry();
     expect(registry.names()).toEqual(['claude', 'codex', 'gemini', 'aider']);
+  });
+
+  it('keeps consolidated CLI provider names in the legacy registry', () => {
+    const registry = createDefaultRegistry();
+    const bridgedNames = cliProviderCatalogEntries().map((entry) => entry.cliRegistryName);
+    expect(registry.names()).toEqual(expect.arrayContaining(bridgedNames));
   });
 
   it('each registered provider is the correct class instance', () => {

--- a/tasks/issue-369-provider-registry-bridge-progress.md
+++ b/tasks/issue-369-provider-registry-bridge-progress.md
@@ -1,0 +1,13 @@
+# Issue #369 Provider Registry Bridge Progress
+
+- [x] Created isolated worktree from `origin/main` on `fix/369-provider-registry-bridge`.
+- [x] Inspected CLI provider registry, consolidated provider registry, and bridge code.
+- [x] Added a shared typed provider catalog/config builder for bridged provider metadata.
+- [x] Wired `dep-bridge` to use typed provider config instead of substring guessing.
+- [x] Wired consolidated `buildProviderList` to instantiate providers through the shared catalog.
+- [x] Wired default CLI provider registry to enumerate shared CLI-capable catalog entries.
+- [x] Added schema fields for bridged provider model/extra args.
+- [x] Added focused tests for CLI bridge mapping/rejection, consolidated provider construction, and registry/catalog alignment.
+- [x] Ran focused provider bridge tests successfully.
+- [x] Ran package tests/typecheck and recorded existing makeTokenSpend failures unrelated to this change.
+- [ ] Push branch, open PR, and trigger Codex review.


### PR DESCRIPTION
## Summary
- Add a shared typed provider catalog used by both the legacy CLI provider registry path and consolidated LLM provider construction.
- Replace substring-based dep bridge provider inference with exact typed provider validation.
- Preserve command/model/extraArgs overrides in bridged provider config and schema.
- Add focused tests covering CLI bridge mapping/rejection, consolidated provider construction, and CLI registry/catalog alignment.

Closes #369

## Test plan
- PASS: `npm --workspace franken-orchestrator exec vitest run tests/unit/cli/dep-bridge.test.ts tests/unit/cli/create-beast-deps.test.ts tests/unit/skills/providers/cli-provider.test.ts` (3 files / 67 tests passed)
- KNOWN PRE-EXISTING FAILURE: `npm --workspace franken-orchestrator run typecheck` fails on `makeTokenSpend` export mismatch in `src/adapters/cli-observer-bridge.ts` and `src/adapters/observer-adapter.ts`
- KNOWN PRE-EXISTING FAILURE: `npm --workspace franken-orchestrator run test` has focused changes passing; full package suite fails on same `makeTokenSpend` issue in observer adapter tests (12 failures), with 220 files / 2231 tests passing before failure summary
