### PR TITLE
Fix live Beast SSE follow-up issues

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -197,8 +197,10 @@ export class ProcessBeastExecutor implements BeastExecutor {
     }
 
     // Flush early exit if process died before attemptId was set
+    let flushedEarlyExit = false;
     if (earlyExit) {
       this.handleProcessExit(run.id, attemptId, earlyExit.code, earlyExit.signal, [...stderrTail]);
+      flushedEarlyExit = true;
     }
 
     const startedEvent = {
@@ -215,6 +217,9 @@ export class ProcessBeastExecutor implements BeastExecutor {
       type: 'run.event',
       data: { runId: run.id, event: startedEvent },
     });
+    if (flushedEarlyExit) {
+      return this.repository.getAttempt(attempt.id) ?? attempt;
+    }
     this.options.eventBus?.publish({
       type: 'run.status',
       data: { runId: run.id, status: 'running' as const, updatedAt: startedAt },

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -518,6 +518,31 @@ describe('ProcessBeastExecutor', () => {
       });
     });
 
+    it('does not publish running after flushing an early process exit', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const eventBus = new BeastEventBus();
+      const publishSpy = vi.spyOn(eventBus, 'publish');
+      const supervisor = {
+        spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+          (callbacks as ProcessCallbacks).onExit(0, null);
+          return { pid: 5150 };
+        }),
+        stop: vi.fn(async () => {}),
+        kill: vi.fn(async () => {}),
+      };
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { eventBus });
+      const run = createTestRun(repo);
+
+      const attempt = await executor.start(run, martinLoopDefinition);
+
+      expect(attempt.status).toBe('completed');
+      const statusEvents = publishSpy.mock.calls.filter(([e]) => e.type === 'run.status');
+      expect(statusEvents.map(([e]) => e.data.status)).toEqual(['completed']);
+      expect(repo.getRun(run.id)).toMatchObject({ status: 'completed' });
+    });
+
     it('publishes run.status event via eventBus on operator stop (finishAttempt)', async () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import brandMark from '../../../../assets/img/frankenbeast-github-logo-478x72.png';
 import { useChatSession } from '../hooks/use-chat-session';
 import { TranscriptPane } from './transcript-pane';
@@ -62,41 +62,31 @@ function PlaceholderPage({ routeId }: { routeId: Exclude<RouteId, 'chat'> }) {
 
 function appendUniqueLogLine(logs: string[], nextLine: string): string[] {
   const nextIdentity = parseLogIdentity(nextLine);
-  if (nextIdentity && logs.some((line) => {
-    const identity = parseLogIdentity(line);
-    return identity
-      && identity.stream === nextIdentity.stream
-      && identity.message === nextIdentity.message
-      && identity.createdAt === nextIdentity.createdAt;
-  })) {
+  if (nextIdentity && logs.some((line) => parseLogIdentity(line)?.eventId === nextIdentity.eventId)) {
     return logs;
   }
   return logs[logs.length - 1] === nextLine ? logs : [...logs, nextLine];
 }
 
-function parseLogIdentity(line: string): { stream?: string; message: string; createdAt?: string } | null {
+function parseLogIdentity(line: string): { eventId: string } | null {
   try {
     const parsed = JSON.parse(line) as unknown;
-    if (typeof parsed !== 'object' || parsed === null || !('message' in parsed)) {
+    if (typeof parsed !== 'object' || parsed === null) {
       return null;
     }
-    const candidate = parsed as { stream?: unknown; message?: unknown; createdAt?: unknown };
-    if (typeof candidate.message !== 'string') {
-      return null;
-    }
-    return {
-      ...(typeof candidate.stream === 'string' ? { stream: candidate.stream } : {}),
-      message: candidate.message,
-      ...(typeof candidate.createdAt === 'string' ? { createdAt: candidate.createdAt } : {}),
-    };
+    const candidate = parsed as { eventId?: unknown };
+    return typeof candidate.eventId === 'string' && candidate.eventId.length > 0
+      ? { eventId: candidate.eventId }
+      : null;
   } catch {
     return null;
   }
 }
 
-function formatStreamedLogLine(event: { stream?: string; line: string; createdAt?: string }): string {
-  if (event.createdAt || event.stream) {
+function formatStreamedLogLine(event: { eventId?: string; stream?: string; line: string; createdAt?: string }): string {
+  if (event.eventId || event.createdAt || event.stream) {
     return JSON.stringify({
+      ...(event.eventId ? { eventId: event.eventId } : {}),
       ...(event.stream ? { stream: event.stream } : {}),
       message: event.line,
       ...(event.createdAt ? { createdAt: event.createdAt } : {}),
@@ -145,6 +135,8 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
   const [beastAgents, setBeastAgents] = useState<TrackedAgentSummary[]>([]);
   const [selectedBeastAgentId, setSelectedBeastAgentId] = useState<string | null>(null);
   const [beastAgentDetail, setBeastAgentDetail] = useState<(TrackedAgentDetail & { run?: BeastRunDetail | null }) | null>(null);
+  const beastAgentsRef = useRef<TrackedAgentSummary[]>([]);
+  const beastAgentDetailRef = useRef<(TrackedAgentDetail & { run?: BeastRunDetail | null }) | null>(null);
   const [beastError, setBeastError] = useState<string | null>(null);
   const [beastRefreshNonce, setBeastRefreshNonce] = useState(0);
   const [networkStatus, setNetworkStatus] = useState<NetworkStatusResponse>({
@@ -231,6 +223,14 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
   }, [chatClient, projectId, activeSessionId, sessionSeed]);
 
   useEffect(() => {
+    beastAgentsRef.current = beastAgents;
+  }, [beastAgents]);
+
+  useEffect(() => {
+    beastAgentDetailRef.current = beastAgentDetail;
+  }, [beastAgentDetail]);
+
+  useEffect(() => {
     if (route !== 'beasts') {
       return;
     }
@@ -299,25 +299,38 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
 
     let cancelled = false;
     let unsubscribe: (() => void) | undefined;
+    const requestBeastRefresh = () => setBeastRefreshNonce((current) => current + 1);
 
     void beastClient.subscribeToEvents({
       snapshot: (snapshot) => {
         if (cancelled || !snapshot.agents) return;
-        setBeastAgents((current) => current.map((agent) => {
-          const next = snapshot.agents?.find((candidate) => candidate.id === agent.id);
-          return next ? { ...agent, ...next } : agent;
-        }));
+        const currentAgents = beastAgentsRef.current;
+        const currentDetail = beastAgentDetailRef.current;
+        const sawUnknownAgent = snapshot.agents.some((candidate) => !currentAgents.some((agent) => agent.id === candidate.id));
+        const selectedSnapshotAgent = currentDetail
+          ? snapshot.agents.find((candidate) => candidate.id === currentDetail.agent.id)
+          : undefined;
+        const selectedAgentLinkedRun = Boolean(currentDetail && !currentDetail.run && selectedSnapshotAgent?.dispatchRunId);
+        setBeastAgents((current) => {
+          return current.map((agent) => {
+            const next = snapshot.agents?.find((candidate) => candidate.id === agent.id);
+            return next ? { ...agent, ...next } : agent;
+          });
+        });
         setBeastAgentDetail((current) => {
           if (!current) return current;
           const next = snapshot.agents?.find((candidate) => candidate.id === current.agent.id);
           return next ? { ...current, agent: { ...current.agent, ...next } } : current;
         });
+        if (sawUnknownAgent || selectedAgentLinkedRun) requestBeastRefresh();
       },
       agentStatus: (event) => {
         if (cancelled) return;
-        setBeastAgents((current) => current.map((agent) => (agent.id === event.agentId
-          ? { ...agent, status: event.status, ...(event.updatedAt ? { updatedAt: event.updatedAt } : {}) }
-          : agent)));
+        const sawKnownAgent = beastAgentsRef.current.some((agent) => agent.id === event.agentId);
+        setBeastAgents((current) => current.map((agent) => {
+          if (agent.id !== event.agentId) return agent;
+          return { ...agent, status: event.status, ...(event.updatedAt ? { updatedAt: event.updatedAt } : {}) };
+        }));
         setBeastAgentDetail((current) => (current?.agent.id === event.agentId
           ? {
               ...current,
@@ -328,10 +341,12 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
               },
             }
           : current));
+        if (!sawKnownAgent) requestBeastRefresh();
         setBeastError(null);
       },
       agentEvent: (event) => {
         if (cancelled) return;
+        const sawSelectedAgent = beastAgentDetailRef.current?.agent.id === event.agentId;
         setBeastAgentDetail((current) => {
           if (!current || current.agent.id !== event.agentId) return current;
           const nextEvent = {
@@ -347,11 +362,20 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
           if (current.events.some((existing) => existing.id === nextEvent.id)) return current;
           return { ...current, events: [...current.events, nextEvent] };
         });
+        if (!sawSelectedAgent) requestBeastRefresh();
       },
       runStatus: (event) => {
         if (cancelled) return;
+        const currentDetail = beastAgentDetailRef.current;
+        const shouldRefreshRun = Boolean(
+          currentDetail
+          && (!currentDetail.run || currentDetail.run.run.id !== event.runId)
+          && currentDetail.agent.dispatchRunId === event.runId,
+        );
         setBeastAgentDetail((current) => {
-          if (!current?.run || current.run.run.id !== event.runId) return current;
+          if (!current?.run || current.run.run.id !== event.runId) {
+            return current;
+          }
           return {
             ...current,
             run: {
@@ -363,11 +387,20 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
             },
           };
         });
+        if (shouldRefreshRun) requestBeastRefresh();
       },
       runLog: (event) => {
         if (cancelled) return;
+        const currentDetail = beastAgentDetailRef.current;
+        const shouldRefreshRun = Boolean(
+          currentDetail
+          && (!currentDetail.run || currentDetail.run.run.id !== event.runId)
+          && currentDetail.agent.dispatchRunId === event.runId,
+        );
         setBeastAgentDetail((current) => {
-          if (!current?.run || current.run.run.id !== event.runId) return current;
+          if (!current?.run || current.run.run.id !== event.runId) {
+            return current;
+          }
           return {
             ...current,
             run: {
@@ -376,6 +409,7 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
             },
           };
         });
+        if (shouldRefreshRun) requestBeastRefresh();
       },
       error: (error) => {
         if (!cancelled) {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -62,25 +62,48 @@ function PlaceholderPage({ routeId }: { routeId: Exclude<RouteId, 'chat'> }) {
 
 function appendUniqueLogLine(logs: string[], nextLine: string): string[] {
   const nextIdentity = parseLogIdentity(nextLine);
-  if (nextIdentity && logs.some((line) => parseLogIdentity(line)?.eventId === nextIdentity.eventId)) {
+  if (nextIdentity?.eventId && logs.some((line) => parseLogIdentity(line)?.eventId === nextIdentity.eventId)) {
+    return logs;
+  }
+  if (nextIdentity?.createdAt && logs.some((line) => {
+    const identity = parseLogIdentity(line);
+    return identity
+      && (!identity.eventId || !nextIdentity.eventId)
+      && identity.stream === nextIdentity.stream
+      && identity.message === nextIdentity.message
+      && identity.createdAt === nextIdentity.createdAt;
+  })) {
     return logs;
   }
   return logs[logs.length - 1] === nextLine ? logs : [...logs, nextLine];
 }
 
-function parseLogIdentity(line: string): { eventId: string } | null {
+function parseLogIdentity(line: string): { eventId?: string; stream?: string; message?: string; createdAt?: string } | null {
   try {
     const parsed = JSON.parse(line) as unknown;
     if (typeof parsed !== 'object' || parsed === null) {
       return null;
     }
-    const candidate = parsed as { eventId?: unknown };
-    return typeof candidate.eventId === 'string' && candidate.eventId.length > 0
-      ? { eventId: candidate.eventId }
-      : null;
+    const candidate = parsed as { eventId?: unknown; stream?: unknown; message?: unknown; createdAt?: unknown };
+    const identity = {
+      ...(typeof candidate.eventId === 'string' && candidate.eventId.length > 0 ? { eventId: candidate.eventId } : {}),
+      ...(typeof candidate.stream === 'string' ? { stream: candidate.stream } : {}),
+      ...(typeof candidate.message === 'string' ? { message: candidate.message } : {}),
+      ...(typeof candidate.createdAt === 'string' ? { createdAt: candidate.createdAt } : {}),
+    };
+    return identity.eventId || (identity.message && identity.createdAt) ? identity : null;
   } catch {
     return null;
   }
+}
+
+function getAgentEventRunId(payload: unknown): string | null {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'runId' in payload
+    && typeof (payload as { runId?: unknown }).runId === 'string'
+    ? (payload as { runId: string }).runId
+    : null;
 }
 
 function formatStreamedLogLine(event: { eventId?: string; stream?: string; line: string; createdAt?: string }): string {
@@ -346,7 +369,22 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
       },
       agentEvent: (event) => {
         if (cancelled) return;
-        const sawSelectedAgent = beastAgentDetailRef.current?.agent.id === event.agentId;
+        const currentDetail = beastAgentDetailRef.current;
+        const sawSelectedAgent = currentDetail?.agent.id === event.agentId;
+        const linkedRunId = getAgentEventRunId(event.event.payload);
+        const selectedAgentLinkedRun = Boolean(
+          sawSelectedAgent
+          && linkedRunId
+          && currentDetail
+          && currentDetail.agent.dispatchRunId !== linkedRunId
+          && currentDetail.run?.run.id !== linkedRunId,
+        );
+        if (selectedAgentLinkedRun && currentDetail && linkedRunId) {
+          beastAgentDetailRef.current = {
+            ...currentDetail,
+            agent: { ...currentDetail.agent, dispatchRunId: linkedRunId },
+          };
+        }
         setBeastAgentDetail((current) => {
           if (!current || current.agent.id !== event.agentId) return current;
           const nextEvent = {
@@ -360,9 +398,13 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
             createdAt: event.event.createdAt ?? new Date().toISOString(),
           };
           if (current.events.some((existing) => existing.id === nextEvent.id)) return current;
-          return { ...current, events: [...current.events, nextEvent] };
+          return {
+            ...current,
+            agent: linkedRunId ? { ...current.agent, dispatchRunId: linkedRunId } : current.agent,
+            events: [...current.events, nextEvent],
+          };
         });
-        if (!sawSelectedAgent) requestBeastRefresh();
+        if (!sawSelectedAgent || selectedAgentLinkedRun) requestBeastRefresh();
       },
       runStatus: (event) => {
         if (cancelled) return;

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -68,6 +68,7 @@ export interface BeastSseRunStatusEvent {
 }
 
 export interface BeastSseRunLogEvent {
+  eventId?: string;
   runId: string;
   attemptId?: string;
   stream?: 'stdout' | 'stderr';
@@ -301,6 +302,10 @@ export class BeastApiClient {
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let lastEventId: string | undefined;
     const parse = <T>(event: MessageEvent): T => JSON.parse(event.data) as T;
+    const parseWithEventId = <T extends object>(event: MessageEvent): T & { eventId?: string } => {
+      const parsed = parse<T>(event);
+      return event.lastEventId ? { ...parsed, eventId: event.lastEventId } : parsed;
+    };
     const rememberEventId = (event: MessageEvent): void => {
       if (event.lastEventId) lastEventId = event.lastEventId;
     };
@@ -346,7 +351,7 @@ export class BeastApiClient {
       });
       nextSource.addEventListener('run.log', (event) => {
         rememberEventId(event as MessageEvent);
-        try { handlers.runLog?.(parse<BeastSseRunLogEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try { handlers.runLog?.(parseWithEventId<BeastSseRunLogEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
       });
       nextSource.addEventListener('run.event', (event) => {
         rememberEventId(event as MessageEvent);
@@ -360,7 +365,12 @@ export class BeastApiClient {
       });
     };
 
-    await connect();
+    await connect().catch((error: unknown) => {
+      if (!closed) {
+        handlers.error?.(toError(error));
+        scheduleReconnect();
+      }
+    });
 
     return () => {
       closed = true;

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -441,10 +441,9 @@ describe('ChatShell', () => {
     });
   });
 
-  it('deduplicates live log events by SSE event id', async () => {
+  it('deduplicates live log events already returned by the REST log load', async () => {
     window.location.hash = '#/beasts';
     const persistedLine = JSON.stringify({
-      eventId: 'log-event-1',
       stream: 'stdout',
       message: 'container line 1',
       createdAt: '2026-03-11T00:00:04.000Z',
@@ -618,9 +617,6 @@ describe('ChatShell', () => {
       expect(document.body.textContent).toContain('No events or logs yet');
     });
 
-    latestBeastEventHandlers?.snapshot?.({
-      agents: [{ id: 'agent-1', dispatchRunId: 'run-2' }],
-    });
     mockGetAgent.mockResolvedValue({
       agent: {
         id: 'agent-1',
@@ -651,6 +647,19 @@ describe('ChatShell', () => {
       events: [],
     });
     mockGetLogs.mockResolvedValue(['linked run log']);
+
+    latestBeastEventHandlers?.agentEvent?.({
+      agentId: 'agent-1',
+      event: {
+        id: 'agent-event-1',
+        sequence: 1,
+        level: 'info',
+        type: 'agent.dispatch.linked',
+        message: 'Dispatch run linked',
+        payload: { runId: 'run-2' },
+        createdAt: '2026-03-11T00:00:03.000Z',
+      },
+    });
 
     latestBeastEventHandlers?.runLog?.({
       eventId: 'log-event-1',

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -311,6 +311,22 @@ afterEach(() => {
   });
   mockResumeAgent.mockReset();
   mockResumeAgent.mockResolvedValue(undefined);
+  mockGetLogs.mockReset();
+  mockGetLogs.mockResolvedValue(['started from chat']);
+  mockGetRun.mockReset();
+  mockGetRun.mockResolvedValue({
+    run: {
+      id: 'run-1',
+      definitionId: 'chunk-plan',
+      status: 'running',
+      dispatchedBy: 'chat',
+      dispatchedByUser: 'chat-session:sess-1',
+      attemptCount: 1,
+      createdAt: '2026-03-11T00:00:02.000Z',
+    },
+    attempts: [],
+    events: [],
+  });
 });
 
 describe('ChatShell', () => {
@@ -425,9 +441,10 @@ describe('ChatShell', () => {
     });
   });
 
-  it('deduplicates live log events already returned by the initial REST log load', async () => {
+  it('deduplicates live log events by SSE event id', async () => {
     window.location.hash = '#/beasts';
     const persistedLine = JSON.stringify({
+      eventId: 'log-event-1',
       stream: 'stdout',
       message: 'container line 1',
       createdAt: '2026-03-11T00:00:04.000Z',
@@ -448,6 +465,7 @@ describe('ChatShell', () => {
     });
 
     latestBeastEventHandlers?.runLog?.({
+      eventId: 'log-event-1',
       runId: 'run-1',
       attemptId: 'attempt-1',
       stream: 'stdout',
@@ -457,6 +475,194 @@ describe('ChatShell', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText(/container line 1/)).toHaveLength(1);
+    });
+  });
+
+  it('does not deduplicate distinct log records that share timestamp and contents', async () => {
+    window.location.hash = '#/beasts';
+    mockGetLogs.mockResolvedValue([]);
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        beastOperatorToken="operator-token"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeToEvents).toHaveBeenCalled();
+    });
+
+    latestBeastEventHandlers?.runLog?.({
+      eventId: 'log-event-1',
+      runId: 'run-1',
+      attemptId: 'attempt-1',
+      stream: 'stdout',
+      line: 'same line',
+      createdAt: '2026-03-11T00:00:04.000Z',
+    });
+    latestBeastEventHandlers?.runLog?.({
+      eventId: 'log-event-2',
+      runId: 'run-1',
+      attemptId: 'attempt-1',
+      stream: 'stdout',
+      line: 'same line',
+      createdAt: '2026-03-11T00:00:04.000Z',
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/same line/)).toHaveLength(2);
+    });
+  });
+
+  it('refreshes the agent list when SSE reports an unknown agent', async () => {
+    window.location.hash = '#/beasts';
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        beastOperatorToken="operator-token"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('agent-1')).toBeDefined();
+    });
+
+    mockListAgents.mockResolvedValue([
+      {
+        id: 'agent-1',
+        definitionId: 'chunk-plan',
+        status: 'dispatching',
+        source: 'chat',
+        createdByUser: 'chat-session:sess-1',
+        initAction: { kind: 'chunk-plan', command: '/plan --design-doc docs/plans/design.md', config: {}, chatSessionId: 'sess-1' },
+        initConfig: {},
+        chatSessionId: 'sess-1',
+        dispatchRunId: 'run-1',
+        createdAt: '2026-03-11T00:00:00.000Z',
+        updatedAt: '2026-03-11T00:00:01.000Z',
+      },
+      {
+        id: 'agent-2',
+        definitionId: 'chunk-plan',
+        status: 'running',
+        source: 'dashboard',
+        createdByUser: 'operator',
+        initAction: { kind: 'chunk-plan', command: '/plan --design-doc docs/next.md', config: {}, chatSessionId: 'sess-1' },
+        initConfig: {},
+        chatSessionId: 'sess-1',
+        dispatchRunId: 'run-2',
+        createdAt: '2026-03-11T00:00:02.000Z',
+        updatedAt: '2026-03-11T00:00:03.000Z',
+      },
+    ]);
+
+    latestBeastEventHandlers?.agentStatus?.({
+      agentId: 'agent-2',
+      status: 'running',
+      updatedAt: '2026-03-11T00:00:03.000Z',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('agent-2')).toBeDefined();
+    });
+  });
+
+  it('refreshes selected agent details when a newly linked run emits logs', async () => {
+    window.location.hash = '#/beasts';
+    mockListAgents.mockResolvedValue([
+      {
+        id: 'agent-1',
+        definitionId: 'chunk-plan',
+        status: 'dispatching',
+        source: 'chat',
+        createdByUser: 'chat-session:sess-1',
+        initAction: { kind: 'chunk-plan', command: '/plan --design-doc docs/plans/design.md', config: {}, chatSessionId: 'sess-1' },
+        initConfig: {},
+        chatSessionId: 'sess-1',
+        createdAt: '2026-03-11T00:00:00.000Z',
+        updatedAt: '2026-03-11T00:00:01.000Z',
+      },
+    ]);
+    mockGetAgent.mockResolvedValue({
+      agent: {
+        id: 'agent-1',
+        definitionId: 'chunk-plan',
+        status: 'dispatching',
+        source: 'chat',
+        createdByUser: 'chat-session:sess-1',
+        initAction: { kind: 'chunk-plan', command: '/plan --design-doc docs/plans/design.md', config: {}, chatSessionId: 'sess-1' },
+        initConfig: {},
+        chatSessionId: 'sess-1',
+        createdAt: '2026-03-11T00:00:00.000Z',
+        updatedAt: '2026-03-11T00:00:01.000Z',
+      },
+      events: [],
+    });
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        beastOperatorToken="operator-token"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('No events or logs yet');
+    });
+
+    latestBeastEventHandlers?.snapshot?.({
+      agents: [{ id: 'agent-1', dispatchRunId: 'run-2' }],
+    });
+    mockGetAgent.mockResolvedValue({
+      agent: {
+        id: 'agent-1',
+        definitionId: 'chunk-plan',
+        status: 'running',
+        source: 'chat',
+        createdByUser: 'chat-session:sess-1',
+        initAction: { kind: 'chunk-plan', command: '/plan --design-doc docs/plans/design.md', config: {}, chatSessionId: 'sess-1' },
+        initConfig: {},
+        chatSessionId: 'sess-1',
+        dispatchRunId: 'run-2',
+        createdAt: '2026-03-11T00:00:00.000Z',
+        updatedAt: '2026-03-11T00:00:03.000Z',
+      },
+      events: [],
+    });
+    mockGetRun.mockResolvedValue({
+      run: {
+        id: 'run-2',
+        definitionId: 'chunk-plan',
+        status: 'running',
+        dispatchedBy: 'chat',
+        dispatchedByUser: 'chat-session:sess-1',
+        attemptCount: 1,
+        createdAt: '2026-03-11T00:00:02.000Z',
+      },
+      attempts: [],
+      events: [],
+    });
+    mockGetLogs.mockResolvedValue(['linked run log']);
+
+    latestBeastEventHandlers?.runLog?.({
+      eventId: 'log-event-1',
+      runId: 'run-2',
+      attemptId: 'attempt-2',
+      stream: 'stdout',
+      line: 'linked run log',
+      createdAt: '2026-03-11T00:00:04.000Z',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/linked run log/)).toBeDefined();
     });
   });
 

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -227,6 +227,50 @@ describe('BeastApiClient', () => {
     }
   });
 
+  it('attaches the EventSource id to parsed run log events', async () => {
+    const close = vi.fn();
+    const listeners: Record<string, (event: { data: string; lastEventId?: string }) => void> = {};
+    const MockEventSource = vi.fn().mockImplementation(() => ({
+      addEventListener: vi.fn((type: string, handler: (event: { data: string; lastEventId?: string }) => void) => {
+        listeners[type] = handler;
+      }),
+      close,
+    }));
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ticket: 'sse-ticket' }),
+    });
+
+    try {
+      const onRunLog = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ runLog: onRunLog });
+
+      listeners['run.log']?.({
+        data: JSON.stringify({ runId: 'run-1', stream: 'stdout', line: 'one' }),
+        lastEventId: 'event-42',
+      });
+      expect(onRunLog).toHaveBeenCalledWith({
+        eventId: 'event-42',
+        runId: 'run-1',
+        stream: 'stdout',
+        line: 'one',
+      });
+
+      unsubscribe();
+    } finally {
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
   it('requests a fresh single-use ticket when the Beast event stream disconnects', async () => {
     vi.useFakeTimers();
     const closeFirst = vi.fn();
@@ -362,6 +406,46 @@ describe('BeastApiClient', () => {
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
         'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-3',
+      );
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('keeps retrying when the initial ticket request fails', async () => {
+    vi.useFakeTimers();
+    const MockEventSource = vi.fn().mockImplementation(() => ({
+      addEventListener: vi.fn(),
+      close: vi.fn(),
+    }));
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({ error: { code: 'UNAVAILABLE' } }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ error: onError });
+
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'HTTP 503' }));
+      expect(MockEventSource).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(MockEventSource).toHaveBeenCalledWith(
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2',
       );
 
       unsubscribe();


### PR DESCRIPTION
Follow-up for actual Codex review comments on merged PR #470.

## Summary
- propagate EventSource `lastEventId` into Beast run-log SSE payloads and dedupe live log lines by event id
- retry initial Beast SSE ticket failures instead of failing the subscription permanently
- refresh Beast state/details when SSE references unknown agents or newly linked dispatch runs
- avoid publishing `running` after a process exits before attempt startup completes

## Verification
- `npm --workspace @frankenbeast/web exec vitest run tests/components/chat-shell.test.tsx -t "refreshes selected agent details when a newly linked run emits logs"`
- `npm --workspace @frankenbeast/web test`
- `npm --workspace franken-orchestrator exec vitest run tests/unit/beasts/process-beast-executor.test.ts`
- `npm run build`
- `npm run typecheck`

Note: `npm test` was also attempted after build; the web and targeted orchestrator coverage passed, but the full turbo run hit two unrelated franken-orchestrator 5s import-timeout tests (`create-beast-deps-optional-critique`, `session-issues`) under the full concurrent run.