### PR TITLE
fix(cli): validate numeric options

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -439,7 +439,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     ? parseFiniteDecimalOption('--budget', values.budget, { min: 0 })
     : 10;
   const port = values.port !== undefined
-    ? parseIntegerOption('--port', values.port, { min: 1, max: 65535 })
+    ? parseIntegerOption('--port', values.port, { min: 0, max: 65535 })
     : (subcommand === 'chat-server' ? 3737 : subcommand === 'beasts-daemon' ? 4050 : undefined);
 
   const hasModuleFlags = values['no-firewall'] || values['no-skills'] || values['no-memory']

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -98,6 +98,8 @@ const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
+const DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const INTEGER_PATTERN = /^[+-]?\d+$/;
 
 const USAGE = `
 Usage: frankenbeast [subcommand] [options]
@@ -223,6 +225,45 @@ Examples:
 
 export function printUsage(): void {
   console.log(USAGE);
+}
+
+function parseFiniteDecimalOption(name: string, value: string, options: { min?: number } = {}): number {
+  const trimmed = value.trim();
+  if (!DECIMAL_PATTERN.test(trimmed)) {
+    throw new TypeError(`Invalid ${name}: expected a finite number, got '${value}'`);
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError(`Invalid ${name}: expected a finite number, got '${value}'`);
+  }
+
+  if (options.min !== undefined && parsed < options.min) {
+    throw new TypeError(`Invalid ${name}: expected a value >= ${options.min}, got ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseIntegerOption(name: string, value: string, options: { min?: number; max?: number } = {}): number {
+  const trimmed = value.trim();
+  if (!INTEGER_PATTERN.test(trimmed)) {
+    throw new TypeError(`Invalid ${name}: expected an integer, got '${value}'`);
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new TypeError(`Invalid ${name}: expected a safe integer, got '${value}'`);
+  }
+
+  if (options.min !== undefined && parsed < options.min) {
+    throw new TypeError(`Invalid ${name}: expected a value >= ${options.min}, got ${value}`);
+  }
+  if (options.max !== undefined && parsed > options.max) {
+    throw new TypeError(`Invalid ${name}: expected a value <= ${options.max}, got ${value}`);
+  }
+
+  return parsed;
 }
 
 export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
@@ -389,10 +430,17 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   const limitRaw = values.limit;
   let issueLimit: number | undefined;
   if (limitRaw !== undefined) {
-    issueLimit = parseInt(limitRaw, 10);
+    issueLimit = parseIntegerOption('--limit', limitRaw, { min: 1 });
   } else if (subcommand === 'issues') {
     issueLimit = 30;
   }
+
+  const budget = values.budget !== undefined
+    ? parseFiniteDecimalOption('--budget', values.budget, { min: 0 })
+    : 10;
+  const port = values.port !== undefined
+    ? parseIntegerOption('--port', values.port, { min: 1, max: 65535 })
+    : (subcommand === 'chat-server' ? 3737 : subcommand === 'beasts-daemon' ? 4050 : undefined);
 
   const hasModuleFlags = values['no-firewall'] || values['no-skills'] || values['no-memory']
     || values['no-planner'] || values['no-critique'] || values['no-governor'] || values['no-heartbeat'];
@@ -423,7 +471,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     securityTarget,
     baseDir: values['base-dir'] ?? process.cwd(),
     baseBranch: values['base-branch'],
-    budget: values.budget ? parseFloat(values.budget) : 10,
+    budget,
     provider,
     providerSpecified: values.provider !== undefined,
     providers,
@@ -435,7 +483,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     interviewOutput: values.output,
     config: values.config,
     host: values.host ?? (subcommand === 'chat-server' || subcommand === 'beasts-daemon' ? '127.0.0.1' : undefined),
-    port: values.port ? parseInt(values.port, 10) : (subcommand === 'chat-server' ? 3737 : subcommand === 'beasts-daemon' ? 4050 : undefined),
+    port,
     allowOrigin: values['allow-origin'],
     noPr: values['no-pr'] ?? false,
     verbose: values.verbose ?? false,

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -471,6 +471,9 @@ describe('parseArgs', () => {
       expect(chatArgs.budget).toBe(12.5);
       expect(chatArgs.port).toBe(4242);
 
+      const ephemeralPortArgs = parseArgs(['chat-server', '--port', '0']);
+      expect(ephemeralPortArgs.port).toBe(0);
+
       const issueArgs = parseArgs(['issues', '--limit', '50']);
       expect(issueArgs.issueLimit).toBe(50);
     });
@@ -491,7 +494,6 @@ describe('parseArgs', () => {
       ['NaN'],
       ['8080abc'],
       ['3.5'],
-      ['0'],
       ['65536'],
     ])('rejects invalid port value %s', (value) => {
       expect(() => parseArgs(['chat-server', '--port', value])).toThrow(/Invalid --port/);

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -465,4 +465,54 @@ describe('parseArgs', () => {
     });
   });
 
+  describe('numeric option validation', () => {
+    it('parses valid decimal and integer values', () => {
+      const chatArgs = parseArgs(['chat-server', '--budget', '12.5', '--port', '4242']);
+      expect(chatArgs.budget).toBe(12.5);
+      expect(chatArgs.port).toBe(4242);
+
+      const issueArgs = parseArgs(['issues', '--limit', '50']);
+      expect(issueArgs.issueLimit).toBe(50);
+    });
+
+    it.each([
+      ['NaN'],
+      ['Infinity'],
+      ['12abc'],
+    ])('rejects invalid budget value %s', (value) => {
+      expect(() => parseArgs(['--budget', value])).toThrow(/Invalid --budget/);
+    });
+
+    it('rejects a negative budget value', () => {
+      expect(() => parseArgs(['--budget=-0.01'])).toThrow(/Invalid --budget/);
+    });
+
+    it.each([
+      ['NaN'],
+      ['8080abc'],
+      ['3.5'],
+      ['0'],
+      ['65536'],
+    ])('rejects invalid port value %s', (value) => {
+      expect(() => parseArgs(['chat-server', '--port', value])).toThrow(/Invalid --port/);
+    });
+
+    it('rejects a negative port value', () => {
+      expect(() => parseArgs(['chat-server', '--port=-1'])).toThrow(/Invalid --port/);
+    });
+
+    it.each([
+      ['NaN'],
+      ['10abc'],
+      ['2.5'],
+      ['0'],
+    ])('rejects invalid issue limit value %s', (value) => {
+      expect(() => parseArgs(['issues', '--limit', value])).toThrow(/Invalid --limit/);
+    });
+
+    it('rejects a negative issue limit value', () => {
+      expect(() => parseArgs(['issues', '--limit=-1'])).toThrow(/Invalid --limit/);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
- Add centralized finite numeric and safe integer parsing for CLI flags
- Reject malformed budgets, invalid issue limits, and out-of-range ports before they reach runtime config
- Cover valid and invalid numeric inputs in CLI parser tests

## Test Plan
- npm run test --workspace packages/franken-orchestrator -- tests/unit/cli/args.test.ts
- npm run test --workspace packages/franken-orchestrator -- tests/unit/cli/session-issues.test.ts
- npm run typecheck
- npm run build
- npm run test (attempted: one franken-orchestrator test timed out in the full parallel suite, then passed when rerun directly)

Closes #413