### PR TITLE
fix(cli): split runnable skill add from scaffold

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -196,7 +196,8 @@ frankenbeast skill list
 frankenbeast skill info <name>
 frankenbeast skill enable <name>
 frankenbeast skill disable <name>
-frankenbeast skill add <name>
+frankenbeast skill add <name> <command> [args]
+frankenbeast skill scaffold <name>
 frankenbeast skill remove <name>
 ```
 

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -41,7 +41,7 @@ export type BeastAction =
   | 'delete'
   | undefined;
 
-export type SkillAction = 'list' | 'add' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
+export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
 
 export interface CliArgs {
@@ -54,6 +54,8 @@ export interface CliArgs {
   networkSet?: string[] | undefined;
   skillAction?: SkillAction;
   skillTarget?: string | undefined;
+  skillCommand?: string | undefined;
+  skillCommandArgs?: string[] | undefined;
   securityAction?: SecurityAction;
   securityTarget?: string | undefined;
   baseDir: string;
@@ -96,7 +98,7 @@ export interface CliArgs {
 const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'help']);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
-const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'remove', 'enable', 'disable', 'info']);
+const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
 
 const USAGE = `
@@ -175,7 +177,8 @@ Beast Commands:
 
 Skill Commands:
   skill list                          List installed skills
-  skill add <name>                    Install a custom skill
+  skill add <name> <command> [args]   Install a custom skill with runnable MCP command
+  skill scaffold <name>               Scaffold an incomplete custom skill for manual config
   skill remove <name>                 Remove an installed skill
   skill enable <name>                 Enable a skill
   skill disable <name>                Disable a skill
@@ -214,7 +217,8 @@ Examples:
   frankenbeast issues --label critical,high # fetch filtered issues
   frankenbeast issues --dry-run             # preview issue fetch
   frankenbeast skill list                   # list installed skills
-  frankenbeast skill add my-tool            # scaffold a new skill
+  frankenbeast skill add my-tool node -- ./server.js  # install a runnable skill
+  frankenbeast skill scaffold my-tool       # scaffold a skill for manual config
   frankenbeast skill enable my-tool         # enable a skill
   frankenbeast skill info my-tool           # show skill details
   frankenbeast security status              # show security profile
@@ -290,6 +294,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let beastTarget: string | undefined;
   let skillAction: SkillAction;
   let skillTarget: string | undefined;
+  let skillCommand: string | undefined;
+  let skillCommandArgs: string[] | undefined;
   let securityAction: SecurityAction;
   let securityTarget: string | undefined;
 
@@ -320,6 +326,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       skillAction = actionCandidate as SkillAction;
     }
     skillTarget = positionals[1];
+    skillCommand = positionals[2];
+    skillCommandArgs = positionals.length > 3 ? positionals.slice(3) : undefined;
   } else if (subcommand === 'security') {
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
@@ -419,6 +427,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     networkSet: values.set,
     skillAction,
     skillTarget,
+    skillCommand,
+    skillCommandArgs,
     securityAction,
     securityTarget,
     baseDir: values['base-dir'] ?? process.cwd(),

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -237,8 +237,9 @@ export function printUsage(): void {
   console.log(USAGE);
 }
 
-function splitSkillAddArgs(args: string[]): { parsedFlagArgs: string[]; rawSkillAddCommandArgs: string[] } {
+function splitSkillAddArgs(args: string[]): { isSkillAdd: boolean; parsedFlagArgs: string[]; rawSkillAddCommandArgs: string[] } {
   let positionalCount = 0;
+  let isSkillAdd = false;
   let commandIndex = args.length;
 
   for (let i = 0; i < args.length; i += 1) {
@@ -265,6 +266,12 @@ function splitSkillAddArgs(args: string[]): { parsedFlagArgs: string[]; rawSkill
     }
 
     positionalCount += 1;
+    if (positionalCount === 1) {
+      if (arg !== 'add') {
+        return { isSkillAdd: false, parsedFlagArgs: args, rawSkillAddCommandArgs: [] };
+      }
+      isSkillAdd = true;
+    }
     if (positionalCount === 3) {
       commandIndex = i;
       break;
@@ -277,6 +284,7 @@ function splitSkillAddArgs(args: string[]): { parsedFlagArgs: string[]; rawSkill
   }
 
   return {
+    isSkillAdd,
     parsedFlagArgs: args.slice(0, commandIndex + 1),
     rawSkillAddCommandArgs,
   };
@@ -333,10 +341,12 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
 
   let rawSkillAddCommandArgs: string[] | undefined;
   let parsedFlagArgs = flagArgs;
-  if (subcommand === 'skill' && flagArgs[0] === 'add') {
+  if (subcommand === 'skill') {
     const split = splitSkillAddArgs(flagArgs);
-    parsedFlagArgs = split.parsedFlagArgs;
-    rawSkillAddCommandArgs = split.rawSkillAddCommandArgs;
+    if (split.isSkillAdd) {
+      parsedFlagArgs = split.parsedFlagArgs;
+      rawSkillAddCommandArgs = split.rawSkillAddCommandArgs;
+    }
   }
 
   const { values, positionals } = nodeParseArgs({

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -217,7 +217,7 @@ Examples:
   frankenbeast issues --label critical,high # fetch filtered issues
   frankenbeast issues --dry-run             # preview issue fetch
   frankenbeast skill list                   # list installed skills
-  frankenbeast skill add my-tool node -- ./server.js  # install a runnable skill
+  frankenbeast skill add my-tool node ./server.js     # install a runnable skill
   frankenbeast skill scaffold my-tool       # scaffold a skill for manual config
   frankenbeast skill enable my-tool         # enable a skill
   frankenbeast skill info my-tool           # show skill details
@@ -239,8 +239,18 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     flagArgs = argv.slice(1);
   }
 
+  let rawSkillAddCommandArgs: string[] | undefined;
+  let parsedFlagArgs = flagArgs;
+  if (subcommand === 'skill' && flagArgs[0] === 'add') {
+    rawSkillAddCommandArgs = flagArgs.slice(3);
+    if (rawSkillAddCommandArgs[0] === '--') {
+      rawSkillAddCommandArgs = rawSkillAddCommandArgs.slice(1);
+    }
+    parsedFlagArgs = flagArgs.slice(0, 3);
+  }
+
   const { values, positionals } = nodeParseArgs({
-    args: flagArgs,
+    args: parsedFlagArgs,
     options: {
       detached: { type: 'boolean', short: 'd', default: false },
       'base-dir': { type: 'string' },
@@ -327,7 +337,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     }
     skillTarget = positionals[1];
     skillCommand = positionals[2];
-    skillCommandArgs = positionals.length > 3 ? positionals.slice(3) : undefined;
+    skillCommandArgs = rawSkillAddCommandArgs !== undefined
+      ? rawSkillAddCommandArgs
+      : positionals.length > 3 ? positionals.slice(3) : undefined;
   } else if (subcommand === 'security') {
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -100,6 +100,12 @@ const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
+const STRING_OPTIONS = new Set([
+  'base-dir', 'base-branch', 'budget', 'provider', 'providers', 'design-doc', 'plan-dir', 'plan-name', 'output-dir',
+  'goal', 'output', 'config', 'host', 'port', 'allow-origin', 'label', 'milestone', 'search', 'assignee', 'limit',
+  'repo', 'mode', 'set',
+]);
+const BOOLEAN_SHORT_OPTIONS = new Set(['d']);
 
 const USAGE = `
 Usage: frankenbeast [subcommand] [options]
@@ -229,6 +235,51 @@ export function printUsage(): void {
   console.log(USAGE);
 }
 
+function splitSkillAddArgs(args: string[]): { parsedFlagArgs: string[]; rawSkillAddCommandArgs: string[] } {
+  let positionalCount = 0;
+  let commandIndex = args.length;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === undefined) break;
+
+    if (arg === '--') {
+      continue;
+    }
+
+    if (positionalCount < 3 && arg.startsWith('--')) {
+      const optionName = arg.slice(2).split('=', 1)[0] ?? '';
+      if (STRING_OPTIONS.has(optionName) && !arg.includes('=')) {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (positionalCount < 3 && arg.startsWith('-') && !arg.startsWith('--')) {
+      const shortName = arg.slice(1, 2);
+      if (BOOLEAN_SHORT_OPTIONS.has(shortName)) {
+        continue;
+      }
+    }
+
+    positionalCount += 1;
+    if (positionalCount === 3) {
+      commandIndex = i;
+      break;
+    }
+  }
+
+  let rawSkillAddCommandArgs = args.slice(commandIndex + 1);
+  if (rawSkillAddCommandArgs[0] === '--') {
+    rawSkillAddCommandArgs = rawSkillAddCommandArgs.slice(1);
+  }
+
+  return {
+    parsedFlagArgs: args.slice(0, commandIndex + 1),
+    rawSkillAddCommandArgs,
+  };
+}
+
 export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   // Extract subcommand if first positional arg matches
   let subcommand: Subcommand;
@@ -242,11 +293,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let rawSkillAddCommandArgs: string[] | undefined;
   let parsedFlagArgs = flagArgs;
   if (subcommand === 'skill' && flagArgs[0] === 'add') {
-    rawSkillAddCommandArgs = flagArgs.slice(3);
-    if (rawSkillAddCommandArgs[0] === '--') {
-      rawSkillAddCommandArgs = rawSkillAddCommandArgs.slice(1);
-    }
-    parsedFlagArgs = flagArgs.slice(0, 3);
+    const split = splitSkillAddArgs(flagArgs);
+    parsedFlagArgs = split.parsedFlagArgs;
+    rawSkillAddCommandArgs = split.rawSkillAddCommandArgs;
   }
 
   const { values, positionals } = nodeParseArgs({

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -312,6 +312,8 @@ export async function main(): Promise<void> {
         skillManager,
         action: args.skillAction,
         target: args.skillTarget,
+        command: args.skillCommand,
+        commandArgs: args.skillCommandArgs,
         print: console.log,
       });
     } catch (err) {

--- a/packages/franken-orchestrator/src/cli/skill-cli.ts
+++ b/packages/franken-orchestrator/src/cli/skill-cli.ts
@@ -5,11 +5,23 @@ export interface SkillCommandDeps {
   skillManager: SkillManager;
   action?: SkillAction;
   target?: string | undefined;
+  command?: string | undefined;
+  commandArgs?: string[] | undefined;
   print(message: string): void;
 }
 
+function scaffoldCommand(name: string): { command: string; args: string[] } {
+  return {
+    command: 'node',
+    args: [
+      '-e',
+      `console.error(${JSON.stringify(`Skill '${name}' was scaffolded but is not configured. Edit skills/${name}/mcp.json with the MCP server command before enabling it.`)}); process.exit(1);`,
+    ],
+  };
+}
+
 export async function handleSkillCommand(deps: SkillCommandDeps): Promise<void> {
-  const { skillManager, action, target, print } = deps;
+  const { skillManager, action, target, command, commandArgs = [], print } = deps;
 
   switch (action) {
     case 'list': {
@@ -27,11 +39,21 @@ export async function handleSkillCommand(deps: SkillCommandDeps): Promise<void> 
     }
     case 'add': {
       if (!target) throw new Error('skill add requires a name');
-      // Create the skill directory with a placeholder mcp.json.
-      // The user must edit mcp.json to set the correct command and args.
-      await skillManager.installCustom(target, { command: 'EDIT_ME', args: [] });
-      print(`Created skill '${target}' in skills directory.`);
-      print(`Edit skills/${target}/mcp.json to configure the MCP server command.`);
+      if (!command) {
+        throw new Error('skill add requires a runnable MCP server command. Use `skill scaffold <name>` to create an incomplete template.');
+      }
+      await skillManager.installCustom(target, { command, args: commandArgs });
+      print(`Installed skill '${target}' with MCP command '${command}'.`);
+      if (commandArgs.length > 0) {
+        print(`Arguments: ${commandArgs.join(' ')}`);
+      }
+      return;
+    }
+    case 'scaffold': {
+      if (!target) throw new Error('skill scaffold requires a name');
+      await skillManager.installCustom(target, scaffoldCommand(target));
+      print(`Scaffolded incomplete skill '${target}' in skills directory.`);
+      print(`Edit skills/${target}/mcp.json with the real MCP server command before enabling it.`);
       return;
     }
     case 'remove': {
@@ -61,6 +83,6 @@ export async function handleSkillCommand(deps: SkillCommandDeps): Promise<void> 
       return;
     }
     default:
-      throw new Error('Usage: frankenbeast skill <list|add|remove|enable|disable|info> [name]');
+      throw new Error('Usage: frankenbeast skill <list|add|scaffold|remove|enable|disable|info> [name]');
   }
 }

--- a/packages/franken-orchestrator/tests/integration/cli/skill-command.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/skill-command.test.ts
@@ -16,7 +16,7 @@ describe('skill CLI integration', () => {
     cleanups.length = 0;
   });
 
-  it('adds, enables, lists, and inspects a skill through the real file-backed manager', async () => {
+  it('adds, enables, lists, and inspects a runnable skill through the real file-backed manager', async () => {
     const root = mkdtempSync(join(tmpdir(), 'skill-cli-'));
     cleanups.push(root);
 
@@ -26,19 +26,48 @@ describe('skill CLI integration', () => {
     const printed: string[] = [];
     const print = (message: string) => printed.push(message);
 
-    await handleSkillCommand({ skillManager: manager, action: 'add', target: 'github', print });
+    await handleSkillCommand({
+      skillManager: manager,
+      action: 'add',
+      target: 'github',
+      command: 'node',
+      commandArgs: ['server.js', '--stdio'],
+      print,
+    });
     await handleSkillCommand({ skillManager: manager, action: 'enable', target: 'github', print });
     await handleSkillCommand({ skillManager: manager, action: 'list', print });
     await handleSkillCommand({ skillManager: manager, action: 'info', target: 'github', print });
 
     expect(manager.exists('github')).toBe(true);
     expect(manager.getEnabledSkills()).toEqual(['github']);
-    expect(printed).toContain("Created skill 'github' in skills directory.");
+    expect(printed).toContain("Installed skill 'github' with MCP command 'node'.");
     expect(printed).toContain("Enabled skill 'github'");
     expect(printed).toContain('  [on] github');
 
     const info = JSON.parse(printed.at(-1) ?? '{}');
     expect(info.name).toBe('github');
-    expect(info.mcpConfig.mcpServers.github.command).toBe('EDIT_ME');
+    expect(info.mcpConfig.mcpServers.github.command).toBe('node');
+    expect(info.mcpConfig.mcpServers.github.args).toEqual(['server.js', '--stdio']);
+  });
+
+  it('scaffolds an explicitly incomplete skill through the real file-backed manager', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'skill-cli-'));
+    cleanups.push(root);
+
+    const skillsDir = join(root, 'skills');
+    const configDir = join(root, '.fbeast');
+    const manager = new SkillManager(skillsDir, new Set(), new SkillConfigStore(configDir));
+    const printed: string[] = [];
+    const print = (message: string) => printed.push(message);
+
+    await handleSkillCommand({ skillManager: manager, action: 'scaffold', target: 'github', print });
+    await handleSkillCommand({ skillManager: manager, action: 'info', target: 'github', print });
+
+    expect(manager.exists('github')).toBe(true);
+    expect(printed).toContain("Scaffolded incomplete skill 'github' in skills directory.");
+
+    const info = JSON.parse(printed.at(-1) ?? '{}');
+    expect(info.mcpConfig.mcpServers.github.command).toBe('node');
+    expect(info.mcpConfig.mcpServers.github.args.join(' ')).toContain('was scaffolded but is not configured');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -383,10 +383,27 @@ describe('parseArgs', () => {
       expect(args.skillAction).toBe('list');
     });
 
-    it('parses skill add with target', () => {
-      const args = parseArgs(['skill', 'add', 'my-skill']);
+    it('parses skill add with target and runnable command', () => {
+      const args = parseArgs(['skill', 'add', 'my-skill', 'node', 'server.js']);
       expect(args.subcommand).toBe('skill');
       expect(args.skillAction).toBe('add');
+      expect(args.skillTarget).toBe('my-skill');
+      expect(args.skillCommand).toBe('node');
+      expect(args.skillCommandArgs).toEqual(['server.js']);
+    });
+
+    it('parses skill add command args after a delimiter', () => {
+      const args = parseArgs(['skill', 'add', 'my-skill', 'npx', '--', '-y', '@acme/mcp-server']);
+      expect(args.skillAction).toBe('add');
+      expect(args.skillTarget).toBe('my-skill');
+      expect(args.skillCommand).toBe('npx');
+      expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server']);
+    });
+
+    it('parses skill scaffold with target', () => {
+      const args = parseArgs(['skill', 'scaffold', 'my-skill']);
+      expect(args.subcommand).toBe('skill');
+      expect(args.skillAction).toBe('scaffold');
       expect(args.skillTarget).toBe('my-skill');
     });
 

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -392,7 +392,16 @@ describe('parseArgs', () => {
       expect(args.skillCommandArgs).toEqual(['server.js']);
     });
 
-    it('parses skill add command args after a delimiter', () => {
+    it('preserves option-like skill add command args without a delimiter', () => {
+      const args = parseArgs(['skill', 'add', 'my-skill', 'npx', '-y', '@acme/mcp-server', '--verbose']);
+      expect(args.skillAction).toBe('add');
+      expect(args.skillTarget).toBe('my-skill');
+      expect(args.skillCommand).toBe('npx');
+      expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server', '--verbose']);
+      expect(args.verbose).toBe(false);
+    });
+
+    it('parses skill add command args after an optional delimiter', () => {
       const args = parseArgs(['skill', 'add', 'my-skill', 'npx', '--', '-y', '@acme/mcp-server']);
       expect(args.skillAction).toBe('add');
       expect(args.skillTarget).toBe('my-skill');

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -401,6 +401,15 @@ describe('parseArgs', () => {
       expect(args.verbose).toBe(false);
     });
 
+    it('parses global options between skill add and the skill name', () => {
+      const args = parseArgs(['skill', 'add', '--base-dir', '/tmp/beast', 'my-skill', 'npx', '-y', '@acme/mcp-server']);
+      expect(args.skillAction).toBe('add');
+      expect(args.baseDir).toBe('/tmp/beast');
+      expect(args.skillTarget).toBe('my-skill');
+      expect(args.skillCommand).toBe('npx');
+      expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server']);
+    });
+
     it('parses skill add command args after an optional delimiter', () => {
       const args = parseArgs(['skill', 'add', 'my-skill', 'npx', '--', '-y', '@acme/mcp-server']);
       expect(args.skillAction).toBe('add');

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -410,6 +410,16 @@ describe('parseArgs', () => {
       expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server']);
     });
 
+    it('preserves skill add command args when global options precede add', () => {
+      const args = parseArgs(['skill', '--base-dir', '/tmp/beast', 'add', 'my-skill', 'npx', '-y', '@acme/mcp-server', '--verbose']);
+      expect(args.skillAction).toBe('add');
+      expect(args.baseDir).toBe('/tmp/beast');
+      expect(args.skillTarget).toBe('my-skill');
+      expect(args.skillCommand).toBe('npx');
+      expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server', '--verbose']);
+      expect(args.verbose).toBe(false);
+    });
+
     it('parses skill add command args after an optional delimiter', () => {
       const args = parseArgs(['skill', 'add', 'my-skill', 'npx', '--', '-y', '@acme/mcp-server']);
       expect(args.skillAction).toBe('add');

--- a/packages/franken-orchestrator/tests/unit/cli/skill-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/skill-cli.test.ts
@@ -45,16 +45,50 @@ describe('handleSkillCommand()', () => {
     expect(print).toHaveBeenCalledWith('No skills installed.');
   });
 
-  it('adds a skill by name', async () => {
+  it('adds a runnable skill by name and command', async () => {
     const print = vi.fn();
     const installCustom = vi.fn().mockResolvedValue(undefined);
     const skillManager = createMockSkillManager({ installCustom });
 
-    await handleSkillCommand({ skillManager, action: 'add', target: 'my-skill', print });
+    await handleSkillCommand({
+      skillManager,
+      action: 'add',
+      target: 'my-skill',
+      command: 'node',
+      commandArgs: ['server.js', '--stdio'],
+      print,
+    });
 
-    expect(installCustom).toHaveBeenCalledWith('my-skill', { command: 'EDIT_ME', args: [] });
-    expect(print).toHaveBeenCalledWith("Created skill 'my-skill' in skills directory.");
-    expect(print).toHaveBeenCalledWith(expect.stringContaining('Edit skills/my-skill/mcp.json'));
+    expect(installCustom).toHaveBeenCalledWith('my-skill', { command: 'node', args: ['server.js', '--stdio'] });
+    expect(print).toHaveBeenCalledWith("Installed skill 'my-skill' with MCP command 'node'.");
+    expect(print).toHaveBeenCalledWith('Arguments: server.js --stdio');
+  });
+
+  it('rejects skill add without a runnable command', async () => {
+    const print = vi.fn();
+    const skillManager = createMockSkillManager();
+
+    await expect(
+      handleSkillCommand({ skillManager, action: 'add', target: 'my-skill', print }),
+    ).rejects.toThrow('skill add requires a runnable MCP server command');
+  });
+
+  it('scaffolds an incomplete skill with an explicit failing command', async () => {
+    const print = vi.fn();
+    const installCustom = vi.fn().mockResolvedValue(undefined);
+    const skillManager = createMockSkillManager({ installCustom });
+
+    await handleSkillCommand({ skillManager, action: 'scaffold', target: 'my-skill', print });
+
+    expect(installCustom).toHaveBeenCalledWith('my-skill', {
+      command: 'node',
+      args: [
+        '-e',
+        expect.stringContaining("Skill 'my-skill' was scaffolded but is not configured"),
+      ],
+    });
+    expect(print).toHaveBeenCalledWith("Scaffolded incomplete skill 'my-skill' in skills directory.");
+    expect(print).toHaveBeenCalledWith(expect.stringContaining('real MCP server command'));
   });
 
   it('throws when add has no target', async () => {
@@ -64,6 +98,15 @@ describe('handleSkillCommand()', () => {
     await expect(
       handleSkillCommand({ skillManager, action: 'add', print }),
     ).rejects.toThrow('skill add requires a name');
+  });
+
+  it('throws when scaffold has no target', async () => {
+    const print = vi.fn();
+    const skillManager = createMockSkillManager();
+
+    await expect(
+      handleSkillCommand({ skillManager, action: 'scaffold', print }),
+    ).rejects.toThrow('skill scaffold requires a name');
   });
 
   it('removes a skill by name', async () => {


### PR DESCRIPTION
## Summary
- make `frankenbeast skill add <name> <command> [args]` install a runnable MCP skill instead of writing an `EDIT_ME` placeholder
- add explicit `frankenbeast skill scaffold <name>` for intentionally incomplete/manual skill templates
- update CLI usage/docs and unit/integration coverage for add/scaffold behavior

## Test Plan
- [x] `npm run test --workspace packages/franken-orchestrator -- tests/unit/cli/skill-cli.test.ts tests/integration/cli/skill-command.test.ts tests/unit/cli/args.test.ts`
- [x] `npm run typecheck --workspace packages/franken-orchestrator`
- [x] `npm run build --workspace packages/franken-orchestrator`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test`
- [x] `git diff --check`

Closes #404
