### PR TITLE
fix(network): track in-process comms gateway

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -220,7 +220,7 @@ async function resolveCommsPublicRef(root: string, ref: string | undefined, secr
   if (resolved) {
     return resolved;
   }
-  return /^[A-Z_][A-Z0-9_]*$/.test(ref) ? undefined : ref.trim();
+  return ref.trim();
 }
 
 function requireCommsChannelFields(

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -603,7 +603,14 @@ async function resolveManagedCommsConfig(
     return undefined;
   }
 
-  const secrets = secretStore ? await new SecretResolver(secretStore).resolveAll(config) : {};
+  let secrets: Awaited<ReturnType<SecretResolver['resolveAll']>> = {};
+  if (secretStore) {
+    try {
+      secrets = await new SecretResolver(secretStore).resolveAll(config);
+    } catch {
+      secrets = {};
+    }
+  }
   const slackBotToken = secrets.slackBotToken
     ?? await resolveConfiguredSecret(root, config.comms.slack.botTokenRef, secretStore);
   const slackSigningSecret = secrets.slackSigningSecret

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -31,7 +31,7 @@ import { tmpdir } from 'node:os';
 import { startChatServer } from '../http/chat-server.js';
 import { createSqliteAnalyticsService } from '../analytics/sqlite-analytics-service.js';
 import { parse as parseDotenv } from 'dotenv';
-import { createSecretStore } from '../network/secret-store.js';
+import { createSecretStore, SecretResolver } from '../network/secret-store.js';
 import { filterNetworkServices, resolveNetworkServices, type ResolvedNetworkService } from '../network/network-registry.js';
 import { NetworkStateStore } from '../network/network-state-store.js';
 import { NetworkLogStore } from '../network/network-logs.js';
@@ -51,6 +51,7 @@ import { resolveSecurityConfig } from '../middleware/security-profiles.js';
 import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
+import type { CommsConfig } from '../comms/config/comms-config.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -393,6 +394,7 @@ export async function main(): Promise<void> {
         secretStore: bootSecretStore,
         config,
       });
+      const managedCommsConfig = await resolveManagedCommsConfig(config, bootSecretStore);
       const analytics = createSqliteAnalyticsService({
         dbPath: join(paths.frankenbeastDir, 'beast.db'),
       });
@@ -429,6 +431,7 @@ export async function main(): Promise<void> {
               },
             }
           : {}),
+        ...(managedCommsConfig ? { commsConfig: managedCommsConfig } : {}),
         networkControl: {
           root,
           frankenbeastDir: paths.frankenbeastDir,
@@ -546,6 +549,34 @@ export async function main(): Promise<void> {
 type NetworkPaths = Pick<ReturnType<typeof getProjectPaths>, 'frankenbeastDir' | 'configFile'>;
 
 type BeastDaemonPaths = ReturnType<typeof getProjectPaths>;
+
+async function resolveManagedCommsConfig(
+  config: OrchestratorConfig,
+  secretStore: ISecretStore | undefined,
+): Promise<CommsConfig | undefined> {
+  if (!config.comms.enabled && !config.comms.slack.enabled && !config.comms.discord.enabled) {
+    return undefined;
+  }
+
+  const secrets = secretStore ? await new SecretResolver(secretStore).resolveAll(config) : {};
+  return {
+    orchestrator: {
+      ...(secrets.orchestratorToken ? { token: secrets.orchestratorToken } : {}),
+    },
+    channels: {
+      slack: {
+        enabled: config.comms.slack.enabled,
+        ...(secrets.slackBotToken ? { token: secrets.slackBotToken } : {}),
+        ...(secrets.slackSigningSecret ? { signingSecret: secrets.slackSigningSecret } : {}),
+      },
+      discord: {
+        enabled: config.comms.discord.enabled,
+        ...(secrets.discordBotToken ? { token: secrets.discordBotToken } : {}),
+        ...(config.comms.discord.publicKeyRef ? { publicKey: config.comms.discord.publicKeyRef } : {}),
+      },
+    },
+  };
+}
 
 async function runBeastDaemonCommand(
   args: CliArgs,

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -212,16 +212,25 @@ async function resolveCommsSecret(root: string, ref: string | undefined, secretS
   return webEnvValue?.trim() ? webEnvValue.trim() : undefined;
 }
 
-async function resolveCommsPublicRef(root: string, ref: string | undefined, secretStore: ISecretStore | undefined): Promise<string | undefined> {
+async function resolveCommsPublicRef(
+  root: string,
+  ref: string | undefined,
+  secretStore: ISecretStore | undefined,
+  isLiteral: (value: string) => boolean,
+): Promise<string | undefined> {
   if (!ref?.trim()) {
     return undefined;
   }
+  const trimmed = ref.trim();
   const resolved = await resolveCommsSecret(root, ref, secretStore);
   if (resolved) {
     return resolved;
   }
-  return ref.trim();
+  return isLiteral(trimmed) ? trimmed : undefined;
 }
+
+const isDiscordPublicKeyLiteral = (value: string): boolean => /^[a-f0-9]{64}$/i.test(value);
+const isWhatsappPhoneNumberIdLiteral = (value: string): boolean => /^\d{5,}$/.test(value);
 
 function requireCommsChannelFields(
   channel: string,
@@ -257,10 +266,20 @@ async function buildChatServerCommsConfig(
   const slackToken = await resolveCommsSecret(root, config.comms.slack.botTokenRef, secretStore);
   const slackSigningSecret = await resolveCommsSecret(root, config.comms.slack.signingSecretRef, secretStore);
   const discordToken = await resolveCommsSecret(root, config.comms.discord.botTokenRef, secretStore);
-  const discordPublicKey = await resolveCommsPublicRef(root, config.comms.discord.publicKeyRef, secretStore);
+  const discordPublicKey = await resolveCommsPublicRef(
+    root,
+    config.comms.discord.publicKeyRef,
+    secretStore,
+    isDiscordPublicKeyLiteral,
+  );
   const telegramBotToken = await resolveCommsSecret(root, config.comms.telegram.botTokenRef, secretStore);
   const whatsappAccessToken = await resolveCommsSecret(root, config.comms.whatsapp.accessTokenRef, secretStore);
-  const whatsappPhoneNumberId = await resolveCommsPublicRef(root, config.comms.whatsapp.phoneNumberIdRef, secretStore);
+  const whatsappPhoneNumberId = await resolveCommsPublicRef(
+    root,
+    config.comms.whatsapp.phoneNumberIdRef,
+    secretStore,
+    isWhatsappPhoneNumberIdLiteral,
+  );
   const whatsappAppSecret = await resolveCommsSecret(root, config.comms.whatsapp.appSecretRef, secretStore);
   const whatsappVerifyToken = await resolveCommsSecret(root, config.comms.whatsapp.verifyTokenRef, secretStore);
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -176,6 +176,50 @@ async function readOperatorTokenFromEnvFile(filePath: string): Promise<string | 
   }
 }
 
+async function readEnvValueFromFile(filePath: string, key: string): Promise<string | undefined> {
+  try {
+    const contents = await readFile(filePath, 'utf8');
+    const parsed = parseDotenv(contents);
+    return parsed[key];
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveConfiguredSecret(
+  root: string,
+  ref: string | undefined,
+  secretStore: ISecretStore | undefined,
+): Promise<string | undefined> {
+  if (!ref) {
+    return undefined;
+  }
+
+  if (secretStore) {
+    try {
+      const storeValue = await secretStore.resolve(ref);
+      if (storeValue?.trim()) {
+        return storeValue.trim();
+      }
+    } catch {
+      // Secret store unavailable (e.g. missing CLI binary) — fall through to env vars.
+    }
+  }
+
+  const envValue = process.env[ref]?.trim();
+  if (envValue) {
+    return envValue;
+  }
+
+  const rootEnvValue = await readEnvValueFromFile(join(root, '.env'), ref);
+  if (rootEnvValue?.trim()) {
+    return rootEnvValue.trim();
+  }
+
+  const webEnvValue = await readEnvValueFromFile(join(root, 'packages', 'franken-web', '.env.local'), ref);
+  return webEnvValue?.trim() ? webEnvValue.trim() : undefined;
+}
+
 async function createChatSurfaceDeps(
   args: CliArgs,
   config: OrchestratorConfig,
@@ -394,7 +438,7 @@ export async function main(): Promise<void> {
         secretStore: bootSecretStore,
         config,
       });
-      const managedCommsConfig = await resolveManagedCommsConfig(config, bootSecretStore);
+      const managedCommsConfig = await resolveManagedCommsConfig(config, bootSecretStore, root);
       const analytics = createSqliteAnalyticsService({
         dbPath: join(paths.frankenbeastDir, 'beast.db'),
       });
@@ -553,12 +597,20 @@ type BeastDaemonPaths = ReturnType<typeof getProjectPaths>;
 async function resolveManagedCommsConfig(
   config: OrchestratorConfig,
   secretStore: ISecretStore | undefined,
+  root: string,
 ): Promise<CommsConfig | undefined> {
   if (!config.comms.enabled && !config.comms.slack.enabled && !config.comms.discord.enabled) {
     return undefined;
   }
 
   const secrets = secretStore ? await new SecretResolver(secretStore).resolveAll(config) : {};
+  const slackBotToken = secrets.slackBotToken
+    ?? await resolveConfiguredSecret(root, config.comms.slack.botTokenRef, secretStore);
+  const slackSigningSecret = secrets.slackSigningSecret
+    ?? await resolveConfiguredSecret(root, config.comms.slack.signingSecretRef, secretStore);
+  const discordBotToken = secrets.discordBotToken
+    ?? await resolveConfiguredSecret(root, config.comms.discord.botTokenRef, secretStore);
+  const discordPublicKey = await resolveConfiguredSecret(root, config.comms.discord.publicKeyRef, secretStore);
   return {
     orchestrator: {
       ...(secrets.orchestratorToken ? { token: secrets.orchestratorToken } : {}),
@@ -566,13 +618,13 @@ async function resolveManagedCommsConfig(
     channels: {
       slack: {
         enabled: config.comms.slack.enabled,
-        ...(secrets.slackBotToken ? { token: secrets.slackBotToken } : {}),
-        ...(secrets.slackSigningSecret ? { signingSecret: secrets.slackSigningSecret } : {}),
+        ...(slackBotToken ? { token: slackBotToken } : {}),
+        ...(slackSigningSecret ? { signingSecret: slackSigningSecret } : {}),
       },
       discord: {
         enabled: config.comms.discord.enabled,
-        ...(secrets.discordBotToken ? { token: secrets.discordBotToken } : {}),
-        ...(config.comms.discord.publicKeyRef ? { publicKey: config.comms.discord.publicKeyRef } : {}),
+        ...(discordBotToken ? { token: discordBotToken } : {}),
+        ...(discordPublicKey ? { publicKey: discordPublicKey } : {}),
       },
     },
   };

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -674,7 +674,7 @@ async function waitForTerminationSignal(root: string): Promise<void> {
   });
 }
 
-function formatStatus(status: { mode?: string; secureBackend?: string; services: Array<{ id: string; status: string }> }): string[] {
+function formatStatus(status: { mode?: string; secureBackend?: string; services: Array<{ id: string; status: string; inProcess?: boolean; channels?: Record<string, boolean> }> }): string[] {
   const lines = [
     `Mode: ${status.mode ?? 'unknown'}`,
   ];
@@ -684,7 +684,11 @@ function formatStatus(status: { mode?: string; secureBackend?: string; services:
   }
 
   for (const service of status.services) {
-    lines.push(`${service.id}: ${service.status}`);
+    const details = [
+      service.inProcess ? 'in-process' : undefined,
+      service.channels ? `channels=${Object.entries(service.channels).map(([name, enabled]) => `${name}:${enabled ? 'on' : 'off'}`).join(',')}` : undefined,
+    ].filter(Boolean).join(' ');
+    lines.push(`${service.id}: ${service.status}${details ? ` (${details})` : ''}`);
   }
 
   return lines;

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -220,6 +220,18 @@ async function resolveConfiguredSecret(
   return webEnvValue?.trim() ? webEnvValue.trim() : undefined;
 }
 
+async function resolveConfiguredPublicValue(
+  root: string,
+  ref: string | undefined,
+  secretStore: ISecretStore | undefined,
+): Promise<string | undefined> {
+  const resolved = await resolveConfiguredSecret(root, ref, secretStore);
+  if (resolved || !ref) {
+    return resolved;
+  }
+  return /^[A-Z_][A-Z0-9_]*$/.test(ref) ? undefined : ref;
+}
+
 async function createChatSurfaceDeps(
   args: CliArgs,
   config: OrchestratorConfig,
@@ -617,7 +629,7 @@ async function resolveManagedCommsConfig(
     ?? await resolveConfiguredSecret(root, config.comms.slack.signingSecretRef, secretStore);
   const discordBotToken = secrets.discordBotToken
     ?? await resolveConfiguredSecret(root, config.comms.discord.botTokenRef, secretStore);
-  const discordPublicKey = await resolveConfiguredSecret(root, config.comms.discord.publicKeyRef, secretStore);
+  const discordPublicKey = await resolveConfiguredPublicValue(root, config.comms.discord.publicKeyRef, secretStore);
   return {
     orchestrator: {
       ...(secrets.orchestratorToken ? { token: secrets.orchestratorToken } : {}),

--- a/packages/franken-orchestrator/src/comms/config/comms-run-config.ts
+++ b/packages/franken-orchestrator/src/comms/config/comms-run-config.ts
@@ -47,8 +47,13 @@ export interface ResolvedCommsSecrets {
   };
 }
 
+const isDiscordPublicKeyLiteral = (value: string): boolean => /^[a-f0-9]{64}$/i.test(value);
+
 function resolvePublicRef(ref: string, env: Record<string, string | undefined>): string | undefined {
-  return env[ref]?.trim() || ref.trim();
+  const resolved = env[ref]?.trim();
+  if (resolved) return resolved;
+  const trimmed = ref.trim();
+  return isDiscordPublicKeyLiteral(trimmed) ? trimmed : undefined;
 }
 
 /**

--- a/packages/franken-orchestrator/src/comms/config/comms-run-config.ts
+++ b/packages/franken-orchestrator/src/comms/config/comms-run-config.ts
@@ -47,6 +47,10 @@ export interface ResolvedCommsSecrets {
   };
 }
 
+function resolvePublicRef(ref: string, env: Record<string, string | undefined>): string | undefined {
+  return env[ref]?.trim() || ref.trim();
+}
+
 /**
  * Resolve *Ref fields to actual values from an env map.
  * Throws if a required secret is missing for an enabled channel.
@@ -67,7 +71,7 @@ export function resolveCommsSecrets(
 
   if (config.channels.discord.enabled) {
     const token = env[config.channels.discord.tokenRef];
-    const publicKey = env[config.channels.discord.publicKeyRef];
+    const publicKey = resolvePublicRef(config.channels.discord.publicKeyRef, env);
     if (!token) throw new Error(`${config.channels.discord.tokenRef} not found in environment`);
     if (!publicKey) throw new Error(`${config.channels.discord.publicKeyRef} not found in environment`);
     secrets.discord = { token, publicKey };

--- a/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
@@ -41,7 +41,7 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
     // Build runtime state
     const state: ChatRuntimeState = {
       sessionId: input.sessionId,
-      pendingApproval: session.state === 'pending_approval',
+      pendingApproval: Boolean(session.pendingApproval) || session.state === 'pending_approval',
       projectId: session.projectId,
       transcript: session.transcript as ChatRuntimeState['transcript'],
       beastContext: session.beastContext as ChatRuntimeState['beastContext'],
@@ -55,7 +55,10 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
       ...session,
       transcript: result.transcript,
       state: result.state,
-      beastContext: result.beastContext,
+      pendingApproval: result.pendingApproval && result.pendingApprovalDescription
+        ? { description: result.pendingApprovalDescription, requestedAt: new Date().toISOString() }
+        : null,
+      beastContext: result.beastContext !== undefined ? result.beastContext : session.beastContext,
     });
 
     // Map to comms outbound format

--- a/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
@@ -18,7 +18,25 @@ export interface CommsSession {
   transcript: Array<{ role: string; content: string; timestamp: string }>;
   state: string;
   beastContext?: unknown;
+  routingMetadata?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+function normalizeRoutingMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const normalized = { ...metadata };
+  if (normalized.channelId === undefined && typeof metadata.externalChannelId === 'string') {
+    normalized.channelId = metadata.externalChannelId;
+  }
+  if (normalized.threadTs === undefined && typeof metadata.externalThreadId === 'string') {
+    normalized.threadTs = metadata.externalThreadId;
+  }
+  if (normalized.threadId === undefined && typeof metadata.externalThreadId === 'string') {
+    normalized.threadId = metadata.externalThreadId;
+  }
+  return normalized;
 }
 
 export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
@@ -49,15 +67,20 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
 
     // Run through ChatRuntime
     const result = await this.runtime.run(input.text, state);
+    const routingMetadata = normalizeRoutingMetadata(input.metadata ?? session.routingMetadata);
+    const pendingApproval = result.pendingApproval
+      ? result.pendingApprovalDescription
+        ? { description: result.pendingApprovalDescription, requestedAt: new Date().toISOString() }
+        : session.pendingApproval ?? null
+      : null;
 
     // Persist updated session
     await this.sessionStore.save(input.sessionId, {
       ...session,
       transcript: result.transcript,
       state: result.state,
-      pendingApproval: result.pendingApproval && result.pendingApprovalDescription
-        ? { description: result.pendingApprovalDescription, requestedAt: new Date().toISOString() }
-        : null,
+      pendingApproval,
+      ...(routingMetadata ? { routingMetadata } : {}),
       beastContext: result.beastContext !== undefined ? result.beastContext : session.beastContext,
     });
 
@@ -69,8 +92,8 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
     if (display?.kind) {
       out.status = display.kind as OutboundMessageStatus;
     }
-    if (input.metadata) {
-      out.metadata = input.metadata;
+    if (routingMetadata) {
+      out.metadata = routingMetadata;
     }
 
     // Add approval buttons when the runtime signals a pending approval

--- a/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
@@ -59,7 +59,7 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
     // Build runtime state
     const state: ChatRuntimeState = {
       sessionId: input.sessionId,
-      pendingApproval: Boolean(session.pendingApproval) || session.state === 'pending_approval',
+      pendingApproval: session.state === 'pending_approval',
       projectId: session.projectId,
       transcript: session.transcript as ChatRuntimeState['transcript'],
       beastContext: session.beastContext as ChatRuntimeState['beastContext'],
@@ -71,7 +71,7 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
     const pendingApproval = result.pendingApproval
       ? result.pendingApprovalDescription
         ? { description: result.pendingApprovalDescription, requestedAt: new Date().toISOString() }
-        : session.pendingApproval ?? null
+        : session.state === 'pending_approval' ? session.pendingApproval ?? null : null
       : null;
 
     // Persist updated session

--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -73,15 +73,20 @@ export class ChatGateway extends EventEmitter {
       externalUserId: 'system',
     });
 
-    const outboundRouteMetadata = routeMetadata ?? this.routeMetadataBySession.get(sessionId);
-    if (routeMetadata) {
-      this.routeMetadataBySession.set(sessionId, routeMetadata);
+    const outboundRouteMetadata = routeMetadata
+      ?? this.routeMetadataBySession.get(sessionId)
+      ?? result.metadata;
+    if (outboundRouteMetadata) {
+      this.routeMetadataBySession.set(sessionId, outboundRouteMetadata);
     }
     const outbound: ChannelOutboundMessage = {
       text: result.text,
       ...(outboundRouteMetadata ? { metadata: outboundRouteMetadata } : {}),
     };
     if (result.status) outbound.status = result.status;
+    if (result.actions) outbound.actions = result.actions;
+    if (result.provider) outbound.provider = result.provider;
+    if (result.phase) outbound.phase = result.phase;
     this.relayToChannel(sessionId, channelType, outbound);
   }
 

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net';
 import type { Hono } from 'hono';
 import type { ILlmClient } from '@franken/types';
 import { FileSessionStore, type ISessionStore } from '../chat/session-store.js';
+import type { ChatSession } from '../chat/types.js';
 import { createChatRuntime, type ChatRuntimeBundle } from '../chat/chat-runtime-factory.js';
 import { ChatBeastDispatchAdapter } from '../chat/beast-dispatch-adapter.js';
 import { BeastDaemonDispatchAdapter } from '../chat/beast-daemon-dispatch-adapter.js';
@@ -14,6 +15,7 @@ import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import type { BeastRoutesDeps } from './routes/beast-routes.js';
 import type { CommsConfig } from '../comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../comms/core/comms-runtime-port.js';
+import { ChatRuntimeCommsAdapter } from '../comms/core/chat-runtime-comms-adapter.js';
 import type { SkillManager } from '../skills/skill-manager.js';
 import type { ProviderRegistry } from '../providers/provider-registry.js';
 import type { DashboardRouteDeps } from './routes/dashboard-routes.js';
@@ -70,6 +72,65 @@ const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'stopped']);
 
 export function resolveChatServerSessionStore(options: Pick<StartChatServerOptions, 'sessionStore' | 'sessionStoreDir'>): ISessionStore {
   return options.sessionStore ?? new FileSessionStore(options.sessionStoreDir);
+}
+
+function createCommsRuntimeAdapter(
+  runtime: ChatRuntimeBundle['runtime'],
+  sessionStore: ISessionStore,
+  projectName: string,
+): CommsRuntimePort {
+  return new ChatRuntimeCommsAdapter(runtime, {
+    load: async (id) => {
+      const session = sessionStore.get(id);
+      if (!session) {
+        return null;
+      }
+      return {
+        sessionId: session.id,
+        projectId: session.projectId,
+        transcript: session.transcript,
+        state: session.state,
+        ...(session.beastContext ? { beastContext: session.beastContext } : {}),
+      };
+    },
+    create: async (id, data) => {
+      const now = new Date().toISOString();
+      const session: ChatSession = {
+        id,
+        projectId: projectName,
+        transcript: [],
+        state: 'active',
+        tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+        costUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+      sessionStore.save(session);
+      return {
+        sessionId: id,
+        projectId: projectName,
+        transcript: [],
+        state: 'active',
+        ...data,
+      };
+    },
+    save: async (id, data) => {
+      const existing = sessionStore.get(id);
+      const now = new Date().toISOString();
+      const session: ChatSession = {
+        id,
+        projectId: typeof data.projectId === 'string' ? data.projectId : (existing?.projectId ?? projectName),
+        transcript: Array.isArray(data.transcript) ? data.transcript as ChatSession['transcript'] : (existing?.transcript ?? []),
+        state: typeof data.state === 'string' ? data.state : (existing?.state ?? 'active'),
+        tokenTotals: existing?.tokenTotals ?? { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+        costUsd: existing?.costUsd ?? 0,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+        ...(data.beastContext ? { beastContext: data.beastContext as ChatSession['beastContext'] } : existing?.beastContext ? { beastContext: existing.beastContext } : {}),
+      };
+      sessionStore.save(session);
+    },
+  });
 }
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
@@ -138,6 +199,8 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
         : {}),
     ...(options.executionLlm ? { executionLlm: options.executionLlm } : {}),
   });
+  const commsRuntime = options.commsRuntime
+    ?? (options.commsConfig ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.projectName) : undefined);
   const app = createChatApp({
     sessionStore,
     engine: runtime.engine,
@@ -148,7 +211,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ...(options.beastControl ? { beastControl: options.beastControl } : {}),
     ...(options.networkControl ? { networkControl: options.networkControl } : {}),
     ...(options.commsConfig ? { commsConfig: options.commsConfig } : {}),
-    ...(options.commsRuntime ? { commsRuntime: options.commsRuntime } : {}),
+    ...(commsRuntime ? { commsRuntime } : {}),
     ...(options.skillManager ? { skillManager: options.skillManager } : {}),
     ...(options.providerRegistry ? { providerRegistry: options.providerRegistry } : {}),
     ...(options.dashboardDeps ? { dashboardDeps: options.dashboardDeps } : {}),

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -1,5 +1,7 @@
 import { createServer, type Server as HttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { Hono } from 'hono';
 import type { ILlmClient } from '@franken/types';
 import { FileSessionStore, type ISessionStore } from '../chat/session-store.js';
@@ -72,6 +74,19 @@ const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'stopped']);
 
 type ChatSessionWithRouting = ChatSession & { routingMetadata?: Record<string, unknown> | undefined };
 
+async function loadLegacyCommsSession(
+  sessionStoreDir: string,
+  id: string,
+): Promise<(ChatSessionWithRouting & { sessionId?: string }) | null> {
+  try {
+    return JSON.parse(
+      await readFile(join(sessionStoreDir, 'comms', `${encodeURIComponent(id)}.json`), 'utf-8'),
+    ) as ChatSessionWithRouting & { sessionId?: string };
+  } catch {
+    return null;
+  }
+}
+
 export function resolveChatServerSessionStore(options: Pick<StartChatServerOptions, 'sessionStore' | 'sessionStoreDir'>): ISessionStore {
   return options.sessionStore ?? new FileSessionStore(options.sessionStoreDir);
 }
@@ -79,6 +94,7 @@ export function resolveChatServerSessionStore(options: Pick<StartChatServerOptio
 function createCommsRuntimeAdapter(
   runtime: ChatRuntimeBundle['runtime'],
   sessionStore: ISessionStore,
+  sessionStoreDir: string,
   projectName: string,
 ): CommsRuntimePort {
   const toStoredSessionId = (id: string): string => encodeURIComponent(id);
@@ -86,7 +102,19 @@ function createCommsRuntimeAdapter(
     load: async (id) => {
       const session = sessionStore.get(toStoredSessionId(id)) as ChatSessionWithRouting | undefined;
       if (!session) {
-        return null;
+        const legacy = await loadLegacyCommsSession(sessionStoreDir, id);
+        if (!legacy) {
+          return null;
+        }
+        return {
+          sessionId: legacy.sessionId ?? id,
+          projectId: legacy.projectId,
+          transcript: legacy.transcript,
+          state: legacy.state,
+          pendingApproval: legacy.pendingApproval ?? null,
+          ...(legacy.beastContext !== undefined ? { beastContext: legacy.beastContext } : {}),
+          ...(legacy.routingMetadata !== undefined ? { routingMetadata: legacy.routingMetadata } : {}),
+        };
       }
       return {
         sessionId: id,
@@ -221,7 +249,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
   });
   const commsRuntime = options.commsRuntime
     ?? (options.commsConfig
-      ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.projectName)
+      ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName)
       : undefined);
   const app = createChatApp({
     sessionStore,

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -81,14 +81,15 @@ function createCommsRuntimeAdapter(
   sessionStore: ISessionStore,
   projectName: string,
 ): CommsRuntimePort {
+  const toStoredSessionId = (id: string): string => encodeURIComponent(id);
   return new ChatRuntimeCommsAdapter(runtime, {
     load: async (id) => {
-      const session = sessionStore.get(id) as ChatSessionWithRouting | undefined;
+      const session = sessionStore.get(toStoredSessionId(id)) as ChatSessionWithRouting | undefined;
       if (!session) {
         return null;
       }
       return {
-        sessionId: session.id,
+        sessionId: id,
         projectId: session.projectId,
         transcript: session.transcript,
         state: session.state,
@@ -99,8 +100,9 @@ function createCommsRuntimeAdapter(
     },
     create: async (id, data) => {
       const now = new Date().toISOString();
+      const storedId = toStoredSessionId(id);
       const session: ChatSessionWithRouting = {
-        id,
+        id: storedId,
         projectId: typeof data.projectId === 'string' ? data.projectId : projectName,
         transcript: Array.isArray(data.transcript) ? data.transcript as ChatSession['transcript'] : [],
         state: typeof data.state === 'string' ? data.state : 'active',
@@ -114,7 +116,7 @@ function createCommsRuntimeAdapter(
       };
       sessionStore.save(session);
       return {
-        sessionId: session.id,
+        sessionId: id,
         projectId: session.projectId,
         transcript: session.transcript,
         state: session.state,
@@ -124,10 +126,11 @@ function createCommsRuntimeAdapter(
       };
     },
     save: async (id, data) => {
-      const existing = sessionStore.get(id) as ChatSessionWithRouting | undefined;
+      const storedId = toStoredSessionId(id);
+      const existing = sessionStore.get(storedId) as ChatSessionWithRouting | undefined;
       const now = new Date().toISOString();
       const session: ChatSessionWithRouting = {
-        id,
+        id: storedId,
         projectId: typeof data.projectId === 'string' ? data.projectId : (existing?.projectId ?? projectName),
         transcript: Array.isArray(data.transcript) ? data.transcript as ChatSession['transcript'] : (existing?.transcript ?? []),
         state: typeof data.state === 'string' ? data.state : (existing?.state ?? 'active'),

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -90,7 +90,8 @@ function createCommsRuntimeAdapter(
         projectId: session.projectId,
         transcript: session.transcript,
         state: session.state,
-        ...(session.beastContext ? { beastContext: session.beastContext } : {}),
+        pendingApproval: session.pendingApproval ?? null,
+        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
       };
     },
     create: async (id, data) => {
@@ -126,7 +127,12 @@ function createCommsRuntimeAdapter(
         costUsd: existing?.costUsd ?? 0,
         createdAt: existing?.createdAt ?? now,
         updatedAt: now,
-        ...(data.beastContext ? { beastContext: data.beastContext as ChatSession['beastContext'] } : existing?.beastContext ? { beastContext: existing.beastContext } : {}),
+        pendingApproval: data.pendingApproval === undefined
+          ? existing?.pendingApproval ?? null
+          : data.pendingApproval as ChatSession['pendingApproval'],
+        beastContext: data.beastContext === undefined
+          ? existing?.beastContext ?? null
+          : data.beastContext as ChatSession['beastContext'],
       };
       sessionStore.save(session);
     },

--- a/packages/franken-orchestrator/src/network/network-health.ts
+++ b/packages/franken-orchestrator/src/network/network-health.ts
@@ -10,11 +10,16 @@ export interface NetworkServiceHealthStatus {
 export async function resolveServiceHealth(
   service: ManagedNetworkServiceState,
   healthcheck: (service: ManagedNetworkServiceState) => Promise<boolean>,
+  services: ManagedNetworkServiceState[] = [service],
 ): Promise<NetworkServiceHealthStatus> {
   if (service.inProcess) {
+    const healthSource = service.hostServiceId
+      ? services.find((candidate) => candidate.id === service.hostServiceId)
+      : undefined;
+    const healthy = healthSource ? await healthcheck(healthSource) : false;
     return {
       id: service.id,
-      status: 'running',
+      status: healthy ? 'running' : 'stale',
       inProcess: true,
       ...(service.channels ? { channels: service.channels } : {}),
     };

--- a/packages/franken-orchestrator/src/network/network-health.ts
+++ b/packages/franken-orchestrator/src/network/network-health.ts
@@ -3,15 +3,27 @@ import type { ManagedNetworkServiceState } from './network-state-store.js';
 export interface NetworkServiceHealthStatus {
   id: string;
   status: 'running' | 'stale';
+  inProcess?: boolean;
+  channels?: Record<string, boolean>;
 }
 
 export async function resolveServiceHealth(
   service: ManagedNetworkServiceState,
   healthcheck: (service: ManagedNetworkServiceState) => Promise<boolean>,
 ): Promise<NetworkServiceHealthStatus> {
+  if (service.inProcess) {
+    return {
+      id: service.id,
+      status: 'running',
+      inProcess: true,
+      ...(service.channels ? { channels: service.channels } : {}),
+    };
+  }
+
   const healthy = await healthcheck(service);
   return {
     id: service.id,
     status: healthy ? 'running' : 'stale',
+    ...(service.channels ? { channels: service.channels } : {}),
   };
 }

--- a/packages/franken-orchestrator/src/network/network-health.ts
+++ b/packages/franken-orchestrator/src/network/network-health.ts
@@ -16,7 +16,9 @@ export async function resolveServiceHealth(
     const healthSource = service.hostServiceId
       ? services.find((candidate) => candidate.id === service.hostServiceId)
       : undefined;
-    const healthy = healthSource ? await healthcheck(healthSource) : false;
+    const healthy = service.healthUrl
+      ? await healthcheck(service)
+      : healthSource ? await healthcheck(healthSource) : false;
     return {
       id: service.id,
       status: healthy ? 'running' : 'stale',

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -26,6 +26,7 @@ export interface NetworkServiceRuntimeConfig {
   composeFile?: string;
   services?: string[];
   suppressManagedBanner?: boolean;
+  inProcess?: boolean;
   process?: {
     command: string;
     args: string[];

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -27,6 +27,7 @@ export interface NetworkServiceRuntimeConfig {
   services?: string[];
   suppressManagedBanner?: boolean;
   inProcess?: boolean;
+  hostServiceId?: NetworkServiceId;
   process?: {
     command: string;
     args: string[];

--- a/packages/franken-orchestrator/src/network/network-state-store.ts
+++ b/packages/franken-orchestrator/src/network/network-state-store.ts
@@ -12,6 +12,8 @@ export interface ManagedNetworkServiceState {
   url?: string | undefined;
   healthUrl?: string | undefined;
   serviceIdentity?: string | undefined;
+  inProcess?: boolean | undefined;
+  channels?: Record<string, boolean> | undefined;
 }
 
 export interface NetworkOperatorState {

--- a/packages/franken-orchestrator/src/network/network-state-store.ts
+++ b/packages/franken-orchestrator/src/network/network-state-store.ts
@@ -13,6 +13,7 @@ export interface ManagedNetworkServiceState {
   healthUrl?: string | undefined;
   serviceIdentity?: string | undefined;
   inProcess?: boolean | undefined;
+  hostServiceId?: string | undefined;
   channels?: Record<string, boolean> | undefined;
 }
 

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -204,12 +204,11 @@ export class NetworkSupervisor {
     const targetService = target === 'all'
       ? undefined
       : state.services.find((service) => service.id === target);
-    const effectiveTarget = targetService?.inProcess && targetService.hostServiceId
-      ? targetService.hostServiceId
-      : target;
     const selected = target === 'all'
       ? state.services
-      : collectDependents(state.services, effectiveTarget);
+      : targetService?.inProcess
+        ? [targetService]
+        : collectDependents(state.services, target);
 
     for (const service of [...selected].reverse()) {
       await this.deps.stopService(service);

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -102,7 +102,12 @@ export class NetworkSupervisor {
     try {
       for (const service of options.services) {
         if (service.runtimeConfig.inProcess) {
-          services.push(this.createInProcessState(service, startedAt, options.detached));
+          const serviceState = this.createInProcessState(service, startedAt, options.detached);
+          services.push(serviceState);
+          const healthy = await this.waitForHealthy(serviceState);
+          if (!healthy) {
+            throw new Error(`Service ${service.id} failed healthcheck during startup`);
+          }
           continue;
         }
 
@@ -204,11 +209,15 @@ export class NetworkSupervisor {
     const targetService = target === 'all'
       ? undefined
       : state.services.find((service) => service.id === target);
+    if (targetService?.inProcess) {
+      throw new Error(
+        `Cannot stop in-process service ${targetService.id} independently; stop its host service ${targetService.hostServiceId ?? 'process'} or all services instead`,
+      );
+    }
+
     const selected = target === 'all'
       ? state.services
-      : targetService?.inProcess
-        ? [targetService]
-        : collectDependents(state.services, target);
+      : collectDependents(state.services, target);
 
     for (const service of [...selected].reverse()) {
       await this.deps.stopService(service);

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -133,6 +133,11 @@ export class NetworkSupervisor {
     if (!hostService) {
       return false;
     }
+    if (hostState.pid <= 0) {
+      throw new Error(
+        `Cannot enable ${serviceState.id}: host service ${hostServiceId} is already running outside this network state; stop that process and retry.`,
+      );
+    }
 
     await this.deps.stopService(hostState);
     const restartedHost = await this.startManagedService(hostService, detached, startedAt);

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -140,6 +140,12 @@ export class NetworkSupervisor {
     }
 
     await this.deps.stopService(hostState);
+    const stopped = await this.waitForStopped(hostState);
+    if (!stopped) {
+      throw new Error(
+        `Cannot enable ${serviceState.id}: host service ${hostServiceId} did not stop before restart; stop that process and retry.`,
+      );
+    }
     const restartedHost = await this.startManagedService(hostService, detached, startedAt);
     services[hostIndex] = restartedHost;
     return this.waitForHealthy(restartedHost);
@@ -324,6 +330,18 @@ export class NetworkSupervisor {
   private async waitForHealthy(service: ManagedNetworkServiceState): Promise<boolean> {
     for (let attempt = 0; attempt < this.startupAttempts; attempt += 1) {
       if (await this.deps.healthcheck(service)) {
+        return true;
+      }
+      if (attempt < this.startupAttempts - 1) {
+        await sleep(this.startupDelayMs);
+      }
+    }
+    return false;
+  }
+
+  private async waitForStopped(service: ManagedNetworkServiceState): Promise<boolean> {
+    for (let attempt = 0; attempt < this.startupAttempts; attempt += 1) {
+      if (!await this.deps.healthcheck(service)) {
         return true;
       }
       if (attempt < this.startupAttempts - 1) {

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -85,6 +85,7 @@ export class NetworkSupervisor {
       ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
       ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
       ...(service.runtimeConfig.channels ? { channels: service.runtimeConfig.channels } : {}),
+      ...(service.runtimeConfig.hostServiceId ? { hostServiceId: service.runtimeConfig.hostServiceId } : {}),
     };
   }
 
@@ -200,9 +201,15 @@ export class NetworkSupervisor {
       return;
     }
 
+    const targetService = target === 'all'
+      ? undefined
+      : state.services.find((service) => service.id === target);
+    const effectiveTarget = targetService?.inProcess && targetService.hostServiceId
+      ? targetService.hostServiceId
+      : target;
     const selected = target === 'all'
       ? state.services
-      : collectDependents(state.services, target);
+      : collectDependents(state.services, effectiveTarget);
 
     for (const service of [...selected].reverse()) {
       await this.deps.stopService(service);
@@ -240,7 +247,7 @@ export class NetworkSupervisor {
     }
 
     const services = await Promise.all(
-      state.services.map((service) => resolveServiceHealth(service, this.deps.healthcheck)),
+      state.services.map((service) => resolveServiceHealth(service, this.deps.healthcheck, state.services)),
     );
 
     return {

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -89,6 +89,57 @@ export class NetworkSupervisor {
     };
   }
 
+  private async startManagedService(
+    service: ResolvedNetworkService,
+    detached: boolean,
+    startedAt: string,
+  ): Promise<ManagedNetworkServiceState> {
+    const logFile = detached ? await this.deps.logStore.register(service.id) : undefined;
+    const { pid } = await this.deps.startService(service, {
+      detached,
+      ...(logFile ? { logFile } : {}),
+    });
+    return {
+      id: service.id,
+      pid,
+      detached,
+      dependsOn: [...service.dependsOn],
+      startedAt,
+      status: 'started',
+      ...(logFile ? { logFile } : {}),
+      ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
+      ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
+      ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
+    };
+  }
+
+  private async restartReusedHostForInProcessService(
+    serviceState: ManagedNetworkServiceState,
+    services: ManagedNetworkServiceState[],
+    resolvedServices: ResolvedNetworkService[],
+    detached: boolean,
+    startedAt: string,
+  ): Promise<boolean> {
+    const hostServiceId = serviceState.hostServiceId;
+    if (!hostServiceId) {
+      return false;
+    }
+    const hostIndex = services.findIndex((candidate) => candidate.id === hostServiceId);
+    const hostState = hostIndex >= 0 ? services[hostIndex] : undefined;
+    if (!hostState || hostState.status !== 'already-running') {
+      return false;
+    }
+    const hostService = resolvedServices.find((candidate) => candidate.id === hostServiceId);
+    if (!hostService) {
+      return false;
+    }
+
+    await this.deps.stopService(hostState);
+    const restartedHost = await this.startManagedService(hostService, detached, startedAt);
+    services[hostIndex] = restartedHost;
+    return this.waitForHealthy(restartedHost);
+  }
+
   async up(options: {
     services: ResolvedNetworkService[];
     detached: boolean;
@@ -104,7 +155,17 @@ export class NetworkSupervisor {
         if (service.runtimeConfig.inProcess === true) {
           const serviceState = this.createInProcessState(service, startedAt, options.detached);
           services.push(serviceState);
-          const healthy = await this.waitForHealthy(serviceState);
+          let healthy = await this.waitForHealthy(serviceState);
+          if (!healthy) {
+            const hostRestarted = await this.restartReusedHostForInProcessService(
+              serviceState,
+              services,
+              options.services,
+              options.detached,
+              startedAt,
+            );
+            healthy = hostRestarted ? await this.waitForHealthy(serviceState) : false;
+          }
           if (!healthy) {
             throw new Error(`Service ${service.id} failed healthcheck during startup`);
           }
@@ -136,23 +197,7 @@ export class NetworkSupervisor {
           continue;
         }
 
-        const logFile = options.detached ? await this.deps.logStore.register(service.id) : undefined;
-        const { pid } = await this.deps.startService(service, {
-          detached: options.detached,
-          ...(logFile ? { logFile } : {}),
-        });
-        const serviceState: ManagedNetworkServiceState = {
-          id: service.id,
-          pid,
-          detached: options.detached,
-          dependsOn: [...service.dependsOn],
-          startedAt,
-          status: 'started',
-          ...(logFile ? { logFile } : {}),
-          ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
-          ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
-          ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
-        };
+        const serviceState = await this.startManagedService(service, options.detached, startedAt);
         services.push(serviceState);
         const healthy = await this.waitForHealthy(serviceState);
         if (!healthy) {

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -68,6 +68,26 @@ export class NetworkSupervisor {
     this.startupDelayMs = deps.startupDelayMs ?? 250;
   }
 
+  private createInProcessState(
+    service: ResolvedNetworkService,
+    startedAt: string,
+    detached: boolean,
+  ): ManagedNetworkServiceState {
+    return {
+      id: service.id,
+      pid: 0,
+      detached,
+      dependsOn: [...service.dependsOn],
+      startedAt,
+      status: 'already-running',
+      inProcess: true,
+      ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
+      ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
+      ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
+      ...(service.runtimeConfig.channels ? { channels: service.runtimeConfig.channels } : {}),
+    };
+  }
+
   async up(options: {
     services: ResolvedNetworkService[];
     detached: boolean;
@@ -80,6 +100,11 @@ export class NetworkSupervisor {
 
     try {
       for (const service of options.services) {
+        if (service.runtimeConfig.inProcess) {
+          services.push(this.createInProcessState(service, startedAt, options.detached));
+          continue;
+        }
+
         const preflight = await this.resolvePreflight(service);
         if (preflight.action === 'conflict') {
           throw new Error(preflight.reason ?? `Port conflict for ${service.id}`);
@@ -98,6 +123,7 @@ export class NetworkSupervisor {
             ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : existingService?.url ? { url: existingService.url } : {}),
             ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : existingService?.healthUrl ? { healthUrl: existingService.healthUrl } : {}),
             ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : existingService?.serviceIdentity ? { serviceIdentity: existingService.serviceIdentity } : {}),
+            ...(service.runtimeConfig.channels ? { channels: service.runtimeConfig.channels } : existingService?.channels ? { channels: existingService.channels } : {}),
           });
           continue;
         }
@@ -118,6 +144,7 @@ export class NetworkSupervisor {
           ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
           ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
           ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
+          ...(service.runtimeConfig.channels ? { channels: service.runtimeConfig.channels } : {}),
         };
         services.push(serviceState);
         const healthy = await this.waitForHealthy(serviceState);

--- a/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
+++ b/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
@@ -22,9 +22,10 @@ export const commsGatewayService: NetworkServiceDefinition = {
   describe: (config: OrchestratorConfig) =>
     `Enabled when comms.enabled=true or a channel is enabled; current channel flags slack=${config.comms.slack.enabled} discord=${config.comms.discord.enabled}.`,
   buildRuntimeConfig: (config: OrchestratorConfig) => ({
-    host: config.comms.host,
-    port: config.comms.port,
-    url: `http://${config.comms.host}:${config.comms.port}`,
+    host: config.chat.host,
+    port: config.chat.port,
+    url: `http://${config.chat.host}:${config.chat.port}/comms/health`,
+    healthUrl: `http://${config.chat.host}:${config.chat.port}/comms/health`,
     orchestratorWsUrl: config.comms.orchestratorWsUrl,
     channels: {
       slack: config.comms.slack.enabled,
@@ -33,5 +34,6 @@ export const commsGatewayService: NetworkServiceDefinition = {
     // Comms webhook routes are now served in-process on the orchestrator's Hono server
     // via commsRoutes() registered in chat-app.ts — no separate process needed.
     inProcess: true,
+    hostServiceId: 'chat-server',
   }),
 };

--- a/packages/franken-orchestrator/tests/unit/chat/types.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/types.test.ts
@@ -110,6 +110,25 @@ describe('ChatSessionSchema', () => {
     expect(() => ChatSessionSchema.parse(session)).not.toThrow();
   });
 
+  it('preserves comms routing metadata for shared chat sessions', () => {
+    const session = {
+      id: 'sess-1',
+      projectId: 'proj-1',
+      transcript: [],
+      state: 'active',
+      routingMetadata: {
+        channelId: 'C123',
+        threadTs: '171234.000100',
+      },
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    expect(ChatSessionSchema.parse(session).routingMetadata).toEqual(session.routingMetadata);
+  });
+
   it('rejects negative cost', () => {
     const session = {
       id: 'sess-1', projectId: 'proj-1', transcript: [], state: 'active',

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -203,6 +203,18 @@ vi.mock('../../../src/cli/config-loader.js', () => ({
     minCritiqueScore: 0.7,
     maxTotalTokens: 100_000,
     providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+    network: { mode: 'secure', secureBackend: 'local-encrypted' },
+    beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+    chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'claude-sonnet-4-6' },
+    dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+    comms: {
+      enabled: false,
+      host: '127.0.0.1',
+      port: 3200,
+      orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+      slack: { enabled: false },
+      discord: { enabled: false },
+    },
   })),
 }));
 
@@ -219,6 +231,7 @@ vi.mock('node:readline', () => ({
 import { resolvePhases, createStdinIO, main, runDirectCli, shouldForceDirectCliExit } from '../../../src/cli/run.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
+import { loadConfig } from '../../../src/cli/config-loader.js';
 import { createInterface } from 'node:readline';
 
 // ── Tests ──
@@ -589,6 +602,74 @@ describe('main() execution', () => {
     }));
     expect(MockSession).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3737'));
+    logSpy.mockRestore();
+  });
+
+  it('passes comms config to chat-server when managed comms is enabled', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(loadConfig).mockResolvedValueOnce({
+      maxCritiqueIterations: 3,
+      maxDurationMs: 600_000,
+      enableTracing: false,
+      enableHeartbeat: false,
+      minCritiqueScore: 0.7,
+      maxTotalTokens: 100_000,
+      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'claude-sonnet-4-6' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+      comms: {
+        enabled: true,
+        host: '127.0.0.1',
+        port: 3200,
+        orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+        slack: { enabled: true },
+        discord: { enabled: false },
+      },
+    });
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: '/mock/project',
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: '127.0.0.1',
+      port: 3737,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+
+    await main();
+
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      commsConfig: expect.objectContaining({
+        channels: expect.objectContaining({
+          slack: expect.objectContaining({ enabled: true }),
+          discord: expect.objectContaining({ enabled: false }),
+        }),
+      }),
+    }));
     logSpy.mockRestore();
   });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -231,6 +231,7 @@ vi.mock('node:readline', () => ({
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
 import { resolvePhases, createStdinIO, main, runDirectCli, shouldForceDirectCliExit } from '../../../src/cli/run.js';
+import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
 import { createInterface } from 'node:readline';
@@ -444,6 +445,8 @@ describe('main() execution', () => {
     delete process.env.VITE_BEAST_OPERATOR_TOKEN;
     delete process.env.FRANKENBEAST_BEAST_OPERATOR_TOKEN;
     delete process.env.FRANKENBEAST_BEAST_DAEMON_URL;
+    delete process.env.DISCORD_BOT_TOKEN;
+    delete process.env.DISCORD_PUBLIC_KEY;
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -606,6 +609,76 @@ describe('main() execution', () => {
     logSpy.mockRestore();
   });
 
+  it('passes literal uppercase Discord public keys into managed comms config', async () => {
+    const publicKey = 'A'.repeat(64);
+    process.env.DISCORD_BOT_TOKEN = 'discord-token';
+    vi.mocked(loadConfig).mockResolvedValueOnce({
+      maxCritiqueIterations: 3,
+      maxDurationMs: 600_000,
+      enableTracing: false,
+      enableHeartbeat: false,
+      minCritiqueScore: 0.7,
+      maxTotalTokens: 100_000,
+      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      network: { mode: 'insecure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+      comms: {
+        enabled: true,
+        host: '127.0.0.1',
+        port: 3200,
+        orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+        slack: { enabled: false },
+        discord: { enabled: true, botTokenRef: 'DISCORD_BOT_TOKEN', publicKeyRef: publicKey },
+        telegram: { enabled: false },
+        whatsapp: { enabled: false },
+      },
+    } as any);
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: '/mock/project',
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+
+    await main();
+
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      commsConfig: expect.objectContaining({
+        channels: expect.objectContaining({
+          discord: expect.objectContaining({ token: 'discord-token', publicKey }),
+        }),
+      }),
+    }));
+    delete process.env.DISCORD_BOT_TOKEN;
+  });
+
   it('prefers the root .env beast operator token for chat-server', async () => {
     const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}`);
     tempDirs.push(root);
@@ -720,6 +793,72 @@ describe('main() execution', () => {
         operatorToken: 'dashboard-file-token',
       }),
     }));
+  });
+
+  it('does not treat unresolved Discord public-key refs as literal keys', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-discord-public-key`);
+    tempDirs.push(root);
+    mkdirSync(join(root, 'packages', 'franken-web'), { recursive: true });
+    process.env.DISCORD_BOT_TOKEN = 'discord-bot-token';
+    delete process.env.DISCORD_PUBLIC_KEY;
+
+    vi.mocked(loadConfig).mockImplementationOnce(async () => ({
+      maxCritiqueIterations: 3,
+      maxDurationMs: 600_000,
+      enableTracing: false,
+      enableHeartbeat: false,
+      minCritiqueScore: 0.7,
+      maxTotalTokens: 100_000,
+      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+      comms: {
+        enabled: true,
+        host: '127.0.0.1',
+        port: 3200,
+        orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+        slack: { enabled: false },
+        discord: { enabled: true, botTokenRef: 'DISCORD_BOT_TOKEN', publicKeyRef: 'DISCORD_PUBLIC_KEY' },
+        telegram: { enabled: false },
+        whatsapp: { enabled: false },
+      },
+    }) as never);
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    } as never);
+
+    await expect(main()).rejects.toThrow('Cannot start enabled discord comms channel; missing resolved publicKey');
+    expect(mockStartChatServer).not.toHaveBeenCalled();
   });
 
   it('proxies chat-server beast routes only when a daemon URL is explicit', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -673,6 +673,102 @@ describe('main() execution', () => {
     logSpy.mockRestore();
   });
 
+  it('resolves managed comms channel refs from root env when the secret store is unavailable', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-comms-env`);
+    tempDirs.push(root);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, '.env'),
+      [
+        'SLACK_BOT_TOKEN=xoxb-root-token',
+        'SLACK_SIGNING_SECRET=root-signing-secret',
+        'DISCORD_BOT_TOKEN=discord-root-token',
+        'DISCORD_PUBLIC_KEY=0123456789abcdef',
+      ].join('\n'),
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(loadConfig).mockResolvedValueOnce({
+      maxCritiqueIterations: 3,
+      maxDurationMs: 600_000,
+      enableTracing: false,
+      enableHeartbeat: false,
+      minCritiqueScore: 0.7,
+      maxTotalTokens: 100_000,
+      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'claude-sonnet-4-6' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+      comms: {
+        enabled: true,
+        host: '127.0.0.1',
+        port: 3200,
+        orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+        slack: {
+          enabled: true,
+          botTokenRef: 'SLACK_BOT_TOKEN',
+          signingSecretRef: 'SLACK_SIGNING_SECRET',
+        },
+        discord: {
+          enabled: true,
+          botTokenRef: 'DISCORD_BOT_TOKEN',
+          publicKeyRef: 'DISCORD_PUBLIC_KEY',
+        },
+      },
+    });
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: '127.0.0.1',
+      port: 3737,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+
+    await main();
+
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      commsConfig: expect.objectContaining({
+        channels: expect.objectContaining({
+          slack: expect.objectContaining({
+            enabled: true,
+            token: 'xoxb-root-token',
+            signingSecret: 'root-signing-secret',
+          }),
+          discord: expect.objectContaining({
+            enabled: true,
+            token: 'discord-root-token',
+            publicKey: '0123456789abcdef',
+          }),
+        }),
+      }),
+    }));
+    logSpy.mockRestore();
+  });
+
   it('prefers the root .env beast operator token for chat-server', async () => {
     const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}`);
     tempDirs.push(root);

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -159,6 +159,25 @@ describe('ChatGateway', () => {
     );
   });
 
+  it('handleAction relays routing metadata returned by the runtime after a restart', async () => {
+    (runtime.processInbound as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      text: 'approved',
+      status: 'reply',
+      metadata: { channelId: 'C-stored', threadTs: '456.789' },
+    } satisfies CommsInboundResult);
+    const slackAdapter = mockAdapter('slack');
+    gateway.registerAdapter(slackAdapter);
+
+    await gateway.handleAction('slack', 'sess-slack', 'approve');
+
+    expect(slackAdapter.send).toHaveBeenCalledWith(
+      'sess-slack',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ channelId: 'C-stored', threadTs: '456.789' }),
+      }),
+    );
+  });
+
   it('handleAction sends rejection text for reject action', async () => {
     const slackAdapter = mockAdapter('slack');
     gateway.registerAdapter(slackAdapter);

--- a/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
@@ -219,6 +219,37 @@ describe('ChatRuntimeCommsAdapter', () => {
     );
   });
 
+  it('does not treat stale approval metadata as pending after approval state resolves', async () => {
+    store._sessions.set('approved-sess', {
+      sessionId: 'approved-sess',
+      projectId: 'proj-1',
+      transcript: [],
+      state: 'approved',
+      pendingApproval: { description: 'deploy production', requestedAt: '2026-03-10T00:00:00.000Z' },
+    });
+    runtime.run.mockResolvedValue({
+      displayMessages: [{ kind: 'reply', content: 'No approval pending' }],
+      events: [],
+      pendingApproval: true,
+      state: 'active',
+      tier: null,
+      transcript: [],
+    });
+
+    await adapter.processInbound({
+      sessionId: 'approved-sess',
+      channelType: 'slack',
+      text: '/status',
+      externalUserId: 'U123',
+    });
+
+    expect(runtime.run).toHaveBeenCalledWith('/status', expect.objectContaining({ pendingApproval: false }));
+    expect(store.save).toHaveBeenCalledWith(
+      'approved-sess',
+      expect.objectContaining({ pendingApproval: null }),
+    );
+  });
+
   it('normalizes and persists channel routing metadata for Slack and Discord adapters', async () => {
     const result = await adapter.processInbound({
       sessionId: 'route-sess',

--- a/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
@@ -177,6 +177,46 @@ describe('ChatRuntimeCommsAdapter', () => {
       { id: 'approve', label: 'Approve', style: 'primary' },
       { id: 'reject', label: 'Reject', style: 'danger' },
     ]);
+    expect(store.save).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({
+        pendingApproval: expect.objectContaining({
+          description: 'rm -rf /',
+          requestedAt: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it('persists explicit null beast context returned by the runtime', async () => {
+    store._sessions.set('beast-sess', {
+      sessionId: 'beast-sess',
+      projectId: 'proj-1',
+      transcript: [],
+      state: 'active',
+      beastContext: { definitionId: 'martin-loop', interviewSessionId: 'interview-1', status: 'interviewing' },
+    });
+    runtime.run.mockResolvedValue({
+      displayMessages: [{ kind: 'reply', content: 'started run' }],
+      events: [],
+      pendingApproval: false,
+      state: 'active',
+      tier: null,
+      transcript: [],
+      beastContext: null,
+    });
+
+    await adapter.processInbound({
+      sessionId: 'beast-sess',
+      channelType: 'slack',
+      text: 'ship it',
+      externalUserId: 'U123',
+    });
+
+    expect(store.save).toHaveBeenCalledWith(
+      'beast-sess',
+      expect.objectContaining({ beastContext: null }),
+    );
   });
 
   it('does not add approval buttons when not pending', async () => {

--- a/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
@@ -188,6 +188,88 @@ describe('ChatRuntimeCommsAdapter', () => {
     );
   });
 
+  it('preserves existing pending approval metadata when a status turn remains pending', async () => {
+    const pendingApproval = { description: 'deploy production', requestedAt: '2026-03-10T00:00:00.000Z' };
+    store._sessions.set('pending-sess', {
+      sessionId: 'pending-sess',
+      projectId: 'proj-1',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval,
+    });
+    runtime.run.mockResolvedValue({
+      displayMessages: [{ kind: 'reply', content: 'Still waiting for approval' }],
+      events: [],
+      pendingApproval: true,
+      state: 'pending_approval',
+      tier: null,
+      transcript: [],
+    });
+
+    await adapter.processInbound({
+      sessionId: 'pending-sess',
+      channelType: 'slack',
+      text: '/status',
+      externalUserId: 'U123',
+    });
+
+    expect(store.save).toHaveBeenCalledWith(
+      'pending-sess',
+      expect.objectContaining({ pendingApproval }),
+    );
+  });
+
+  it('normalizes and persists channel routing metadata for Slack and Discord adapters', async () => {
+    const result = await adapter.processInbound({
+      sessionId: 'route-sess',
+      channelType: 'slack',
+      text: 'hello',
+      externalUserId: 'U123',
+      metadata: {
+        externalChannelId: 'C123',
+        externalThreadId: '171234.000100',
+      },
+    });
+
+    expect(result.metadata).toEqual(expect.objectContaining({
+      externalChannelId: 'C123',
+      externalThreadId: '171234.000100',
+      channelId: 'C123',
+      threadTs: '171234.000100',
+      threadId: '171234.000100',
+    }));
+    expect(store.save).toHaveBeenCalledWith(
+      'route-sess',
+      expect.objectContaining({
+        routingMetadata: expect.objectContaining({ channelId: 'C123', threadTs: '171234.000100' }),
+      }),
+    );
+  });
+
+  it('reuses stored routing metadata when processing follow-up channel actions', async () => {
+    store._sessions.set('route-sess', {
+      sessionId: 'route-sess',
+      projectId: 'proj-1',
+      transcript: [],
+      state: 'pending_approval',
+      routingMetadata: {
+        externalChannelId: 'C123',
+        externalThreadId: '171234.000100',
+        channelId: 'C123',
+        threadTs: '171234.000100',
+      },
+    });
+
+    const result = await adapter.processInbound({
+      sessionId: 'route-sess',
+      channelType: 'slack',
+      text: '/approve',
+      externalUserId: 'system',
+    });
+
+    expect(result.metadata).toEqual(expect.objectContaining({ channelId: 'C123', threadTs: '171234.000100' }));
+  });
+
   it('persists explicit null beast context returned by the runtime', async () => {
     store._sessions.set('beast-sess', {
       sessionId: 'beast-sess',

--- a/packages/franken-orchestrator/tests/unit/comms/comms-run-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/comms-run-config.test.ts
@@ -68,6 +68,16 @@ describe('resolveCommsSecrets', () => {
     expect(secrets.telegram).toEqual({ botToken: 'tg-123' });
   });
 
+  it('preserves literal Discord public keys when no env value exists', () => {
+    const publicKey = 'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789';
+    const config = CommsRunConfigSchema.parse({
+      channels: { discord: { enabled: true, publicKeyRef: publicKey } },
+    });
+    const secrets = resolveCommsSecrets(config, { DISCORD_BOT_TOKEN: 'discord-token' });
+
+    expect(secrets.discord).toEqual({ token: 'discord-token', publicKey });
+  });
+
   it('skips disabled channels', () => {
     const config = CommsRunConfigSchema.parse({});
     const secrets = resolveCommsSecrets(config, {});

--- a/packages/franken-orchestrator/tests/unit/comms/comms-run-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/comms-run-config.test.ts
@@ -78,6 +78,15 @@ describe('resolveCommsSecrets', () => {
     expect(secrets.discord).toEqual({ token: 'discord-token', publicKey });
   });
 
+  it('rejects unresolved Discord public key ref names', () => {
+    const config = CommsRunConfigSchema.parse({
+      channels: { discord: { enabled: true, publicKeyRef: 'DISCORD_PUBLIC_KEY' } },
+    });
+
+    expect(() => resolveCommsSecrets(config, { DISCORD_BOT_TOKEN: 'discord-token' }))
+      .toThrow('DISCORD_PUBLIC_KEY not found in environment');
+  });
+
   it('skips disabled channels', () => {
     const config = CommsRunConfigSchema.parse({});
     const secrets = resolveCommsSecrets(config, {});

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 vi.mock('../../../src/http/chat-app.js', () => {
   const { Hono } = require('hono') as typeof import('hono');
@@ -20,6 +23,7 @@ const mockedCreateChatApp = vi.mocked(createChatApp);
 
 describe('startChatServer comms pass-through', () => {
   let handle: ChatServerHandle | undefined;
+  let tempDirs: string[] = [];
 
   beforeEach(() => {
     mockedCreateChatApp.mockClear();
@@ -30,6 +34,8 @@ describe('startChatServer comms pass-through', () => {
       await handle.close();
       handle = undefined;
     }
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs = [];
   });
 
   it('passes commsConfig and commsRuntime to createChatApp when provided', async () => {
@@ -78,6 +84,41 @@ describe('startChatServer comms pass-through', () => {
     expect(opts.commsRuntime).toEqual(expect.objectContaining({
       processInbound: expect.any(Function),
     }));
+  });
+
+  it('stores auto-wired comms sessions under encoded ids and preserves routing metadata', async () => {
+    const sessionStoreDir = await mkdtemp(join(tmpdir(), 'chat-server-comms-store-'));
+    tempDirs.push(sessionStoreDir);
+    const commsConfig: CommsConfig = {
+      orchestrator: {},
+      channels: {},
+    };
+
+    handle = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir,
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      commsConfig,
+    });
+
+    const opts = mockedCreateChatApp.mock.calls[0]![0];
+    await opts.commsRuntime!.processInbound({
+      sessionId: 'slack/team/thread',
+      channelType: 'slack',
+      text: '/status',
+      externalUserId: 'U123',
+      metadata: { externalChannelId: 'C123', externalThreadId: '171234.000100' },
+    });
+
+    expect(await readdir(sessionStoreDir)).toEqual(['slack%2Fteam%2Fthread.json']);
+    const stored = handle.sessionStore.get('slack%2Fteam%2Fthread') as { routingMetadata?: Record<string, unknown> } | undefined;
+    expect(stored?.routingMetadata).toEqual(expect.objectContaining({
+      channelId: 'C123',
+      threadTs: '171234.000100',
+    }));
+    expect(handle.sessionStore.get('slack/team/thread')).toBeUndefined();
   });
 
   it('does not pass commsConfig or commsRuntime when not provided', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -119,6 +119,43 @@ describe('startChatServer comms pass-through', () => {
       threadTs: '171234.000100',
     }));
     expect(handle.sessionStore.get('slack/team/thread')).toBeUndefined();
+  });
+
+  it('loads legacy encoded comms sessions before creating a shared chat session', async () => {
+    const sessionStoreDir = await mkdtemp(join(tmpdir(), 'chat-server-comms-legacy-'));
+    tempDirs.push(sessionStoreDir);
+    await mkdir(join(sessionStoreDir, 'comms'));
+    await writeFile(join(sessionStoreDir, 'comms', `${encodeURIComponent('slack/team/thread')}.json`), JSON.stringify({
+      sessionId: 'slack/team/thread',
+      projectId: 'legacy-project',
+      transcript: [{ role: 'assistant', content: 'approval pending', timestamp: '2026-07-04T00:00:00.000Z' }],
+      state: 'pending_approval',
+      pendingApproval: { description: 'legacy approval', requestedAt: '2026-07-04T00:00:00.000Z' },
+      routingMetadata: { channelId: 'C-legacy', threadTs: '123.456' },
+    }), 'utf-8');
+
+    handle = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir,
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      commsConfig: { orchestrator: {}, channels: {} },
+    });
+
+    const opts = mockedCreateChatApp.mock.calls[0]![0];
+    await opts.commsRuntime!.processInbound({
+      sessionId: 'slack/team/thread',
+      channelType: 'slack',
+      text: '/approve',
+      externalUserId: 'U123',
+    });
+
+    const stored = handle.sessionStore.get('slack%2Fteam%2Fthread') as { routingMetadata?: Record<string, unknown>; transcript?: unknown[] } | undefined;
+    expect(stored?.routingMetadata).toEqual(expect.objectContaining({ channelId: 'C-legacy', threadTs: '123.456' }));
+    expect(stored?.transcript).toEqual(expect.arrayContaining([
+      expect.objectContaining({ content: 'approval pending' }),
+    ]));
   });
 
   it('does not pass commsConfig or commsRuntime when not provided', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -57,6 +57,29 @@ describe('startChatServer comms pass-through', () => {
     expect(opts).toHaveProperty('commsRuntime', commsRuntime);
   });
 
+  it('creates a chat-runtime comms adapter when commsConfig is provided without a runtime', async () => {
+    const commsConfig: CommsConfig = {
+      orchestrator: {},
+      channels: {},
+    };
+
+    handle = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir: '/tmp/chat-server-comms-test',
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      commsConfig,
+    });
+
+    expect(mockedCreateChatApp).toHaveBeenCalledOnce();
+    const opts = mockedCreateChatApp.mock.calls[0]![0];
+    expect(opts).toHaveProperty('commsConfig', commsConfig);
+    expect(opts.commsRuntime).toEqual(expect.objectContaining({
+      processInbound: expect.any(Function),
+    }));
+  });
+
   it('does not pass commsConfig or commsRuntime when not provided', async () => {
     handle = await startChatServer({
       host: '127.0.0.1',

--- a/packages/franken-orchestrator/tests/unit/network/network-health.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-health.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveServiceHealth } from '../../../src/network/network-health.js';
+import type { ManagedNetworkServiceState } from '../../../src/network/network-state-store.js';
+
+function service(overrides: Partial<ManagedNetworkServiceState>): ManagedNetworkServiceState {
+  return {
+    id: 'chat-server',
+    pid: 123,
+    dependsOn: [],
+    startedAt: '2026-03-10T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('resolveServiceHealth', () => {
+  it('probes an in-process service healthUrl instead of only its host service', async () => {
+    const chatServer = service({
+      id: 'chat-server',
+      healthUrl: 'http://127.0.0.1:3737/health',
+    });
+    const commsGateway = service({
+      id: 'comms-gateway',
+      inProcess: true,
+      hostServiceId: 'chat-server',
+      healthUrl: 'http://127.0.0.1:3737/comms/health',
+      channels: { slack: true, discord: false },
+    });
+    const healthcheck = vi.fn(async (candidate: ManagedNetworkServiceState) => candidate.id === 'comms-gateway');
+
+    await expect(resolveServiceHealth(commsGateway, healthcheck, [chatServer, commsGateway])).resolves.toEqual({
+      id: 'comms-gateway',
+      status: 'running',
+      inProcess: true,
+      channels: { slack: true, discord: false },
+    });
+    expect(healthcheck).toHaveBeenCalledWith(commsGateway);
+    expect(healthcheck).not.toHaveBeenCalledWith(chatServer);
+  });
+
+  it('falls back to host service health for legacy in-process state without a healthUrl', async () => {
+    const chatServer = service({ id: 'chat-server' });
+    const legacyCommsGateway = service({
+      id: 'comms-gateway',
+      inProcess: true,
+      hostServiceId: 'chat-server',
+    });
+    const healthcheck = vi.fn(async (candidate: ManagedNetworkServiceState) => candidate.id === 'chat-server');
+
+    await expect(resolveServiceHealth(legacyCommsGateway, healthcheck, [chatServer, legacyCommsGateway])).resolves.toEqual({
+      id: 'comms-gateway',
+      status: 'running',
+      inProcess: true,
+    });
+    expect(healthcheck).toHaveBeenCalledWith(chatServer);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -24,6 +24,13 @@ describe('network-registry', () => {
       'dashboard-web',
       'comms-gateway',
     ]);
+    expect(services.find((service) => service.id === 'comms-gateway')?.runtimeConfig).toMatchObject({
+      inProcess: true,
+      channels: {
+        slack: true,
+        discord: false,
+      },
+    });
   });
 
   it('skips disabled services cleanly', () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -251,6 +251,22 @@ describe('NetworkSupervisor', () => {
     const config = defaultConfig();
     config.comms.telegram.enabled = true;
     const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+    await stateStore.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: false,
+      startedAt: '2026-03-10T00:00:00.000Z',
+      services: [
+        {
+          id: 'chat-server',
+          pid: 500,
+          detached: false,
+          dependsOn: ['beasts-daemon'],
+          startedAt: '2026-03-10T00:00:00.000Z',
+          status: 'started',
+        },
+      ],
+    });
     const startService = vi.fn(async () => ({ pid: 601 }));
     const stopService = vi.fn(async () => undefined);
     const healthcheck = vi.fn(async (service) => {
@@ -287,6 +303,57 @@ describe('NetworkSupervisor', () => {
       expect.objectContaining({ id: 'comms-gateway', inProcess: true }),
     ]));
   });
+
+  it('reports reused pid-zero chat-server hosts instead of spawning a duplicate for in-process comms', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const config = defaultConfig();
+    config.comms.telegram.enabled = true;
+    const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+    await stateStore.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: false,
+      startedAt: '2026-03-09T00:00:00.000Z',
+      services: [
+        {
+          id: 'chat-server',
+          pid: 0,
+          detached: false,
+          dependsOn: ['beasts-daemon'],
+          startedAt: '2026-03-09T00:00:00.000Z',
+          status: 'already-running',
+        },
+      ],
+    });
+    const startService = vi.fn(async () => ({ pid: 601 }));
+    const stopService = vi.fn(async () => undefined);
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService,
+      stopService,
+      healthcheck: vi.fn(async (service) => service.id !== 'comms-gateway'),
+      preflightService: vi.fn(async (service) => service.id === 'chat-server'
+        ? { action: 'reuse' as const }
+        : { action: 'start' as const }),
+      now: () => '2026-03-10T00:00:00.000Z',
+      startupAttempts: 1,
+    });
+
+    await expect(supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    })).rejects.toThrow(/host service chat-server is already running outside this network state/);
+
+    expect(stopService).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
+    expect(startService).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }), expect.any(Object));
+  });
+
 
   it('allows reused pid-zero services to stop because they are not in-process markers', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -244,6 +244,50 @@ describe('NetworkSupervisor', () => {
     expect(stopService).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
   });
 
+  it('restarts a reused chat-server when in-process comms routes are missing', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const config = defaultConfig();
+    config.comms.telegram.enabled = true;
+    const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+    const startService = vi.fn(async () => ({ pid: 601 }));
+    const stopService = vi.fn(async () => undefined);
+    const healthcheck = vi.fn(async (service) => {
+      if (service.id === 'comms-gateway') {
+        return startService.mock.calls.some(([startedService]) => startedService.id === 'chat-server');
+      }
+      return true;
+    });
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService,
+      stopService,
+      healthcheck,
+      preflightService: vi.fn(async (service) => service.id === 'chat-server'
+        ? { action: 'reuse' as const }
+        : { action: 'start' as const }),
+      now: () => '2026-03-10T00:00:00.000Z',
+      startupAttempts: 1,
+    });
+
+    const state = await supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    });
+
+    expect(stopService).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
+    expect(startService).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }), expect.any(Object));
+    expect(state.services).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'chat-server', pid: 601, status: 'started' }),
+      expect.objectContaining({ id: 'comms-gateway', inProcess: true }),
+    ]));
+  });
+
   it('allows reused pid-zero services to stop because they are not in-process markers', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -174,7 +174,7 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
-  it('attaches in-process comms gateway without spawning a standalone process', async () => {
+  it('attaches in-process comms gateway after verifying its own health endpoint', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
     const logStore = new NetworkLogStore(join(workDir, 'logs'));
@@ -229,8 +229,37 @@ describe('NetworkSupervisor', () => {
         },
       }),
     ]));
-    expect(healthcheck).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }));
+    expect(healthcheck).toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }));
     expect(healthcheck).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
+  });
+
+  it('fails startup when an in-process comms gateway health endpoint is not mounted', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const config = defaultConfig();
+    config.comms.enabled = true;
+    config.comms.slack.enabled = true;
+    const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(async () => ({ pid: 202 })),
+      stopService: vi.fn(async () => undefined),
+      healthcheck: vi.fn(async (service) => service.id !== 'comms-gateway'),
+      preflightService: vi.fn(async () => ({ action: 'start' as const })),
+      now: () => '2026-03-10T00:00:00.000Z',
+      startupAttempts: 1,
+      startupDelayMs: 0,
+    });
+
+    await expect(supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    })).rejects.toThrow(/Service comms-gateway failed healthcheck during startup/);
   });
 
   it('marks in-process comms gateway stale when its host is unhealthy', async () => {
@@ -279,7 +308,7 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
-  it('stops the in-process comms gateway without terminating its host service', async () => {
+  it('rejects stopping the in-process comms gateway without changing persisted state', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
     const logStore = new NetworkLogStore(join(workDir, 'logs'));
@@ -323,13 +352,14 @@ describe('NetworkSupervisor', () => {
       now: () => '2026-03-09T00:00:00.000Z',
     });
 
-    await supervisor.stop('comms-gateway');
+    await expect(supervisor.stop('comms-gateway')).rejects.toThrow(/Cannot stop in-process service comms-gateway independently/);
 
-    expect(stopped).toEqual(['comms-gateway']);
+    expect(stopped).toEqual([]);
     await expect(stateStore.load()).resolves.toEqual(expect.objectContaining({
       services: expect.arrayContaining([
         expect.objectContaining({ id: 'chat-server' }),
         expect.objectContaining({ id: 'dashboard-web' }),
+        expect.objectContaining({ id: 'comms-gateway' }),
       ]),
     }));
   });

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -268,10 +268,16 @@ describe('NetworkSupervisor', () => {
       ],
     });
     const startService = vi.fn(async () => ({ pid: 601 }));
-    const stopService = vi.fn(async () => undefined);
+    let hostStopped = false;
+    const stopService = vi.fn(async () => {
+      hostStopped = true;
+    });
     const healthcheck = vi.fn(async (service) => {
       if (service.id === 'comms-gateway') {
         return startService.mock.calls.some(([startedService]) => startedService.id === 'chat-server');
+      }
+      if (service.id === 'chat-server' && service.pid === 500 && hostStopped) {
+        return false;
       }
       return true;
     });

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -211,6 +211,7 @@ describe('NetworkSupervisor', () => {
         id: 'comms-gateway',
         pid: 0,
         inProcess: true,
+        hostServiceId: 'chat-server',
         channels: {
           slack: true,
           discord: false,
@@ -229,6 +230,103 @@ describe('NetworkSupervisor', () => {
       }),
     ]));
     expect(healthcheck).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }));
+    expect(healthcheck).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
+  });
+
+  it('marks in-process comms gateway stale when its host is unhealthy', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+
+    await stateStore.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: true,
+      startedAt: '2026-03-09T00:00:00.000Z',
+      services: [
+        {
+          id: 'chat-server',
+          pid: 301,
+          dependsOn: [],
+          startedAt: '2026-03-09T00:00:00.000Z',
+        },
+        {
+          id: 'comms-gateway',
+          pid: 0,
+          dependsOn: ['chat-server'],
+          startedAt: '2026-03-09T00:00:00.000Z',
+          inProcess: true,
+          hostServiceId: 'chat-server',
+          channels: { slack: true, discord: false },
+        },
+      ],
+    });
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(),
+      stopService: vi.fn(),
+      healthcheck: vi.fn(async () => false),
+      now: () => '2026-03-09T00:00:00.000Z',
+    });
+
+    const status = await supervisor.status();
+
+    expect(status.services).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'chat-server', status: 'stale' }),
+      expect.objectContaining({ id: 'comms-gateway', status: 'stale', inProcess: true }),
+    ]));
+  });
+
+  it('stops the in-process comms gateway through its host service', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const stopped: string[] = [];
+
+    await stateStore.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: true,
+      startedAt: '2026-03-09T00:00:00.000Z',
+      services: [
+        {
+          id: 'chat-server',
+          pid: 301,
+          dependsOn: [],
+          startedAt: '2026-03-09T00:00:00.000Z',
+        },
+        {
+          id: 'dashboard-web',
+          pid: 302,
+          dependsOn: ['chat-server'],
+          startedAt: '2026-03-09T00:00:00.000Z',
+        },
+        {
+          id: 'comms-gateway',
+          pid: 0,
+          dependsOn: ['chat-server'],
+          startedAt: '2026-03-09T00:00:00.000Z',
+          inProcess: true,
+          hostServiceId: 'chat-server',
+        },
+      ],
+    });
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(),
+      stopService: vi.fn(async (service) => { stopped.push(service.id); }),
+      healthcheck: vi.fn(async () => true),
+      now: () => '2026-03-09T00:00:00.000Z',
+    });
+
+    await supervisor.stop('comms-gateway');
+
+    expect(stopped).toEqual(['comms-gateway', 'dashboard-web', 'chat-server']);
+    await expect(stateStore.load()).resolves.toBeUndefined();
   });
 
   it('fails fast and rolls back started services when an unmanaged conflict owns a service port', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -279,7 +279,7 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
-  it('stops the in-process comms gateway through its host service', async () => {
+  it('stops the in-process comms gateway without terminating its host service', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
     const logStore = new NetworkLogStore(join(workDir, 'logs'));
@@ -325,8 +325,13 @@ describe('NetworkSupervisor', () => {
 
     await supervisor.stop('comms-gateway');
 
-    expect(stopped).toEqual(['comms-gateway', 'dashboard-web', 'chat-server']);
-    await expect(stateStore.load()).resolves.toBeUndefined();
+    expect(stopped).toEqual(['comms-gateway']);
+    await expect(stateStore.load()).resolves.toEqual(expect.objectContaining({
+      services: expect.arrayContaining([
+        expect.objectContaining({ id: 'chat-server' }),
+        expect.objectContaining({ id: 'dashboard-web' }),
+      ]),
+    }));
   });
 
   it('fails fast and rolls back started services when an unmanaged conflict owns a service port', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -174,6 +174,63 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
+  it('attaches in-process comms gateway without spawning a standalone process', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const config = defaultConfig();
+    config.comms.enabled = true;
+    config.comms.slack.enabled = true;
+    const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+    const startService = vi.fn(async (service: { id: string }) => ({ pid: service.id === 'dashboard-web' ? 203 : 202 }));
+    const healthcheck = vi.fn(async () => true);
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService,
+      stopService: vi.fn(async () => undefined),
+      healthcheck,
+      preflightService: vi.fn(async () => ({ action: 'start' as const })),
+      now: () => '2026-03-10T00:00:00.000Z',
+    });
+
+    const state = await supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    });
+    await stateStore.save(state);
+    const status = await supervisor.status();
+
+    expect(startService).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }), expect.any(Object));
+    expect(startService).toHaveBeenCalledTimes(3);
+    expect(state.services).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'comms-gateway',
+        pid: 0,
+        inProcess: true,
+        channels: {
+          slack: true,
+          discord: false,
+        },
+      }),
+    ]));
+    expect(status.services).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'comms-gateway',
+        status: 'running',
+        inProcess: true,
+        channels: {
+          slack: true,
+          discord: false,
+        },
+      }),
+    ]));
+    expect(healthcheck).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }));
+  });
+
   it('fails fast and rolls back started services when an unmanaged conflict owns a service port', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -48,6 +48,7 @@ export const ChatSessionResponseSchema = z.object({
   state: z.string(),
   pendingApproval: PendingApprovalSchema.nullable().optional(),
   beastContext: ChatBeastContextSchema.nullable().optional(),
+  routingMetadata: z.record(z.unknown()).optional(),
   socketToken: z.string(),
   tokenTotals: TokenTotalsSchema,
   costUsd: z.number().nonnegative(),

--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -3,6 +3,8 @@ interface NetworkServiceItem {
   status: string;
   explanation?: string;
   url?: string;
+  inProcess?: boolean;
+  channels?: Record<string, boolean>;
 }
 
 interface NetworkServiceListProps {
@@ -29,8 +31,10 @@ export function NetworkServiceList({
             <div>
               <strong>{service.id}</strong>
               <p>{service.status}</p>
+              {service.inProcess && <small>in-process</small>}
               {service.explanation && <span>{service.explanation}</span>}
               {service.url && <small>{service.url}</small>}
+              {service.channels && <small>{Object.entries(service.channels).map(([name, enabled]) => `${name}:${enabled ? 'on' : 'off'}`).join(' ')}</small>}
             </div>
             <div className="network-services__actions">
               <button className="button button--secondary button--small" type="button" onClick={() => onStart(service.id)} aria-label={`Start ${service.id}`}>Start</button>

--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -26,7 +26,9 @@ export function NetworkServiceList({
         <p className="eyebrow">Services</p>
       </div>
       <div className="network-services__list">
-        {services.map((service) => (
+        {services.map((service) => {
+          const disableInProcessControls = Boolean(service.inProcess);
+          return (
           <article key={service.id} className="network-services__item">
             <div>
               <strong>{service.id}</strong>
@@ -38,11 +40,12 @@ export function NetworkServiceList({
             </div>
             <div className="network-services__actions">
               <button className="button button--secondary button--small" type="button" onClick={() => onStart(service.id)} aria-label={`Start ${service.id}`}>Start</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => onStop(service.id)} aria-label={`Stop ${service.id}`}>Stop</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => onRestart(service.id)} aria-label={`Restart ${service.id}`}>Restart</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => onStop(service.id)} aria-label={`Stop ${service.id}`} disabled={disableInProcessControls}>Stop</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => onRestart(service.id)} aria-label={`Restart ${service.id}`} disabled={disableInProcessControls}>Restart</button>
             </div>
           </article>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -1,7 +1,14 @@
 export interface NetworkStatusResponse {
   mode?: string;
   secureBackend?: string;
-  services: Array<{ id: string; status: string; explanation?: string; url?: string }>;
+  services: Array<{
+    id: string;
+    status: string;
+    explanation?: string;
+    url?: string;
+    inProcess?: boolean;
+    channels?: Record<string, boolean>;
+  }>;
 }
 
 export interface NetworkConfigResponse {

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -6,7 +6,7 @@ import type { NetworkConfigResponse, NetworkStatusResponse } from '../lib/networ
 
 interface NetworkPageProps {
   status: Pick<NetworkStatusResponse, 'mode' | 'secureBackend'>;
-  services: Array<{ id: string; status: string; explanation?: string; url?: string }>;
+  services: NetworkStatusResponse['services'];
   logs: string[];
   config: NetworkConfigResponse;
   onRefresh(): void;

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -79,4 +79,47 @@ describe('NetworkPage', () => {
     expect(onRestart).toHaveBeenCalledWith('chat-server');
     expect(onSaveConfig).toHaveBeenCalledWith(['chat.model=gpt-5']);
   });
+
+  it('disables unsupported stop and restart controls for in-process services', () => {
+    const onStart = vi.fn();
+    const onStop = vi.fn();
+    const onRestart = vi.fn();
+
+    render(
+      <NetworkPage
+        config={{
+          network: { mode: 'secure', secureBackend: 'local-encrypted' },
+          chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+        }}
+        logs={[]}
+        onRefresh={vi.fn()}
+        onRestart={onRestart}
+        onSaveConfig={vi.fn()}
+        onStart={onStart}
+        onStop={onStop}
+        services={[
+          {
+            id: 'comms-gateway',
+            status: 'running',
+            inProcess: true,
+            channels: { slack: true, discord: false },
+          },
+        ]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    const stopButton = screen.getByRole('button', { name: 'Stop comms-gateway' });
+    const restartButton = screen.getByRole('button', { name: 'Restart comms-gateway' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start comms-gateway' }));
+    fireEvent.click(stopButton);
+    fireEvent.click(restartButton);
+
+    expect(stopButton).toHaveProperty('disabled', true);
+    expect(restartButton).toHaveProperty('disabled', true);
+    expect(onStart).toHaveBeenCalledWith('comms-gateway');
+    expect(onStop).not.toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- model the comms gateway as an in-process network service instead of trying to spawn it
- surface in-process/channel metadata in CLI and dashboard network status
- preserve status/health reporting without probing pid=0 in-process services

## Test Plan
- npm --workspace packages/franken-orchestrator run test -- tests/unit/network/network-supervisor.test.ts tests/unit/network/network-registry.test.ts
- npm --workspace packages/franken-orchestrator run typecheck
- npm --workspace packages/franken-orchestrator run build
- npm --workspace packages/franken-web run typecheck
- npm --workspace packages/franken-web run build

Closes #416