### PR TITLE
docs: align CLAUDE.md monorepo layout and README secret-backend docs with reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,23 @@ This project uses AI-assisted development. Rules in `.cursor/rules/` provide gui
 
 ## Monorepo Layout
 
-This is an npm workspaces monorepo with Turborepo for build orchestration. All 11 packages live under `packages/`:
+This is an npm workspaces monorepo with Turborepo for build orchestration. All 10 packages live under `packages/`:
 
 ```
 packages/
-├── franken-types/           # Shared type definitions
-├── frankenfirewall/         # MOD-01: LLM proxy
-├── franken-skills/          # MOD-02: Skill registry
-├── franken-brain/           # MOD-03: Memory systems
-├── franken-planner/         # MOD-04: DAG planning
-├── franken-observer/        # MOD-05: Tracing & cost
-├── franken-critique/        # MOD-06: Self-critique
-├── franken-governor/        # MOD-07: HITL governance
-├── franken-heartbeat/       # MOD-08: Reflection
-├── franken-mcp/             # MCP server registry
-└── franken-orchestrator/    # The Beast Loop & CLI
+├── franken-types/           # Shared types + runtime Zod schemas (@franken/types)
+├── franken-brain/           # MOD-03: SQLite-backed memory (working + episodic)
+├── franken-planner/         # MOD-04: DAG planning, strategies, recovery primitives
+├── franken-observer/        # MOD-05: Tracing, token/cost tracking, circuit breaker (@frankenbeast/observer)
+├── franken-critique/        # MOD-06: Self-critique evaluators + reviewer loop (@franken/critique)
+├── franken-governor/        # MOD-07: HITL governance, triggers, approval gateway (@franken/governor)
+├── franken-orchestrator/    # The Beast Loop, CLI (frankenbeast/franken/frkn), chat/network servers
+├── franken-mcp-suite/       # fbeast CLI, MCP servers, hooks, proxy (@fbeast/mcp-suite)
+├── franken-web/             # React dashboard (@frankenbeast/web)
+└── live-bench/              # Live CLI benchmark tooling (@fbeast/live-bench)
 ```
+
+Former packages `frankenfirewall` (MOD-01), `franken-skills` (MOD-02), `franken-heartbeat` (MOD-08), `franken-mcp`, and `franken-comms` were consolidated into `franken-orchestrator` and `franken-mcp-suite` per [ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md); their capabilities live on as internal adapters.
 
 **Build commands** (all via Turborepo):
 - `npm run build` — runs `turbo run build` (dependency-ordered)
@@ -27,7 +28,7 @@ packages/
 - `npm run typecheck` — runs `turbo run typecheck`
 - Per-package: `npx turbo run test --filter=franken-brain`
 
-Cross-package dependencies are managed by npm workspaces (e.g., `@frankenbeast/types`). See [ADR-011](docs/adr/011-monorepo-migration.md) for the migration from individual repos.
+Cross-package dependencies are managed by npm workspaces (e.g., `@franken/types`). See [ADR-011](docs/adr/011-real-monorepo-migration.md) for the migration from individual repos.
 
 ## Installed Templates
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Frankenbeast stores secrets outside the config file. The config references secre
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
 | Local encrypted file | `local-encrypted` | CI/CD or offline environments |
 
-Set `network.secureBackend` in `frankenbeast.example.json` or in `.fbeast/config.json`, the project config that `frankenbeast init` reads and updates, to choose a backend.
+Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config.json`, then set `network.secureBackend` there. `frankenbeast init` reads and updates `.fbeast/config.json`.
 
 ### Setup per backend
 
@@ -545,7 +545,7 @@ Set `network.secureBackend` in `frankenbeast.example.json` or in `.fbeast/config
 ```bash
 frankenbeast init   # interactive — prompts for a passphrase, generates and stores the token
 ```
-When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/CD, set `FRANKENBEAST_PASSPHRASE` in the environment and run `frankenbeast init --non-interactive`.
+When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/CD, set `FRANKENBEAST_PASSPHRASE` in the environment; `frankenbeast init --non-interactive` verifies an already-complete `.fbeast/config.json` and init state rather than creating a fresh vault.
 
 **OS keychain:**
 ```json
@@ -557,7 +557,7 @@ Set this in `.fbeast/config.json`, then run `frankenbeast init` — the token is
 ```json
 { "network": { "secureBackend": "1password" } }
 ```
-Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is no `--backend` CLI flag). Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is no `--backend` CLI flag). For 1Password, create or use a vault literally named `frankenbeast`; items are stored with titles like `frankenbeast/operator-token`. Bitwarden stores secure-note items with the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Set this in `.fbeast/config.json`, then run `frankenbeast init` — the token is
 ```json
 { "network": { "secureBackend": "1password" } }
 ```
-Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is no `--backend` CLI flag). For 1Password, create or use a vault literally named `frankenbeast`; items are stored with titles like `frankenbeast/operator-token`. Bitwarden stores secure-note items with the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is no `--backend` CLI flag). For 1Password, create or use a vault literally named `frankenbeast`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, run `bw login`/`bw unlock` and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 
@@ -571,10 +571,10 @@ Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is
 
 ```bash
 export FRANKENBEAST_PASSPHRASE=<passphrase>
-frankenbeast run --config frankenbeast.config.json
+frankenbeast run
 ```
 
-With `local-encrypted` backend and `FRANKENBEAST_PASSPHRASE` set, the orchestrator decrypts the vault without prompting.
+With `local-encrypted` backend and `FRANKENBEAST_PASSPHRASE` set, the orchestrator decrypts the vault from `.fbeast/config.json` without prompting. If you run with `--config <path>`, keep that file in sync with the backend and token refs written by `frankenbeast init`.
 
 ### References
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Frankenbeast stores secrets outside the config file. The config references secre
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
 | Local encrypted file | `local-encrypted` | CI/CD or offline environments |
 
-Set `network.secureBackend` in `frankenbeast.example.json` (or your project's `frankenbeast.config.json`) to choose a backend.
+Set `network.secureBackend` in `frankenbeast.example.json` or in the config file the CLI will load (`.fbeast/config.json` by default, or another file passed with `--config`) to choose a backend.
 
 ### Setup per backend
 
@@ -551,13 +551,13 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 ```json
 { "network": { "secureBackend": "os-keychain" } }
 ```
-Set this in your project config, then run `frankenbeast init` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
+Set this in `.fbeast/config.json`, or pass the config explicitly with `frankenbeast init --config frankenbeast.config.json` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
 
 **1Password / Bitwarden:**
 ```json
 { "network": { "secureBackend": "1password" } }
 ```
-Set the backend in config (there is no `--backend` CLI flag), then run `frankenbeast init`. Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+Set the backend in `.fbeast/config.json`, or pass the config explicitly with `frankenbeast init --config frankenbeast.config.json` (there is no `--backend` CLI flag). Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 

--- a/README.md
+++ b/README.md
@@ -541,23 +541,23 @@ Set `network.secureBackend` in `frankenbeast.example.json` (or your project's `f
 
 ### Setup per backend
 
-**OS keychain (default for local dev):**
+**Local encrypted file (the default):**
 ```bash
-frankenbeast init   # interactive — generates and stores token automatically
+frankenbeast init   # interactive — prompts for a passphrase, generates and stores the token
 ```
+When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/CD, set `FRANKENBEAST_PASSPHRASE` in the environment and run `frankenbeast init --non-interactive`.
 
-**Local encrypted file (CI/CD):**
-```bash
-export FRANKENBEAST_PASSPHRASE=<strong-random-passphrase>
-frankenbeast init --non-interactive
+**OS keychain:**
+```json
+{ "network": { "secureBackend": "os-keychain" } }
 ```
-The passphrase encrypts the local vault at `.fbeast/secrets.enc`. Set `FRANKENBEAST_PASSPHRASE` in your CI environment.
+Set this in your project config, then run `frankenbeast init` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
 
 **1Password / Bitwarden:**
-```bash
-frankenbeast init --backend 1password   # opens browser sign-in flow
+```json
+{ "network": { "secureBackend": "1password" } }
 ```
-Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+Set the backend in config (there is no `--backend` CLI flag), then run `frankenbeast init`. Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 
@@ -633,7 +633,7 @@ Tasks execute in topological order from the DAG. High-stakes tasks pause for hum
 
 **Modules:** MOD-05 (Observer) + MOD-08 (Heartbeat)
 
-The trace is closed and token spend summarised. In the current local CLI path, heartbeat is still stubbed in `franken-orchestrator/src/cli/dep-factory.ts`, so heartbeat-driven self-improvement should be treated as target architecture rather than a verified end-to-end local flow.
+The trace is closed and token spend summarised. In the current local CLI path, heartbeat is a thin reflection adapter (`ReflectionHeartbeatAdapter`, wired in `franken-orchestrator/src/cli/create-beast-deps.ts`), so heartbeat-driven self-improvement beyond per-run reflection should be treated as target architecture rather than a verified end-to-end local flow.
 
 ### Circuit Breakers
 
@@ -768,7 +768,7 @@ frankenbeast/
 │   ├── RAMP_UP.md               # Concise agent onboarding doc
 │   ├── CONTRACT_MATRIX.md       # Port interface compatibility matrix
 │   ├── beast-loop-explained.md  # Iteration mechanics deep dive
-│   ├── adr/                     # 16 Architecture Decision Records
+│   ├── adr/                     # Architecture Decision Records
 │   ├── guides/                  # Quickstart, add-provider, wrap-agent, run-dashboard-chat
 │   └── plans/                   # Design docs and implementation plans
 ├── tests/                       # Root-level integration tests

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Frankenbeast stores secrets outside the config file. The config references secre
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
 | Local encrypted file | `local-encrypted` | CI/CD or offline environments |
 
-Set `network.secureBackend` in `frankenbeast.example.json` or in the config file the CLI will load (`.fbeast/config.json` by default, or another file passed with `--config`) to choose a backend.
+Set `network.secureBackend` in `frankenbeast.example.json` or in `.fbeast/config.json`, the project config that `frankenbeast init` reads and updates, to choose a backend.
 
 ### Setup per backend
 
@@ -551,13 +551,13 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 ```json
 { "network": { "secureBackend": "os-keychain" } }
 ```
-Set this in `.fbeast/config.json`, or pass the config explicitly with `frankenbeast init --config frankenbeast.config.json` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
+Set this in `.fbeast/config.json`, then run `frankenbeast init` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
 
 **1Password / Bitwarden:**
 ```json
 { "network": { "secureBackend": "1password" } }
 ```
-Set the backend in `.fbeast/config.json`, or pass the config explicitly with `frankenbeast init --config frankenbeast.config.json` (there is no `--backend` CLI flag). Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is no `--backend` CLI flag). Secrets are stored in your vault under the `frankenbeast` item. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 


### PR DESCRIPTION
## Summary
Fixes the two highest-visibility root-doc gaps found in the 2026-07-04 docs-vs-reality audit.

### CLAUDE.md (#507)
- Replaced the stale 11-package tree (listing deleted `frankenfirewall`, `franken-skills`, `franken-heartbeat`, `franken-mcp` and omitting `franken-mcp-suite`, `franken-web`, `live-bench`) with the real 10-package layout including workspace names, plus a note on the ADR-031 consolidation.
- `@frankenbeast/types` → `@franken/types` (real workspace name per packages/franken-types/package.json).
- Fixed broken ADR-011 link (`011-monorepo-migration.md` → `011-real-monorepo-migration.md`).

### README.md (#508)
- Removed the documented `frankenbeast init --backend 1password` flag — args.ts parses with `strict: true` and has no `backend` option, so the documented command crashes with a TypeError. Backend selection is via `network.secureBackend` config (init-command.ts:55); the docs now say so.
- Corrected the default backend: `local-encrypted` with passphrase prompt (init-command.ts:55), not OS keychain; OS keychain documented as config opt-in.
- Fixed the stale heartbeat pointer: wired as `ReflectionHeartbeatAdapter` in `create-beast-deps.ts`, not "stubbed in dep-factory.ts" (which contains no heartbeat code).
- Dropped the wrong hard-coded ADR count (claimed 16; there are 42).

Docs-only change — no code touched.

Closes #507
Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)