### PR TITLE
docs: fix package README drift across governor, observer, brain, critique

### DIFF
--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -1,6 +1,6 @@
 # franken-brain — MOD-03: Memory Systems
 
-Current public API: `SqliteBrain`.
+Current public API: `SqliteBrain`, `WorkingMemoryLimitError`, `DEFAULT_WORKING_MEMORY_LIMITS`, and the `WorkingMemoryLimits` type.
 
 `franken-brain` provides SQLite-backed working memory, episodic event recall, and recovery checkpoints for the Frankenbeast runtime. Older design docs described a `MemoryOrchestrator` with ChromaDB-backed semantic memory and PII-decorator stores; those classes are not exported by the current package.
 

--- a/packages/franken-critique/docs/RAMP_UP.md
+++ b/packages/franken-critique/docs/RAMP_UP.md
@@ -10,7 +10,7 @@
 - **Evaluators**:
     - `SafetyEvaluator`: Checks for guardrail violations.
     - `GhostDependencyEvaluator`: Detects undeclared imports.
-    - `ADRCompliance`: Checks against stored Architecture Decision Records.
+    - `ADRComplianceEvaluator`: Checks against stored Architecture Decision Records.
 - **Circuit Breakers**: Prevents infinite critique spirals.
 
 ## Integration Gap
@@ -19,7 +19,7 @@ The `franken-orchestrator` currently skips the reflection phase by using a stub 
 ## Key API
 - `CritiquePipeline`: Executes a sequence of evaluators.
 - `CritiqueLoop`: Orchestrates the retry-until-pass logic.
-- `Reviewer`: The high-level factory for creating a pre-wired critique service.
+- `Reviewer`: The interface of the pre-wired critique service; create one with the `createReviewer` factory.
 
 ## Build & Test
 ```bash

--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -653,7 +653,9 @@ const recorder = new GovernorAuditRecorder(memoryPort);
 | `ApprovalTimeoutError` | No response within `config.timeoutMs` |
 | `ChannelUnavailableError` | Channel fails (e.g., Slack webhook down) |
 | `SignatureVerificationError` | HMAC signature verification fails |
-| `TriggerEvaluationError` | Trigger evaluation throws |
+| `ApprovalConfigurationError` | `config.requireSignedApprovals` is `true` but no signature verifier is configured (no `config.signingSecret` and no `ApprovalGatewayDeps.signatureVerifier`) |
+| `ApprovalMismatchError` | A channel response's `requestId` does not match the active request (stale, replayed, or misrouted response) |
+| `TriggerEvaluationError` | Reserved — exported but not currently thrown by any code path |
 
 ## Testing
 

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -214,8 +214,13 @@ Default pricing (USD, 2025-Q4):
 | `claude-opus-4-6` | $15.00 | $75.00 |
 | `claude-sonnet-4-6` | $3.00 | $15.00 |
 | `claude-haiku-4-5` | $0.80 | $4.00 |
+| `claude` (alias for sonnet) | $3.00 | $15.00 |
 | `gpt-4o` | $5.00 | $15.00 |
 | `gpt-4o-mini` | $0.15 | $0.60 |
+| `gemini-2.0-flash` | $0.10 | $0.40 |
+| `gemini` (alias for flash) | $0.10 | $0.40 |
+| `codex` | $5.00 | $15.00 |
+| `aider` (uses sonnet by default) | $3.00 | $15.00 |
 
 ### `CircuitBreaker`
 
@@ -755,14 +760,14 @@ EVAL=true npm run test:eval
 npm run test:watch
 ```
 
-249 unit tests. All adapters and integrations are tested with injectable `fetch` functions — no network calls in CI.
+The package ships an extensive unit test suite. All adapters and integrations are tested with injectable `fetch` functions — no network calls in CI.
 
 ---
 
 ## Building
 
 ```bash
-npm run build       # CJS + ESM + DTS → dist/
+npm run build       # tsc → dist/ (ESM + DTS)
 npm run typecheck   # tsc --noEmit
 ```
 
@@ -770,12 +775,10 @@ Output:
 
 ```
 dist/index.js      # ESM
-dist/index.cjs     # CommonJS
 dist/index.d.ts    # TypeScript declarations
-dist/index.d.cts   # CJS declarations
 ```
 
-The package exports are configured so that `types` is resolved first, making the package compatible with all TypeScript `moduleResolution` modes.
+The build is plain `tsc` and the output is **ESM-only** (`"type": "module"`). The `exports` map has `types` and `import` conditions but no `require` entry, so the package cannot be `require()`d from CommonJS — consumers must use `import` (or a dynamic `import()` from CJS).
 
 ---
 


### PR DESCRIPTION
Docs-only PR correcting per-package README/ramp-up drift against the real exports and build config. All claims were verified in source before editing.

## Corrections

### `packages/franken-governor/README.md`
- Error table: added `ApprovalConfigurationError` (thrown when `config.requireSignedApprovals` is `true` but no signature verifier is configured — no `config.signingSecret` and no `ApprovalGatewayDeps.signatureVerifier`; `approval-gateway.ts:44`) and `ApprovalMismatchError` (thrown when a channel response's `requestId` does not match the active request — stale/replayed/misrouted response; `approval-gateway.ts:58`).
- Marked `TriggerEvaluationError` as reserved — it is exported but `new TriggerEvaluationError` appears nowhere in the codebase.
- Quick Start left untouched on purpose: its "Blocked" branch mismatch is tracked as code issue #490 and the README will follow whichever contract lands there.

### `packages/franken-observer/README.md`
- Building section: build is plain `tsc`, output is **ESM-only** (`dist/index.js` + `dist/index.d.ts`); removed the false `dist/index.cjs`/`index.d.cts` outputs and the "all moduleResolution modes" claim. Now honestly states the `exports` map has no `require` entry, so CJS consumers must use dynamic `import()`.
- Replaced the brittle "249 unit tests" count with non-brittle phrasing.
- Extended the default pricing table from 5 rows to the full 10 entries in `defaultPricing.ts` (added `claude` alias, `gemini-2.0-flash`, `gemini` alias, `codex`, `aider`).

### `packages/franken-brain/README.md`
- Public API line now lists the full surface of `src/index.ts`: `SqliteBrain`, `WorkingMemoryLimitError`, `DEFAULT_WORKING_MEMORY_LIMITS`, and the `WorkingMemoryLimits` type.

### `packages/franken-critique/docs/RAMP_UP.md`
- `ADRCompliance` → `ADRComplianceEvaluator` (the real export).
- `Reviewer` is now described as the interface of the pre-wired critique service, with `createReviewer` named as the factory.

No code, build, or test changes.

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)