### PR TITLE
fix(web): stream dashboard sse updates

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -55,12 +55,12 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
       };
 
       const snapshotInterval = setInterval(async () => {
-        const nextSnapshot = JSON.stringify(buildSnapshot(deps));
-        if (nextSnapshot === lastSnapshot) {
-          return;
-        }
-        lastSnapshot = nextSnapshot;
         try {
+          const nextSnapshot = JSON.stringify(buildSnapshot(deps));
+          if (nextSnapshot === lastSnapshot) {
+            return;
+          }
+          lastSnapshot = nextSnapshot;
           await stream.writeSSE({ event: 'snapshot', data: nextSnapshot });
         } catch {
           clearAll();

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -55,12 +55,18 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
       };
 
       const snapshotInterval = setInterval(async () => {
+        let nextSnapshot: string;
         try {
-          const nextSnapshot = JSON.stringify(buildSnapshot(deps));
-          if (nextSnapshot === lastSnapshot) {
-            return;
-          }
-          lastSnapshot = nextSnapshot;
+          nextSnapshot = JSON.stringify(buildSnapshot(deps));
+        } catch {
+          return;
+        }
+
+        if (nextSnapshot === lastSnapshot) {
+          return;
+        }
+        lastSnapshot = nextSnapshot;
+        try {
           await stream.writeSSE({ event: 'snapshot', data: nextSnapshot });
         } catch {
           clearAll();

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -3,6 +3,9 @@ import { streamSSE } from 'hono/streaming';
 import type { SkillManager } from '../../skills/skill-manager.js';
 import type { SecurityConfig } from '../../middleware/security-profiles.js';
 
+const DASHBOARD_SNAPSHOT_POLL_MS = 1_000;
+const DASHBOARD_HEARTBEAT_MS = 30_000;
+
 export interface DashboardRouteDeps {
   skillManager: SkillManager;
   getSecurityConfig: () => SecurityConfig;
@@ -36,26 +39,48 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   // GET /api/dashboard/events — SSE stream for real-time dashboard updates
   app.get('/events', (c) => {
     return streamSSE(c, async (stream) => {
+      let lastSnapshot = JSON.stringify(buildSnapshot(deps));
+
       // Send initial snapshot
       await stream.writeSSE({
         event: 'snapshot',
-        data: JSON.stringify(buildSnapshot(deps)),
+        data: lastSnapshot,
       });
 
-      // Keep connection alive with periodic heartbeats
-      // Real event push would be wired to SkillManager/SecurityConfig change events
-      const interval = setInterval(async () => {
+      const cleanup: Array<() => void> = [];
+      const clearAll = () => {
+        while (cleanup.length > 0) {
+          cleanup.pop()?.();
+        }
+      };
+
+      const snapshotInterval = setInterval(async () => {
+        const nextSnapshot = JSON.stringify(buildSnapshot(deps));
+        if (nextSnapshot === lastSnapshot) {
+          return;
+        }
+        lastSnapshot = nextSnapshot;
+        try {
+          await stream.writeSSE({ event: 'snapshot', data: nextSnapshot });
+        } catch {
+          clearAll();
+        }
+      }, DASHBOARD_SNAPSHOT_POLL_MS);
+      cleanup.push(() => clearInterval(snapshotInterval));
+
+      const heartbeatInterval = setInterval(async () => {
         try {
           await stream.writeSSE({ event: 'heartbeat', data: '' });
         } catch {
-          clearInterval(interval);
+          clearAll();
         }
-      }, 30_000);
+      }, DASHBOARD_HEARTBEAT_MS);
+      cleanup.push(() => clearInterval(heartbeatInterval));
 
       // Block until client disconnects (single onAbort — Hono stores one callback, not a list)
       await new Promise<void>((resolve) => {
         stream.onAbort(() => {
-          clearInterval(interval);
+          clearAll();
           resolve();
         });
       });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -160,5 +160,26 @@ describe('dashboard routes', () => {
         vi.useRealTimers();
       }
     });
+
+    it('does not reject the polling timer when refreshing the snapshot throws', async () => {
+      vi.useFakeTimers();
+      try {
+        const deps = createMockDeps();
+        const providers = deps.getProviders as ReturnType<typeof vi.fn>;
+        const app = createDashboardRoutes(deps);
+        const res = await app.request('/events');
+        const reader = res.body!.getReader();
+
+        await reader.read();
+        providers.mockImplementation(() => {
+          throw new Error('config read failed');
+        });
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        reader.cancel();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -126,5 +126,39 @@ describe('dashboard routes', () => {
       expect(data.security.profile).toBe('standard');
       expect(data.providers).toHaveLength(1);
     });
+
+    it('streams a fresh snapshot when dashboard state changes after connect', async () => {
+      vi.useFakeTimers();
+      try {
+        const deps = createMockDeps();
+        const providers = deps.getProviders as ReturnType<typeof vi.fn>;
+        const app = createDashboardRoutes(deps);
+        const res = await app.request('/events');
+
+        const reader = res.body!.getReader();
+        const decoder = new TextDecoder();
+        let text = '';
+        for (let i = 0; i < 10; i++) {
+          const { value, done } = await reader.read();
+          if (value) text += decoder.decode(value, { stream: true });
+          if (done || text.includes('event: snapshot')) break;
+        }
+
+        providers.mockReturnValue([
+          { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
+          { name: 'ollama', type: 'ollama', available: true, failoverOrder: 1 },
+        ]);
+
+        const nextRead = reader.read();
+        await vi.advanceTimersByTimeAsync(1_000);
+        const { value } = await nextRead;
+        if (value) text += decoder.decode(value, { stream: true });
+        reader.cancel();
+
+        expect(text).toContain('"name":"ollama"');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -161,7 +161,7 @@ describe('dashboard routes', () => {
       }
     });
 
-    it('does not reject the polling timer when refreshing the snapshot throws', async () => {
+    it('keeps polling after one snapshot refresh throws', async () => {
       vi.useFakeTimers();
       try {
         const deps = createMockDeps();
@@ -176,7 +176,18 @@ describe('dashboard routes', () => {
         });
 
         await vi.advanceTimersByTimeAsync(1_000);
+        providers.mockReturnValue([
+          { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
+          { name: 'ollama', type: 'ollama', available: true, failoverOrder: 1 },
+        ]);
+
+        const nextRead = reader.read();
+        await vi.advanceTimersByTimeAsync(1_000);
+        const { value } = await nextRead;
+        const text = value ? new TextDecoder().decode(value) : '';
         reader.cancel();
+
+        expect(text).toContain('"name":"ollama"');
       } finally {
         vi.useRealTimers();
       }


### PR DESCRIPTION
## Summary
- emit fresh dashboard SSE snapshot events when aggregate dashboard state changes after connection
- keep heartbeat events as connection liveness only
- cover post-connect snapshot updates with a regression test

## Test Plan
- npm run test --workspace packages/franken-orchestrator -- tests/unit/http/dashboard-routes.test.ts
- npm run build --workspace packages/franken-types
- npm run build --workspace packages/franken-observer
- npm run build --workspace packages/franken-brain
- npm run build --workspace packages/franken-critique
- npm run build --workspace packages/franken-governor
- npm run build --workspace packages/franken-planner
- npm run typecheck --workspace packages/franken-orchestrator
- npm run build --workspace packages/franken-orchestrator
- npm run lint --workspace packages/franken-orchestrator
- git diff --check

Closes #409