### PR TITLE
fix(web): sync network config editor

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -776,7 +776,9 @@ export function ChatShell({ baseUrl, beastOperatorToken, projectId, sessionId, v
             }}
             onSaveConfig={(assignments) => {
               const client = new NetworkApiClient(baseUrl, beastOperatorToken);
-              void client.updateConfig(assignments).then(setNetworkConfig).catch(() => undefined);
+              return client.updateConfig(assignments).then((nextConfig) => {
+                setNetworkConfig(nextConfig);
+              });
             }}
             onStart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl, beastOperatorToken);

--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -1,31 +1,227 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { NetworkConfigResponse } from '../lib/network-api';
 
 interface NetworkConfigEditorProps {
   config: NetworkConfigResponse;
-  onSave(assignments: string[]): void;
+  onSave(assignments: string[]): Promise<void> | void;
+}
+
+interface NetworkConfigFormState {
+  networkMode: string;
+  secureBackend: string;
+  chatEnabled: boolean;
+  chatModel: string;
+  chatHost: string;
+  chatPort: string;
+  dashboardEnabled: boolean;
+  dashboardHost: string;
+  dashboardPort: string;
+  dashboardApiUrl: string;
+  commsEnabled: boolean;
+}
+
+function formStateFromConfig(config: NetworkConfigResponse): NetworkConfigFormState {
+  return {
+    networkMode: config.network.mode,
+    secureBackend: config.network.secureBackend ?? '',
+    chatEnabled: config.chat.enabled,
+    chatModel: config.chat.model,
+    chatHost: config.chat.host ?? '',
+    chatPort: config.chat.port === undefined ? '' : String(config.chat.port),
+    dashboardEnabled: config.dashboard?.enabled ?? false,
+    dashboardHost: config.dashboard?.host ?? '',
+    dashboardPort: config.dashboard?.port === undefined ? '' : String(config.dashboard.port),
+    dashboardApiUrl: config.dashboard?.apiUrl ?? '',
+    commsEnabled: config.comms?.enabled ?? false,
+  };
+}
+
+function assignment(key: string, value: string | boolean): string {
+  return `${key}=${String(value)}`;
+}
+
+function hasChanged(current: string | boolean, initial: string | boolean): boolean {
+  return current !== initial;
+}
+
+function buildAssignments(current: NetworkConfigFormState, initial: NetworkConfigFormState): string[] {
+  const candidates: Array<[key: string, current: string | boolean, initial: string | boolean]> = [
+    ['network.mode', current.networkMode, initial.networkMode],
+    ['network.secureBackend', current.secureBackend, initial.secureBackend],
+    ['chat.enabled', current.chatEnabled, initial.chatEnabled],
+    ['chat.model', current.chatModel, initial.chatModel],
+    ['chat.host', current.chatHost, initial.chatHost],
+    ['chat.port', current.chatPort, initial.chatPort],
+    ['dashboard.enabled', current.dashboardEnabled, initial.dashboardEnabled],
+    ['dashboard.host', current.dashboardHost, initial.dashboardHost],
+    ['dashboard.port', current.dashboardPort, initial.dashboardPort],
+    ['dashboard.apiUrl', current.dashboardApiUrl, initial.dashboardApiUrl],
+    ['comms.enabled', current.commsEnabled, initial.commsEnabled],
+  ];
+
+  return candidates
+    .filter(([, value, previous]) => hasChanged(value, previous))
+    .map(([key, value]) => assignment(key, value));
 }
 
 export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps) {
-  const [chatModel, setChatModel] = useState(config.chat.model);
+  const initialState = useMemo(() => formStateFromConfig(config), [config]);
+  const [formState, setFormState] = useState<NetworkConfigFormState>(initialState);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const assignments = buildAssignments(formState, initialState);
+
+  useEffect(() => {
+    setFormState(initialState);
+    setError(null);
+  }, [initialState]);
+
+  function update<K extends keyof NetworkConfigFormState>(key: K, value: NetworkConfigFormState[K]) {
+    setFormState((current) => ({ ...current, [key]: value }));
+  }
+
+  async function save() {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSave(assignments);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to save network config.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
 
   return (
     <section className="rail-card network-config-editor">
       <div className="rail-card__header">
         <p className="eyebrow">Config</p>
       </div>
+
+      <label className="network-config-editor__field">
+        <span>Network mode</span>
+        <input
+          aria-label="Network mode"
+          className="field-control"
+          type="text"
+          value={formState.networkMode}
+          onChange={(event) => update('networkMode', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field">
+        <span>Secure backend</span>
+        <input
+          aria-label="Secure backend"
+          className="field-control"
+          type="text"
+          value={formState.secureBackend}
+          onChange={(event) => update('secureBackend', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field network-config-editor__field--checkbox">
+        <input
+          aria-label="Chat enabled"
+          type="checkbox"
+          checked={formState.chatEnabled}
+          onChange={(event) => update('chatEnabled', event.target.checked)}
+        />
+        <span>Chat enabled</span>
+      </label>
+
       <label className="network-config-editor__field">
         <span>Chat model</span>
         <input
           aria-label="Chat model"
           className="field-control"
           type="text"
-          value={chatModel}
-          onChange={(event) => setChatModel(event.target.value)}
+          value={formState.chatModel}
+          onChange={(event) => update('chatModel', event.target.value)}
         />
       </label>
-      <button className="button button--primary" type="button" onClick={() => onSave([`chat.model=${chatModel}`])}>
-        Save config
+
+      <label className="network-config-editor__field">
+        <span>Chat host</span>
+        <input
+          aria-label="Chat host"
+          className="field-control"
+          type="text"
+          value={formState.chatHost}
+          onChange={(event) => update('chatHost', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field">
+        <span>Chat port</span>
+        <input
+          aria-label="Chat port"
+          className="field-control"
+          inputMode="numeric"
+          type="number"
+          value={formState.chatPort}
+          onChange={(event) => update('chatPort', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field network-config-editor__field--checkbox">
+        <input
+          aria-label="Dashboard enabled"
+          type="checkbox"
+          checked={formState.dashboardEnabled}
+          onChange={(event) => update('dashboardEnabled', event.target.checked)}
+        />
+        <span>Dashboard enabled</span>
+      </label>
+
+      <label className="network-config-editor__field">
+        <span>Dashboard host</span>
+        <input
+          aria-label="Dashboard host"
+          className="field-control"
+          type="text"
+          value={formState.dashboardHost}
+          onChange={(event) => update('dashboardHost', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field">
+        <span>Dashboard port</span>
+        <input
+          aria-label="Dashboard port"
+          className="field-control"
+          inputMode="numeric"
+          type="number"
+          value={formState.dashboardPort}
+          onChange={(event) => update('dashboardPort', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field">
+        <span>Dashboard API URL</span>
+        <input
+          aria-label="Dashboard API URL"
+          className="field-control"
+          type="text"
+          value={formState.dashboardApiUrl}
+          onChange={(event) => update('dashboardApiUrl', event.target.value)}
+        />
+      </label>
+
+      <label className="network-config-editor__field network-config-editor__field--checkbox">
+        <input
+          aria-label="Comms enabled"
+          type="checkbox"
+          checked={formState.commsEnabled}
+          onChange={(event) => update('commsEnabled', event.target.checked)}
+        />
+        <span>Comms enabled</span>
+      </label>
+
+      {error && <p role="alert">{error}</p>}
+
+      <button className="button button--primary" type="button" disabled={isSaving} onClick={() => { void save(); }}>
+        {isSaving ? 'Saving…' : 'Save config'}
       </button>
     </section>
   );

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -13,7 +13,7 @@ interface NetworkPageProps {
   onStart(serviceId: string): void;
   onStop(serviceId: string): void;
   onRestart(serviceId: string): void;
-  onSaveConfig(assignments: string[]): void;
+  onSaveConfig(assignments: string[]): Promise<void> | void;
 }
 
 export function NetworkPage({

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NetworkPage } from '../../src/pages/network-page';
+import type { NetworkConfigResponse } from '../../src/lib/network-api';
+
+const baseConfig: NetworkConfigResponse = {
+  network: { mode: 'secure', secureBackend: 'local-encrypted' },
+  chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+  dashboard: { enabled: true, host: '127.0.0.1', port: 4173, apiUrl: 'http://127.0.0.1:3737' },
+  comms: { enabled: false },
+};
 
 afterEach(cleanup);
 
@@ -8,10 +16,7 @@ describe('NetworkPage', () => {
   it('renders status, service controls, secure mode, and logs', () => {
     render(
       <NetworkPage
-        config={{
-          network: { mode: 'secure', secureBackend: 'local-encrypted' },
-          chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
-        }}
+        config={baseConfig}
         logs={['/tmp/chat-server.log']}
         onRefresh={vi.fn()}
         onRestart={vi.fn()}
@@ -34,11 +39,13 @@ describe('NetworkPage', () => {
     expect(screen.getByText('chat-server')).toBeDefined();
     expect(screen.getByText('/tmp/chat-server.log')).toBeDefined();
     expect(screen.getByDisplayValue('claude-sonnet-4-6')).toBeDefined();
+    expect(screen.getByDisplayValue('local-encrypted')).toBeDefined();
+    expect((screen.getByLabelText('Chat enabled') as HTMLInputElement).checked).toBe(true);
     expect(screen.getByRole('button', { name: 'Refresh' }).getAttribute('class')).toContain('button--secondary');
     expect(screen.getByRole('button', { name: 'Save config' }).getAttribute('class')).toContain('button--primary');
   });
 
-  it('invokes service controls and config save interactions', () => {
+  it('invokes service controls and saves all changed config assignments atomically', () => {
     const onStart = vi.fn();
     const onStop = vi.fn();
     const onRestart = vi.fn();
@@ -46,10 +53,7 @@ describe('NetworkPage', () => {
 
     render(
       <NetworkPage
-        config={{
-          network: { mode: 'secure', secureBackend: 'local-encrypted' },
-          chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
-        }}
+        config={baseConfig}
         logs={[]}
         onRefresh={vi.fn()}
         onRestart={onRestart}
@@ -71,12 +75,91 @@ describe('NetworkPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start chat-server' }));
     fireEvent.click(screen.getByRole('button', { name: 'Stop chat-server' }));
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat-server' }));
+    fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'hybrid' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
+    fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });
+    fireEvent.change(screen.getByLabelText('Dashboard port'), { target: { value: '5173' } });
+    fireEvent.click(screen.getByLabelText('Comms enabled'));
     fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
 
     expect(onStart).toHaveBeenCalledWith('chat-server');
     expect(onStop).toHaveBeenCalledWith('chat-server');
     expect(onRestart).toHaveBeenCalledWith('chat-server');
-    expect(onSaveConfig).toHaveBeenCalledWith(['chat.model=gpt-5']);
+    expect(onSaveConfig).toHaveBeenCalledWith([
+      'network.mode=hybrid',
+      'chat.model=gpt-5',
+      'chat.host=0.0.0.0',
+      'dashboard.port=5173',
+      'comms.enabled=true',
+    ]);
+  });
+
+  it('updates editor values when fetched config props change', () => {
+    const { rerender } = render(
+      <NetworkPage
+        config={{
+          network: { mode: 'secure', secureBackend: 'local-encrypted' },
+          chat: { model: 'loading-model', enabled: true, host: '127.0.0.1', port: 3737 },
+        }}
+        logs={[]}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('loading-model')).toBeDefined();
+
+    rerender(
+      <NetworkPage
+        config={{
+          network: { mode: 'hybrid', secureBackend: 'remote-vault' },
+          chat: { model: 'fetched-model', enabled: false, host: '0.0.0.0', port: 4747 },
+          dashboard: { enabled: true, host: 'localhost', port: 5173, apiUrl: 'http://localhost:4747' },
+          comms: { enabled: true },
+        }}
+        logs={[]}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('fetched-model')).toBeDefined();
+    expect(screen.getByDisplayValue('hybrid')).toBeDefined();
+    expect(screen.getByDisplayValue('remote-vault')).toBeDefined();
+    expect((screen.getByLabelText('Chat enabled') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText('Comms enabled') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('surfaces save errors from the network config API', async () => {
+    const onSaveConfig = vi.fn().mockRejectedValue(new Error('HTTP 400'));
+
+    render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'bad-model' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('HTTP 400'));
   });
 });


### PR DESCRIPTION
## Summary
- sync network config editor form state when fetched config props change
- expose safe network/chat/dashboard/comms fields and save changed assignments in one payload
- surface save failures in the editor instead of swallowing update errors

## Test Plan
- npm run test --workspace packages/franken-web -- tests/components/network-page.test.tsx
- npm run typecheck --workspace packages/franken-web
- npm run build --workspace packages/franken-web

Closes #425