### PR TITLE
fix(orchestrator): abort martin loop on budget exceedance

### DIFF
--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -574,6 +574,16 @@ export class CliSkillExecutor {
     });
 
     if (!martinResult.completed) {
+      const finalBudgetResult = this.observer.breaker.check(this.computeCurrentCost());
+      if (finalBudgetResult.tripped) {
+        this.resetBudgetAbortedWorktree();
+        this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
+        return {
+          output: `Budget exceeded: $${finalBudgetResult.spendUsd.toFixed(2)} / $${finalBudgetResult.limitUsd.toFixed(2)}`,
+          tokensUsed: chunkTokensUsed,
+        };
+      }
+
       const emittedTagsMsg = martinResult.emittedPromiseTags && martinResult.emittedPromiseTags.length > 0
         ? `; emitted tags: ${martinResult.emittedPromiseTags.join(', ')}`
         : '';

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -163,6 +163,8 @@ function safeReplayJson(value: unknown): string {
 // ── CliSkillExecutor ──
 
 type CommitMessageFn = (diffStat: string, objective: string) => Promise<string | null>;
+const BUDGET_POLL_INTERVAL_MS = 100;
+
 type DefaultMartinConfig = Pick<MartinLoopConfig, 'provider'> & Partial<Pick<
   MartinLoopConfig,
   'command' | 'providers' | 'planName' | 'sessionStore' | 'snapshotStore' | 'renderer' | 'compactor' | 'contextUsage'
@@ -239,6 +241,23 @@ export class CliSkillExecutor {
     }
 
     const chunkId = this.extractChunkId(skillId);
+    const budgetAbortController = new AbortController();
+    let budgetAbortResult: CircuitBreakerResult | undefined;
+    const abortForBudget = (result: CircuitBreakerResult): void => {
+      budgetAbortResult = result;
+      if (!budgetAbortController.signal.aborted) {
+        budgetAbortController.abort(new BudgetExceededError(result.spendUsd, result.limitUsd));
+      }
+    };
+    const upstreamAbortSignal = config.martin?.abortSignal;
+    if (upstreamAbortSignal?.aborted) {
+      budgetAbortController.abort(upstreamAbortSignal.reason);
+    } else if (upstreamAbortSignal) {
+      upstreamAbortSignal.addEventListener('abort', () => {
+        budgetAbortController.abort(upstreamAbortSignal.reason);
+      }, { once: true });
+    }
+
     this.observer.recordReplay?.({
       kind: 'tool.call',
       runId: input.sessionId,
@@ -291,11 +310,19 @@ export class CliSkillExecutor {
     const wrappedConfig: MartinLoopConfig = {
       ...martinDefaults,
       ...config.martin,
+      abortSignal: budgetAbortController.signal,
       onRateLimit: (provider: string) => {
         this.logger?.warn('MartinLoop: provider rate limited', { chunkId, provider }, 'martin');
         return config.martin?.onRateLimit?.(provider);
       },
       onProviderAttempt: (provider: string, iteration: number) => {
+        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig);
+        const estimatedBudgetResult = this.observer.breaker.check(estimatedSpend);
+        if (estimatedBudgetResult.tripped) {
+          abortForBudget(estimatedBudgetResult);
+          throw new BudgetExceededError(estimatedBudgetResult.spendUsd, estimatedBudgetResult.limitUsd);
+        }
+
         this.logger?.info('MartinLoop: provider attempt', { chunkId, provider, iteration }, 'martin');
         // Show in-place progress line (overwritten by next update or final summary)
         writeProgress(
@@ -427,19 +454,34 @@ export class CliSkillExecutor {
     let martinResult: MartinLoopResult;
     let lastStaleMateSignature = '';
     let stalledIterations = 0;
+    const budgetPoll = setInterval(() => {
+      const currentCost = this.computeCurrentCost();
+      const budgetResult = this.observer.breaker.check(currentCost);
+      if (budgetResult.tripped) {
+        abortForBudget(budgetResult);
+      }
+    }, BUDGET_POLL_INTERVAL_MS);
+    budgetPoll.unref?.();
+
     try {
       martinResult = await this.martin.run(wrappedConfig);
     } catch (err) {
-      if (err instanceof BudgetExceededError) {
+      const budgetError = err instanceof BudgetExceededError
+        ? err
+        : budgetAbortResult
+          ? new BudgetExceededError(budgetAbortResult.spendUsd, budgetAbortResult.limitUsd)
+          : undefined;
+
+      if (budgetError) {
         const postTokens = this.observer.counter.grandTotal();
         this.observer.setMetadata(chunkSpan, {
           budgetExceeded: true,
-          spent: err.spent,
-          limit: err.limit,
+          spent: budgetError.spent,
+          limit: budgetError.limit,
         });
         this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
         return {
-          output: `Budget exceeded: $${err.spent.toFixed(2)} / $${err.limit.toFixed(2)}`,
+          output: `Budget exceeded: $${budgetError.spent.toFixed(2)} / $${budgetError.limit.toFixed(2)}`,
           tokensUsed: postTokens.totalTokens - preTokens.totalTokens,
         };
       }
@@ -447,6 +489,8 @@ export class CliSkillExecutor {
       throw new Error(
         `MartinLoop failed for chunk "${chunkId}": ${err instanceof Error ? err.message : String(err)}`,
       );
+    } finally {
+      clearInterval(budgetPoll);
     }
 
     // Generate commit message for squash merge (if available)
@@ -618,6 +662,14 @@ export class CliSkillExecutor {
       return { model: m, promptTokens: t.promptTokens, completionTokens: t.completionTokens };
     });
     return this.observer.costCalc.totalCost(entries);
+  }
+
+  private estimateUpcomingIterationCost(config: MartinLoopConfig): number {
+    return this.observer.costCalc.totalCost([{
+      model: config.provider,
+      promptTokens: Math.ceil(config.prompt.length / 4),
+      completionTokens: Math.max(config.maxTurns, 1) * 1_000,
+    }]);
   }
 
   private recordSessionCommit(taskId: string, commitHash: string): void {

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -253,6 +253,12 @@ export class CliSkillExecutor {
     };
     const upstreamAbortSignal = config.martin?.abortSignal;
     let upstreamAbortHandler: (() => void) | undefined;
+    const cleanupUpstreamAbortHandler = (): void => {
+      if (upstreamAbortSignal && upstreamAbortHandler) {
+        upstreamAbortSignal.removeEventListener('abort', upstreamAbortHandler);
+        upstreamAbortHandler = undefined;
+      }
+    };
     if (upstreamAbortSignal?.aborted) {
       budgetAbortController.abort(upstreamAbortSignal.reason);
     } else if (upstreamAbortSignal) {
@@ -277,6 +283,7 @@ export class CliSkillExecutor {
     const preCost = this.computeCurrentCost();
     const preCheck = this.observer.breaker.check(preCost);
     if (preCheck.tripped) {
+      cleanupUpstreamAbortHandler();
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
       return {
         output: `Budget exceeded: $${preCheck.spendUsd.toFixed(2)} / $${preCheck.limitUsd.toFixed(2)}`,
@@ -288,6 +295,7 @@ export class CliSkillExecutor {
     try {
       this.git.isolate(chunkId);
     } catch (err) {
+      cleanupUpstreamAbortHandler();
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: String(err) });
       throw new Error(
         `Git isolation failed for chunk "${chunkId}": ${err instanceof Error ? err.message : String(err)}`,
@@ -319,9 +327,9 @@ export class CliSkillExecutor {
         this.logger?.warn('MartinLoop: provider rate limited', { chunkId, provider }, 'martin');
         return config.martin?.onRateLimit?.(provider);
       },
-      onProviderAttempt: (provider: string, iteration: number) => {
+      onProviderAttempt: (provider: string, iteration: number, renderedPrompt?: string) => {
         activeProvider = provider;
-        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, provider);
+        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, provider, renderedPrompt);
         const estimatedBudgetResult = this.observer.breaker.check(estimatedSpend);
         if (estimatedBudgetResult.tripped) {
           abortForBudget(estimatedBudgetResult);
@@ -497,9 +505,7 @@ export class CliSkillExecutor {
       );
     } finally {
       clearInterval(budgetPoll);
-      if (upstreamAbortSignal && upstreamAbortHandler) {
-        upstreamAbortSignal.removeEventListener('abort', upstreamAbortHandler);
-      }
+      cleanupUpstreamAbortHandler();
     }
 
     if (budgetAbortResult) {
@@ -688,10 +694,10 @@ export class CliSkillExecutor {
     return this.observer.costCalc.totalCost(entries);
   }
 
-  private estimateUpcomingIterationCost(config: MartinLoopConfig, provider = config.provider): number {
+  private estimateUpcomingIterationCost(config: MartinLoopConfig, provider = config.provider, prompt = config.prompt): number {
     return this.observer.costCalc.totalCost([{
       model: provider,
-      promptTokens: Math.ceil(config.prompt.length / 4),
+      promptTokens: Math.ceil(prompt.length / 4),
       completionTokens: Math.max(config.maxTurns, 1) * 1_000,
     }]);
   }
@@ -699,6 +705,7 @@ export class CliSkillExecutor {
   private resetBudgetAbortedWorktree(): void {
     if (this.git.getStatus().length === 0) return;
     this.git.resetHard(this.git.getCurrentHead());
+    this.git.cleanUntracked();
   }
 
   private recordSessionCommit(taskId: string, commitHash: string): void {

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -243,7 +243,6 @@ export class CliSkillExecutor {
     const chunkId = this.extractChunkId(skillId);
     const budgetAbortController = new AbortController();
     let budgetAbortResult: CircuitBreakerResult | undefined;
-    let activeProvider = config.martin?.provider ?? this.defaultMartinConfig.provider;
 
     const abortForBudget = (result: CircuitBreakerResult): void => {
       budgetAbortResult = result;
@@ -301,6 +300,7 @@ export class CliSkillExecutor {
         `Git isolation failed for chunk "${chunkId}": ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+    const preMartinUntrackedFiles = this.untrackedFilesFromStatus(this.git.getStatus());
 
     // Build martin config with defaults from input when not explicitly provided
     const isImpl = taskId ? !taskId.startsWith('harden:') : true;
@@ -328,7 +328,6 @@ export class CliSkillExecutor {
         return config.martin?.onRateLimit?.(provider);
       },
       onProviderAttempt: (provider: string, iteration: number, renderedPrompt?: string) => {
-        activeProvider = provider;
         const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, provider, renderedPrompt);
         const estimatedBudgetResult = this.observer.breaker.check(estimatedSpend);
         if (estimatedBudgetResult.tripped) {
@@ -468,7 +467,7 @@ export class CliSkillExecutor {
     let lastStaleMateSignature = '';
     let stalledIterations = 0;
     const budgetPoll = setInterval(() => {
-      const currentCost = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, activeProvider);
+      const currentCost = this.computeCurrentCost();
       const budgetResult = this.observer.breaker.check(currentCost);
       if (budgetResult.tripped) {
         abortForBudget(budgetResult);
@@ -486,7 +485,7 @@ export class CliSkillExecutor {
           : undefined;
 
       if (budgetError) {
-        this.resetBudgetAbortedWorktree();
+        this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
         const postTokens = this.observer.counter.grandTotal();
         this.observer.setMetadata(chunkSpan, {
           budgetExceeded: true,
@@ -509,7 +508,7 @@ export class CliSkillExecutor {
     }
 
     if (budgetAbortResult) {
-      this.resetBudgetAbortedWorktree();
+      this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
       const postTokens = this.observer.counter.grandTotal();
       this.observer.setMetadata(chunkSpan, {
         budgetExceeded: true,
@@ -576,7 +575,7 @@ export class CliSkillExecutor {
     if (!martinResult.completed) {
       const finalBudgetResult = this.observer.breaker.check(this.computeCurrentCost());
       if (finalBudgetResult.tripped) {
-        this.resetBudgetAbortedWorktree();
+        this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
         this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
         return {
           output: `Budget exceeded: $${finalBudgetResult.spendUsd.toFixed(2)} / $${finalBudgetResult.limitUsd.toFixed(2)}`,
@@ -712,10 +711,24 @@ export class CliSkillExecutor {
     }]);
   }
 
-  private resetBudgetAbortedWorktree(): void {
-    if (this.git.getStatus().length === 0) return;
+  private resetBudgetAbortedWorktree(preExistingUntrackedFiles: readonly string[] = []): void {
+    const status = this.git.getStatus();
+    if (status.length === 0) return;
     this.git.resetHard(this.git.getCurrentHead());
-    this.git.cleanUntracked();
+    const preExisting = new Set(preExistingUntrackedFiles);
+    const newUntracked = this.untrackedFilesFromStatus(status).filter(file => !preExisting.has(file));
+    if (newUntracked.length > 0) {
+      this.git.cleanUntracked(newUntracked);
+    }
+  }
+
+  private untrackedFilesFromStatus(status: string): string[] {
+    return status
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.startsWith('?? '))
+      .map(line => line.slice(3).trim())
+      .filter(file => file.length > 0);
   }
 
   private recordSessionCommit(taskId: string, commitHash: string): void {

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -243,6 +243,8 @@ export class CliSkillExecutor {
     const chunkId = this.extractChunkId(skillId);
     const budgetAbortController = new AbortController();
     let budgetAbortResult: CircuitBreakerResult | undefined;
+    let activeProvider = config.martin?.provider ?? this.defaultMartinConfig.provider;
+
     const abortForBudget = (result: CircuitBreakerResult): void => {
       budgetAbortResult = result;
       if (!budgetAbortController.signal.aborted) {
@@ -250,12 +252,14 @@ export class CliSkillExecutor {
       }
     };
     const upstreamAbortSignal = config.martin?.abortSignal;
+    let upstreamAbortHandler: (() => void) | undefined;
     if (upstreamAbortSignal?.aborted) {
       budgetAbortController.abort(upstreamAbortSignal.reason);
     } else if (upstreamAbortSignal) {
-      upstreamAbortSignal.addEventListener('abort', () => {
+      upstreamAbortHandler = () => {
         budgetAbortController.abort(upstreamAbortSignal.reason);
-      }, { once: true });
+      };
+      upstreamAbortSignal.addEventListener('abort', upstreamAbortHandler, { once: true });
     }
 
     this.observer.recordReplay?.({
@@ -316,7 +320,8 @@ export class CliSkillExecutor {
         return config.martin?.onRateLimit?.(provider);
       },
       onProviderAttempt: (provider: string, iteration: number) => {
-        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig);
+        activeProvider = provider;
+        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, provider);
         const estimatedBudgetResult = this.observer.breaker.check(estimatedSpend);
         if (estimatedBudgetResult.tripped) {
           abortForBudget(estimatedBudgetResult);
@@ -455,7 +460,7 @@ export class CliSkillExecutor {
     let lastStaleMateSignature = '';
     let stalledIterations = 0;
     const budgetPoll = setInterval(() => {
-      const currentCost = this.computeCurrentCost();
+      const currentCost = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, activeProvider);
       const budgetResult = this.observer.breaker.check(currentCost);
       if (budgetResult.tripped) {
         abortForBudget(budgetResult);
@@ -473,6 +478,7 @@ export class CliSkillExecutor {
           : undefined;
 
       if (budgetError) {
+        this.resetBudgetAbortedWorktree();
         const postTokens = this.observer.counter.grandTotal();
         this.observer.setMetadata(chunkSpan, {
           budgetExceeded: true,
@@ -491,6 +497,9 @@ export class CliSkillExecutor {
       );
     } finally {
       clearInterval(budgetPoll);
+      if (upstreamAbortSignal && upstreamAbortHandler) {
+        upstreamAbortSignal.removeEventListener('abort', upstreamAbortHandler);
+      }
     }
 
     // Generate commit message for squash merge (if available)
@@ -664,12 +673,17 @@ export class CliSkillExecutor {
     return this.observer.costCalc.totalCost(entries);
   }
 
-  private estimateUpcomingIterationCost(config: MartinLoopConfig): number {
+  private estimateUpcomingIterationCost(config: MartinLoopConfig, provider = config.provider): number {
     return this.observer.costCalc.totalCost([{
-      model: config.provider,
+      model: provider,
       promptTokens: Math.ceil(config.prompt.length / 4),
       completionTokens: Math.max(config.maxTurns, 1) * 1_000,
     }]);
+  }
+
+  private resetBudgetAbortedWorktree(): void {
+    if (this.git.getStatus().length === 0) return;
+    this.git.resetHard(this.git.getCurrentHead());
   }
 
   private recordSessionCommit(taskId: string, commitHash: string): void {

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -300,7 +300,15 @@ export class CliSkillExecutor {
         `Git isolation failed for chunk "${chunkId}": ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    const preMartinUntrackedFiles = this.untrackedFilesFromStatus(this.git.getStatus());
+    const preMartinStatus = this.git.getStatus();
+    const preMartinTrackedChanges = this.trackedChangesFromStatus(preMartinStatus);
+    if (preMartinTrackedChanges.length > 0) {
+      cleanupUpstreamAbortHandler();
+      const errorMessage = 'git worktree has pre-existing tracked changes after isolation; refusing budget-managed execution';
+      this.observer.endSpan(chunkSpan, { status: 'error', errorMessage });
+      throw new Error(`${errorMessage}: ${preMartinTrackedChanges.join(', ')}`);
+    }
+    const preMartinUntrackedFiles = this.untrackedFilesFromStatus(preMartinStatus);
 
     // Build martin config with defaults from input when not explicitly provided
     const isImpl = taskId ? !taskId.startsWith('harden:') : true;
@@ -341,7 +349,7 @@ export class CliSkillExecutor {
           formatIterationProgress({ chunkId, iteration, maxIterations: wrappedConfig.maxIterations }),
           { final: false },
         );
-        config.martin?.onProviderAttempt?.(provider, iteration);
+        config.martin?.onProviderAttempt?.(provider, iteration, renderedPrompt);
       },
       onProviderSwitch: (fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset') => {
         this.logger?.warn('MartinLoop: provider switch', { chunkId, fromProvider, toProvider, reason }, 'martin');
@@ -486,17 +494,13 @@ export class CliSkillExecutor {
 
       if (budgetError) {
         this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
-        const postTokens = this.observer.counter.grandTotal();
         this.observer.setMetadata(chunkSpan, {
           budgetExceeded: true,
           spent: budgetError.spent,
           limit: budgetError.limit,
         });
         this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
-        return {
-          output: `Budget exceeded: $${budgetError.spent.toFixed(2)} / $${budgetError.limit.toFixed(2)}`,
-          tokensUsed: postTokens.totalTokens - preTokens.totalTokens,
-        };
+        throw budgetError;
       }
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: String(err) });
       throw new Error(
@@ -509,17 +513,41 @@ export class CliSkillExecutor {
 
     if (budgetAbortResult) {
       this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
-      const postTokens = this.observer.counter.grandTotal();
       this.observer.setMetadata(chunkSpan, {
         budgetExceeded: true,
         spent: budgetAbortResult.spendUsd,
         limit: budgetAbortResult.limitUsd,
       });
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
-      return {
-        output: `Budget exceeded: $${budgetAbortResult.spendUsd.toFixed(2)} / $${budgetAbortResult.limitUsd.toFixed(2)}`,
-        tokensUsed: postTokens.totalTokens - preTokens.totalTokens,
-      };
+      throw new BudgetExceededError(budgetAbortResult.spendUsd, budgetAbortResult.limitUsd);
+    }
+
+    const postMartinTokens = this.observer.counter.grandTotal();
+    const postMartinTokensUsed = postMartinTokens.totalTokens - preTokens.totalTokens;
+    if (!martinResult.completed) {
+      const finalBudgetResult = this.observer.breaker.check(this.computeCurrentCost());
+      if (finalBudgetResult.tripped) {
+        this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
+        this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
+        throw new BudgetExceededError(finalBudgetResult.spendUsd, finalBudgetResult.limitUsd);
+      }
+
+      const emittedTagsMsg = martinResult.emittedPromiseTags && martinResult.emittedPromiseTags.length > 0
+        ? `; emitted tags: ${martinResult.emittedPromiseTags.join(', ')}`
+        : '';
+      const errorMsg =
+        `MartinLoop did not complete for chunk "${chunkId}" after ${martinResult.iterations} iterations `
+        + `(no matching promise tag detected${emittedTagsMsg})`;
+      this.logger?.error('CliSkillExecutor: chunk failed — promise not detected', {
+        chunkId,
+        iterations: martinResult.iterations,
+        tokensUsed: postMartinTokensUsed,
+        ...(martinResult.emittedPromiseTags && martinResult.emittedPromiseTags.length > 0
+          ? { emittedPromiseTags: martinResult.emittedPromiseTags }
+          : {}),
+      });
+      this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: errorMsg });
+      throw new Error(errorMsg);
     }
 
     // Generate commit message for squash merge (if available)
@@ -571,35 +599,6 @@ export class CliSkillExecutor {
       merged: mergeResult.merged,
       commits: mergeResult.commits,
     });
-
-    if (!martinResult.completed) {
-      const finalBudgetResult = this.observer.breaker.check(this.computeCurrentCost());
-      if (finalBudgetResult.tripped) {
-        this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
-        this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
-        return {
-          output: `Budget exceeded: $${finalBudgetResult.spendUsd.toFixed(2)} / $${finalBudgetResult.limitUsd.toFixed(2)}`,
-          tokensUsed: chunkTokensUsed,
-        };
-      }
-
-      const emittedTagsMsg = martinResult.emittedPromiseTags && martinResult.emittedPromiseTags.length > 0
-        ? `; emitted tags: ${martinResult.emittedPromiseTags.join(', ')}`
-        : '';
-      const errorMsg =
-        `MartinLoop did not complete for chunk "${chunkId}" after ${martinResult.iterations} iterations `
-        + `(no matching promise tag detected${emittedTagsMsg})`;
-      this.logger?.error('CliSkillExecutor: chunk failed — promise not detected', {
-        chunkId,
-        iterations: martinResult.iterations,
-        tokensUsed: chunkTokensUsed,
-        ...(martinResult.emittedPromiseTags && martinResult.emittedPromiseTags.length > 0
-          ? { emittedPromiseTags: martinResult.emittedPromiseTags }
-          : {}),
-      });
-      this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: errorMsg });
-      throw new Error(errorMsg);
-    }
 
     this.observer.endSpan(chunkSpan, { status: 'completed' });
     this.observer.recordReplay?.({
@@ -727,6 +726,15 @@ export class CliSkillExecutor {
       .split('\n')
       .map(line => line.trim())
       .filter(line => line.startsWith('?? '))
+      .map(line => line.slice(3).trim())
+      .filter(file => file.length > 0);
+  }
+
+  private trackedChangesFromStatus(status: string): string[] {
+    return status
+      .split('\n')
+      .map(line => line.trimEnd())
+      .filter(line => line.length > 0 && !line.startsWith('?? '))
       .map(line => line.slice(3).trim())
       .filter(file => file.length > 0);
   }

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -502,6 +502,21 @@ export class CliSkillExecutor {
       }
     }
 
+    if (budgetAbortResult) {
+      this.resetBudgetAbortedWorktree();
+      const postTokens = this.observer.counter.grandTotal();
+      this.observer.setMetadata(chunkSpan, {
+        budgetExceeded: true,
+        spent: budgetAbortResult.spendUsd,
+        limit: budgetAbortResult.limitUsd,
+      });
+      this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
+      return {
+        output: `Budget exceeded: $${budgetAbortResult.spendUsd.toFixed(2)} / $${budgetAbortResult.limitUsd.toFixed(2)}`,
+        tokensUsed: postTokens.totalTokens - preTokens.totalTokens,
+      };
+    }
+
     // Generate commit message for squash merge (if available)
     let commitMessage: string | undefined;
     if (this.commitMessageFn) {

--- a/packages/franken-orchestrator/src/skills/cli-types.ts
+++ b/packages/franken-orchestrator/src/skills/cli-types.ts
@@ -53,7 +53,7 @@ export interface MartinLoopConfig {
   readonly onRateLimit?: ((provider: string) => string | undefined) | undefined;
   readonly onIteration?: ((iteration: number, result: IterationResult) => void) | undefined;
   readonly onSleep?: ((durationMs: number, source: string) => void) | undefined;
-  readonly onProviderAttempt?: ((provider: string, iteration: number) => void) | undefined;
+  readonly onProviderAttempt?: ((provider: string, iteration: number, renderedPrompt?: string) => void) | undefined;
   readonly onProviderSwitch?: ((fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset') => void) | undefined;
   readonly onSpawnError?: ((provider: string, error: string) => void) | undefined;
   readonly onProviderTimeout?: ((provider: string, timeoutMs: number) => void) | undefined;

--- a/packages/franken-orchestrator/src/skills/git-branch-isolator.ts
+++ b/packages/franken-orchestrator/src/skills/git-branch-isolator.ts
@@ -344,7 +344,11 @@ export class GitBranchIsolator {
     this.git(['reset', '--hard', commitHash]);
   }
 
-  cleanUntracked(): void {
+  cleanUntracked(paths?: readonly string[]): void {
+    if (paths && paths.length > 0) {
+      this.git(['clean', '-fd', '--', ...paths]);
+      return;
+    }
     this.git(['clean', '-fd']);
   }
 

--- a/packages/franken-orchestrator/src/skills/git-branch-isolator.ts
+++ b/packages/franken-orchestrator/src/skills/git-branch-isolator.ts
@@ -344,6 +344,10 @@ export class GitBranchIsolator {
     this.git(['reset', '--hard', commitHash]);
   }
 
+  cleanUntracked(): void {
+    this.git(['clean', '-fd']);
+  }
+
   getWorkingDir(): string {
     return this.config.workingDir;
   }

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -45,6 +45,10 @@ function abortError(): Error {
   return error;
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 /** Exported for tests: regression coverage that no abort listeners leak (issue #39). */
 export function sleepWithAbort(
   ms: number,
@@ -261,6 +265,11 @@ function spawnIteration(
   sessionContinue = false,
 ): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean; cleanStdout: string }> {
   return new Promise((resolve, reject) => {
+    if (config.abortSignal?.aborted) {
+      reject(abortError());
+      return;
+    }
+
     const cmd = config.command ?? provider.command;
     const providerArgs = provider.buildArgs({ maxTurns: config.maxTurns, sessionContinue });
     const prompt = (promptOverride ?? config.prompt) + NO_COMMIT_CONSTRAINT;
@@ -286,6 +295,7 @@ function spawnIteration(
     const finish = (result: { stdout: string; stderr: string; exitCode: number; timedOut: boolean; cleanStdout: string }): void => {
       if (settled) return;
       settled = true;
+      config.abortSignal?.removeEventListener('abort', onAbort);
       resolve(result);
     };
 
@@ -344,6 +354,20 @@ function spawnIteration(
       escalationTimers.length = 0;
     };
 
+    const fail = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      config.abortSignal?.removeEventListener('abort', onAbort);
+      reject(err);
+    };
+
+    const onAbort = (): void => {
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      fail(abortError());
+    };
+    config.abortSignal?.addEventListener('abort', onAbort, { once: true });
+
     child.on('close', (code) => {
       clearTimers();
       if (streamBuffer) {
@@ -354,8 +378,7 @@ function spawnIteration(
     });
 
     child.on('error', (err) => {
-      clearTimers();
-      reject(err);
+      fail(err);
     });
   });
 }
@@ -406,6 +429,9 @@ export class MartinLoop {
       try {
         result = await spawnIteration(config, resolved, renderedPrompt, sessionContinue);
       } catch (error) {
+        if (isAbortError(error)) {
+          throw error;
+        }
         const msg = error instanceof Error ? error.message : String(error);
         config.onSpawnError?.(activeProvider, msg);
         continue;

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -359,6 +359,10 @@ function spawnIteration(
       escalationTimers.length = 0;
     };
 
+    const clearProviderTimeout = (): void => {
+      clearTimeout(timer);
+    };
+
     const fail = (err: Error): void => {
       if (settled) return;
       settled = true;
@@ -369,6 +373,7 @@ function spawnIteration(
 
     const onAbort = (): void => {
       aborted = true;
+      clearProviderTimeout();
       try { child.kill('SIGTERM'); } catch { /* already dead */ }
       escalationTimers.push(setTimeout(() => {
         try { child.kill('SIGKILL'); } catch { /* already dead */ }
@@ -378,6 +383,7 @@ function spawnIteration(
           const remaining = streamBuffer.flush();
           for (const line of remaining) cleanParts.push(line);
         }
+        clearTimers();
         finish({
           stdout,
           stderr: `${stderr}\n[MartinLoop] iteration aborted`,
@@ -436,7 +442,6 @@ export class MartinLoop {
       const startTime = Date.now();
 
       const resolved = this.registry.get(activeProvider);
-      config.onProviderAttempt?.(activeProvider, iteration);
       let renderedPrompt = config.prompt;
       let sessionContinue = false;
 
@@ -445,6 +450,8 @@ export class MartinLoop {
         renderedPrompt = rendered.prompt;
         sessionContinue = rendered.sessionContinue;
       }
+
+      config.onProviderAttempt?.(activeProvider, iteration, renderedPrompt);
 
       let result: { stdout: string; stderr: string; exitCode: number; timedOut: boolean; cleanStdout: string };
       try {
@@ -456,6 +463,10 @@ export class MartinLoop {
         const msg = error instanceof Error ? error.message : String(error);
         config.onSpawnError?.(activeProvider, msg);
         continue;
+      }
+
+      if (config.abortSignal?.aborted) {
+        throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
       }
 
       const durationMs = Date.now() - startTime;

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -288,6 +288,7 @@ function spawnIteration(
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let aborted = false;
     let timedOut = false;
     const cleanParts: string[] = [];
     const streamBuffer = provider.supportsStreamJson() ? new StreamLineBuffer() : null;
@@ -296,6 +297,10 @@ function spawnIteration(
       if (settled) return;
       settled = true;
       config.abortSignal?.removeEventListener('abort', onAbort);
+      if (aborted) {
+        reject(abortError());
+        return;
+      }
       resolve(result);
     };
 
@@ -363,8 +368,24 @@ function spawnIteration(
     };
 
     const onAbort = (): void => {
+      aborted = true;
       try { child.kill('SIGTERM'); } catch { /* already dead */ }
-      fail(abortError());
+      escalationTimers.push(setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch { /* already dead */ }
+      }, 5_000));
+      escalationTimers.push(setTimeout(() => {
+        if (streamBuffer) {
+          const remaining = streamBuffer.flush();
+          for (const line of remaining) cleanParts.push(line);
+        }
+        finish({
+          stdout,
+          stderr: `${stderr}\n[MartinLoop] iteration aborted`,
+          exitCode: 130,
+          timedOut,
+          cleanStdout: cleanParts.join('\n'),
+        });
+      }, 7_000));
     };
     config.abortSignal?.addEventListener('abort', onAbort, { once: true });
 

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -11,6 +11,7 @@ function fakeGit(): GitBranchIsolator {
     getWorkingDir: () => process.cwd(),
     getStatus: () => '',
     resetHard: () => undefined,
+    cleanUntracked: () => undefined,
     autoCommit: () => false,
     getCurrentHead: () => 'HEAD',
     getDiffStat: () => '',

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -1,5 +1,40 @@
 import { describe, it, expect } from 'vitest';
 import { CliObserverBridge } from '../../src/adapters/cli-observer-bridge.js';
+import { CliSkillExecutor } from '../../src/skills/cli-skill-executor.js';
+import { GitBranchIsolator } from '../../src/skills/git-branch-isolator.js';
+import { MartinLoop } from '../../src/skills/martin-loop.js';
+import { ProviderRegistry, type ICliProvider } from '../../src/skills/providers/cli-provider.js';
+
+function fakeGit(): GitBranchIsolator {
+  return {
+    isolate: () => undefined,
+    getWorkingDir: () => process.cwd(),
+    autoCommit: () => false,
+    getCurrentHead: () => 'HEAD',
+    getDiffStat: () => '',
+    merge: () => ({ merged: true, commits: 0 }),
+    abortMerge: () => undefined,
+    getConflictDiff: () => '',
+    getConflictedFiles: () => [],
+  } as unknown as GitBranchIsolator;
+}
+
+function provider(name: string, script: string): ICliProvider {
+  return {
+    name,
+    command: 'node',
+    chatModel: name,
+    buildArgs: () => ['-e', script],
+    normalizeOutput: (raw) => raw,
+    estimateTokens: (text) => Math.ceil(text.length / 4),
+    isRateLimited: () => false,
+    parseRetryAfter: () => undefined,
+    filterEnv: (env) => env,
+    supportsStreamJson: () => false,
+    supportsNativeSessionResume: () => false,
+    defaultContextWindowTokens: () => 200_000,
+  };
+}
 
 describe('Budget enforcement integration', () => {
   it('trips the circuit breaker when recorded cost exceeds budget', async () => {
@@ -80,5 +115,78 @@ describe('Budget enforcement integration', () => {
     expect(typeof deps.endSpan).toBe('function');
     expect(typeof deps.recordTokenUsage).toBe('function');
     expect(typeof deps.setMetadata).toBe('function');
+  });
+
+  it('checks estimated iteration cost before spawning a provider process', async () => {
+    const bridge = new CliObserverBridge({ budgetLimitUsd: 0.000001 });
+    bridge.startTrace('budget-preflight-abort');
+
+    const registry = new ProviderRegistry();
+    registry.register(provider('gpt-4o', 'process.stdout.write("should not spawn")'));
+    const executor = new CliSkillExecutor(
+      new MartinLoop(registry),
+      fakeGit(),
+      bridge.observerDeps,
+    );
+
+    const result = await executor.execute(
+      'cli:budget-preflight',
+      { objective: 'expensive task', sessionId: 'budget-preflight', dependencyOutputs: new Map() },
+      {
+        martin: {
+          prompt: 'expensive task',
+          promiseTag: 'DONE',
+          maxIterations: 1,
+          maxTurns: 25,
+          provider: 'gpt-4o',
+          timeoutMs: 5_000,
+        },
+      },
+    );
+
+    expect(result.output).toContain('Budget exceeded:');
+  });
+
+  it('aborts an in-flight MartinLoop iteration when budget is exceeded mid-execution', async () => {
+    const bridge = new CliObserverBridge({ budgetLimitUsd: 0.02 });
+    bridge.startTrace('budget-mid-execution-abort');
+
+    const registry = new ProviderRegistry();
+    registry.register(provider('gpt-4o', 'setInterval(() => process.stdout.write("working\\n"), 50)'));
+    const executor = new CliSkillExecutor(
+      new MartinLoop(registry),
+      fakeGit(),
+      bridge.observerDeps,
+    );
+
+    const startedAt = Date.now();
+    const resultPromise = executor.execute(
+      'cli:budget-mid-execution',
+      { objective: 'long running task', sessionId: 'budget-mid-execution', dependencyOutputs: new Map() },
+      {
+        martin: {
+          prompt: 'long running task',
+          promiseTag: 'DONE',
+          maxIterations: 1,
+          maxTurns: 1,
+          provider: 'gpt-4o',
+          timeoutMs: 5_000,
+        },
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const span = bridge.observerDeps.startSpan(bridge.observerDeps.trace, { name: 'mid-run-spend' });
+    bridge.observerDeps.recordTokenUsage(
+      span,
+      { promptTokens: 2_000, completionTokens: 2_000, model: 'gpt-4o' },
+      bridge.observerDeps.counter,
+    );
+    bridge.observerDeps.endSpan(span);
+
+    const result = await resultPromise;
+
+    expect(result.output).toContain('Budget exceeded:');
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 });

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -138,7 +138,7 @@ describe('Budget enforcement integration', () => {
       bridge.observerDeps,
     );
 
-    const result = await executor.execute(
+    await expect(executor.execute(
       'cli:budget-preflight',
       { objective: 'expensive task', context: emptyContext, sessionId: 'budget-preflight', projectId: 'test-project', dependencyOutputs: new Map() },
       {
@@ -151,9 +151,7 @@ describe('Budget enforcement integration', () => {
           timeoutMs: 5_000,
         },
       },
-    );
-
-    expect(result.output).toContain('Budget exceeded:');
+    )).rejects.toThrow(/Budget exceeded:/);
   });
 
   it('aborts an in-flight MartinLoop iteration when budget is exceeded mid-execution', async () => {
@@ -196,10 +194,45 @@ describe('Budget enforcement integration', () => {
     );
     bridge.observerDeps.endSpan(span);
 
-    const result = await resultPromise;
-
-    expect(result.output).toContain('Budget exceeded:');
+    await expect(resultPromise).rejects.toThrow(/Budget exceeded:/);
     expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it('refuses budget-managed execution with pre-existing tracked changes', async () => {
+    const bridge = new CliObserverBridge({ budgetLimitUsd: 1 });
+    bridge.startTrace('budget-refuse-tracked-dirty');
+
+    const registry = new ProviderRegistry();
+    registry.register(provider('gpt-4o', 'process.stdout.write("should not spawn")'));
+    const resetHeads: string[] = [];
+    const cleaned: string[][] = [];
+    const executor = new CliSkillExecutor(
+      new MartinLoop(registry),
+      fakeGit({
+        getStatus: () => ' M user-work.ts\n?? user-notes.md',
+        resetHard: (commitHash) => resetHeads.push(commitHash),
+        cleanUntracked: (paths) => cleaned.push([...(paths ?? [])]),
+      }),
+      bridge.observerDeps,
+    );
+
+    await expect(executor.execute(
+      'cli:budget-refuse-tracked-dirty',
+      { objective: 'task', context: emptyContext, sessionId: 'budget-refuse-tracked-dirty', projectId: 'test-project', dependencyOutputs: new Map() },
+      {
+        martin: {
+          prompt: 'task',
+          promiseTag: 'DONE',
+          maxIterations: 1,
+          maxTurns: 1,
+          provider: 'gpt-4o',
+          timeoutMs: 5_000,
+        },
+      },
+    )).rejects.toThrow(/pre-existing tracked changes/);
+
+    expect(resetHeads).toEqual([]);
+    expect(cleaned).toEqual([]);
   });
 
   it('cleans only untracked files created after Martin starts on budget abort', async () => {
@@ -247,9 +280,7 @@ describe('Budget enforcement integration', () => {
     );
     bridge.observerDeps.endSpan(span);
 
-    const result = await resultPromise;
-
-    expect(result.output).toContain('Budget exceeded:');
+    await expect(resultPromise).rejects.toThrow(/Budget exceeded:/);
     expect(resetHeads).toEqual(['HEAD']);
     expect(cleaned).toEqual([['generated-output.md']]);
   });

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -178,7 +178,10 @@ describe('Budget enforcement integration', () => {
       },
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Record spend immediately after the provider has been launched. Waiting on
+    // an additional timer here made the test race the provider timeout on
+    // slower CI workers, even though the budget polling path is the behavior
+    // under test.
     const span = bridge.observerDeps.startSpan(bridge.observerDeps.trace, { name: 'mid-run-spend' });
     bridge.observerDeps.recordTokenUsage(
       span,

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -9,6 +9,8 @@ function fakeGit(): GitBranchIsolator {
   return {
     isolate: () => undefined,
     getWorkingDir: () => process.cwd(),
+    getStatus: () => '',
+    resetHard: () => undefined,
     autoCommit: () => false,
     getCurrentHead: () => 'HEAD',
     getDiffStat: () => '',
@@ -131,7 +133,7 @@ describe('Budget enforcement integration', () => {
 
     const result = await executor.execute(
       'cli:budget-preflight',
-      { objective: 'expensive task', sessionId: 'budget-preflight', dependencyOutputs: new Map() },
+      { objective: 'expensive task', context: '', sessionId: 'budget-preflight', dependencyOutputs: new Map() },
       {
         martin: {
           prompt: 'expensive task',
@@ -162,7 +164,7 @@ describe('Budget enforcement integration', () => {
     const startedAt = Date.now();
     const resultPromise = executor.execute(
       'cli:budget-mid-execution',
-      { objective: 'long running task', sessionId: 'budget-mid-execution', dependencyOutputs: new Map() },
+      { objective: 'long running task', context: '', sessionId: 'budget-mid-execution', dependencyOutputs: new Map() },
       {
         martin: {
           prompt: 'long running task',

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -5,13 +5,19 @@ import { GitBranchIsolator } from '../../src/skills/git-branch-isolator.js';
 import { MartinLoop } from '../../src/skills/martin-loop.js';
 import { ProviderRegistry, type ICliProvider } from '../../src/skills/providers/cli-provider.js';
 
-function fakeGit(): GitBranchIsolator {
+const emptyContext = { adrs: [], knownErrors: [], rules: [] };
+
+function fakeGit(options: {
+  getStatus?: () => string;
+  resetHard?: (commitHash: string) => void;
+  cleanUntracked?: (paths?: readonly string[]) => void;
+} = {}): GitBranchIsolator {
   return {
     isolate: () => undefined,
     getWorkingDir: () => process.cwd(),
-    getStatus: () => '',
-    resetHard: () => undefined,
-    cleanUntracked: () => undefined,
+    getStatus: options.getStatus ?? (() => ''),
+    resetHard: options.resetHard ?? (() => undefined),
+    cleanUntracked: options.cleanUntracked ?? (() => undefined),
     autoCommit: () => false,
     getCurrentHead: () => 'HEAD',
     getDiffStat: () => '',
@@ -134,7 +140,7 @@ describe('Budget enforcement integration', () => {
 
     const result = await executor.execute(
       'cli:budget-preflight',
-      { objective: 'expensive task', context: '', sessionId: 'budget-preflight', dependencyOutputs: new Map() },
+      { objective: 'expensive task', context: emptyContext, sessionId: 'budget-preflight', projectId: 'test-project', dependencyOutputs: new Map() },
       {
         martin: {
           prompt: 'expensive task',
@@ -165,7 +171,7 @@ describe('Budget enforcement integration', () => {
     const startedAt = Date.now();
     const resultPromise = executor.execute(
       'cli:budget-mid-execution',
-      { objective: 'long running task', context: '', sessionId: 'budget-mid-execution', dependencyOutputs: new Map() },
+      { objective: 'long running task', context: emptyContext, sessionId: 'budget-mid-execution', projectId: 'test-project', dependencyOutputs: new Map() },
       {
         martin: {
           prompt: 'long running task',
@@ -194,5 +200,57 @@ describe('Budget enforcement integration', () => {
 
     expect(result.output).toContain('Budget exceeded:');
     expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it('cleans only untracked files created after Martin starts on budget abort', async () => {
+    const bridge = new CliObserverBridge({ budgetLimitUsd: 0.02 });
+    bridge.startTrace('budget-clean-new-untracked-only');
+
+    const statuses = [
+      '?? user-notes.md',
+      ' M tracked.ts\n?? user-notes.md\n?? generated-output.md',
+    ];
+    const cleaned: string[][] = [];
+    const resetHeads: string[] = [];
+    const registry = new ProviderRegistry();
+    registry.register(provider('gpt-4o', 'setInterval(() => process.stdout.write("working\\n"), 50)'));
+    const executor = new CliSkillExecutor(
+      new MartinLoop(registry),
+      fakeGit({
+        getStatus: () => statuses.shift() ?? ' M tracked.ts\n?? user-notes.md\n?? generated-output.md',
+        resetHard: (commitHash) => resetHeads.push(commitHash),
+        cleanUntracked: (paths) => cleaned.push([...(paths ?? [])]),
+      }),
+      bridge.observerDeps,
+    );
+
+    const resultPromise = executor.execute(
+      'cli:budget-clean-new-untracked-only',
+      { objective: 'long running task', context: emptyContext, sessionId: 'budget-clean-new-untracked-only', projectId: 'test-project', dependencyOutputs: new Map() },
+      {
+        martin: {
+          prompt: 'long running task',
+          promiseTag: 'DONE',
+          maxIterations: 1,
+          maxTurns: 1,
+          provider: 'gpt-4o',
+          timeoutMs: 5_000,
+        },
+      },
+    );
+
+    const span = bridge.observerDeps.startSpan(bridge.observerDeps.trace, { name: 'mid-run-spend' });
+    bridge.observerDeps.recordTokenUsage(
+      span,
+      { promptTokens: 2_000, completionTokens: 2_000, model: 'gpt-4o' },
+      bridge.observerDeps.counter,
+    );
+    bridge.observerDeps.endSpan(span);
+
+    const result = await resultPromise;
+
+    expect(result.output).toContain('Budget exceeded:');
+    expect(resetHeads).toEqual(['HEAD']);
+    expect(cleaned).toEqual([['generated-output.md']]);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -30,6 +30,7 @@ type MockGit = GitBranchIsolator & {
   getWorkingDir: ReturnType<typeof vi.fn<GitBranchIsolator['getWorkingDir']>>;
   getStatus: ReturnType<typeof vi.fn<GitBranchIsolator['getStatus']>>;
   resetHard: ReturnType<typeof vi.fn<GitBranchIsolator['resetHard']>>;
+  cleanUntracked: ReturnType<typeof vi.fn<GitBranchIsolator['cleanUntracked']>>;
   getConflictedFiles: ReturnType<typeof vi.fn<GitBranchIsolator['getConflictedFiles']>>;
   getConflictDiff: ReturnType<typeof vi.fn<GitBranchIsolator['getConflictDiff']>>;
   completeMerge: ReturnType<typeof vi.fn<GitBranchIsolator['completeMerge']>>;
@@ -164,6 +165,7 @@ function makeMockGit(): MockGit {
     getWorkingDir: vi.fn<GitBranchIsolator['getWorkingDir']>().mockReturnValue('/tmp/test-repo'),
     getStatus: vi.fn<GitBranchIsolator['getStatus']>().mockReturnValue(''),
     resetHard: vi.fn<GitBranchIsolator['resetHard']>(),
+    cleanUntracked: vi.fn<GitBranchIsolator['cleanUntracked']>(),
     getConflictedFiles: vi.fn<GitBranchIsolator['getConflictedFiles']>().mockReturnValue([]),
     getConflictDiff: vi.fn<GitBranchIsolator['getConflictDiff']>().mockReturnValue(''),
     completeMerge: vi.fn<GitBranchIsolator['completeMerge']>(),
@@ -374,6 +376,20 @@ describe('CliSkillExecutor', () => {
       expect(result.tokensUsed).toBe(300);
     });
 
+    it('forwards rendered prompts to provider-attempt callbacks', async () => {
+      const onProviderAttempt = vi.fn<NonNullable<MartinLoopConfig['onProviderAttempt']>>();
+      martin.run.mockImplementation(async (config: MartinLoopConfig) => {
+        config.onProviderAttempt?.('claude', 2, 'rendered session prompt');
+        return { completed: true, iterations: 1, output: '<promise>IMPL_01_DONE</promise>', tokensUsed: 250 };
+      });
+
+      await createAndExecute('cli:01_types', makeSkillInput(), makeCliConfig({
+        martin: { onProviderAttempt },
+      }));
+
+      expect(onProviderAttempt).toHaveBeenCalledWith('claude', 2, 'rendered session prompt');
+    });
+
     it('uses executor-level provider defaults when execution passes no martin config', async () => {
       const executor = harness.executor({
         defaultMartinConfig: {
@@ -461,7 +477,7 @@ describe('CliSkillExecutor', () => {
   });
 
   describe('budget exceeded mid-loop', () => {
-    it('stops loop early and returns partial result', async () => {
+    it('stops loop early and propagates a budget failure', async () => {
       observer.breaker.check
         .mockReturnValueOnce({ tripped: false, limitUsd: 10, spendUsd: 0 })
         .mockReturnValue({ tripped: true, limitUsd: 10, spendUsd: 11 });
@@ -472,14 +488,22 @@ describe('CliSkillExecutor', () => {
         return { completed: true, iterations: 1, output: 'done', tokensUsed: 5000 };
       });
 
-      const result = await createAndExecute();
-
-      expect(result.output).toContain('Budget exceeded');
+      await expect(createAndExecute()).rejects.toThrow(/Budget exceeded/);
       expect(git.merge).not.toHaveBeenCalled();
       expect(observer.endSpan).toHaveBeenCalledWith(
         expect.any(Object),
         expect.objectContaining({ errorMessage: 'budget-exceeded' }),
       );
+    });
+
+    it('refuses to run when isolation leaves pre-existing tracked changes', async () => {
+      git.getStatus.mockReturnValue(' M src/user-work.ts\n?? notes.md');
+
+      await expect(createAndExecute()).rejects.toThrow(/pre-existing tracked changes.*src\/user-work\.ts/);
+
+      expect(martin.run).not.toHaveBeenCalled();
+      expect(git.resetHard).not.toHaveBeenCalled();
+      expect(git.cleanUntracked).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- pass a budget-controlled AbortSignal into MartinLoop
- check estimated iteration cost before spawning providers
- poll spend during execution and abort the child process when budget is exceeded
- cover preflight and in-flight budget termination in orchestrator tests

## Test Plan
- npm run build --workspace packages/franken-observer
- npm run build --workspace packages/franken-types
- npm run build --workspace packages/franken-brain
- npm run build --workspace packages/franken-critique
- npm run build --workspace packages/franken-governor
- npm run test --workspace packages/franken-orchestrator -- budget-enforcement.test.ts
- npm run typecheck --workspace packages/franken-orchestrator
- npm run build --workspace packages/franken-orchestrator

Closes #53