### PR TITLE
fix(orchestrator): allow dashboard CORS origins

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -261,6 +261,19 @@ export async function resolveConfig(args: CliArgs, defaultConfigPath?: string): 
   return loadConfig(args, defaultConfigPath);
 }
 
+export function resolveDashboardAllowedOrigins(config: OrchestratorConfig): string[] {
+  if (!config.dashboard?.enabled) {
+    return [];
+  }
+
+  const { host, port } = config.dashboard;
+  const origins = [`http://${host}:${port}`];
+  if (host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') {
+    origins.push(`http://localhost:${port}`);
+  }
+  return origins;
+}
+
 interface ChatSurfaceDeps {
   chatLlm: AdapterLlmClient;
   execLlm: AdapterLlmClient;
@@ -728,12 +741,9 @@ export async function main(): Promise<void> {
             root,
           })
         : undefined;
-      const dashboardOrigin = config.dashboard?.enabled
-        ? `http://${config.dashboard.host}:${config.dashboard.port}`
-        : undefined;
       const allowedOrigins = Array.from(new Set([
         ...(args.allowOrigin ? [args.allowOrigin] : []),
-        ...(dashboardOrigin ? [dashboardOrigin] : []),
+        ...resolveDashboardAllowedOrigins(config),
       ]));
       const server = await startChatServer({
         sessionStoreDir,

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -728,6 +728,13 @@ export async function main(): Promise<void> {
             root,
           })
         : undefined;
+      const dashboardOrigin = config.dashboard?.enabled
+        ? `http://${config.dashboard.host}:${config.dashboard.port}`
+        : undefined;
+      const allowedOrigins = Array.from(new Set([
+        ...(args.allowOrigin ? [args.allowOrigin] : []),
+        ...(dashboardOrigin ? [dashboardOrigin] : []),
+      ]));
       const server = await startChatServer({
         sessionStoreDir,
         llm: chatLlm,
@@ -765,7 +772,7 @@ export async function main(): Promise<void> {
         ...(commsConfig ? { commsConfig } : {}),
         ...(args.host ? { host: args.host } : {}),
         ...(args.port !== undefined ? { port: args.port } : {}),
-        ...(args.allowOrigin ? { allowedOrigins: [args.allowOrigin] } : {}),
+        ...(allowedOrigins.length > 0 ? { allowedOrigins } : {}),
         // Consolidated deps — skill/dashboard routes activate when providers are configured
         ...(skillManager ? { skillManager } : {}),
         ...(providerRegistry ? { providerRegistry } : {}),

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -267,9 +267,13 @@ export function resolveDashboardAllowedOrigins(config: OrchestratorConfig): stri
   }
 
   const { host, port } = config.dashboard;
-  const origins = [`http://${host}:${port}`];
-  if (host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') {
+  const originHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+  const origins = [`http://${originHost}:${port}`];
+  if (host === '127.0.0.1' || host === '::1' || host === '[::1]' || host === '0.0.0.0') {
     origins.push(`http://localhost:${port}`);
+  }
+  if (host === '0.0.0.0') {
+    origins.push(`http://127.0.0.1:${port}`);
   }
   return origins;
 }

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 import type { ILlmClient } from '@franken/types';
 import { FileSessionStore } from '../chat/session-store.js';
 import type { ISessionStore } from '../chat/session-store.js';
@@ -38,6 +39,7 @@ export interface ChatAppOptions {
   sessionContinuation?: boolean;
   sessionTokenSecret?: string;
   operatorToken?: string;
+  allowedOrigins?: string[];
   engine?: ConversationEngine;
   runtime?: ChatRuntime;
   turnRunner?: TurnRunner;
@@ -101,6 +103,16 @@ export function createChatApp(opts: ChatAppOptions): Hono {
 
   const app = new Hono();
   app.use('*', requestId);
+  if (opts.allowedOrigins && opts.allowedOrigins.length > 0) {
+    const allowedOrigins = new Set(opts.allowedOrigins);
+    app.use('*', cors({
+      origin: (origin) => (allowedOrigins.has(origin) ? origin : null),
+      allowMethods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+      allowHeaders: ['authorization', 'content-type', 'x-frankenbeast-operator-token'],
+      credentials: true,
+      maxAge: 600,
+    }));
+  }
   app.use('/v1/chat/*', requestSizeLimit(DEFAULT_MAX_BODY_SIZE));
   // Chat /v1/chat/* is gated by an operator token whenever one is configured.
   // The same operator token authorizes the beast control plane and chat in

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -258,6 +258,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     turnRunner: runtime.turnRunner,
     sessionTokenSecret: tokenSecret,
     ...(options.operatorToken ? { operatorToken: options.operatorToken } : {}),
+    ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
     ...(options.beastControl ? { beastControl: options.beastControl } : {}),
     ...(options.networkControl ? { networkControl: options.networkControl } : {}),
     ...(options.commsConfig ? { commsConfig: options.commsConfig } : {}),

--- a/packages/franken-orchestrator/src/http/http-server-utils.ts
+++ b/packages/franken-orchestrator/src/http/http-server-utils.ts
@@ -37,8 +37,10 @@ function toRequest(request: IncomingMessage): Request {
   const abortController = new AbortController();
 
   const abortRequest = () => abortController.abort();
-  request.once('aborted', abortRequest);
-  request.once('close', abortRequest);
+  request.on('aborted', abortRequest);
+  request.on('close', abortRequest);
+  request.on('error', abortRequest);
+  // If the request is already aborted or destroyed, abort immediately.
   if (request.aborted || request.destroyed) {
     abortRequest();
   }

--- a/packages/franken-orchestrator/src/http/security/transport-security.ts
+++ b/packages/franken-orchestrator/src/http/security/transport-security.ts
@@ -88,7 +88,7 @@ export class TransportSecurityService {
   verifySocketRequest(options: VerifySocketRequestOptions) {
     const allowedOrigins = options.allowedOrigins ?? [];
     if (allowedOrigins.length > 0) {
-      if (!options.origin || !allowedOrigins.includes(options.origin)) {
+      if (options.origin && !allowedOrigins.includes(options.origin)) {
         return { ok: false as const, status: 403 as const };
       }
     }

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -12,6 +12,7 @@ import {
 } from './ws-chat-auth.js';
 import {
   ClientSocketEventSchema,
+  type ClientSocketEvent,
   type ServerSocketEvent,
 } from '@franken/types';
 
@@ -140,7 +141,7 @@ export class ChatSocketController {
       return;
     }
 
-    let event;
+    let event: ClientSocketEvent;
     try {
       event = ClientSocketEventSchema.parse(JSON.parse(raw));
     } catch {
@@ -166,7 +167,13 @@ export class ChatSocketController {
 
     switch (event.type) {
       case 'message.send':
-        await this.handleMessageSend(peer, session, event.clientMessageId, event.content, event.executionMode);
+        await this.handleMessageSend(
+          peer,
+          session,
+          event.clientMessageId,
+          event.content,
+          'executionMode' in event ? event.executionMode : undefined,
+        );
         return;
       case 'approval.respond':
         await this.handleApproval(peer, session, event.approved);

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -51,6 +51,59 @@ describe('Chat HTTP Routes', () => {
     expect(body.status).toBe('ok');
   });
 
+  it('allows configured dashboard origins to call authenticated API routes directly', async () => {
+    app = createChatApp({
+      sessionStoreDir: TMP,
+      llm: { complete: llmComplete },
+      projectName: 'test-project',
+      operatorToken: 'operator-token',
+      allowedOrigins: ['http://127.0.0.1:5173'],
+    });
+
+    const preflight = await app.request('/v1/chat/sessions', {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'http://127.0.0.1:5173',
+        'access-control-request-method': 'GET',
+        'access-control-request-headers': 'authorization, content-type',
+      },
+    });
+
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get('access-control-allow-origin')).toBe('http://127.0.0.1:5173');
+    expect(preflight.headers.get('access-control-allow-headers')).toContain('authorization');
+
+    const response = await app.request('/v1/chat/sessions', {
+      headers: {
+        origin: 'http://127.0.0.1:5173',
+        authorization: 'Bearer operator-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBe('http://127.0.0.1:5173');
+  });
+
+  it('does not emit CORS headers for unconfigured origins', async () => {
+    app = createChatApp({
+      sessionStoreDir: TMP,
+      llm: { complete: llmComplete },
+      projectName: 'test-project',
+      operatorToken: 'operator-token',
+      allowedOrigins: ['http://127.0.0.1:5173'],
+    });
+
+    const response = await app.request('/v1/chat/sessions', {
+      headers: {
+        origin: 'https://evil.example',
+        authorization: 'Bearer operator-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
   // --- Create session ---
 
   it('POST /v1/chat/sessions creates a session', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -532,6 +532,30 @@ describe('discoverResumeTarget', () => {
     expect(inferResumeBaseBranch(root)).toBeUndefined();
 
     rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('resolveDashboardAllowedOrigins', () => {
+  it('includes localhost as an alias for loopback dashboard defaults', () => {
+    expect(resolveDashboardAllowedOrigins({
+      dashboard: {
+        enabled: true,
+        host: '127.0.0.1',
+        port: 5173,
+        apiUrl: 'http://127.0.0.1:3737',
+      },
+    } as never)).toEqual(['http://127.0.0.1:5173', 'http://localhost:5173']);
+  });
+
+  it('does not add a localhost alias for non-loopback dashboard hosts', () => {
+    expect(resolveDashboardAllowedOrigins({
+      dashboard: {
+        enabled: true,
+        host: 'dashboard.example.com',
+        port: 5173,
+        apiUrl: 'http://127.0.0.1:3737',
+      },
+    } as never)).toEqual(['http://dashboard.example.com:5173']);
   });
 });
 
@@ -997,7 +1021,7 @@ describe('main() execution', () => {
     expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
       host: '127.0.0.1',
       port: 3737,
-      allowedOrigins: ['http://localhost:5173'],
+      allowedOrigins: ['http://localhost:5173', 'http://127.0.0.1:5173'],
       sessionStoreDir: '/mock/project/.fbeast/chat',
       projectName: 'project',
       operatorToken: 'dashboard-operator-token',

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -547,6 +547,28 @@ describe('resolveDashboardAllowedOrigins', () => {
     } as never)).toEqual(['http://127.0.0.1:5173', 'http://localhost:5173']);
   });
 
+  it('wraps IPv6 loopback origins before allowlisting them', () => {
+    expect(resolveDashboardAllowedOrigins({
+      dashboard: {
+        enabled: true,
+        host: '::1',
+        port: 5173,
+        apiUrl: 'http://127.0.0.1:3737',
+      },
+    } as never)).toEqual(['http://[::1]:5173', 'http://localhost:5173']);
+  });
+
+  it('adds usable loopback aliases for wildcard dashboard binds', () => {
+    expect(resolveDashboardAllowedOrigins({
+      dashboard: {
+        enabled: true,
+        host: '0.0.0.0',
+        port: 5173,
+        apiUrl: 'http://127.0.0.1:3737',
+      },
+    } as never)).toEqual(['http://0.0.0.0:5173', 'http://localhost:5173', 'http://127.0.0.1:5173']);
+  });
+
   it('does not add a localhost alias for non-loopback dashboard hosts', () => {
     expect(resolveDashboardAllowedOrigins({
       dashboard: {

--- a/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
+
+describe('TransportSecurityService', () => {
+  it('allows signed websocket requests without an Origin header', () => {
+    const security = new TransportSecurityService();
+    const secret = security.createSecret();
+    const token = security.issueSignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+    });
+
+    expect(security.verifySocketRequest({
+      allowedOrigins: ['http://127.0.0.1:5173', 'http://localhost:5173'],
+      origin: null,
+      scope: 'chat:socket',
+      secret,
+      subject: 'session-1',
+      token,
+    })).toEqual({ ok: true });
+  });
+
+  it('rejects websocket requests from disallowed Origin headers', () => {
+    const security = new TransportSecurityService();
+    const secret = security.createSecret();
+    const token = security.issueSignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+    });
+
+    expect(security.verifySocketRequest({
+      allowedOrigins: ['http://127.0.0.1:5173', 'http://localhost:5173'],
+      origin: 'https://evil.example',
+      scope: 'chat:socket',
+      secret,
+      subject: 'session-1',
+      token,
+    })).toEqual({ ok: false, status: 403 });
+  });
+});

--- a/tasks/resolve-issues-402-progress.md
+++ b/tasks/resolve-issues-402-progress.md
@@ -1,0 +1,11 @@
+# Issue #402 Progress
+
+- [x] Refresh live issue and PR state for #402.
+- [x] Create isolated worktree and branch `resolve/issue-402-dashboard-cors`.
+- [x] Add configured-origin CORS support for direct dashboard API mode.
+- [x] Add regression tests for allowed and disallowed origins.
+- [x] Run relevant orchestrator tests/typecheck/build.
+- [x] Commit, push, open PR with `Closes #402`.
+- [x] Address current-head Codex findings for dashboard CORS localhost and no-Origin managed chat sockets.
+- [x] Run targeted tests/typecheck/build after Codex fixes.
+- [ ] Push Codex fixes, rerun GitHub Codex review loop, and merge only when CI/Codex are clean.


### PR DESCRIPTION
## Summary
- add CORS middleware to the chat/control-plane app for configured origins
- pass chat-server allowed origins into both HTTP CORS and websocket origin checks
- allow the configured dashboard web origin by default while preserving --allow-origin overrides
- add regression tests for allowed and unconfigured origins

## Test Plan
- npm --workspace packages/franken-orchestrator test -- tests/integration/chat/chat-routes.test.ts tests/unit/cli/run.test.ts
- npm --workspace packages/franken-orchestrator run typecheck
- npm --workspace packages/franken-orchestrator run build
- git diff --check

Closes #402