### PR TITLE
fix: address container Codex follow-ups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Keep the sandbox image build context small and free of local state/secrets.
+.git
+.git/**
+
+.env
+.env.*
+!.env.example
+
+.fbeast
+.fbeast/**
+.codex
+.codex/**
+
+node_modules
+node_modules/**
+packages/*/node_modules
+packages/*/node_modules/**
+
+coverage
+coverage/**
+dist
+dist/**
+packages/*/dist
+packages/*/dist/**
+
+*.log
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM node:22-bookworm-slim
 ARG SANDBOX_UID=10001
 ARG SANDBOX_GID=10001
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --gid "${SANDBOX_GID}" fbeast \
   && useradd --uid "${SANDBOX_UID}" --gid "${SANDBOX_GID}" --create-home --shell /usr/sbin/nologin fbeast \
   && mkdir -p /workspace \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG SANDBOX_GID=10001
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git \
+  && git config --system --add safe.directory /workspace \
   && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid "${SANDBOX_GID}" fbeast \

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -145,6 +145,8 @@ Container mode requires Docker and the in-repo sandbox image. Build the default 
 docker build -t fbeast/sandbox:latest -f Dockerfile .
 ```
 
+The repository includes a root `.dockerignore` for this build context. Keep local secrets and agent state out of the image context by filtering `.env*` (except `.env.example`), `.fbeast/`, `.codex/`, `node_modules/`, `.git/`, build outputs, coverage, and logs before running `docker build`.
+
 Unit tests do not require a Docker daemon because they assert the generated Docker command and Dockerfile hardening instead of launching Docker. Docker-backed integration tests are also present and are skipped automatically when Docker is unavailable; when Docker is installed they build `fbeast/sandbox:latest`, verify writable non-root workspace behavior, and run a memory-exceeding workload under the configured limits.
 
 The default env allowlist is intentionally narrow: `PATH`, `HOME`, `LANG`, `LC_ALL`, `FRANKENBEAST_RUN_CONFIG`, `FRANKENBEAST_SPAWNED`, and the `FRANKENBEAST_MODULE_*` toggles for firewall, skills, memory, planner, critique, governor, and heartbeat. Secrets such as `GITHUB_TOKEN`, provider API keys, and arbitrary shell environment variables are not inherited unless the Beast definition explicitly places them in `spec.env` and the runtime policy allows the key.

--- a/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
@@ -17,8 +17,8 @@ export interface ContainerBeastExecutorDeps {
   readonly supervisorFactory?: () => ProcessSupervisorLike;
 }
 
-function containerNameForRun(run: BeastRun): string {
-  return `fbeast-${run.id}`.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 128);
+function containerNameForRunAttempt(run: BeastRun, attemptNumber: number): string {
+  return `fbeast-${run.id}-attempt-${attemptNumber}`.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 128);
 }
 
 function containerAttemptMetadata(
@@ -27,8 +27,9 @@ function containerAttemptMetadata(
   originalSpec: BeastProcessSpec,
   dockerSpec: BeastProcessSpec,
   handle: { pid: number },
+  attemptNumber: number,
 ): Readonly<Record<string, unknown>> {
-  const containerName = containerNameForRun(run);
+  const containerName = containerNameForRunAttempt(run, attemptNumber);
   const resourceSnapshot = {
     memory: policy.resourceLimits.memory,
     cpus: policy.resourceLimits.cpus,
@@ -69,11 +70,12 @@ export class ContainerBeastExecutor implements BeastExecutor {
     if (deps.eventBus) {
       options.eventBus = deps.eventBus;
     }
+    const nextAttemptNumber = (run: BeastRun): number => deps.repository.listAttempts(run.id).length + 1;
     options.transformSpec = (run, _originalSpec, mergedSpec) => toDockerSpec(mergedSpec, policy, {
-      containerName: containerNameForRun(run),
+      containerName: containerNameForRunAttempt(run, nextAttemptNumber(run)),
     });
     options.attemptMetadata = (run, originalSpec, dockerSpec, handle) => (
-      containerAttemptMetadata(policy, run, originalSpec, dockerSpec, handle)
+      containerAttemptMetadata(policy, run, originalSpec, dockerSpec, handle, nextAttemptNumber(run))
     );
 
     this.inner = new ProcessBeastExecutor(

--- a/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
@@ -1,7 +1,7 @@
 import type { BeastProcessSpec } from '../types.js';
 import type { SandboxPolicy } from './sandbox-policy.js';
 import { basename, isAbsolute, relative, resolve, sep } from 'node:path';
-import { realpathSync } from 'node:fs';
+import { realpathSync, statSync } from 'node:fs';
 
 function canonicalExistingPath(path: string): string {
   try {
@@ -57,6 +57,23 @@ function workspaceMount(policy: SandboxPolicy): string {
   return `${policy.workspaceHostPath}:${policy.workspaceContainerPath}${accessMode}`;
 }
 
+function writableWorkspaceUser(policy: SandboxPolicy): `${number}:${number}` {
+  if (policy.readOnlyWorkspaceMount) {
+    return policy.user;
+  }
+  try {
+    const workspace = statSync(policy.workspaceHostPath);
+    if (workspace.uid > 0) {
+      return `${workspace.uid}:${workspace.gid}`;
+    }
+  } catch {
+    // Fall through to the configured sandbox user when the workspace cannot be
+    // inspected yet. This keeps behavior deterministic for callers that create
+    // the directory later.
+  }
+  return policy.user;
+}
+
 export interface DockerSpecOptions {
   readonly containerName?: string | undefined;
 }
@@ -81,7 +98,7 @@ export function toDockerSpec(
       '--pids-limit',
       String(policy.resourceLimits.pidsLimit),
       '--user',
-      policy.user,
+      writableWorkspaceUser(policy),
       '--security-opt',
       'no-new-privileges',
       '-v',

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -52,6 +52,17 @@ function runWithContainerFields(run: BeastRun | undefined, attempts: BeastRunAtt
   };
 }
 
+function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunAttempt[] {
+  if (!run || run.executionMode !== 'container') {
+    return [];
+  }
+  return deps.runs.listAttempts(run.id);
+}
+
+function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunResponse | undefined {
+  return runWithContainerFields(run, attemptsForContainerRun(run, deps));
+}
+
 const ModuleConfigSchema = z.object({
   firewall: z.boolean().optional(),
   skills: z.boolean().optional(),
@@ -142,14 +153,13 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       }
       throw error;
     }
-    const attempts = deps.runs.listAttempts(run.id);
-    return c.json({ data: runWithContainerFields(run, attempts) }, 201);
+    return c.json({ data: runResponse(run, deps) }, 201);
   });
 
   app.get('/v1/beasts/runs', (c) => {
     return c.json({
       data: {
-        runs: deps.runs.listRuns().map((run) => runWithContainerFields(run, deps.runs.listAttempts(run.id))),
+        runs: deps.runs.listRuns().map((run) => runResponse(run, deps)),
       },
     });
   });
@@ -185,22 +195,22 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
 
   app.post('/v1/beasts/runs/:runId/start', async (c) => {
     const run = await deps.runs.start(c.req.param('runId'), 'operator');
-    return c.json({ data: run });
+    return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/runs/:runId/stop', async (c) => {
     const run = await deps.runs.stop(c.req.param('runId'), 'operator');
-    return c.json({ data: run });
+    return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/runs/:runId/kill', async (c) => {
     const run = await deps.runs.kill(c.req.param('runId'), 'operator');
-    return c.json({ data: run });
+    return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/runs/:runId/restart', async (c) => {
     const run = await deps.runs.restart(c.req.param('runId'), 'operator');
-    return c.json({ data: run });
+    return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/interviews/:definitionId/start', (c) => {

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -125,7 +125,7 @@ function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; 
     },
   });
 
-  return { app, operatorToken, fakeContainerSupervisor };
+  return { app, operatorToken, fakeContainerSupervisor, repository };
 }
 
 describe('beast routes', () => {
@@ -235,7 +235,7 @@ describe('beast routes', () => {
     expect(created.data).toMatchObject({
       executionMode: 'container',
       status: 'running',
-      containerId: `fbeast-${created.data.id}`,
+      containerId: `fbeast-${created.data.id}-attempt-1`,
       containerRuntime: 'docker',
       image: 'fbeast/sandbox:test',
       containerImage: 'fbeast/sandbox:test',
@@ -259,18 +259,90 @@ describe('beast routes', () => {
       };
     };
     expect(detail.data.run).toMatchObject({
-      containerId: `fbeast-${created.data.id}`,
+      containerId: `fbeast-${created.data.id}-attempt-1`,
       image: 'fbeast/sandbox:test',
       containerImage: 'fbeast/sandbox:test',
       workspaceContainerPath: '/workspace',
     });
     expect(detail.data.attempts[0]?.executorMetadata).toMatchObject({
       backend: 'container',
-      containerId: `fbeast-${created.data.id}`,
+      containerId: `fbeast-${created.data.id}-attempt-1`,
       containerRuntime: 'docker',
       image: 'fbeast/sandbox:test',
       containerImage: 'fbeast/sandbox:test',
       dockerCommand: 'docker',
+    });
+  });
+
+  it('does not require attempts when listing stale process-mode runs', async () => {
+    const { app, operatorToken, repository } = createBeastApp();
+    const staleRun = repository.createRun({
+      definitionId: 'deleted-definition',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const response = await app.request('/v1/beasts/runs', {
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { runs: Array<{ id: string }> } };
+    expect(body.data.runs.map((run) => run.id)).toContain(staleRun.id);
+  });
+
+  it('exposes container fields in start and restart action responses', async () => {
+    const { app, operatorToken } = createBeastApp({ realContainer: true });
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+
+    const createRun = async () => {
+      const response = await app.request('/v1/beasts/runs', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          definitionId: 'martin-loop',
+          config: {
+            provider: 'claude',
+            objective: 'Exercise container action response',
+            chunkDirectory: 'docs/chunks',
+          },
+          executionMode: 'container',
+          startNow: false,
+        }),
+      });
+      expect(response.status).toBe(201);
+      return await response.json() as { data: { id: string } };
+    };
+
+    const startCandidate = await createRun();
+    const startResponse = await app.request(`/v1/beasts/runs/${startCandidate.data.id}/start`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(startResponse.status).toBe(200);
+    const started = await startResponse.json() as { data: { containerId?: string; containerRuntime?: string } };
+    expect(started.data).toMatchObject({
+      containerId: `fbeast-${startCandidate.data.id}-attempt-1`,
+      containerRuntime: 'docker',
+    });
+
+    const restartCandidate = await createRun();
+    const restartResponse = await app.request(`/v1/beasts/runs/${restartCandidate.data.id}/restart`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(restartResponse.status).toBe(200);
+    const restarted = await restartResponse.json() as { data: { containerId?: string; containerRuntime?: string } };
+    expect(restarted.data).toMatchObject({
+      containerId: `fbeast-${restartCandidate.data.id}-attempt-1`,
+      containerRuntime: 'docker',
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
@@ -68,8 +68,8 @@ describe('ContainerBeastExecutor', () => {
     expect(attempt.executorMetadata).toMatchObject({
       backend: 'container',
       containerRuntime: 'docker',
-      containerId: run.id.replace(/^/, 'fbeast-'),
-      containerName: run.id.replace(/^/, 'fbeast-'),
+      containerId: `${run.id.replace(/^/, 'fbeast-')}-attempt-1`,
+      containerName: `${run.id.replace(/^/, 'fbeast-')}-attempt-1`,
       image: 'fbeast/sandbox:test',
       containerImage: 'fbeast/sandbox:test',
       containerNetwork: 'none',
@@ -80,7 +80,60 @@ describe('ContainerBeastExecutor', () => {
     });
     expect(spawned).toHaveLength(1);
     expect(spawned[0].command).toBe('docker');
-    expect(spawned[0].args).toEqual(expect.arrayContaining(['--name', `fbeast-${run.id}`]));
+    expect(spawned[0].args).toEqual(expect.arrayContaining(['--name', `fbeast-${run.id}-attempt-1`]));
     expect(spawned[0].args).toEqual(expect.arrayContaining(['--network', 'none']));
+  });
+
+  it('uses a distinct Docker container name for each retry attempt', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-container-executor-'));
+    const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logStore = new BeastLogStore(join(workDir, 'logs'));
+    const eventBus = new BeastEventBus();
+    const spawned: BeastProcessSpec[] = [];
+    const fakeSupervisor: ProcessSupervisorLike = {
+      spawn: vi.fn(async (spec: BeastProcessSpec, _callbacks: ProcessCallbacks) => {
+        spawned.push(spec);
+        return { pid: 4242 + spawned.length };
+      }),
+      stop: vi.fn(async () => undefined),
+      kill: vi.fn(async () => undefined),
+    };
+    const executor = new ContainerBeastExecutor({
+      repository,
+      logStore,
+      eventBus,
+      supervisorFactory: () => fakeSupervisor,
+      policy: { ...DEFAULT_SANDBOX_POLICY, image: 'fbeast/sandbox:test', workspaceHostPath: workDir },
+    });
+    const run = repository.createRun({
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'container',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const definition = {
+      id: 'test-beast',
+      version: 1,
+      label: 'Test Beast',
+      description: 'Test beast',
+      executionModeDefault: 'container' as const,
+      configSchema: { parse: (value: unknown) => value },
+      interviewPrompts: [],
+      telemetryLabels: {},
+      buildProcessSpec: () => ({ command: 'node', args: ['agent.js'], cwd: workDir, env: {} }),
+    };
+
+    const first = await executor.start(run, definition);
+    repository.updateAttempt(first.id, { status: 'stopped', finishedAt: '2026-03-10T00:02:00.000Z' });
+    repository.updateRun(run.id, { status: 'stopped', currentAttemptId: undefined });
+    const second = await executor.start(repository.getRun(run.id)!, definition);
+
+    expect(first.executorMetadata?.containerName).toBe(`fbeast-${run.id}-attempt-1`);
+    expect(second.executorMetadata?.containerName).toBe(`fbeast-${run.id}-attempt-2`);
+    expect(spawned[0].args).toEqual(expect.arrayContaining(['--name', `fbeast-${run.id}-attempt-1`]));
+    expect(spawned[1].args).toEqual(expect.arrayContaining(['--name', `fbeast-${run.id}-attempt-2`]));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
@@ -56,6 +56,31 @@ describe('toDockerSpec', () => {
     expect(user?.split(':')[0]).not.toBe('0');
   });
 
+  it('uses the writable workspace owner UID/GID for bind-mounted workspaces', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'fbeast-owned-workspace-'));
+    const spec = toDockerSpec(base, {
+      ...DEFAULT_SANDBOX_POLICY,
+      workspaceHostPath: workspace,
+      user: '10001:10001',
+    });
+
+    const userFlag = spec.args.indexOf('--user');
+    expect(spec.args[userFlag + 1]).toBe(`${process.getuid?.()}:${process.getgid?.()}`);
+  });
+
+  it('keeps the configured user for read-only workspace mounts', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'fbeast-readonly-workspace-'));
+    const spec = toDockerSpec(base, {
+      ...DEFAULT_SANDBOX_POLICY,
+      workspaceHostPath: workspace,
+      readOnlyWorkspaceMount: true,
+      user: '10001:10001',
+    });
+
+    const userFlag = spec.args.indexOf('--user');
+    expect(spec.args[userFlag + 1]).toBe('10001:10001');
+  });
+
   it('supports an opt-in read-only workspace mount', () => {
     const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj', readOnlyWorkspaceMount: true });
 

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
@@ -65,7 +65,10 @@ describe('toDockerSpec', () => {
     });
 
     const userFlag = spec.args.indexOf('--user');
-    expect(spec.args[userFlag + 1]).toBe(`${process.getuid?.()}:${process.getgid?.()}`);
+    const expectedUser = process.getuid?.() === 0
+      ? '10001:10001'
+      : `${process.getuid?.()}:${process.getgid?.()}`;
+    expect(spec.args[userFlag + 1]).toBe(expectedUser);
   });
 
   it('keeps the configured user for read-only workspace mounts', () => {

--- a/tasks/codex-followup-465-468-progress.md
+++ b/tasks/codex-followup-465-468-progress.md
@@ -1,0 +1,10 @@
+# Codex follow-up #465/#468 progress
+
+- [x] Create fresh worktree from origin/main without deleting existing directories.
+- [x] Fix container runtime sandbox comments from merged PR #465.
+- [x] Fix run response comments from merged PR #468.
+- [x] Add/adjust tests and docs.
+- [x] Run focused tests/typecheck/build.
+- [ ] Open follow-up PR.
+- [ ] Trigger GitHub @codex review and resolve actionable comments until clear.
+- [ ] Verify CI is green and merge if clear.

--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -21,6 +21,21 @@ describe('sandbox Dockerfile', () => {
     expect(dockerfile).toContain('WORKDIR /workspace');
   });
 
+  it('installs git for sandboxed martin-loop branch isolation', () => {
+    expect(dockerfile).toContain('apt-get install -y --no-install-recommends git');
+  });
+
+  it('filters local secrets and heavy directories from the Docker build context', () => {
+    const dockerignore = readFileSync(resolve('.dockerignore'), 'utf8');
+
+    expect(dockerignore).toContain('.env');
+    expect(dockerignore).toContain('!.env.example');
+    expect(dockerignore).toContain('.fbeast');
+    expect(dockerignore).toContain('.codex');
+    expect(dockerignore).toContain('node_modules');
+    expect(dockerignore).toContain('.git');
+  });
+
   dockerIt('actually builds fbeast/sandbox:latest from the repo Dockerfile when Docker is available', () => {
     execFileSync('docker', ['build', '-t', 'fbeast/sandbox:latest', '-f', 'Dockerfile', '.'], {
       cwd: resolve('.'),

--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -25,6 +25,10 @@ describe('sandbox Dockerfile', () => {
     expect(dockerfile).toContain('apt-get install -y --no-install-recommends git');
   });
 
+  it('marks the mounted workspace safe for git when runtime falls back from root-owned mounts', () => {
+    expect(dockerfile).toContain('git config --system --add safe.directory /workspace');
+  });
+
   it('filters local secrets and heavy directories from the Docker build context', () => {
     const dockerignore = readFileSync(resolve('.dockerignore'), 'utf8');
 


### PR DESCRIPTION
## Summary

Follow-up for actual GitHub Codex bot comments on merged PRs #465 and #468 around container sandbox/runtime/run response behavior.

- Make Docker runs use the bind-mounted workspace owner UID/GID for writable workspaces, keep read-only mounts on configured sandbox user, install `git` in the default sandbox image, and add a root `.dockerignore` plus docs for build-context filtering.
- Give container runs attempt-unique Docker container names so retries do not reuse the prior attempt name.
- Normalize container metadata onto create/start/stop/kill/restart run responses while avoiding attempt lookups for non-container run listings.
- Add regression coverage for Docker spec user selection, container attempt naming, build-context filtering, Dockerfile git availability, stale process-run listing, and start/restart container response normalization.

## Verification

- `npm run test:root -- tests/sandbox-dockerfile.test.ts`
- `npm --workspace=packages/franken-orchestrator test -- tests/unit/beasts/execution/docker-container-runtime.test.ts tests/unit/beasts/container-beast-executor.test.ts tests/integration/beasts/beast-routes.test.ts`
- `npm run typecheck`
- `npm run build`

## Codex follow-up references

Addresses follow-up comments from merged PR #465 and PR #468.
