### PR TITLE
fix(web): add analytics event pagination controls

### DIFF
--- a/packages/franken-web/src/lib/analytics-api.test.ts
+++ b/packages/franken-web/src/lib/analytics-api.test.ts
@@ -36,8 +36,10 @@ describe('AnalyticsApiClient', () => {
     const client = new AnalyticsApiClient(BASE_URL);
 
     await expect(client.fetchSessions({ timeWindow: '24h' })).resolves.toEqual([{ id: 'session-a' }]);
-    await expect(client.fetchEvents({ toolQuery: 'observer' })).resolves.toMatchObject({ total: 1 });
+    await expect(client.fetchEvents({ toolQuery: 'observer', page: 2, pageSize: 25 })).resolves.toMatchObject({ total: 1 });
     await expect(client.fetchEventDetail('audit:1')).resolves.toMatchObject({ id: 'audit:1' });
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(2, `${BASE_URL}/api/analytics/events?toolQuery=observer&page=2&pageSize=25`);
   });
 
   it('throws on failed responses', async () => {

--- a/packages/franken-web/src/lib/analytics-api.ts
+++ b/packages/franken-web/src/lib/analytics-api.ts
@@ -11,6 +11,11 @@ export interface AnalyticsFilters {
   timeWindow?: string;
 }
 
+export interface AnalyticsEventFilters extends AnalyticsFilters {
+  page?: number;
+  pageSize?: number;
+}
+
 export interface AnalyticsSummary {
   totalEvents: number;
   uniqueSessions: number;
@@ -74,7 +79,7 @@ export class AnalyticsApiClient {
     return response.sessions;
   }
 
-  async fetchEvents(filters: AnalyticsFilters): Promise<AnalyticsEventPage> {
+  async fetchEvents(filters: AnalyticsEventFilters): Promise<AnalyticsEventPage> {
     return this.fetchJson<AnalyticsEventPage>(`/api/analytics/events${queryString(filters)}`);
   }
 
@@ -92,12 +97,14 @@ export class AnalyticsApiClient {
   }
 }
 
-function queryString(filters: AnalyticsFilters): string {
+function queryString(filters: AnalyticsEventFilters): string {
   const params = new URLSearchParams();
   if (filters.sessionId) params.set('sessionId', filters.sessionId);
   if (filters.toolQuery) params.set('toolQuery', filters.toolQuery);
   if (filters.outcome) params.set('outcome', filters.outcome);
   if (filters.timeWindow) params.set('timeWindow', filters.timeWindow);
+  if (filters.page) params.set('page', String(filters.page));
+  if (filters.pageSize) params.set('pageSize', String(filters.pageSize));
   const value = params.toString();
   return value ? `?${value}` : '';
 }

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -191,7 +191,8 @@ describe('AnalyticsPage', () => {
 
     expect(await screen.findByText('HTTP 500')).toBeTruthy();
     expect(screen.queryByText('First page event')).toBeNull();
-    expect(screen.getByText('Page 1 of 1 · 0 events')).toBeTruthy();
+    expect(screen.getByText('Page 2 of 2 · 75 events')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Previous' })).toHaveProperty('disabled', false);
   });
 
   it('resets to the first page when filters or page size change', async () => {

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -95,7 +95,56 @@ describe('AnalyticsPage', () => {
 
     await waitFor(() => {
       expect(client.fetchSummary).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a' }));
-      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a' }));
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a', page: 1 }));
+    });
+  });
+
+  it('navigates event pages and exposes disabled pagination states', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchEvents)
+      .mockResolvedValueOnce({ total: 75, page: 1, pageSize: 50, events: [] })
+      .mockResolvedValueOnce({ total: 75, page: 2, pageSize: 50, events: [] });
+
+    render(<AnalyticsPage client={client} />);
+
+    const previous = await screen.findByRole('button', { name: 'Previous' });
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(previous).toHaveProperty('disabled', true);
+    expect(next).toHaveProperty('disabled', false);
+    expect(screen.getByText('Page 1 of 2 · 75 events')).toBeTruthy();
+
+    fireEvent.click(next);
+
+    await waitFor(() => {
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2, pageSize: 50 }));
+    });
+    expect(await screen.findByText('Page 2 of 2 · 75 events')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
+  });
+
+  it('resets to the first page when filters or page size change', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchEvents)
+      .mockResolvedValueOnce({ total: 75, page: 1, pageSize: 50, events: [] })
+      .mockResolvedValueOnce({ total: 75, page: 2, pageSize: 50, events: [] })
+      .mockResolvedValueOnce({ total: 1, page: 1, pageSize: 50, events: [] })
+      .mockResolvedValueOnce({ total: 1, page: 1, pageSize: 25, events: [] });
+
+    render(<AnalyticsPage client={client} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Next' }));
+
+    await waitFor(() => {
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    });
+
+    fireEvent.change(screen.getByLabelText('Session'), { target: { value: 'session-a' } });
+    await waitFor(() => {
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a', page: 1, pageSize: 50 }));
+    });
+
+    fireEvent.change(screen.getByLabelText('Page size'), { target: { value: '25' } });
+    await waitFor(() => {
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a', page: 1, pageSize: 25 }));
     });
   });
 

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AnalyticsPage } from './analytics-page';
-import type { AnalyticsApiClient } from '../lib/analytics-api';
+import type { AnalyticsApiClient, AnalyticsEventPage } from '../lib/analytics-api';
 
 function mockClient(): AnalyticsApiClient {
   return {
@@ -101,9 +101,13 @@ describe('AnalyticsPage', () => {
 
   it('navigates event pages and exposes disabled pagination states', async () => {
     const client = mockClient();
+    let resolveSecondPage!: (page: AnalyticsEventPage) => void;
+    const secondPage = new Promise<AnalyticsEventPage>((resolve) => {
+      resolveSecondPage = resolve;
+    });
     vi.mocked(client.fetchEvents)
       .mockResolvedValueOnce({ total: 75, page: 1, pageSize: 50, events: [] })
-      .mockResolvedValueOnce({ total: 75, page: 2, pageSize: 50, events: [] });
+      .mockReturnValueOnce(secondPage);
 
     render(<AnalyticsPage client={client} />);
 
@@ -118,8 +122,40 @@ describe('AnalyticsPage', () => {
     await waitFor(() => {
       expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2, pageSize: 50 }));
     });
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(client.fetchEvents).toHaveBeenCalledTimes(2);
+
+    resolveSecondPage({ total: 75, page: 2, pageSize: 50, events: [] });
     expect(await screen.findByText('Page 2 of 2 · 75 events')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
+  });
+
+  it('only refetches events for pagination changes', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchEvents)
+      .mockResolvedValueOnce({ total: 75, page: 1, pageSize: 50, events: [] })
+      .mockResolvedValueOnce({ total: 75, page: 2, pageSize: 50, events: [] })
+      .mockResolvedValueOnce({ total: 75, page: 1, pageSize: 25, events: [] });
+
+    render(<AnalyticsPage client={client} />);
+    await screen.findByText('Page 1 of 2 · 75 events');
+
+    expect(client.fetchSummary).toHaveBeenCalledTimes(1);
+    expect(client.fetchSessions).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2, pageSize: 50 }));
+    });
+
+    fireEvent.change(screen.getByLabelText('Page size'), { target: { value: '25' } });
+    await waitFor(() => {
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1, pageSize: 25 }));
+    });
+
+    expect(client.fetchSummary).toHaveBeenCalledTimes(1);
+    expect(client.fetchSessions).toHaveBeenCalledTimes(1);
   });
 
   it('resets to the first page when filters or page size change', async () => {

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -123,6 +123,7 @@ describe('AnalyticsPage', () => {
       expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2, pageSize: 50 }));
     });
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
+    expect(screen.getByText('Loading analytics...')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     expect(client.fetchEvents).toHaveBeenCalledTimes(2);
 

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -159,6 +159,41 @@ describe('AnalyticsPage', () => {
     expect(client.fetchSessions).toHaveBeenCalledTimes(1);
   });
 
+  it('clears stale events when a page fetch fails', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchEvents)
+      .mockResolvedValueOnce({
+        total: 75,
+        page: 1,
+        pageSize: 50,
+        events: [
+          {
+            id: 'audit:first-page',
+            timestamp: '2026-04-28T12:00:00.000Z',
+            sessionId: 'session-a',
+            toolName: 'fbeast_observer_log',
+            source: 'observer',
+            category: 'tool_call',
+            outcome: 'approved',
+            summary: 'First page event',
+            severity: 'info',
+            raw: { event: 'tool_call' },
+            links: {},
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error('HTTP 500'));
+
+    render(<AnalyticsPage client={client} />);
+    expect(await screen.findByText('First page event')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(await screen.findByText('HTTP 500')).toBeTruthy();
+    expect(screen.queryByText('First page event')).toBeNull();
+    expect(screen.getByText('Page 2 of 1 · 0 events')).toBeTruthy();
+  });
+
   it('resets to the first page when filters or page size change', async () => {
     const client = mockClient();
     vi.mocked(client.fetchEvents)

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -191,7 +191,7 @@ describe('AnalyticsPage', () => {
 
     expect(await screen.findByText('HTTP 500')).toBeTruthy();
     expect(screen.queryByText('First page event')).toBeNull();
-    expect(screen.getByText('Page 2 of 1 · 0 events')).toBeTruthy();
+    expect(screen.getByText('Page 1 of 1 · 0 events')).toBeTruthy();
   });
 
   it('resets to the first page when filters or page size change', async () => {

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -82,6 +82,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       setEventPage(eventsResult);
     }).catch((error: unknown) => {
       if (cancelled) return;
+      setEventPage(null);
       setEventsError(error instanceof Error ? error.message : 'Unable to load analytics.');
     }).finally(() => {
       if (!cancelled) {

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -30,8 +30,13 @@ const TIME_WINDOWS = [
   { value: 'all', label: 'All time' },
 ];
 
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+const DEFAULT_PAGE_SIZE = 50;
+
 export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [filters, setFilters] = useState<AnalyticsFilters>({ timeWindow: '24h' });
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
   const [sessions, setSessions] = useState<AnalyticsSessionOption[]>([]);
   const [eventPage, setEventPage] = useState<AnalyticsEventPage | null>(null);
@@ -48,7 +53,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
     void Promise.allSettled([
       client.fetchSummary(filters),
       client.fetchSessions(filters),
-      client.fetchEvents(filters),
+      client.fetchEvents({ ...filters, page, pageSize }),
     ]).then(([summaryResult, sessionsResult, eventsResult]) => {
       if (cancelled) return;
       const errors = [summaryResult, sessionsResult, eventsResult]
@@ -73,9 +78,15 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
     return () => {
       cancelled = true;
     };
-  }, [client, filters]);
+  }, [client, filters, page, pageSize]);
 
   const events = eventPage?.events ?? [];
+  const totalEvents = eventPage?.total ?? 0;
+  const currentPage = eventPage?.page ?? page;
+  const currentPageSize = eventPage?.pageSize ?? pageSize;
+  const totalPages = Math.max(1, Math.ceil(totalEvents / currentPageSize));
+  const canGoPrevious = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
   const activityEvents = useMemo(
     () => events.filter((event) => event.outcome === 'approved' && event.source !== 'governor'),
     [events],
@@ -100,6 +111,12 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       ...current,
       ...next,
     }));
+    setPage(1);
+  }
+
+  function updatePageSize(nextPageSize: number) {
+    setPageSize(nextPageSize);
+    setPage(1);
   }
 
   return (
@@ -109,7 +126,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
           <p className="eyebrow">Analytics</p>
           <h2>Observer Activity</h2>
         </div>
-        <p>{eventPage?.total ?? 0} normalized events</p>
+        <p>{totalEvents} normalized events</p>
       </section>
 
       {loadError && <div className="analytics-alert">{loadError}</div>}
@@ -184,6 +201,46 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
             ))}
           </select>
         </label>
+
+        <label className="field-stack">
+          <span>Page size</span>
+          <select
+            aria-label="Page size"
+            className="field-control"
+            value={pageSize}
+            onChange={(event) => updatePageSize(Number(event.target.value))}
+          >
+            {PAGE_SIZE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option} per page
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      <section className="analytics-pagination" aria-label="Analytics pagination">
+        <div>
+          Page {currentPage} of {totalPages} · {totalEvents} events
+        </div>
+        <div className="analytics-pagination__actions">
+          <button
+            className="button button--secondary button--small"
+            disabled={!canGoPrevious}
+            type="button"
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            Previous
+          </button>
+          <button
+            className="button button--secondary button--small"
+            disabled={!canGoNext}
+            type="button"
+            onClick={() => setPage((current) => current + 1)}
+          >
+            Next
+          </button>
+        </div>
       </section>
 
       {isLoading ? (

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -82,7 +82,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       setEventPage(eventsResult);
     }).catch((error: unknown) => {
       if (cancelled) return;
-      setEventPage(null);
+      setEventPage((current) => current ? { ...current, events: [] } : null);
       setEventsError(error instanceof Error ? error.message : 'Unable to load analytics.');
     }).finally(() => {
       if (!cancelled) {
@@ -97,7 +97,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 
   const events = eventPage?.events ?? [];
   const totalEvents = eventPage?.total ?? 0;
-  const currentPage = eventPage?.page ?? 1;
+  const currentPage = page;
   const currentPageSize = eventPage?.pageSize ?? pageSize;
   const totalPages = Math.max(1, Math.ceil(totalEvents / currentPageSize));
   const canGoPrevious = currentPage > 1 && !isEventsLoading;

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -42,21 +42,20 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [eventPage, setEventPage] = useState<AnalyticsEventPage | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<AnalyticsEvent | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [overviewError, setOverviewError] = useState<string | null>(null);
+  const [eventsError, setEventsError] = useState<string | null>(null);
+  const [isEventsLoading, setIsEventsLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
-    setIsLoading(true);
-    setLoadError(null);
+    setOverviewError(null);
 
     void Promise.allSettled([
       client.fetchSummary(filters),
       client.fetchSessions(filters),
-      client.fetchEvents({ ...filters, page, pageSize }),
-    ]).then(([summaryResult, sessionsResult, eventsResult]) => {
+    ]).then(([summaryResult, sessionsResult]) => {
       if (cancelled) return;
-      const errors = [summaryResult, sessionsResult, eventsResult]
+      const errors = [summaryResult, sessionsResult]
         .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
         .map((result) => result.reason instanceof Error ? result.reason.message : 'Unable to load analytics.');
       if (summaryResult.status === 'fulfilled') {
@@ -65,13 +64,28 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       if (sessionsResult.status === 'fulfilled') {
         setSessions(sessionsResult.value);
       }
-      if (eventsResult.status === 'fulfilled') {
-        setEventPage(eventsResult.value);
-      }
-      setLoadError(errors.length > 0 ? errors.join('; ') : null);
+      setOverviewError(errors.length > 0 ? errors.join('; ') : null);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, filters]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsEventsLoading(true);
+    setEventsError(null);
+
+    void client.fetchEvents({ ...filters, page, pageSize }).then((eventsResult) => {
+      if (cancelled) return;
+      setEventPage(eventsResult);
+    }).catch((error: unknown) => {
+      if (cancelled) return;
+      setEventsError(error instanceof Error ? error.message : 'Unable to load analytics.');
     }).finally(() => {
       if (!cancelled) {
-        setIsLoading(false);
+        setIsEventsLoading(false);
       }
     });
 
@@ -82,11 +96,12 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 
   const events = eventPage?.events ?? [];
   const totalEvents = eventPage?.total ?? 0;
-  const currentPage = eventPage?.page ?? page;
+  const currentPage = page;
   const currentPageSize = eventPage?.pageSize ?? pageSize;
   const totalPages = Math.max(1, Math.ceil(totalEvents / currentPageSize));
-  const canGoPrevious = currentPage > 1;
-  const canGoNext = currentPage < totalPages;
+  const canGoPrevious = currentPage > 1 && !isEventsLoading;
+  const canGoNext = currentPage < totalPages && !isEventsLoading;
+  const loadError = [overviewError, eventsError].filter(Boolean).join('; ') || null;
   const activityEvents = useMemo(
     () => events.filter((event) => event.outcome === 'approved' && event.source !== 'governor'),
     [events],
@@ -236,14 +251,14 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
             className="button button--secondary button--small"
             disabled={!canGoNext}
             type="button"
-            onClick={() => setPage((current) => current + 1)}
+            onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
           >
             Next
           </button>
         </div>
       </section>
 
-      {isLoading ? (
+      {isEventsLoading && !eventPage ? (
         <section className="empty-state">Loading analytics...</section>
       ) : (
         <section className="analytics-table-grid">

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -97,7 +97,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 
   const events = eventPage?.events ?? [];
   const totalEvents = eventPage?.total ?? 0;
-  const currentPage = page;
+  const currentPage = eventPage?.page ?? 1;
   const currentPageSize = eventPage?.pageSize ?? pageSize;
   const totalPages = Math.max(1, Math.ceil(totalEvents / currentPageSize));
   const canGoPrevious = currentPage > 1 && !isEventsLoading;

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -258,7 +258,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
         </div>
       </section>
 
-      {isEventsLoading && !eventPage ? (
+      {isEventsLoading ? (
         <section className="empty-state">Loading analytics...</section>
       ) : (
         <section className="analytics-table-grid">

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -839,6 +839,7 @@ button {
 
 .analytics-header,
 .analytics-filter-bar,
+.analytics-pagination,
 .analytics-panel,
 .analytics-metric,
 .analytics-drawer {
@@ -909,10 +910,28 @@ button {
 
 .analytics-filter-bar {
   display: grid;
-  grid-template-columns: minmax(12rem, 1.1fr) minmax(12rem, 1.1fr) minmax(10rem, 0.8fr) minmax(10rem, 0.7fr);
+  grid-template-columns: minmax(12rem, 1.1fr) minmax(12rem, 1.1fr) minmax(10rem, 0.8fr) minmax(10rem, 0.7fr) minmax(9rem, 0.6fr);
   gap: 0.8rem;
   padding: 1rem;
   border-radius: 1.15rem;
+}
+
+.analytics-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1.15rem;
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.85rem;
+}
+
+.analytics-pagination__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 .analytics-filter-bar .field-stack {
@@ -1094,6 +1113,15 @@ button {
   .analytics-table-grid,
   .analytics-filter-bar {
     grid-template-columns: 1fr;
+  }
+
+  .analytics-pagination {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .analytics-pagination__actions {
+    justify-content: space-between;
   }
 
   .session-switcher,


### PR DESCRIPTION
## Summary
- adds page/pageSize support to the analytics events API client
- adds analytics UI previous/next controls plus page-size selection
- resets event pagination to page 1 when filters or page size change

## Test Plan
- npm --workspace @frankenbeast/web test -- src/lib/analytics-api.test.ts src/pages/analytics-page.test.tsx
- npm --workspace @frankenbeast/web run typecheck
- npm --workspace @frankenbeast/web run build
- npm run typecheck
- npm run build

Closes #422