### PR TITLE
fix(orchestrator): finalize issue-mode sessions

### DIFF
--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -122,75 +122,77 @@ export class Session {
       dryRun,
     });
 
-    if (!issueDeps) {
-      throw new Error('Issue dependencies not created');
-    }
-
-    const { fetcher, triage, review, graphBuilder, runner, executor, git, prCreator, checkpoint, issueRuntime } = issueDeps;
-
-    // Resolve canonical repo for the entire issues pipeline.
-    let repo: string;
-    if (this.config.targetUpstream) {
-      repo = await resolveUpstreamRepo();
-    } else if (this.config.issueRepo) {
-      repo = this.config.issueRepo;
-    } else {
-      try {
-        repo = await fetcher.inferRepo();
-      } catch {
-        throw new Error('Could not infer repository. Use --repo <owner/repo> to specify.');
+    try {
+      if (!issueDeps) {
+        throw new Error('Issue dependencies not created');
       }
-    }
 
-    // Build fetch options from CLI args
-    const fetchOptions: IssueFetchOptions = {
-      repo,
-      label: this.config.issueLabel,
-      milestone: this.config.issueMilestone,
-      search: this.config.issueSearch,
-      assignee: this.config.issueAssignee,
-      limit: this.config.issueLimit,
-    };
+      const { fetcher, triage, review, graphBuilder, runner, git, checkpoint, issueRuntime } = issueDeps;
 
-    // Fetch
-    logger.info('Fetching issues...', 'issues');
-    const issues = await fetcher.fetch(fetchOptions);
-    logger.info(`Found ${issues.length} issue(s)`, 'issues');
+      // Resolve canonical repo for the entire issues pipeline.
+      let repo: string;
+      if (this.config.targetUpstream) {
+        repo = await resolveUpstreamRepo();
+      } else if (this.config.issueRepo) {
+        repo = this.config.issueRepo;
+      } else {
+        try {
+          repo = await fetcher.inferRepo();
+        } catch {
+          throw new Error('Could not infer repository. Use --repo <owner/repo> to specify.');
+        }
+      }
 
-    // Triage
-    logger.info('Triaging issues...', 'issues');
-    const triageResults = await triage.triage(issues);
+      // Build fetch options from CLI args
+      const fetchOptions: IssueFetchOptions = {
+        repo,
+        label: this.config.issueLabel,
+        milestone: this.config.issueMilestone,
+        search: this.config.issueSearch,
+        assignee: this.config.issueAssignee,
+        limit: this.config.issueLimit,
+      };
 
-    // Review (HITL)
-    const decision = await review.review(issues, triageResults);
+      // Fetch
+      logger.info('Fetching issues...', 'issues');
+      const issues = await fetcher.fetch(fetchOptions);
+      logger.info(`Found ${issues.length} issue(s)`, 'issues');
 
-    if (decision.action === 'abort') {
-      logger.info('Issue processing aborted by user', 'issues');
+      // Triage
+      logger.info('Triaging issues...', 'issues');
+      const triageResults = await triage.triage(issues);
+
+      // Review (HITL)
+      const decision = await review.review(issues, triageResults);
+
+      if (decision.action === 'abort') {
+        logger.info('Issue processing aborted by user', 'issues');
+        return;
+      }
+
+      // Execute approved issues
+      logger.info('Executing approved issues...', 'issues');
+
+      const approvedNumbers = new Set(decision.approved.map(t => t.issueNumber));
+      const approvedIssues = issues.filter(i => approvedNumbers.has(i.number));
+
+      const outcomes = await runner.run({
+        issues: approvedIssues,
+        triageResults: decision.approved,
+        graphBuilder,
+        fullDeps: deps,
+        git,
+        logger,
+        budget,
+        repo,
+        issueRuntime,
+        checkpoint,
+      });
+
+      this.displayIssueSummary(outcomes);
+    } finally {
       await finalize();
-      return;
     }
-
-    // Execute approved issues
-    logger.info('Executing approved issues...', 'issues');
-
-    const approvedNumbers = new Set(decision.approved.map(t => t.issueNumber));
-    const approvedIssues = issues.filter(i => approvedNumbers.has(i.number));
-
-    const outcomes = await runner.run({
-      issues: approvedIssues,
-      triageResults: decision.approved,
-      graphBuilder,
-      fullDeps: deps,
-      git,
-      logger,
-      budget,
-      repo,
-      issueRuntime,
-      checkpoint,
-    });
-
-    this.displayIssueSummary(outcomes);
-    await finalize();
   }
 
   private async runInterview(): Promise<'continue' | 'exit'> {

--- a/packages/franken-orchestrator/tests/unit/cli/session-issues.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-issues.test.ts
@@ -324,6 +324,28 @@ describe('Session.runIssues()', () => {
     expect(mockFinalize).toHaveBeenCalled();
   });
 
+  it('finalizes issue-mode dependencies when fetching issues throws', async () => {
+    const { Session } = await import('../../../src/cli/session.js');
+    mockFetcher.fetch.mockRejectedValueOnce(new Error('fetch failed'));
+    const config = makeConfig();
+    const session = new Session(config);
+
+    await expect(session.runIssues()).rejects.toThrow('fetch failed');
+
+    expect(mockFinalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('finalizes issue-mode dependencies when execution throws', async () => {
+    const { Session } = await import('../../../src/cli/session.js');
+    mockRunnerInstance.run.mockRejectedValueOnce(new Error('runner failed'));
+    const config = makeConfig();
+    const session = new Session(config);
+
+    await expect(session.runIssues()).rejects.toThrow('runner failed');
+
+    expect(mockFinalize).toHaveBeenCalledTimes(1);
+  });
+
   it('constructs fetch options from CLI args', async () => {
     const { Session } = await import('../../../src/cli/session.js');
     const config = makeConfig({


### PR DESCRIPTION
## Summary
- wrap issue-mode execution after dependency creation in a guaranteed finalize envelope
- keep abort handling as a normal return while allowing exceptions to propagate after cleanup
- add regression coverage for fetch and runner failures invoking finalize

## Test Plan
- npm run build -- --filter=@franken/types --filter=@frankenbeast/observer --filter=@franken/critique --filter=@franken/governor --filter=franken-brain
- npm --workspace packages/franken-orchestrator run test -- tests/unit/cli/session-issues.test.ts
- npm --workspace packages/franken-orchestrator run typecheck
- npm --workspace packages/franken-orchestrator run build

Closes #366