### PR TITLE
fix(critique): align warning evaluator verdicts

### DIFF
--- a/packages/franken-critique/src/evaluators/adr-compliance.ts
+++ b/packages/franken-critique/src/evaluators/adr-compliance.ts
@@ -35,7 +35,7 @@ export class ADRComplianceEvaluator implements Evaluator {
 
     return {
       evaluatorName: this.name,
-      verdict: findings.length === 0 ? 'pass' : 'fail',
+      verdict: findings.length === 0 ? 'pass' : 'warn',
       score,
       findings,
     };

--- a/packages/franken-critique/src/evaluators/factuality.ts
+++ b/packages/franken-critique/src/evaluators/factuality.ts
@@ -34,7 +34,7 @@ export class FactualityEvaluator implements Evaluator {
 
     return {
       evaluatorName: this.name,
-      verdict: 'pass',
+      verdict: findings.length === 0 ? 'pass' : 'warn',
       score,
       findings,
     };

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -49,8 +49,9 @@ export class CritiqueLoop {
       const postResult = await this.checkBreakers(state, config, 'post');
       if (postResult) return postResult;
 
-      // Pass: return success
-      if (critiqueResult.verdict === 'pass') {
+      // Pass/warn: warnings are non-critical findings that should surface in
+      // results without forcing correction iterations.
+      if (critiqueResult.verdict === 'pass' || critiqueResult.verdict === 'warn') {
         return { verdict: 'pass', iterations: state.iterations };
       }
 

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -37,7 +37,9 @@ export class LessonRecorder {
     taskId: TaskId,
   ): CritiqueLesson[] {
     const lessons: CritiqueLesson[] = [];
-    const passingIteration = allIterations.find((it) => it.result.verdict === 'pass');
+    const passingIteration = allIterations.find(
+      (it) => it.result.verdict === 'pass' || it.result.verdict === 'warn',
+    );
 
     for (const evalResult of failingIteration.result.results) {
       if (evalResult.verdict === 'fail' && evalResult.findings.length > 0) {

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -34,9 +34,10 @@ export class CritiquePipeline {
 
     const overallScore = results.reduce((sum, r) => sum + r.score, 0) / results.length;
     const hasFailure = results.some((r) => r.verdict === 'fail');
+    const hasWarning = results.some((r) => r.verdict === 'warn');
 
     return {
-      verdict: hasFailure ? 'fail' : 'pass',
+      verdict: hasFailure ? 'fail' : hasWarning ? 'warn' : 'pass',
       overallScore,
       results,
       shortCircuited,

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -2,6 +2,10 @@ import type { Evaluator, EvaluationInput, EvaluationResult, CritiqueResult } fro
 
 const SAFETY_EVALUATOR_NAME = 'safety';
 
+function hasWarningFinding(result: EvaluationResult): boolean {
+  return result.findings.some((finding) => finding.severity !== 'info');
+}
+
 export class CritiquePipeline {
   private readonly evaluators: readonly Evaluator[];
 
@@ -35,7 +39,7 @@ export class CritiquePipeline {
     const overallScore = results.reduce((sum, r) => sum + r.score, 0) / results.length;
     const hasFailure = results.some((r) => r.verdict === 'fail');
     const hasWarning = results.some(
-      (r) => r.verdict === 'warn' || (r.verdict === 'pass' && r.findings.length > 0),
+      (r) => r.verdict === 'warn' || (r.verdict === 'pass' && hasWarningFinding(r)),
     );
 
     return {

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -34,7 +34,9 @@ export class CritiquePipeline {
 
     const overallScore = results.reduce((sum, r) => sum + r.score, 0) / results.length;
     const hasFailure = results.some((r) => r.verdict === 'fail');
-    const hasWarning = results.some((r) => r.verdict === 'warn');
+    const hasWarning = results.some(
+      (r) => r.verdict === 'warn' || (r.verdict === 'pass' && r.findings.length > 0),
+    );
 
     return {
       verdict: hasFailure ? 'fail' : hasWarning ? 'warn' : 'pass',

--- a/packages/franken-critique/src/types/evaluation.ts
+++ b/packages/franken-critique/src/types/evaluation.ts
@@ -26,7 +26,7 @@ export interface EvaluationFinding {
 export interface EvaluationResult {
   /** Name of the evaluator that produced this result. */
   readonly evaluatorName: string;
-  /** Pass or fail verdict. */
+  /** Pass, warn, or fail verdict. */
   readonly verdict: Verdict;
   /** Normalized score (0-1). */
   readonly score: Score;
@@ -36,7 +36,7 @@ export interface EvaluationResult {
 
 /** Aggregated result from all evaluators in the pipeline. */
 export interface CritiqueResult {
-  /** Overall verdict (fail if any evaluator fails). */
+  /** Overall verdict (fail if any evaluator fails, warn if only warnings exist). */
   readonly verdict: Verdict;
   /** Average score across all evaluators. */
   readonly overallScore: Score;

--- a/packages/franken-critique/tests/unit/evaluators/adr-compliance.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/adr-compliance.test.ts
@@ -48,6 +48,8 @@ describe('ADRComplianceEvaluator', () => {
 
     const result = await evaluator.evaluate(createInput('// @ts-nocheck\nconst x: any = 1;'));
 
+    expect(result.verdict).toBe('warn');
+    expect(result.score).toBe(0.5);
     expect(result.findings.length).toBeGreaterThan(0);
     expect(result.findings[0]!.message).toContain('adr-001');
   });

--- a/packages/franken-critique/tests/unit/evaluators/factuality.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/factuality.test.ts
@@ -35,7 +35,7 @@ describe('FactualityEvaluator', () => {
     expect(result.score).toBe(1);
   });
 
-  it('passes when content references matching ADR topics', async () => {
+  it('warns when content references matching ADR topics', async () => {
     const port = createMockMemoryPort([
       { id: 'adr-001', title: 'Use TypeScript', content: 'All code must be TypeScript', relevanceScore: 0.9 },
     ]);
@@ -43,7 +43,8 @@ describe('FactualityEvaluator', () => {
 
     const result = await evaluator.evaluate(createInput('const x: number = 1;'));
 
-    expect(result.verdict).toBe('pass');
+    expect(result.verdict).toBe('warn');
+    expect(result.score).toBeLessThan(1);
   });
 
   it('calls searchADRs with content-derived query', async () => {
@@ -73,6 +74,7 @@ describe('FactualityEvaluator', () => {
       createInput('const fs = require("fs");'),
     );
 
+    expect(result.verdict).toBe('warn');
     expect(result.findings.length).toBeGreaterThan(0);
     expect(result.findings[0]!.message).toContain('ADR');
   });

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -14,7 +14,7 @@ function createMockMemoryPort(): MemoryPort {
 
 function createIteration(
   index: number,
-  verdict: 'pass' | 'fail',
+  verdict: 'pass' | 'warn' | 'fail',
   evaluatorName = 'mock',
   findings: { message: string; severity: 'critical' | 'warning' | 'info' }[] = [],
 ): CritiqueIteration {
@@ -98,6 +98,26 @@ describe('LessonRecorder', () => {
     };
     expect(call.correctionApplied).toBeTruthy();
     expect(call.timestamp).toBeTruthy();
+  });
+
+  it('uses a warning-only terminal iteration as the applied correction', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'complexity', [{ message: 'too many params', severity: 'warning' }]),
+        createIteration(1, 'warn', 'adr-compliance', [{ message: 'review ADR', severity: 'warning' }]),
+      ],
+    };
+
+    await recorder.record(result, 'task-123');
+
+    const call = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      correctionApplied: string;
+    };
+    expect(call.correctionApplied).toBe('Corrected in iteration 1');
   });
 
   it('does not record on fail verdict', async () => {

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -76,6 +76,19 @@ describe('CritiquePipeline', () => {
     expect(result.results).toHaveLength(2);
   });
 
+  it('returns warn when a passing evaluator reports warning findings', async () => {
+    const warning = createMockEvaluator('warning-rule', 'deterministic', {
+      verdict: 'pass',
+      score: 0.8,
+      findings: [{ message: 'review this', severity: 'warning' }],
+    });
+    const pipeline = new CritiquePipeline([warning]);
+    const result = await pipeline.run(createInput('code'));
+
+    expect(result.verdict).toBe('warn');
+    expect(result.overallScore).toBe(0.8);
+  });
+
   it('runs deterministic evaluators before heuristic', async () => {
     const callOrder: string[] = [];
     const heuristic: Evaluator = {

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -61,6 +61,21 @@ describe('CritiquePipeline', () => {
     expect(result.results).toHaveLength(2);
   });
 
+  it('returns warn when evaluators only report non-critical warnings', async () => {
+    const passing = createMockEvaluator('passing', 'deterministic');
+    const warning = createMockEvaluator('warning', 'heuristic', {
+      verdict: 'warn',
+      score: 0.5,
+      findings: [{ message: 'review this', severity: 'warning' }],
+    });
+    const pipeline = new CritiquePipeline([passing, warning]);
+    const result = await pipeline.run(createInput('code'));
+
+    expect(result.verdict).toBe('warn');
+    expect(result.overallScore).toBe(0.75);
+    expect(result.results).toHaveLength(2);
+  });
+
   it('runs deterministic evaluators before heuristic', async () => {
     const callOrder: string[] = [];
     const heuristic: Evaluator = {

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -89,6 +89,19 @@ describe('CritiquePipeline', () => {
     expect(result.overallScore).toBe(0.8);
   });
 
+  it('keeps passing evaluator info findings informational', async () => {
+    const informational = createMockEvaluator('reflection', 'heuristic', {
+      verdict: 'pass',
+      score: 0.9,
+      findings: [{ message: 'on track', severity: 'info' }],
+    });
+    const pipeline = new CritiquePipeline([informational]);
+    const result = await pipeline.run(createInput('code'));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.overallScore).toBe(0.9);
+  });
+
   it('runs deterministic evaluators before heuristic', async () => {
     const callOrder: string[] = [];
     const heuristic: Evaluator = {

--- a/packages/franken-types/src/verdict.ts
+++ b/packages/franken-types/src/verdict.ts
@@ -1,2 +1,2 @@
-/** Binary verdict for evaluation results. */
-export type Verdict = 'pass' | 'fail';
+/** Evaluation verdict. Warnings indicate non-critical findings. */
+export type Verdict = 'pass' | 'warn' | 'fail';


### PR DESCRIPTION
## Summary
- add a non-critical `warn` verdict to shared evaluation verdicts
- return `warn` from ADR compliance and factuality when they surface non-critical findings
- keep critique loops from treating warnings as correction-triggering failures

## Test Plan
- npm test --workspace packages/franken-critique -- --run tests/unit/evaluators/adr-compliance.test.ts tests/unit/evaluators/factuality.test.ts tests/unit/pipeline/critique-pipeline.test.ts
- npm run typecheck
- npm run build
- git diff --check

Closes #66