### PR TITLE
docs: add dashboard beast deploy guide

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -746,6 +746,8 @@ Most inter-module communication uses typed port interfaces defined in each modul
 
 ## Deployment Modes
 
+These are toolkit deployment modes: ways to run or embed Frankenbeast surfaces. Beast *execution modes* are a narrower per-run boundary selected when dispatching a Beast. Do not conflate the two.
+
 ```
 ┌─────────────────────────────────────────────────────┐
 │  Mode 1: Full Orchestration                         │
@@ -768,6 +770,17 @@ Most inter-module communication uses typed port interfaces defined in each modul
 │  Import planner/observer/critique/governor/brain    │
 └─────────────────────────────────────────────────────┘
 ```
+
+### Beast execution modes
+
+The Beast dispatcher supports execution-mode selection per run, independent of whether the run was created from the CLI, API, chat-server, or dashboard.
+
+| Beast execution mode | Boundary | Notes |
+|----------------------|----------|-------|
+| `process` | Host child process supervised by the Beast runtime. | Uses the Beast env allowlist and project-root `cwd` containment, but remains a host process and is not a hard sandbox. |
+| `container` | Docker-backed child process transformed from the same Beast process spec. | Uses `docker run --rm --network none`, a single explicit workspace mount, `/workspace` working directory remapping, and the same env allowlist. Requires Docker and a suitable sandbox image. Docker `--network none` is not micro-VM, gVisor, Firecracker, Wasm, or seccomp isolation. |
+
+See [ADR-036](adr/036-sandboxed-beast-execution.md) and [Deploy Beasts from the Dashboard](guides/deploy-beasts.md) for the current operator flow and sprint-status caveats.
 
 ## @fbeast/mcp-suite
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -773,7 +773,7 @@ These are toolkit deployment modes: ways to run or embed Frankenbeast surfaces. 
 
 ### Beast execution modes
 
-The Beast dispatcher supports execution-mode selection per run, independent of whether the run was created from the CLI, API, chat-server, or dashboard.
+Raw CLI/API Beast runs support execution-mode selection per run. Dashboard tracked-agent and chat/WS dispatch paths continue to use each Beast definition's default execution mode until the #455/#457 deploy-beasts follow-ups wire container selection through those entry points.
 
 | Beast execution mode | Boundary | Notes |
 |----------------------|----------|-------|

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -392,7 +392,7 @@ Append-only `AuditTrail` with hash-verified integrity, `AuditTrailStore` persist
 
 - **Chunk A** (#262): Wired `createBeastDeps()` into `dep-factory.ts`, replacing stubs with real adapters. Added dep-bridge, comms config, token aggregation, skill route mounting, commsConfig pass-through.
 - **Chunk B** (#264): Deleted legacy episodic memory + types from franken-brain (-796 lines), removed ulid/zod deps.
-- **Chunk C** (#265): Added `skill`, `provider`, `security`, `dashboard` CLI command groups.
+- **Chunk C** (#265): Added CLI command groups during consolidation; current live CLI subcommands are `init`, `interview`, `plan`, `run`, `beasts`, `issues`, `chat`, `chat-server`, `network`, `skill`, and `security`. Earlier top-level `provider`/`dashboard` command surfaces were removed when provider config, `chat-server`, HTTP dashboard routes, and `franken-web` became the supported surfaces.
 - **Chunk E** (#268): Created skill directory equivalents for beast definitions.
 - **Chunk F** (#267): Added `SkillConfigStore` for persistent skill toggle state.
 - **One-Shots**: Deleted standalone comms server files, added HITL integration test, fixed checkpoint flush.
@@ -423,9 +423,14 @@ Append-only `AuditTrail` with hash-verified integrity, `AuditTrailStore` persist
 1. **Orchestrator depends on port interfaces, not implementations** (by design — hexagonal architecture). Concrete module wiring is done in `dep-factory.ts` via `createBeastDeps()`.
 2. **No `--non-interactive` flag**: Review loops require stdin. For CI/headless use, pipe `"y\n"` to stdin.
 3. **E2E tests require `npm run build`**: No `pretest:e2e` script yet.
-4. **Provider/dashboard CLI commands are stubs**: `frankenbeast provider` and `frankenbeast dashboard` print instructions but don't execute.
+4. **No top-level `provider` or `dashboard` CLI subcommands**: `packages/franken-orchestrator/src/cli/args.ts` currently exposes `init`, `interview`, `plan`, `run`, `beasts`, `issues`, `chat`, `chat-server`, `network`, `skill`, and `security`. Provider/dashboard functionality lives in provider config, `chat-server`, HTTP routes, and `franken-web`.
 5. **ProviderRegistry only active in reflection path**: Task execution still flows through CliLlmAdapter → MartinLoop → spawn(). Multi-provider failover applies to heartbeat/reflection LLM calls only. This is by design — middleware applies to prompt text in-process, not subprocess stdio.
 6. **SkillManagerAdapter.execute() and McpSdkAdapter.callTool() are stubs**: Return hardcoded strings. Real MCP tool dispatch is a future effort.
+
+## Deploy-Beasts / Sandboxed Execution Tracking
+
+- **ADR-036** (`docs/adr/036-sandboxed-beast-execution.md`, Accepted 2026-05-23): documents the current Beast execution boundaries. `process` mode is a host child process with env allowlist and project-root cwd containment; `container` mode transforms the Beast process spec into Docker `--network none` with one explicit workspace mount and the same env allowlist. Docker container mode is not micro-VM/gVisor/Firecracker/Wasm/seccomp isolation.
+- **Dashboard deploy guide**: `docs/guides/deploy-beasts.md` covers the current dashboard tracked-agent deploy flow, monitoring, stop/kill controls, and sprint caveats while #455/#457/#459 remain open.
 
 ## Notes
 - Critical path: PR-15 → 19 → 20 → 25 → 26 → 27 → 28 → 29 → 30 → 36 → 37 → 38

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -430,7 +430,7 @@ Append-only `AuditTrail` with hash-verified integrity, `AuditTrailStore` persist
 ## Deploy-Beasts / Sandboxed Execution Tracking
 
 - **ADR-036** (`docs/adr/036-sandboxed-beast-execution.md`, Accepted 2026-05-23): documents the current Beast execution boundaries. `process` mode is a host child process with env allowlist and project-root cwd containment; `container` mode transforms the Beast process spec into Docker `--network none` with one explicit workspace mount and the same env allowlist. Docker container mode is not micro-VM/gVisor/Firecracker/Wasm/seccomp isolation.
-- **Dashboard deploy guide**: `docs/guides/deploy-beasts.md` covers the current dashboard tracked-agent deploy flow, monitoring, stop/kill controls, and sprint caveats while #455/#457/#459 remain open.
+- **Dashboard deploy guide**: `docs/guides/deploy-beasts.md` covers the current dashboard tracked-agent deploy flow, monitoring, stop/kill controls, and sprint caveats while #455/#457/#458 remain open.
 
 ## Notes
 - Critical path: PR-15 → 19 → 20 → 25 → 26 → 27 → 28 → 29 → 30 → 36 → 37 → 38

--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -150,7 +150,7 @@ Most packages build with `tsc`; `franken-web` uses `tsc && vite build`.
 1. **ProviderRegistry only active in reflection path**: Task execution flows through `CliLlmAdapter → MartinLoop → spawn()`. Multi-provider failover applies to heartbeat/reflection calls only. By design — middleware applies to in-process prompt text, not subprocess stdio.
 2. **SkillManagerAdapter.execute() and McpSdkAdapter.callTool() are stubs**: Return hardcoded strings. Real MCP tool dispatch is a future effort.
 3. **No `--non-interactive` flag**: Headless usage relies on starting at `plan` or `run` with existing inputs.
-4. **Provider/dashboard CLI commands are stubs**: `frankenbeast provider` and `frankenbeast dashboard` print instructions but don't execute.
+4. **No top-level `provider` or `dashboard` CLI subcommands**: Current subcommands are `init`, `interview`, `plan`, `run`, `beasts`, `issues`, `chat`, `chat-server`, `network`, `skill`, and `security` (see `packages/franken-orchestrator/src/cli/args.ts`). Provider/dashboard capabilities are exposed through provider config, `chat-server`, the HTTP dashboard routes, and `franken-web`.
 5. **`--resume` parsed but not a distinct control path**: Checkpoint-based task skipping works from existing checkpoint files.
 
 ## Key Documentation
@@ -159,8 +159,8 @@ Most packages build with `tsc`; `franken-web` uses `tsc && vite build`.
 |------|---------|
 | `docs/ARCHITECTURE.md` | Full system overview with Mermaid diagrams |
 | `docs/PROGRESS.md` | PR-by-PR progress tracking, verified test counts, and Phase 8 CLI gap-closure work |
-| `docs/adr/` | ADRs covering monorepo structure, hex architecture, Hono, shared types, Beast Loop, circuit breakers, CLI execution, Approach C, pluggable CLI providers, multi-pass planning, chat dispatch, external comms, network operator control plane, and tracked-agent init workflow |
-| `docs/guides/` | quickstart, run-dashboard-chat, add-llm-provider, wrap-external-agent, fix-github-issues |
+| `docs/adr/` | ADRs covering monorepo structure, hex architecture, Hono, shared types, Beast Loop, circuit breakers, CLI execution, Approach C, pluggable CLI providers, multi-pass planning, chat dispatch, external comms, network operator control plane, tracked-agent init workflow, and ADR-036 sandboxed Beast execution |
+| `docs/guides/` | quickstart, run-dashboard-chat, deploy-beasts, add-llm-provider, wrap-external-agent, fix-github-issues |
 | `docs/plans/` | Design docs and implementation plans (MCP, beast-runner, approach-c, CLI E2E, pluggable providers, interview UX, etc.) |
 
 ## Secret Store

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -1,0 +1,203 @@
+# Deploy Beasts from the Dashboard
+
+This guide walks an operator through starting the local dashboard, creating a tracked Beast agent, dispatching a run, monitoring status/logs, and stopping or killing the run.
+
+> **Sprint status note:** this guide is written against current `origin/main` after PR #466 / issue #456 merged. Container execution exists in the Beast CLI/API, but the dashboard execution-mode selector (#457), chat/WS container dispatch wiring (#455), and sandbox image/resource hardening (#459) are still open. Until those land, the dashboard deploy flow creates and controls tracked agents through the default Beast definition execution mode. Use the CLI/API container-mode workaround below when you need an actual `container` run.
+
+## What you are deploying
+
+The dashboard talks to `frankenbeast chat-server`, which serves both the chat UI backend and the secure Beast control API:
+
+- `GET /v1/beasts/catalog` lists deployable Beast definitions.
+- `POST /v1/beasts/agents` creates a tracked dashboard agent from the wizard.
+- Agent actions (`start`, `stop`, `restart`, `resume`, `kill`, `delete`) control the linked run.
+- Run detail and logs are read from `/v1/beasts/runs/:runId` and `/v1/beasts/runs/:runId/logs`.
+
+## Prerequisites
+
+- Node.js >= 22 and repo dependencies installed (`npm install`).
+- At least one supported CLI provider works locally for chat/execution.
+- An operator token is configured so Beast control routes are enabled.
+- For container mode: Docker is installed and the sandbox image exists locally (`fbeast/sandbox:latest` by default). Current main does **not** include the hardening/image work from #459 yet.
+
+Set a local operator token in one shell and reuse the same value for the backend and frontend:
+
+```bash
+export OPERATOR_TOKEN='dev-operator-token'
+export FRANKENBEAST_BEAST_OPERATOR_TOKEN="$OPERATOR_TOKEN"
+export VITE_BEAST_OPERATOR_TOKEN="$OPERATOR_TOKEN"
+```
+
+`chat-server` also discovers the token from the repo `.env` or `packages/franken-web/.env.local` using either `FRANKENBEAST_BEAST_OPERATOR_TOKEN` or `VITE_BEAST_OPERATOR_TOKEN`.
+
+## 1. Start the backend
+
+From the repo root:
+
+```bash
+npm --workspace franken-orchestrator run chat-server
+```
+
+Default bind:
+
+- API: `http://127.0.0.1:3737`
+- Chat WebSocket: `ws://127.0.0.1:3737/v1/chat/ws`
+- Beast API: `http://127.0.0.1:3737/v1/beasts/*`
+
+Useful overrides:
+
+```bash
+npm --workspace franken-orchestrator run chat-server -- --port 4242
+npm --workspace franken-orchestrator run chat-server -- --provider codex
+npm --workspace franken-orchestrator run chat-server -- --allow-origin http://localhost:5173
+```
+
+If you bind to a non-loopback host or run in managed network mode, the server refuses to start without an operator token.
+
+## 2. Start the dashboard
+
+In a second terminal:
+
+```bash
+VITE_BEAST_OPERATOR_TOKEN="$OPERATOR_TOKEN" \
+  npm --workspace @frankenbeast/web run dev:chat
+```
+
+If the backend is not on `http://127.0.0.1:3737`, pass `VITE_API_URL`:
+
+```bash
+VITE_API_URL=http://127.0.0.1:4242 \
+VITE_BEAST_OPERATOR_TOKEN="$OPERATOR_TOKEN" \
+  npm --workspace @frankenbeast/web run dev
+```
+
+Open the Vite URL, usually `http://127.0.0.1:5173/`, and navigate to **Beasts**.
+
+## 3. Choose a Beast and execution boundary
+
+Current catalog entries are:
+
+| Definition | Use when | Typical inputs |
+|------------|----------|----------------|
+| `design-interview` | You want the Beast to interview for requirements and produce a design. | Goal text, constraints. |
+| `chunk-plan` | You already have a design doc and need chunk files. | Path to the design doc. |
+| `martin-loop` | You already have chunks and want the implementation loop to execute them. | Plan/chunk path and execution settings. |
+
+Execution boundary choices are a Beast-run concept, separate from the four toolkit deployment modes in `docs/ARCHITECTURE.md`:
+
+| Mode | Boundary | Current dashboard status |
+|------|----------|--------------------------|
+| `process` | Host child process with supervised lifecycle, env allowlist, and project-root `cwd` containment. Not a hard sandbox. | Available through the dashboard tracked-agent flow. |
+| `container` | Docker-backed run using `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, and the same env allowlist. Not a micro-VM/gVisor/Firecracker sandbox. | Available in CLI/API after #456; dashboard selector is pending #457, so use the workaround below on current main. |
+
+### Container-mode workaround until #457 lands
+
+To create an actual container run before the dashboard has a selector, use the CLI or Beast API, then monitor/control the run from the dashboard once it is linked or visible in run state.
+
+CLI example:
+
+```bash
+frankenbeast beasts spawn martin-loop --mode container
+# or
+frankenbeast beasts create martin-loop --mode container
+```
+
+API example:
+
+```bash
+curl -sS http://127.0.0.1:3737/v1/beasts/runs \
+  -H "x-frankenbeast-operator-token: $OPERATOR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "definitionId": "martin-loop",
+    "executionMode": "container",
+    "config": { "planDir": ".fbeast/plans/my-plan/chunks" },
+    "startNow": true
+  }'
+```
+
+## 4. Create and launch from the dashboard
+
+1. Open **Beasts** in the left navigation.
+2. Click **Create Agent**.
+3. Fill the wizard:
+   - **Identity**: name/description for the tracked agent.
+   - **Workflow**: choose the flow (`design-interview`, `chunk-plan`, or `martin-loop`).
+   - **LLM Targets**: select provider/model routing.
+   - **Modules**: keep guardrail modules enabled unless you intentionally need a narrower run.
+   - **Skills** and **Prompts**: attach context and prompt material.
+   - **Git**: choose branch/worktree and PR behavior.
+4. Review the generated launch config.
+5. Click **Launch Agent**.
+
+The dashboard creates a tracked agent first. Starting the agent dispatches the linked Beast run. If the agent does not start immediately, select it in the list and click **Start** from the detail panel.
+
+## 5. Monitor status, events, and logs
+
+The Beasts page refreshes approximately every four seconds while open.
+
+Use the agent detail panel to inspect:
+
+- current tracked-agent status (`initializing`, `dispatching`, `running`, `stopped`, `failed`, `completed`),
+- init metadata and workflow config,
+- agent events,
+- linked run ID and attempts,
+- run logs.
+
+If you need to verify from the API:
+
+```bash
+curl -sS http://127.0.0.1:3737/v1/beasts/agents \
+  -H "x-frankenbeast-operator-token: $OPERATOR_TOKEN"
+
+curl -sS http://127.0.0.1:3737/v1/beasts/runs/<run-id>/logs \
+  -H "x-frankenbeast-operator-token: $OPERATOR_TOKEN"
+```
+
+## 6. Stop, kill, restart, resume, or delete
+
+From the selected agent detail panel:
+
+- **Stop** asks the run to stop cleanly. Use this first for normal interruption.
+- **Kill** force-stops the run. Use this when the run is stuck or ignoring stop.
+- **Restart** starts a new attempt for a stopped/failed/completed or currently running agent.
+- **Resume** resumes a tracked agent's linked run when resumable state exists.
+- **Delete** soft-deletes the tracked agent from the dashboard list.
+
+Equivalent CLI controls are available for raw run IDs:
+
+```bash
+frankenbeast beasts list
+frankenbeast beasts status <run-id>
+frankenbeast beasts logs <run-id>
+frankenbeast beasts stop <run-id>
+frankenbeast beasts kill <run-id>
+frankenbeast beasts restart <run-id>
+frankenbeast beasts resume <agent-id>
+frankenbeast beasts delete <agent-id>
+```
+
+## Troubleshooting
+
+`The Beasts page says to set VITE_BEAST_OPERATOR_TOKEN`
+
+- Start the frontend with `VITE_BEAST_OPERATOR_TOKEN` set.
+- Make sure the backend has the same token via `FRANKENBEAST_BEAST_OPERATOR_TOKEN`, `VITE_BEAST_OPERATOR_TOKEN`, `.env`, or `packages/franken-web/.env.local`.
+
+`The catalog or agents fail with 401`
+
+- The frontend token and backend token differ. Use one shared token for chat, network, dashboard, and Beast routes.
+
+`I cannot choose container mode in the dashboard`
+
+- Expected on current main. PR #466 added CLI/API container mode; #457 is the pending dashboard execution-mode selector. Use the CLI/API workaround above until #457 merges.
+
+`Container mode fails to start`
+
+- Verify Docker is running and the sandbox image named by the runtime policy exists locally.
+- Remember that #459 hardening/image work is still pending on current main.
+
+`The UI loads but does not connect to the backend`
+
+- Confirm `VITE_API_URL` matches the backend URL.
+- If using a non-default origin, start the backend with `--allow-origin <frontend-url>`.

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -111,7 +111,11 @@ curl -sS http://127.0.0.1:3737/v1/beasts/runs \
   -d '{
     "definitionId": "martin-loop",
     "executionMode": "container",
-    "config": { "planDir": ".fbeast/plans/my-plan/chunks" },
+    "config": {
+      "provider": "codex",
+      "objective": "Run the implementation chunks",
+      "chunkDirectory": ".fbeast/plans/my-plan/chunks"
+    },
     "startNow": true
   }'
 ```
@@ -164,7 +168,7 @@ From the selected agent detail panel:
 - **Resume** resumes a tracked agent's linked run when resumable state exists.
 - **Delete** soft-deletes the tracked agent from the dashboard list.
 
-Equivalent CLI controls are available for raw run IDs:
+Equivalent CLI controls for raw run IDs:
 
 ```bash
 frankenbeast beasts list
@@ -173,6 +177,11 @@ frankenbeast beasts logs <run-id>
 frankenbeast beasts stop <run-id>
 frankenbeast beasts kill <run-id>
 frankenbeast beasts restart <run-id>
+```
+
+Tracked-agent-only CLI controls use agent IDs, not raw run IDs:
+
+```bash
 frankenbeast beasts resume <agent-id>
 frankenbeast beasts delete <agent-id>
 ```

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -2,7 +2,7 @@
 
 This guide walks an operator through starting the local dashboard, creating a tracked Beast agent, dispatching a run, monitoring status/logs, and stopping or killing the run.
 
-> **Sprint status note:** this guide is written against current `origin/main` after PR #466 / issue #456 merged. Container execution exists in the Beast CLI/API, but the dashboard execution-mode selector (#457), chat/WS container dispatch wiring (#455), and sandbox image/resource hardening (#459) are still open. Until those land, the dashboard deploy flow creates and controls tracked agents through the default Beast definition execution mode. Use the CLI/API container-mode workaround below when you need an actual `container` run.
+> **Sprint status note:** this guide is written against current `origin/main` after PR #465 / issue #459 and PR #466 / issue #456 merged. Container execution exists in the Beast CLI/API and the in-repo sandbox image/hardening defaults are present, but the dashboard execution-mode selector (#457), chat/WS container dispatch wiring (#455), and live container streaming work (#458) are still open. Until those land, the dashboard deploy flow creates and controls tracked agents through the default Beast definition execution mode. Use the CLI/API container-mode workaround below when you need an actual container run before the dashboard selector lands.
 
 ## What you are deploying
 
@@ -18,7 +18,7 @@ The dashboard talks to `frankenbeast chat-server`, which serves both the chat UI
 - Node.js >= 22 and repo dependencies installed (`npm install`).
 - At least one supported CLI provider works locally for chat/execution.
 - An operator token is configured so Beast control routes are enabled.
-- For container mode: Docker is installed and the sandbox image exists locally (`fbeast/sandbox:latest` by default). Current main does **not** include the hardening/image work from #459 yet.
+- For container mode: Docker is installed and the sandbox image exists locally (`fbeast/sandbox:latest` by default). Current main includes the in-repo `Dockerfile`, non-root user policy, resource-limit defaults, `no-new-privileges`, and optional read-only workspace support from #459.
 
 Set a local operator token in one shell and reuse the same value for the backend and frontend:
 
@@ -88,11 +88,11 @@ Execution boundary choices are a Beast-run concept, separate from the four toolk
 | Mode | Boundary | Current dashboard status |
 |------|----------|--------------------------|
 | `process` | Host child process with supervised lifecycle, env allowlist, and project-root `cwd` containment. Not a hard sandbox. | Available through the dashboard tracked-agent flow. |
-| `container` | Docker-backed run using `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, and the same env allowlist. Not a micro-VM/gVisor/Firecracker sandbox. | Available in CLI/API after #456; dashboard selector is pending #457, so use the workaround below on current main. |
+| `container` | Docker-backed run using `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, non-root user policy, memory/CPU/PID limits, `no-new-privileges`, and the same env allowlist. Not a micro-VM/gVisor/Firecracker sandbox. | Available in CLI/API after #456; dashboard selector is pending #457, so use the workaround below on current main. |
 
 ### Container-mode workaround until #457 lands
 
-To create an actual container run before the dashboard has a selector, use the CLI or Beast API, then monitor/control the run from the dashboard once it is linked or visible in run state.
+To create an actual container run before the dashboard has a selector, use the CLI or Beast runs API. These raw runs are not tracked-agent dashboard entries today, so monitor and control them with the CLI commands or the `/v1/beasts/runs/*` API until #457/#458 wire container selection and live run streaming into the dashboard.
 
 CLI example:
 
@@ -195,7 +195,7 @@ frankenbeast beasts delete <agent-id>
 `Container mode fails to start`
 
 - Verify Docker is running and the sandbox image named by the runtime policy exists locally.
-- Remember that #459 hardening/image work is still pending on current main.
+- Build the default sandbox image from the repo root if it is missing: `docker build -t fbeast/sandbox:latest -f Dockerfile .`.
 
 `The UI loads but does not connect to the backend`
 

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -126,13 +126,13 @@ curl -sS http://127.0.0.1:3737/v1/beasts/runs \
 2. Click **Create Agent**.
 3. Fill the wizard:
    - **Identity**: name/description for the tracked agent.
-   - **Workflow**: choose the flow (`design-interview`, `chunk-plan`, or `martin-loop`).
+   - **Workflow**: choose one of the deployable Beast catalog flows (`design-interview`, `chunk-plan`, or `martin-loop`). The wizard may also show UI-only presets such as `issues-agent`; those are not deployable Beast catalog entries until their backend definition exists.
    - **LLM Targets**: select provider/model routing.
    - **Modules**: keep guardrail modules enabled unless you intentionally need a narrower run.
    - **Skills** and **Prompts**: attach context and prompt material.
    - **Git**: choose branch/worktree and PR behavior.
 4. Review the generated launch config.
-5. Click **Launch Agent**.
+5. Click **Launch**.
 
 The dashboard creates a tracked agent first. Starting the agent dispatches the linked Beast run. If the agent does not start immediately, select it in the list and click **Start** from the detail panel.
 

--- a/tasks/deploy-beasts-docs-progress.md
+++ b/tasks/deploy-beasts-docs-progress.md
@@ -1,0 +1,20 @@
+# Deploy Beasts Docs Progress
+
+- [x] Create isolated issue-460 worktree from current `origin/main`.
+- [x] Inspect issue #460 acceptance criteria and current sprint dependency status.
+- [x] Verify current CLI subcommands in `packages/franken-orchestrator/src/cli/args.ts`.
+- [x] Add `docs/guides/deploy-beasts.md` with the dashboard deploy flow and current sprint caveats.
+- [x] Update `docs/ARCHITECTURE.md` Deployment Modes with beast execution-mode boundaries.
+- [x] Correct stale provider/dashboard CLI-stub references in `docs/RAMP_UP.md` and `docs/PROGRESS.md`.
+- [x] Reference ADR-036 from ramp-up/progress tracking.
+- [x] Run relevant docs/check commands.
+- [x] Complete review loop and fix findings.
+- [ ] Push branch, open PR with `Closes #460`, and merge when eligible.
+
+## Notes
+
+- `gh auth status` passed for `djm204`.
+- `codex doctor` reports no Codex credentials; standalone Codex CLI review is blocked, so use Hermes/Codex-model review loop and document this blocker.
+- Dependency status checked 2026-07-01: issue #456 / PR #466 is merged; issues #455, #457, and #459 remain open. Docs must not claim dashboard execution-mode selection, chat/WS container dispatch, or hardened sandbox image behavior as available on current `origin/main`.
+- Verification: `git diff --check` passed; `npm run build` passed (10/10 turbo tasks cached); `npm --workspace franken-orchestrator run typecheck` passed after workspace build generated dependent package dists; `npm --workspace @frankenbeast/web run typecheck` passed. Initial typecheck attempts failed before `npm install`/workspace build because `tsc` and dependent package declarations were unavailable.
+- Review: standalone `codex` review was unavailable because `codex doctor` reported no credentials. Hermes/Codex-model review checked the diff against issue #460 acceptance, current `args.ts`, and open sprint dependency status; finding to avoid ambiguous Authorization examples was fixed by switching curl examples to `x-frankenbeast-operator-token`. Follow-up review found no blocking issues.

--- a/tasks/deploy-beasts-docs-progress.md
+++ b/tasks/deploy-beasts-docs-progress.md
@@ -15,6 +15,6 @@
 
 - `gh auth status` passed for `djm204`.
 - `codex doctor` reports no Codex credentials; standalone Codex CLI review is blocked, so use Hermes/Codex-model review loop and document this blocker.
-- Dependency status checked 2026-07-01: issue #456 / PR #466 is merged; issues #455, #457, and #459 remain open. Docs must not claim dashboard execution-mode selection, chat/WS container dispatch, or hardened sandbox image behavior as available on current `origin/main`.
+- Dependency status checked 2026-07-01: issue #456 / PR #466 and issue #459 / PR #465 are merged; issues #455, #457, and #458 remain open. Docs must not claim dashboard execution-mode selection, chat/WS container dispatch, or live container streaming as available on current `origin/main`.
 - Verification: `git diff --check` passed; `npm run build` passed (10/10 turbo tasks cached); `npm --workspace franken-orchestrator run typecheck` passed after workspace build generated dependent package dists; `npm --workspace @frankenbeast/web run typecheck` passed. Initial typecheck attempts failed before `npm install`/workspace build because `tsc` and dependent package declarations were unavailable.
 - Review: standalone `codex` review was unavailable because `codex doctor` reported no credentials. Hermes/Codex-model review checked the diff against issue #460 acceptance, current `args.ts`, and open sprint dependency status; finding to avoid ambiguous Authorization examples was fixed by switching curl examples to `x-frankenbeast-operator-token`. Follow-up review found no blocking issues.


### PR DESCRIPTION
## Summary
- add `docs/guides/deploy-beasts.md` for the dashboard Beast deploy/control flow
- document current process/container execution-mode status and sprint caveats for open #455/#457/#459
- update architecture/ramp-up/progress docs for Beast execution modes, current CLI subcommands, and ADR-036 discoverability

Closes #460

## Verification
- `git diff --check`
- `npm run build`
- `npm --workspace franken-orchestrator run typecheck`
- `npm --workspace @frankenbeast/web run typecheck`

## Review
- Standalone `codex` review unavailable: `codex doctor` reports no Codex credentials. Used Hermes/Codex-model review loop instead; follow-up review found no blocking issues.