### PR TITLE
docs: defer ADR-027 beast daemon extraction

### DIFF
--- a/docs/adr/027-beast-daemon-independent-service.md
+++ b/docs/adr/027-beast-daemon-independent-service.md
@@ -15,9 +15,9 @@ a new process boundary.
 Follow-on implementation is tracked in
 [#463](https://github.com/djm204/frankenbeast/issues/463). Until that issue is
 implemented, `chat-server` continues to host the beast control APIs used by the
-dashboard and CLI. ADR-027 should be revisited when the daemon becomes active so
-`docs/RAMP_UP.md` and operator guides can be updated to describe the new default
-route.
+dashboard, while CLI/direct service paths remain unchanged. ADR-027 should be
+revisited when the daemon becomes active so `docs/RAMP_UP.md` and operator guides
+can be updated to describe the new default route.
 
 ## Context
 

--- a/docs/adr/027-beast-daemon-independent-service.md
+++ b/docs/adr/027-beast-daemon-independent-service.md
@@ -1,8 +1,23 @@
 # ADR-027: Beast Daemon as Independent Service
 
 - **Date:** 2026-03-16
-- **Status:** Accepted
+- **Status:** Accepted (deferred; follow-up implementation tracked in [#463](https://github.com/djm204/frankenbeast/issues/463))
 - **Deciders:** pfk
+
+## 2026-07-01 Deploy-Beasts Decision
+
+ADR-027 remains accepted as the target architecture for an independently
+deployable beast control plane, but it is **deferred until after the current
+deploy-beasts MVP**. The sprint MVP routes dashboard beast deployment through
+the existing `chat-server` so the container-deploy work can land without adding
+a new process boundary.
+
+Follow-on implementation is tracked in
+[#463](https://github.com/djm204/frankenbeast/issues/463). Until that issue is
+implemented, `chat-server` continues to host the beast control APIs used by the
+dashboard and CLI. ADR-027 should be revisited when the daemon becomes active so
+`docs/RAMP_UP.md` and operator guides can be updated to describe the new default
+route.
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Keep ADR-027 accepted, but explicitly defer the standalone beast-daemon extraction until after the deploy-beasts MVP
- Document that the MVP continues routing beast deploy/control APIs through the existing chat-server
- Link follow-on implementation issue #463

Closes #461

## Checks
- `git diff --check origin/main...HEAD`

## Review
- Attempted `codex review --uncommitted`, but Codex CLI has no credentials in this environment (`codex doctor`: no Codex credentials found; review failed with 401 Missing bearer/basic auth). No Codex findings were produced.