### PR TITLE
fix(mcp): render fbeast init validation failures as clean CLI errors

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init-options.ts
+++ b/packages/franken-mcp-suite/src/cli/init-options.ts
@@ -4,6 +4,7 @@ import type { FbeastServer } from '../shared/config.js';
 const ALL_SERVERS: FbeastServer[] = [
   'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
 ];
+const INIT_MODE_VALUES = ['standard', 'proxy'] as const;
 
 export interface ResolvedInitOptions {
   hooks: boolean;
@@ -42,8 +43,8 @@ export async function resolveInitOptions(
 }
 
 function parseModeArg(value: string): 'standard' | 'proxy' {
-  if (value === 'standard' || value === 'proxy') return value;
-  throw new Error(`Unknown --mode value: ${value}. Expected 'standard' or 'proxy'.`);
+  if ((INIT_MODE_VALUES as readonly string[]).includes(value)) return value as 'standard' | 'proxy';
+  throw new Error(`Unknown --mode value: ${value}. Expected one of: ${INIT_MODE_VALUES.join(', ')}.`);
 }
 
 export function parseServerSelection(value: string): FbeastServer[] {
@@ -60,7 +61,7 @@ export function parseServerSelection(value: string): FbeastServer[] {
   const invalid = [...requested].filter((entry) => !ALL_SERVERS.includes(entry));
 
   if (invalid.length > 0) {
-    throw new Error(`Unknown fbeast servers: ${invalid.join(', ')}`);
+    throw new Error(`Unknown --pick value(s): ${invalid.join(', ')}. Expected one or more of: ${ALL_SERVERS.join(', ')}.`);
   }
 
   return ALL_SERVERS.filter((server) => requested.has(server));

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -7,6 +7,7 @@ describe('fbeast main CLI', () => {
     process.argv = originalArgv;
     vi.restoreAllMocks();
     vi.resetModules();
+    vi.doUnmock('./init.js');
     vi.doUnmock('./uninstall.js');
   });
 
@@ -19,6 +20,76 @@ describe('fbeast main CLI', () => {
     await import('./main.js');
 
     expect(runUninstall).toHaveBeenCalledWith(expect.objectContaining({ client: 'codex' }));
+  });
+
+  it('reports invalid init mode as a clean CLI error without a stack trace', async () => {
+    const runInit = vi.fn();
+    vi.doMock('./init.js', () => ({ runInit }));
+
+    process.argv = ['node', 'fbeast', 'mcp', 'init', '--mode=bad', '--client=claude'];
+
+    const mockError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('process.exit'); }) as never);
+
+    try {
+      await import('./main.js');
+    } catch {
+      // process.exit throws in test
+    }
+
+    const message = mockError.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(message).toContain('fbeast mcp init: Unknown --mode value: bad');
+    expect(message).toContain('standard, proxy');
+    expect(message).toContain('--client=claude|gemini|codex');
+    expect(message).not.toContain(' at ');
+    expect(runInit).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('reports invalid init client as a clean CLI error without a stack trace', async () => {
+    const runInit = vi.fn();
+    vi.doMock('./init.js', () => ({ runInit }));
+
+    process.argv = ['node', 'fbeast', 'mcp', 'init', '--client=bad'];
+
+    const mockError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('process.exit'); }) as never);
+
+    try {
+      await import('./main.js');
+    } catch {
+      // process.exit throws in test
+    }
+
+    const message = mockError.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(message).toContain('fbeast mcp init: Invalid --client value "bad"');
+    expect(message).toContain('claude, gemini, or codex');
+    expect(message).not.toContain(' at ');
+    expect(runInit).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('reports invalid init pick values as a clean CLI error without a stack trace', async () => {
+    const runInit = vi.fn();
+    vi.doMock('./init.js', () => ({ runInit }));
+
+    process.argv = ['node', 'fbeast', 'mcp', 'init', '--client=claude', '--pick=memory,bad'];
+
+    const mockError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('process.exit'); }) as never);
+
+    try {
+      await import('./main.js');
+    } catch {
+      // process.exit throws in test
+    }
+
+    const message = mockError.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(message).toContain('fbeast mcp init: Unknown --pick value(s): bad');
+    expect(message).toContain('memory');
+    expect(message).not.toContain(' at ');
+    expect(runInit).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('passes through non-mcp commands to frankenbeast', async () => {

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -12,6 +12,13 @@ function resolveClient(): McpClient {
   return clientArg ?? detectMcpClient({ cwd: process.cwd(), homeDir: homedir(), exists: existsSync });
 }
 
+function reportMcpInitError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`fbeast mcp init: ${message}`);
+  console.error('  Known flags: --hooks  --pick[=<servers>]  --mode=standard|proxy  --client=claude|gemini|codex');
+  process.exit(1);
+}
+
 function passthrough(): never {
   const result = spawnSync('frankenbeast', process.argv.slice(2), {
     stdio: 'inherit',
@@ -52,12 +59,16 @@ switch (subcommand) {
       console.error('  Known flags: --hooks  --pick[=<servers>]  --mode=standard|proxy  --client=claude|gemini|codex');
       process.exit(1);
     }
-    const { runInit } = await import('./init.js');
-    const root = process.cwd();
-    const client = resolveClient();
-    const claudeDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
-    const initOptions = await resolveInitOptions(process.argv);
-    runInit({ root, claudeDir, client, ...initOptions });
+    try {
+      const { runInit } = await import('./init.js');
+      const root = process.cwd();
+      const client = resolveClient();
+      const claudeDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
+      const initOptions = await resolveInitOptions(process.argv);
+      runInit({ root, claudeDir, client, ...initOptions });
+    } catch (error) {
+      reportMcpInitError(error);
+    }
     break;
   }
   case 'uninstall': {


### PR DESCRIPTION
Closes #419\n\nImplemented concise CLI error handling for invalid --mode, --client, and --pick flags. Added tests covering validation errors.\n\n