### PR TITLE
Wire container mode through chat dispatch

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
@@ -4,7 +4,7 @@ import type { BeastLogStore } from '../events/beast-log-store.js';
 import type { BeastEventBus } from '../events/beast-event-bus.js';
 import type { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import { ProcessBeastExecutor, type ProcessBeastExecutorOptions } from './process-beast-executor.js';
-import { ProcessSupervisor, type ProcessCallbacks, type ProcessSupervisorLike } from './process-supervisor.js';
+import { ProcessSupervisor, type ProcessSupervisorLike } from './process-supervisor.js';
 import { toDockerSpec } from './docker-container-runtime.js';
 import { DEFAULT_SANDBOX_POLICY, type SandboxPolicy } from './sandbox-policy.js';
 
@@ -17,23 +17,41 @@ export interface ContainerBeastExecutorDeps {
   readonly supervisorFactory?: () => ProcessSupervisorLike;
 }
 
-class DockerSupervisor implements ProcessSupervisorLike {
-  constructor(
-    private readonly inner: ProcessSupervisorLike,
-    private readonly policy: SandboxPolicy,
-  ) {}
+function containerNameForRun(run: BeastRun): string {
+  return `fbeast-${run.id}`.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 128);
+}
 
-  spawn(spec: BeastProcessSpec, callbacks: ProcessCallbacks) {
-    return this.inner.spawn(toDockerSpec(spec, this.policy), callbacks);
-  }
-
-  stop(pid: number) {
-    return this.inner.stop(pid);
-  }
-
-  kill(pid: number) {
-    return this.inner.kill(pid);
-  }
+function containerAttemptMetadata(
+  policy: SandboxPolicy,
+  run: BeastRun,
+  originalSpec: BeastProcessSpec,
+  dockerSpec: BeastProcessSpec,
+  handle: { pid: number },
+): Readonly<Record<string, unknown>> {
+  const containerName = containerNameForRun(run);
+  const resourceSnapshot = {
+    memory: policy.resourceLimits.memory,
+    cpus: policy.resourceLimits.cpus,
+    pidsLimit: policy.resourceLimits.pidsLimit,
+  };
+  return {
+    backend: 'container',
+    containerRuntime: 'docker',
+    containerId: containerName,
+    containerName,
+    image: policy.image,
+    containerImage: policy.image,
+    containerNetwork: policy.network,
+    resourceSnapshot,
+    resources: resourceSnapshot,
+    workspaceHostPath: policy.workspaceHostPath,
+    workspaceContainerPath: policy.workspaceContainerPath,
+    supervisorPid: handle.pid,
+    command: originalSpec.command,
+    args: [...originalSpec.args],
+    dockerCommand: dockerSpec.command,
+    dockerArgs: [...dockerSpec.args],
+  };
 }
 
 export class ContainerBeastExecutor implements BeastExecutor {
@@ -51,11 +69,17 @@ export class ContainerBeastExecutor implements BeastExecutor {
     if (deps.eventBus) {
       options.eventBus = deps.eventBus;
     }
+    options.transformSpec = (run, _originalSpec, mergedSpec) => toDockerSpec(mergedSpec, policy, {
+      containerName: containerNameForRun(run),
+    });
+    options.attemptMetadata = (run, originalSpec, dockerSpec, handle) => (
+      containerAttemptMetadata(policy, run, originalSpec, dockerSpec, handle)
+    );
 
     this.inner = new ProcessBeastExecutor(
       deps.repository,
       deps.logStore,
-      new DockerSupervisor(baseSupervisor, policy),
+      baseSupervisor,
       options,
     );
   }

--- a/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
@@ -57,12 +57,21 @@ function workspaceMount(policy: SandboxPolicy): string {
   return `${policy.workspaceHostPath}:${policy.workspaceContainerPath}${accessMode}`;
 }
 
-export function toDockerSpec(spec: BeastProcessSpec, policy: SandboxPolicy): BeastProcessSpec {
+export interface DockerSpecOptions {
+  readonly containerName?: string | undefined;
+}
+
+export function toDockerSpec(
+  spec: BeastProcessSpec,
+  policy: SandboxPolicy,
+  options: DockerSpecOptions = {},
+): BeastProcessSpec {
   return {
     command: 'docker',
     args: [
       'run',
       '--rm',
+      ...(options.containerName ? ['--name', options.containerName] : []),
       '--network',
       policy.network,
       '--memory',

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -5,7 +5,7 @@ import type { BeastEventBus } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import type { BeastExecutor, StopOptions } from './beast-executor.js';
 import type { ProcessSupervisorLike } from './process-supervisor.js';
-import type { BeastDefinition, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
+import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
 const STDERR_BUFFER_SIZE = 50;
 
@@ -25,6 +25,17 @@ export interface ProcessBeastExecutorOptions {
   onRunStatusChange?: (runId: string) => void;
   eventBus?: BeastEventBus;
   defaultStopTimeoutMs?: number;
+  transformSpec?: (
+    run: BeastRun,
+    originalSpec: BeastProcessSpec,
+    mergedSpec: BeastProcessSpec,
+  ) => BeastProcessSpec;
+  attemptMetadata?: (
+    run: BeastRun,
+    originalSpec: BeastProcessSpec,
+    spawnedSpec: BeastProcessSpec,
+    handle: { pid: number },
+  ) => Readonly<Record<string, unknown>>;
 }
 
 export class ProcessBeastExecutor implements BeastExecutor {
@@ -64,6 +75,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         FRANKENBEAST_RUN_CONFIG: configFilePath,
       },
     };
+    const spawnedSpec = this.options.transformSpec?.(run, processSpec, mergedSpec) ?? mergedSpec;
 
     // eslint-disable-next-line prefer-const -- reassigned after attempt creation (line 162)
     let attemptId: string | undefined;
@@ -74,7 +86,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
 
     let handle: { pid: number };
     try {
-      handle = await this.supervisor.spawn(mergedSpec, {
+      handle = await this.supervisor.spawn(spawnedSpec, {
         onStdout: (line) => {
           if (attemptId) {
             void this.logs.append(run.id, attemptId, 'stdout', line);
@@ -155,7 +167,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       status: 'running',
       pid: handle.pid,
       startedAt,
-      executorMetadata: {
+      executorMetadata: this.options.attemptMetadata?.(run, processSpec, spawnedSpec, handle) ?? {
         backend: 'process',
         command: processSpec.command,
         args: [...processSpec.args],

--- a/packages/franken-orchestrator/src/beasts/services/agent-init-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-init-service.ts
@@ -1,4 +1,4 @@
-import type { TrackedAgent, TrackedAgentInitActionKind, BeastRun } from '../types.js';
+import type { TrackedAgent, TrackedAgentInitActionKind, BeastExecutionMode, BeastRun } from '../types.js';
 import type { BeastDispatchService } from './beast-dispatch-service.js';
 import { AgentService } from './agent-service.js';
 
@@ -14,6 +14,7 @@ export interface DispatchTrackedAgentRequest {
   readonly definitionId: string;
   readonly chatSessionId: string;
   readonly config: Readonly<Record<string, unknown>>;
+  readonly executionMode?: BeastExecutionMode | undefined;
 }
 
 export class AgentInitService {
@@ -83,6 +84,7 @@ export class AgentInitService {
       dispatchedByUser: `chat-session:${request.chatSessionId}`,
       trackedAgentId: agentId,
       startNow: true,
+      ...(request.executionMode ? { executionMode: request.executionMode } : {}),
     });
   }
 }

--- a/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
@@ -2,6 +2,7 @@ import type { BeastCatalogService } from '../beasts/services/beast-catalog-servi
 import type { BeastDispatchService } from '../beasts/services/beast-dispatch-service.js';
 import type { BeastInterviewService, BeastInterviewProgress } from '../beasts/services/beast-interview-service.js';
 import type { AgentInitService } from '../beasts/services/agent-init-service.js';
+import type { BeastExecutionMode } from '../beasts/types.js';
 import type { ChatBeastContext, TranscriptMessage } from './types.js';
 
 export interface ChatBeastDispatchState {
@@ -9,6 +10,7 @@ export interface ChatBeastDispatchState {
   readonly sessionId: string;
   readonly transcript: TranscriptMessage[];
   readonly beastContext?: ChatBeastContext | null | undefined;
+  readonly executionMode?: BeastExecutionMode | undefined;
 }
 
 export interface ChatBeastDispatchResult {
@@ -38,7 +40,9 @@ export class ChatBeastDispatchAdapter {
   constructor(private readonly options: ChatBeastDispatchAdapterOptions) {}
 
   async handle(input: string, state: ChatBeastDispatchState): Promise<ChatBeastDispatchResult | null> {
-    const activeContext = state.beastContext;
+    const activeContext = state.beastContext && state.executionMode
+      ? { ...state.beastContext, executionMode: state.executionMode }
+      : state.beastContext;
     if (activeContext?.status === 'interviewing' && activeContext.interviewSessionId) {
       const progress = this.options.interviews.answer(activeContext.interviewSessionId, input);
       return this.resultFromProgress(progress, activeContext, state.sessionId);
@@ -71,6 +75,7 @@ export class ChatBeastDispatchAdapter {
         agentId: agent.id,
         definitionId: definition.id,
         interviewSessionId: interview.id,
+        ...(state.executionMode ? { executionMode: state.executionMode } : {}),
         status: 'interviewing',
       },
     };
@@ -95,6 +100,7 @@ export class ChatBeastDispatchAdapter {
           ...(context.agentId ? { agentId: context.agentId } : {}),
           definitionId,
           interviewSessionId: progress.session.id,
+          ...(context.executionMode ? { executionMode: context.executionMode } : {}),
           status: 'interviewing',
         },
       };
@@ -105,6 +111,7 @@ export class ChatBeastDispatchAdapter {
           definitionId,
           chatSessionId: sessionId,
           config: progress.config,
+          ...(context.executionMode ? { executionMode: context.executionMode } : {}),
         })
       : await this.options.dispatch.createRun({
           definitionId,
@@ -112,6 +119,7 @@ export class ChatBeastDispatchAdapter {
           dispatchedBy: 'chat',
           dispatchedByUser: `chat-session:${sessionId}`,
           startNow: true,
+          ...(context.executionMode ? { executionMode: context.executionMode } : {}),
         });
 
     return {

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -3,6 +3,7 @@ import type { TurnRunner, TurnEvent, TurnRunResult } from './turn-runner.js';
 import type { ChatBeastContext, ExecuteOutcome, TranscriptMessage, TurnOutcome } from './types.js';
 import { sanitizeChatOutput } from './output-sanitizer.js';
 import type { ChatBeastDispatchAdapter } from './beast-dispatch-adapter.js';
+import type { BeastExecutionMode } from '../beasts/types.js';
 
 const SLASH_COMMANDS = new Set([
   '/plan',
@@ -19,6 +20,7 @@ export interface ChatRuntimeState {
   projectId: string;
   transcript: TranscriptMessage[];
   beastContext?: ChatBeastContext | null | undefined;
+  executionMode?: BeastExecutionMode | undefined;
 }
 
 export interface ChatDisplayMessage {
@@ -172,6 +174,7 @@ export class ChatRuntime {
         sessionId: state.sessionId,
         transcript: state.transcript,
         ...(state.beastContext !== undefined ? { beastContext: state.beastContext } : {}),
+        ...(state.executionMode ? { executionMode: state.executionMode } : {}),
       });
       if (beastResult) {
         const transcript = appendTranscript(state.transcript, input, beastResult.assistantMessage);

--- a/packages/franken-orchestrator/src/chat/types.ts
+++ b/packages/franken-orchestrator/src/chat/types.ts
@@ -50,6 +50,7 @@ export const ChatBeastContextSchema = z.object({
   agentId: z.string().min(1).optional(),
   definitionId: z.string().min(1),
   interviewSessionId: z.string().min(1),
+  executionMode: z.enum(['process', 'container']).optional(),
   status: z.enum(['interviewing']),
 });
 export type ChatBeastContext = z.infer<typeof ChatBeastContextSchema>;

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -13,6 +13,44 @@ import type { SseConnectionTicketStore } from '../../beasts/events/sse-connectio
 import type { BeastMetrics } from '../../beasts/telemetry/beast-metrics.js';
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { TransportSecurityService } from '../security/transport-security.js';
+import type { BeastRun, BeastRunAttempt } from '../../beasts/types.js';
+
+type BeastRunResponse = BeastRun & {
+  readonly containerId?: unknown;
+  readonly containerName?: unknown;
+  readonly containerRuntime?: unknown;
+  readonly image?: unknown;
+  readonly containerImage?: unknown;
+  readonly containerNetwork?: unknown;
+  readonly resourceSnapshot?: unknown;
+  readonly resources?: unknown;
+  readonly workspaceHostPath?: unknown;
+  readonly workspaceContainerPath?: unknown;
+};
+
+function runWithContainerFields(run: BeastRun | undefined, attempts: BeastRunAttempt[]): BeastRunResponse | undefined {
+  if (!run || run.executionMode !== 'container') {
+    return run;
+  }
+  const currentAttempt = attempts.find((attempt) => attempt.id === run.currentAttemptId) ?? attempts.at(-1);
+  const metadata = currentAttempt?.executorMetadata;
+  if (!metadata) {
+    return run;
+  }
+  return {
+    ...run,
+    ...(metadata.containerId !== undefined ? { containerId: metadata.containerId } : {}),
+    ...(metadata.containerName !== undefined ? { containerName: metadata.containerName } : {}),
+    ...(metadata.containerRuntime !== undefined ? { containerRuntime: metadata.containerRuntime } : {}),
+    ...(metadata.image !== undefined ? { image: metadata.image } : {}),
+    ...(metadata.containerImage !== undefined ? { containerImage: metadata.containerImage } : {}),
+    ...(metadata.containerNetwork !== undefined ? { containerNetwork: metadata.containerNetwork } : {}),
+    ...(metadata.resourceSnapshot !== undefined ? { resourceSnapshot: metadata.resourceSnapshot } : {}),
+    ...(metadata.resources !== undefined ? { resources: metadata.resources } : {}),
+    ...(metadata.workspaceHostPath !== undefined ? { workspaceHostPath: metadata.workspaceHostPath } : {}),
+    ...(metadata.workspaceContainerPath !== undefined ? { workspaceContainerPath: metadata.workspaceContainerPath } : {}),
+  };
+}
 
 const ModuleConfigSchema = z.object({
   firewall: z.boolean().optional(),
@@ -104,19 +142,26 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       }
       throw error;
     }
-    return c.json({ data: run }, 201);
+    const attempts = deps.runs.listAttempts(run.id);
+    return c.json({ data: runWithContainerFields(run, attempts) }, 201);
   });
 
   app.get('/v1/beasts/runs', (c) => {
-    return c.json({ data: { runs: deps.runs.listRuns() } });
+    return c.json({
+      data: {
+        runs: deps.runs.listRuns().map((run) => runWithContainerFields(run, deps.runs.listAttempts(run.id))),
+      },
+    });
   });
 
   app.get('/v1/beasts/runs/:runId', (c) => {
     const runId = c.req.param('runId');
+    const run = deps.runs.getRun(runId);
+    const attempts = deps.runs.listAttempts(runId);
     return c.json({
       data: {
-        run: deps.runs.getRun(runId),
-        attempts: deps.runs.listAttempts(runId),
+        run: runWithContainerFields(run, attempts),
+        attempts,
         events: deps.runs.listEvents(runId),
       },
     });

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -13,6 +13,7 @@ const CreateSessionBody = z.object({
 
 const SubmitMessageBody = z.object({
   content: z.string().min(1),
+  executionMode: z.enum(['process', 'container']).optional(),
 }).strict();
 
 const ApproveBody = z.object({
@@ -78,7 +79,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
   app.post('/v1/chat/sessions/:id/messages', async (c) => {
     const id = c.req.param('id');
     const body = await parseJsonBody(c);
-    const { content } = validateBody(SubmitMessageBody, body);
+    const { content, executionMode } = validateBody(SubmitMessageBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
     const result = await runtime.run(content, {
@@ -87,6 +88,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       projectId: session.projectId,
       transcript: session.transcript,
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+      ...(executionMode ? { executionMode } : {}),
     });
 
     session.transcript = result.transcript;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -166,7 +166,7 @@ export class ChatSocketController {
 
     switch (event.type) {
       case 'message.send':
-        await this.handleMessageSend(peer, session, event.clientMessageId, event.content);
+        await this.handleMessageSend(peer, session, event.clientMessageId, event.content, event.executionMode);
         return;
       case 'approval.respond':
         await this.handleApproval(peer, session, event.approved);
@@ -189,6 +189,7 @@ export class ChatSocketController {
     session: ChatSession,
     clientMessageId: string,
     content: string,
+    executionMode?: 'process' | 'container',
   ): Promise<void> {
     this.emit(peer, {
       type: 'message.accepted',
@@ -213,6 +214,7 @@ export class ChatSocketController {
       projectId: session.projectId,
       transcript: session.transcript,
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+      ...(executionMode ? { executionMode } : {}),
     });
 
     session.transcript = result.transcript;

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -14,16 +14,34 @@ import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
+import { ContainerBeastExecutor } from '../../../src/beasts/execution/container-beast-executor.js';
+import { DEFAULT_SANDBOX_POLICY } from '../../../src/beasts/execution/sandbox-policy.js';
+import type { BeastProcessSpec } from '../../../src/beasts/types.js';
+import type { ProcessCallbacks, ProcessSupervisorLike } from '../../../src/beasts/execution/process-supervisor.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/beast-routes');
 
-function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean }) {
+function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; realContainer?: boolean }) {
   mkdirSync(TMP, { recursive: true });
   const repository = new SQLiteBeastRepository(join(TMP, 'beasts.db'));
   const logStore = new BeastLogStore(join(TMP, 'logs'));
   const catalog = new BeastCatalogService();
   const metrics = new PrometheusBeastMetrics();
+  const fakeContainerSupervisor: ProcessSupervisorLike = {
+    spawn: vi.fn(async (_spec: BeastProcessSpec, _callbacks: ProcessCallbacks) => ({ pid: 5678 })),
+    stop: vi.fn(async () => undefined),
+    kill: vi.fn(async () => undefined),
+  };
+  const containerExecutor = options?.realContainer
+    ? new ContainerBeastExecutor({
+      repository,
+      logStore,
+      eventBus: new BeastEventBus(),
+      supervisorFactory: () => fakeContainerSupervisor,
+      policy: { ...DEFAULT_SANDBOX_POLICY, image: 'fbeast/sandbox:test', workspaceHostPath: TMP },
+    })
+    : undefined;
   const executors = {
     process: {
       start: vi.fn(async (run, _definition) => {
@@ -72,7 +90,7 @@ function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean }
         return repository.getAttempt(attemptId)!;
       }),
     },
-    container: {
+    container: containerExecutor ?? {
       start: vi.fn(),
       stop: vi.fn(),
       kill: vi.fn(),
@@ -107,7 +125,7 @@ function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean }
     },
   });
 
-  return { app, operatorToken };
+  return { app, operatorToken, fakeContainerSupervisor };
 }
 
 describe('beast routes', () => {
@@ -175,6 +193,85 @@ describe('beast routes', () => {
     });
     const logsBody = await logsResponse.json() as { data: { logs: string[] } };
     expect(logsBody.data.logs.some((line) => line.includes('started'))).toBe(true);
+  });
+
+  it('dispatches a real container executor through the API and exposes container fields', async () => {
+    const { app, operatorToken, fakeContainerSupervisor } = createBeastApp({ realContainer: true });
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+
+    const createResponse = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Exercise container API dispatch',
+          chunkDirectory: 'docs/chunks',
+        },
+        executionMode: 'container',
+        startNow: true,
+      }),
+    });
+
+    expect(createResponse.status).toBe(201);
+    const created = await createResponse.json() as {
+      data: {
+        id: string;
+        executionMode: string;
+        status: string;
+        containerId?: string;
+        containerRuntime?: string;
+        image?: string;
+        containerImage?: string;
+        containerNetwork?: string;
+        resourceSnapshot?: Record<string, unknown>;
+        workspaceContainerPath?: string;
+      };
+    };
+    expect(created.data).toMatchObject({
+      executionMode: 'container',
+      status: 'running',
+      containerId: `fbeast-${created.data.id}`,
+      containerRuntime: 'docker',
+      image: 'fbeast/sandbox:test',
+      containerImage: 'fbeast/sandbox:test',
+      containerNetwork: 'none',
+      resourceSnapshot: { memory: '512m', cpus: '1.0', pidsLimit: 256 },
+      workspaceContainerPath: '/workspace',
+    });
+    expect(fakeContainerSupervisor.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'docker' }),
+      expect.any(Object),
+    );
+
+    const detailResponse = await app.request(`/v1/beasts/runs/${created.data.id}`, {
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(detailResponse.status).toBe(200);
+    const detail = await detailResponse.json() as {
+      data: {
+        run: { containerId?: string; image?: string; containerImage?: string; workspaceContainerPath?: string };
+        attempts: Array<{ executorMetadata?: Record<string, unknown> }>;
+      };
+    };
+    expect(detail.data.run).toMatchObject({
+      containerId: `fbeast-${created.data.id}`,
+      image: 'fbeast/sandbox:test',
+      containerImage: 'fbeast/sandbox:test',
+      workspaceContainerPath: '/workspace',
+    });
+    expect(detail.data.attempts[0]?.executorMetadata).toMatchObject({
+      backend: 'container',
+      containerId: `fbeast-${created.data.id}`,
+      containerRuntime: 'docker',
+      image: 'fbeast/sandbox:test',
+      containerImage: 'fbeast/sandbox:test',
+      dockerCommand: 'docker',
+    });
   });
 
   it('supports interview start and answer flow', async () => {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -16,6 +16,10 @@ import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
+import { ContainerBeastExecutor } from '../../../src/beasts/execution/container-beast-executor.js';
+import { DEFAULT_SANDBOX_POLICY } from '../../../src/beasts/execution/sandbox-policy.js';
+import type { BeastProcessSpec } from '../../../src/beasts/types.js';
+import type { ProcessCallbacks, ProcessSupervisorLike } from '../../../src/beasts/execution/process-supervisor.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/http-chat');
@@ -173,6 +177,18 @@ describe('Chat HTTP Routes', () => {
     const catalog = new BeastCatalogService();
     const metrics = new PrometheusBeastMetrics();
     const agents = new AgentService(repository);
+    const fakeContainerSupervisor: ProcessSupervisorLike = {
+      spawn: vi.fn(async (_spec: BeastProcessSpec, _callbacks: ProcessCallbacks) => ({ pid: 8765 })),
+      stop: vi.fn(async () => undefined),
+      kill: vi.fn(async () => undefined),
+    };
+    const containerExecutor = new ContainerBeastExecutor({
+      repository,
+      logStore,
+      eventBus: new BeastEventBus(),
+      supervisorFactory: () => fakeContainerSupervisor,
+      policy: { ...DEFAULT_SANDBOX_POLICY, image: 'fbeast/sandbox:test', workspaceHostPath: TMP },
+    });
     const executors = {
       process: {
         start: vi.fn(async (run, _definition) => {
@@ -194,11 +210,7 @@ describe('Chat HTTP Routes', () => {
         stop: vi.fn(),
         kill: vi.fn(),
       },
-      container: {
-        start: vi.fn(),
-        stop: vi.fn(),
-        kill: vi.fn(),
-      },
+      container: containerExecutor,
     };
     app = createChatApp({
       sessionStoreDir: join(TMP, 'chat-with-beasts'),
@@ -237,7 +249,7 @@ describe('Chat HTTP Routes', () => {
     const promptOneRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
       method: 'POST',
       headers: authHeaders,
-      body: JSON.stringify({ content: 'spawn a martin beast' }),
+      body: JSON.stringify({ content: 'spawn a martin beast', executionMode: 'container' }),
     });
     expect(promptOneRes.status).toBe(200);
     const promptOne = await promptOneRes.json();
@@ -288,8 +300,19 @@ describe('Chat HTTP Routes', () => {
       definitionId: 'martin-loop',
       dispatchedBy: 'chat',
       dispatchedByUser: `chat-session:${created.id}`,
+      executionMode: 'container',
       status: 'running',
+      containerId: expect.stringMatching(/^fbeast-run_/),
+      containerRuntime: 'docker',
+      image: 'fbeast/sandbox:test',
+      containerImage: 'fbeast/sandbox:test',
+      resourceSnapshot: { memory: '512m', cpus: '1.0', pidsLimit: 256 },
+      workspaceContainerPath: '/workspace',
     });
+    expect(fakeContainerSupervisor.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'docker' }),
+      expect.any(Object),
+    );
   });
 
   it('uses the default LLM-backed executor for code-request turns', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-init-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-init-service.test.ts
@@ -76,6 +76,7 @@ describe('AgentInitService', () => {
         designDocPath: 'docs/plans/design.md',
         outputDir: 'docs/chunks',
       },
+      executionMode: 'container',
     });
     const detail = agents.getAgentDetail(agent.id);
 
@@ -89,6 +90,7 @@ describe('AgentInitService', () => {
       dispatchedByUser: 'chat-session:sess-1',
       trackedAgentId: agent.id,
       startNow: true,
+      executionMode: 'container',
     });
     expect(run.id).toBe('run-123');
     expect(detail.events.map((event) => event.type)).toContain('agent.dispatch.requested');

--- a/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
@@ -65,8 +65,22 @@ describe('ContainerBeastExecutor', () => {
     const attempt = await executor.start(run, definition);
 
     expect(attempt.pid).toBe(4242);
+    expect(attempt.executorMetadata).toMatchObject({
+      backend: 'container',
+      containerRuntime: 'docker',
+      containerId: run.id.replace(/^/, 'fbeast-'),
+      containerName: run.id.replace(/^/, 'fbeast-'),
+      image: 'fbeast/sandbox:test',
+      containerImage: 'fbeast/sandbox:test',
+      containerNetwork: 'none',
+      resourceSnapshot: { memory: DEFAULT_SANDBOX_POLICY.resourceLimits.memory },
+      workspaceHostPath: workDir,
+      workspaceContainerPath: '/workspace',
+      dockerCommand: 'docker',
+    });
     expect(spawned).toHaveLength(1);
     expect(spawned[0].command).toBe('docker');
+    expect(spawned[0].args).toEqual(expect.arrayContaining(['--name', `fbeast-${run.id}`]));
     expect(spawned[0].args).toEqual(expect.arrayContaining(['--network', 'none']));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/chat/beast-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-dispatch-adapter.test.ts
@@ -152,6 +152,7 @@ describe('ChatBeastDispatchAdapter', () => {
       projectId: 'proj',
       sessionId: 'chat-1',
       transcript: [],
+      executionMode: 'container',
       beastContext: {
         agentId: 'agent-1',
         definitionId: 'martin-loop',
@@ -164,6 +165,7 @@ describe('ChatBeastDispatchAdapter', () => {
       definitionId: 'martin-loop',
       chatSessionId: 'chat-1',
       config: { provider: 'claude', objective: 'Ship Beast monitoring' },
+      executionMode: 'container',
     });
     expect(dispatched).toMatchObject({
       kind: 'dispatch',

--- a/packages/franken-types/src/comms.ts
+++ b/packages/franken-types/src/comms.ts
@@ -5,6 +5,7 @@ export const ClientSocketEventSchema = z.discriminatedUnion('type', [
     type: z.literal('message.send'),
     clientMessageId: z.string().min(1),
     content: z.string().min(1).max(16_384),
+    executionMode: z.enum(['process', 'container']).optional(),
   }).strict(),
   z.object({
     type: z.literal('approval.respond'),

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -20,9 +20,22 @@ export interface BeastRunSummary {
   trackedAgentId?: string;
   definitionId: string;
   status: string;
+  executionMode: 'process' | 'container';
   dispatchedBy: string;
   dispatchedByUser: string;
   attemptCount: number;
+  currentAttemptId?: string;
+  stopReason?: string;
+  containerId?: string;
+  containerName?: string;
+  containerRuntime?: string;
+  image?: string;
+  containerImage?: string;
+  containerNetwork?: string;
+  resourceSnapshot?: Record<string, unknown>;
+  resources?: Record<string, unknown>;
+  workspaceHostPath?: string;
+  workspaceContainerPath?: string;
   createdAt: string;
 }
 

--- a/tasks/issue-455-progress.md
+++ b/tasks/issue-455-progress.md
@@ -1,0 +1,13 @@
+# Issue 455 Progress
+
+Note: fbeast MCP tools referenced by AGENTS.md are not available in this tool environment; proceeding with repo instructions that are available.
+
+- [x] Create isolated worktree from origin/main.
+- [x] Inspect dispatch, executor metadata, API/web schemas, and tests.
+- [x] Forward executionMode through chat/WS dispatch path.
+- [x] Add container-specific attempt/executor metadata fields and surface via REST/web API types.
+- [x] Add real integration coverage for container-mode API dispatch with fields.
+- [x] Run targeted tests and relevant typecheck/build.
+- [x] Run Codex review loop until all-clear. (Codex CLI attempted and blocked by 401 unauthenticated; performed self-review equivalent with no actionable issues found.)
+- [ ] Commit, push, and open PR with Closes #455.
+- [ ] Merge if eligible.


### PR DESCRIPTION
## Summary
- Forward optional container execution mode through HTTP chat and WebSocket dispatch, preserving it across Beast interview context and tracked-agent initialization.
- Populate container attempts with container name/id, image, resource snapshot, workspace, runtime, and docker command metadata, and expose those fields in Beast REST responses and web API types.
- Add API/chat integration coverage for container-mode dispatch through the real ContainerBeastExecutor path plus unit coverage for executor metadata and chat dispatch forwarding.

Closes #455

## Tests
- npm test -- --filter=franken-orchestrator -- tests/unit/beasts/container-beast-executor.test.ts tests/unit/chat/beast-dispatch-adapter.test.ts tests/integration/beasts/beast-routes.test.ts tests/integration/chat/chat-routes.test.ts
- npm run typecheck -- --filter=franken-orchestrator --filter=@franken/types --filter=@frankenbeast/web
- npm run build -- --filter=franken-orchestrator --filter=@franken/types --filter=@frankenbeast/web

## Review
- Codex CLI review attempted; blocked by 401 unauthenticated in this environment.
- Self-review equivalent completed: no actionable issues found.
