### PR TITLE
fix(planner): preserve governance rejection in parallel strategy

### DIFF
--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -30,7 +30,7 @@ export class ParallelPlanner implements PlanningStrategy {
       // Run all ready tasks concurrently; convert ordinary task exceptions into
       // failures, but let governance rejections propagate to the Planner so they
       // retain first-class non-retryable semantics across strategies.
-      const waveResults = await Promise.all(
+      const settledWaveResults = await Promise.allSettled(
         ready.map((task) =>
           context.executor(task).catch((err: unknown) => {
             if (err instanceof RationaleRejectedError) {
@@ -45,6 +45,25 @@ export class ParallelPlanner implements PlanningStrategy {
           })
         )
       );
+
+      const rejectedRationale = settledWaveResults.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected' && result.reason instanceof RationaleRejectedError
+      );
+      if (rejectedRationale) {
+        throw rejectedRationale.reason;
+      }
+
+      const waveResults = settledWaveResults.map((result) => {
+        if (result.status === 'fulfilled') {
+          return result.value;
+        }
+
+        // The executor wrapper above converts ordinary exceptions into task
+        // failures, so any remaining rejection is unexpected and should keep
+        // the strategy contract honest instead of fabricating a task id.
+        throw result.reason;
+      });
 
       allResults.push(...waveResults);
 

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -1,3 +1,4 @@
+import { RationaleRejectedError } from '../core/errors.js';
 import type { PlanResult, TaskId, TaskResult } from '../core/types.js';
 import type { PlanGraph } from '../core/dag.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
@@ -26,14 +27,22 @@ export class ParallelPlanner implements PlanningStrategy {
 
       if (ready.length === 0) break; // no progress — cycle guard (should not happen in a valid DAG)
 
-      // Run all ready tasks concurrently; wrap executor so Promise.all never rejects
+      // Run all ready tasks concurrently; convert ordinary task exceptions into
+      // failures, but let governance rejections propagate to the Planner so they
+      // retain first-class non-retryable semantics across strategies.
       const waveResults = await Promise.all(
         ready.map((task) =>
-          context.executor(task).catch((err: unknown) => ({
-            status: 'failure' as const,
-            taskId: task.id,
-            error: err instanceof Error ? err : new Error(String(err)),
-          }))
+          context.executor(task).catch((err: unknown) => {
+            if (err instanceof RationaleRejectedError) {
+              throw err;
+            }
+
+            return {
+              status: 'failure' as const,
+              taskId: task.id,
+              error: err instanceof Error ? err : new Error(String(err)),
+            };
+          })
         )
       );
 

--- a/packages/franken-planner/tests/integration/planner-parallel.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-parallel.integration.test.ts
@@ -10,6 +10,7 @@ import { PlanGraph } from '../../src/core/dag';
 import { createTaskId } from '../../src/core/types';
 import type { Task, TaskResult } from '../../src/core/types';
 import type { GuardrailsModule } from '../../src/modules/mod01';
+import type { SelfCritiqueModule } from '../../src/modules/mod07';
 import type { GraphBuilder, TaskExecutor } from '../../src/planners/types';
 import type { MemoryModule } from '../../src/modules/mod03';
 
@@ -35,7 +36,11 @@ function stubMemory(): MemoryModule {
   };
 }
 
-function buildParallelPlanner(graph: PlanGraph, executor: TaskExecutor): Planner {
+function buildParallelPlanner(
+  graph: PlanGraph,
+  executor: TaskExecutor,
+  selfCritique?: SelfCritiqueModule
+): Planner {
   const recovery = new RecoveryController(stubMemory());
   return new Planner(
     stubGuardrails(),
@@ -43,7 +48,8 @@ function buildParallelPlanner(graph: PlanGraph, executor: TaskExecutor): Planner
     executor,
     new StubHITLGate(),
     new ParallelPlanner(),
-    recovery
+    recovery,
+    selfCritique
   );
 }
 
@@ -128,6 +134,24 @@ describe('Integration — ParallelPlanner', () => {
     const result = await buildParallelPlanner(graph, executor).plan('...');
 
     expect(result.status).toBe('failed');
+  });
+
+  it('returns rationale_rejected when CoT rejects a task rationale', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'));
+    const executor = vi.fn().mockImplementation((t: Task) => Promise.resolve(ok(t.id)));
+    const selfCritique: SelfCritiqueModule = {
+      verifyRationale: vi.fn()
+        .mockResolvedValueOnce({ verdict: 'approved' })
+        .mockResolvedValueOnce({ verdict: 'rejected', reason: 'unsafe rationale' }),
+    };
+
+    const result = await buildParallelPlanner(graph, executor, selfCritique).plan('...');
+
+    expect(result.status).toBe('rationale_rejected');
+    if (result.status !== 'rationale_rejected') throw new Error('unexpected');
+    expect(result.taskId).toBe(createTaskId('b'));
   });
 
   it('collects results from all tasks in a completed plan', async () => {

--- a/packages/franken-planner/tests/integration/planner-parallel.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-parallel.integration.test.ts
@@ -140,11 +140,25 @@ describe('Integration — ParallelPlanner', () => {
     const graph = PlanGraph.empty()
       .addTask(makeTask('a'))
       .addTask(makeTask('b'));
-    const executor = vi.fn().mockImplementation((t: Task) => Promise.resolve(ok(t.id)));
+    let approvedSiblingCompleted = false;
+    const executor = vi.fn().mockImplementation((t: Task) => {
+      if (t.id === createTaskId('a')) {
+        return new Promise<TaskResult>((resolve) => {
+          setTimeout(() => {
+            approvedSiblingCompleted = true;
+            resolve(ok(t.id));
+          }, 10);
+        });
+      }
+      return Promise.resolve(ok(t.id));
+    });
     const selfCritique: SelfCritiqueModule = {
-      verifyRationale: vi.fn()
-        .mockResolvedValueOnce({ verdict: 'approved' })
-        .mockResolvedValueOnce({ verdict: 'rejected', reason: 'unsafe rationale' }),
+      verifyRationale: vi.fn().mockImplementation((rationale) => {
+        if (rationale.taskId === createTaskId('b')) {
+          return Promise.resolve({ verdict: 'rejected', reason: 'unsafe rationale' });
+        }
+        return Promise.resolve({ verdict: 'approved' });
+      }),
     };
 
     const result = await buildParallelPlanner(graph, executor, selfCritique).plan('...');
@@ -152,6 +166,7 @@ describe('Integration — ParallelPlanner', () => {
     expect(result.status).toBe('rationale_rejected');
     if (result.status !== 'rationale_rejected') throw new Error('unexpected');
     expect(result.taskId).toBe(createTaskId('b'));
+    expect(approvedSiblingCompleted).toBe(true);
   });
 
   it('collects results from all tasks in a completed plan', async () => {


### PR DESCRIPTION
## Summary
- Lets `RationaleRejectedError` propagate through `ParallelPlanner` instead of being converted into an ordinary task failure
- Adds a parallel planner integration test covering CoT rejection semantics

## Test Plan
- `npm run test --workspace packages/franken-planner -- planner-parallel.integration.test.ts`
- `npm run typecheck --workspace packages/franken-planner`
- `npm run build --workspace packages/franken-planner`

Closes #365