### PR TITLE
feat(orchestrator): add CLI container beast mode

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -88,6 +88,7 @@ export interface CliArgs {
   initVerify: boolean;
   initRepair: boolean;
   initNonInteractive: boolean;
+  beastExecutionMode?: import('../beasts/types.js').BeastExecutionMode | undefined;
   moduleConfig?: import('../beasts/types.js').ModuleConfig | undefined;
 }
 
@@ -159,11 +160,11 @@ Network Commands:
 
 Beast Commands:
   beasts catalog                      List fixed Beast definitions
-  beasts create <definition-id>       Create a Beast run (alias for spawn)
-  beasts spawn <definition-id>        Spawn a Beast run via interactive prompts
+  beasts create <definition-id>       Create a Beast run (alias for spawn; use --mode process|container)
+  beasts spawn <definition-id>        Spawn a Beast run via interactive prompts (use --mode process|container)
   beasts list                         List Beast runs
-  beasts status <run-id>              Show one Beast run
-  beasts logs <run-id>                Show logs for the current attempt
+  beasts status <run-id>              Show one Beast run, including container fields when present
+  beasts logs <run-id>                Show logs for the current attempt, including container context when present
   beasts stop <run-id>                Stop a running Beast
   beasts kill <run-id>                Force-stop a Beast
   beasts restart <run-id>             Restart a Beast with a new attempt
@@ -183,6 +184,7 @@ Security Commands:
   security set <profile>              Set security profile (strict|standard|permissive)
 
 Module Toggles (for beasts spawn):
+  --mode <mode>                        Execution mode for beasts create/spawn: process|container (default: process)
   --no-firewall                       Disable firewall module
   --no-skills                         Disable skills module
   --no-memory                         Disable memory module
@@ -266,6 +268,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       repo: { type: 'string' },
       'target-upstream': { type: 'boolean', default: false },
       'dry-run': { type: 'boolean', default: false },
+      mode: { type: 'string' },
       set: { type: 'string', multiple: true },
       'no-firewall': { type: 'boolean', default: false },
       'no-skills': { type: 'boolean', default: false },
@@ -334,6 +337,30 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   }
 
   const provider = values.provider?.toLowerCase() ?? 'claude';
+
+  const beastExecutionModeRaw = values.mode?.toLowerCase();
+  let beastExecutionMode: import('../beasts/types.js').BeastExecutionMode | undefined;
+  if (beastExecutionModeRaw !== undefined) {
+    if (beastExecutionModeRaw !== 'process' && beastExecutionModeRaw !== 'container') {
+      throw new TypeError(`Invalid beast execution mode '${values.mode}'. Valid: process, container`);
+    }
+    beastExecutionMode = beastExecutionModeRaw;
+  }
+
+  if (beastExecutionMode !== undefined && subcommand !== 'beasts') {
+    throw new TypeError('--mode is only supported for beasts commands');
+  }
+
+  if (
+    beastExecutionMode !== undefined
+    && beastAction !== undefined
+    && beastAction !== 'create'
+    && beastAction !== 'spawn'
+    && beastAction !== 'status'
+    && beastAction !== 'logs'
+  ) {
+    throw new TypeError('--mode is only supported for beasts create, spawn, status, and logs');
+  }
 
   const providersRaw = values.providers;
   const providers = providersRaw
@@ -424,6 +451,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     issueRepo: values.repo,
     targetUpstream: values['target-upstream'] ?? undefined,
     dryRun: values['dry-run'] ?? undefined,
+    beastExecutionMode,
     moduleConfig,
   };
 }

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -4,7 +4,8 @@ import { createBeastServices } from '../beasts/create-beast-services.js';
 import { collectBeastConfig } from './beast-prompts.js';
 import type { ProjectPaths } from './project-root.js';
 import { createBeastControlClient } from './beast-control-client.js';
-import type { BeastRun } from '../beasts/types.js';
+import type { BeastExecutionMode, BeastRun, BeastRunAttempt } from '../beasts/types.js';
+import { spawnSync } from 'node:child_process';
 
 type BeastControlClient = Omit<ReturnType<typeof createBeastControlClient>, 'dispose'> & {
   dispose?: () => void;
@@ -19,6 +20,64 @@ const liveRunStatuses = new Set<BeastRun['status']>([
 
 function shouldKeepServicesAliveForRun(run: Pick<BeastRun, 'status' | 'currentAttemptId'>): boolean {
   return Boolean(run.currentAttemptId && liveRunStatuses.has(run.status));
+}
+
+function assertContainerRuntimeAvailable(): void {
+  const result = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message ?? result.stderr?.trim() ?? 'docker version failed';
+    throw new Error(`Container Beast execution requires a working Docker runtime. Install/start Docker and retry, or use --mode process. Details: ${detail}`);
+  }
+}
+
+function latestAttempt(run: BeastRun, attempts: readonly BeastRunAttempt[]): BeastRunAttempt | undefined {
+  return attempts.find((attempt) => attempt.id === run.currentAttemptId)
+    ?? [...attempts].sort((left, right) => right.attemptNumber - left.attemptNumber)[0];
+}
+
+function pickContainerMetadata(metadata: Readonly<Record<string, unknown>> | undefined): Readonly<Record<string, unknown>> | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const entries = Object.entries(metadata).filter(([key]) => (
+    key === 'containerId'
+    || key === 'containerName'
+    || key === 'image'
+    || key === 'resourceSnapshot'
+    || key === 'resources'
+  ));
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function statusPayload(run: BeastRun, attempts: readonly BeastRunAttempt[]) {
+  const currentAttempt = latestAttempt(run, attempts);
+  const containerMetadata = run.executionMode === 'container'
+    ? pickContainerMetadata(currentAttempt?.executorMetadata)
+    : undefined;
+  return {
+    ...run,
+    ...(currentAttempt ? { currentAttempt } : {}),
+    ...(containerMetadata
+      ? { container: containerMetadata }
+      : {}),
+  };
+}
+
+function containerLogHeader(run: BeastRun, attempts: readonly BeastRunAttempt[]): string[] {
+  if (run.executionMode !== 'container') {
+    return [];
+  }
+  const metadata = pickContainerMetadata(latestAttempt(run, attempts)?.executorMetadata);
+  if (!metadata) {
+    return [`# Beast container run ${run.id}`, '# Container metadata: unavailable'];
+  }
+  return [
+    `# Beast container run ${run.id}`,
+    `# Container metadata: ${JSON.stringify(metadata)}`,
+  ];
 }
 
 interface BeastCommandDeps {
@@ -63,13 +122,17 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
         if (!definition) {
           throw new Error(`Unknown Beast definition: ${args.beastTarget}`);
         }
+        const executionMode: BeastExecutionMode = args.beastExecutionMode ?? 'process';
+        if (executionMode === 'container') {
+          assertContainerRuntimeAvailable();
+        }
         const config = await collectBeastConfig(io, definition);
         const run = await services.dispatch.createRun({
           definitionId: definition.id,
           config,
           dispatchedBy: 'cli',
           dispatchedByUser: actor,
-          executionMode: 'process',
+          executionMode,
           startNow: true,
           ...(args.moduleConfig ? { moduleConfig: args.moduleConfig } : {}),
         });
@@ -86,15 +149,19 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
         if (!args.beastTarget) {
           throw new Error('beasts status requires a run id');
         }
-        print(JSON.stringify(services.runs.getRun(args.beastTarget), null, 2));
+        const run = services.runs.getRun(args.beastTarget);
+        const attempts = run ? services.runs.listAttempts(args.beastTarget) : [];
+        print(JSON.stringify(run ? statusPayload(run, attempts) : undefined, null, 2));
         return;
       }
       case 'logs': {
         if (!args.beastTarget) {
           throw new Error('beasts logs requires a run id');
         }
+        const run = services.runs.getRun(args.beastTarget);
+        const header = run ? containerLogHeader(run, services.runs.listAttempts(args.beastTarget)) : [];
         const logs = await services.runs.readLogs(args.beastTarget);
-        print(logs.join('\n'));
+        print([...header, ...logs].join('\n'));
         return;
       }
       case 'stop': {

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -68,6 +68,26 @@ describe('parseArgs', () => {
     expect(args.beastTarget).toBe('martin-loop');
   });
 
+  it('parses beasts execution mode for spawn/create/status/logs', () => {
+    const spawn = parseArgs(['beasts', 'spawn', 'martin-loop', '--mode', 'container']);
+    expect(spawn.beastExecutionMode).toBe('container');
+
+    const create = parseArgs(['beasts', 'create', 'martin-loop', '--mode', 'process']);
+    expect(create.beastExecutionMode).toBe('process');
+
+    const status = parseArgs(['beasts', 'status', 'run-1', '--mode', 'container']);
+    expect(status.beastExecutionMode).toBe('container');
+
+    const logs = parseArgs(['beasts', 'logs', 'run-1', '--mode', 'container']);
+    expect(logs.beastExecutionMode).toBe('container');
+  });
+
+  it('rejects invalid beasts execution modes', () => {
+    expect(() => parseArgs(['beasts', 'spawn', 'martin-loop', '--mode', 'vm'])).toThrow('Invalid beast execution mode');
+    expect(() => parseArgs(['run', '--mode', 'container'])).toThrow('--mode is only supported for beasts commands');
+    expect(() => parseArgs(['beasts', 'kill', 'run-1', '--mode', 'container'])).toThrow('--mode is only supported for beasts create, spawn, status, and logs');
+  });
+
   it('parses beasts restart target', () => {
     const args = parseArgs(['beasts', 'restart', 'run-1']);
     expect(args.subcommand).toBe('beasts');

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { handleBeastCommand } from '../../../src/cli/beast-cli.js';
 import type { CliArgs } from '../../../src/cli/args.js';
 import type { ProjectPaths } from '../../../src/cli/project-root.js';
+import { spawnSync } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0, stderr: '' })),
+}));
 
 const mockServices = vi.hoisted(() => ({
   catalog: {
@@ -14,6 +19,7 @@ const mockServices = vi.hoisted(() => ({
   runs: {
     listRuns: vi.fn(),
     getRun: vi.fn(),
+    listAttempts: vi.fn(),
     readLogs: vi.fn(),
     stop: vi.fn(),
     kill: vi.fn(),
@@ -53,6 +59,7 @@ function makeDeps(overrides: Partial<Parameters<typeof handleBeastCommand>[0]> =
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(spawnSync).mockReturnValue({ status: 0, stderr: '' } as any);
 });
 
 describe('handleBeastCommand() catalog', () => {
@@ -101,6 +108,59 @@ describe('handleBeastCommand() spawn', () => {
     expect(mockServices.dispose).not.toHaveBeenCalled();
   });
 
+  it('passes --mode container through to dispatch after validating Docker', async () => {
+    mockServices.catalog.getDefinition.mockReturnValue({
+      id: 'design-interview',
+      description: 'Design interview',
+      interviewPrompts: [],
+      configSchema: { parse: vi.fn(() => ({})) },
+    });
+    mockServices.dispatch.createRun.mockResolvedValue({
+      id: 'run-1',
+      definitionId: 'design-interview',
+      status: 'running',
+      currentAttemptId: 'attempt-1',
+    });
+    const deps = makeDeps({
+      args: {
+        subcommand: 'beasts',
+        beastAction: 'spawn',
+        beastTarget: 'design-interview',
+        beastExecutionMode: 'container',
+      } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(spawnSync).toHaveBeenCalledWith('docker', ['version', '--format', '{{.Server.Version}}'], expect.any(Object));
+    expect(mockServices.dispatch.createRun).toHaveBeenCalledWith(expect.objectContaining({
+      definitionId: 'design-interview',
+      executionMode: 'container',
+      startNow: true,
+    }));
+  });
+
+  it('fails container mode with a clean actionable error when Docker is unavailable', async () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1, stderr: 'Cannot connect to the Docker daemon' } as any);
+    mockServices.catalog.getDefinition.mockReturnValue({
+      id: 'design-interview',
+      description: 'Design interview',
+      interviewPrompts: [],
+      configSchema: { parse: vi.fn(() => ({})) },
+    });
+    const deps = makeDeps({
+      args: {
+        subcommand: 'beasts',
+        beastAction: 'spawn',
+        beastTarget: 'design-interview',
+        beastExecutionMode: 'container',
+      } as CliArgs,
+    });
+
+    await expect(handleBeastCommand(deps)).rejects.toThrow('Container Beast execution requires a working Docker runtime');
+    expect(mockServices.dispatch.createRun).not.toHaveBeenCalled();
+  });
+
   it('disposes services if spawn fails before a run is started', async () => {
     mockServices.catalog.getDefinition.mockReturnValue(undefined);
     const deps = makeDeps({
@@ -132,6 +192,64 @@ describe('handleBeastCommand() spawn', () => {
 
     expect(deps.print).toHaveBeenCalledWith('Spawned design-interview as run-1');
     expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleBeastCommand() status and logs', () => {
+  it('renders current attempt container metadata in status output', async () => {
+    mockServices.runs.getRun.mockReturnValue({
+      id: 'run-1',
+      definitionId: 'design-interview',
+      executionMode: 'container',
+      status: 'running',
+      currentAttemptId: 'attempt-1',
+    });
+    mockServices.runs.listAttempts.mockReturnValue([
+      {
+        id: 'attempt-1',
+        runId: 'run-1',
+        attemptNumber: 1,
+        status: 'running',
+        executorMetadata: { containerId: 'abc123', image: 'fbeast/sandbox:latest' },
+      },
+    ]);
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'status', beastTarget: 'run-1', beastExecutionMode: 'container' } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    const payload = JSON.parse(vi.mocked(deps.print).mock.calls[0]?.[0] as string);
+    expect(payload.container).toEqual({ containerId: 'abc123', image: 'fbeast/sandbox:latest' });
+    expect(payload.currentAttempt.executorMetadata.containerId).toBe('abc123');
+  });
+
+  it('prefixes container logs with container metadata when available', async () => {
+    mockServices.runs.getRun.mockReturnValue({
+      id: 'run-1',
+      definitionId: 'design-interview',
+      executionMode: 'container',
+      status: 'running',
+      currentAttemptId: 'attempt-1',
+    });
+    mockServices.runs.listAttempts.mockReturnValue([
+      {
+        id: 'attempt-1',
+        runId: 'run-1',
+        attemptNumber: 1,
+        status: 'running',
+        executorMetadata: { containerId: 'abc123', image: 'fbeast/sandbox:latest' },
+      },
+    ]);
+    mockServices.runs.readLogs.mockResolvedValue(['line one']);
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'logs', beastTarget: 'run-1', beastExecutionMode: 'container' } as CliArgs,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(deps.print).toHaveBeenCalledWith(expect.stringContaining('"containerId":"abc123"'));
+    expect(deps.print).toHaveBeenCalledWith(expect.stringContaining('line one'));
   });
 });
 

--- a/tasks/issue-456-cli-container-mode-progress.md
+++ b/tasks/issue-456-cli-container-mode-progress.md
@@ -1,0 +1,17 @@
+# Issue #456 CLI Container Mode Progress
+
+- [x] Created isolated worktree `/home/pfkagent/dev/deploy-beasts-wt/issue-456` from `origin/main`.
+- [x] Inspect CLI parser and beast CLI implementation.
+- [x] Add `--mode process|container` parsing for `beasts create`/`spawn`.
+- [x] Validate missing Docker runtime produces clear CLI error for container mode.
+- [x] Render container-specific fields in status/logs defensively when present.
+- [x] Add/update tests and help output coverage.
+- [x] Run targeted tests and relevant package checks.
+- [x] Run Codex review loop until all-clear equivalent.
+- [ ] Push branch, open PR with `Closes #456`, and merge when eligible.
+
+Notes:
+- fbeast MCP tools referenced in AGENTS.md are not available in this Hermes session/toolset.
+- #455 may add richer container metadata fields later; this issue should remain logically separate and render those fields defensively if present.
+- Standalone `codex` CLI review was attempted but blocked by `codex doctor`: no Codex credentials found. Used a Codex-model Hermes review loop instead; first pass found two issues, both fixed; second pass returned `No issues found`.
+- Checks passed: `npm --workspace franken-orchestrator test -- tests/unit/cli/args.test.ts tests/unit/cli/beast-cli.test.ts`, `npm run typecheck`, `npm run build`.


### PR DESCRIPTION
## Summary
- Add `--mode process|container` parsing for `frankenbeast beasts create/spawn`.
- Fail fast with a clear Docker-runtime error before interactive prompts for container mode.
- Show container-specific attempt fields in `beasts status`/`beasts logs` when those fields are available from #455-era metadata, without mislabeling generic executor metadata.

## Test Plan
- `npm --workspace franken-orchestrator test -- tests/unit/cli/args.test.ts tests/unit/cli/beast-cli.test.ts` — 78 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `node packages/franken-orchestrator/dist/cli/run.js --help | grep -A20 'Beast Commands:'` — help text includes `--mode process|container`

## Review loop
- Attempted standalone `codex exec` review, but this environment's `codex doctor` reports: `no Codex credentials were found`.
- Used a Codex-model Hermes review loop as the available Codex review fallback.
- First pass found two actionable issues: generic metadata labeling and Docker validation order. Both were fixed.
- Second pass returned: `No issues found.`

Closes #456
