### PR TITLE
fix(runtime): scope beast run configs to project root

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -1,3 +1,4 @@
+import { join, resolve } from 'node:path';
 import { BeastEventBus } from './events/beast-event-bus.js';
 import { BeastLogStore } from './events/beast-log-store.js';
 import { SseConnectionTicketStore } from './events/sse-connection-ticket.js';
@@ -34,7 +35,8 @@ export interface BeastServiceBundle {
 export function createBeastServices(paths: BeastServicePaths): BeastServiceBundle {
   const repository = new SQLiteBeastRepository(paths.beastsDb);
   const logStore = new BeastLogStore(paths.beastLogsDir);
-  const projectRoot = paths.root ?? process.env.FBEAST_ROOT ?? process.cwd();
+  const projectRoot = resolve(paths.root ?? process.env.FBEAST_ROOT ?? process.cwd());
+  const runConfigDir = join(projectRoot, '.fbeast', '.build', 'run-configs');
   const catalog = new BeastCatalogService();
   const metrics = new PrometheusBeastMetrics();
   const eventBus = new BeastEventBus();
@@ -47,6 +49,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     process: new ProcessBeastExecutor(repository, logStore, new ProcessSupervisor({ projectRoot }), {
       onRunStatusChange: (runId: string) => runService.notifyRunStatusChange(runId),
       eventBus,
+      runConfigDir,
     }),
     container: new ContainerBeastExecutor({
       repository,

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -25,6 +25,7 @@ export interface ProcessBeastExecutorOptions {
   onRunStatusChange?: (runId: string) => void;
   eventBus?: BeastEventBus;
   defaultStopTimeoutMs?: number;
+  runConfigDir?: string;
   transformSpec?: (
     run: BeastRun,
     originalSpec: BeastProcessSpec,
@@ -55,12 +56,9 @@ export class ProcessBeastExecutor implements BeastExecutor {
     this.supervisor.validateCwd?.(processSpec.cwd);
 
     // Write configSnapshot to a JSON file for the spawned process to load
-    const configRoot = resolve(processSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd());
-    const configDir = join(
-      configRoot,
-      '.fbeast',
-      '.build',
-      'run-configs',
+    const configDir = resolve(
+      this.options.runConfigDir ??
+      join(processSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd(), '.fbeast', '.build', 'run-configs'),
     );
     mkdirSync(configDir, { recursive: true });
     const configFilePath = join(configDir, `${run.id}.json`);

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const processExecutorConstructor = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/beasts/execution/process-beast-executor.js', () => ({
+  ProcessBeastExecutor: class ProcessBeastExecutorMock {
+    readonly start = vi.fn();
+    readonly stop = vi.fn();
+    readonly kill = vi.fn();
+
+    constructor(...args: unknown[]) {
+      processExecutorConstructor(...args);
+    }
+  },
+}));
+
+describe('createBeastServices', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    processExecutorConstructor.mockClear();
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+      tempDir = undefined;
+    }
+  });
+
+  it('passes a run-config directory under the resolved project .fbeast build path', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-create-beast-services-'));
+    const parentCwd = join(tempDir, 'parent-cwd');
+    const projectRoot = join(tempDir, 'target-project');
+    const originalCwd = process.cwd();
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(parentCwd, { recursive: true });
+    await mkdir(projectRoot, { recursive: true });
+
+    try {
+      process.chdir(parentCwd);
+      const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
+      const services = createBeastServices({
+        beastsDb: join(projectRoot, '.fbeast', 'beast.db'),
+        beastLogsDir: join(projectRoot, '.fbeast', 'logs'),
+        root: projectRoot,
+      });
+
+      const expectedRunConfigDir = join(resolve(projectRoot), '.fbeast', '.build', 'run-configs');
+      const matchingCall = processExecutorConstructor.mock.calls.find(([, , , options]) => (
+        options as { runConfigDir?: string } | undefined
+      )?.runConfigDir === expectedRunConfigDir);
+      expect(matchingCall).toBeDefined();
+      const [, , supervisor, options] = matchingCall!;
+      expect(options).toMatchObject({ runConfigDir: expectedRunConfigDir });
+      expect(supervisor).toMatchObject({ options: { projectRoot: resolve(projectRoot) } });
+
+      services.dispose();
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -159,6 +160,35 @@ describe('ProcessBeastExecutor', () => {
   });
 
   describe('ProcessCallbacks wiring', () => {
+    it('writes run config files to an explicit run-config directory and removes them on exit', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const runConfigDir = join(workDir, 'project-root', '.fbeast', '.build', 'run-configs');
+      let capturedCallbacks: ProcessCallbacks | undefined;
+      const supervisor = {
+        spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+          capturedCallbacks = callbacks as ProcessCallbacks;
+          return { pid: 4242 };
+        }),
+        stop: vi.fn(async () => {}),
+        kill: vi.fn(async () => {}),
+      };
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { runConfigDir });
+      const run = createTestRun(repo);
+
+      await executor.start(run, martinLoopDefinition);
+
+      const [spawnedSpec] = supervisor.spawn.mock.calls[0];
+      const configPath = join(runConfigDir, `${run.id}.json`);
+      expect((spawnedSpec as { env: Record<string, string> }).env.FRANKENBEAST_RUN_CONFIG).toBe(configPath);
+      expect(existsSync(configPath)).toBe(true);
+
+      capturedCallbacks!.onExit(0, null);
+
+      expect(existsSync(configPath)).toBe(false);
+    });
+
     it('passes ProcessCallbacks to supervisor.spawn()', async () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
@@ -715,20 +745,19 @@ describe('ProcessBeastExecutor', () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
-      const { existsSync } = await import('node:fs');
+      const runConfigDir = join(workDir, 'project-root', '.fbeast', '.build', 'run-configs');
       const supervisor = {
         spawn: vi.fn(async () => { throw new Error('spawn failed'); }),
         stop: vi.fn(async () => {}),
         kill: vi.fn(async () => {}),
       };
-      const executor = new ProcessBeastExecutor(repo, logs, supervisor);
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { runConfigDir });
       const run = createTestRun(repo);
 
       await expect(executor.start(run, martinLoopDefinition)).rejects.toThrow();
 
       // Config file should have been cleaned up
-      const configDir = join(process.cwd(), '.fbeast', '.build', 'run-configs');
-      const configPath = join(configDir, `${run.id}.json`);
+      const configPath = join(runConfigDir, `${run.id}.json`);
       expect(existsSync(configPath)).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary
- pass an explicit project-scoped run-config directory from createBeastServices into ProcessBeastExecutor
- write FRANKENBEAST_RUN_CONFIG snapshots under the resolved project .fbeast/.build tree instead of the parent process cwd
- cover parent-CWD-vs-project-root behavior and config cleanup on exit/failure

## Test Plan
- npm test --workspace packages/franken-orchestrator -- tests/unit/beasts/process-beast-executor.test.ts tests/unit/beasts/create-beast-services.test.ts
- npm run typecheck
- npm run build
- git diff --check

Closes #421