### PR TITLE
feat(comms): enable Telegram and WhatsApp runtime transports

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -51,6 +51,7 @@ import { resolveSecurityConfig } from '../middleware/security-profiles.js';
 import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
+import { CommsConfigSchema, type CommsConfig } from '../comms/config/comms-config.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -173,6 +174,66 @@ async function readOperatorTokenFromEnvFile(filePath: string): Promise<string | 
   } catch {
     return undefined;
   }
+}
+
+async function resolveCommsSecret(ref: string | undefined, secretStore: ISecretStore | undefined): Promise<string | undefined> {
+  if (!ref?.trim()) {
+    return undefined;
+  }
+  if (secretStore) {
+    try {
+      const resolved = await secretStore.resolve(ref);
+      if (resolved?.trim()) {
+        return resolved.trim();
+      }
+    } catch {
+      // Fall through to environment lookup for deploys that keep refs as env var names.
+    }
+  }
+  return process.env[ref]?.trim() || undefined;
+}
+
+async function buildChatServerCommsConfig(
+  config: OrchestratorConfig,
+  secretStore: ISecretStore | undefined,
+): Promise<CommsConfig | undefined> {
+  if (!config.comms.enabled
+    && !config.comms.slack.enabled
+    && !config.comms.discord.enabled
+    && !config.comms.telegram.enabled
+    && !config.comms.whatsapp.enabled) {
+    return undefined;
+  }
+
+  return CommsConfigSchema.parse({
+    orchestrator: {
+      wsUrl: config.comms.orchestratorWsUrl,
+      token: await resolveCommsSecret(config.comms.orchestratorTokenRef, secretStore),
+    },
+    channels: {
+      slack: {
+        enabled: config.comms.slack.enabled,
+        token: await resolveCommsSecret(config.comms.slack.botTokenRef, secretStore),
+        signingSecret: await resolveCommsSecret(config.comms.slack.signingSecretRef, secretStore),
+      },
+      discord: {
+        enabled: config.comms.discord.enabled,
+        token: await resolveCommsSecret(config.comms.discord.botTokenRef, secretStore),
+        publicKey: config.comms.discord.publicKeyRef,
+      },
+      telegram: {
+        enabled: config.comms.telegram.enabled,
+        botToken: await resolveCommsSecret(config.comms.telegram.botTokenRef, secretStore),
+      },
+      whatsapp: {
+        enabled: config.comms.whatsapp.enabled,
+        accessToken: await resolveCommsSecret(config.comms.whatsapp.accessTokenRef, secretStore),
+        phoneNumberId: config.comms.whatsapp.phoneNumberIdRef,
+        appSecret: await resolveCommsSecret(config.comms.whatsapp.appSecretRef, secretStore),
+        verifyToken: await resolveCommsSecret(config.comms.whatsapp.verifyTokenRef, secretStore),
+      },
+    },
+  });
 }
 
 async function createChatSurfaceDeps(
@@ -396,6 +457,7 @@ export async function main(): Promise<void> {
       const analytics = createSqliteAnalyticsService({
         dbPath: join(paths.frankenbeastDir, 'beast.db'),
       });
+      const commsConfig = await buildChatServerCommsConfig(config, bootSecretStore);
       const explicitBeastDaemonUrl = process.env.FRANKENBEAST_BEAST_DAEMON_URL;
       const localBeastServices = beastOperatorToken && !explicitBeastDaemonUrl
         ? createBeastServices({
@@ -438,6 +500,7 @@ export async function main(): Promise<void> {
             mutableConfig = nextConfig;
           },
         },
+        ...(commsConfig ? { commsConfig } : {}),
         ...(args.host ? { host: args.host } : {}),
         ...(args.port !== undefined ? { port: args.port } : {}),
         ...(args.allowOrigin ? { allowedOrigins: [args.allowOrigin] } : {}),

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -26,7 +26,7 @@ import { createCliDeps } from './dep-factory.js';
 import { createDefaultRegistry } from '../skills/providers/cli-provider.js';
 import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
 import { CliLlmAdapter } from '../adapters/cli-llm-adapter.js';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import { tmpdir } from 'node:os';
 import { startChatServer } from '../http/chat-server.js';
 import { createSqliteAnalyticsService } from '../analytics/sqlite-analytics-service.js';
@@ -867,8 +867,9 @@ export async function runNetworkCommand(
     return;
   }
 
+  const configFile = args.config ? resolvePath(args.config) : undefined;
   const services = filterNetworkServices(
-    deps.resolveServices(config, { repoRoot: root, ...(args.config ? { configFile: args.config } : {}) }),
+    deps.resolveServices(config, { repoRoot: root, ...(configFile ? { configFile } : {}) }),
     action === 'up' ? undefined : args.networkTarget,
   );
 
@@ -898,7 +899,10 @@ export async function runNetworkCommand(
     }
     if (!args.networkDetached) {
       await deps.waitForShutdown();
-      await supervisor.stopAll(state);
+      await supervisor.stopAll({
+        ...state,
+        services: state.services.filter((service) => service.status === 'started'),
+      });
     }
     return;
   }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -193,6 +193,13 @@ async function resolveCommsSecret(ref: string | undefined, secretStore: ISecretS
   return process.env[ref]?.trim() || undefined;
 }
 
+async function resolveCommsPublicRef(ref: string | undefined, secretStore: ISecretStore | undefined): Promise<string | undefined> {
+  if (!ref?.trim()) {
+    return undefined;
+  }
+  return (await resolveCommsSecret(ref, secretStore)) ?? ref.trim();
+}
+
 async function buildChatServerCommsConfig(
   config: OrchestratorConfig,
   secretStore: ISecretStore | undefined,
@@ -219,7 +226,7 @@ async function buildChatServerCommsConfig(
       discord: {
         enabled: config.comms.discord.enabled,
         token: await resolveCommsSecret(config.comms.discord.botTokenRef, secretStore),
-        publicKey: config.comms.discord.publicKeyRef,
+        publicKey: await resolveCommsPublicRef(config.comms.discord.publicKeyRef, secretStore),
       },
       telegram: {
         enabled: config.comms.telegram.enabled,
@@ -228,7 +235,7 @@ async function buildChatServerCommsConfig(
       whatsapp: {
         enabled: config.comms.whatsapp.enabled,
         accessToken: await resolveCommsSecret(config.comms.whatsapp.accessTokenRef, secretStore),
-        phoneNumberId: config.comms.whatsapp.phoneNumberIdRef,
+        phoneNumberId: await resolveCommsPublicRef(config.comms.whatsapp.phoneNumberIdRef, secretStore),
         appSecret: await resolveCommsSecret(config.comms.whatsapp.appSecretRef, secretStore),
         verifyToken: await resolveCommsSecret(config.comms.whatsapp.verifyTokenRef, secretStore),
       },

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -200,6 +200,24 @@ async function resolveCommsPublicRef(ref: string | undefined, secretStore: ISecr
   return (await resolveCommsSecret(ref, secretStore)) ?? ref.trim();
 }
 
+function requireCommsChannelFields(
+  channel: string,
+  enabled: boolean,
+  fields: Record<string, string | undefined>,
+): void {
+  if (!enabled) {
+    return;
+  }
+  const missing = Object.entries(fields)
+    .filter(([, value]) => !value?.trim())
+    .map(([field]) => field);
+  if (missing.length > 0) {
+    throw new Error(
+      `Cannot start enabled ${channel} comms channel; missing resolved ${missing.join(', ')}`,
+    );
+  }
+}
+
 async function buildChatServerCommsConfig(
   config: OrchestratorConfig,
   secretStore: ISecretStore | undefined,
@@ -212,6 +230,34 @@ async function buildChatServerCommsConfig(
     return undefined;
   }
 
+  const slackToken = await resolveCommsSecret(config.comms.slack.botTokenRef, secretStore);
+  const slackSigningSecret = await resolveCommsSecret(config.comms.slack.signingSecretRef, secretStore);
+  const discordToken = await resolveCommsSecret(config.comms.discord.botTokenRef, secretStore);
+  const discordPublicKey = await resolveCommsPublicRef(config.comms.discord.publicKeyRef, secretStore);
+  const telegramBotToken = await resolveCommsSecret(config.comms.telegram.botTokenRef, secretStore);
+  const whatsappAccessToken = await resolveCommsSecret(config.comms.whatsapp.accessTokenRef, secretStore);
+  const whatsappPhoneNumberId = await resolveCommsPublicRef(config.comms.whatsapp.phoneNumberIdRef, secretStore);
+  const whatsappAppSecret = await resolveCommsSecret(config.comms.whatsapp.appSecretRef, secretStore);
+  const whatsappVerifyToken = await resolveCommsSecret(config.comms.whatsapp.verifyTokenRef, secretStore);
+
+  requireCommsChannelFields('slack', config.comms.slack.enabled, {
+    token: slackToken,
+    signingSecret: slackSigningSecret,
+  });
+  requireCommsChannelFields('discord', config.comms.discord.enabled, {
+    token: discordToken,
+    publicKey: discordPublicKey,
+  });
+  requireCommsChannelFields('telegram', config.comms.telegram.enabled, {
+    botToken: telegramBotToken,
+  });
+  requireCommsChannelFields('whatsapp', config.comms.whatsapp.enabled, {
+    accessToken: whatsappAccessToken,
+    phoneNumberId: whatsappPhoneNumberId,
+    appSecret: whatsappAppSecret,
+    verifyToken: whatsappVerifyToken,
+  });
+
   return CommsConfigSchema.parse({
     orchestrator: {
       wsUrl: config.comms.orchestratorWsUrl,
@@ -220,24 +266,24 @@ async function buildChatServerCommsConfig(
     channels: {
       slack: {
         enabled: config.comms.slack.enabled,
-        token: await resolveCommsSecret(config.comms.slack.botTokenRef, secretStore),
-        signingSecret: await resolveCommsSecret(config.comms.slack.signingSecretRef, secretStore),
+        token: slackToken,
+        signingSecret: slackSigningSecret,
       },
       discord: {
         enabled: config.comms.discord.enabled,
-        token: await resolveCommsSecret(config.comms.discord.botTokenRef, secretStore),
-        publicKey: await resolveCommsPublicRef(config.comms.discord.publicKeyRef, secretStore),
+        token: discordToken,
+        publicKey: discordPublicKey,
       },
       telegram: {
         enabled: config.comms.telegram.enabled,
-        botToken: await resolveCommsSecret(config.comms.telegram.botTokenRef, secretStore),
+        botToken: telegramBotToken,
       },
       whatsapp: {
         enabled: config.comms.whatsapp.enabled,
-        accessToken: await resolveCommsSecret(config.comms.whatsapp.accessTokenRef, secretStore),
-        phoneNumberId: await resolveCommsPublicRef(config.comms.whatsapp.phoneNumberIdRef, secretStore),
-        appSecret: await resolveCommsSecret(config.comms.whatsapp.appSecretRef, secretStore),
-        verifyToken: await resolveCommsSecret(config.comms.whatsapp.verifyTokenRef, secretStore),
+        accessToken: whatsappAccessToken,
+        phoneNumberId: whatsappPhoneNumberId,
+        appSecret: whatsappAppSecret,
+        verifyToken: whatsappVerifyToken,
       },
     },
   });

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -719,6 +719,7 @@ export interface NetworkCommandSupervisorLike {
     mode: 'secure' | 'insecure';
     secureBackend: string;
   }): Promise<{ services: { id: string; url?: string | undefined; status?: 'started' | 'already-running' | undefined }[] }>;
+  stopAll(state: Awaited<ReturnType<NetworkCommandSupervisorLike['up']>>): Promise<void>;
   down(): Promise<void>;
   status(): Promise<{ mode?: string; secureBackend?: string; services: Array<{ id: string; status: string }> }>;
   stop(target: string | 'all'): Promise<void>;
@@ -897,7 +898,7 @@ export async function runNetworkCommand(
     }
     if (!args.networkDetached) {
       await deps.waitForShutdown();
-      await supervisor.stop(args.networkTarget ?? 'all');
+      await supervisor.stopAll(state);
     }
     return;
   }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -869,7 +869,11 @@ export async function runNetworkCommand(
 
   const configFile = args.config ? resolvePath(args.config) : undefined;
   const services = filterNetworkServices(
-    deps.resolveServices(config, { repoRoot: root, ...(configFile ? { configFile } : {}) }),
+    deps.resolveServices(config, {
+      repoRoot: root,
+      ...(configFile ? { configFile } : {}),
+      ...(args.networkSet ? { configOverrides: args.networkSet } : {}),
+    }),
     action === 'up' ? undefined : args.networkTarget,
   );
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -868,7 +868,7 @@ export async function runNetworkCommand(
   }
 
   const services = filterNetworkServices(
-    deps.resolveServices(config, { repoRoot: root }),
+    deps.resolveServices(config, { repoRoot: root, ...(args.config ? { configFile: args.config } : {}) }),
     action === 'up' ? undefined : args.networkTarget,
   );
 

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
@@ -9,6 +9,28 @@ export interface TelegramAdapterOptions {
   token: string;
 }
 
+const CALLBACK_DATA_PREFIX = 'fb';
+
+export function encodeTelegramCallbackData(sessionId: string, actionId: string): string {
+  const encoded = `${CALLBACK_DATA_PREFIX}:${sessionId}:${actionId}`;
+  return encoded.length <= 64 ? encoded : actionId;
+}
+
+export function decodeTelegramCallbackData(data: string): { actionId: string; sessionId?: string | undefined } {
+  const prefix = `${CALLBACK_DATA_PREFIX}:`;
+  if (!data.startsWith(prefix)) {
+    return { actionId: data };
+  }
+  const remainder = data.slice(prefix.length);
+  const separatorIndex = remainder.indexOf(':');
+  if (separatorIndex < 0) {
+    return { actionId: data };
+  }
+  const sessionId = remainder.slice(0, separatorIndex);
+  const actionId = remainder.slice(separatorIndex + 1);
+  return actionId && sessionId ? { actionId, sessionId } : { actionId: data };
+}
+
 export class TelegramAdapter implements ChannelAdapter {
   readonly type: ChannelType = 'telegram';
   readonly capabilities: ChannelCapabilities = {
@@ -28,7 +50,7 @@ export class TelegramAdapter implements ChannelAdapter {
 
   async send(sessionId: string, message: ChannelOutboundMessage): Promise<void> {
     const chatId = (message.metadata?.chatId as string) || 'unknown';
-    const body = this.formatPayload(chatId, message);
+    const body = this.formatPayload(sessionId, chatId, message);
 
     const response = await fetch(`https://api.telegram.org/bot${this.token}/sendMessage`, {
       method: 'POST',
@@ -44,7 +66,7 @@ export class TelegramAdapter implements ChannelAdapter {
     }
   }
 
-  private formatPayload(chatId: string, message: ChannelOutboundMessage): Record<string, unknown> {
+  private formatPayload(sessionId: string, chatId: string, message: ChannelOutboundMessage): Record<string, unknown> {
     const payload: Record<string, unknown> = {
       chat_id: chatId,
       text: this.escapeMarkdown(message.text),
@@ -56,7 +78,7 @@ export class TelegramAdapter implements ChannelAdapter {
         inline_keyboard: [
           message.actions.map((action) => ({
             text: action.label,
-            callback_data: action.id,
+            callback_data: encodeTelegramCallbackData(sessionId, action.id),
           })),
         ],
       };

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { TelegramUpdateSchema } from './telegram-schemas.js';
+import { decodeTelegramCallbackData } from './telegram-adapter.js';
 import type { ChatGateway } from '../../gateway/chat-gateway.js';
 import type { SessionMapper } from '../../core/session-mapper.js';
 
@@ -63,13 +64,14 @@ export function telegramRouter(options: TelegramRouterOptions) {
       const userId = query.from.id.toString();
 
       if (chatId) {
-        const sessionId = sessionMapper.mapToSessionId({
+        const callback = decodeTelegramCallbackData(update.callback_query.data);
+        const sessionId = callback.sessionId ?? sessionMapper.mapToSessionId({
           channelType: 'telegram',
           externalUserId: userId,
           externalChannelId: chatId,
         });
 
-        await gateway.handleAction('telegram', sessionId, update.callback_query.data, {
+        await gateway.handleAction('telegram', sessionId, callback.actionId, {
           externalChannelId: chatId,
           chatId,
         });

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
@@ -17,8 +17,14 @@ export function telegramRouter(options: TelegramRouterOptions) {
   const { gateway, sessionMapper, botToken } = options;
   const app = new Hono();
 
-  // Telegram recommends using the bot token in the webhook URL for security
-  app.post(`/${botToken}`, async (c) => {
+  // Telegram recommends using the bot token in the webhook URL for security.
+  // Compare the token as route data instead of interpolating it into the route
+  // template because Telegram tokens contain ':' and Hono treats ':' as a
+  // parameter marker in literal route strings.
+  app.post('/:token', async (c) => {
+    if (c.req.param('token') !== botToken) {
+      return c.json({ error: 'Not found' }, 404);
+    }
     const body = await c.req.json();
     const update = TelegramUpdateSchema.parse(body);
 
@@ -63,7 +69,10 @@ export function telegramRouter(options: TelegramRouterOptions) {
           externalChannelId: chatId,
         });
 
-        await gateway.handleAction('telegram', sessionId, update.callback_query.data);
+        await gateway.handleAction('telegram', sessionId, update.callback_query.data, {
+          externalChannelId: chatId,
+          chatId,
+        });
       }
 
       // Acknowledge callback query

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
@@ -65,7 +65,10 @@ export function whatsappRouter(options: WhatsAppRouterOptions) {
           // Handle interactive button reply
           if (message.type === 'interactive' && message.interactive?.button_reply) {
             const actionId = message.interactive.button_reply.id;
-            await gateway.handleAction('whatsapp', sessionId, actionId);
+            await gateway.handleAction('whatsapp', sessionId, actionId, {
+              externalChannelId: from,
+              phoneNumber: from,
+            });
           }
         }
       }

--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -89,6 +89,14 @@ export class ChatGateway extends EventEmitter {
     return {
       externalChannelId: message.externalChannelId,
       externalThreadId: message.externalThreadId,
+      ...(message.channelType === 'slack' ? {
+        channelId: message.externalChannelId,
+        threadTs: message.externalThreadId,
+      } : {}),
+      ...(message.channelType === 'discord' ? {
+        channelId: message.externalChannelId,
+        threadId: message.externalThreadId,
+      } : {}),
       ...(message.channelType === 'telegram' ? { chatId: message.externalChannelId } : {}),
       ...(message.channelType === 'whatsapp' ? { phoneNumber: message.externalChannelId } : {}),
     };

--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -11,6 +11,7 @@ import type {
 export class ChatGateway extends EventEmitter {
   private readonly adapters = new Map<ChannelType, ChannelAdapter>();
   private readonly sessionMapper = new SessionMapper();
+  private readonly routeMetadataBySession = new Map<string, Record<string, unknown>>();
   private readonly runtime: CommsRuntimePort;
 
   constructor(runtime: CommsRuntimePort) {
@@ -29,6 +30,8 @@ export class ChatGateway extends EventEmitter {
       externalChannelId: message.externalChannelId,
       externalThreadId: message.externalThreadId,
     });
+    const routeMetadata = this.toRouteMetadata(message);
+    this.routeMetadataBySession.set(sessionId, routeMetadata);
 
     const result = await this.runtime.processInbound({
       sessionId,
@@ -36,15 +39,14 @@ export class ChatGateway extends EventEmitter {
       text: message.text,
       externalUserId: message.externalUserId,
       metadata: {
-        externalChannelId: message.externalChannelId,
-        externalThreadId: message.externalThreadId,
+        ...routeMetadata,
       },
     });
 
-    const outbound: ChannelOutboundMessage = { text: result.text };
+    const outbound: ChannelOutboundMessage = { text: result.text, metadata: routeMetadata };
     if (result.status) outbound.status = result.status;
     if (result.actions) outbound.actions = result.actions;
-    if (result.metadata) outbound.metadata = result.metadata;
+    if (result.metadata) outbound.metadata = { ...routeMetadata, ...result.metadata };
     if (result.provider) outbound.provider = result.provider;
     if (result.phase) outbound.phase = result.phase;
     this.relayToChannel(sessionId, message.channelType, outbound);
@@ -70,9 +72,22 @@ export class ChatGateway extends EventEmitter {
       externalUserId: 'system',
     });
 
-    const outbound: ChannelOutboundMessage = { text: result.text };
+    const routeMetadata = this.routeMetadataBySession.get(sessionId);
+    const outbound: ChannelOutboundMessage = {
+      text: result.text,
+      ...(routeMetadata ? { metadata: routeMetadata } : {}),
+    };
     if (result.status) outbound.status = result.status;
     this.relayToChannel(sessionId, channelType, outbound);
+  }
+
+  private toRouteMetadata(message: ChannelInboundMessage): Record<string, unknown> {
+    return {
+      externalChannelId: message.externalChannelId,
+      externalThreadId: message.externalThreadId,
+      ...(message.channelType === 'telegram' ? { chatId: message.externalChannelId } : {}),
+      ...(message.channelType === 'whatsapp' ? { phoneNumber: message.externalChannelId } : {}),
+    };
   }
 
   private relayToChannel(

--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -56,6 +56,7 @@ export class ChatGateway extends EventEmitter {
     channelType: ChannelType,
     sessionId: string,
     actionId: string,
+    routeMetadata?: Record<string, unknown>,
   ): Promise<void> {
     // Map action IDs to the appropriate slash command.
     // /approve approves the pending action; rejection is a plain-text
@@ -72,10 +73,13 @@ export class ChatGateway extends EventEmitter {
       externalUserId: 'system',
     });
 
-    const routeMetadata = this.routeMetadataBySession.get(sessionId);
+    const outboundRouteMetadata = routeMetadata ?? this.routeMetadataBySession.get(sessionId);
+    if (routeMetadata) {
+      this.routeMetadataBySession.set(sessionId, routeMetadata);
+    }
     const outbound: ChannelOutboundMessage = {
       text: result.text,
-      ...(routeMetadata ? { metadata: routeMetadata } : {}),
+      ...(outboundRouteMetadata ? { metadata: outboundRouteMetadata } : {}),
     };
     if (result.status) outbound.status = result.status;
     this.relayToChannel(sessionId, channelType, outbound);

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -1,5 +1,7 @@
 import { createServer, type Server as HttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { Hono } from 'hono';
 import type { ILlmClient } from '@franken/types';
 import { FileSessionStore, type ISessionStore } from '../chat/session-store.js';
@@ -14,6 +16,11 @@ import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import type { BeastRoutesDeps } from './routes/beast-routes.js';
 import type { CommsConfig } from '../comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../comms/core/comms-runtime-port.js';
+import {
+  ChatRuntimeCommsAdapter,
+  type CommsSession,
+  type CommsSessionStore,
+} from '../comms/core/chat-runtime-comms-adapter.js';
 import type { SkillManager } from '../skills/skill-manager.js';
 import type { ProviderRegistry } from '../providers/provider-registry.js';
 import type { DashboardRouteDeps } from './routes/dashboard-routes.js';
@@ -70,6 +77,42 @@ const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'stopped']);
 
 export function resolveChatServerSessionStore(options: Pick<StartChatServerOptions, 'sessionStore' | 'sessionStoreDir'>): ISessionStore {
   return options.sessionStore ?? new FileSessionStore(options.sessionStoreDir);
+}
+
+class FileCommsSessionStore implements CommsSessionStore {
+  constructor(
+    private readonly storeDir: string,
+    private readonly projectId: string,
+  ) {}
+
+  async load(id: string): Promise<CommsSession | null> {
+    try {
+      return JSON.parse(readFileSync(this.filePath(id), 'utf-8')) as CommsSession;
+    } catch {
+      return null;
+    }
+  }
+
+  async create(id: string, data: Record<string, unknown>): Promise<CommsSession> {
+    const session: CommsSession = {
+      sessionId: id,
+      projectId: this.projectId,
+      transcript: [],
+      state: 'active',
+      ...data,
+    };
+    await this.save(id, session);
+    return session;
+  }
+
+  async save(id: string, data: Record<string, unknown>): Promise<void> {
+    mkdirSync(this.storeDir, { recursive: true });
+    writeFileSync(this.filePath(id), JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  private filePath(id: string): string {
+    return join(this.storeDir, `${encodeURIComponent(id)}.json`);
+  }
 }
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
@@ -138,6 +181,13 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
         : {}),
     ...(options.executionLlm ? { executionLlm: options.executionLlm } : {}),
   });
+  const commsRuntime = options.commsRuntime
+    ?? (options.commsConfig
+      ? new ChatRuntimeCommsAdapter(
+          runtime.runtime,
+          new FileCommsSessionStore(join(options.sessionStoreDir, 'comms'), options.projectName),
+        )
+      : undefined);
   const app = createChatApp({
     sessionStore,
     engine: runtime.engine,
@@ -148,7 +198,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ...(options.beastControl ? { beastControl: options.beastControl } : {}),
     ...(options.networkControl ? { networkControl: options.networkControl } : {}),
     ...(options.commsConfig ? { commsConfig: options.commsConfig } : {}),
-    ...(options.commsRuntime ? { commsRuntime: options.commsRuntime } : {}),
+    ...(commsRuntime ? { commsRuntime } : {}),
     ...(options.skillManager ? { skillManager: options.skillManager } : {}),
     ...(options.providerRegistry ? { providerRegistry: options.providerRegistry } : {}),
     ...(options.dashboardDeps ? { dashboardDeps: options.dashboardDeps } : {}),

--- a/packages/franken-orchestrator/src/init/comms-transport-registry.ts
+++ b/packages/franken-orchestrator/src/init/comms-transport-registry.ts
@@ -21,12 +21,12 @@ const KNOWN_TRANSPORTS: readonly CommsTransportDefinition[] = [
   {
     id: 'telegram',
     label: 'Telegram',
-    description: 'Known future transport; not yet wired through orchestrator runtime.',
+    description: 'Telegram Bot API webhooks via the managed comms gateway.',
   },
   {
     id: 'whatsapp',
     label: 'WhatsApp',
-    description: 'Known future transport; not yet wired through orchestrator runtime.',
+    description: 'WhatsApp Cloud API webhooks via the managed comms gateway.',
   },
 ];
 
@@ -35,7 +35,9 @@ function runtimeSupportedTransportIds(): Set<SupportedCommsTransportId> {
   const reserved = new Set(['enabled', 'host', 'port', 'orchestratorWsUrl', 'orchestratorTokenRef']);
   const supported = Object.keys(comms)
     .filter((key) => !reserved.has(key))
-    .filter((key): key is SupportedCommsTransportId => key === 'slack' || key === 'discord');
+    .filter((key): key is SupportedCommsTransportId =>
+      key === 'slack' || key === 'discord' || key === 'telegram' || key === 'whatsapp',
+    );
   return new Set(supported);
 }
 

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -86,6 +86,10 @@ export async function runRepairInit(options: RunRepairInitOptions): Promise<Init
         return ['slack'] as const;
       case 'discord-incomplete':
         return ['discord'] as const;
+      case 'telegram-incomplete':
+        return ['telegram'] as const;
+      case 'whatsapp-incomplete':
+        return ['whatsapp'] as const;
       default:
         return [] as const;
     }

--- a/packages/franken-orchestrator/src/init/init-types.ts
+++ b/packages/franken-orchestrator/src/init/init-types.ts
@@ -2,7 +2,7 @@ import type { NetworkMode } from '../network/network-config.js';
 
 export type InitModuleId = 'chat' | 'dashboard' | 'comms';
 export type KnownCommsTransportId = 'slack' | 'discord' | 'telegram' | 'whatsapp';
-export type SupportedCommsTransportId = 'slack' | 'discord';
+export type SupportedCommsTransportId = KnownCommsTransportId;
 export type InitStepId =
   | 'module-selection'
   | 'provider-config'

--- a/packages/franken-orchestrator/src/init/init-verify.ts
+++ b/packages/franken-orchestrator/src/init/init-verify.ts
@@ -8,6 +8,8 @@ export type InitIssueCode =
   | 'missing-init-state'
   | 'slack-incomplete'
   | 'discord-incomplete'
+  | 'telegram-incomplete'
+  | 'whatsapp-incomplete'
   | 'secret-backend-unavailable';
 
 export interface InitVerificationIssue {
@@ -89,6 +91,31 @@ export async function verifyInit(options: {
       issues.push({
         code: 'discord-incomplete',
         message: `Discord config is incomplete: missing ${missing.join(', ')}.`,
+      });
+    }
+  }
+
+  if (config.comms.telegram.enabled) {
+    const missing: string[] = [];
+    if (!config.comms.telegram.botTokenRef) missing.push('botTokenRef');
+    if (missing.length > 0) {
+      issues.push({
+        code: 'telegram-incomplete',
+        message: `Telegram config is incomplete: missing ${missing.join(', ')}.`,
+      });
+    }
+  }
+
+  if (config.comms.whatsapp.enabled) {
+    const missing: string[] = [];
+    if (!config.comms.whatsapp.accessTokenRef) missing.push('accessTokenRef');
+    if (!config.comms.whatsapp.phoneNumberIdRef) missing.push('phoneNumberIdRef');
+    if (!config.comms.whatsapp.appSecretRef) missing.push('appSecretRef');
+    if (!config.comms.whatsapp.verifyTokenRef) missing.push('verifyTokenRef');
+    if (missing.length > 0) {
+      issues.push({
+        code: 'whatsapp-incomplete',
+        message: `WhatsApp config is incomplete: missing ${missing.join(', ')}.`,
       });
     }
   }

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -207,11 +207,17 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
 
   if (enableComms) {
     for (const transport of listSupportedCommsTransports()) {
-      const targetedTransportOnly = options.scope !== undefined
-        && !options.scope.includes('modules')
-        && !options.scope.includes('provider')
-        && !options.scope.includes('security')
-        && options.scope.includes(transport.id);
+      const activeScope = options.scope;
+      const activeTransportScope = activeScope !== undefined
+        && !activeScope.includes('modules')
+        && !activeScope.includes('provider')
+        && !activeScope.includes('security')
+        ? activeScope
+        : undefined;
+      if (activeTransportScope && !activeTransportScope.includes(transport.id)) {
+        continue;
+      }
+      const targetedTransportOnly = activeTransportScope !== undefined && activeTransportScope.includes(transport.id);
       const enabled = targetedTransportOnly
         ? transportDefault(options.initialState, config, transport.id)
         : await askBoolean(
@@ -302,7 +308,11 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
             answers['comms.telegram.botTokenRef'] = 'comms.telegram.botTokenRef';
           }
         } else {
-          const currentBotTokenRef = String(stateValue(options.initialState, 'comms.telegram.botTokenRef') ?? '');
+          const currentBotTokenRef = String(
+            stateValue(options.initialState, 'comms.telegram.botTokenRef')
+              ?? config.comms.telegram.botTokenRef
+              ?? '',
+          );
           if (!scope.has('telegram') || currentBotTokenRef.length === 0) {
             answers['comms.telegram.botTokenRef'] = await askText(options.io, 'Telegram bot token ref', currentBotTokenRef);
           }
@@ -331,19 +341,35 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
             answers['comms.whatsapp.verifyTokenRef'] = 'comms.whatsapp.verifyTokenRef';
           }
         } else {
-          const currentAccessTokenRef = String(stateValue(options.initialState, 'comms.whatsapp.accessTokenRef') ?? '');
+          const currentAccessTokenRef = String(
+            stateValue(options.initialState, 'comms.whatsapp.accessTokenRef')
+              ?? config.comms.whatsapp.accessTokenRef
+              ?? '',
+          );
           if (!scope.has('whatsapp') || currentAccessTokenRef.length === 0) {
             answers['comms.whatsapp.accessTokenRef'] = await askText(options.io, 'WhatsApp access token ref', currentAccessTokenRef);
           }
-          const currentPhoneNumberIdRef = String(stateValue(options.initialState, 'comms.whatsapp.phoneNumberIdRef') ?? '');
+          const currentPhoneNumberIdRef = String(
+            stateValue(options.initialState, 'comms.whatsapp.phoneNumberIdRef')
+              ?? config.comms.whatsapp.phoneNumberIdRef
+              ?? '',
+          );
           if (!scope.has('whatsapp') || currentPhoneNumberIdRef.length === 0) {
             answers['comms.whatsapp.phoneNumberIdRef'] = await askText(options.io, 'WhatsApp phone number ID ref', currentPhoneNumberIdRef);
           }
-          const currentAppSecretRef = String(stateValue(options.initialState, 'comms.whatsapp.appSecretRef') ?? '');
+          const currentAppSecretRef = String(
+            stateValue(options.initialState, 'comms.whatsapp.appSecretRef')
+              ?? config.comms.whatsapp.appSecretRef
+              ?? '',
+          );
           if (!scope.has('whatsapp') || currentAppSecretRef.length === 0) {
             answers['comms.whatsapp.appSecretRef'] = await askText(options.io, 'WhatsApp app secret ref', currentAppSecretRef);
           }
-          const currentVerifyTokenRef = String(stateValue(options.initialState, 'comms.whatsapp.verifyTokenRef') ?? '');
+          const currentVerifyTokenRef = String(
+            stateValue(options.initialState, 'comms.whatsapp.verifyTokenRef')
+              ?? config.comms.whatsapp.verifyTokenRef
+              ?? '',
+          );
           if (!scope.has('whatsapp') || currentVerifyTokenRef.length === 0) {
             answers['comms.whatsapp.verifyTokenRef'] = await askText(options.io, 'WhatsApp verify token ref', currentVerifyTokenRef);
           }

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -315,6 +315,8 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
           );
           if (!scope.has('telegram') || currentBotTokenRef.length === 0) {
             answers['comms.telegram.botTokenRef'] = await askText(options.io, 'Telegram bot token ref', currentBotTokenRef);
+          } else {
+            answers['comms.telegram.botTokenRef'] = currentBotTokenRef;
           }
         }
       }
@@ -348,6 +350,8 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
           );
           if (!scope.has('whatsapp') || currentAccessTokenRef.length === 0) {
             answers['comms.whatsapp.accessTokenRef'] = await askText(options.io, 'WhatsApp access token ref', currentAccessTokenRef);
+          } else {
+            answers['comms.whatsapp.accessTokenRef'] = currentAccessTokenRef;
           }
           const currentPhoneNumberIdRef = String(
             stateValue(options.initialState, 'comms.whatsapp.phoneNumberIdRef')
@@ -356,6 +360,8 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
           );
           if (!scope.has('whatsapp') || currentPhoneNumberIdRef.length === 0) {
             answers['comms.whatsapp.phoneNumberIdRef'] = await askText(options.io, 'WhatsApp phone number ID ref', currentPhoneNumberIdRef);
+          } else {
+            answers['comms.whatsapp.phoneNumberIdRef'] = currentPhoneNumberIdRef;
           }
           const currentAppSecretRef = String(
             stateValue(options.initialState, 'comms.whatsapp.appSecretRef')
@@ -364,6 +370,8 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
           );
           if (!scope.has('whatsapp') || currentAppSecretRef.length === 0) {
             answers['comms.whatsapp.appSecretRef'] = await askText(options.io, 'WhatsApp app secret ref', currentAppSecretRef);
+          } else {
+            answers['comms.whatsapp.appSecretRef'] = currentAppSecretRef;
           }
           const currentVerifyTokenRef = String(
             stateValue(options.initialState, 'comms.whatsapp.verifyTokenRef')
@@ -372,6 +380,8 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
           );
           if (!scope.has('whatsapp') || currentVerifyTokenRef.length === 0) {
             answers['comms.whatsapp.verifyTokenRef'] = await askText(options.io, 'WhatsApp verify token ref', currentVerifyTokenRef);
+          } else {
+            answers['comms.whatsapp.verifyTokenRef'] = currentVerifyTokenRef;
           }
         }
       }

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -86,29 +86,29 @@ function buildConfig(baseConfig: OrchestratorConfig, state: InitState): Orchestr
       slack: {
         ...baseConfig.comms.slack,
         enabled: state.selectedCommsTransports.includes('slack'),
-        appId: stateValue(state, 'comms.slack.appId') as string | undefined,
-        botTokenRef: stateValue(state, 'comms.slack.botTokenRef') as string | undefined,
-        signingSecretRef: stateValue(state, 'comms.slack.signingSecretRef') as string | undefined,
+        appId: stateValue<string>(state, 'comms.slack.appId') ?? baseConfig.comms.slack.appId,
+        botTokenRef: stateValue<string>(state, 'comms.slack.botTokenRef') ?? baseConfig.comms.slack.botTokenRef,
+        signingSecretRef: stateValue<string>(state, 'comms.slack.signingSecretRef') ?? baseConfig.comms.slack.signingSecretRef,
       },
       discord: {
         ...baseConfig.comms.discord,
         enabled: state.selectedCommsTransports.includes('discord'),
-        applicationId: stateValue(state, 'comms.discord.applicationId') as string | undefined,
-        botTokenRef: stateValue(state, 'comms.discord.botTokenRef') as string | undefined,
-        publicKeyRef: stateValue(state, 'comms.discord.publicKeyRef') as string | undefined,
+        applicationId: stateValue<string>(state, 'comms.discord.applicationId') ?? baseConfig.comms.discord.applicationId,
+        botTokenRef: stateValue<string>(state, 'comms.discord.botTokenRef') ?? baseConfig.comms.discord.botTokenRef,
+        publicKeyRef: stateValue<string>(state, 'comms.discord.publicKeyRef') ?? baseConfig.comms.discord.publicKeyRef,
       },
       telegram: {
         ...baseConfig.comms.telegram,
         enabled: state.selectedCommsTransports.includes('telegram'),
-        botTokenRef: stateValue(state, 'comms.telegram.botTokenRef') as string | undefined,
+        botTokenRef: stateValue<string>(state, 'comms.telegram.botTokenRef') ?? baseConfig.comms.telegram.botTokenRef,
       },
       whatsapp: {
         ...baseConfig.comms.whatsapp,
         enabled: state.selectedCommsTransports.includes('whatsapp'),
-        accessTokenRef: stateValue(state, 'comms.whatsapp.accessTokenRef') as string | undefined,
-        phoneNumberIdRef: stateValue(state, 'comms.whatsapp.phoneNumberIdRef') as string | undefined,
-        appSecretRef: stateValue(state, 'comms.whatsapp.appSecretRef') as string | undefined,
-        verifyTokenRef: stateValue(state, 'comms.whatsapp.verifyTokenRef') as string | undefined,
+        accessTokenRef: stateValue<string>(state, 'comms.whatsapp.accessTokenRef') ?? baseConfig.comms.whatsapp.accessTokenRef,
+        phoneNumberIdRef: stateValue<string>(state, 'comms.whatsapp.phoneNumberIdRef') ?? baseConfig.comms.whatsapp.phoneNumberIdRef,
+        appSecretRef: stateValue<string>(state, 'comms.whatsapp.appSecretRef') ?? baseConfig.comms.whatsapp.appSecretRef,
+        verifyTokenRef: stateValue<string>(state, 'comms.whatsapp.verifyTokenRef') ?? baseConfig.comms.whatsapp.verifyTokenRef,
       },
     },
   });
@@ -219,7 +219,7 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
       }
       const targetedTransportOnly = activeTransportScope !== undefined && activeTransportScope.includes(transport.id);
       const enabled = targetedTransportOnly
-        ? transportDefault(options.initialState, config, transport.id)
+        ? config.comms[transport.id].enabled
         : await askBoolean(
           options.io,
           `Enable ${transport.label}? [y/N]`,

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -10,7 +10,15 @@ export interface InitWizardResult {
   state: InitState;
 }
 
-export type InitWizardScope = 'modules' | 'provider' | 'security' | 'slack' | 'discord' | 'secret-backend';
+export type InitWizardScope =
+  | 'modules'
+  | 'provider'
+  | 'security'
+  | 'slack'
+  | 'discord'
+  | 'telegram'
+  | 'whatsapp'
+  | 'secret-backend';
 
 interface RunInitWizardOptions {
   io: InterviewIO;
@@ -89,6 +97,19 @@ function buildConfig(baseConfig: OrchestratorConfig, state: InitState): Orchestr
         botTokenRef: stateValue(state, 'comms.discord.botTokenRef') as string | undefined,
         publicKeyRef: stateValue(state, 'comms.discord.publicKeyRef') as string | undefined,
       },
+      telegram: {
+        ...baseConfig.comms.telegram,
+        enabled: state.selectedCommsTransports.includes('telegram'),
+        botTokenRef: stateValue(state, 'comms.telegram.botTokenRef') as string | undefined,
+      },
+      whatsapp: {
+        ...baseConfig.comms.whatsapp,
+        enabled: state.selectedCommsTransports.includes('whatsapp'),
+        accessTokenRef: stateValue(state, 'comms.whatsapp.accessTokenRef') as string | undefined,
+        phoneNumberIdRef: stateValue(state, 'comms.whatsapp.phoneNumberIdRef') as string | undefined,
+        appSecretRef: stateValue(state, 'comms.whatsapp.appSecretRef') as string | undefined,
+        verifyTokenRef: stateValue(state, 'comms.whatsapp.verifyTokenRef') as string | undefined,
+      },
     },
   });
 }
@@ -103,7 +124,9 @@ function isSecretBackendOnlyScope(scope: readonly InitWizardScope[] | undefined)
 
 export async function runInitWizard(options: RunInitWizardOptions): Promise<InitWizardResult> {
   const config = options.baseConfig ?? defaultConfig();
-  const scope = new Set<InitWizardScope>(options.scope ?? ['modules', 'provider', 'security', 'slack', 'discord']);
+  const scope = new Set<InitWizardScope>(
+    options.scope ?? ['modules', 'provider', 'security', 'slack', 'discord', 'telegram', 'whatsapp'],
+  );
   const secretBackendOnly = isSecretBackendOnlyScope(options.scope);
 
   let enableChat = moduleDefault(options.initialState, config, 'chat');
@@ -267,6 +290,62 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
           const currentPublicKeyRef = String(stateValue(options.initialState, 'comms.discord.publicKeyRef') ?? '');
           if (!scope.has('discord') || currentPublicKeyRef.length === 0) {
             answers['comms.discord.publicKeyRef'] = await askText(options.io, 'Discord public key ref', currentPublicKeyRef);
+          }
+        }
+      }
+
+      if (transport.id === 'telegram') {
+        if (options.secretStore) {
+          const rawBotToken = await askText(options.io, 'Enter your Telegram bot token:', '');
+          if (rawBotToken.length > 0) {
+            await options.secretStore.store('comms.telegram.botTokenRef', rawBotToken);
+            answers['comms.telegram.botTokenRef'] = 'comms.telegram.botTokenRef';
+          }
+        } else {
+          const currentBotTokenRef = String(stateValue(options.initialState, 'comms.telegram.botTokenRef') ?? '');
+          if (!scope.has('telegram') || currentBotTokenRef.length === 0) {
+            answers['comms.telegram.botTokenRef'] = await askText(options.io, 'Telegram bot token ref', currentBotTokenRef);
+          }
+        }
+      }
+
+      if (transport.id === 'whatsapp') {
+        if (options.secretStore) {
+          const rawAccessToken = await askText(options.io, 'Enter your WhatsApp access token:', '');
+          if (rawAccessToken.length > 0) {
+            await options.secretStore.store('comms.whatsapp.accessTokenRef', rawAccessToken);
+            answers['comms.whatsapp.accessTokenRef'] = 'comms.whatsapp.accessTokenRef';
+          }
+          const rawPhoneNumberId = await askText(options.io, 'Enter your WhatsApp phone number ID:', '');
+          if (rawPhoneNumberId.length > 0) {
+            answers['comms.whatsapp.phoneNumberIdRef'] = rawPhoneNumberId;
+          }
+          const rawAppSecret = await askText(options.io, 'Enter your WhatsApp app secret:', '');
+          if (rawAppSecret.length > 0) {
+            await options.secretStore.store('comms.whatsapp.appSecretRef', rawAppSecret);
+            answers['comms.whatsapp.appSecretRef'] = 'comms.whatsapp.appSecretRef';
+          }
+          const rawVerifyToken = await askText(options.io, 'Enter your WhatsApp verify token:', '');
+          if (rawVerifyToken.length > 0) {
+            await options.secretStore.store('comms.whatsapp.verifyTokenRef', rawVerifyToken);
+            answers['comms.whatsapp.verifyTokenRef'] = 'comms.whatsapp.verifyTokenRef';
+          }
+        } else {
+          const currentAccessTokenRef = String(stateValue(options.initialState, 'comms.whatsapp.accessTokenRef') ?? '');
+          if (!scope.has('whatsapp') || currentAccessTokenRef.length === 0) {
+            answers['comms.whatsapp.accessTokenRef'] = await askText(options.io, 'WhatsApp access token ref', currentAccessTokenRef);
+          }
+          const currentPhoneNumberIdRef = String(stateValue(options.initialState, 'comms.whatsapp.phoneNumberIdRef') ?? '');
+          if (!scope.has('whatsapp') || currentPhoneNumberIdRef.length === 0) {
+            answers['comms.whatsapp.phoneNumberIdRef'] = await askText(options.io, 'WhatsApp phone number ID ref', currentPhoneNumberIdRef);
+          }
+          const currentAppSecretRef = String(stateValue(options.initialState, 'comms.whatsapp.appSecretRef') ?? '');
+          if (!scope.has('whatsapp') || currentAppSecretRef.length === 0) {
+            answers['comms.whatsapp.appSecretRef'] = await askText(options.io, 'WhatsApp app secret ref', currentAppSecretRef);
+          }
+          const currentVerifyTokenRef = String(stateValue(options.initialState, 'comms.whatsapp.verifyTokenRef') ?? '');
+          if (!scope.has('whatsapp') || currentVerifyTokenRef.length === 0) {
+            answers['comms.whatsapp.verifyTokenRef'] = await askText(options.io, 'WhatsApp verify token ref', currentVerifyTokenRef);
           }
         }
       }

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -46,6 +46,20 @@ function transportDefault(state: InitState, config: OrchestratorConfig, id: Supp
   return config.comms[id].enabled;
 }
 
+function hasTransportOnlyScope(scope: readonly InitWizardScope[] | undefined): boolean {
+  return scope !== undefined
+    && scope.some((item) => item === 'slack' || item === 'discord' || item === 'telegram' || item === 'whatsapp')
+    && !scope.includes('modules')
+    && !scope.includes('provider')
+    && !scope.includes('security');
+}
+
+function hasEnabledScopedTransport(config: OrchestratorConfig, scope: readonly InitWizardScope[] | undefined): boolean {
+  return hasTransportOnlyScope(scope)
+    && scope!.some((item) => (item === 'slack' || item === 'discord' || item === 'telegram' || item === 'whatsapp')
+      && config.comms[item].enabled);
+}
+
 async function askBoolean(io: InterviewIO, prompt: string, defaultValue: boolean): Promise<boolean> {
   const raw = (await io.ask(prompt)).trim().toLowerCase();
   if (raw.length === 0) {
@@ -131,7 +145,9 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
 
   let enableChat = moduleDefault(options.initialState, config, 'chat');
   let enableDashboard = moduleDefault(options.initialState, config, 'dashboard');
-  let enableComms = moduleDefault(options.initialState, config, 'comms');
+  let enableComms = hasEnabledScopedTransport(config, options.scope)
+    ? true
+    : moduleDefault(options.initialState, config, 'comms');
   if (!secretBackendOnly && scope.has('modules')) {
     enableChat = await askBoolean(options.io, 'Enable Chat? [Y/n]', enableChat);
     enableDashboard = await askBoolean(options.io, 'Enable Dashboard? [Y/n]', enableDashboard);

--- a/packages/franken-orchestrator/src/network/network-config-paths.ts
+++ b/packages/franken-orchestrator/src/network/network-config-paths.ts
@@ -29,6 +29,13 @@ const NETWORK_CONFIG_PATH_DEFINITIONS = {
   'comms.discord.applicationId': { type: 'string' },
   'comms.discord.botTokenRef': { type: 'string', sensitive: true },
   'comms.discord.publicKeyRef': { type: 'string' },
+  'comms.telegram.enabled': { type: 'boolean' },
+  'comms.telegram.botTokenRef': { type: 'string', sensitive: true },
+  'comms.whatsapp.enabled': { type: 'boolean' },
+  'comms.whatsapp.accessTokenRef': { type: 'string', sensitive: true },
+  'comms.whatsapp.phoneNumberIdRef': { type: 'string' },
+  'comms.whatsapp.appSecretRef': { type: 'string', sensitive: true },
+  'comms.whatsapp.verifyTokenRef': { type: 'string', sensitive: true },
 } as const;
 
 type ConfigValueType = 'boolean' | 'number' | 'string' | 'enum';

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -56,6 +56,19 @@ export const DiscordChannelConfigSchema = z.object({
   publicKeyRef: z.string().min(1).optional(),
 });
 
+export const TelegramChannelConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  botTokenRef: z.string().min(1).optional(),
+});
+
+export const WhatsAppChannelConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  accessTokenRef: z.string().min(1).optional(),
+  phoneNumberIdRef: z.string().min(1).optional(),
+  appSecretRef: z.string().min(1).optional(),
+  verifyTokenRef: z.string().min(1).optional(),
+});
+
 export const CommsServiceConfigSchema = z.object({
   enabled: z.boolean().default(false),
   host: HostSchema,
@@ -64,6 +77,8 @@ export const CommsServiceConfigSchema = z.object({
   orchestratorTokenRef: z.string().min(1).optional(),
   slack: SlackChannelConfigSchema.default({}),
   discord: DiscordChannelConfigSchema.default({}),
+  telegram: TelegramChannelConfigSchema.default({}),
+  whatsapp: WhatsAppChannelConfigSchema.default({}),
 });
 
 export const NetworkConfigSchema = z.object({

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -11,6 +11,7 @@ export type NetworkServiceKind = 'app' | 'infra';
 export interface NetworkRegistryContext {
   repoRoot: string;
   configFile?: string | undefined;
+  configOverrides?: string[] | undefined;
 }
 
 export interface NetworkServiceRuntimeConfig {

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -26,6 +26,7 @@ export interface NetworkServiceRuntimeConfig {
   composeFile?: string;
   services?: string[];
   suppressManagedBanner?: boolean;
+  inProcess?: boolean;
   process?: {
     command: string;
     args: string[];

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -10,6 +10,7 @@ export type NetworkServiceKind = 'app' | 'infra';
 
 export interface NetworkRegistryContext {
   repoRoot: string;
+  configFile?: string | undefined;
 }
 
 export interface NetworkServiceRuntimeConfig {

--- a/packages/franken-orchestrator/src/network/network-secrets.ts
+++ b/packages/franken-orchestrator/src/network/network-secrets.ts
@@ -43,6 +43,10 @@ const SENSITIVE_CONFIG_PATHS = [
   'comms.slack.botTokenRef',
   'comms.slack.signingSecretRef',
   'comms.discord.botTokenRef',
+  'comms.telegram.botTokenRef',
+  'comms.whatsapp.accessTokenRef',
+  'comms.whatsapp.appSecretRef',
+  'comms.whatsapp.verifyTokenRef',
 ] as const;
 
 export function resolveSecretMode(config: OrchestratorConfig): 'secure' | 'insecure' {

--- a/packages/franken-orchestrator/src/network/network-state-store.ts
+++ b/packages/franken-orchestrator/src/network/network-state-store.ts
@@ -8,6 +8,7 @@ export interface ManagedNetworkServiceState {
   dependsOn: string[];
   startedAt: string;
   status?: 'started' | 'already-running';
+  inProcess?: boolean | undefined;
   logFile?: string | undefined;
   url?: string | undefined;
   healthUrl?: string | undefined;

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -102,6 +102,21 @@ export class NetworkSupervisor {
           continue;
         }
 
+        if (service.runtimeConfig.inProcess === true) {
+          services.push({
+            id: service.id,
+            pid: 0,
+            detached: options.detached,
+            dependsOn: [...service.dependsOn],
+            startedAt,
+            status: 'already-running',
+            ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
+            ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
+            ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
+          });
+          continue;
+        }
+
         const logFile = options.detached ? await this.deps.logStore.register(service.id) : undefined;
         const { pid } = await this.deps.startService(service, {
           detached: options.detached,

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -80,6 +80,21 @@ export class NetworkSupervisor {
 
     try {
       for (const service of options.services) {
+        if (service.runtimeConfig.inProcess === true) {
+          services.push({
+            id: service.id,
+            pid: 0,
+            detached: options.detached,
+            dependsOn: [...service.dependsOn],
+            startedAt,
+            status: 'already-running',
+            ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
+            ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
+            ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
+          });
+          continue;
+        }
+
         const preflight = await this.resolvePreflight(service);
         if (preflight.action === 'conflict') {
           throw new Error(preflight.reason ?? `Port conflict for ${service.id}`);
@@ -98,21 +113,6 @@ export class NetworkSupervisor {
             ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : existingService?.url ? { url: existingService.url } : {}),
             ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : existingService?.healthUrl ? { healthUrl: existingService.healthUrl } : {}),
             ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : existingService?.serviceIdentity ? { serviceIdentity: existingService.serviceIdentity } : {}),
-          });
-          continue;
-        }
-
-        if (service.runtimeConfig.inProcess === true) {
-          services.push({
-            id: service.id,
-            pid: 0,
-            detached: options.detached,
-            dependsOn: [...service.dependsOn],
-            startedAt,
-            status: 'already-running',
-            ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
-            ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
-            ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
           });
           continue;
         }

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -192,6 +192,13 @@ export class NetworkSupervisor {
       ? state.services
       : collectDependents(state.services, target);
 
+    const targetState = target === 'all' ? undefined : state.services.find((service) => service.id === target);
+    if (targetState && isInProcessService(targetState)) {
+      throw new Error(
+        `Service ${target} is hosted in-process by chat-server; stop chat-server or all services instead.`,
+      );
+    }
+
     for (const service of [...selected].reverse()) {
       await this.deps.stopService(service);
     }
@@ -260,4 +267,8 @@ export class NetworkSupervisor {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isInProcessService(service: ManagedNetworkServiceState): boolean {
+  return service.pid <= 0 && service.status === 'already-running';
 }

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -81,17 +81,23 @@ export class NetworkSupervisor {
     try {
       for (const service of options.services) {
         if (service.runtimeConfig.inProcess === true) {
-          services.push({
+          const serviceState: ManagedNetworkServiceState = {
             id: service.id,
             pid: 0,
             detached: options.detached,
             dependsOn: [...service.dependsOn],
             startedAt,
             status: 'already-running',
+            inProcess: true,
             ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : {}),
             ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : {}),
             ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : {}),
-          });
+          };
+          services.push(serviceState);
+          const healthy = await this.waitForHealthy(serviceState);
+          if (!healthy) {
+            throw new Error(`Service ${service.id} failed healthcheck during startup`);
+          }
           continue;
         }
 
@@ -113,6 +119,7 @@ export class NetworkSupervisor {
             ...(service.runtimeConfig.url ? { url: service.runtimeConfig.url } : existingService?.url ? { url: existingService.url } : {}),
             ...(service.runtimeConfig.healthUrl ? { healthUrl: service.runtimeConfig.healthUrl } : existingService?.healthUrl ? { healthUrl: existingService.healthUrl } : {}),
             ...(service.runtimeConfig.serviceIdentity ? { serviceIdentity: service.runtimeConfig.serviceIdentity } : existingService?.serviceIdentity ? { serviceIdentity: existingService.serviceIdentity } : {}),
+            ...(existingService?.inProcess ? { inProcess: existingService.inProcess } : {}),
           });
           continue;
         }
@@ -270,5 +277,5 @@ function sleep(ms: number): Promise<void> {
 }
 
 function isInProcessService(service: ManagedNetworkServiceState): boolean {
-  return service.pid <= 0 && service.status === 'already-running';
+  return service.inProcess === true;
 }

--- a/packages/franken-orchestrator/src/network/secret-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-store.ts
@@ -117,8 +117,8 @@ export class SecretResolver {
     const whatsappAccessToken = config.comms.whatsapp.enabled && config.comms.whatsapp.accessTokenRef
       ? await this.store.resolve(config.comms.whatsapp.accessTokenRef)
       : undefined;
-    const whatsappPhoneNumberId = config.comms.whatsapp.enabled && config.comms.whatsapp.phoneNumberIdRef
-      ? await this.store.resolve(config.comms.whatsapp.phoneNumberIdRef)
+    const whatsappPhoneNumberId = config.comms.whatsapp.enabled
+      ? config.comms.whatsapp.phoneNumberIdRef
       : undefined;
     const whatsappAppSecret = config.comms.whatsapp.enabled && config.comms.whatsapp.appSecretRef
       ? await this.store.resolve(config.comms.whatsapp.appSecretRef)

--- a/packages/franken-orchestrator/src/network/secret-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-store.ts
@@ -74,6 +74,11 @@ export interface ResolvedSecrets {
   slackBotToken?: string | undefined;
   slackSigningSecret?: string | undefined;
   discordBotToken?: string | undefined;
+  telegramBotToken?: string | undefined;
+  whatsappAccessToken?: string | undefined;
+  whatsappPhoneNumberId?: string | undefined;
+  whatsappAppSecret?: string | undefined;
+  whatsappVerifyToken?: string | undefined;
 }
 
 export class SecretResolver {
@@ -105,12 +110,34 @@ export class SecretResolver {
       ? await this.store.resolve(config.comms.discord.botTokenRef)
       : undefined;
 
+    const telegramBotToken = config.comms.telegram.enabled && config.comms.telegram.botTokenRef
+      ? await this.store.resolve(config.comms.telegram.botTokenRef)
+      : undefined;
+
+    const whatsappAccessToken = config.comms.whatsapp.enabled && config.comms.whatsapp.accessTokenRef
+      ? await this.store.resolve(config.comms.whatsapp.accessTokenRef)
+      : undefined;
+    const whatsappPhoneNumberId = config.comms.whatsapp.enabled && config.comms.whatsapp.phoneNumberIdRef
+      ? await this.store.resolve(config.comms.whatsapp.phoneNumberIdRef)
+      : undefined;
+    const whatsappAppSecret = config.comms.whatsapp.enabled && config.comms.whatsapp.appSecretRef
+      ? await this.store.resolve(config.comms.whatsapp.appSecretRef)
+      : undefined;
+    const whatsappVerifyToken = config.comms.whatsapp.enabled && config.comms.whatsapp.verifyTokenRef
+      ? await this.store.resolve(config.comms.whatsapp.verifyTokenRef)
+      : undefined;
+
     return {
       operatorToken,
       orchestratorToken,
       slackBotToken,
       slackSigningSecret,
       discordBotToken,
+      telegramBotToken,
+      whatsappAccessToken,
+      whatsappPhoneNumberId,
+      whatsappAppSecret,
+      whatsappVerifyToken,
     };
   }
 }

--- a/packages/franken-orchestrator/src/network/services/chat-server-service.ts
+++ b/packages/franken-orchestrator/src/network/services/chat-server-service.ts
@@ -32,6 +32,7 @@ export const chatServerService: NetworkServiceDefinition = {
         config.chat.host,
         '--port',
         String(config.chat.port),
+        ...(context.configFile ? ['--config', context.configFile] : []),
       ],
       cwd: context.repoRoot,
       env: {

--- a/packages/franken-orchestrator/src/network/services/chat-server-service.ts
+++ b/packages/franken-orchestrator/src/network/services/chat-server-service.ts
@@ -33,6 +33,7 @@ export const chatServerService: NetworkServiceDefinition = {
         '--port',
         String(config.chat.port),
         ...(context.configFile ? ['--config', context.configFile] : []),
+        ...(context.configOverrides?.flatMap((override) => ['--set', override]) ?? []),
       ],
       cwd: context.repoRoot,
       env: {

--- a/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
+++ b/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
@@ -29,9 +29,10 @@ export const commsGatewayService: NetworkServiceDefinition = {
       + `slack=${config.comms.slack.enabled} discord=${config.comms.discord.enabled} `
       + `telegram=${config.comms.telegram.enabled} whatsapp=${config.comms.whatsapp.enabled}.`,
   buildRuntimeConfig: (config: OrchestratorConfig) => ({
-    host: config.comms.host,
-    port: config.comms.port,
-    url: `http://${config.comms.host}:${config.comms.port}`,
+    host: config.chat.host,
+    port: config.chat.port,
+    url: `http://${config.chat.host}:${config.chat.port}`,
+    healthUrl: `http://${config.chat.host}:${config.chat.port}/comms/health`,
     orchestratorWsUrl: config.comms.orchestratorWsUrl,
     channels: {
       slack: config.comms.slack.enabled,

--- a/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
+++ b/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
@@ -2,7 +2,10 @@ import type { OrchestratorConfig } from '../../config/orchestrator-config.js';
 import type { NetworkServiceDefinition } from '../network-registry.js';
 
 function hasEnabledChannels(config: OrchestratorConfig): boolean {
-  return config.comms.slack.enabled || config.comms.discord.enabled;
+  return config.comms.slack.enabled
+    || config.comms.discord.enabled
+    || config.comms.telegram.enabled
+    || config.comms.whatsapp.enabled;
 }
 
 export const commsGatewayService: NetworkServiceDefinition = {
@@ -17,10 +20,14 @@ export const commsGatewayService: NetworkServiceDefinition = {
     'comms.orchestratorWsUrl',
     'comms.slack.enabled',
     'comms.discord.enabled',
+    'comms.telegram.enabled',
+    'comms.whatsapp.enabled',
   ],
   enabled: (config: OrchestratorConfig) => config.comms.enabled || hasEnabledChannels(config),
   describe: (config: OrchestratorConfig) =>
-    `Enabled when comms.enabled=true or a channel is enabled; current channel flags slack=${config.comms.slack.enabled} discord=${config.comms.discord.enabled}.`,
+    'Enabled when comms.enabled=true or a channel is enabled; current channel flags '
+      + `slack=${config.comms.slack.enabled} discord=${config.comms.discord.enabled} `
+      + `telegram=${config.comms.telegram.enabled} whatsapp=${config.comms.whatsapp.enabled}.`,
   buildRuntimeConfig: (config: OrchestratorConfig) => ({
     host: config.comms.host,
     port: config.comms.port,
@@ -29,6 +36,8 @@ export const commsGatewayService: NetworkServiceDefinition = {
     channels: {
       slack: config.comms.slack.enabled,
       discord: config.comms.discord.enabled,
+      telegram: config.comms.telegram.enabled,
+      whatsapp: config.comms.whatsapp.enabled,
     },
     // Comms webhook routes are now served in-process on the orchestrator's Hono server
     // via commsRoutes() registered in chat-app.ts — no separate process needed.

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve as resolvePath } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { CliArgs } from '../../../src/cli/args.js';
 import { runNetworkCommand } from '../../../src/cli/run.js';
@@ -91,6 +91,7 @@ describe('runNetworkCommand', () => {
         resolveServices: vi.fn(() => services),
         createSupervisor: vi.fn(() => ({
           up,
+          stopAll: vi.fn(),
           down: vi.fn(),
           status: vi.fn(),
           stop: vi.fn(),
@@ -132,6 +133,7 @@ describe('runNetworkCommand', () => {
               { id: 'chat-server', pid: 0, dependsOn: [], startedAt: '2026-03-10T00:00:00.000Z', url: 'http://127.0.0.1:3737', status: 'already-running' },
             ],
           })),
+          stopAll: vi.fn(),
           down: vi.fn(),
           status: vi.fn(),
           stop: vi.fn(),
@@ -145,6 +147,75 @@ describe('runNetworkCommand', () => {
     );
 
     expect(print).toHaveBeenCalledWith('Already running 1 service.');
+  });
+
+  it('resolves relative config paths before forwarding them to managed services', async () => {
+    const config = defaultConfig();
+    const resolveServices = vi.fn(() => [makeService('chat-server')]);
+
+    await runNetworkCommand(
+      makeArgs({ networkAction: 'up', networkDetached: true, config: 'configs/runtime.json' }),
+      config,
+      '/repo/frankenbeast',
+      makePaths(),
+      {
+        resolveServices,
+        createSupervisor: vi.fn(() => ({
+          up: vi.fn(async () => ({ services: [] })),
+          stopAll: vi.fn(),
+          down: vi.fn(),
+          status: vi.fn(),
+          stop: vi.fn(),
+          logs: vi.fn(),
+        })),
+        print: vi.fn(),
+        printError: vi.fn(),
+        renderHelp: () => 'network help',
+        waitForShutdown: vi.fn(async () => undefined),
+      },
+    );
+
+    expect(resolveServices).toHaveBeenCalledWith(config, {
+      repoRoot: '/repo/frankenbeast',
+      configFile: resolvePath('configs/runtime.json'),
+    });
+  });
+
+  it('foreground shutdown stops only services started by this invocation', async () => {
+    const stopAll = vi.fn(async () => undefined);
+    const waitForShutdown = vi.fn(async () => undefined);
+
+    await runNetworkCommand(
+      makeArgs({ networkAction: 'up', networkDetached: false }),
+      defaultConfig(),
+      '/repo/frankenbeast',
+      makePaths(),
+      {
+        resolveServices: vi.fn(() => [makeService('chat-server'), makeService('dashboard-web')]),
+        createSupervisor: vi.fn(() => ({
+          up: vi.fn(async () => ({
+            services: [
+              { id: 'chat-server', pid: 0, dependsOn: [], startedAt: '2026-03-10T00:00:00.000Z', status: 'already-running' as const },
+              { id: 'dashboard-web', pid: 102, dependsOn: ['chat-server'], startedAt: '2026-03-10T00:00:00.000Z', status: 'started' as const },
+            ],
+          })),
+          stopAll,
+          down: vi.fn(),
+          status: vi.fn(),
+          stop: vi.fn(),
+          logs: vi.fn(),
+        })),
+        print: vi.fn(),
+        printError: vi.fn(),
+        renderHelp: () => 'network help',
+        waitForShutdown,
+      },
+    );
+
+    expect(waitForShutdown).toHaveBeenCalled();
+    expect(stopAll).toHaveBeenCalledWith(expect.objectContaining({
+      services: [expect.objectContaining({ id: 'dashboard-web', status: 'started' })],
+    }));
   });
 
   it('up does not print started when the supervisor rejects startup', async () => {
@@ -161,6 +232,7 @@ describe('runNetworkCommand', () => {
           up: vi.fn(async () => {
             throw new Error('Port conflict for chat-server on 127.0.0.1:3737');
           }),
+          stopAll: vi.fn(),
           down: vi.fn(),
           status: vi.fn(),
           stop: vi.fn(),
@@ -188,6 +260,7 @@ describe('runNetworkCommand', () => {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(() => ({
           up: vi.fn(),
+          stopAll: vi.fn(),
           down,
           status: vi.fn(),
           stop: vi.fn(),
@@ -220,6 +293,7 @@ describe('runNetworkCommand', () => {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(() => ({
           up: vi.fn(),
+          stopAll: vi.fn(),
           down: vi.fn(),
           status: vi.fn(async () => status),
           stop: vi.fn(),
@@ -251,6 +325,7 @@ describe('runNetworkCommand', () => {
       resolveServices: vi.fn(() => services),
       createSupervisor: vi.fn(() => ({
         up,
+        stopAll: vi.fn(),
         down: vi.fn(),
         status: vi.fn(),
         stop,
@@ -302,6 +377,7 @@ describe('runNetworkCommand', () => {
         resolveServices: vi.fn(() => []),
         createSupervisor: vi.fn(() => ({
           up: vi.fn(),
+          stopAll: vi.fn(),
           down: vi.fn(),
           status: vi.fn(),
           stop: vi.fn(),
@@ -345,7 +421,8 @@ describe('runNetworkCommand', () => {
           resolveServices: vi.fn(() => []),
           createSupervisor: vi.fn(() => ({
             up: vi.fn(),
-            down: vi.fn(),
+            stopAll: vi.fn(),
+          down: vi.fn(),
             status: vi.fn(),
             stop: vi.fn(),
             logs: vi.fn(),
@@ -389,7 +466,8 @@ describe('runNetworkCommand', () => {
           resolveServices: vi.fn(() => []),
           createSupervisor: vi.fn(() => ({
             up: vi.fn(),
-            down: vi.fn(),
+            stopAll: vi.fn(),
+          down: vi.fn(),
             status: vi.fn(),
             stop: vi.fn(),
             logs: vi.fn(),

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -181,6 +181,42 @@ describe('runNetworkCommand', () => {
     });
   });
 
+  it('forwards network --set overrides to managed services', async () => {
+    const config = defaultConfig();
+    const resolveServices = vi.fn(() => [makeService('chat-server')]);
+
+    await runNetworkCommand(
+      makeArgs({
+        networkAction: 'up',
+        networkDetached: true,
+        networkSet: ['comms.telegram.enabled=true'],
+      }),
+      config,
+      '/repo/frankenbeast',
+      makePaths(),
+      {
+        resolveServices,
+        createSupervisor: vi.fn(() => ({
+          up: vi.fn(async () => ({ services: [] })),
+          stopAll: vi.fn(),
+          down: vi.fn(),
+          status: vi.fn(),
+          stop: vi.fn(),
+          logs: vi.fn(),
+        })),
+        print: vi.fn(),
+        printError: vi.fn(),
+        renderHelp: () => 'network help',
+        waitForShutdown: vi.fn(async () => undefined),
+      },
+    );
+
+    expect(resolveServices).toHaveBeenCalledWith(config, {
+      repoRoot: '/repo/frankenbeast',
+      configOverrides: ['comms.telegram.enabled=true'],
+    });
+  });
+
   it('foreground shutdown stops only services started by this invocation', async () => {
     const stopAll = vi.fn(async () => undefined);
     const waitForShutdown = vi.fn(async () => undefined);

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -203,6 +203,20 @@ vi.mock('../../../src/cli/config-loader.js', () => ({
     minCritiqueScore: 0.7,
     maxTotalTokens: 100_000,
     providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+    network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
+    beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+    chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
+    dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+    comms: {
+      enabled: false,
+      host: '127.0.0.1',
+      port: 3200,
+      orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+      slack: { enabled: false },
+      discord: { enabled: false },
+      telegram: { enabled: false },
+      whatsapp: { enabled: false },
+    },
   })),
 }));
 

--- a/packages/franken-orchestrator/tests/unit/cli/session-issues.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-issues.test.ts
@@ -536,5 +536,5 @@ describe('resolvePhases handles issues subcommand', () => {
     const { resolvePhases } = await import('../../../src/cli/run.js');
     const result = resolvePhases({ subcommand: 'issues' });
     expect(result.entryPhase).toBeDefined();
-  });
+  }, 15_000);
 });

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -103,6 +103,8 @@ describe('ChatGateway', () => {
 
   it('passes channel routing metadata through to outbound replies', async () => {
     for (const [type, expectedMetadata] of [
+      ['slack', { externalChannelId: 'C-slack', channelId: 'C-slack' }],
+      ['discord', { externalChannelId: 'C-discord', channelId: 'C-discord' }],
       ['telegram', { externalChannelId: 'C-telegram', chatId: 'C-telegram' }],
       ['whatsapp', { externalChannelId: 'C-whatsapp', phoneNumber: 'C-whatsapp' }],
     ] as const) {

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -101,6 +101,31 @@ describe('ChatGateway', () => {
     }
   });
 
+  it('passes channel routing metadata through to outbound replies', async () => {
+    for (const [type, expectedMetadata] of [
+      ['telegram', { externalChannelId: 'C-telegram', chatId: 'C-telegram' }],
+      ['whatsapp', { externalChannelId: 'C-whatsapp', phoneNumber: 'C-whatsapp' }],
+    ] as const) {
+      const adapter = mockAdapter(type);
+      gateway.registerAdapter(adapter);
+
+      await gateway.handleInbound({
+        channelType: type,
+        externalUserId: `U-${type}`,
+        externalChannelId: `C-${type}`,
+        externalMessageId: `M-${type}`,
+        text: 'test',
+        receivedAt: new Date().toISOString(),
+        rawEvent: {},
+      });
+
+      expect(adapter.send).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ metadata: expect.objectContaining(expectedMetadata) }),
+      );
+    }
+  });
+
   it('handleAction sends /approve for approve action', async () => {
     const slackAdapter = mockAdapter('slack');
     gateway.registerAdapter(slackAdapter);

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -140,6 +140,23 @@ describe('ChatGateway', () => {
     );
   });
 
+  it('handleAction relays explicit route metadata after a restart', async () => {
+    const telegramAdapter = mockAdapter('telegram');
+    gateway.registerAdapter(telegramAdapter);
+
+    await gateway.handleAction('telegram', 'sess-telegram', 'approve', {
+      chatId: 'chat-123',
+      externalChannelId: 'chat-123',
+    });
+
+    expect(telegramAdapter.send).toHaveBeenCalledWith(
+      'sess-telegram',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ chatId: 'chat-123' }),
+      }),
+    );
+  });
+
   it('handleAction sends rejection text for reject action', async () => {
     const slackAdapter = mockAdapter('slack');
     gateway.registerAdapter(slackAdapter);

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
@@ -43,6 +43,6 @@ describe('TelegramAdapter', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1]!.body as string);
     expect(body.reply_markup.inline_keyboard[0][0].text).toBe('Approve');
-    expect(body.reply_markup.inline_keyboard[0][0].callback_data).toBe('approve');
+    expect(body.reply_markup.inline_keyboard[0][0].callback_data).toBe('fb:session-123:approve');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
@@ -76,4 +76,30 @@ describe('telegramRouter', () => {
       expect.any(Object)
     );
   });
+
+  it('uses embedded session ids from callback data when another group operator clicks', async () => {
+    const body = JSON.stringify({
+      update_id: 3,
+      callback_query: {
+        id: 'q2',
+        from: { id: 999 },
+        message: {
+          message_id: 101,
+          chat: { id: 456 },
+        },
+        data: 'fb:original-session:approve',
+      },
+    });
+
+    const res = await app.request(`/${botToken}`, {
+      method: 'POST',
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    expect(gateway.handleAction).toHaveBeenCalledWith('telegram', 'original-session', 'approve', {
+      chatId: '456',
+      externalChannelId: '456',
+    });
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
@@ -67,7 +67,10 @@ describe('telegramRouter', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(gateway.handleAction).toHaveBeenCalledWith('telegram', 'session-123', 'approve');
+    expect(gateway.handleAction).toHaveBeenCalledWith('telegram', 'session-123', 'approve', {
+      chatId: '456',
+      externalChannelId: '456',
+    });
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('answerCallbackQuery'),
       expect.any(Object)

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
@@ -103,6 +103,9 @@ describe('whatsappRouter', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(gateway.handleAction).toHaveBeenCalledWith('whatsapp', 'session-123', 'approve');
+    expect(gateway.handleAction).toHaveBeenCalledWith('whatsapp', 'session-123', 'approve', {
+      externalChannelId: '123456',
+      phoneNumber: '123456',
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -85,4 +85,41 @@ describe('commsRoutes', () => {
   it('throws when runtime is not provided', () => {
     expect(() => commsRoutes({ config: minimalConfig() })).toThrow('CommsRuntimePort');
   });
+
+  it('requires the full Telegram token segment before accepting updates', async () => {
+    const app = commsRoutes({
+      config: minimalConfig({
+        channels: {
+          telegram: { enabled: true, botToken: '123456:secret-token' },
+        },
+      }),
+      runtime: mockRuntime(),
+    });
+
+    const body = {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        date: 1,
+        text: 'hello',
+        chat: { id: 123456, type: 'private' },
+        from: { id: 42, is_bot: false, first_name: 'Ada' },
+      },
+    };
+    const headers = { 'Content-Type': 'application/json' };
+
+    const partial = await app.request('/webhooks/telegram/123456anything', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    expect(partial.status).toBe(404);
+
+    const exact = await app.request('/webhooks/telegram/123456:secret-token', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    expect(exact.status).toBe(200);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/init/comms-transport-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/comms-transport-registry.test.ts
@@ -3,10 +3,15 @@ import { listKnownCommsTransports, listSupportedCommsTransports } from '../../..
 
 describe('comms transport registry', () => {
   it('returns only runtime-supported transports', () => {
-    expect(listSupportedCommsTransports().map((transport) => transport.id)).toEqual(['slack', 'discord']);
+    expect(listSupportedCommsTransports().map((transport) => transport.id)).toEqual([
+      'slack',
+      'discord',
+      'telegram',
+      'whatsapp',
+    ]);
   });
 
-  it('keeps known future transports without surfacing them as supported', () => {
+  it('lists every known transport in runtime-supported order', () => {
     expect(listKnownCommsTransports().map((transport) => transport.id)).toEqual([
       'slack',
       'discord',

--- a/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
@@ -75,6 +75,33 @@ describe('verifyInit', () => {
     expect(result.messages.join('\n')).not.toContain('Discord');
   });
 
+  it('validates enabled Telegram and WhatsApp transports', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-verify-'));
+    const configFile = join(tempDir, '.fbeast', 'config.json');
+    const stateStore = new FileInitStateStore(join(tempDir, '.fbeast', 'init-state.json'));
+    const config = defaultConfig();
+    config.comms.enabled = true;
+    config.comms.telegram.enabled = true;
+    config.comms.whatsapp.enabled = true;
+    config.comms.whatsapp.accessTokenRef = 'op://whatsapp/access-token';
+    await mkdir(join(tempDir, '.fbeast'), { recursive: true });
+    await writeFile(configFile, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    await stateStore.save({
+      ...createEmptyInitState(configFile),
+      selectedModules: ['comms'],
+      selectedCommsTransports: ['telegram', 'whatsapp'],
+    });
+
+    const result = await verifyInit({
+      configFile,
+      stateStore,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.messages.join('\n')).toContain('Telegram config is incomplete: missing botTokenRef');
+    expect(result.messages.join('\n')).toContain('WhatsApp config is incomplete: missing phoneNumberIdRef, appSecretRef, verifyTokenRef');
+  });
+
   it('repair revisits only failing sections and preserves valid answers', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-init-verify-'));
     const configFile = join(tempDir, '.fbeast', 'config.json');

--- a/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
@@ -143,29 +143,31 @@ describe('verifyInit', () => {
     expect(prompts.some((prompt) => prompt.includes('Default provider'))).toBe(false);
   });
 
-  it('repair maps Telegram and WhatsApp verification issues to their transport scopes', async () => {
+  it('repair keeps config-enabled transports even when init state is stale', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-init-verify-'));
     const configFile = join(tempDir, '.fbeast', 'config.json');
     const stateStore = new FileInitStateStore(join(tempDir, '.fbeast', 'init-state.json'));
     const config = defaultConfig();
     config.comms.enabled = true;
+    config.comms.slack.enabled = true;
+    config.comms.slack.appId = 'existing-app';
+    config.comms.slack.botTokenRef = 'op://slack/bot-token';
+    config.comms.slack.signingSecretRef = 'op://slack/signing-secret';
     config.comms.telegram.enabled = true;
-    config.comms.whatsapp.enabled = true;
     await mkdir(join(tempDir, '.fbeast'), { recursive: true });
     await writeFile(configFile, JSON.stringify(config, null, 2) + '\n', 'utf-8');
     await stateStore.save({
       ...createEmptyInitState(configFile),
       selectedModules: ['comms'],
-      selectedCommsTransports: ['telegram', 'whatsapp'],
+      selectedCommsTransports: ['slack'],
       completedSteps: ['module-selection', 'provider-config', 'security-selection', 'comms-transport-selection'],
+      answers: {
+        'comms.slack.appId': 'existing-app',
+        'comms.slack.botTokenRef': 'op://slack/bot-token',
+        'comms.slack.signingSecretRef': 'op://slack/signing-secret',
+      },
     });
-    const { io, prompts } = scriptedIo(
-      'op://telegram/bot-token',
-      'op://whatsapp/access-token',
-      'wa-phone-number-id',
-      'op://whatsapp/app-secret',
-      'op://whatsapp/verify-token',
-    );
+    const { io, prompts } = scriptedIo('op://telegram/bot-token');
 
     const result = await runRepairInit({
       configFile,
@@ -173,12 +175,10 @@ describe('verifyInit', () => {
       io,
     });
 
+    expect(result.config.comms.slack.enabled).toBe(true);
+    expect(result.config.comms.telegram.enabled).toBe(true);
     expect(result.config.comms.telegram.botTokenRef).toBe('op://telegram/bot-token');
-    expect(result.config.comms.whatsapp.accessTokenRef).toBe('op://whatsapp/access-token');
-    expect(result.config.comms.whatsapp.phoneNumberIdRef).toBe('wa-phone-number-id');
-    expect(result.config.comms.whatsapp.appSecretRef).toBe('op://whatsapp/app-secret');
-    expect(result.config.comms.whatsapp.verifyTokenRef).toBe('op://whatsapp/verify-token');
-    expect(prompts.every((prompt) => !prompt.includes('Enable Slack'))).toBe(true);
-    expect(prompts.every((prompt) => !prompt.includes('Enable Discord'))).toBe(true);
+    expect(result.state.selectedCommsTransports).toEqual(['slack', 'telegram']);
+    expect(prompts).toEqual(['Telegram bot token ref']);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
@@ -181,4 +181,35 @@ describe('verifyInit', () => {
     expect(result.state.selectedCommsTransports).toEqual(['slack', 'telegram']);
     expect(prompts).toEqual(['Telegram bot token ref']);
   });
+
+  it('repair treats directly enabled channel flags as comms-enabled', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-verify-'));
+    const configFile = join(tempDir, '.fbeast', 'config.json');
+    const stateStore = new FileInitStateStore(join(tempDir, '.fbeast', 'init-state.json'));
+    const config = defaultConfig();
+    config.comms.enabled = false;
+    config.comms.telegram.enabled = true;
+    await mkdir(join(tempDir, '.fbeast'), { recursive: true });
+    await writeFile(configFile, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    await stateStore.save({
+      ...createEmptyInitState(configFile),
+      selectedModules: [],
+      selectedCommsTransports: [],
+      completedSteps: ['module-selection', 'provider-config', 'security-selection', 'comms-transport-selection'],
+      answers: {},
+    });
+    const { io, prompts } = scriptedIo('op://telegram/bot-token');
+
+    const result = await runRepairInit({
+      configFile,
+      stateStore,
+      io,
+    });
+
+    expect(result.config.comms.enabled).toBe(true);
+    expect(result.config.comms.telegram.enabled).toBe(true);
+    expect(result.config.comms.telegram.botTokenRef).toBe('op://telegram/bot-token');
+    expect(result.state.selectedCommsTransports).toEqual(['telegram']);
+    expect(prompts).toEqual(['Telegram bot token ref']);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
@@ -142,4 +142,43 @@ describe('verifyInit', () => {
     expect(prompts.some((prompt) => prompt.includes('Enable Chat'))).toBe(false);
     expect(prompts.some((prompt) => prompt.includes('Default provider'))).toBe(false);
   });
+
+  it('repair maps Telegram and WhatsApp verification issues to their transport scopes', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-verify-'));
+    const configFile = join(tempDir, '.fbeast', 'config.json');
+    const stateStore = new FileInitStateStore(join(tempDir, '.fbeast', 'init-state.json'));
+    const config = defaultConfig();
+    config.comms.enabled = true;
+    config.comms.telegram.enabled = true;
+    config.comms.whatsapp.enabled = true;
+    await mkdir(join(tempDir, '.fbeast'), { recursive: true });
+    await writeFile(configFile, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    await stateStore.save({
+      ...createEmptyInitState(configFile),
+      selectedModules: ['comms'],
+      selectedCommsTransports: ['telegram', 'whatsapp'],
+      completedSteps: ['module-selection', 'provider-config', 'security-selection', 'comms-transport-selection'],
+    });
+    const { io, prompts } = scriptedIo(
+      'op://telegram/bot-token',
+      'op://whatsapp/access-token',
+      'wa-phone-number-id',
+      'op://whatsapp/app-secret',
+      'op://whatsapp/verify-token',
+    );
+
+    const result = await runRepairInit({
+      configFile,
+      stateStore,
+      io,
+    });
+
+    expect(result.config.comms.telegram.botTokenRef).toBe('op://telegram/bot-token');
+    expect(result.config.comms.whatsapp.accessTokenRef).toBe('op://whatsapp/access-token');
+    expect(result.config.comms.whatsapp.phoneNumberIdRef).toBe('wa-phone-number-id');
+    expect(result.config.comms.whatsapp.appSecretRef).toBe('op://whatsapp/app-secret');
+    expect(result.config.comms.whatsapp.verifyTokenRef).toBe('op://whatsapp/verify-token');
+    expect(prompts.every((prompt) => !prompt.includes('Enable Slack'))).toBe(true);
+    expect(prompts.every((prompt) => !prompt.includes('Enable Discord'))).toBe(true);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -3,6 +3,7 @@ import type { InterviewIO } from '../../../src/planning/interview-loop.js';
 import type { ISecretStore, SecretStoreDetection } from '../../../src/network/secret-store.js';
 import { runInitWizard, type InitWizardScope } from '../../../src/init/init-wizard.js';
 import { createEmptyInitState } from '../../../src/init/init-types.js';
+import { defaultConfig } from '../../../src/config/orchestrator-config.js';
 
 // ------------------------------------------------------------------
 // Helpers
@@ -221,6 +222,40 @@ describe('runInitWizard – with Telegram and WhatsApp enabled', () => {
     expect(secretStore.stored.get('comms.whatsapp.accessTokenRef')).toBe('wa-access-token');
     expect(secretStore.stored.get('comms.whatsapp.appSecretRef')).toBe('wa-app-secret');
     expect(secretStore.stored.get('comms.whatsapp.verifyTokenRef')).toBe('wa-verify-token');
+  });
+
+  it('preserves existing Telegram and WhatsApp refs when rerunning scoped prompts without a secret store', async () => {
+    const io = makeIO([]);
+    const state = createEmptyInitState('/tmp/test-config.json');
+    state.selectedModules = ['comms'];
+    state.selectedCommsTransports = ['telegram', 'whatsapp'];
+    const baseConfig = defaultConfig();
+    baseConfig.comms.enabled = true;
+    baseConfig.comms.telegram = {
+      enabled: true,
+      botTokenRef: 'secret://existing/telegram-token',
+    };
+    baseConfig.comms.whatsapp = {
+      enabled: true,
+      accessTokenRef: 'secret://existing/whatsapp-access',
+      phoneNumberIdRef: 'existing-phone-number-id',
+      appSecretRef: 'secret://existing/whatsapp-app-secret',
+      verifyTokenRef: 'secret://existing/whatsapp-verify',
+    };
+
+    const result = await runInitWizard({
+      io,
+      initialState: state,
+      baseConfig,
+      scope: ['telegram', 'whatsapp'],
+    });
+
+    expect(io.ask).not.toHaveBeenCalled();
+    expect(result.config.comms.telegram.botTokenRef).toBe('secret://existing/telegram-token');
+    expect(result.config.comms.whatsapp.accessTokenRef).toBe('secret://existing/whatsapp-access');
+    expect(result.config.comms.whatsapp.phoneNumberIdRef).toBe('existing-phone-number-id');
+    expect(result.config.comms.whatsapp.appSecretRef).toBe('secret://existing/whatsapp-app-secret');
+    expect(result.config.comms.whatsapp.verifyTokenRef).toBe('secret://existing/whatsapp-verify');
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -142,6 +142,8 @@ describe('runInitWizard – with secretStore and Slack enabled', () => {
       'xoxb-abc',     // Slack bot token (raw value)
       'signsecret',   // Slack signing secret (raw value)
       'n',            // Enable Discord?
+      'n',            // Enable Telegram?
+      'n',            // Enable WhatsApp?
       '',             // Operator token (blank → auto)
     ]);
     const secretStore = makeSecretStore({ available: true });
@@ -169,6 +171,8 @@ describe('runInitWizard – with secretStore and Discord enabled', () => {
       '1234567890',      // Discord application ID
       'discord-bot-tok', // Discord bot token (raw value)
       'pubkey-abc',      // Discord public key (raw value)
+      'n',               // Enable Telegram?
+      'n',               // Enable WhatsApp?
       '',                // Operator token (blank → auto)
     ]);
     const secretStore = makeSecretStore({ available: true });
@@ -179,6 +183,44 @@ describe('runInitWizard – with secretStore and Discord enabled', () => {
     expect(secretStore.stored.has('comms.discord.publicKeyRef')).toBe(false);
     expect(result.config.comms.discord.botTokenRef).toBe('comms.discord.botTokenRef');
     expect(result.config.comms.discord.publicKeyRef).toBe('pubkey-abc');
+  });
+});
+
+describe('runInitWizard – with Telegram and WhatsApp enabled', () => {
+  it('prompts for runtime-supported Telegram and WhatsApp secrets', async () => {
+    const io = makeIO([
+      'y',                    // Enable Chat?
+      'y',                    // Enable Dashboard?
+      'y',                    // Enable Comms?
+      'claude',               // Default provider
+      'secure',               // Security mode
+      'n',                    // Enable Slack?
+      'n',                    // Enable Discord?
+      'y',                    // Enable Telegram?
+      'telegram-bot-token',   // Telegram bot token (raw value)
+      'y',                    // Enable WhatsApp?
+      'wa-access-token',      // WhatsApp access token (raw value)
+      'wa-phone-number-id',   // WhatsApp phone number ID
+      'wa-app-secret',        // WhatsApp app secret (raw value)
+      'wa-verify-token',      // WhatsApp verify token (raw value)
+      '',                     // Operator token (blank → auto)
+    ]);
+    const secretStore = makeSecretStore({ available: true });
+    const state = createEmptyInitState('/tmp/test-config.json');
+
+    const result = await runInitWizard({ io, initialState: state, secretStore });
+
+    expect(result.config.comms.telegram.enabled).toBe(true);
+    expect(result.config.comms.telegram.botTokenRef).toBe('comms.telegram.botTokenRef');
+    expect(secretStore.stored.get('comms.telegram.botTokenRef')).toBe('telegram-bot-token');
+    expect(result.config.comms.whatsapp.enabled).toBe(true);
+    expect(result.config.comms.whatsapp.accessTokenRef).toBe('comms.whatsapp.accessTokenRef');
+    expect(result.config.comms.whatsapp.phoneNumberIdRef).toBe('wa-phone-number-id');
+    expect(result.config.comms.whatsapp.appSecretRef).toBe('comms.whatsapp.appSecretRef');
+    expect(result.config.comms.whatsapp.verifyTokenRef).toBe('comms.whatsapp.verifyTokenRef');
+    expect(secretStore.stored.get('comms.whatsapp.accessTokenRef')).toBe('wa-access-token');
+    expect(secretStore.stored.get('comms.whatsapp.appSecretRef')).toBe('wa-app-secret');
+    expect(secretStore.stored.get('comms.whatsapp.verifyTokenRef')).toBe('wa-verify-token');
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/network/network-config-paths.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-config-paths.test.ts
@@ -42,6 +42,11 @@ describe('network-config-paths', () => {
     expect(isSensitiveConfigPath('comms.slack.signingSecretRef')).toBe(true);
     expect(isSensitiveConfigPath('comms.discord.botTokenRef')).toBe(true);
     expect(isSensitiveConfigPath('comms.discord.publicKeyRef')).toBe(false);
+    expect(isSensitiveConfigPath('comms.telegram.botTokenRef')).toBe(true);
+    expect(isSensitiveConfigPath('comms.whatsapp.accessTokenRef')).toBe(true);
+    expect(isSensitiveConfigPath('comms.whatsapp.phoneNumberIdRef')).toBe(false);
+    expect(isSensitiveConfigPath('comms.whatsapp.appSecretRef')).toBe(true);
+    expect(isSensitiveConfigPath('comms.whatsapp.verifyTokenRef')).toBe(true);
     expect(isSensitiveConfigPath('chat.model')).toBe(false);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -133,6 +133,19 @@ describe('network-registry', () => {
     });
   });
 
+  it('forwards an explicit config path to spawned chat servers', () => {
+    const services = resolveNetworkServices(defaultConfig(), {
+      repoRoot: '/repo/frankenbeast',
+      configFile: '/tmp/custom-frankenbeast.json',
+    });
+    const chatServer = services.find((service) => service.id === 'chat-server');
+
+    expect(chatServer?.runtimeConfig.process?.args).toEqual(expect.arrayContaining([
+      '--config',
+      '/tmp/custom-frankenbeast.json',
+    ]));
+  });
+
   it('provides explanation strings for help and status', () => {
     const registry = createNetworkRegistry();
 

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -26,6 +26,33 @@ describe('network-registry', () => {
     ]);
   });
 
+  it('starts comms gateway when Telegram or WhatsApp channels are enabled', () => {
+    const telegramConfig = defaultConfig();
+    telegramConfig.comms.telegram.enabled = true;
+    const telegramServices = resolveNetworkServices(telegramConfig, context);
+    const telegramGateway = telegramServices.find((service) => service.id === 'comms-gateway');
+
+    expect(telegramServices.map((service) => service.id)).toContain('comms-gateway');
+    expect(telegramGateway?.runtimeConfig).toMatchObject({
+      channels: {
+        telegram: true,
+        whatsapp: false,
+      },
+    });
+
+    const whatsappConfig = defaultConfig();
+    whatsappConfig.comms.whatsapp.enabled = true;
+    const whatsappGateway = resolveNetworkServices(whatsappConfig, context)
+      .find((service) => service.id === 'comms-gateway');
+
+    expect(whatsappGateway?.runtimeConfig).toMatchObject({
+      channels: {
+        telegram: false,
+        whatsapp: true,
+      },
+    });
+  });
+
   it('skips disabled services cleanly', () => {
     const config = defaultConfig();
     config.dashboard.enabled = false;

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -34,6 +34,10 @@ describe('network-registry', () => {
 
     expect(telegramServices.map((service) => service.id)).toContain('comms-gateway');
     expect(telegramGateway?.runtimeConfig).toMatchObject({
+      host: '127.0.0.1',
+      port: 3737,
+      url: 'http://127.0.0.1:3737',
+      healthUrl: 'http://127.0.0.1:3737/comms/health',
       channels: {
         telegram: true,
         whatsapp: false,

--- a/packages/franken-orchestrator/tests/unit/network/network-secrets.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-secrets.test.ts
@@ -18,11 +18,21 @@ describe('network-secrets', () => {
   it('redacts sensitive values in config output', () => {
     const config = defaultConfig();
     config.comms.slack.botTokenRef = 'secret://secure/comms.slack.botTokenRef/abc123';
+    config.comms.telegram.botTokenRef = 'secret://secure/comms.telegram.botTokenRef/abc123';
+    config.comms.whatsapp.accessTokenRef = 'secret://secure/comms.whatsapp.accessTokenRef/abc123';
+    config.comms.whatsapp.phoneNumberIdRef = 'public-phone-number-id';
+    config.comms.whatsapp.appSecretRef = 'secret://secure/comms.whatsapp.appSecretRef/abc123';
+    config.comms.whatsapp.verifyTokenRef = 'secret://secure/comms.whatsapp.verifyTokenRef/abc123';
     config.comms.discord.publicKeyRef = 'public://discord/public-key';
 
     const redacted = redactSensitiveConfig(config);
 
     expect(redacted.comms.slack.botTokenRef).toBe('[redacted]');
+    expect(redacted.comms.telegram.botTokenRef).toBe('[redacted]');
+    expect(redacted.comms.whatsapp.accessTokenRef).toBe('[redacted]');
+    expect(redacted.comms.whatsapp.phoneNumberIdRef).toBe('public-phone-number-id');
+    expect(redacted.comms.whatsapp.appSecretRef).toBe('[redacted]');
+    expect(redacted.comms.whatsapp.verifyTokenRef).toBe('[redacted]');
     expect(redacted.comms.discord.publicKeyRef).toBe('public://discord/public-key');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -182,6 +182,9 @@ describe('NetworkSupervisor', () => {
     config.comms.telegram.enabled = true;
     const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
     const startService = vi.fn(async (service) => ({ pid: service.id === 'dashboard-web' ? 202 : 201 }));
+    const preflightService = vi.fn(async (service) => service.id === 'comms-gateway'
+      ? { action: 'conflict' as const, reason: 'Port conflict for comms-gateway on 127.0.0.1:3200' }
+      : { action: 'start' as const });
 
     const supervisor = new NetworkSupervisor({
       stateStore,
@@ -189,6 +192,7 @@ describe('NetworkSupervisor', () => {
       startService,
       stopService: vi.fn(async () => undefined),
       healthcheck: vi.fn(async () => true),
+      preflightService,
       now: () => '2026-03-10T00:00:00.000Z',
     });
 
@@ -200,6 +204,7 @@ describe('NetworkSupervisor', () => {
     });
 
     expect(startService).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }), expect.any(Object));
+    expect(preflightService).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }));
     expect(state.services).toEqual(expect.arrayContaining([
       expect.objectContaining({
         id: 'comms-gateway',

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -174,6 +174,41 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
+  it('records in-process services without spawning a child process', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const config = defaultConfig();
+    config.comms.telegram.enabled = true;
+    const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+    const startService = vi.fn(async (service) => ({ pid: service.id === 'dashboard-web' ? 202 : 201 }));
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService,
+      stopService: vi.fn(async () => undefined),
+      healthcheck: vi.fn(async () => true),
+      now: () => '2026-03-10T00:00:00.000Z',
+    });
+
+    const state = await supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    });
+
+    expect(startService).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'comms-gateway' }), expect.any(Object));
+    expect(state.services).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'comms-gateway',
+        pid: 0,
+        status: 'already-running',
+      }),
+    ]));
+  });
+
   it('fails fast and rolls back started services when an unmanaged conflict owns a service port', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -210,8 +210,72 @@ describe('NetworkSupervisor', () => {
         id: 'comms-gateway',
         pid: 0,
         status: 'already-running',
+        inProcess: true,
       }),
     ]));
+  });
+
+  it('probes in-process comms health before reporting it ready', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const config = defaultConfig();
+    config.comms.telegram.enabled = true;
+    const services = resolveNetworkServices(config, { repoRoot: '/repo/frankenbeast' });
+    const stopService = vi.fn(async () => undefined);
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(async () => ({ pid: 501 })),
+      stopService,
+      healthcheck: vi.fn(async (service) => service.id !== 'comms-gateway'),
+      now: () => '2026-03-10T00:00:00.000Z',
+      startupAttempts: 1,
+    });
+
+    await expect(supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    })).rejects.toThrow(/Service comms-gateway failed healthcheck/);
+
+    expect(stopService).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
+  });
+
+  it('allows reused pid-zero services to stop because they are not in-process markers', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const stopService = vi.fn(async () => undefined);
+    await stateStore.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: true,
+      startedAt: '2026-03-10T00:00:00.000Z',
+      services: [
+        {
+          id: 'chat-server',
+          pid: 0,
+          detached: true,
+          dependsOn: ['beasts-daemon'],
+          startedAt: '2026-03-10T00:00:00.000Z',
+          status: 'already-running',
+        },
+      ],
+    });
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(),
+      stopService,
+      healthcheck: vi.fn(async () => true),
+    });
+
+    await supervisor.stop('chat-server');
+    expect(stopService).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-server' }));
   });
 
   it('rejects stopping an in-process service as an independent process', async () => {
@@ -240,6 +304,7 @@ describe('NetworkSupervisor', () => {
           dependsOn: ['chat-server'],
           startedAt: '2026-03-10T00:00:00.000Z',
           status: 'already-running',
+          inProcess: true,
         },
       ],
     });

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -214,6 +214,48 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
+  it('rejects stopping an in-process service as an independent process', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const stopService = vi.fn(async () => undefined);
+    await stateStore.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: true,
+      startedAt: '2026-03-10T00:00:00.000Z',
+      services: [
+        {
+          id: 'chat-server',
+          pid: 501,
+          detached: true,
+          dependsOn: ['beasts-daemon'],
+          startedAt: '2026-03-10T00:00:00.000Z',
+          status: 'started',
+        },
+        {
+          id: 'comms-gateway',
+          pid: 0,
+          detached: true,
+          dependsOn: ['chat-server'],
+          startedAt: '2026-03-10T00:00:00.000Z',
+          status: 'already-running',
+        },
+      ],
+    });
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(),
+      stopService,
+      healthcheck: vi.fn(async () => true),
+    });
+
+    await expect(supervisor.stop('comms-gateway')).rejects.toThrow(/hosted in-process by chat-server/);
+    expect(stopService).not.toHaveBeenCalled();
+  });
+
   it('fails fast and rolls back started services when an unmanaged conflict owns a service port', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));

--- a/packages/franken-orchestrator/tests/unit/network/secret-resolver.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-resolver.test.ts
@@ -37,7 +37,6 @@ describe('SecretResolver', () => {
       'my-slack-signing-key': 'signing-test',
       'my-telegram-bot-key': 'telegram-token',
       'my-wa-access-key': 'wa-access-token',
-      'my-wa-phone-key': 'wa-phone-number-id',
       'my-wa-app-key': 'wa-app-secret',
       'my-wa-verify-key': 'wa-verify-token',
     });
@@ -52,7 +51,7 @@ describe('SecretResolver', () => {
     config.comms.telegram.botTokenRef = 'my-telegram-bot-key';
     config.comms.whatsapp.enabled = true;
     config.comms.whatsapp.accessTokenRef = 'my-wa-access-key';
-    config.comms.whatsapp.phoneNumberIdRef = 'my-wa-phone-key';
+    config.comms.whatsapp.phoneNumberIdRef = 'wa-phone-number-id';
     config.comms.whatsapp.appSecretRef = 'my-wa-app-key';
     config.comms.whatsapp.verifyTokenRef = 'my-wa-verify-key';
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-resolver.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-resolver.test.ts
@@ -35,6 +35,11 @@ describe('SecretResolver', () => {
       'my-operator-key': 'op-token',
       'my-slack-bot-key': 'xoxb-test',
       'my-slack-signing-key': 'signing-test',
+      'my-telegram-bot-key': 'telegram-token',
+      'my-wa-access-key': 'wa-access-token',
+      'my-wa-phone-key': 'wa-phone-number-id',
+      'my-wa-app-key': 'wa-app-secret',
+      'my-wa-verify-key': 'wa-verify-token',
     });
     const resolver = new SecretResolver(store);
     const config = defaultConfig();
@@ -43,11 +48,23 @@ describe('SecretResolver', () => {
     config.comms.slack.enabled = true;
     config.comms.slack.botTokenRef = 'my-slack-bot-key';
     config.comms.slack.signingSecretRef = 'my-slack-signing-key';
+    config.comms.telegram.enabled = true;
+    config.comms.telegram.botTokenRef = 'my-telegram-bot-key';
+    config.comms.whatsapp.enabled = true;
+    config.comms.whatsapp.accessTokenRef = 'my-wa-access-key';
+    config.comms.whatsapp.phoneNumberIdRef = 'my-wa-phone-key';
+    config.comms.whatsapp.appSecretRef = 'my-wa-app-key';
+    config.comms.whatsapp.verifyTokenRef = 'my-wa-verify-key';
 
     const resolved = await resolver.resolveAll(config);
     expect(resolved.operatorToken).toBe('op-token');
     expect(resolved.slackBotToken).toBe('xoxb-test');
     expect(resolved.slackSigningSecret).toBe('signing-test');
+    expect(resolved.telegramBotToken).toBe('telegram-token');
+    expect(resolved.whatsappAccessToken).toBe('wa-access-token');
+    expect(resolved.whatsappPhoneNumberId).toBe('wa-phone-number-id');
+    expect(resolved.whatsappAppSecret).toBe('wa-app-secret');
+    expect(resolved.whatsappVerifyToken).toBe('wa-verify-token');
   });
 
   it('returns undefined for disabled transport secrets', async () => {


### PR DESCRIPTION
## Summary
- promote Telegram and WhatsApp from future/internal transports to runtime-supported init transports
- add network config schema, config-path sensitivity, secret redaction/resolution, and init verification for Telegram/WhatsApp fields
- extend init wizard coverage for Telegram and WhatsApp setup

## Test Plan
- npm test --workspace packages/franken-orchestrator -- tests/unit/init/comms-transport-registry.test.ts tests/unit/init/init-wizard.test.ts tests/unit/init/init-verify.test.ts tests/unit/network/network-config-paths.test.ts tests/unit/network/network-secrets.test.ts tests/unit/network/secret-resolver.test.ts
- npm run typecheck
- npm run build
- git diff --check

Closes #406