### PR TITLE
fix(orchestrator): rehydrate checkpointed dependency outputs

### DIFF
--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -13,6 +13,7 @@ import {
 } from 'node:fs';
 import { createHash, randomBytes } from 'node:crypto';
 import { dirname, join } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import { deserialize, serialize } from 'node:v8';
 import type { ICheckpointStore } from '../deps.js';
 
@@ -123,6 +124,10 @@ export class FileCheckpointStore implements ICheckpointStore {
   }
 
   clear(): void {
+    if (!existsSync(this.checkpointPath) && !existsSync(this.taskOutputDir)) {
+      return;
+    }
+    mkdirSync(dirname(this.checkpointPath), { recursive: true });
     this.withLock(() => {
       if (existsSync(this.checkpointPath)) {
         this.atomicReplace([]);
@@ -135,11 +140,17 @@ export class FileCheckpointStore implements ICheckpointStore {
     const outputPath = this.taskOutputPath(taskId);
     let payload: string;
     try {
-      payload = serialize(output).toString('base64');
+      const serialized = serialize(output);
+      const rehydrated = deserialize(serialized);
+      if (!isDeepStrictEqual(rehydrated, output)) {
+        this.deleteTaskOutput(outputPath);
+        return;
+      }
+      payload = serialized.toString('base64');
     } catch {
       // Checkpoint markers must never fail a successful task just because its
-      // output cannot be cloned. Persist what can be rehydrated and fall back
-      // to marker-only recovery for non-serializable values.
+      // output cannot be cloned or faithfully rehydrated. Persist what can be
+      // safely rehydrated and fall back to marker-only recovery otherwise.
       this.deleteTaskOutput(outputPath);
       return;
     }
@@ -159,7 +170,11 @@ export class FileCheckpointStore implements ICheckpointStore {
       }
       throw error;
     }
-    return { found: true, output: deserialize(Buffer.from(payload, 'base64')) };
+    try {
+      return { found: true, output: deserialize(Buffer.from(payload, 'base64')) };
+    } catch {
+      return { found: false };
+    }
   }
 
   recordCommit(taskId: string, stage: string, iteration: number, commitHash: string): void {

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -6,6 +6,7 @@ import {
   openSync,
   readFileSync,
   renameSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeSync,
@@ -122,15 +123,16 @@ export class FileCheckpointStore implements ICheckpointStore {
   }
 
   clear(): void {
-    if (!existsSync(this.checkpointPath)) {
-      return;
-    }
     this.withLock(() => {
-      this.atomicReplace([]);
+      if (existsSync(this.checkpointPath)) {
+        this.atomicReplace([]);
+      }
+      rmSync(this.taskOutputDir, { recursive: true, force: true });
     });
   }
 
   writeTaskOutput(taskId: string, output: unknown): void {
+    const outputPath = this.taskOutputPath(taskId);
     let payload: string;
     try {
       payload = serialize(output).toString('base64');
@@ -138,9 +140,9 @@ export class FileCheckpointStore implements ICheckpointStore {
       // Checkpoint markers must never fail a successful task just because its
       // output cannot be cloned. Persist what can be rehydrated and fall back
       // to marker-only recovery for non-serializable values.
+      this.deleteTaskOutput(outputPath);
       return;
     }
-    const outputPath = this.taskOutputPath(taskId);
     mkdirSync(dirname(outputPath), { recursive: true });
     this.withLock(() => {
       this.atomicWriteFile(outputPath, payload);
@@ -195,7 +197,21 @@ export class FileCheckpointStore implements ICheckpointStore {
 
   private taskOutputPath(taskId: string): string {
     const outputKey = createHash('sha256').update(taskId).digest('hex');
-    return join(`${this.checkpointPath}.outputs`, `${outputKey}.v8`);
+    return join(this.taskOutputDir, `${outputKey}.v8`);
+  }
+
+  private get taskOutputDir(): string {
+    return `${this.checkpointPath}.outputs`;
+  }
+
+  private deleteTaskOutput(outputPath: string): void {
+    try {
+      unlinkSync(outputPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
   }
 
   /** Write-to-temp + fsync + rename + dir fsync so readers never observe a torn file. */

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -10,8 +10,9 @@ import {
   unlinkSync,
   writeSync,
 } from 'node:fs';
-import { randomBytes } from 'node:crypto';
-import { dirname } from 'node:path';
+import { createHash, randomBytes } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { deserialize, serialize } from 'node:v8';
 import type { ICheckpointStore } from '../deps.js';
 
 const LOCK_RETRY_MS = 5;
@@ -129,6 +130,36 @@ export class FileCheckpointStore implements ICheckpointStore {
     });
   }
 
+  writeTaskOutput(taskId: string, output: unknown): void {
+    let payload: string;
+    try {
+      payload = serialize(output).toString('base64');
+    } catch {
+      // Checkpoint markers must never fail a successful task just because its
+      // output cannot be cloned. Persist what can be rehydrated and fall back
+      // to marker-only recovery for non-serializable values.
+      return;
+    }
+    const outputPath = this.taskOutputPath(taskId);
+    mkdirSync(dirname(outputPath), { recursive: true });
+    this.withLock(() => {
+      this.atomicWriteFile(outputPath, payload);
+    });
+  }
+
+  readTaskOutput(taskId: string): { found: boolean; output?: unknown } {
+    let payload: string;
+    try {
+      payload = readFileSync(this.taskOutputPath(taskId), 'utf-8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { found: false };
+      }
+      throw error;
+    }
+    return { found: true, output: deserialize(Buffer.from(payload, 'base64')) };
+  }
+
   recordCommit(taskId: string, stage: string, iteration: number, commitHash: string): void {
     this.write(`${taskId}:${stage}:iter_${iteration}:commit_${commitHash}`);
   }
@@ -162,19 +193,29 @@ export class FileCheckpointStore implements ICheckpointStore {
     return content.split('\n').filter(isValidEntry);
   }
 
+  private taskOutputPath(taskId: string): string {
+    const outputKey = createHash('sha256').update(taskId).digest('hex');
+    return join(`${this.checkpointPath}.outputs`, `${outputKey}.v8`);
+  }
+
   /** Write-to-temp + fsync + rename + dir fsync so readers never observe a torn file. */
   private atomicReplace(entries: string[]): void {
-    const tmpPath = `${this.checkpointPath}.tmp.${process.pid}.${this.writeCounter++}`;
+    const payload = entries.length > 0 ? entries.join('\n') + '\n' : '';
+    this.atomicWriteFile(this.checkpointPath, payload);
+  }
+
+  /** Write-to-temp + fsync + rename + dir fsync so readers never observe a torn file. */
+  private atomicWriteFile(targetPath: string, payload: string): void {
+    const tmpPath = `${targetPath}.tmp.${process.pid}.${this.writeCounter++}`;
     try {
       const fd = openSync(tmpPath, 'w');
       try {
-        const payload = entries.length > 0 ? entries.join('\n') + '\n' : '';
         writeAll(fd, payload);
         fsyncSync(fd);
       } finally {
         closeSync(fd);
       }
-      renameSync(tmpPath, this.checkpointPath);
+      renameSync(tmpPath, targetPath);
     } catch (error) {
       try {
         unlinkSync(tmpPath);
@@ -183,7 +224,7 @@ export class FileCheckpointStore implements ICheckpointStore {
       }
       throw error;
     }
-    fsyncDir(dirname(this.checkpointPath));
+    fsyncDir(dirname(targetPath));
   }
 
   private get lockOwnerRecord(): string {

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -247,16 +247,19 @@ function createSessionArtifacts(options: CliDepOptions): SessionArtifacts {
 
 function clearSessionArtifacts(options: CliDepOptions, artifacts: SessionArtifacts): void {
   const { paths } = options;
+  const checkpointOutputDir = `${artifacts.checkpointFile}.outputs`;
   if (options.reset) {
     const memoryDbPath = resolve(paths.buildDir, 'memory.db');
     for (const f of [artifacts.checkpointFile, paths.tracesDb, memoryDbPath]) {
       try { if (existsSync(f)) unlinkSync(f); } catch {}
     }
+    try { if (existsSync(checkpointOutputDir)) rmSync(checkpointOutputDir, { recursive: true, force: true }); } catch {}
     for (const dir of [resolve(paths.buildDir, 'issues'), paths.chunkSessionsDir, paths.chunkSessionSnapshotsDir]) {
       try { if (existsSync(dir)) rmSync(dir, { recursive: true, force: true }); } catch {}
     }
   } else if (!options.resume) {
     try { if (existsSync(artifacts.checkpointFile)) unlinkSync(artifacts.checkpointFile); } catch {}
+    try { if (existsSync(checkpointOutputDir)) rmSync(checkpointOutputDir, { recursive: true, force: true }); } catch {}
     for (const dir of [paths.chunkSessionsDir, paths.chunkSessionSnapshotsDir]) {
       try { if (existsSync(dir)) rmSync(dir, { recursive: true, force: true }); } catch {}
     }

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -200,12 +200,19 @@ export interface McpToolInfo {
 }
 
 /** Checkpoint persistence for crash recovery. */
+export interface CheckpointTaskOutput {
+  readonly found: boolean;
+  readonly output?: unknown;
+}
+
 export interface ICheckpointStore {
   readonly checkpointPath?: string | undefined;
   has(key: string): boolean;
   write(key: string): void;
   readAll(): Set<string>;
   clear(): void;
+  writeTaskOutput?(taskId: string, output: unknown): void;
+  readTaskOutput?(taskId: string): CheckpointTaskOutput;
   recordCommit(taskId: string, stage: string, iteration: number, commitHash: string): void;
   lastCommit(taskId: string, stage: string): string | undefined;
 }

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -105,8 +105,12 @@ export async function runExecution(
 
     // Skip tasks already completed in a previous run (checkpoint recovery)
     if (checkpoint?.has(`${task.id}:done`)) {
+      const checkpointedOutput = checkpoint.readTaskOutput?.(task.id);
       logger.info('Execution: Skipping checkpointed task', { taskId: task.id });
-      outcomes.push({ taskId: task.id, status: 'success' });
+      if (checkpointedOutput?.found) {
+        completedOutputs.set(task.id, checkpointedOutput.output);
+      }
+      outcomes.push({ taskId: task.id, status: 'success', output: checkpointedOutput?.output });
       completed.add(task.id);
       continue;
     }
@@ -127,6 +131,9 @@ export async function runExecution(
     outcomes.push(outcome);
 
     if (outcome.status === 'success') {
+      // Persist the task output before the done marker so a crash after marking
+      // done can still rehydrate dependency outputs for downstream tasks.
+      checkpoint?.writeTaskOutput?.(task.id, outcome.output);
       // Persist the checkpoint before mutating in-memory state so a crash here
       // is recovered as "done" on restart instead of silently re-running the task.
       checkpoint?.write(`${task.id}:done`);

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -461,6 +461,21 @@ describe('dep-factory provider wiring', () => {
     expect(existsSync(chunkSession)).toBe(false);
   });
 
+  it('clears session checkpoint sidecars on cold starts', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    const opts = makeOpts({ resume: false });
+    const checkpoint = resolve(opts.paths.buildDir, 'session.checkpoint');
+    const checkpointOutputs = `${checkpoint}.outputs`;
+    mkdirSync(checkpointOutputs, { recursive: true });
+    writeFileSync(checkpoint, 'task-1:done\n');
+    writeFileSync(resolve(checkpointOutputs, 'task-1.v8'), 'serialized-output');
+
+    await createCliDeps(opts);
+
+    expect(existsSync(checkpoint)).toBe(false);
+    expect(existsSync(checkpointOutputs)).toBe(false);
+  });
+
   it('fails closed when an enabled critique module is truly missing', async () => {
     delete process.env.FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES;
     optionalModuleMocks.critiqueError = Object.assign(

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -110,6 +110,14 @@ describe('FileCheckpointStore', () => {
     it('handles clear on non-existent file', () => {
       expect(() => store.clear()).not.toThrow();
     });
+
+    it('handles clear on a fresh nested checkpoint path', () => {
+      const nestedPath = join(tmpDir, 'fresh', 'nested', 'checkpoint.log');
+      const nestedStore = new FileCheckpointStore(nestedPath);
+
+      expect(() => nestedStore.clear()).not.toThrow();
+      expect(existsSync(nestedPath)).toBe(false);
+    });
   });
 
   describe('task output persistence', () => {
@@ -146,6 +154,20 @@ describe('FileCheckpointStore', () => {
       store.writeTaskOutput('task-1', 'old-output');
 
       expect(() => store.writeTaskOutput('task-1', () => 'not cloneable')).not.toThrow();
+
+      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+    });
+
+    it('treats corrupted task output sidecars as missing', () => {
+      store.writeTaskOutput('task-1', 'old-output');
+      const [outputFile] = readdirSync(`${filePath}.outputs`);
+      writeFileSync(join(`${filePath}.outputs`, outputFile!), 'not-valid-base64-v8-payload');
+
+      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+    });
+
+    it('does not persist outputs that cannot be rehydrated faithfully', () => {
+      store.writeTaskOutput('task-1', new URL('https://example.com/path'));
 
       expect(store.readTaskOutput('task-1')).toEqual({ found: false });
     });

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -142,6 +142,24 @@ describe('FileCheckpointStore', () => {
       expect(store.readTaskOutput('task-1')).toEqual({ found: false });
     });
 
+    it('removes stale task output when falling back to marker-only recovery', () => {
+      store.writeTaskOutput('task-1', 'old-output');
+
+      expect(() => store.writeTaskOutput('task-1', () => 'not cloneable')).not.toThrow();
+
+      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+    });
+
+    it('clears persisted sidecar task outputs', () => {
+      store.writeTaskOutput('task-1', 'old-output');
+      expect(existsSync(`${filePath}.outputs`)).toBe(true);
+
+      store.clear();
+
+      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+      expect(existsSync(`${filePath}.outputs`)).toBe(false);
+    });
+
     it('stores task outputs under filesystem-safe hashed filenames', () => {
       const taskId = `../${'nested/'.repeat(40)}task`;
 

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -112,6 +112,47 @@ describe('FileCheckpointStore', () => {
     });
   });
 
+  describe('task output persistence', () => {
+    it('round-trips structured task outputs outside the line-oriented checkpoint markers', () => {
+      const output = new Map<string, unknown>([
+        ['dependency', { value: 42 }],
+        ['list', ['a', 'b']],
+      ]);
+
+      store.writeTaskOutput('task-1', output);
+
+      const result = store.readTaskOutput('task-1');
+      expect(result.found).toBe(true);
+      expect(result.output).toBeInstanceOf(Map);
+      expect(result.output).toEqual(output);
+      expect(store.readAll()).toEqual(new Set());
+    });
+
+    it('reports missing task output separately from an undefined output value', () => {
+      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+
+      store.writeTaskOutput('task-1', undefined);
+
+      expect(store.readTaskOutput('task-1')).toEqual({ found: true, output: undefined });
+    });
+
+    it('does not fail checkpointing when a task output cannot be serialized', () => {
+      expect(() => store.writeTaskOutput('task-1', () => 'not cloneable')).not.toThrow();
+
+      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+    });
+
+    it('stores task outputs under filesystem-safe hashed filenames', () => {
+      const taskId = `../${'nested/'.repeat(40)}task`;
+
+      store.writeTaskOutput(taskId, 'safe-output');
+
+      expect(store.readTaskOutput(taskId)).toEqual({ found: true, output: 'safe-output' });
+      expect(readdirSync(`${filePath}.outputs`)).toHaveLength(1);
+      expect(existsSync(join(tmpDir, 'nested'))).toBe(false);
+    });
+  });
+
   describe('atomicity', () => {
     it('leaves no temp or lock files behind after writes', () => {
       store.write('key-a');

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -185,6 +185,53 @@ describe('runExecution', () => {
     expect(secondInput.dependencyOutputs.get('t1')).toBe('alpha-output');
   });
 
+  it('rehydrates dependency outputs for checkpointed tasks on resume', async () => {
+    const execute = vi.fn(async (skillId: string, input: SkillInput) => {
+      if (skillId === 'alpha') {
+        return { output: { message: 'alpha-output' }, tokensUsed: 1 };
+      }
+      if (skillId === 'beta') {
+        return { output: input.dependencyOutputs.get('t1'), tokensUsed: 1 };
+      }
+      throw new Error(`Unexpected skill: ${skillId}`);
+    });
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      execute,
+    });
+    const checkpointOutputs = new Map<string, unknown>();
+    const checkpointEntries = new Set<string>(['t1:done']);
+    const checkpoint = {
+      checkpointPath: '/tmp/franken-checkpoint.txt',
+      has: vi.fn((key: string) => checkpointEntries.has(key)),
+      write: vi.fn((key: string) => checkpointEntries.add(key)),
+      readAll: vi.fn(() => new Set(checkpointEntries)),
+      clear: vi.fn(),
+      recordCommit: vi.fn(),
+      lastCommit: vi.fn(),
+      readTaskOutput: vi.fn((taskId: string) => ({
+        found: checkpointOutputs.has(taskId),
+        output: checkpointOutputs.get(taskId),
+      })),
+      writeTaskOutput: vi.fn((taskId: string, output: unknown) => {
+        checkpointOutputs.set(taskId, output);
+      }),
+    };
+    checkpointOutputs.set('t1', { message: 'persisted-alpha-output' });
+    const c = ctx([
+      { id: 't1', objective: 'first', requiredSkills: ['alpha'], dependsOn: [] },
+      { id: 't2', objective: 'second', requiredSkills: ['beta'], dependsOn: ['t1'] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), undefined, undefined, undefined, checkpoint);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]![0]).toBe('beta');
+    expect(checkpoint.readTaskOutput).toHaveBeenCalledWith('t1');
+    expect(outcomes[0]).toEqual({ taskId: 't1', status: 'success', output: { message: 'persisted-alpha-output' } });
+    expect(outcomes[1]!.output).toEqual({ message: 'persisted-alpha-output' });
+  });
+
   it('passes through dependency output when no skills are required', async () => {
     const execute = vi.fn(async (skillId: string) => ({
       output: `${skillId}-output`,


### PR DESCRIPTION
## Summary
- persist successful task outputs alongside checkpoint done markers
- rehydrate skipped checkpointed tasks into completedOutputs during resume
- add regression coverage for resumed dependency outputs and checkpoint output persistence

## Test Plan
- [x] npm --workspace franken-orchestrator test -- tests/unit/phases/execution.test.ts tests/unit/file-checkpoint-store.test.ts
- [x] npm --workspace franken-orchestrator test
- [x] npm run typecheck
- [x] npm run build
- [ ] npm run test (observed unrelated timeout in @franken/critique safety test)

Closes #335