### PR TITLE
fix(planner): keep stub HITL gate test-only

### DIFF
--- a/packages/franken-planner/README.md
+++ b/packages/franken-planner/README.md
@@ -49,7 +49,7 @@ PlanResult
 | `src/hitl/types.ts` | `HITLGate` interface and approval result types |
 | `src/hitl/plan-exporter.ts` | `PlanExporter` — renders `PlanGraph` as Markdown checklist |
 | `src/hitl/plan-modifier.ts` | `applyModifications` — applies `TaskModification[]` to a graph |
-| `src/hitl/stub-hitl-gate.ts` | `StubHITLGate` — configurable test double |
+| `src/hitl/stub-hitl-gate.ts` | Internal `StubHITLGate` test double (not a public package export) |
 | `src/recovery/error-ingester.ts` | `ErrorIngester` — classifies errors against known patterns |
 | `src/recovery/recovery-plan-generator.ts` | `RecoveryPlanGenerator` — injects a fix-it task into the graph |
 | `src/recovery/recovery-controller.ts` | `RecoveryController` — orchestrates recovery with circuit breaker |
@@ -62,15 +62,24 @@ PlanResult
 import {
   Planner,
   LinearPlanner,
-  StubHITLGate,
   RecoveryController,
+  type ApprovalResult,
+  type HITLGate,
 } from 'franken-planner';
+
+class BrowserConfirmHITLGate implements HITLGate {
+  async requestApproval(markdown: string): Promise<ApprovalResult> {
+    return window.confirm(markdown)
+      ? { decision: 'approved' }
+      : { decision: 'aborted', reason: 'User rejected plan' };
+  }
+}
 
 const planner = new Planner(
   guardrailsModule,   // GuardrailsModule — sanitizes raw input
   graphBuilder,       // GraphBuilder — converts Intent to PlanGraph
   taskExecutor,       // TaskExecutor — executes a single Task
-  new StubHITLGate(), // HITLGate — approve / modify / abort the plan
+  new BrowserConfirmHITLGate(), // HITLGate — approve / modify / abort the plan
   new LinearPlanner(),
   new RecoveryController(memoryModule),
   selfCritiqueModule  // optional SelfCritiqueModule — enables CoT enforcement
@@ -101,7 +110,10 @@ interface HITLGate {
 //               | { decision: 'aborted'; reason: string }
 ```
 
-Use `StubHITLGate` in tests (auto-approves by default).
+Implement this interface at the application boundary (CLI prompt, browser UI,
+chat approval flow, etc.). The package's `StubHITLGate` is an internal test
+double for this repository's tests and is intentionally not exported from the
+public package entrypoint.
 
 ### CoT enforcement
 
@@ -137,7 +149,7 @@ tests/
 │   ├── core/           # DAG, types, errors
 │   ├── planners/       # LinearPlanner, ParallelPlanner, RecursivePlanner
 │   ├── cot/            # RationaleEnforcer, CoT gate
-│   ├── hitl/           # PlanExporter, plan-modifier, StubHITLGate
+│   ├── hitl/           # PlanExporter, plan-modifier, internal StubHITLGate
 │   ├── recovery/       # ErrorIngester, RecoveryPlanGenerator, RecoveryController
 │   └── planner.test.ts # Planner orchestrator unit tests
 └── integration/

--- a/packages/franken-planner/src/hitl/stub-hitl-gate.ts
+++ b/packages/franken-planner/src/hitl/stub-hitl-gate.ts
@@ -1,6 +1,11 @@
 import type { ApprovalResult, HITLGate } from './types.js';
 
-// stub — always returns approved (configurable via constructor)
+/**
+ * Test-only HITL gate that returns a configured decision.
+ *
+ * This helper intentionally is not exported from the package entrypoint; production
+ * consumers should inject a real boundary implementation of {@link HITLGate}.
+ */
 export class StubHITLGate implements HITLGate {
   constructor(private readonly result: ApprovalResult = { decision: 'approved' }) {}
 

--- a/packages/franken-planner/src/index.ts
+++ b/packages/franken-planner/src/index.ts
@@ -60,7 +60,6 @@ export { RationaleEnforcer } from './cot/rationale-enforcer.js';
 // ── HITL (Human-in-the-Loop) ───────────────────────────────────────
 export { PlanExporter } from './hitl/plan-exporter.js';
 export { applyModifications } from './hitl/plan-modifier.js';
-export { StubHITLGate } from './hitl/stub-hitl-gate.js';
 export type {
   TaskModification,
   ApprovalResult,

--- a/packages/franken-planner/tests/unit/hitl/hitl-gate.test.ts
+++ b/packages/franken-planner/tests/unit/hitl/hitl-gate.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import * as plannerExports from '../../../src/index';
 import { StubHITLGate } from '../../../src/hitl/stub-hitl-gate';
 import { applyModifications } from '../../../src/hitl/plan-modifier';
 import { PlanGraph } from '../../../src/core/dag';
@@ -19,6 +20,10 @@ function makeTask(id: string): Task {
 // ─── StubHITLGate ─────────────────────────────────────────────────────────────
 
 describe('StubHITLGate', () => {
+  it('is kept out of the public package entrypoint', () => {
+    expect('StubHITLGate' in (plannerExports as Record<string, unknown>)).toBe(false);
+  });
+
   it('returns "approved" by default', async () => {
     const gate = new StubHITLGate();
     const result = await gate.requestApproval('# Plan\n');


### PR DESCRIPTION
## Summary
- remove StubHITLGate from the public franken-planner package entrypoint
- document StubHITLGate as a test-only helper for internal tests
- add coverage that the package entrypoint does not export the stub gate

## Test Plan
- npm run build --workspace packages/franken-types
- npm test --workspace packages/franken-planner -- tests/unit/hitl/hitl-gate.test.ts
- npm run typecheck --workspace packages/franken-planner
- npm run typecheck
- npm run build

Closes #412