### PR TITLE
fix(brain): hydrate sqlite working memory

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -42,7 +42,23 @@ class SqliteWorkingMemory implements IWorkingMemory {
   constructor(
     private db: Database.Database,
     private limits: WorkingMemoryLimits = DEFAULT_WORKING_MEMORY_LIMITS,
-  ) {}
+  ) {
+    this.loadFromDb();
+  }
+
+  /** Hydrate in-memory state from persisted SQLite working_memory rows. */
+  private loadFromDb(): void {
+    const rows = this.db
+      .prepare(`SELECT key, value FROM working_memory ORDER BY key ASC`)
+      .all() as Array<{ key: string; value: string }>;
+    const snap: Record<string, unknown> = {};
+
+    for (const row of rows) {
+      snap[row.key] = JSON.parse(row.value) as unknown;
+    }
+
+    this.restore(snap);
+  }
 
   /** Flush in-memory Map to SQLite working_memory table (called on checkpoint). */
   flushToDb(): void {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -412,6 +412,7 @@ export class SqliteBrain implements IBrain {
   ): SqliteBrain {
     const brain = new SqliteBrain(dbPath, workingMemoryLimits, { hydrateWorkingMemoryFromDb: false });
     brain.working.restore(snapshot.working);
+    brain.flush();
     for (const event of snapshot.episodic) {
       brain.episodic.record(event);
     }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -42,8 +42,11 @@ class SqliteWorkingMemory implements IWorkingMemory {
   constructor(
     private db: Database.Database,
     private limits: WorkingMemoryLimits = DEFAULT_WORKING_MEMORY_LIMITS,
+    hydrateFromDb = true,
   ) {
-    this.loadFromDb();
+    if (hydrateFromDb) {
+      this.loadFromDb();
+    }
   }
 
   /** Hydrate in-memory state from persisted SQLite working_memory rows. */
@@ -54,7 +57,12 @@ class SqliteWorkingMemory implements IWorkingMemory {
     const snap: Record<string, unknown> = {};
 
     for (const row of rows) {
-      snap[row.key] = JSON.parse(row.value) as unknown;
+      Object.defineProperty(snap, row.key, {
+        value: parseStoredWorkingMemoryValue(row.value),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
     }
 
     this.restore(snap);
@@ -145,7 +153,12 @@ class SqliteWorkingMemory implements IWorkingMemory {
   snapshot(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const [key, value] of this.store) {
-      result[key] = value;
+      Object.defineProperty(result, key, {
+        value,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
     }
     return result;
   }
@@ -330,7 +343,11 @@ export class SqliteBrain implements IBrain {
 
   private db: Database.Database;
 
-  constructor(dbPath: string = ':memory:', workingMemoryLimits?: Partial<WorkingMemoryLimits>) {
+  constructor(
+    dbPath: string = ':memory:',
+    workingMemoryLimits?: Partial<WorkingMemoryLimits>,
+    options: { hydrateWorkingMemoryFromDb?: boolean } = {},
+  ) {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');
@@ -338,7 +355,7 @@ export class SqliteBrain implements IBrain {
     this.working = new SqliteWorkingMemory(this.db, {
       ...DEFAULT_WORKING_MEMORY_LIMITS,
       ...workingMemoryLimits,
-    });
+    }, options.hydrateWorkingMemoryFromDb ?? true);
     this.episodic = new SqliteEpisodicMemory(this.db);
     this.recovery = new SqliteRecoveryMemory(this.db, () => this.working.flushToDb());
   }
@@ -393,7 +410,7 @@ export class SqliteBrain implements IBrain {
     dbPath: string = ':memory:',
     workingMemoryLimits?: Partial<WorkingMemoryLimits>,
   ): SqliteBrain {
-    const brain = new SqliteBrain(dbPath, workingMemoryLimits);
+    const brain = new SqliteBrain(dbPath, workingMemoryLimits, { hydrateWorkingMemoryFromDb: false });
     brain.working.restore(snapshot.working);
     for (const event of snapshot.episodic) {
       brain.episodic.record(event);
@@ -425,6 +442,14 @@ const STOPWORDS = new Set([
 
 function escapeLike(s: string): string {
   return s.replace(/[%_\\]/g, '\\$&');
+}
+
+function parseStoredWorkingMemoryValue(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
 }
 
 function rowToEvent(row: EpisodicRow): EpisodicEvent {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -463,6 +463,73 @@ describe('SqliteBrain', () => {
       }
     });
 
+    it('hydrates legacy plain-text working memory values', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const first = new SqliteBrain(dbPath);
+        (first as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } } })
+          .db.prepare('INSERT INTO working_memory (key, value, updated_at) VALUES (?, ?, ?)')
+          .run('legacy', 'plain text value', '2026-07-04T00:00:00Z');
+        first.close();
+
+        const reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.get('legacy')).toBe('plain text value');
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves special keys such as __proto__ when hydrating from SQLite', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const first = new SqliteBrain(dbPath);
+        first.working.set('__proto__', 'safe value');
+        first.flush();
+        first.close();
+
+        const reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.has('__proto__')).toBe(true);
+        expect(reopened.working.get('__proto__')).toBe('safe value');
+        expect(Object.entries(reopened.working.snapshot())).toEqual([['__proto__', 'safe value']]);
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('skips existing SQLite working memory when hydrating from a snapshot', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const stale = new SqliteBrain(dbPath);
+        stale.working.set('old-a', 1);
+        stale.working.set('old-b', 2);
+        stale.flush();
+        stale.close();
+
+        const snapshot: BrainSnapshot = {
+          version: 1,
+          timestamp: '2026-07-04T00:00:00Z',
+          working: { fresh: 'snapshot' },
+          episodic: [],
+          checkpoint: null,
+          metadata: { lastProvider: '', switchReason: '', totalTokensUsed: 0 },
+        };
+
+        const hydrated = SqliteBrain.hydrate(snapshot, dbPath, { maxEntries: 1 });
+        expect(hydrated.working.snapshot()).toEqual({ fresh: 'snapshot' });
+        hydrated.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('defaults to in-memory database', () => {
       const memBrain = new SqliteBrain();
       memBrain.working.set('test', true);

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -525,6 +525,10 @@ describe('SqliteBrain', () => {
         const hydrated = SqliteBrain.hydrate(snapshot, dbPath, { maxEntries: 1 });
         expect(hydrated.working.snapshot()).toEqual({ fresh: 'snapshot' });
         hydrated.close();
+
+        const reopened = new SqliteBrain(dbPath, { maxEntries: 1 });
+        expect(reopened.working.snapshot()).toEqual({ fresh: 'snapshot' });
+        reopened.close();
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BrainSnapshotSchema } from '@franken/types';
 import type { EpisodicEvent, ExecutionState, BrainSnapshot } from '@franken/types';
@@ -437,6 +440,27 @@ describe('SqliteBrain', () => {
       tmpBrain.working.set('test', 'value');
       expect(tmpBrain.working.get('test')).toBe('value');
       tmpBrain.close();
+    });
+
+    it('hydrates persisted working memory from an existing SQLite file', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const first = new SqliteBrain(dbPath);
+        first.working.set('adrs', ['ADR-001']);
+        first.working.set('rules', { review: 'required' });
+        first.flush();
+        first.close();
+
+        const reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.get('adrs')).toEqual(['ADR-001']);
+        expect(reopened.working.get('rules')).toEqual({ review: 'required' });
+        expect(reopened.working.usage().entries).toBe(2);
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('defaults to in-memory database', () => {


### PR DESCRIPTION
## Summary
- hydrate `SqliteWorkingMemory` from persisted `working_memory` rows when `SqliteBrain` opens an existing SQLite file
- add a regression test covering reopen-same-db working memory persistence

## Test Plan
- npm run build --workspace packages/franken-types
- npm test --workspace packages/franken-brain -- --run tests/unit/sqlite-brain.test.ts -t "hydrates persisted working memory"
- npm test --workspace packages/franken-brain -- --run tests/unit/sqlite-brain.test.ts
- npm run typecheck --workspace packages/franken-brain
- npm run build --workspace packages/franken-brain
- git diff --check

Closes #367