### PR TITLE
fix(observer): detect orphaned spans

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -1,5 +1,6 @@
 import type { Trace } from '../../core/types.js'
 import type { ExportAdapter } from '../../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 
 export interface BatchAdapterOptions {
   /** Underlying adapter that receives traces when the batch is drained. */
@@ -65,6 +66,7 @@ export class BatchAdapter implements ExportAdapter {
 
   /** Add a trace to the buffer. Drains immediately if `maxBatchSize` is reached. */
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'BatchAdapter')
     this.buffer.push(trace)
     if (this.buffer.length >= this.maxBatchSize) {
       await this.drain()

--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
@@ -1,5 +1,6 @@
 import type { Trace } from '../../core/types.js'
 import type { ExportAdapter } from '../../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 
 export interface MultiAdapterOptions {
   /** Adapters to fan-out to. Order matters for queryByTraceId (first-wins). */
@@ -39,6 +40,7 @@ export class MultiAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'MultiAdapter')
     const results = await Promise.allSettled(this.adapters.map(a => a.flush(trace)))
 
     if (this.throwOnError) {

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -1,4 +1,5 @@
 import type { ExportAdapter } from '../../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 import type { Trace } from '../../core/types.js'
 import type { PricingTable } from '../../cost/defaultPricing.js'
 
@@ -36,6 +37,7 @@ export class PrometheusAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'PrometheusAdapter')
     for (const span of trace.spans) {
       // Span status counter
       this.spanCounters.set(span.status, (this.spanCounters.get(span.status) ?? 0) + 1)

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3'
 import type { Trace, Span } from '../../core/types.js'
 import type { ExportAdapter } from '../../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 import {
   CREATE_TABLES,
   UPSERT_TRACE,
@@ -78,6 +79,7 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'SQLiteAdapter')
     const upsertTrace = this.db.prepare(UPSERT_TRACE)
     const upsertSpan = this.db.prepare(UPSERT_SPAN)
 

--- a/packages/franken-observer/src/core/TraceContext.test.ts
+++ b/packages/franken-observer/src/core/TraceContext.test.ts
@@ -121,4 +121,53 @@ describe('TraceContext', () => {
       expect(() => TraceContext.endTrace(trace)).toThrow()
     })
   })
+
+  describe('validateTrace()', () => {
+    it('reports active spans without mutating them by default', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'step' })
+      span.startedAt = 1_000
+
+      const result = TraceContext.validateTrace(trace, { now: 1_250 })
+
+      expect(result.ok).toBe(false)
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          type: 'active-span',
+          spanId: span.id,
+          spanName: 'step',
+          ageMs: 250,
+        }),
+      ])
+      expect(span.status).toBe('active')
+      expect(span.endedAt).toBeUndefined()
+    })
+
+    it('returns ok=true when all spans are closed', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'step' })
+      TraceContext.endSpan(span)
+
+      expect(TraceContext.validateTrace(trace).ok).toBe(true)
+    })
+
+    it('auto-closes timed-out active spans when configured', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'slow-step' })
+      span.startedAt = 1_000
+
+      const result = TraceContext.validateTrace(trace, {
+        now: 2_500,
+        activeSpanTimeoutMs: 1_000,
+        autoCloseTimedOutSpans: true,
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.issues[0]).toEqual(expect.objectContaining({ autoClosed: true, ageMs: 1_500 }))
+      expect(span.status).toBe('error')
+      expect(span.endedAt).toBe(2_500)
+      expect(span.durationMs).toBe(1_500)
+      expect(span.errorMessage).toMatch(/auto-closed/)
+    })
+  })
 })

--- a/packages/franken-observer/src/core/TraceContext.ts
+++ b/packages/franken-observer/src/core/TraceContext.ts
@@ -1,5 +1,12 @@
 import { randomUUID } from 'node:crypto'
-import type { Trace, Span, StartSpanOptions, EndSpanOptions } from './types.js'
+import type {
+  Trace,
+  Span,
+  StartSpanOptions,
+  EndSpanOptions,
+  TraceValidationOptions,
+  TraceValidationResult,
+} from './types.js'
 import type { LoopDetector } from '../incident/LoopDetector.js'
 
 export const TraceContext = {
@@ -50,5 +57,41 @@ export const TraceContext = {
     }
     trace.endedAt = Date.now()
     trace.status = 'completed'
+  },
+
+  validateTrace(trace: Trace, options: TraceValidationOptions = {}): TraceValidationResult {
+    const now = options.now ?? Date.now()
+    const issues = trace.spans
+      .filter(span => span.status === 'active')
+      .map(span => {
+        const ageMs = Math.max(0, now - span.startedAt)
+        const timedOut =
+          options.activeSpanTimeoutMs !== undefined &&
+          ageMs >= options.activeSpanTimeoutMs
+        const autoClosed = Boolean(options.autoCloseTimedOutSpans && timedOut)
+
+        if (autoClosed) {
+          span.endedAt = now
+          span.durationMs = ageMs
+          span.status = 'error'
+          span.errorMessage = `Span was auto-closed after ${ageMs}ms without explicit end`
+        }
+
+        return {
+          type: 'active-span' as const,
+          spanId: span.id,
+          spanName: span.name,
+          ageMs,
+          message: autoClosed
+            ? `Span "${span.name}" (${span.id}) was auto-closed after ${ageMs}ms without explicit end`
+            : `Span "${span.name}" (${span.id}) is still active after ${ageMs}ms`,
+          ...(autoClosed ? { autoClosed: true as const } : {}),
+        }
+      })
+
+    return {
+      ok: issues.length === 0,
+      issues,
+    }
   },
 }

--- a/packages/franken-observer/src/core/types.ts
+++ b/packages/franken-observer/src/core/types.ts
@@ -33,3 +33,29 @@ export interface EndSpanOptions {
   status?: 'completed' | 'error'
   errorMessage?: string
 }
+
+export interface TraceValidationIssue {
+  type: 'active-span'
+  spanId: string
+  spanName: string
+  ageMs: number
+  message: string
+  autoClosed?: true
+}
+
+export interface TraceValidationOptions {
+  /** Clock override for deterministic tests. Defaults to Date.now(). */
+  now?: number
+  /**
+   * When set, active spans older than this threshold are considered timed out.
+   * Detection still reports all active spans; auto-close only applies to timed-out spans.
+   */
+  activeSpanTimeoutMs?: number
+  /** Mark timed-out active spans as error instead of only reporting them. */
+  autoCloseTimedOutSpans?: boolean
+}
+
+export interface TraceValidationResult {
+  ok: boolean
+  issues: TraceValidationIssue[]
+}

--- a/packages/franken-observer/src/export/ExportAdapter.test.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.test.ts
@@ -1,13 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { TraceContext } from '../core/TraceContext.js'
 import { SpanLifecycle } from '../core/SpanLifecycle.js'
 import { InMemoryAdapter } from './InMemoryAdapter.js'
 
 describe('InMemoryAdapter', () => {
   let adapter: InMemoryAdapter
+  let warningSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     adapter = new InMemoryAdapter()
+    warningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    warningSpy.mockRestore()
   })
 
   describe('flush()', () => {
@@ -52,6 +58,16 @@ describe('InMemoryAdapter', () => {
 
       const retrieved = await adapter.queryByTraceId(trace.id)
       expect(retrieved!.goal).toBe('updated goal')
+    })
+
+    it('warns when exporting a trace that still has active spans', async () => {
+      const trace = TraceContext.createTrace('goal')
+      TraceContext.startSpan(trace, { name: 'orphaned' })
+
+      await adapter.flush(trace)
+
+      expect(warningSpy).toHaveBeenCalledWith(expect.stringContaining('active span(s)'))
+      expect(warningSpy).toHaveBeenCalledWith(expect.stringContaining('orphaned'))
     })
   })
 

--- a/packages/franken-observer/src/export/ExportAdapter.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.ts
@@ -1,4 +1,16 @@
 import type { Trace } from '../core/types.js'
+import { TraceContext } from '../core/TraceContext.js'
+
+export function warnIfTraceHasActiveSpans(trace: Trace, destination = 'export'): void {
+  const validation = TraceContext.validateTrace(trace)
+  if (validation.ok) return
+
+  const activeSpans = validation.issues.map(issue => `${issue.spanName} (${issue.spanId})`).join(', ')
+  process.emitWarning(
+    `[franken-observer] Exporting trace ${trace.id} to ${destination} with ` +
+      `${validation.issues.length} active span(s): ${activeSpans}`,
+  )
+}
 
 /**
  * Pluggable export backend. All adapters implement this interface.

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -1,5 +1,6 @@
 import type { Trace } from '../core/types.js'
 import type { ExportAdapter } from './ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from './ExportAdapter.js'
 
 /**
  * Zero-dependency in-process adapter. Useful in tests and as a
@@ -9,6 +10,7 @@ export class InMemoryAdapter implements ExportAdapter {
   private readonly store = new Map<string, Trace>()
 
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'InMemoryAdapter')
     this.store.set(trace.id, trace)
   }
 

--- a/packages/franken-observer/src/export/OTELSerializer.ts
+++ b/packages/franken-observer/src/export/OTELSerializer.ts
@@ -1,4 +1,5 @@
 import type { Trace, Span } from '../core/types.js'
+import { warnIfTraceHasActiveSpans } from './ExportAdapter.js'
 
 // ── OTEL-shaped output types ──────────────────────────────────────────────────
 
@@ -93,6 +94,7 @@ function serializeSpan(span: Span): OTELSpan {
 
 export const OTELSerializer = {
   serializeTrace(trace: Trace): OTELPayload {
+    warnIfTraceHasActiveSpans(trace, 'OTELSerializer')
     return {
       resourceSpans: [
         {

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -65,7 +65,17 @@ export type { ToolCallSchema, ToolCallAccuracyInput } from './evals/deterministi
 export type { ADRRule, ArchitecturalAdherenceInput } from './evals/deterministic/ArchitecturalAdherence.js'
 export type { GoldenTrace, GoldenSpan, GoldenTraceInput } from './evals/regression/GoldenTraceEval.js'
 export type { JudgeFunction, JudgeResponse, LLMJudgeEvalOptions } from './evals/llm-judge/LLMJudgeEval.js'
-export type { Trace, Span, SpanStatus, TraceStatus, StartSpanOptions, EndSpanOptions } from './core/types.js'
+export type {
+  Trace,
+  Span,
+  SpanStatus,
+  TraceStatus,
+  StartSpanOptions,
+  EndSpanOptions,
+  TraceValidationIssue,
+  TraceValidationOptions,
+  TraceValidationResult,
+} from './core/types.js'
 export type { TokenUsage } from './core/SpanLifecycle.js'
 export type { TokenRecord, TokenTotals } from './cost/TokenCounter.js'
 export type { CostCalculatorOptions } from './cost/CostCalculator.js'

--- a/packages/franken-observer/src/redaction/SpanRedactor.ts
+++ b/packages/franken-observer/src/redaction/SpanRedactor.ts
@@ -1,5 +1,6 @@
 import type { Trace, Span } from '../core/types.js'
 import type { ExportAdapter } from '../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../export/ExportAdapter.js'
 
 // ── Rule types ────────────────────────────────────────────────────────────────
 
@@ -71,6 +72,7 @@ export class SpanRedactor implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'SpanRedactor')
     const redacted: Trace = {
       ...trace,
       spans: trace.spans.map(span => this.redactSpan(span)),

--- a/packages/franken-observer/src/sampling/TraceSampler.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.ts
@@ -1,5 +1,6 @@
 import type { Trace } from '../core/types.js'
 import type { ExportAdapter } from '../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../export/ExportAdapter.js'
 
 // ── Strategy interface ────────────────────────────────────────────────────────
 
@@ -128,6 +129,7 @@ export class SamplingAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'SamplingAdapter')
     if (this.strategy.shouldSample(trace.id)) {
       await this.inner.flush(trace)
     }


### PR DESCRIPTION
## Summary
- add TraceContext.validateTrace() to report active/orphaned spans
- support optional timeout-based auto-closing of active spans as errors
- warn through export paths when traces still contain active spans

## Test Plan
- npm --workspace packages/franken-observer run test
- npm --workspace packages/franken-observer run typecheck
- npm --workspace packages/franken-observer run build

Closes #57