### PR TITLE
fix(critique): share max-iteration boundary logic

### DIFF
--- a/packages/franken-critique/src/breakers/max-iteration.ts
+++ b/packages/franken-critique/src/breakers/max-iteration.ts
@@ -1,18 +1,11 @@
 import type { CircuitBreaker, CircuitBreakerResult, LoopState, LoopConfig } from './circuit-breaker.js';
-import { ConfigurationError } from '../errors/index.js';
+import { hasReachedMaxIterations } from '../loop/iteration-limit.js';
 
 export class MaxIterationBreaker implements CircuitBreaker {
   readonly name = 'max-iteration';
 
   async check(state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
-    if (config.maxIterations < 1 || config.maxIterations > 5) {
-      throw new ConfigurationError(
-        `maxIterations must be between 1 and 5, got ${config.maxIterations}`,
-        { context: { maxIterations: config.maxIterations } },
-      );
-    }
-
-    if (state.iterationCount >= config.maxIterations) {
+    if (hasReachedMaxIterations(state.iterationCount, config.maxIterations)) {
       return {
         tripped: true,
         reason: `Maximum iterations reached (${config.maxIterations})`,

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types/loop.js';
 import type { EscalationRequest } from '../types/contracts.js';
 import type { CritiquePipeline } from '../pipeline/critique-pipeline.js';
+import { hasReachedMaxIterations } from './iteration-limit.js';
 
 export class CritiqueLoop {
   private readonly pipeline: CritiquePipeline;
@@ -65,7 +66,7 @@ export class CritiqueLoop {
 
       // If this is the last possible iteration, return fail with correction
       // (next iteration's breaker check will halt, so build the correction now)
-      if (state.iterationCount >= config.maxIterations) {
+      if (hasReachedMaxIterations(state.iterationCount, config.maxIterations)) {
         return {
           verdict: 'fail',
           iterations: state.iterations,

--- a/packages/franken-critique/src/loop/iteration-limit.ts
+++ b/packages/franken-critique/src/loop/iteration-limit.ts
@@ -1,0 +1,18 @@
+import { ConfigurationError } from '../errors/index.js';
+
+const MIN_MAX_ITERATIONS = 1;
+const MAX_MAX_ITERATIONS = 5;
+
+export function assertValidMaxIterations(maxIterations: number): void {
+  if (maxIterations < MIN_MAX_ITERATIONS || maxIterations > MAX_MAX_ITERATIONS) {
+    throw new ConfigurationError(
+      `maxIterations must be between ${MIN_MAX_ITERATIONS} and ${MAX_MAX_ITERATIONS}, got ${maxIterations}`,
+      { context: { maxIterations } },
+    );
+  }
+}
+
+export function hasReachedMaxIterations(iterationCount: number, maxIterations: number): boolean {
+  assertValidMaxIterations(maxIterations);
+  return iterationCount >= maxIterations;
+}

--- a/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
+++ b/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
+import { MaxIterationBreaker } from '../../../src/breakers/max-iteration.js';
 import { CritiqueLoop } from '../../../src/loop/critique-loop.js';
 import { CritiquePipeline } from '../../../src/pipeline/critique-pipeline.js';
-import type { Evaluator, EvaluationInput } from '../../../src/types/evaluation.js';
+import type { Evaluator, EvaluationFinding, EvaluationInput } from '../../../src/types/evaluation.js';
 import type { CircuitBreaker, LoopConfig, CircuitBreakerResult, LoopState } from '../../../src/types/loop.js';
 
 function createInput(content: string): EvaluationInput {
@@ -33,7 +34,7 @@ function createPassingPipeline(): CritiquePipeline {
   return new CritiquePipeline([evaluator]);
 }
 
-function createFailingPipeline(findings = [{ message: 'issue found', severity: 'warning' as const }]): CritiquePipeline {
+function createFailingPipeline(findings: readonly EvaluationFinding[] = [{ message: 'issue found', severity: 'warning' }]): CritiquePipeline {
   const evaluator: Evaluator = {
     name: 'mock',
     category: 'deterministic',
@@ -75,6 +76,18 @@ describe('CritiqueLoop', () => {
       expect(result.correction.findings).toHaveLength(1);
       expect(result.correction.summary).toBeTruthy();
       expect(result.correction.iterationCount).toBe(1);
+    }
+  });
+
+  it('runs exactly maxIterations failing iterations before returning correction', async () => {
+    const loop = new CritiqueLoop(createFailingPipeline(), [new MaxIterationBreaker()]);
+    const result = await loop.run(createInput('bad code'), createConfig({ maxIterations: 2 }));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.iterations).toHaveLength(2);
+    expect(result.iterations.map((iteration) => iteration.index)).toEqual([0, 1]);
+    if (result.verdict === 'fail') {
+      expect(result.correction.iterationCount).toBe(2);
     }
   });
 


### PR DESCRIPTION
## Summary
- add a shared max-iteration boundary helper used by both CritiqueLoop and MaxIterationBreaker
- keep failing loops returning correction after exactly the configured max iterations
- add regression coverage proving maxIterations=N runs exactly N failed iterations before correction

## Test Plan
- npm test --workspace packages/franken-critique -- tests/unit/loop/critique-loop.test.ts tests/unit/breakers/max-iteration.test.ts
- npm run build --workspace packages/franken-types && npm run build --workspace packages/franken-critique
- git diff --check

Note: npm run typecheck --workspace packages/franken-critique is unavailable because @franken/critique has no typecheck script.

Closes #71