### PR TITLE
Hardening sandbox container execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-bookworm-slim
+
+ARG SANDBOX_UID=10001
+ARG SANDBOX_GID=10001
+
+RUN groupadd --gid "${SANDBOX_GID}" fbeast \
+  && useradd --uid "${SANDBOX_UID}" --gid "${SANDBOX_GID}" --create-home --shell /usr/sbin/nologin fbeast \
+  && mkdir -p /workspace \
+  && chown -R "${SANDBOX_UID}:${SANDBOX_GID}" /workspace /home/fbeast
+
+ENV HOME=/home/fbeast \
+  NODE_ENV=production
+
+WORKDIR /workspace
+USER 10001:10001
+
+CMD ["node", "--version"]

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -137,7 +137,7 @@ Beast dispatch supports two execution modes:
 | Mode | Boundary |
 |------|----------|
 | `process` | Host process with supervised lifecycle, env allowlist, and project-root cwd containment. This is **not** a hard sandbox. |
-| `container` | Docker-backed execution through `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, non-root UID/GID `10001:10001`, memory/CPU/PID limits, `no-new-privileges`, and the same env allowlist. |
+| `container` | Docker-backed execution through `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, non-root UID/GID enforcement (defaults to the invoking host UID/GID when non-root, otherwise `10001:10001`), memory/CPU/PID limits, `no-new-privileges`, and the same env allowlist. |
 
 Container mode requires Docker and the in-repo sandbox image. Build the default image with:
 
@@ -145,7 +145,7 @@ Container mode requires Docker and the in-repo sandbox image. Build the default 
 docker build -t fbeast/sandbox:latest -f Dockerfile .
 ```
 
-Unit tests do not require a Docker daemon because they assert the generated Docker command and Dockerfile hardening instead of launching Docker.
+Unit tests do not require a Docker daemon because they assert the generated Docker command and Dockerfile hardening instead of launching Docker. Docker-backed integration tests are also present and are skipped automatically when Docker is unavailable; when Docker is installed they build `fbeast/sandbox:latest`, verify writable non-root workspace behavior, and run a memory-exceeding workload under the configured limits.
 
 The default env allowlist is intentionally narrow: `PATH`, `HOME`, `LANG`, `LC_ALL`, `FRANKENBEAST_RUN_CONFIG`, `FRANKENBEAST_SPAWNED`, and the `FRANKENBEAST_MODULE_*` toggles for firewall, skills, memory, planner, critique, governor, and heartbeat. Secrets such as `GITHUB_TOKEN`, provider API keys, and arbitrary shell environment variables are not inherited unless the Beast definition explicitly places them in `spec.env` and the runtime policy allows the key.
 

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -137,13 +137,23 @@ Beast dispatch supports two execution modes:
 | Mode | Boundary |
 |------|----------|
 | `process` | Host process with supervised lifecycle, env allowlist, and project-root cwd containment. This is **not** a hard sandbox. |
-| `container` | Docker-backed execution through `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, and the same env allowlist. |
+| `container` | Docker-backed execution through `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, non-root UID/GID `10001:10001`, memory/CPU/PID limits, `no-new-privileges`, and the same env allowlist. |
 
-Container mode requires Docker and a sandbox image (`fbeast/sandbox:latest` by default in the runtime policy). It does not require a Docker daemon during unit tests because tests assert the generated Docker command instead of launching Docker.
+Container mode requires Docker and the in-repo sandbox image. Build the default image with:
+
+```bash
+docker build -t fbeast/sandbox:latest -f Dockerfile .
+```
+
+Unit tests do not require a Docker daemon because they assert the generated Docker command and Dockerfile hardening instead of launching Docker.
 
 The default env allowlist is intentionally narrow: `PATH`, `HOME`, `LANG`, `LC_ALL`, `FRANKENBEAST_RUN_CONFIG`, `FRANKENBEAST_SPAWNED`, and the `FRANKENBEAST_MODULE_*` toggles for firewall, skills, memory, planner, critique, governor, and heartbeat. Secrets such as `GITHUB_TOKEN`, provider API keys, and arbitrary shell environment variables are not inherited unless the Beast definition explicitly places them in `spec.env` and the runtime policy allows the key.
 
-`container` mode uses Docker `--network none` to deny container network access. `process` mode does not have OS-level network isolation; use firewall/governor controls as advisory gates only, or choose container mode when network denial is required. Docker `--network none` is not a micro-VM, gVisor, Firecracker, Wasm, or seccomp sandbox.
+`container` mode uses Docker `--network none` to deny container network access and defaults to `--memory 512m --cpus 1.0 --pids-limit 256`. `process` mode does not have OS-level network isolation; use firewall/governor controls as advisory gates only, or choose container mode when network denial is required. Docker `--network none` is not a micro-VM, gVisor, Firecracker, Wasm, or seccomp sandbox.
+
+`SandboxPolicy.readOnlyWorkspaceMount` supports an opt-in `:ro` workspace bind mount for workloads that do not need to write to the checkout. It remains disabled by default because current beast runs write run config, checkpoints, and artifacts under the workspace; a disposable per-run workspace is safer future work for write-heavy tasks.
+
+A franken-governor pre-deploy hook should be integrated at the dispatch/API layer where user, target, budget, and audit context are available. This Docker runtime layer now enforces the concrete container boundary, but it intentionally does not decide deployment approval policy.
 
 ---
 

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -2,7 +2,7 @@ import { BeastEventBus } from './events/beast-event-bus.js';
 import { BeastLogStore } from './events/beast-log-store.js';
 import { SseConnectionTicketStore } from './events/sse-connection-ticket.js';
 import { ContainerBeastExecutor } from './execution/container-beast-executor.js';
-import { DEFAULT_SANDBOX_POLICY } from './execution/sandbox-policy.js';
+import { DEFAULT_SANDBOX_POLICY, nonRootUserForWorkspace } from './execution/sandbox-policy.js';
 import { ProcessBeastExecutor } from './execution/process-beast-executor.js';
 import { ProcessSupervisor } from './execution/process-supervisor.js';
 import { SQLiteBeastRepository } from './repository/sqlite-beast-repository.js';
@@ -55,6 +55,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
       policy: {
         ...DEFAULT_SANDBOX_POLICY,
         workspaceHostPath: projectRoot,
+        user: nonRootUserForWorkspace(projectRoot),
       },
     }),
   };

--- a/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
@@ -52,6 +52,11 @@ function containerCwd(spec: BeastProcessSpec, policy: SandboxPolicy): string {
   return remapHostWorkspacePath(spec.cwd ?? policy.workspaceHostPath, policy);
 }
 
+function workspaceMount(policy: SandboxPolicy): string {
+  const accessMode = policy.readOnlyWorkspaceMount ? ':ro' : '';
+  return `${policy.workspaceHostPath}:${policy.workspaceContainerPath}${accessMode}`;
+}
+
 export function toDockerSpec(spec: BeastProcessSpec, policy: SandboxPolicy): BeastProcessSpec {
   return {
     command: 'docker',
@@ -60,8 +65,18 @@ export function toDockerSpec(spec: BeastProcessSpec, policy: SandboxPolicy): Bea
       '--rm',
       '--network',
       policy.network,
+      '--memory',
+      policy.resourceLimits.memory,
+      '--cpus',
+      policy.resourceLimits.cpus,
+      '--pids-limit',
+      String(policy.resourceLimits.pidsLimit),
+      '--user',
+      policy.user,
+      '--security-opt',
+      'no-new-privileges',
       '-v',
-      `${policy.workspaceHostPath}:${policy.workspaceContainerPath}`,
+      workspaceMount(policy),
       '-w',
       containerCwd(spec, policy),
       ...dockerEnvArgs(spec, policy),

--- a/packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts
@@ -4,6 +4,15 @@ export interface SandboxPolicy {
   readonly workspaceHostPath: string;
   readonly workspaceContainerPath: '/workspace';
   readonly envAllowlist: readonly string[];
+  readonly user: `${number}:${number}`;
+  readonly resourceLimits: SandboxResourceLimits;
+  readonly readOnlyWorkspaceMount: boolean;
+}
+
+export interface SandboxResourceLimits {
+  readonly memory: string;
+  readonly cpus: string;
+  readonly pidsLimit: number;
 }
 
 export const DEFAULT_BEAST_ENV_ALLOWLIST = [
@@ -28,4 +37,11 @@ export const DEFAULT_SANDBOX_POLICY: SandboxPolicy = {
   workspaceHostPath: process.cwd(),
   workspaceContainerPath: '/workspace',
   envAllowlist: DEFAULT_BEAST_ENV_ALLOWLIST,
+  user: '10001:10001',
+  resourceLimits: {
+    memory: '512m',
+    cpus: '1.0',
+    pidsLimit: 256,
+  },
+  readOnlyWorkspaceMount: false,
 };

--- a/packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts
@@ -1,3 +1,5 @@
+import { statSync } from 'node:fs';
+
 export interface SandboxPolicy {
   readonly image: string;
   readonly network: 'none';
@@ -15,11 +17,20 @@ export interface SandboxResourceLimits {
   readonly pidsLimit: number;
 }
 
-function defaultNonRootUser(): `${number}:${number}` {
+export function nonRootUserForWorkspace(workspaceHostPath: string): `${number}:${number}` {
   const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
   const gid = typeof process.getgid === 'function' ? process.getgid() : undefined;
   if (uid !== undefined && gid !== undefined && uid > 0) {
     return `${uid}:${gid}`;
+  }
+  try {
+    const workspace = statSync(workspaceHostPath);
+    if (workspace.uid > 0) {
+      return `${workspace.uid}:${workspace.gid}`;
+    }
+  } catch {
+    // Fall back to the image's non-root user when the workspace path does not
+    // exist yet or cannot be inspected.
   }
   return '10001:10001';
 }
@@ -46,7 +57,7 @@ export const DEFAULT_SANDBOX_POLICY: SandboxPolicy = {
   workspaceHostPath: process.cwd(),
   workspaceContainerPath: '/workspace',
   envAllowlist: DEFAULT_BEAST_ENV_ALLOWLIST,
-  user: defaultNonRootUser(),
+  user: nonRootUserForWorkspace(process.cwd()),
   resourceLimits: {
     memory: '512m',
     cpus: '1.0',

--- a/packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/sandbox-policy.ts
@@ -15,6 +15,15 @@ export interface SandboxResourceLimits {
   readonly pidsLimit: number;
 }
 
+function defaultNonRootUser(): `${number}:${number}` {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  const gid = typeof process.getgid === 'function' ? process.getgid() : undefined;
+  if (uid !== undefined && gid !== undefined && uid > 0) {
+    return `${uid}:${gid}`;
+  }
+  return '10001:10001';
+}
+
 export const DEFAULT_BEAST_ENV_ALLOWLIST = [
   'PATH',
   'HOME',
@@ -37,7 +46,7 @@ export const DEFAULT_SANDBOX_POLICY: SandboxPolicy = {
   workspaceHostPath: process.cwd(),
   workspaceContainerPath: '/workspace',
   envAllowlist: DEFAULT_BEAST_ENV_ALLOWLIST,
-  user: '10001:10001',
+  user: defaultNonRootUser(),
   resourceLimits: {
     memory: '512m',
     cpus: '1.0',

--- a/packages/franken-orchestrator/tests/integration/beasts/container-runtime-docker.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/container-runtime-docker.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { chownSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -24,6 +24,18 @@ function testNonRootUser(): `${number}:${number}` {
   return '10001:10001';
 }
 
+function makeWritableForUser(path: string, user: `${number}:${number}`): void {
+  const [uid, gid] = user.split(':').map(Number);
+  if (Number.isInteger(uid) && Number.isInteger(gid)) {
+    try {
+      chownSync(path, uid, gid);
+    } catch {
+      // Non-root test processes cannot chown; in that case the fallback user is
+      // the host user and the freshly-created temp path is already writable.
+    }
+  }
+}
+
 const dockerIt = hasDocker() ? it : it.skip;
 
 describe('sandbox Docker runtime enforcement', () => {
@@ -37,6 +49,9 @@ describe('sandbox Docker runtime enforcement', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'fbeast-sandbox-runtime-'));
     const script = join(workspace, 'memory-hog.js');
     writeFileSync(script, 'const chunks=[]; while (true) chunks.push(Buffer.alloc(32 * 1024 * 1024));\n', 'utf8');
+    const user = testNonRootUser();
+    makeWritableForUser(workspace, user);
+    makeWritableForUser(script, user);
 
     const result = spawnSync('docker', [
       'run',
@@ -50,7 +65,7 @@ describe('sandbox Docker runtime enforcement', () => {
       '--pids-limit',
       '64',
       '--user',
-      testNonRootUser(),
+      user,
       '-v',
       `${workspace}:/workspace`,
       '-w',
@@ -64,6 +79,7 @@ describe('sandbox Docker runtime enforcement', () => {
     });
 
     expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain('Cannot find module');
   }, 60_000);
 
   dockerIt('runs the default writable workspace mount as a non-root host UID/GID that can write artifacts', () => {
@@ -74,8 +90,10 @@ describe('sandbox Docker runtime enforcement', () => {
     });
 
     const workspace = mkdtempSync(join(tmpdir(), 'fbeast-sandbox-write-'));
-    const [uid, gid] = testNonRootUser().split(':');
+    const user = testNonRootUser();
+    const [uid] = user.split(':');
     expect(uid).not.toBe('0');
+    makeWritableForUser(workspace, user);
 
     const result = spawnSync('docker', [
       'run',
@@ -83,7 +101,7 @@ describe('sandbox Docker runtime enforcement', () => {
       '--network',
       'none',
       '--user',
-      `${uid}:${gid}`,
+      user,
       '-v',
       `${workspace}:/workspace`,
       '-w',

--- a/packages/franken-orchestrator/tests/integration/beasts/container-runtime-docker.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/container-runtime-docker.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function hasDocker(): boolean {
+  const result = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return !result.error && result.status === 0;
+}
+
+const dockerIt = hasDocker() ? it : it.skip;
+
+describe('sandbox Docker runtime enforcement', () => {
+  dockerIt('builds the sandbox image and enforces memory limits on an exceeding workload', () => {
+    const tag = `fbeast/sandbox:test-${process.pid}`;
+    execFileSync('docker', ['build', '-t', tag, '-f', 'Dockerfile', '.'], {
+      cwd: join(__dirname, '../../../../..'),
+      stdio: 'pipe',
+    });
+
+    const workspace = mkdtempSync(join(tmpdir(), 'fbeast-sandbox-runtime-'));
+    const script = join(workspace, 'memory-hog.js');
+    writeFileSync(script, 'const chunks=[]; while (true) chunks.push(Buffer.alloc(32 * 1024 * 1024));\n', 'utf8');
+
+    const result = spawnSync('docker', [
+      'run',
+      '--rm',
+      '--network',
+      'none',
+      '--memory',
+      '64m',
+      '--cpus',
+      '1.0',
+      '--pids-limit',
+      '64',
+      '--user',
+      `${process.getuid?.() ?? 10001}:${process.getgid?.() ?? 10001}`,
+      '-v',
+      `${workspace}:/workspace`,
+      '-w',
+      '/workspace',
+      tag,
+      'node',
+      'memory-hog.js',
+    ], {
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+
+    expect(result.status).not.toBe(0);
+  }, 60_000);
+
+  dockerIt('runs the default writable workspace mount as a non-root host UID/GID that can write artifacts', () => {
+    const tag = `fbeast/sandbox:test-${process.pid}`;
+    execFileSync('docker', ['build', '-t', tag, '-f', 'Dockerfile', '.'], {
+      cwd: join(__dirname, '../../../../..'),
+      stdio: 'pipe',
+    });
+
+    const workspace = mkdtempSync(join(tmpdir(), 'fbeast-sandbox-write-'));
+    const uid = process.getuid?.() ?? 10001;
+    const gid = process.getgid?.() ?? 10001;
+    expect(uid).not.toBe(0);
+
+    const result = spawnSync('docker', [
+      'run',
+      '--rm',
+      '--network',
+      'none',
+      '--user',
+      `${uid}:${gid}`,
+      '-v',
+      `${workspace}:/workspace`,
+      '-w',
+      '/workspace',
+      tag,
+      'sh',
+      '-lc',
+      'test "$(id -u)" != "0" && echo artifact > .fbeast-container-write-test',
+    ], {
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+
+    expect(result.status).toBe(0);
+  }, 60_000);
+});

--- a/packages/franken-orchestrator/tests/integration/beasts/container-runtime-docker.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/container-runtime-docker.test.ts
@@ -15,6 +15,15 @@ function hasDocker(): boolean {
   return !result.error && result.status === 0;
 }
 
+function testNonRootUser(): `${number}:${number}` {
+  const uid = process.getuid?.();
+  const gid = process.getgid?.();
+  if (uid !== undefined && gid !== undefined && uid > 0) {
+    return `${uid}:${gid}`;
+  }
+  return '10001:10001';
+}
+
 const dockerIt = hasDocker() ? it : it.skip;
 
 describe('sandbox Docker runtime enforcement', () => {
@@ -41,7 +50,7 @@ describe('sandbox Docker runtime enforcement', () => {
       '--pids-limit',
       '64',
       '--user',
-      `${process.getuid?.() ?? 10001}:${process.getgid?.() ?? 10001}`,
+      testNonRootUser(),
       '-v',
       `${workspace}:/workspace`,
       '-w',
@@ -65,9 +74,8 @@ describe('sandbox Docker runtime enforcement', () => {
     });
 
     const workspace = mkdtempSync(join(tmpdir(), 'fbeast-sandbox-write-'));
-    const uid = process.getuid?.() ?? 10001;
-    const gid = process.getgid?.() ?? 10001;
-    expect(uid).not.toBe(0);
+    const [uid, gid] = testNonRootUser().split(':');
+    expect(uid).not.toBe('0');
 
     const result = spawnSync('docker', [
       'run',

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
@@ -25,7 +25,7 @@ describe('toDockerSpec', () => {
     expect(spec.args).toEqual(expect.arrayContaining(['-v', '/proj:/workspace']));
   });
 
-  it('enforces default resource limits for a workload that attempts to exceed them', () => {
+  it('enforces default resource limit flags for a memory-exceeding workload', () => {
     const exceedingWorkload = {
       ...base,
       args: [

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
@@ -25,6 +25,43 @@ describe('toDockerSpec', () => {
     expect(spec.args).toEqual(expect.arrayContaining(['-v', '/proj:/workspace']));
   });
 
+  it('enforces default resource limits for a workload that attempts to exceed them', () => {
+    const exceedingWorkload = {
+      ...base,
+      args: [
+        '-e',
+        'const chunks=[]; while (true) chunks.push(Buffer.alloc(64 * 1024 * 1024));',
+      ],
+    };
+
+    const spec = toDockerSpec(exceedingWorkload, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj' });
+
+    expect(spec.args).toEqual(expect.arrayContaining([
+      '--memory',
+      DEFAULT_SANDBOX_POLICY.resourceLimits.memory,
+      '--cpus',
+      DEFAULT_SANDBOX_POLICY.resourceLimits.cpus,
+      '--pids-limit',
+      String(DEFAULT_SANDBOX_POLICY.resourceLimits.pidsLimit),
+    ]));
+  });
+
+  it('runs containers as a non-root UID/GID', () => {
+    const spec = toDockerSpec({ ...base, command: 'id', args: ['-u'] }, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj' });
+
+    const userFlag = spec.args.indexOf('--user');
+    expect(userFlag).toBeGreaterThan(-1);
+    const user = spec.args[userFlag + 1];
+    expect(user).toBe(DEFAULT_SANDBOX_POLICY.user);
+    expect(user?.split(':')[0]).not.toBe('0');
+  });
+
+  it('supports an opt-in read-only workspace mount', () => {
+    const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj', readOnlyWorkspaceMount: true });
+
+    expect(spec.args).toEqual(expect.arrayContaining(['-v', '/proj:/workspace:ro']));
+  });
+
   it('passes only allowlisted env via explicit -e values and inherits no host env', () => {
     const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj' });
 

--- a/tasks/issue-459-sandbox-hardening-progress.md
+++ b/tasks/issue-459-sandbox-hardening-progress.md
@@ -1,0 +1,18 @@
+# Issue #459 sandbox hardening progress
+
+- [x] Create isolated worktree from `origin/main`.
+- [x] Note fbeast MCP tools referenced by AGENTS.md are unavailable in this tool session.
+- [x] Inspect current sandbox policy/runtime/tests.
+- [x] Add in-repo Dockerfile for `fbeast/sandbox:latest` with non-root default user.
+- [x] Add configurable resource limits and non-root user enforcement to container runtime.
+- [x] Evaluate and document read-only workspace option and governor pre-deploy hook.
+- [x] Add/update tests for Docker args, resource limits, and UID != 0 behavior.
+- [x] Build image from repo Dockerfile if Docker is available. (Attempted; blocked because `docker` is not installed in this environment.)
+- [x] Run targeted and relevant broader checks.
+  - [x] `npm test -- --run tests/unit/beasts/execution/docker-container-runtime.test.ts tests/unit/beasts/container-beast-executor.test.ts` in `packages/franken-orchestrator` passed (12 tests).
+  - [x] `npm run test:root -- --run tests/sandbox-dockerfile.test.ts` passed (2 tests).
+  - [x] `npm run build` passed at repo root.
+  - [x] `npm run typecheck` passed at repo root.
+  - [x] `npm test` at repo root was attempted; unrelated existing/flaky timeout in `@franken/critique` safety evaluator (`allows disjoint and deterministic repeated alternatives`) after 5s.
+- [x] Run Codex review loops until all-clear; fix real findings or document rejected findings. (Attempted twice; blocked because Codex CLI has no credentials in this environment, per `codex doctor`.)
+- [ ] Push branch and open PR with `Closes #459`.

--- a/tasks/issue-459-sandbox-hardening-progress.md
+++ b/tasks/issue-459-sandbox-hardening-progress.md
@@ -15,4 +15,4 @@
   - [x] `npm run typecheck` passed at repo root.
   - [x] `npm test` at repo root was attempted; unrelated existing/flaky timeout in `@franken/critique` safety evaluator (`allows disjoint and deterministic repeated alternatives`) after 5s.
 - [x] Run Codex review loops until all-clear; fix real findings or document rejected findings. (Attempted twice; blocked because Codex CLI has no credentials in this environment, per `codex doctor`.)
-- [ ] Push branch and open PR with `Closes #459`.
+- [x] Push branch and open PR with `Closes #459`. PR: https://github.com/djm204/frankenbeast/pull/465

--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('sandbox Dockerfile', () => {
+  const dockerfile = readFileSync(resolve('Dockerfile'), 'utf8');
+
+  it('builds the fbeast/sandbox image from an in-repo Node runtime Dockerfile', () => {
+    expect(dockerfile).toContain('FROM node:22-bookworm-slim');
+    expect(dockerfile).toContain('WORKDIR /workspace');
+  });
+
+  it('declares a non-root default container UID', () => {
+    const userLine = dockerfile.split('\n').find((line) => line.startsWith('USER '));
+
+    expect(userLine).toBeDefined();
+    expect(userLine).not.toBe('USER root');
+    expect(userLine).not.toBe('USER 0');
+    expect(userLine?.split(/\s+/)[1]?.split(':')[0]).not.toBe('0');
+  });
+});

--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -1,6 +1,17 @@
 import { readFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+
+function hasDocker(): boolean {
+  const result = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return !result.error && result.status === 0;
+}
+
+const dockerIt = hasDocker() ? it : it.skip;
 
 describe('sandbox Dockerfile', () => {
   const dockerfile = readFileSync(resolve('Dockerfile'), 'utf8');
@@ -9,6 +20,13 @@ describe('sandbox Dockerfile', () => {
     expect(dockerfile).toContain('FROM node:22-bookworm-slim');
     expect(dockerfile).toContain('WORKDIR /workspace');
   });
+
+  dockerIt('actually builds fbeast/sandbox:latest from the repo Dockerfile when Docker is available', () => {
+    execFileSync('docker', ['build', '-t', 'fbeast/sandbox:latest', '-f', 'Dockerfile', '.'], {
+      cwd: resolve('.'),
+      stdio: 'pipe',
+    });
+  }, 60_000);
 
   it('declares a non-root default container UID', () => {
     const userLine = dockerfile.split('\n').find((line) => line.startsWith('USER '));


### PR DESCRIPTION
## Summary
- add an in-repo `Dockerfile` for the default `fbeast/sandbox:latest` Node sandbox image with non-root UID/GID `10001:10001`
- add sandbox policy defaults for memory/CPU/PID limits, non-root Docker `--user`, `no-new-privileges`, and an opt-in read-only workspace mount
- cover Docker hardening with tests for resource-limit args on an exceeding workload, non-root UID, read-only mount support, and Dockerfile non-root defaults
- document build instructions plus read-only workspace/governor pre-deploy evaluation

Closes #459

## Verification
- ✅ `npm test -- --run tests/unit/beasts/execution/docker-container-runtime.test.ts tests/unit/beasts/container-beast-executor.test.ts` from `packages/franken-orchestrator` — 12 tests passed
- ✅ `npm run test:root -- --run tests/sandbox-dockerfile.test.ts` — 2 tests passed
- ✅ `npm run build` — passed
- ✅ `npm run typecheck` — passed
- ⚠️ `docker build -t fbeast/sandbox:latest -f Dockerfile .` — not runnable in this environment because `docker` is not installed (`docker: command not found`)
- ⚠️ `npm test` — broader suite attempted; failed in unrelated existing/flaky `@franken/critique` test timeout: `SafetyEvaluator > allows disjoint and deterministic repeated alternatives` timed out after 5000ms

## Codex review
Attempted required Codex review loop:
- `codex review --uncommitted --base origin/main ...` was rejected by CLI argument rules
- `codex review --uncommitted` failed because this environment has no Codex credentials (`401 Unauthorized`); `codex doctor` confirms `auth: no Codex credentials were found`

No Codex all-clear could be obtained from this tool environment. I did not ignore any Codex findings; the review could not start due missing credentials.
