### PR TITLE
fix(orchestrator): mark container workspaces git-safe

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -137,7 +137,7 @@ Beast dispatch supports two execution modes:
 | Mode | Boundary |
 |------|----------|
 | `process` | Host process with supervised lifecycle, env allowlist, and project-root cwd containment. This is **not** a hard sandbox. |
-| `container` | Docker-backed execution through `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, non-root UID/GID enforcement (defaults to the invoking host UID/GID when non-root, otherwise `10001:10001`), memory/CPU/PID limits, `no-new-privileges`, and the same env allowlist. |
+| `container` | Docker-backed execution through `docker run --rm --network none`, one explicit workspace mount, `/workspace` working directory, git safe-directory configuration for the mounted checkout, non-root UID/GID enforcement (defaults to the invoking host UID/GID when non-root, otherwise `10001:10001`), memory/CPU/PID limits, `no-new-privileges`, and the same env allowlist. |
 
 Container mode requires Docker and the in-repo sandbox image. Build the default image with:
 

--- a/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
@@ -38,7 +38,14 @@ function containerCommand(command: string, policy: SandboxPolicy): string {
 }
 
 function dockerEnvArgs(spec: BeastProcessSpec, policy: SandboxPolicy): string[] {
-  const args: string[] = [];
+  const args: string[] = [
+    '-e',
+    'GIT_CONFIG_COUNT=1',
+    '-e',
+    'GIT_CONFIG_KEY_0=safe.directory',
+    '-e',
+    `GIT_CONFIG_VALUE_0=${policy.workspaceContainerPath}`,
+  ];
   for (const key of policy.envAllowlist) {
     const value = spec.env?.[key];
     if (value !== undefined) {

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/docker-container-runtime.test.ts
@@ -93,7 +93,16 @@ describe('toDockerSpec', () => {
   it('passes only allowlisted env via explicit -e values and inherits no host env', () => {
     const spec = toDockerSpec(base, { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: '/proj' });
 
-    expect(spec.args).toEqual(expect.arrayContaining(['-e', 'FRANKENBEAST_RUN_CONFIG=/workspace/.fbeast/rc.json']));
+    expect(spec.args).toEqual(expect.arrayContaining([
+      '-e',
+      'GIT_CONFIG_COUNT=1',
+      '-e',
+      'GIT_CONFIG_KEY_0=safe.directory',
+      '-e',
+      'GIT_CONFIG_VALUE_0=/workspace',
+      '-e',
+      'FRANKENBEAST_RUN_CONFIG=/workspace/.fbeast/rc.json',
+    ]));
     expect(spec.args).not.toEqual(expect.arrayContaining(['-e', 'GITHUB_TOKEN=ghp_should_not_leak']));
     expect(spec.env).toEqual({});
   });


### PR DESCRIPTION
## Summary
- Follow up on the late Codex finding from merged PR #472 around root-owned bind mounts.
- Inject Git safe-directory runtime config into Docker-backed Beast runs so custom/default sandbox images treat /workspace as safe even when the container UID differs from the bind mount owner.
- Document the safe-directory behavior and cover the generated Docker args in unit tests.

## Verification
- npm --workspace franken-orchestrator test -- --run tests/unit/beasts/execution/docker-container-runtime.test.ts
- npm --workspace @franken/types run build && npm --workspace @frankenbeast/observer run build && npm --workspace franken-brain run build && npm --workspace @franken/critique run build && npm --workspace @franken/governor run build && npm --workspace franken-planner run build && npm --workspace franken-orchestrator run typecheck

Follow-up to #472 / #465.