### PR TITLE
fix(mcp-memory): align frontload scope contract

### DIFF
--- a/docs/walkthrough-mcp-suite.md
+++ b/docs/walkthrough-mcp-suite.md
@@ -265,7 +265,7 @@ Once installed, Claude Code has access to these tools:
 
 | Tool | Server | Description |
 |------|--------|-------------|
-| `fbeast_memory_frontload` | memory | Load all working + episodic memory as context |
+| `fbeast_memory_frontload` | memory | Load all working + episodic memory from this database as context |
 | `fbeast_memory_store` | memory | Store a key/value entry (working or episodic) |
 | `fbeast_memory_query` | memory | Search memory by keyword |
 | `fbeast_memory_forget` | memory | Delete a working memory entry |

--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -90,7 +90,7 @@ For Beast controls, set `FRANKENBEAST_BEAST_OPERATOR_TOKEN` in the repo root `.e
 | `fbeast-firewall` | `fbeast_firewall_scan`, `fbeast_firewall_scan_file` | Prompt injection detection (standard/strict tiers) |
 | `fbeast-skills` | `fbeast_skills_list`, `fbeast_skills_discover`, `fbeast_skills_load` | Skill registry discovery and loading |
 
-All servers share `.fbeast/beast.db` (SQLite, WAL mode).
+All servers share `.fbeast/beast.db` (SQLite, WAL mode). Memory frontload is scoped to that database: use a separate database per project when project isolation is required.
 
 ## Combined server
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -22,7 +22,7 @@ export interface BrainFrontloadSection {
 export interface BrainAdapter {
   query(input: BrainQueryInput): Promise<BrainMemoryEntry[]>;
   store(input: { key: string; value: string; type: string }): Promise<void>;
-  frontload(projectId: string): Promise<BrainFrontloadSection[]>;
+  frontload(): Promise<BrainFrontloadSection[]>;
   forget(key: string): Promise<boolean>;
 }
 
@@ -94,7 +94,7 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
       brain.flush();
     },
 
-    async frontload(_projectId) {
+    async frontload() {
       const sections: BrainFrontloadSection[] = [];
 
       // Working memory

--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -47,8 +47,9 @@ describe('Memory Server', () => {
     expect(queryResult.content[0]!.text).toContain('use adapters');
 
     expect(frontloadTool.inputSchema.required).toBeUndefined();
+    expect(frontloadTool.inputSchema.properties).toHaveProperty('projectId');
 
-    const frontloadResult = await frontloadTool.handler({});
+    const frontloadResult = await frontloadTool.handler({ projectId: 'test-project' });
     expect(brain.frontload).toHaveBeenCalledWith();
     expect(frontloadResult.content[0]!.text).toContain('adr: use adapters');
 

--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -46,8 +46,10 @@ describe('Memory Server', () => {
     expect(brain.query).toHaveBeenCalledWith({ query: 'adr', type: 'working', limit: 5 });
     expect(queryResult.content[0]!.text).toContain('use adapters');
 
-    const frontloadResult = await frontloadTool.handler({ projectId: 'test-project' });
-    expect(brain.frontload).toHaveBeenCalledWith('test-project');
+    expect(frontloadTool.inputSchema.required).toBeUndefined();
+
+    const frontloadResult = await frontloadTool.handler({});
+    expect(brain.frontload).toHaveBeenCalledWith();
     expect(frontloadResult.content[0]!.text).toContain('adr: use adapters');
 
     const forgetResult = await forgetTool.handler({ key: 'adr' });

--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -63,17 +63,13 @@ export function createMemoryServer(deps: MemoryServerDeps, options: CreateMcpSer
     },
     {
       name: 'fbeast_memory_frontload',
-      description: 'Load all memory entries for project context. Returns everything stored.',
+      description: 'Load all memory entries from this database. Returns everything stored.',
       inputSchema: {
         type: 'object',
-        properties: {
-          projectId: { type: 'string', description: 'Project identifier (for future multi-project support)' },
-        },
-        required: ['projectId'],
+        properties: {},
       },
-      async handler(args) {
-        const projectId = String(args['projectId']);
-        const sections = await brain.frontload(projectId);
+      async handler(_args) {
+        const sections = await brain.frontload();
 
         if (sections.length === 0) {
           return { content: [{ type: 'text', text: 'No memory entries stored yet.' }] };

--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -66,7 +66,9 @@ export function createMemoryServer(deps: MemoryServerDeps, options: CreateMcpSer
       description: 'Load all memory entries from this database. Returns everything stored.',
       inputSchema: {
         type: 'object',
-        properties: {},
+        properties: {
+          projectId: { type: 'string', description: 'Optional legacy project identifier; frontload is database-scoped' },
+        },
       },
       async handler(_args) {
         const sections = await brain.frontload();

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -102,17 +102,13 @@ const TOOLS: ToolFull[] = [
   {
     name: 'fbeast_memory_frontload',
     server: 'memory',
-    description: 'Load all memory entries for project context',
+    description: 'Load all memory entries from this database',
     inputSchema: {
       type: 'object',
-      properties: {
-        projectId: { type: 'string', description: 'Project identifier (for future multi-project support)' },
-      },
-      required: ['projectId'],
+      properties: {},
     },
-    makeHandler: ({ brain }) => async (args) => {
-      const projectId = String(args['projectId']);
-      const sections = await brain.frontload(projectId);
+    makeHandler: ({ brain }) => async () => {
+      const sections = await brain.frontload();
       if (sections.length === 0) {
         return { content: [{ type: 'text', text: 'No memory entries stored yet.' }] };
       }

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -105,7 +105,9 @@ const TOOLS: ToolFull[] = [
     description: 'Load all memory entries from this database',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        projectId: { type: 'string', description: 'Optional legacy project identifier; frontload is database-scoped' },
+      },
     },
     makeHandler: ({ brain }) => async () => {
       const sections = await brain.frontload();


### PR DESCRIPTION
## Summary
- remove the ignored projectId requirement from fbeast_memory_frontload
- document memory frontload as database-scoped rather than project-scoped
- update memory server tests for the corrected contract

## Test Plan
- npm test --workspace packages/franken-mcp-suite -- --run src/servers/memory.test.ts src/shared/tool-registry.test.ts
- npm run typecheck
- npm run build
- git diff --check

Closes #432