### PR TITLE
feat(web): stream beast run status and logs

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -9,6 +9,7 @@ export class BeastLogStore {
     attemptId: string,
     stream: 'stdout' | 'stderr',
     message: string,
+    createdAt = new Date().toISOString(),
   ): Promise<void> {
     const filePath = this.resolvePath(runId, attemptId);
     try {
@@ -18,7 +19,7 @@ export class BeastLogStore {
         `${JSON.stringify({
           stream,
           message,
-          createdAt: new Date().toISOString(),
+          createdAt,
         })}\n`,
         'utf-8',
       );

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -89,10 +89,11 @@ export class ProcessBeastExecutor implements BeastExecutor {
       handle = await this.supervisor.spawn(spawnedSpec, {
         onStdout: (line) => {
           if (attemptId) {
-            void this.logs.append(run.id, attemptId, 'stdout', line);
+            const createdAt = new Date().toISOString();
+            void this.logs.append(run.id, attemptId, 'stdout', line, createdAt);
             this.options.eventBus?.publish({
               type: 'run.log',
-              data: { runId: run.id, attemptId, stream: 'stdout', line },
+              data: { runId: run.id, attemptId, stream: 'stdout', line, createdAt },
             });
           } else {
             earlyStdoutLines.push(line);
@@ -102,10 +103,11 @@ export class ProcessBeastExecutor implements BeastExecutor {
           stderrTail.push(line);
           if (stderrTail.length > STDERR_BUFFER_SIZE) stderrTail.shift();
           if (attemptId) {
-            void this.logs.append(run.id, attemptId, 'stderr', line);
+            const createdAt = new Date().toISOString();
+            void this.logs.append(run.id, attemptId, 'stderr', line, createdAt);
             this.options.eventBus?.publish({
               type: 'run.log',
-              data: { runId: run.id, attemptId, stream: 'stderr', line },
+              data: { runId: run.id, attemptId, stream: 'stderr', line, createdAt },
             });
           } else {
             earlyStderrLines.push(line);
@@ -178,17 +180,19 @@ export class ProcessBeastExecutor implements BeastExecutor {
 
     // Flush early buffered lines to logs and SSE
     for (const line of earlyStdoutLines) {
-      void this.logs.append(run.id, attemptId, 'stdout', line);
+      const createdAt = new Date().toISOString();
+      void this.logs.append(run.id, attemptId, 'stdout', line, createdAt);
       this.options.eventBus?.publish({
         type: 'run.log',
-        data: { runId: run.id, attemptId, stream: 'stdout', line },
+        data: { runId: run.id, attemptId, stream: 'stdout', line, createdAt },
       });
     }
     for (const line of earlyStderrLines) {
-      void this.logs.append(run.id, attemptId, 'stderr', line);
+      const createdAt = new Date().toISOString();
+      void this.logs.append(run.id, attemptId, 'stderr', line, createdAt);
       this.options.eventBus?.publish({
         type: 'run.log',
-        data: { runId: run.id, attemptId, stream: 'stderr', line },
+        data: { runId: run.id, attemptId, stream: 'stderr', line, createdAt },
       });
     }
 
@@ -211,7 +215,16 @@ export class ProcessBeastExecutor implements BeastExecutor {
       type: 'run.event',
       data: { runId: run.id, event: startedEvent },
     });
-    await this.logs.append(run.id, attempt.id, 'stdout', `started pid=${handle.pid}`);
+    this.options.eventBus?.publish({
+      type: 'run.status',
+      data: { runId: run.id, status: 'running' as const, updatedAt: startedAt },
+    });
+    const startLogLine = `started pid=${handle.pid}`;
+    await this.logs.append(run.id, attempt.id, 'stdout', startLogLine, startedAt);
+    this.options.eventBus?.publish({
+      type: 'run.log',
+      data: { runId: run.id, attemptId: attempt.id, stream: 'stdout', line: startLogLine, createdAt: startedAt },
+    });
     return attempt;
   }
 
@@ -379,7 +392,11 @@ export class ProcessBeastExecutor implements BeastExecutor {
       type: 'run.event',
       data: { runId, event: finishEvent },
     });
-    void this.logs.append(runId, attempt.id, 'stderr', stopReason);
+    void this.logs.append(runId, attempt.id, 'stderr', stopReason, finishedAt);
+    this.options.eventBus?.publish({
+      type: 'run.log',
+      data: { runId, attemptId: attempt.id, stream: 'stderr', line: stopReason, createdAt: finishedAt },
+    });
 
     this.options.eventBus?.publish({
       type: 'run.status',

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -39,7 +39,7 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }
 
-    const lastEventId = c.req.header('Last-Event-ID');
+    const lastEventId = c.req.header('Last-Event-ID') ?? c.req.query('lastEventId');
 
     return streamSSE(c, async (stream) => {
       // Send initial snapshot if no Last-Event-ID (fresh connect, not reconnect)

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -181,6 +181,28 @@ describe('Beast SSE routes', () => {
     expect(events.find((e) => e.id === '3')).toBeDefined();
   });
 
+  it('replays missed events via lastEventId query parameter for browser EventSource reconnects', async () => {
+    const ctx = createSseApp();
+    ticketStore = ctx.ticketStore;
+
+    ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
+    ctx.bus.publish({ type: 'run.status', data: { runId: 'r1', status: 'active' } });
+
+    const ticket = await issueTicket(ctx.app);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 100);
+
+    const req = new Request(`http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`, {
+      signal: controller.signal,
+    });
+    const res = await ctx.app.request(req);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+
+    expect(events.find((e) => e.id === '1')).toBeUndefined();
+    expect(events.find((e) => e.id === '2')).toBeDefined();
+  });
+
   it('does not send snapshot on reconnect with Last-Event-ID', async () => {
     const ctx = createSseApp({
       getSnapshot: () => ({ agents: [] }),

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -203,6 +203,7 @@ describe('ProcessBeastExecutor', () => {
         attempt.id,
         'stdout',
         'hello world',
+        expect.any(String),
       );
     });
 
@@ -229,6 +230,7 @@ describe('ProcessBeastExecutor', () => {
         attempt.id,
         'stderr',
         'something went wrong',
+        expect.any(String),
       );
     });
 
@@ -303,8 +305,8 @@ describe('ProcessBeastExecutor', () => {
       await new Promise((r) => setTimeout(r, 10));
 
       // Early lines should have been flushed after attempt creation
-      expect(appendSpy).toHaveBeenCalledWith(run.id, attempt.id, 'stdout', 'early line 1');
-      expect(appendSpy).toHaveBeenCalledWith(run.id, attempt.id, 'stdout', 'early line 2');
+      expect(appendSpy).toHaveBeenCalledWith(run.id, attempt.id, 'stdout', 'early line 1', expect.any(String));
+      expect(appendSpy).toHaveBeenCalledWith(run.id, attempt.id, 'stdout', 'early line 2', expect.any(String));
     });
   });
 
@@ -505,8 +507,12 @@ describe('ProcessBeastExecutor', () => {
       cb.onExit(0, null);
 
       const statusEvents = publishSpy.mock.calls.filter(([e]) => e.type === 'run.status');
-      expect(statusEvents).toHaveLength(1);
+      expect(statusEvents).toHaveLength(2);
       expect(statusEvents[0][0].data).toMatchObject({
+        runId: run.id,
+        status: 'running',
+      });
+      expect(statusEvents[1][0].data).toMatchObject({
         runId: run.id,
         status: 'completed',
       });
@@ -526,8 +532,12 @@ describe('ProcessBeastExecutor', () => {
       await executor.stop(run.id, attempt.id);
 
       const statusEvents = publishSpy.mock.calls.filter(([e]) => e.type === 'run.status');
-      expect(statusEvents).toHaveLength(1);
+      expect(statusEvents).toHaveLength(2);
       expect(statusEvents[0][0].data).toMatchObject({
+        runId: run.id,
+        status: 'running',
+      });
+      expect(statusEvents[1][0].data).toMatchObject({
         runId: run.id,
         status: 'stopped',
       });
@@ -547,8 +557,12 @@ describe('ProcessBeastExecutor', () => {
       await executor.kill(run.id, attempt.id);
 
       const statusEvents = publishSpy.mock.calls.filter(([e]) => e.type === 'run.status');
-      expect(statusEvents).toHaveLength(1);
+      expect(statusEvents).toHaveLength(2);
       expect(statusEvents[0][0].data).toMatchObject({
+        runId: run.id,
+        status: 'running',
+      });
+      expect(statusEvents[1][0].data).toMatchObject({
         runId: run.id,
         status: 'stopped',
       });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -60,6 +60,51 @@ function PlaceholderPage({ routeId }: { routeId: Exclude<RouteId, 'chat'> }) {
   );
 }
 
+function appendUniqueLogLine(logs: string[], nextLine: string): string[] {
+  const nextIdentity = parseLogIdentity(nextLine);
+  if (nextIdentity && logs.some((line) => {
+    const identity = parseLogIdentity(line);
+    return identity
+      && identity.stream === nextIdentity.stream
+      && identity.message === nextIdentity.message
+      && identity.createdAt === nextIdentity.createdAt;
+  })) {
+    return logs;
+  }
+  return logs[logs.length - 1] === nextLine ? logs : [...logs, nextLine];
+}
+
+function parseLogIdentity(line: string): { stream?: string; message: string; createdAt?: string } | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || !('message' in parsed)) {
+      return null;
+    }
+    const candidate = parsed as { stream?: unknown; message?: unknown; createdAt?: unknown };
+    if (typeof candidate.message !== 'string') {
+      return null;
+    }
+    return {
+      ...(typeof candidate.stream === 'string' ? { stream: candidate.stream } : {}),
+      message: candidate.message,
+      ...(typeof candidate.createdAt === 'string' ? { createdAt: candidate.createdAt } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function formatStreamedLogLine(event: { stream?: string; line: string; createdAt?: string }): string {
+  if (event.createdAt || event.stream) {
+    return JSON.stringify({
+      ...(event.stream ? { stream: event.stream } : {}),
+      message: event.line,
+      ...(event.createdAt ? { createdAt: event.createdAt } : {}),
+    });
+  }
+  return event.line;
+}
+
 function buildInitAction(
   definitionId: string,
   config: Record<string, unknown>,
@@ -241,15 +286,119 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
     }
 
     void refreshBeasts();
-    const interval = window.setInterval(() => {
-      void refreshBeasts();
-    }, 4000);
 
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
     };
   }, [route, beastClient, selectedBeastAgentId, beastRefreshNonce]);
+
+  useEffect(() => {
+    if (route !== 'beasts' || !beastClient) {
+      return;
+    }
+
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+
+    void beastClient.subscribeToEvents({
+      snapshot: (snapshot) => {
+        if (cancelled || !snapshot.agents) return;
+        setBeastAgents((current) => current.map((agent) => {
+          const next = snapshot.agents?.find((candidate) => candidate.id === agent.id);
+          return next ? { ...agent, ...next } : agent;
+        }));
+        setBeastAgentDetail((current) => {
+          if (!current) return current;
+          const next = snapshot.agents?.find((candidate) => candidate.id === current.agent.id);
+          return next ? { ...current, agent: { ...current.agent, ...next } } : current;
+        });
+      },
+      agentStatus: (event) => {
+        if (cancelled) return;
+        setBeastAgents((current) => current.map((agent) => (agent.id === event.agentId
+          ? { ...agent, status: event.status, ...(event.updatedAt ? { updatedAt: event.updatedAt } : {}) }
+          : agent)));
+        setBeastAgentDetail((current) => (current?.agent.id === event.agentId
+          ? {
+              ...current,
+              agent: {
+                ...current.agent,
+                status: event.status,
+                ...(event.updatedAt ? { updatedAt: event.updatedAt } : {}),
+              },
+            }
+          : current));
+        setBeastError(null);
+      },
+      agentEvent: (event) => {
+        if (cancelled) return;
+        setBeastAgentDetail((current) => {
+          if (!current || current.agent.id !== event.agentId) return current;
+          const nextEvent = {
+            id: event.event.id ?? `stream-${event.agentId}-${event.event.createdAt ?? Date.now()}`,
+            agentId: event.agentId,
+            sequence: event.event.sequence ?? current.events.length + 1,
+            level: event.event.level ?? 'info',
+            type: event.event.type ?? 'agent.event',
+            message: event.event.message ?? '',
+            payload: event.event.payload ?? {},
+            createdAt: event.event.createdAt ?? new Date().toISOString(),
+          };
+          if (current.events.some((existing) => existing.id === nextEvent.id)) return current;
+          return { ...current, events: [...current.events, nextEvent] };
+        });
+      },
+      runStatus: (event) => {
+        if (cancelled) return;
+        setBeastAgentDetail((current) => {
+          if (!current?.run || current.run.run.id !== event.runId) return current;
+          return {
+            ...current,
+            run: {
+              ...current.run,
+              run: {
+                ...current.run.run,
+                status: event.status,
+              },
+            },
+          };
+        });
+      },
+      runLog: (event) => {
+        if (cancelled) return;
+        setBeastAgentDetail((current) => {
+          if (!current?.run || current.run.run.id !== event.runId) return current;
+          return {
+            ...current,
+            run: {
+              ...current.run,
+              logs: appendUniqueLogLine(current.run.logs, formatStreamedLogLine(event)),
+            },
+          };
+        });
+      },
+      error: (error) => {
+        if (!cancelled) {
+          setBeastError(error.message);
+        }
+      },
+    }).then((unsub) => {
+      if (cancelled) {
+        unsub();
+      } else {
+        unsubscribe = unsub;
+      }
+    }).catch((error: unknown) => {
+      if (!cancelled) {
+        setBeastError(error instanceof Error ? error.message : 'Unable to subscribe to Beast events.');
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [route, beastClient]);
 
   useEffect(() => {
     if (!window.location.hash) {

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -46,6 +46,50 @@ export interface BeastRunDetail {
   logs: string[];
 }
 
+export interface BeastSseSnapshot {
+  agents?: Array<Partial<TrackedAgentSummary> & { id: string }>;
+}
+
+export interface BeastSseAgentStatusEvent {
+  agentId: string;
+  status: string;
+  updatedAt?: string;
+}
+
+export interface BeastSseAgentEvent {
+  agentId: string;
+  event: Omit<TrackedAgentEvent, 'id' | 'agentId' | 'sequence'> & Partial<TrackedAgentEvent>;
+}
+
+export interface BeastSseRunStatusEvent {
+  runId: string;
+  status: string;
+  updatedAt?: string;
+}
+
+export interface BeastSseRunLogEvent {
+  runId: string;
+  attemptId?: string;
+  stream?: 'stdout' | 'stderr';
+  line: string;
+  createdAt?: string;
+}
+
+export interface BeastSseRunEvent {
+  runId: string;
+  event: Record<string, unknown>;
+}
+
+export interface BeastEventHandlers {
+  snapshot?: (snapshot: BeastSseSnapshot) => void;
+  agentStatus?: (event: BeastSseAgentStatusEvent) => void;
+  agentEvent?: (event: BeastSseAgentEvent) => void;
+  runStatus?: (event: BeastSseRunStatusEvent) => void;
+  runLog?: (event: BeastSseRunLogEvent) => void;
+  runEvent?: (event: BeastSseRunEvent) => void;
+  error?: (error: Error) => void;
+}
+
 export interface TrackedAgentInitAction {
   kind: 'design-interview' | 'chunk-plan' | 'martin-loop';
   command: string;
@@ -251,6 +295,80 @@ export class BeastApiClient {
     });
   }
 
+  async subscribeToEvents(handlers: BeastEventHandlers): Promise<() => void> {
+    let closed = false;
+    let eventSource: EventSource | undefined;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let lastEventId: string | undefined;
+    const parse = <T>(event: MessageEvent): T => JSON.parse(event.data) as T;
+    const rememberEventId = (event: MessageEvent): void => {
+      if (event.lastEventId) lastEventId = event.lastEventId;
+    };
+    const scheduleReconnect = () => {
+      if (closed || reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        void connect().catch((error: unknown) => {
+          if (!closed) {
+            handlers.error?.(toError(error));
+            scheduleReconnect();
+          }
+        });
+      }, 1_000);
+    };
+
+    const connect = async () => {
+      const body = await this.requestRaw<{ ticket: string }>('/v1/beasts/events/ticket', { method: 'POST' });
+      if (closed) return;
+      eventSource?.close();
+      const query = new URLSearchParams({ ticket: body.ticket });
+      if (lastEventId) query.set('lastEventId', lastEventId);
+      const nextSource = new EventSource(
+        `${this.baseUrl}/v1/beasts/events/stream?${query.toString()}`,
+      );
+      eventSource = nextSource;
+
+      nextSource.addEventListener('snapshot', (event) => {
+        rememberEventId(event as MessageEvent);
+        try { handlers.snapshot?.(parse<BeastSseSnapshot>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+      });
+      nextSource.addEventListener('agent.status', (event) => {
+        rememberEventId(event as MessageEvent);
+        try { handlers.agentStatus?.(parse<BeastSseAgentStatusEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+      });
+      nextSource.addEventListener('agent.event', (event) => {
+        rememberEventId(event as MessageEvent);
+        try { handlers.agentEvent?.(parse<BeastSseAgentEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+      });
+      nextSource.addEventListener('run.status', (event) => {
+        rememberEventId(event as MessageEvent);
+        try { handlers.runStatus?.(parse<BeastSseRunStatusEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+      });
+      nextSource.addEventListener('run.log', (event) => {
+        rememberEventId(event as MessageEvent);
+        try { handlers.runLog?.(parse<BeastSseRunLogEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+      });
+      nextSource.addEventListener('run.event', (event) => {
+        rememberEventId(event as MessageEvent);
+        try { handlers.runEvent?.(parse<BeastSseRunEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+      });
+      nextSource.addEventListener('error', () => {
+        if (closed) return;
+        nextSource.close();
+        handlers.error?.(new Error('Beast event stream disconnected; reconnecting'));
+        scheduleReconnect();
+      });
+    };
+
+    await connect();
+
+    return () => {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      eventSource?.close();
+    };
+  }
+
   private async postAction(runId: string, action: 'start' | 'stop' | 'kill' | 'restart'): Promise<BeastRunSummary> {
     return this.request(`/v1/beasts/runs/${encodeURIComponent(runId)}/${action}`, {
       method: 'POST',
@@ -267,6 +385,11 @@ export class BeastApiClient {
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const body = await this.requestRaw<{ data: T }>(path, init);
+    return body.data;
+  }
+
+  private async requestRaw<T>(path: string, init: RequestInit): Promise<T> {
     const headers = normalizeHeaders(init.headers);
     headers.authorization = `Bearer ${this.operatorToken}`;
 
@@ -277,8 +400,7 @@ export class BeastApiClient {
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const body = await response.json() as { data: T };
-    return body.data;
+    return response.json() as Promise<T>;
   }
 
   private async requestVoid(path: string, init: RequestInit): Promise<void> {
@@ -306,4 +428,8 @@ function normalizeHeaders(headers: HeadersInit | undefined): Record<string, stri
     return Object.fromEntries(headers);
   }
   return { ...headers };
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -130,6 +130,11 @@ const mockRestartAgent = vi.fn().mockResolvedValue(undefined);
 const mockResumeAgent = vi.fn().mockResolvedValue(undefined);
 const mockStartAgent = vi.fn().mockResolvedValue(undefined);
 const mockStopAgent = vi.fn().mockResolvedValue(undefined);
+let latestBeastEventHandlers: Record<string, (event: unknown) => void> | null = null;
+const mockSubscribeToEvents = vi.fn().mockImplementation((handlers: Record<string, (event: unknown) => void>) => {
+  latestBeastEventHandlers = handlers;
+  return Promise.resolve(vi.fn());
+});
 
 vi.mock('../../src/hooks/use-chat-session.js', () => ({
   useChatSession: () => ({
@@ -191,6 +196,7 @@ vi.mock('../../src/lib/beast-api.js', () => ({
     stopRun: ReturnType<typeof vi.fn>;
     killRun: ReturnType<typeof vi.fn>;
     restartRun: ReturnType<typeof vi.fn>;
+    subscribeToEvents: typeof mockSubscribeToEvents;
   }) {
     this.getCatalog = mockGetCatalog;
     this.listAgents = mockListAgents;
@@ -208,6 +214,7 @@ vi.mock('../../src/lib/beast-api.js', () => ({
     this.stopRun = vi.fn().mockResolvedValue(undefined);
     this.killRun = vi.fn().mockResolvedValue(undefined);
     this.restartRun = vi.fn().mockResolvedValue(undefined);
+    this.subscribeToEvents = mockSubscribeToEvents;
   }),
 }));
 
@@ -234,6 +241,11 @@ afterEach(() => {
   cleanup();
   window.location.hash = '';
   vi.clearAllMocks();
+  latestBeastEventHandlers = null;
+  mockSubscribeToEvents.mockImplementation((handlers: Record<string, (event: unknown) => void>) => {
+    latestBeastEventHandlers = handlers;
+    return Promise.resolve(vi.fn());
+  });
   mockListSessions.mockResolvedValue([
     {
       id: 'sess-1',
@@ -369,6 +381,83 @@ describe('ChatShell', () => {
 
     expect(screen.getByRole('heading', { name: 'Beasts' })).toBeDefined();
     expect(mockListAgents).toHaveBeenCalled();
+  });
+
+  it('applies Beast SSE status and log updates incrementally', async () => {
+    window.location.hash = '#/beasts';
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        beastOperatorToken="operator-token"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeToEvents).toHaveBeenCalled();
+      expect(screen.getAllByText('agent-1').length).toBeGreaterThan(0);
+      expect(screen.getByText(/started from chat/)).toBeDefined();
+    });
+
+    latestBeastEventHandlers?.agentStatus?.({
+      agentId: 'agent-1',
+      status: 'running',
+      updatedAt: '2026-03-11T00:00:03.000Z',
+    });
+    latestBeastEventHandlers?.runLog?.({
+      runId: 'run-1',
+      attemptId: 'attempt-1',
+      stream: 'stdout',
+      line: 'container line 1',
+      createdAt: '2026-03-11T00:00:04.000Z',
+    });
+    latestBeastEventHandlers?.runStatus?.({
+      runId: 'run-1',
+      status: 'completed',
+      updatedAt: '2026-03-11T00:00:05.000Z',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/container line 1/)).toBeDefined();
+      expect(screen.getAllByText('running').length).toBeGreaterThan(0);
+      expect(screen.getByText('completed')).toBeDefined();
+    });
+  });
+
+  it('deduplicates live log events already returned by the initial REST log load', async () => {
+    window.location.hash = '#/beasts';
+    const persistedLine = JSON.stringify({
+      stream: 'stdout',
+      message: 'container line 1',
+      createdAt: '2026-03-11T00:00:04.000Z',
+    });
+    mockGetLogs.mockResolvedValue([persistedLine]);
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        beastOperatorToken="operator-token"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/container line 1/)).toBeDefined();
+    });
+
+    latestBeastEventHandlers?.runLog?.({
+      runId: 'run-1',
+      attemptId: 'attempt-1',
+      stream: 'stdout',
+      line: 'container line 1',
+      createdAt: '2026-03-11T00:00:04.000Z',
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/container line 1/)).toHaveLength(1);
+    });
   });
 
   it('renders stopped agents in the beasts list', async () => {

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -178,4 +178,201 @@ describe('BeastApiClient', () => {
       expect.objectContaining({ method: 'DELETE' }),
     );
   });
+
+  it('opens the ticket-authenticated Beast event stream', async () => {
+    const close = vi.fn();
+    const listeners: Record<string, (event: { data: string }) => void> = {};
+    const MockEventSource = vi.fn().mockImplementation(() => ({
+      addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+        listeners[type] = handler;
+      }),
+      close,
+    }));
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ticket: 'sse-ticket' }),
+    });
+
+    try {
+      const onRunLog = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ runLog: onRunLog });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/v1/beasts/events/ticket',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ authorization: 'Bearer operator-token' }),
+        }),
+      );
+      expect(MockEventSource).toHaveBeenCalledWith(
+        'http://localhost:3000/v1/beasts/events/stream?ticket=sse-ticket',
+      );
+
+      listeners['run.log']?.({ data: JSON.stringify({ runId: 'run-1', stream: 'stdout', line: 'one' }) });
+      expect(onRunLog).toHaveBeenCalledWith({ runId: 'run-1', stream: 'stdout', line: 'one' });
+
+      unsubscribe();
+      expect(close).toHaveBeenCalled();
+    } finally {
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('requests a fresh single-use ticket when the Beast event stream disconnects', async () => {
+    vi.useFakeTimers();
+    const closeFirst = vi.fn();
+    const closeSecond = vi.fn();
+    const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
+    const MockEventSource = vi.fn().mockImplementation(() => {
+      const instanceListeners: Record<string, (event: { data: string }) => void> = {};
+      listeners.push(instanceListeners);
+      return {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: listeners.length === 1 ? closeFirst : closeSecond,
+      };
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ error: onError });
+
+      listeners[0]?.error?.({ data: '' });
+      expect(closeFirst).toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('reconnecting') }));
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(MockEventSource).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2',
+      );
+
+      unsubscribe();
+      expect(closeSecond).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('passes the last received SSE event id when reconnecting with a fresh ticket', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];
+    const MockEventSource = vi.fn().mockImplementation(() => {
+      const instanceListeners: Record<string, (event: { data: string; lastEventId?: string }) => void> = {};
+      listeners.push(instanceListeners);
+      return {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string; lastEventId?: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      };
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const unsubscribe = await client.subscribeToEvents({ runStatus: vi.fn(), error: vi.fn() });
+
+      listeners[0]?.['run.status']?.({
+        data: JSON.stringify({ runId: 'run-1', status: 'running' }),
+        lastEventId: '42',
+      });
+      listeners[0]?.error?.({ data: '' });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(MockEventSource).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=42',
+      );
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('keeps retrying when a reconnect ticket request fails once', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
+    const MockEventSource = vi.fn().mockImplementation(() => {
+      const instanceListeners: Record<string, (event: { data: string }) => void> = {};
+      listeners.push(instanceListeners);
+      return {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      };
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({ error: { code: 'UNAVAILABLE' } }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-3' }) });
+
+    try {
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ error: onError });
+
+      listeners[0]?.error?.({ data: '' });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'HTTP 500' }));
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(MockEventSource).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-3',
+      );
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
 });

--- a/tasks/issue-458-container-live-streaming-progress.md
+++ b/tasks/issue-458-container-live-streaming-progress.md
@@ -1,0 +1,10 @@
+# Issue 458 Container Live Streaming Progress
+
+- [x] Create isolated worktree and inspect existing Beast dashboard/SSE flow.
+- [x] Add authenticated Beast SSE client support for snapshots, status, events, and incremental logs.
+- [x] Wire Beasts dashboard state to SSE updates without broad polling-only behavior.
+- [x] Add/adjust tests for incremental container log/status streaming.
+- [x] Run relevant tests/typecheck/build.
+- [x] Complete review loop and address findings.
+- [ ] Push branch, open PR with `Closes #458`, and merge if eligible.
+  - Codex CLI review attempted but unavailable (401 unauthenticated); completed fallback Codex-model self-review with no actionable findings.


### PR DESCRIPTION
## Summary
- Subscribe the Beasts dashboard to the authenticated Beast SSE stream for live agent/run status and incremental run logs.
- Emit process/container run status and log events from the executor path used by container Beast runs.
- Harden SSE reconnect behavior for single-use tickets, including fresh-ticket reconnects, replay via `lastEventId`, retry after transient ticket failures, and log dedupe between REST-loaded logs and streamed events.

## Verification
- `npm --workspace @frankenbeast/web test -- --run tests/lib/beast-api.test.ts tests/components/chat-shell.test.tsx`
- `npm --workspace franken-orchestrator test -- --run tests/unit/beasts/process-beast-executor.test.ts tests/unit/beasts/container-beast-executor.test.ts tests/integration/beasts/sse-stream.test.ts`
- `npx turbo run typecheck --filter=franken-orchestrator --filter=@frankenbeast/web`
- `npm --workspace @frankenbeast/web run build`
- `npm --workspace franken-orchestrator run build`
- Codex-model fallback review loop: No issues found.

## Notes
- Standalone `codex review` remains blocked in this environment by missing/invalid Codex credentials / 401 responses, so I used the Codex-model Hermes review fallback and fixed findings through three review rounds.
- Related to #409: this uses the Beast SSE stream directly and does not modify the older dashboard heartbeat-only event path.

Closes #458
