### PR TITLE
feat(web): add beast execution mode selection

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -30,6 +30,7 @@ const CreateAgentBody = z.object({
   initConfig: z.record(z.string(), z.unknown()),
   chatSessionId: z.string().min(1).optional(),
   moduleConfig: ModuleConfigSchema.optional(),
+  executionMode: z.enum(['process', 'container']).optional(),
 }).strict();
 
 export interface AgentRoutesDeps {
@@ -110,6 +111,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
         dispatchedByUser: body.chatSessionId ? `chat-session:${body.chatSessionId}` : 'operator',
         trackedAgentId: agent.id,
         startNow: true,
+        ...(body.executionMode ? { executionMode: body.executionMode } : {}),
         ...(body.moduleConfig ? { moduleConfig: body.moduleConfig } : {}),
       });
     } catch (error) {

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { execFileSync } from 'node:child_process';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
 import { UnknownTrackedAgentError } from '../../beasts/errors.js';
@@ -129,6 +130,10 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     });
   });
 
+  app.get('/v1/beasts/runtime/container', (c) => {
+    return c.json({ data: getContainerRuntimeStatus() });
+  });
+
   app.post('/v1/beasts/runs', async (c) => {
     const body = validateBody(CreateRunBody, await parseJsonBody(c));
     let run;
@@ -225,4 +230,23 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   });
 
   return app;
+}
+
+function getContainerRuntimeStatus(): { available: boolean; reason?: string } {
+  try {
+    execFileSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 2000,
+    });
+    return { available: true };
+  } catch (error) {
+    const reason = error instanceof Error && error.message
+      ? error.message
+      : 'Docker runtime is unavailable.';
+    return {
+      available: false,
+      reason: `Docker runtime unavailable: ${reason}`,
+    };
+  }
 }

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
 import { UnknownTrackedAgentError } from '../../beasts/errors.js';
@@ -130,8 +131,8 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     });
   });
 
-  app.get('/v1/beasts/runtime/container', (c) => {
-    return c.json({ data: getContainerRuntimeStatus() });
+  app.get('/v1/beasts/runtime/container', async (c) => {
+    return c.json({ data: await getContainerRuntimeStatus() });
   });
 
   app.post('/v1/beasts/runs', async (c) => {
@@ -232,11 +233,38 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   return app;
 }
 
-function getContainerRuntimeStatus(): { available: boolean; reason?: string } {
+const execFileAsync = promisify(execFile);
+const CONTAINER_RUNTIME_STATUS_CACHE_MS = 30_000;
+
+type ContainerRuntimeStatus = { available: boolean; reason?: string };
+
+let containerRuntimeStatusCache: {
+  readonly checkedAt: number;
+  readonly status: ContainerRuntimeStatus;
+} | undefined;
+let containerRuntimeStatusProbe: Promise<ContainerRuntimeStatus> | undefined;
+
+async function getContainerRuntimeStatus(now = Date.now()): Promise<ContainerRuntimeStatus> {
+  if (containerRuntimeStatusCache && now - containerRuntimeStatusCache.checkedAt < CONTAINER_RUNTIME_STATUS_CACHE_MS) {
+    return containerRuntimeStatusCache.status;
+  }
+
+  containerRuntimeStatusProbe ??= probeContainerRuntime()
+    .then((status) => {
+      containerRuntimeStatusCache = { checkedAt: Date.now(), status };
+      return status;
+    })
+    .finally(() => {
+      containerRuntimeStatusProbe = undefined;
+    });
+
+  return containerRuntimeStatusProbe;
+}
+
+async function probeContainerRuntime(): Promise<ContainerRuntimeStatus> {
   try {
-    execFileSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+    await execFileAsync('docker', ['version', '--format', '{{.Server.Version}}'], {
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 2000,
     });
     return { available: true };

--- a/packages/franken-web/src/components/beasts/agent-list.tsx
+++ b/packages/franken-web/src/components/beasts/agent-list.tsx
@@ -1,17 +1,18 @@
 import { useState } from 'react';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
-import type { TrackedAgentSummary } from '../../lib/beast-api';
+import type { BeastRunSummary, TrackedAgentSummary } from '../../lib/beast-api';
 import { AgentRow, type Density } from './agent-row';
 
 interface AgentListProps {
   agents: TrackedAgentSummary[];
+  runs: BeastRunSummary[];
   selectedAgentId: string | null;
   onSelectAgent: (agentId: string) => void;
   onCreateAgent: () => void;
 }
 
-export function AgentList({ agents, selectedAgentId, onSelectAgent, onCreateAgent }: AgentListProps) {
+export function AgentList({ agents, runs, selectedAgentId, onSelectAgent, onCreateAgent }: AgentListProps) {
   const [density, setDensity] = useState<Density>('comfortable');
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('');
@@ -27,6 +28,7 @@ export function AgentList({ agents, selectedAgentId, onSelectAgent, onCreateAgen
     if (statusFilter && a.status !== statusFilter) return false;
     return true;
   });
+  const runsById = new Map(runs.map((run) => [run.id, run] as const));
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -99,6 +101,7 @@ export function AgentList({ agents, selectedAgentId, onSelectAgent, onCreateAgen
                 <AgentRow
                   key={agent.id}
                   agent={agent}
+                  run={agent.dispatchRunId ? runsById.get(agent.dispatchRunId) : undefined}
                   density={density}
                   selected={agent.id === selectedAgentId}
                   onClick={onSelectAgent}

--- a/packages/franken-web/src/components/beasts/agent-row.tsx
+++ b/packages/franken-web/src/components/beasts/agent-row.tsx
@@ -1,10 +1,11 @@
-import type { TrackedAgentSummary } from '../../lib/beast-api';
+import type { BeastRunSummary, TrackedAgentSummary } from '../../lib/beast-api';
 import { StatusLight } from './status-light';
 
 export type Density = 'compact' | 'comfortable' | 'detailed';
 
 interface AgentRowProps {
   agent: TrackedAgentSummary;
+  run?: BeastRunSummary;
   density: Density;
   selected: boolean;
   onClick: (agentId: string) => void;
@@ -14,8 +15,9 @@ function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-export function AgentRow({ agent, density, selected, onClick }: AgentRowProps) {
+export function AgentRow({ agent, run, density, selected, onClick }: AgentRowProps) {
   const selectedClass = selected ? 'bg-beast-accent-soft border-beast-accent' : 'border-beast-border';
+  const executionMode = run?.executionMode ?? agent.executionMode;
 
   return (
     <button
@@ -40,6 +42,11 @@ export function AgentRow({ agent, density, selected, onClick }: AgentRowProps) {
               {Object.values(agent.moduleConfig).filter(Boolean).length} modules
             </span>
           )}
+          {executionMode && (
+            <span className="text-xs px-2.5 py-1 rounded-full bg-beast-control text-beast-muted border border-beast-border">
+              {executionMode} mode
+            </span>
+          )}
         </div>
       )}
 
@@ -47,6 +54,7 @@ export function AgentRow({ agent, density, selected, onClick }: AgentRowProps) {
         <div className="flex items-center gap-4 mt-2 ml-6 text-xs text-beast-subtle">
           <span>by {agent.createdByUser}</span>
           {agent.dispatchRunId && <span>run: {agent.dispatchRunId.slice(0, 8)}…</span>}
+          {executionMode && <span>mode: {executionMode}</span>}
         </div>
       )}
     </button>

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { useBeastStore } from '../../../stores/beast-store';
 import { PresetCardGroup } from '../shared/preset-card';
+import type { BeastContainerRuntimeStatus, BeastExecutionMode } from '../../../lib/beast-api';
 
 const WORKFLOWS = [
   { id: 'design-interview', title: 'Design Interview', description: 'Launch interactive design session' },
@@ -8,9 +10,28 @@ const WORKFLOWS = [
   { id: 'martin-loop', title: 'Run Chunked Project', description: 'Execute an already-chunked plan' },
 ];
 
-export function StepWorkflow() {
+interface StepWorkflowProps {
+  containerRuntime?: BeastContainerRuntimeStatus;
+}
+
+const DEFAULT_CONTAINER_UNAVAILABLE_REASON = 'Container runtime availability has not been reported by the backend.';
+
+export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
   const { stepValues, setStepValues } = useBeastStore();
-  const values = (stepValues[1] ?? {}) as { workflowType?: string; [key: string]: unknown };
+  const values = (stepValues[1] ?? {}) as { workflowType?: string; executionMode?: BeastExecutionMode; [key: string]: unknown };
+  const selectedExecutionMode = values.executionMode ?? 'process';
+  const containerUnavailableReason = containerRuntime?.available === true
+    ? null
+    : (containerRuntime?.reason ?? DEFAULT_CONTAINER_UNAVAILABLE_REASON);
+  const effectiveExecutionMode = selectedExecutionMode === 'container' && containerUnavailableReason
+    ? 'process'
+    : selectedExecutionMode;
+
+  useEffect(() => {
+    if (selectedExecutionMode === 'container' && containerUnavailableReason) {
+      setStepValues(1, { ...values, executionMode: 'process' });
+    }
+  }, [containerUnavailableReason, selectedExecutionMode, setStepValues, values]);
 
   function handleSelect(id: string) {
     setStepValues(1, { ...values, workflowType: id });
@@ -20,9 +41,58 @@ export function StepWorkflow() {
     setStepValues(1, { ...values, [field]: value });
   }
 
+  function updateExecutionMode(executionMode: BeastExecutionMode) {
+    if (executionMode === 'container' && containerUnavailableReason) {
+      return;
+    }
+    setStepValues(1, { ...values, executionMode });
+  }
+
   return (
     <div className="p-8 space-y-6">
       <PresetCardGroup presets={WORKFLOWS} selected={values.workflowType ?? ''} onSelect={handleSelect} />
+
+      <fieldset className="space-y-3 rounded-xl border border-beast-border bg-beast-panel p-4">
+        <legend className="px-1 text-sm font-medium text-beast-text">Execution mode</legend>
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className={`rounded-lg border p-4 transition-colors ${effectiveExecutionMode === 'process' ? 'border-beast-accent bg-beast-accent-soft' : 'border-beast-border bg-beast-control'}`}>
+            <input
+              aria-label="Process execution mode"
+              checked={effectiveExecutionMode === 'process'}
+              className="sr-only"
+              name="execution-mode"
+              onChange={() => updateExecutionMode('process')}
+              type="radio"
+              value="process"
+            />
+            <span className="block text-sm font-semibold text-beast-text">Process</span>
+            <span className="mt-1 block text-xs text-beast-muted">Run as a local supervised process.</span>
+          </label>
+          <label
+            className={`rounded-lg border p-4 transition-colors ${containerUnavailableReason ? 'cursor-not-allowed border-beast-border bg-beast-control opacity-60' : effectiveExecutionMode === 'container' ? 'border-beast-accent bg-beast-accent-soft' : 'border-beast-border bg-beast-control'}`}
+            title={containerUnavailableReason ?? 'Run inside the configured container sandbox.'}
+          >
+            <input
+              aria-describedby={containerUnavailableReason ? 'container-mode-disabled-reason' : undefined}
+              aria-label="Container execution mode"
+              checked={effectiveExecutionMode === 'container'}
+              className="sr-only"
+              disabled={Boolean(containerUnavailableReason)}
+              name="execution-mode"
+              onChange={() => updateExecutionMode('container')}
+              type="radio"
+              value="container"
+            />
+            <span className="block text-sm font-semibold text-beast-text">Container</span>
+            <span className="mt-1 block text-xs text-beast-muted">Run inside the configured container sandbox.</span>
+          </label>
+        </div>
+        {containerUnavailableReason && (
+          <p id="container-mode-disabled-reason" className="text-xs text-beast-muted">
+            Container mode unavailable: {containerUnavailableReason}
+          </p>
+        )}
+      </fieldset>
 
       {values.workflowType === 'design-interview' && (
         <div>

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -11,6 +11,7 @@ import { StepPrompts } from './steps/step-prompts';
 import { StepGit } from './steps/step-git';
 import { StepReview } from './steps/step-review';
 import { buildWizardLaunchConfig } from './wizard-launch-config';
+import type { BeastContainerRuntimeStatus } from '../../lib/beast-api';
 
 const STEP_LABELS = ['Identity', 'Workflow', 'LLM Targets', 'Modules', 'Skills', 'Prompts', 'Git', 'Review'];
 
@@ -18,11 +19,12 @@ interface WizardDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onLaunch: (config: Record<string, unknown>) => void;
+  containerRuntime?: BeastContainerRuntimeStatus;
   launching?: boolean;
   launchError?: string | null;
 }
 
-export function WizardDialog({ isOpen, onClose, onLaunch, launching, launchError }: WizardDialogProps) {
+export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, launching, launchError }: WizardDialogProps) {
   const { wizardStep, highestCompleted, wizardMode, nextStep, prevStep, setWizardStep, toggleWizardMode, stepValues } =
     useBeastStore();
 
@@ -44,7 +46,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, launching, launchError
   function renderStep() {
     switch (wizardStep) {
       case 0: return <StepIdentity />;
-      case 1: return <StepWorkflow />;
+      case 1: return <StepWorkflow containerRuntime={containerRuntime} />;
       case 2: return <StepLlmTargets />;
       case 3: return <StepModules />;
       case 4: return <StepSkills />;
@@ -106,7 +108,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, launching, launchError
             {wizardMode === 'wizard' ? renderStep() : (
               <div className="space-y-8 p-8">
                 <FormSection title="Identity"><StepIdentity /></FormSection>
-                <FormSection title="Workflow"><StepWorkflow /></FormSection>
+                <FormSection title="Workflow"><StepWorkflow containerRuntime={containerRuntime} /></FormSection>
                 <FormSection title="LLM Targets"><StepLlmTargets /></FormSection>
                 <FormSection title="Modules"><StepModules /></FormSection>
                 <FormSection title="Skills"><StepSkills /></FormSection>

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -12,6 +12,12 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
   }
 
   const workflow = config.workflow as Record<string, unknown> | undefined;
+  if (workflow?.executionMode === 'process' || workflow?.executionMode === 'container') {
+    config.executionMode = workflow.executionMode;
+  } else {
+    config.executionMode = 'process';
+  }
+
   if (workflow?.workflowType === 'chunk-plan' && typeof workflow.docPath === 'string') {
     config.designDocPath = workflow.docPath;
   }

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -9,8 +9,10 @@ import { CostBadge } from './cost-badge';
 import { NetworkPage } from '../pages/network-page';
 import {
   BeastApiClient,
+  type BeastContainerRuntimeStatus,
   type BeastCatalogEntry,
   type BeastRunDetail,
+  type BeastRunSummary,
   type TrackedAgentDetail,
   type TrackedAgentInitAction,
   type TrackedAgentSummary,
@@ -156,6 +158,8 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
   const [chatSessions, setChatSessions] = useState<ChatSessionSummary[]>([]);
   const [beastCatalog, setBeastCatalog] = useState<BeastCatalogEntry[]>([]);
   const [beastAgents, setBeastAgents] = useState<TrackedAgentSummary[]>([]);
+  const [beastRuns, setBeastRuns] = useState<BeastRunSummary[]>([]);
+  const [beastContainerRuntime, setBeastContainerRuntime] = useState<BeastContainerRuntimeStatus | undefined>(undefined);
   const [selectedBeastAgentId, setSelectedBeastAgentId] = useState<string | null>(null);
   const [beastAgentDetail, setBeastAgentDetail] = useState<(TrackedAgentDetail & { run?: BeastRunDetail | null }) | null>(null);
   const beastAgentsRef = useRef<TrackedAgentSummary[]>([]);
@@ -261,6 +265,8 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
       setBeastError('Set VITE_BEAST_OPERATOR_TOKEN to use the secure Beast control API.');
       setBeastCatalog([]);
       setBeastAgents([]);
+      setBeastRuns([]);
+      setBeastContainerRuntime(undefined);
       setBeastAgentDetail(null);
       return;
     }
@@ -270,17 +276,24 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
 
     async function refreshBeasts() {
       try {
-        const [catalog, runs] = await Promise.all([
+        const [catalog, agents, runs, containerRuntime] = await Promise.all([
           client.getCatalog(),
           client.listAgents(),
+          client.listRuns(),
+          client.getContainerRuntimeStatus().catch((error) => ({
+            available: false,
+            reason: error instanceof Error ? error.message : 'Container runtime status unavailable.',
+          })),
         ]);
         if (cancelled) {
           return;
         }
         setBeastError(null);
         setBeastCatalog(catalog);
-        setBeastAgents(runs);
-        const currentAgentId = selectedBeastAgentId ?? runs[0]?.id ?? null;
+        setBeastAgents(agents);
+        setBeastRuns(runs);
+        setBeastContainerRuntime(containerRuntime);
+        const currentAgentId = selectedBeastAgentId ?? agents[0]?.id ?? null;
         setSelectedBeastAgentId(currentAgentId);
 
         if (currentAgentId) {
@@ -677,6 +690,8 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
             agents={beastAgents}
             agentDetail={beastAgentDetail}
             catalog={beastCatalog}
+            runs={beastRuns}
+            containerRuntime={beastContainerRuntime}
             disabled={!beastClient}
             error={beastError}
             logs={beastAgentDetail?.run?.logs ?? []}
@@ -689,8 +704,9 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
               if (!beastClient) throw new Error('Beast API not available. Check VITE_BEAST_OPERATOR_TOKEN.');
               const workflow = config.workflow as Record<string, unknown> | undefined;
               const definitionId = String(workflow?.workflowType ?? 'martin-loop');
+              const executionMode = config.executionMode === 'container' ? 'container' : 'process';
               const initAction = buildInitAction(definitionId, config, selectedSessionId);
-              await beastClient.createAgent({ definitionId, initAction, initConfig: config });
+              await beastClient.createAgent({ definitionId, initAction, initConfig: config, executionMode });
               setBeastRefreshNonce((current) => current + 1);
             }}
             onDelete={(agentId) => {

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -6,12 +6,20 @@ export interface BeastInterviewPrompt {
   options?: readonly string[];
 }
 
+export type BeastExecutionMode = 'process' | 'container';
+
+export interface BeastContainerRuntimeStatus {
+  available: boolean;
+  reason?: string;
+}
+
 export interface BeastCatalogEntry {
   id: string;
   version?: number;
   label: string;
   description: string;
-  executionModeDefault: 'process' | 'container';
+  executionModeDefault: BeastExecutionMode;
+  containerRuntime?: BeastContainerRuntimeStatus;
   interviewPrompts: BeastInterviewPrompt[];
 }
 
@@ -122,6 +130,7 @@ export interface TrackedAgentSummary {
   initAction: TrackedAgentInitAction;
   initConfig: Record<string, unknown>;
   moduleConfig?: ModuleConfig;
+  executionMode?: BeastExecutionMode;
   chatSessionId?: string;
   dispatchRunId?: string;
   createdAt: string;
@@ -192,6 +201,10 @@ export class BeastApiClient {
     return this.request<BeastCatalogEntry[]>('/v1/beasts/catalog', { method: 'GET' });
   }
 
+  async getContainerRuntimeStatus(): Promise<BeastContainerRuntimeStatus> {
+    return this.request<BeastContainerRuntimeStatus>('/v1/beasts/runtime/container', { method: 'GET' });
+  }
+
   async listRuns(): Promise<BeastRunSummary[]> {
     const body = await this.request<{ runs: BeastRunSummary[] }>('/v1/beasts/runs', { method: 'GET' });
     return body.runs;
@@ -219,7 +232,7 @@ export class BeastApiClient {
     definitionId: string;
     config: Record<string, unknown>;
     trackedAgentId?: string;
-    executionMode?: 'process' | 'container';
+    executionMode?: BeastExecutionMode;
     startNow?: boolean;
     moduleConfig?: ModuleConfig;
   }): Promise<BeastRunSummary> {
@@ -236,6 +249,7 @@ export class BeastApiClient {
     initConfig: Record<string, unknown>;
     chatSessionId?: string;
     moduleConfig?: ModuleConfig;
+    executionMode?: BeastExecutionMode;
   }): Promise<TrackedAgentSummary> {
     return this.request('/v1/beasts/agents', {
       method: 'POST',

--- a/packages/franken-web/src/pages/beast-dispatch-page.tsx
+++ b/packages/franken-web/src/pages/beast-dispatch-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type {
   BeastCatalogEntry,
+  BeastExecutionMode,
   BeastInterviewPrompt,
   BeastRunDetail,
   ModuleConfig,
@@ -14,7 +15,7 @@ interface BeastDispatchPageProps {
   disabled: boolean;
   error: string | null;
   onDelete(agentId: string): void;
-  onDispatch(definitionId: string, config: Record<string, unknown>, moduleConfig?: ModuleConfig): void;
+  onDispatch(definitionId: string, config: Record<string, unknown>, moduleConfig?: ModuleConfig, executionMode?: BeastExecutionMode): void;
   onKill(runId: string): void;
   onRestart(agentId: string): void;
   onResume(agentId: string): void;
@@ -29,6 +30,7 @@ interface BeastDispatchPageProps {
 
 type FormState = Record<string, Record<string, string>>;
 type ModuleTogglesState = Record<string, ModuleConfig>;
+type ExecutionModeState = Record<string, BeastExecutionMode>;
 type FormErrors = Record<string, Record<string, string>>;
 
 function buildInitialFormState(catalog: BeastCatalogEntry[]): FormState {
@@ -97,6 +99,7 @@ function canRestartAgent(agent: TrackedAgentSummary): boolean {
 export function BeastDispatchPage(props: BeastDispatchPageProps) {
   const [forms, setForms] = useState<FormState>(() => buildInitialFormState(props.catalog));
   const [moduleToggles, setModuleToggles] = useState<ModuleTogglesState>({});
+  const [executionModes, setExecutionModes] = useState<ExecutionModeState>({});
   const [errors, setErrors] = useState<FormErrors>({});
   const pickerRefs = useRef<Record<string, HTMLInputElement | null>>({});
 
@@ -159,7 +162,7 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
     }
     const toggles = moduleToggles[definition.id];
     const hasDisabled = toggles && Object.values(toggles).some((v) => v === false);
-    props.onDispatch(definition.id, values, hasDisabled ? toggles : undefined);
+    props.onDispatch(definition.id, values, hasDisabled ? toggles : undefined, executionModes[definition.id] ?? definition.executionModeDefault ?? 'process');
   }
 
   return (
@@ -190,6 +193,37 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
                 <span className="sidebar__status">{definition.executionModeDefault}</span>
               </div>
               <p className="beast-card__description">{definition.description}</p>
+              <fieldset className="beast-card__modules">
+                <legend>Execution mode</legend>
+                <label className="beast-module-toggle">
+                  <input
+                    aria-label={`${definition.label} process execution mode`}
+                    checked={(executionModes[definition.id] ?? definition.executionModeDefault) === 'process'}
+                    disabled={props.disabled}
+                    name={`${definition.id}-execution-mode`}
+                    onChange={() => setExecutionModes((current) => ({ ...current, [definition.id]: 'process' }))}
+                    type="radio"
+                  />
+                  <span>process</span>
+                </label>
+                <label className="beast-module-toggle" title={definition.containerRuntime?.available === false ? definition.containerRuntime.reason ?? 'Container runtime unavailable.' : undefined}>
+                  <input
+                    aria-describedby={definition.containerRuntime?.available === false ? `${definition.id}-container-disabled` : undefined}
+                    aria-label={`${definition.label} container execution mode`}
+                    checked={(executionModes[definition.id] ?? definition.executionModeDefault) === 'container'}
+                    disabled={props.disabled || definition.containerRuntime?.available === false}
+                    name={`${definition.id}-execution-mode`}
+                    onChange={() => setExecutionModes((current) => ({ ...current, [definition.id]: 'container' }))}
+                    type="radio"
+                  />
+                  <span>container</span>
+                </label>
+                {definition.containerRuntime?.available === false && (
+                  <small id={`${definition.id}-container-disabled`} className="field-error">
+                    Container unavailable: {definition.containerRuntime.reason ?? 'Container runtime unavailable.'}
+                  </small>
+                )}
+              </fieldset>
               <div className="beast-card__form">
                 {definition.interviewPrompts.map((prompt) => {
                   const inputId = buildPromptId(definition, prompt);

--- a/packages/franken-web/src/pages/beasts-page.tsx
+++ b/packages/franken-web/src/pages/beasts-page.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import type { TrackedAgentDetail, TrackedAgentSummary, BeastCatalogEntry } from '../lib/beast-api';
+import type {
+  BeastCatalogEntry,
+  BeastContainerRuntimeStatus,
+  BeastRunSummary,
+  TrackedAgentDetail,
+  TrackedAgentSummary,
+} from '../lib/beast-api';
 import { AgentList } from '../components/beasts/agent-list';
 import { AgentDetailPanel } from '../components/beasts/agent-detail-panel';
 import { WizardDialog } from '../components/beasts/wizard-dialog';
@@ -9,6 +15,8 @@ interface BeastsPageProps {
   agents: TrackedAgentSummary[];
   agentDetail: TrackedAgentDetail | null;
   catalog: BeastCatalogEntry[];
+  runs: BeastRunSummary[];
+  containerRuntime?: BeastContainerRuntimeStatus;
   disabled: boolean;
   error: string | null;
   logs: string[];
@@ -27,6 +35,8 @@ interface BeastsPageProps {
 export function BeastsPage({
   agents,
   agentDetail,
+  runs,
+  containerRuntime,
   disabled,
   error,
   logs,
@@ -88,6 +98,7 @@ export function BeastsPage({
 
       <AgentList
         agents={agents}
+        runs={runs}
         selectedAgentId={selectedAgentId}
         onSelectAgent={onSelectAgent}
         onCreateAgent={handleOpenWizard}
@@ -112,6 +123,7 @@ export function BeastsPage({
         isOpen={showWizard}
         onClose={() => setShowWizard(false)}
         onLaunch={handleLaunch}
+        containerRuntime={containerRuntime}
         launching={launching}
         launchError={launchError}
       />

--- a/packages/franken-web/tests/components/beasts/agent-list.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-list.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { AgentList } from '../../../src/components/beasts/agent-list';
-import type { TrackedAgentSummary } from '../../../src/lib/beast-api';
+import type { BeastRunSummary, TrackedAgentSummary } from '../../../src/lib/beast-api';
 
 afterEach(cleanup);
 
@@ -22,18 +22,18 @@ const agents: TrackedAgentSummary[] = [
 
 describe('AgentList', () => {
   it('renders all agents', () => {
-    render(<AgentList agents={agents} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
+    render(<AgentList agents={agents} runs={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
     expect(screen.getByText('agent-1')).toBeTruthy();
     expect(screen.getByText('agent-2')).toBeTruthy();
   });
 
   it('shows empty state when no agents', () => {
-    render(<AgentList agents={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
+    render(<AgentList agents={[]} runs={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
     expect(screen.getByText(/no agents yet/i)).toBeTruthy();
   });
 
   it('filters agents by search text', () => {
-    render(<AgentList agents={agents} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
+    render(<AgentList agents={agents} runs={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
     const search = screen.getByPlaceholderText(/search/i);
     fireEvent.change(search, { target: { value: 'agent-1' } });
     expect(screen.getByText('agent-1')).toBeTruthy();
@@ -41,7 +41,7 @@ describe('AgentList', () => {
   });
 
   it('filters agents by status', () => {
-    render(<AgentList agents={agents} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
+    render(<AgentList agents={agents} runs={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
     const statusSelect = screen.getByLabelText(/filter by status/i);
     fireEvent.change(statusSelect, { target: { value: 'running' } });
     expect(screen.getByText('agent-1')).toBeTruthy();
@@ -50,8 +50,29 @@ describe('AgentList', () => {
 
   it('has create agent button in empty state', () => {
     const onCreate = vi.fn();
-    render(<AgentList agents={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={onCreate} />);
+    render(<AgentList agents={[]} runs={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={onCreate} />);
     fireEvent.click(screen.getByText(/create your first agent/i));
     expect(onCreate).toHaveBeenCalled();
+  });
+
+  it('shows execution mode from the agent dispatch run rather than an older run', () => {
+    const linkedAgent = { ...agents[0]!, dispatchRunId: 'run-new' };
+    const runs: BeastRunSummary[] = [
+      {
+        id: 'run-old', definitionId: 'design-interview', status: 'completed', dispatchedBy: 'api',
+        dispatchedByUser: 'pfk', trackedAgentId: 'agent-1', attemptCount: 1, executionMode: 'process',
+        createdAt: '2026-03-15T09:00:00Z',
+      },
+      {
+        id: 'run-new', definitionId: 'design-interview', status: 'running', dispatchedBy: 'api',
+        dispatchedByUser: 'pfk', trackedAgentId: 'agent-1', attemptCount: 1, executionMode: 'container',
+        createdAt: '2026-03-15T10:00:00Z',
+      },
+    ];
+
+    render(<AgentList agents={[linkedAgent]} runs={runs} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
+
+    expect(screen.getByText('container mode')).toBeTruthy();
+    expect(screen.queryByText('process mode')).toBeNull();
   });
 });

--- a/packages/franken-web/tests/components/beasts/agent-row.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-row.test.tsx
@@ -30,6 +30,22 @@ describe('AgentRow', () => {
     expect(screen.getByText('design-interview')).toBeTruthy();
   });
 
+  it('shows execution mode from linked run', () => {
+    render(<AgentRow agent={agent} run={{
+      id: 'run-1',
+      definitionId: 'design-interview',
+      status: 'running',
+      dispatchedBy: 'api',
+      dispatchedByUser: 'pfk',
+      trackedAgentId: 'agent-1',
+      attemptCount: 1,
+      executionMode: 'container',
+      createdAt: '2026-03-15T10:00:00Z',
+    }} density="comfortable" selected={false} onClick={vi.fn()} />);
+
+    expect(screen.getByText('container mode')).toBeTruthy();
+  });
+
   it('calls onClick when clicked', () => {
     const onClick = vi.fn();
     render(<AgentRow agent={agent} density="compact" selected={false} onClick={onClick} />);

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -36,6 +36,7 @@ describe('StepReview', () => {
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Test Agent', description: 'A test agent' },
       workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
+      executionMode: 'process',
       designDocPath: 'docs/design.md',
       outputDir: 'tasks/chunks',
       llm: { defaultProvider: 'codex', defaultModel: 'gpt-5.1' },

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { StepWorkflow } from '../../../../src/components/beasts/steps/step-workflow';
 import { useBeastStore } from '../../../../src/stores/beast-store';
 
@@ -41,6 +41,34 @@ describe('StepWorkflow', () => {
       workflowType: 'chunk-plan',
       docPath: 'docs/design.md',
       outputDir: 'tasks/chunks',
+    });
+  });
+
+  it('stores selected container execution mode when runtime is available', () => {
+    render(<StepWorkflow containerRuntime={{ available: true }} />);
+
+    fireEvent.click(screen.getByLabelText('Container execution mode'));
+
+    expect(useBeastStore.getState().stepValues[1]?.executionMode).toBe('container');
+  });
+
+  it('disables container execution mode with backend reason when unavailable', () => {
+    render(<StepWorkflow containerRuntime={{ available: false, reason: 'Docker daemon is offline' }} />);
+
+    const containerMode = screen.getByLabelText('Container execution mode') as HTMLInputElement;
+    expect(containerMode.disabled).toBe(true);
+    expect(screen.getByText(/Container mode unavailable: Docker daemon is offline/i)).toBeTruthy();
+  });
+
+  it('resets stale container execution mode when runtime becomes unavailable', async () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview', executionMode: 'container' });
+
+    render(<StepWorkflow containerRuntime={{ available: false, reason: 'Docker daemon is offline' }} />);
+
+    expect(screen.getByLabelText('Process execution mode')).toHaveProperty('checked', true);
+    expect(screen.getByLabelText('Container execution mode')).toHaveProperty('checked', false);
+    await waitFor(() => {
+      expect(useBeastStore.getState().stepValues[1]?.executionMode).toBe('process');
     });
   });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -42,6 +42,7 @@ describe('WizardDialog', () => {
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Footer Agent' },
       workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
+      executionMode: 'process',
       designDocPath: 'docs/design.md',
       outputDir: 'tasks/chunks',
     });

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -59,6 +59,21 @@ const mockListAgents = vi.fn().mockResolvedValue([
   },
 ]);
 
+const mockListRuns = vi.fn().mockResolvedValue([
+  {
+    id: 'run-1',
+    definitionId: 'chunk-plan',
+    status: 'running',
+    dispatchedBy: 'chat',
+    dispatchedByUser: 'chat-session:sess-1',
+    trackedAgentId: 'agent-1',
+    attemptCount: 1,
+    executionMode: 'process',
+    createdAt: '2026-03-11T00:00:02.000Z',
+  },
+]);
+const mockGetContainerRuntimeStatus = vi.fn().mockResolvedValue({ available: true });
+
 const mockGetAgent = vi.fn().mockResolvedValue({
   agent: {
     id: 'agent-1',
@@ -182,6 +197,8 @@ vi.mock('../../src/lib/beast-api.js', () => ({
   BeastApiClient: vi.fn(function (this: {
     getCatalog: typeof mockGetCatalog;
     listAgents: typeof mockListAgents;
+    listRuns: typeof mockListRuns;
+    getContainerRuntimeStatus: typeof mockGetContainerRuntimeStatus;
     getAgent: typeof mockGetAgent;
     getRun: typeof mockGetRun;
     getLogs: typeof mockGetLogs;
@@ -200,6 +217,8 @@ vi.mock('../../src/lib/beast-api.js', () => ({
   }) {
     this.getCatalog = mockGetCatalog;
     this.listAgents = mockListAgents;
+    this.listRuns = mockListRuns;
+    this.getContainerRuntimeStatus = mockGetContainerRuntimeStatus;
     this.getAgent = mockGetAgent;
     this.getRun = mockGetRun;
     this.getLogs = mockGetLogs;
@@ -277,6 +296,20 @@ afterEach(() => {
       updatedAt: '2026-03-11T00:00:01.000Z',
     },
   ]);
+  mockListRuns.mockResolvedValue([
+    {
+      id: 'run-1',
+      definitionId: 'chunk-plan',
+      status: 'running',
+      dispatchedBy: 'chat',
+      dispatchedByUser: 'chat-session:sess-1',
+      trackedAgentId: 'agent-1',
+      attemptCount: 1,
+      executionMode: 'process',
+      createdAt: '2026-03-11T00:00:02.000Z',
+    },
+  ]);
+  mockGetContainerRuntimeStatus.mockResolvedValue({ available: true });
   mockGetAgent.mockResolvedValue({
     agent: {
       id: 'agent-1',

--- a/packages/franken-web/tests/pages/beasts-page.test.tsx
+++ b/packages/franken-web/tests/pages/beasts-page.test.tsx
@@ -20,6 +20,7 @@ const baseProps = {
   ],
   agentDetail: null,
   catalog: [],
+  runs: [],
   disabled: false,
   error: null,
   logs: [] as string[],

--- a/tasks/issue-457-dashboard-execution-mode-progress.md
+++ b/tasks/issue-457-dashboard-execution-mode-progress.md
@@ -1,0 +1,11 @@
+# Issue 457 Dashboard Execution Mode Progress
+
+- [x] Create/reuse isolated worktree and branch from `origin/main`.
+- [x] Inspect current dashboard Beast dispatch flow and API types.
+- [x] Add process/container execution-mode selection to dashboard dispatch.
+- [x] Disable container mode visibly when backend reports it unavailable.
+- [x] Show execution mode in Beast run/agent list.
+- [x] Add/update focused tests.
+- [x] Run relevant tests/build/typecheck.
+- [x] Complete review loop and fix findings.
+- [ ] Push branch, open PR with `Closes #457`, and merge if eligible.


### PR DESCRIPTION
## Summary
- Add process/container execution-mode selection to the Beast dashboard dispatch flow.
- Disable container mode with the backend-provided runtime availability reason when Docker/container execution is unavailable.
- Thread selected execution mode through dashboard agent creation and display the linked run's execution mode in the Beast agent list.

## Verification
- `npm --workspace @frankenbeast/web test -- --run tests/components/beasts/steps/step-workflow.test.tsx tests/components/beasts/agent-list.test.tsx tests/components/beasts/agent-row.test.tsx tests/components/beasts/step-review.test.tsx tests/components/beasts/wizard-dialog.test.tsx tests/components/chat-shell.test.tsx tests/pages/beasts-page.test.tsx`
- `npm --workspace @frankenbeast/web test -- --run tests/components/beasts/steps/step-review.test.tsx tests/components/beasts/wizard-launch-config.test.tsx`
- `npm --workspace @frankenbeast/web run typecheck`
- `npm --workspace @frankenbeast/web run build`
- `npm --workspace franken-orchestrator run typecheck`
- `npm --workspace franken-orchestrator test -- --run tests/unit/http/beast-routes.test.ts tests/integration/beasts/beast-routes.test.ts tests/unit/http/agent-routes.test.ts`
- Codex-model fallback review loop: No issues found.

## Notes
- Standalone `codex review` remains blocked in this environment by missing/invalid Codex credentials / 401 responses, so I used the Codex-model Hermes review fallback and fixed prior findings before this PR.

Closes #457
