### PR TITLE
fix(cli): persist security profile changes

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -326,8 +326,9 @@ export async function main(): Promise<void> {
       await handleSecurityCommand({
         action: args.securityAction,
         target: args.securityTarget,
-        configPath: paths.configFile,
+        configPath: args.config ?? paths.configFile,
         ...(config.security?.profile ? { currentProfile: config.security.profile } : {}),
+        ...(config.security ? { currentSecurity: config.security } : {}),
         print: console.log,
       });
     } catch (err) {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -326,6 +326,8 @@ export async function main(): Promise<void> {
       await handleSecurityCommand({
         action: args.securityAction,
         target: args.securityTarget,
+        configPath: paths.configFile,
+        ...(config.security?.profile ? { currentProfile: config.security.profile } : {}),
         print: console.log,
       });
     } catch (err) {

--- a/packages/franken-orchestrator/src/cli/security-cli.ts
+++ b/packages/franken-orchestrator/src/cli/security-cli.ts
@@ -1,3 +1,5 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import type { SecurityAction } from './args.js';
 import { resolveSecurityConfig, type SecurityProfile } from '../middleware/security-profiles.js';
 
@@ -5,11 +7,50 @@ export interface SecurityCommandDeps {
   action?: SecurityAction;
   target?: string | undefined;
   currentProfile?: SecurityProfile;
+  configPath?: string | undefined;
   print(message: string): void;
 }
 
+const VALID_SECURITY_PROFILES = ['strict', 'standard', 'permissive'] as const;
+
+function isSecurityProfile(value: string): value is SecurityProfile {
+  return (VALID_SECURITY_PROFILES as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function readConfigFile(configPath: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      throw new Error(`Config file must contain a JSON object: ${configPath}`);
+    }
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw err;
+  }
+}
+
+async function persistSecurityProfile(configPath: string, profile: SecurityProfile): Promise<void> {
+  const config = await readConfigFile(configPath);
+  const currentSecurity = config.security;
+  config.security = {
+    ...(isRecord(currentSecurity) ? currentSecurity : {}),
+    profile,
+  };
+
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}
+
 export async function handleSecurityCommand(deps: SecurityCommandDeps): Promise<void> {
-  const { action, target, currentProfile, print } = deps;
+  const { action, target, currentProfile, configPath, print } = deps;
 
   switch (action) {
     case 'status': {
@@ -23,11 +64,14 @@ export async function handleSecurityCommand(deps: SecurityCommandDeps): Promise<
     }
     case 'set': {
       if (!target) throw new Error('Usage: frankenbeast security set <strict|standard|permissive>');
-      const valid = ['strict', 'standard', 'permissive'];
-      if (!valid.includes(target)) {
-        throw new Error(`Invalid security profile '${target}'. Valid: ${valid.join(', ')}`);
+      if (!isSecurityProfile(target)) {
+        throw new Error(`Invalid security profile '${target}'. Valid: ${VALID_SECURITY_PROFILES.join(', ')}`);
       }
-      print(`To apply the '${target}' security profile, set "security.profile": "${target}" in your run-config.yaml or .fbeast/config.json.`);
+      if (!configPath) {
+        throw new Error('Cannot persist security profile: missing config path');
+      }
+      await persistSecurityProfile(configPath, target);
+      print(`Security profile set to '${target}' in ${configPath}.`);
       return;
     }
     default:

--- a/packages/franken-orchestrator/src/cli/security-cli.ts
+++ b/packages/franken-orchestrator/src/cli/security-cli.ts
@@ -1,12 +1,20 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { SecurityAction } from './args.js';
-import { resolveSecurityConfig, type SecurityProfile } from '../middleware/security-profiles.js';
+import type { OrchestratorConfig } from '../config/orchestrator-config.js';
+import {
+  resolveSecurityConfig,
+  type SecurityConfig,
+  type SecurityProfile,
+} from '../middleware/security-profiles.js';
+
+type SecurityConfigInput = NonNullable<OrchestratorConfig['security']>;
 
 export interface SecurityCommandDeps {
   action?: SecurityAction;
   target?: string | undefined;
   currentProfile?: SecurityProfile;
+  currentSecurity?: SecurityConfigInput;
   configPath?: string | undefined;
   print(message: string): void;
 }
@@ -40,8 +48,16 @@ async function readConfigFile(configPath: string): Promise<Record<string, unknow
 async function persistSecurityProfile(configPath: string, profile: SecurityProfile): Promise<void> {
   const config = await readConfigFile(configPath);
   const currentSecurity = config.security;
+  const existingSecurity = isRecord(currentSecurity) ? currentSecurity : {};
+  const allowedDomains = existingSecurity.allowedDomains;
+  if (
+    profile === 'strict'
+    && (!Array.isArray(allowedDomains) || allowedDomains.length === 0)
+  ) {
+    throw new Error('Security profile "strict" requires allowedDomains to be configured');
+  }
   config.security = {
-    ...(isRecord(currentSecurity) ? currentSecurity : {}),
+    ...existingSecurity,
     profile,
   };
 
@@ -50,12 +66,24 @@ async function persistSecurityProfile(configPath: string, profile: SecurityProfi
 }
 
 export async function handleSecurityCommand(deps: SecurityCommandDeps): Promise<void> {
-  const { action, target, currentProfile, configPath, print } = deps;
+  const { action, target, currentProfile, currentSecurity, configPath, print } = deps;
 
   switch (action) {
     case 'status': {
-      const profile = currentProfile ?? 'standard';
-      const config = resolveSecurityConfig(profile);
+      const profile = currentSecurity?.profile ?? currentProfile ?? 'standard';
+      const overrides: Partial<Omit<SecurityConfig, 'profile'>> = {
+        ...(currentSecurity?.injectionDetection !== undefined
+          ? { injectionDetection: currentSecurity.injectionDetection }
+          : {}),
+        ...(currentSecurity?.piiMasking !== undefined ? { piiMasking: currentSecurity.piiMasking } : {}),
+        ...(currentSecurity?.outputValidation !== undefined
+          ? { outputValidation: currentSecurity.outputValidation }
+          : {}),
+        ...(currentSecurity?.allowedDomains !== undefined ? { allowedDomains: currentSecurity.allowedDomains } : {}),
+        ...(currentSecurity?.maxTokenBudget !== undefined ? { maxTokenBudget: currentSecurity.maxTokenBudget } : {}),
+        ...(currentSecurity?.requireApproval !== undefined ? { requireApproval: currentSecurity.requireApproval } : {}),
+      };
+      const config = resolveSecurityConfig(profile, overrides);
       print(`Security Profile: ${profile}`);
       print(`  Injection Detection: ${config.injectionDetection ? 'on' : 'off'}`);
       print(`  PII Masking: ${config.piiMasking ? 'on' : 'off'}`);

--- a/packages/franken-orchestrator/tests/integration/cli/security-command.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/security-command.test.ts
@@ -11,11 +11,15 @@ describe('security CLI integration', () => {
     const dir = await mkdtemp(join(tmpdir(), 'security-command-'));
     const configPath = join(dir, '.fbeast', 'config.json');
 
-    await handleSecurityCommand({ action: 'status', currentProfile: 'strict', print });
+    await handleSecurityCommand({
+      action: 'status',
+      currentSecurity: { profile: 'permissive', piiMasking: true },
+      print,
+    });
     await handleSecurityCommand({ action: 'set', target: 'permissive', configPath, print });
 
-    expect(printed).toContain('Security Profile: strict');
-    expect(printed).toContain('  Injection Detection: on');
+    expect(printed).toContain('Security Profile: permissive');
+    expect(printed).toContain('  Injection Detection: off');
     expect(printed).toContain('  PII Masking: on');
     expect(printed).toContain('  Output Validation: on');
     expect(printed.at(-1)).toBe(`Security profile set to 'permissive' in ${configPath}.`);

--- a/packages/franken-orchestrator/tests/integration/cli/security-command.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/security-command.test.ts
@@ -1,18 +1,24 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { describe, it, expect } from 'vitest';
 import { handleSecurityCommand } from '../../../src/cli/security-cli.js';
 
 describe('security CLI integration', () => {
-  it('renders the live security profile status and configuration instructions without mocks', async () => {
+  it('renders the live security profile status and persists profile changes without mocks', async () => {
     const printed: string[] = [];
     const print = (message: string) => printed.push(message);
+    const dir = await mkdtemp(join(tmpdir(), 'security-command-'));
+    const configPath = join(dir, '.fbeast', 'config.json');
 
     await handleSecurityCommand({ action: 'status', currentProfile: 'strict', print });
-    await handleSecurityCommand({ action: 'set', target: 'permissive', print });
+    await handleSecurityCommand({ action: 'set', target: 'permissive', configPath, print });
 
     expect(printed).toContain('Security Profile: strict');
     expect(printed).toContain('  Injection Detection: on');
     expect(printed).toContain('  PII Masking: on');
     expect(printed).toContain('  Output Validation: on');
-    expect(printed.at(-1)).toContain('"security.profile": "permissive"');
+    expect(printed.at(-1)).toBe(`Security profile set to 'permissive' in ${configPath}.`);
+    await expect(readFile(configPath, 'utf-8')).resolves.toContain('"profile": "permissive"');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/security-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/security-cli.test.ts
@@ -49,10 +49,54 @@ describe('handleSecurityCommand()', () => {
     const dir = await mkdtemp(join(tmpdir(), 'security-cli-'));
     const configPath = join(dir, '.fbeast', 'config.json');
 
+    await handleSecurityCommand({ action: 'set', target: 'permissive', configPath, print });
+
+    await expect(readFile(configPath, 'utf-8')).resolves.toContain('"profile": "permissive"');
+    expect(print).toHaveBeenCalledWith(`Security profile set to 'permissive' in ${configPath}.`);
+  });
+
+  it('rejects strict profile without configured allowedDomains', async () => {
+    const print = vi.fn();
+    const dir = await mkdtemp(join(tmpdir(), 'security-cli-'));
+    const configPath = join(dir, '.fbeast', 'config.json');
+
+    await expect(
+      handleSecurityCommand({ action: 'set', target: 'strict', configPath, print }),
+    ).rejects.toThrow(/requires allowedDomains/);
+  });
+
+  it('persists strict profile when allowedDomains are already configured', async () => {
+    const print = vi.fn();
+    const dir = await mkdtemp(join(tmpdir(), 'security-cli-'));
+    const configPath = join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify({
+      security: { allowedDomains: ['example.com'] },
+    }), 'utf-8');
+
     await handleSecurityCommand({ action: 'set', target: 'strict', configPath, print });
 
-    await expect(readFile(configPath, 'utf-8')).resolves.toContain('"profile": "strict"');
-    expect(print).toHaveBeenCalledWith(`Security profile set to 'strict' in ${configPath}.`);
+    const config = JSON.parse(await readFile(configPath, 'utf-8')) as {
+      security?: { profile?: string; allowedDomains?: string[] };
+    };
+    expect(config.security).toEqual({
+      allowedDomains: ['example.com'],
+      profile: 'strict',
+    });
+  });
+
+  it('shows status with security overrides from config', async () => {
+    const print = vi.fn();
+
+    await handleSecurityCommand({
+      action: 'status',
+      currentSecurity: { profile: 'permissive', piiMasking: true },
+      print,
+    });
+
+    expect(print).toHaveBeenCalledWith('Security Profile: permissive');
+    expect(print).toHaveBeenCalledWith('  Injection Detection: off');
+    expect(print).toHaveBeenCalledWith('  PII Masking: on');
+    expect(print).toHaveBeenCalledWith('  Output Validation: on');
   });
 
   it('preserves existing config and security settings when setting profile', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/security-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/security-cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { describe, it, expect, vi } from 'vitest';
 import { handleSecurityCommand } from '../../../src/cli/security-cli.js';
 
@@ -41,17 +44,46 @@ describe('handleSecurityCommand()', () => {
     expect(print).toHaveBeenCalledWith('  Output Validation: on');
   });
 
-  it('prints config instructions for set', async () => {
+  it('persists the selected security profile', async () => {
+    const print = vi.fn();
+    const dir = await mkdtemp(join(tmpdir(), 'security-cli-'));
+    const configPath = join(dir, '.fbeast', 'config.json');
+
+    await handleSecurityCommand({ action: 'set', target: 'strict', configPath, print });
+
+    await expect(readFile(configPath, 'utf-8')).resolves.toContain('"profile": "strict"');
+    expect(print).toHaveBeenCalledWith(`Security profile set to 'strict' in ${configPath}.`);
+  });
+
+  it('preserves existing config and security settings when setting profile', async () => {
+    const print = vi.fn();
+    const dir = await mkdtemp(join(tmpdir(), 'security-cli-'));
+    const configPath = join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify({
+      maxDurationMs: 120_000,
+      security: { piiMasking: false, outputValidation: true },
+    }), 'utf-8');
+
+    await handleSecurityCommand({ action: 'set', target: 'permissive', configPath, print });
+
+    const config = JSON.parse(await readFile(configPath, 'utf-8')) as {
+      maxDurationMs?: number;
+      security?: { profile?: string; piiMasking?: boolean; outputValidation?: boolean };
+    };
+    expect(config.maxDurationMs).toBe(120_000);
+    expect(config.security).toEqual({
+      piiMasking: false,
+      outputValidation: true,
+      profile: 'permissive',
+    });
+  });
+
+  it('requires a config path for set', async () => {
     const print = vi.fn();
 
-    await handleSecurityCommand({ action: 'set', target: 'strict', print });
-
-    expect(print).toHaveBeenCalledWith(
-      expect.stringContaining('security.profile'),
-    );
-    expect(print).toHaveBeenCalledWith(
-      expect.stringContaining('strict'),
-    );
+    await expect(
+      handleSecurityCommand({ action: 'set', target: 'strict', print }),
+    ).rejects.toThrow(/missing config path/);
   });
 
   it('throws on invalid profile name', async () => {


### PR DESCRIPTION
## Summary
- persist `frankenbeast security set <profile>` to the project .fbeast config file
- preserve existing config and security options while updating only `security.profile`
- make `security status` use the loaded config profile when invoked through the CLI

## Test Plan
- npm test --workspace packages/franken-orchestrator -- tests/unit/cli/security-cli.test.ts tests/integration/cli/security-command.test.ts
- npm run typecheck
- npm run build

Closes #403