### PR TITLE
fix(orchestrator): validate refreshed execution plans

### DIFF
--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -57,41 +57,44 @@ export async function runExecution(
   const completedOutputs = new Map<string, unknown>();
   const knownTaskIds = new Set(ctx.plan.tasks.map((t) => t.id));
 
-  // Simple topological execution: iterate tasks, skip those with unmet deps
-  const pending = [...ctx.plan.tasks];
+  // Simple topological execution: keep a keyed FIFO queue so plan refreshes can
+  // atomically add newly discovered tasks without duplicating overlapping work.
+  const pending = new Map(ctx.plan.tasks.map((task) => [task.id, task]));
   let iterations = 0;
-  let maxIterations = Math.max(pending.length * 2, 10); // safety guard
+  let maxIterations = Math.max(pending.size * 2, 10); // safety guard
 
-  while (pending.length > 0 && iterations < maxIterations) {
+  while (pending.size > 0 && iterations < maxIterations) {
     iterations++;
     if (refreshPlanTasks) {
       const latestTasks = await refreshPlanTasks();
-      let addedCount = 0;
-      for (const task of latestTasks) {
-        if (!knownTaskIds.has(task.id)) {
+      const refreshedTasks = collectNewRefreshTasks(latestTasks, knownTaskIds);
+
+      if (refreshedTasks.length > 0) {
+        const refreshedPlan: PlanTask[] = [...ctx.plan.tasks, ...refreshedTasks];
+        validateAcyclicPlan(refreshedPlan);
+
+        for (const task of refreshedTasks) {
           knownTaskIds.add(task.id);
-          pending.push(task);
-          addedCount++;
+          pending.set(task.id, task);
         }
-      }
-      if (addedCount > 0) {
-        maxIterations += addedCount * 2;
-        ctx.plan = { tasks: [...ctx.plan.tasks, ...latestTasks.filter(t => !ctx.plan!.tasks.some(p => p.id === t.id))] };
+
+        maxIterations += refreshedTasks.length * 2;
+        ctx.plan = { tasks: refreshedPlan };
         logger.info('Execution: plan refreshed', {
-          addedTasks: addedCount,
+          addedTasks: refreshedTasks.length,
           totalTasks: knownTaskIds.size,
         });
       }
     }
 
-    const readyIndex = pending.findIndex(t =>
-      t.dependsOn.every(dep => completed.has(dep)),
+    const readyEntry = [...pending].find(([, task]) =>
+      task.dependsOn.every(dep => completed.has(dep)),
     );
 
-    if (readyIndex === -1) {
+    if (!readyEntry) {
       // All remaining tasks have unmet dependencies — deadlock
       ctx.circuitBreakerTripped = true;
-      for (const task of pending) {
+      for (const task of pending.values()) {
         outcomes.push({
           taskId: task.id,
           status: 'skipped',
@@ -101,7 +104,8 @@ export async function runExecution(
       break;
     }
 
-    const task = pending.splice(readyIndex, 1)[0]!;
+    const [taskId, task] = readyEntry;
+    pending.delete(taskId);
 
     // Skip tasks already completed in a previous run (checkpoint recovery)
     if (checkpoint?.has(`${task.id}:done`)) {
@@ -149,6 +153,64 @@ export async function runExecution(
   });
 
   return outcomes;
+}
+
+function collectNewRefreshTasks(
+  latestTasks: readonly PlanTask[],
+  knownTaskIds: ReadonlySet<string>,
+): PlanTask[] {
+  const seen = new Set(knownTaskIds);
+  const newTasks: PlanTask[] = [];
+
+  for (const task of latestTasks) {
+    if (seen.has(task.id)) {
+      continue;
+    }
+    seen.add(task.id);
+    newTasks.push(task);
+  }
+
+  return newTasks;
+}
+
+function validateAcyclicPlan(tasks: readonly PlanTask[]): void {
+  const taskById = new Map<string, PlanTask>();
+  for (const task of tasks) {
+    if (taskById.has(task.id)) {
+      throw new Error(`Refreshed plan contains duplicate task id '${task.id}'`);
+    }
+    taskById.set(task.id, task);
+  }
+
+  const state = new Map<string, 'visiting' | 'visited'>();
+  const path: string[] = [];
+
+  const visit = (task: PlanTask): void => {
+    const currentState = state.get(task.id);
+    if (currentState === 'visited') {
+      return;
+    }
+    if (currentState === 'visiting') {
+      const cycleStart = path.indexOf(task.id);
+      const cycle = [...path.slice(cycleStart), task.id].join(' -> ');
+      throw new Error(`Refreshed plan cycle detected: ${cycle}`);
+    }
+
+    state.set(task.id, 'visiting');
+    path.push(task.id);
+    for (const dep of task.dependsOn) {
+      const dependency = taskById.get(dep);
+      if (dependency) {
+        visit(dependency);
+      }
+    }
+    path.pop();
+    state.set(task.id, 'visited');
+  };
+
+  for (const task of tasks) {
+    visit(task);
+  }
 }
 
 async function executeTask(

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -55,6 +55,7 @@ export async function runExecution(
   const outcomes: TaskOutcome[] = [];
   const completed = new Set<string>();
   const completedOutputs = new Map<string, unknown>();
+  validateAcyclicPlan(ctx.plan.tasks);
   const knownTaskIds = new Set(ctx.plan.tasks.map((t) => t.id));
 
   // Simple topological execution: keep a keyed FIFO queue so plan refreshes can

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -947,6 +947,16 @@ describe('runExecution', () => {
     expect(c.plan!.tasks.map(t => t.id)).toEqual(['t1']);
   });
 
+  it('rejects duplicate initial task ids before queueing pending work', async () => {
+    const c = ctx([
+      { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },
+      { id: 't1', objective: 'duplicate first', requiredSkills: [], dependsOn: [] },
+    ]);
+
+    await expect(runExecution(c, makeSkills(), makeGovernor(), makeMemory(), makeObserver()))
+      .rejects.toThrow("duplicate task id 't1'");
+  });
+
   it('keeps refreshed duplicate tasks out of the pending execution queue', async () => {
     const c = ctx([
       { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -916,4 +916,67 @@ describe('runExecution', () => {
     expect(outcomes.map(o => o.taskId)).toEqual(['t1', 't2']);
     expect(outcomes.every(o => o.status === 'success')).toBe(true);
   });
+
+  it('rejects refreshed tasks that introduce dependency cycles before mutating the plan', async () => {
+    const c = ctx([
+      { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },
+    ]);
+    const refreshPlanTasks = vi
+      .fn<() => Promise<readonly { id: string; objective: string; requiredSkills: readonly string[]; dependsOn: readonly string[] }[]>>()
+      .mockResolvedValueOnce([
+        { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },
+        { id: 't2', objective: 'second', requiredSkills: [], dependsOn: ['t3'] },
+        { id: 't3', objective: 'third', requiredSkills: [], dependsOn: ['t2'] },
+      ]);
+
+    await expect(
+      runExecution(
+        c,
+        makeSkills(),
+        makeGovernor(),
+        makeMemory(),
+        makeObserver(),
+        undefined,
+        makeLogger(),
+        undefined,
+        undefined,
+        refreshPlanTasks,
+      ),
+    ).rejects.toThrow('cycle detected');
+
+    expect(c.plan!.tasks.map(t => t.id)).toEqual(['t1']);
+  });
+
+  it('keeps refreshed duplicate tasks out of the pending execution queue', async () => {
+    const c = ctx([
+      { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },
+    ]);
+    const refreshPlanTasks = vi
+      .fn<() => Promise<readonly { id: string; objective: string; requiredSkills: readonly string[]; dependsOn: readonly string[] }[]>>()
+      .mockResolvedValueOnce([
+        { id: 't1', objective: 'duplicate first', requiredSkills: [], dependsOn: [] },
+        { id: 't2', objective: 'second', requiredSkills: [], dependsOn: ['t1'] },
+        { id: 't2', objective: 'duplicate second', requiredSkills: [], dependsOn: ['t1'] },
+      ])
+      .mockResolvedValueOnce([
+        { id: 't1', objective: 'duplicate first', requiredSkills: [], dependsOn: [] },
+        { id: 't2', objective: 'second', requiredSkills: [], dependsOn: ['t1'] },
+      ]);
+
+    const outcomes = await runExecution(
+      c,
+      makeSkills(),
+      makeGovernor(),
+      makeMemory(),
+      makeObserver(),
+      undefined,
+      makeLogger(),
+      undefined,
+      undefined,
+      refreshPlanTasks,
+    );
+
+    expect(outcomes.map(o => o.taskId)).toEqual(['t1', 't2']);
+    expect(c.plan!.tasks.map(t => t.id)).toEqual(['t1', 't2']);
+  });
 });


### PR DESCRIPTION
## Summary
- replace refreshed execution pending array mutation with a keyed FIFO queue
- deduplicate refreshed task IDs before adding them to pending work
- validate the merged execution plan for dependency cycles before mutating ctx.plan

## Test Plan
- [x] npm run test --workspace packages/franken-orchestrator -- tests/unit/phases/execution.test.ts
- [x] npm run typecheck
- [x] npm run build
- [x] npm run lint --workspace packages/franken-orchestrator (passes with existing warnings)
- [x] git diff --check
- [x] npm run test (fails only on two unrelated flaky tests; both pass when rerun directly: tests/unit/cli/session-issues.test.ts and tests/unit/http/http-server-utils.test.ts)

Closes #73