### PR TITLE
fix(web): fall back to REST for approvals

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -119,14 +119,14 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { approved } = validateBody(ApproveBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
-    if (!session.pendingApproval) {
+    if (!session.pendingApproval && session.state !== 'pending_approval') {
       return c.json({ data: { id: session.id, approved, state: session.state } });
     }
 
     if (approved) {
       const result = await runtime.run('/approve', {
         sessionId: session.id,
-        pendingApproval: Boolean(session.pendingApproval),
+        pendingApproval: Boolean(session.pendingApproval) || session.state === 'pending_approval',
         projectId: session.projectId,
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -119,7 +119,26 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { approved } = validateBody(ApproveBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
-    session.state = approved ? 'approved' : 'rejected';
+    if (!session.pendingApproval) {
+      return c.json({ data: { id: session.id, approved, state: session.state } });
+    }
+
+    if (approved) {
+      const result = await runtime.run('/approve', {
+        sessionId: session.id,
+        pendingApproval: Boolean(session.pendingApproval),
+        projectId: session.projectId,
+        transcript: session.transcript,
+        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+      });
+
+      session.state = result.state === 'active' ? 'approved' : result.state;
+      session.pendingApproval = null;
+      session.beastContext = result.beastContext ?? null;
+    } else {
+      session.state = 'rejected';
+      session.pendingApproval = null;
+    }
     session.updatedAt = new Date().toISOString();
     sessionStore.save(session);
 

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -446,6 +446,61 @@ describe('Chat HTTP Routes', () => {
     expect(sessionBody.data.pendingApproval).toBeNull();
   });
 
+  it('POST /v1/chat/sessions/:id/approve handles state-only pending approvals', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-state-only-pending',
+      projectId: 'proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: null,
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'approval' as const, content: 'Approved.' }],
+        events: [],
+        pendingApproval: false,
+        state: 'approved',
+        tier: null,
+        transcript: [],
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: 'test-secret-for-http-routes',
+    });
+
+    const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.state).toBe('approved');
+    expect(runtime.run).toHaveBeenCalledWith('/approve', expect.objectContaining({
+      pendingApproval: true,
+    }));
+    expect(session.state).toBe('approved');
+    expect(session.pendingApproval).toBeNull();
+  });
+
   it('POST /v1/chat/sessions/:id/approve does not downgrade approved sessions when runtime reports active', async () => {
     const now = new Date().toISOString();
     const session: ChatSession = {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { createChatApp } from '../../../src/http/chat-app.js';
 import { verifySessionToken } from '../../../src/http/ws-chat-auth.js';
+import type { ChatSession } from '../../../src/chat/types.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
 import { BeastCatalogService } from '../../../src/beasts/services/beast-catalog-service.js';
@@ -405,6 +406,126 @@ describe('Chat HTTP Routes', () => {
     const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
     const sessionBody = await sessionRes.json();
     expect(sessionBody.data.state).toBe('approved');
+    expect(sessionBody.data.pendingApproval).toBeNull();
+  });
+
+  it('POST /v1/chat/sessions/:id/approve is idempotent when no approval is pending', async () => {
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+
+    const submitRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'run deployment' }),
+    });
+    expect(submitRes.status).toBe(200);
+
+    const approveRes = await app.request(`/v1/chat/sessions/${created.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    expect(approveRes.status).toBe(200);
+    expect((await approveRes.json()).data.state).toBe('approved');
+
+    const retryRes = await app.request(`/v1/chat/sessions/${created.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    expect(retryRes.status).toBe(200);
+    expect((await retryRes.json()).data.state).toBe('approved');
+
+    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
+    const sessionBody = await sessionRes.json();
+    expect(sessionBody.data.state).toBe('approved');
+    expect(sessionBody.data.pendingApproval).toBeNull();
+  });
+
+  it('POST /v1/chat/sessions/:id/approve does not downgrade approved sessions when runtime reports active', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-active-result',
+      projectId: 'proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: { description: 'Deploy?', requestedAt: now },
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'status' as const, content: 'Nothing pending.' }],
+        events: [],
+        pendingApproval: false,
+        state: 'active',
+        tier: null,
+        transcript: [],
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: 'test-secret-for-http-routes',
+    });
+
+    const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.state).toBe('approved');
+    expect(session.state).toBe('approved');
+    expect(session.pendingApproval).toBeNull();
+  });
+
+  it('POST /v1/chat/sessions/:id/approve clears pending approval when rejected', async () => {
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+
+    const submitRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'run deployment' }),
+    });
+    expect(submitRes.status).toBe(200);
+
+    const res = await app.request(`/v1/chat/sessions/${created.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: false }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.state).toBe('rejected');
+
+    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
+    const sessionBody = await sessionRes.json();
+    expect(sessionBody.data.state).toBe('rejected');
+    expect(sessionBody.data.pendingApproval).toBeNull();
   });
 
   it('POST /v1/chat/sessions/:id/approve returns 404 for unknown session', async () => {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -176,10 +176,10 @@ function applySessionSnapshot(session: ChatSession): ChatMessage[] {
 function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): ChatMessage[] {
   const snapshot = applySessionSnapshot(session);
   const snapshotById = new Map(snapshot.map((message) => [message.id, message]));
-  const snapshotEquivalentCounts = new Map<string, number>();
+  const snapshotEquivalentMessages = new Map<string, ChatMessage[]>();
   for (const message of snapshot) {
     const key = `${message.role}\u0000${message.content}`;
-    snapshotEquivalentCounts.set(key, (snapshotEquivalentCounts.get(key) ?? 0) + 1);
+    snapshotEquivalentMessages.set(key, [...(snapshotEquivalentMessages.get(key) ?? []), message]);
   }
   const seen = new Set<string>();
   const merged = current.flatMap((message) => {
@@ -190,10 +190,11 @@ function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): Cha
     }
 
     const key = `${message.role}\u0000${message.content}`;
-    const equivalentCount = snapshotEquivalentCounts.get(key) ?? 0;
-    if (equivalentCount > 0) {
-      snapshotEquivalentCounts.set(key, equivalentCount - 1);
-      return [];
+    const equivalentMessages = snapshotEquivalentMessages.get(key) ?? [];
+    const equivalentMessage = equivalentMessages.shift();
+    if (equivalentMessage) {
+      seen.add(equivalentMessage.id);
+      return [equivalentMessage];
     }
 
     return [message];
@@ -468,6 +469,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         readyRef.current = true;
         setMessages((current) => mergeSessionSnapshot(current, refreshed));
         setPendingApproval(refreshed.pendingApproval ?? null);
+        setActivity((current) => [
+          ...current,
+          {
+            type: 'turn.approval.resolved',
+            data: { approved },
+            timestamp: new Date().toISOString(),
+          },
+        ]);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);
         setStatus('idle');

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -176,10 +176,27 @@ function applySessionSnapshot(session: ChatSession): ChatMessage[] {
 function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): ChatMessage[] {
   const snapshot = applySessionSnapshot(session);
   const snapshotById = new Map(snapshot.map((message) => [message.id, message]));
+  const snapshotEquivalentCounts = new Map<string, number>();
+  for (const message of snapshot) {
+    const key = `${message.role}\u0000${message.content}`;
+    snapshotEquivalentCounts.set(key, (snapshotEquivalentCounts.get(key) ?? 0) + 1);
+  }
   const seen = new Set<string>();
-  const merged = current.map((message) => {
-    seen.add(message.id);
-    return snapshotById.get(message.id) ?? message;
+  const merged = current.flatMap((message) => {
+    const snapshotMessage = snapshotById.get(message.id);
+    if (snapshotMessage) {
+      seen.add(message.id);
+      return [snapshotMessage];
+    }
+
+    const key = `${message.role}\u0000${message.content}`;
+    const equivalentCount = snapshotEquivalentCounts.get(key) ?? 0;
+    if (equivalentCount > 0) {
+      snapshotEquivalentCounts.set(key, equivalentCount - 1);
+      return [];
+    }
+
+    return [message];
   });
 
   return [

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -173,6 +173,21 @@ function applySessionSnapshot(session: ChatSession): ChatMessage[] {
   return normalizeTranscript(session.transcript);
 }
 
+function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): ChatMessage[] {
+  const snapshot = applySessionSnapshot(session);
+  const snapshotById = new Map(snapshot.map((message) => [message.id, message]));
+  const seen = new Set<string>();
+  const merged = current.map((message) => {
+    seen.add(message.id);
+    return snapshotById.get(message.id) ?? message;
+  });
+
+  return [
+    ...merged,
+    ...snapshot.filter((message) => !seen.has(message.id)),
+  ];
+}
+
 export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResult {
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting');
@@ -433,7 +448,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       try {
         await clientRef.current.approve(sessionId, approved);
         const refreshed = await clientRef.current.getSession(sessionId);
-        setMessages(applySessionSnapshot(refreshed));
+        readyRef.current = true;
+        setMessages((current) => mergeSessionSnapshot(current, refreshed));
         setPendingApproval(refreshed.pendingApproval ?? null);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -424,11 +424,26 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
   async function approve(approved: boolean): Promise<void> {
     const socket = socketRef.current;
-    if (!socket || socket.readyState !== 1) {
+    if (!sessionId) {
       return;
     }
 
     setStatus('sending');
+    if (!socket || socket.readyState !== 1) {
+      try {
+        await clientRef.current.approve(sessionId, approved);
+        const refreshed = await clientRef.current.getSession(sessionId);
+        setMessages(applySessionSnapshot(refreshed));
+        setPendingApproval(refreshed.pendingApproval ?? null);
+        setTokenTotals(refreshed.tokenTotals);
+        setCostUsd(refreshed.costUsd);
+        setStatus('idle');
+      } catch {
+        setStatus('error');
+      }
+      return;
+    }
+
     socket.send(JSON.stringify({
       type: 'approval.respond',
       approved,

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -297,6 +297,104 @@ describe('useChatSession', () => {
     expect(result.current.status).toBe('idle');
   });
 
+  it('preserves streamed messages after HTTP approval fallback', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+
+    act(() => {
+      socket.message({
+        type: 'assistant.message.delta',
+        messageId: 'assistant-streamed',
+        chunk: 'Ready to deploy',
+        modelTier: 'cheap',
+      });
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+    });
+
+    mockGetSession.mockResolvedValueOnce({
+      id: 'chat-1',
+      projectId: 'test-proj',
+      transcript: [],
+      state: 'approved',
+      pendingApproval: null,
+      socketToken: 'signed-token',
+      tokenTotals: { cheap: 1, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0.01,
+      createdAt: '2026-03-09T00:00:00Z',
+      updatedAt: '2026-03-09T00:00:07Z',
+    });
+
+    await act(async () => {
+      await result.current.approve(true);
+    });
+
+    expect(result.current.messages).toContainEqual(expect.objectContaining({
+      id: 'assistant-streamed',
+      content: 'Ready to deploy',
+    }));
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
+  it('ignores stale session.ready after HTTP approval fallback', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+
+    act(() => {
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+    });
+
+    mockGetSession.mockResolvedValueOnce({
+      id: 'chat-1',
+      projectId: 'test-proj',
+      transcript: [],
+      state: 'approved',
+      pendingApproval: null,
+      socketToken: 'signed-token',
+      tokenTotals: { cheap: 1, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0.01,
+      createdAt: '2026-03-09T00:00:00Z',
+      updatedAt: '2026-03-09T00:00:07Z',
+    });
+
+    await act(async () => {
+      await result.current.approve(true);
+    });
+
+    act(() => {
+      socket.message({
+        type: 'session.ready',
+        sessionId: 'chat-1',
+        projectId: 'test-proj',
+        transcript: [],
+        state: 'active',
+        pendingApproval: {
+          description: 'Deploy the generated fix',
+          requestedAt: '2026-03-09T00:00:06Z',
+        },
+      });
+    });
+
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
   it('resumes an existing session and reconnects when the socket closes', async () => {
     mockGetSession.mockResolvedValue({
       id: 'existing-sess',

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -5,6 +5,7 @@ import { useChatSession } from '../../src/hooks/use-chat-session';
 const mockCreateSession = vi.fn();
 const mockGetSession = vi.fn();
 const mockSendMessage = vi.fn();
+const mockApprove = vi.fn();
 const mockSocketUrl = vi.fn();
 
 vi.mock('../../src/lib/api', () => ({
@@ -12,11 +13,13 @@ vi.mock('../../src/lib/api', () => ({
     createSession: typeof mockCreateSession;
     getSession: typeof mockGetSession;
     sendMessage: typeof mockSendMessage;
+    approve: typeof mockApprove;
     socketUrl: typeof mockSocketUrl;
   }) {
     this.createSession = mockCreateSession;
     this.getSession = mockGetSession;
     this.sendMessage = mockSendMessage;
+    this.approve = mockApprove;
     this.socketUrl = mockSocketUrl;
   }),
 }));
@@ -100,6 +103,11 @@ describe('useChatSession', () => {
     mockSendMessage.mockResolvedValue({
       outcome: { kind: 'reply', content: 'Fallback reply', modelTier: 'cheap' },
       tier: 'cheap',
+      state: 'active',
+    });
+    mockApprove.mockResolvedValue({
+      id: 'chat-1',
+      approved: true,
       state: 'active',
     });
     mockSocketUrl.mockReturnValue('ws://localhost:3000/v1/chat/ws?sessionId=chat-1&token=signed-token');
@@ -257,6 +265,36 @@ describe('useChatSession', () => {
       type: 'approval.respond',
       approved: true,
     });
+  });
+
+  it('falls back to HTTP approval when the websocket is not ready', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+
+    act(() => {
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+    });
+
+    expect(result.current.pendingApproval?.description).toBe('Deploy the generated fix');
+
+    await act(async () => {
+      await result.current.approve(false);
+    });
+
+    expect(mockApprove).toHaveBeenCalledWith('chat-1', false);
+    expect(mockGetSession).toHaveBeenCalledWith('chat-1');
+    expect(socket.sent).toHaveLength(0);
+    expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.status).toBe('idle');
   });
 
   it('resumes an existing session and reconnects when the socket closes', async () => {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -347,6 +347,78 @@ describe('useChatSession', () => {
     }));
     expect(result.current.messages.filter((message) => message.content === 'Ready to deploy')).toHaveLength(1);
     expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.activity).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.resolved',
+      data: { approved: true },
+    }));
+  });
+
+  it('replaces equivalent REST snapshot messages in place', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+      socket.message({
+        type: 'session.ready',
+        sessionId: 'chat-1',
+        projectId: 'test-proj',
+        transcript: [],
+        state: 'active',
+        pendingApproval: null,
+      });
+    });
+
+    await act(async () => {
+      await result.current.send('Deploy the generated fix');
+    });
+
+    act(() => {
+      socket.message({
+        type: 'assistant.message.delta',
+        messageId: 'approval-prompt',
+        chunk: 'Approve deployment?',
+        modelTier: 'cheap',
+      });
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+      socket.shutdown();
+    });
+
+    mockGetSession.mockResolvedValueOnce({
+      id: 'chat-1',
+      projectId: 'test-proj',
+      transcript: [{
+        id: 'server-user',
+        role: 'user',
+        content: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:07Z',
+      }],
+      state: 'approved',
+      pendingApproval: null,
+      socketToken: 'signed-token',
+      tokenTotals: { cheap: 1, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0.01,
+      createdAt: '2026-03-09T00:00:00Z',
+      updatedAt: '2026-03-09T00:00:07Z',
+    });
+
+    await act(async () => {
+      await result.current.approve(true);
+    });
+
+    expect(result.current.messages.map((message) => message.content)).toEqual([
+      'Deploy the generated fix',
+      'Approve deployment?',
+    ]);
+    expect(result.current.messages[0]?.id).toBe('server-user');
   });
 
   it('ignores stale session.ready after HTTP approval fallback', async () => {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -323,7 +323,12 @@ describe('useChatSession', () => {
     mockGetSession.mockResolvedValueOnce({
       id: 'chat-1',
       projectId: 'test-proj',
-      transcript: [],
+      transcript: [{
+        id: 'server-assistant',
+        role: 'assistant',
+        content: 'Ready to deploy',
+        timestamp: '2026-03-09T00:00:07Z',
+      }],
       state: 'approved',
       pendingApproval: null,
       socketToken: 'signed-token',
@@ -338,9 +343,9 @@ describe('useChatSession', () => {
     });
 
     expect(result.current.messages).toContainEqual(expect.objectContaining({
-      id: 'assistant-streamed',
       content: 'Ready to deploy',
     }));
+    expect(result.current.messages.filter((message) => message.content === 'Ready to deploy')).toHaveLength(1);
     expect(result.current.pendingApproval).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- fall back to the REST approval endpoint when the chat WebSocket is not open
- refresh the chat session snapshot after REST approval completion
- add hook coverage for approval fallback behavior

## Test Plan
- npm test --workspace packages/franken-web -- tests/hooks/use-chat-session.test.ts
- npm run typecheck --workspace packages/franken-web

Closes #357