### PR TITLE
fix(cli): auto-detect smart resume state

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -26,7 +26,7 @@ import { createCliDeps } from './dep-factory.js';
 import { createDefaultRegistry } from '../skills/providers/cli-provider.js';
 import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
 import { CliLlmAdapter } from '../adapters/cli-llm-adapter.js';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { startChatServer } from '../http/chat-server.js';
 import { createSqliteAnalyticsService } from '../analytics/sqlite-analytics-service.js';
@@ -108,6 +108,7 @@ export function resolvePhases(args: Partial<Pick<CliArgs, 'subcommand' | 'design
 export interface ResumeTarget {
   planName: string;
   checkpointFile: string;
+  planDir?: string;
 }
 
 export function discoverResumeTarget(root: string): ResumeTarget | undefined {
@@ -116,6 +117,7 @@ export function discoverResumeTarget(root: string): ResumeTarget | undefined {
 
   try {
     for (const entry of readdirSync(buildDir)) {
+      if (entry === '.checkpoint') continue;
       if (!entry.endsWith('.checkpoint')) continue;
       const checkpointFile = join(buildDir, entry);
       const stats = statSync(checkpointFile);
@@ -130,15 +132,30 @@ export function discoverResumeTarget(root: string): ResumeTarget | undefined {
 
   if (!newest) return undefined;
 
-  const fileName = newest.checkpointFile.split('/').pop() ?? '';
+  const fileName = basename(newest.checkpointFile);
   const planName = fileName.replace(/\.checkpoint$/i, '');
-  if (!planName || planName === '.checkpoint') return undefined;
+  if (!planName) return undefined;
 
-  return { planName, checkpointFile: newest.checkpointFile };
+  const scopedPlanDir = join(root, '.fbeast', 'plans', planName);
+  const customPlanDir = join(root, planName);
+  const planDir = !existsSync(scopedPlanDir) && existsSync(customPlanDir)
+    ? customPlanDir
+    : undefined;
+
+  return { planName, checkpointFile: newest.checkpointFile, ...(planDir ? { planDir } : {}) };
+}
+
+function isConventionalBaseBranch(branch: string): boolean {
+  return /^(main|master|trunk|develop|dev|release(?:\/.*)?)$/.test(branch);
 }
 
 export function inferResumeBaseBranch(root: string): string {
   try {
+    const currentBranch = execFileSync('git', ['branch', '--show-current'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
     const reflog = execFileSync('git', ['reflog', '--format=%gs'], {
       cwd: root,
       encoding: 'utf-8',
@@ -146,8 +163,13 @@ export function inferResumeBaseBranch(root: string): string {
     });
     for (const line of reflog.split('\n')) {
       const match = /^checkout: moving from (\S+) to (\S+)$/.exec(line.trim());
-      if (match?.[1] && match[1] !== 'HEAD') {
-        return match[1];
+      if (!match) continue;
+      const [, fromBranch, toBranch] = match;
+      if (toBranch === currentBranch && isConventionalBaseBranch(toBranch)) {
+        return toBranch;
+      }
+      if (fromBranch && fromBranch !== 'HEAD') {
+        return fromBranch;
       }
     }
   } catch {
@@ -302,9 +324,12 @@ export async function main(): Promise<void> {
   const resumeTarget = args.resume && !args.planDir && !args.planName
     ? discoverResumeTarget(root)
     : undefined;
+  const planDirOverride = args.planDir ?? resumeTarget?.planDir;
 
   // Resolve project root — scope plans by name unless --plan-dir overrides
-  const planName = args.planDir ? undefined : (args.planName ?? resumeTarget?.planName ?? generatePlanName(args.designDoc));
+  const planName = planDirOverride
+    ? undefined
+    : (args.planName ?? resumeTarget?.planName ?? generatePlanName(args.designDoc));
   const paths = getProjectPaths(root, planName);
   const config = await resolveConfig(args, paths.configFile);
 
@@ -574,7 +599,9 @@ export async function main(): Promise<void> {
     entryPhase,
     ...(exitAfter !== undefined ? { exitAfter } : {}),
     ...(args.designDoc !== undefined ? { designDocPath: args.designDoc } : {}),
-    ...(args.planDir !== undefined ? { planDirOverride: args.planDir } : {}),
+    ...(planDirOverride !== undefined
+      ? { planDirOverride }
+      : {}),
     // Issue-specific config
     issueLabel: args.issueLabel,
     issueMilestone: args.issueMilestone,

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -110,9 +110,10 @@ export interface ResumeTarget {
   planName: string;
   checkpointFile: string;
   planDir?: string;
+  ambiguousPlanDir?: boolean;
 }
 
-function findUniquePlanDirByBasename(root: string, planName: string): string | undefined {
+function findUniquePlanDirByBasename(root: string, planName: string): string | undefined | null {
   const skip = new Set(['.git', '.fbeast', 'node_modules']);
   const matches: string[] = [];
 
@@ -143,7 +144,8 @@ function findUniquePlanDirByBasename(root: string, planName: string): string | u
   }
 
   visit(root);
-  return matches.length === 1 ? matches[0] : undefined;
+  if (matches.length === 0) return undefined;
+  return matches.length === 1 ? matches[0] : null;
 }
 
 export function discoverResumeTarget(root: string): ResumeTarget | undefined {
@@ -174,19 +176,28 @@ export function discoverResumeTarget(root: string): ResumeTarget | undefined {
   const scopedPlanDir = join(root, '.fbeast', 'plans', planName);
   const fbeastPlanDir = join(root, '.fbeast', planName);
   const customPlanDir = join(root, planName);
+  const nestedPlanDir = !existsSync(scopedPlanDir) && !existsSync(customPlanDir) && !existsSync(fbeastPlanDir)
+    ? findUniquePlanDirByBasename(root, planName)
+    : undefined;
   const planDir = !existsSync(scopedPlanDir) && existsSync(customPlanDir)
     ? customPlanDir
     : !existsSync(scopedPlanDir) && existsSync(fbeastPlanDir)
       ? fbeastPlanDir
-    : !existsSync(scopedPlanDir)
-      ? findUniquePlanDirByBasename(root, planName)
-    : undefined;
+    : nestedPlanDir ?? undefined;
+
+  if (nestedPlanDir === null) {
+    return { planName, checkpointFile: newest.checkpointFile, ambiguousPlanDir: true };
+  }
 
   return { planName, checkpointFile: newest.checkpointFile, ...(planDir ? { planDir } : {}) };
 }
 
-function isConventionalBaseBranch(branch: string): boolean {
-  return /^(main|master|trunk|develop|dev|release(?:\/.*)?)$/.test(branch);
+function ensureResumeTargetIsUsable(resumeTarget: ResumeTarget | undefined): void {
+  if (resumeTarget?.ambiguousPlanDir) {
+    throw new Error(
+      `Multiple custom plan directories named "${resumeTarget.planName}" match ${resumeTarget.checkpointFile}; pass --plan-dir explicitly to resume this checkpoint.`,
+    );
+  }
 }
 
 function branchExists(root: string, branch: string): boolean {
@@ -197,16 +208,12 @@ function branchExists(root: string, branch: string): boolean {
     });
     return true;
   } catch {
-    try {
-      execFileSync('git', ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`], {
-        cwd: root,
-        stdio: 'ignore',
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    return false;
   }
+}
+
+function isConventionalBaseBranch(branch: string): boolean {
+  return /^(main|master|trunk|develop|dev|release(?:\/.*)?)$/.test(branch);
 }
 
 export function inferResumeBaseBranch(root: string): string | undefined {
@@ -236,11 +243,12 @@ export function inferResumeBaseBranch(root: string): string | undefined {
     const originalBaseBranch = candidateBaseBranches.at(-1);
     if (originalBaseBranch) return originalBaseBranch;
   } catch {
-    // Fall through to the conventional default when reflog is unavailable.
+    // Fall through to the normal base-branch resolver when reflog is unavailable.
   }
 
   return undefined;
 }
+
 
 /**
  * Validates config path and loads config from all sources.
@@ -500,6 +508,7 @@ export async function main(): Promise<void> {
   const resumeTarget = args.resume && !args.planDir && !args.planName && (!args.subcommand || args.subcommand === 'run')
     ? discoverResumeTarget(root)
     : undefined;
+  ensureResumeTargetIsUsable(resumeTarget);
   const planDirOverride = args.planDir ?? resumeTarget?.planDir;
 
   // Resolve project root — scope plans by name unless --plan-dir overrides

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -185,7 +185,7 @@ function isConventionalBaseBranch(branch: string): boolean {
   return /^(main|master|trunk|develop|dev|release(?:\/.*)?)$/.test(branch);
 }
 
-export function inferResumeBaseBranch(root: string): string {
+export function inferResumeBaseBranch(root: string): string | undefined {
   try {
     const currentBranch = execFileSync('git', ['branch', '--show-current'], {
       cwd: root,
@@ -215,7 +215,7 @@ export function inferResumeBaseBranch(root: string): string {
     // Fall through to the conventional default when reflog is unavailable.
   }
 
-  return 'main';
+  return undefined;
 }
 
 /**
@@ -360,7 +360,7 @@ export async function main(): Promise<void> {
     console.log(await renderBanner(root));
   }
 
-  const resumeTarget = args.resume && !args.planDir && !args.planName
+  const resumeTarget = args.resume && !args.planDir && !args.planName && (!args.subcommand || args.subcommand === 'run')
     ? discoverResumeTarget(root)
     : undefined;
   const planDirOverride = args.planDir ?? resumeTarget?.planDir;
@@ -368,6 +368,8 @@ export async function main(): Promise<void> {
   // Resolve project root — scope plans by name unless --plan-dir overrides
   const planName = planDirOverride
     ? undefined
+    : args.subcommand === 'issues'
+      ? undefined
     : (args.planName ?? resumeTarget?.planName ?? generatePlanName(args.designDoc));
   const paths = getProjectPaths(root, planName);
   const config = await resolveConfig(args, paths.configFile);
@@ -614,7 +616,7 @@ export async function main(): Promise<void> {
   // feature branch, so infer the original base from git reflog unless the
   // user supplied an explicit --base-branch override.
   const baseBranch = args.resume && !args.baseBranch
-    ? inferResumeBaseBranch(root)
+    ? (inferResumeBaseBranch(root) ?? await resolveBaseBranch(root, args.baseBranch, io))
     : await resolveBaseBranch(root, args.baseBranch, io);
 
   // Determine phases

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -2,8 +2,8 @@
 
 import { mkdir, open, readFile, writeFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
-import { existsSync } from 'node:fs';
-import { spawn } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
 import { handleBeastCommand } from './beast-cli.js';
@@ -72,7 +72,7 @@ export function createStdinIO(): InterviewIO & { close(): void } {
  * Determines entry phase and exit behavior from CLI args.
  * Subcommand takes precedence, then flags, then default.
  */
-export function resolvePhases(args: Pick<CliArgs, 'subcommand' | 'designDoc' | 'planDir'>): {
+export function resolvePhases(args: Partial<Pick<CliArgs, 'subcommand' | 'designDoc' | 'planDir' | 'resume'>>): {
   entryPhase: SessionPhase;
   exitAfter?: SessionPhase;
 } {
@@ -91,6 +91,9 @@ export function resolvePhases(args: Pick<CliArgs, 'subcommand' | 'designDoc' | '
   }
 
   // Default mode — detect entry from provided files
+  if (args.resume) {
+    return { entryPhase: 'execute' };
+  }
   if (args.planDir) {
     return { entryPhase: 'execute' };
   }
@@ -100,6 +103,58 @@ export function resolvePhases(args: Pick<CliArgs, 'subcommand' | 'designDoc' | '
 
   // No files, no subcommand — full interactive flow
   return { entryPhase: 'interview' };
+}
+
+export interface ResumeTarget {
+  planName: string;
+  checkpointFile: string;
+}
+
+export function discoverResumeTarget(root: string): ResumeTarget | undefined {
+  const buildDir = join(root, '.fbeast', '.build');
+  let newest: { checkpointFile: string; mtimeMs: number } | undefined;
+
+  try {
+    for (const entry of readdirSync(buildDir)) {
+      if (!entry.endsWith('.checkpoint')) continue;
+      const checkpointFile = join(buildDir, entry);
+      const stats = statSync(checkpointFile);
+      if (!stats.isFile()) continue;
+      if (!newest || stats.mtimeMs > newest.mtimeMs) {
+        newest = { checkpointFile, mtimeMs: stats.mtimeMs };
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  if (!newest) return undefined;
+
+  const fileName = newest.checkpointFile.split('/').pop() ?? '';
+  const planName = fileName.replace(/\.checkpoint$/i, '');
+  if (!planName || planName === '.checkpoint') return undefined;
+
+  return { planName, checkpointFile: newest.checkpointFile };
+}
+
+export function inferResumeBaseBranch(root: string): string {
+  try {
+    const reflog = execFileSync('git', ['reflog', '--format=%gs'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    for (const line of reflog.split('\n')) {
+      const match = /^checkout: moving from (\S+) to (\S+)$/.exec(line.trim());
+      if (match?.[1] && match[1] !== 'HEAD') {
+        return match[1];
+      }
+    }
+  } catch {
+    // Fall through to the conventional default when reflog is unavailable.
+  }
+
+  return 'main';
 }
 
 /**
@@ -244,8 +299,12 @@ export async function main(): Promise<void> {
     console.log(await renderBanner(root));
   }
 
+  const resumeTarget = args.resume && !args.planDir && !args.planName
+    ? discoverResumeTarget(root)
+    : undefined;
+
   // Resolve project root — scope plans by name unless --plan-dir overrides
-  const planName = args.planDir ? undefined : (args.planName ?? generatePlanName(args.designDoc));
+  const planName = args.planDir ? undefined : (args.planName ?? resumeTarget?.planName ?? generatePlanName(args.designDoc));
   const paths = getProjectPaths(root, planName);
   const config = await resolveConfig(args, paths.configFile);
 
@@ -258,6 +317,10 @@ export async function main(): Promise<void> {
 
   if (args.verbose) {
     console.log('Config:', JSON.stringify(config, null, 2));
+  }
+
+  if (resumeTarget) {
+    logger.info(`Resuming ${resumeTarget.planName} from ${resumeTarget.checkpointFile}`, 'session');
   }
 
   scaffoldFrankenbeast(paths);
@@ -483,8 +546,12 @@ export async function main(): Promise<void> {
   // Create IO for non-chat interactive prompts (chat owns its own readline)
   const io = createStdinIO();
 
-  // Resolve base branch
-  const baseBranch = await resolveBaseBranch(root, args.baseBranch, io);
+  // Resolve base branch. Resume usually starts from the interrupted run's
+  // feature branch, so infer the original base from git reflog unless the
+  // user supplied an explicit --base-branch override.
+  const baseBranch = args.resume && !args.baseBranch
+    ? inferResumeBaseBranch(root)
+    : await resolveBaseBranch(root, args.baseBranch, io);
 
   // Determine phases
   const { entryPhase, exitAfter } = resolvePhases(args);

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -111,6 +111,40 @@ export interface ResumeTarget {
   planDir?: string;
 }
 
+function findUniquePlanDirByBasename(root: string, planName: string): string | undefined {
+  const skip = new Set(['.git', '.fbeast', 'node_modules']);
+  const matches: string[] = [];
+
+  function visit(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (skip.has(entry)) continue;
+      const path = join(dir, entry);
+      let stats;
+      try {
+        stats = statSync(path);
+      } catch {
+        continue;
+      }
+      if (!stats.isDirectory()) continue;
+      if (entry === planName) {
+        matches.push(path);
+        continue;
+      }
+      visit(path);
+    }
+  }
+
+  visit(root);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 export function discoverResumeTarget(root: string): ResumeTarget | undefined {
   const buildDir = join(root, '.fbeast', '.build');
   let newest: { checkpointFile: string; mtimeMs: number } | undefined;
@@ -140,6 +174,8 @@ export function discoverResumeTarget(root: string): ResumeTarget | undefined {
   const customPlanDir = join(root, planName);
   const planDir = !existsSync(scopedPlanDir) && existsSync(customPlanDir)
     ? customPlanDir
+    : !existsSync(scopedPlanDir)
+      ? findUniquePlanDirByBasename(root, planName)
     : undefined;
 
   return { planName, checkpointFile: newest.checkpointFile, ...(planDir ? { planDir } : {}) };
@@ -161,6 +197,7 @@ export function inferResumeBaseBranch(root: string): string {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });
+    const candidateBaseBranches: string[] = [];
     for (const line of reflog.split('\n')) {
       const match = /^checkout: moving from (\S+) to (\S+)$/.exec(line.trim());
       if (!match) continue;
@@ -168,10 +205,12 @@ export function inferResumeBaseBranch(root: string): string {
       if (toBranch === currentBranch && isConventionalBaseBranch(toBranch)) {
         return toBranch;
       }
-      if (fromBranch && fromBranch !== 'HEAD' && isConventionalBaseBranch(fromBranch)) {
-        return fromBranch;
+      if (toBranch === currentBranch && fromBranch && fromBranch !== 'HEAD' && isConventionalBaseBranch(fromBranch)) {
+        candidateBaseBranches.push(fromBranch);
       }
     }
+    const originalBaseBranch = candidateBaseBranches.at(-1);
+    if (originalBaseBranch) return originalBaseBranch;
   } catch {
     // Fall through to the conventional default when reflog is unavailable.
   }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -168,7 +168,7 @@ export function inferResumeBaseBranch(root: string): string {
       if (toBranch === currentBranch && isConventionalBaseBranch(toBranch)) {
         return toBranch;
       }
-      if (fromBranch && fromBranch !== 'HEAD') {
+      if (fromBranch && fromBranch !== 'HEAD' && isConventionalBaseBranch(fromBranch)) {
         return fromBranch;
       }
     }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -2,7 +2,7 @@
 
 import { mkdir, open, readFile, writeFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, statSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
@@ -128,7 +128,7 @@ function findUniquePlanDirByBasename(root: string, planName: string): string | u
       const path = join(dir, entry);
       let stats;
       try {
-        stats = statSync(path);
+        stats = lstatSync(path);
       } catch {
         continue;
       }
@@ -171,9 +171,12 @@ export function discoverResumeTarget(root: string): ResumeTarget | undefined {
   if (!planName) return undefined;
 
   const scopedPlanDir = join(root, '.fbeast', 'plans', planName);
+  const fbeastPlanDir = join(root, '.fbeast', planName);
   const customPlanDir = join(root, planName);
   const planDir = !existsSync(scopedPlanDir) && existsSync(customPlanDir)
     ? customPlanDir
+    : !existsSync(scopedPlanDir) && existsSync(fbeastPlanDir)
+      ? fbeastPlanDir
     : !existsSync(scopedPlanDir)
       ? findUniquePlanDirByBasename(root, planName)
     : undefined;
@@ -183,6 +186,26 @@ export function discoverResumeTarget(root: string): ResumeTarget | undefined {
 
 function isConventionalBaseBranch(branch: string): boolean {
   return /^(main|master|trunk|develop|dev|release(?:\/.*)?)$/.test(branch);
+}
+
+function branchExists(root: string, branch: string): boolean {
+  try {
+    execFileSync('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`], {
+      cwd: root,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    try {
+      execFileSync('git', ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`], {
+        cwd: root,
+        stdio: 'ignore',
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }
 
 export function inferResumeBaseBranch(root: string): string | undefined {
@@ -202,10 +225,10 @@ export function inferResumeBaseBranch(root: string): string | undefined {
       const match = /^checkout: moving from (\S+) to (\S+)$/.exec(line.trim());
       if (!match) continue;
       const [, fromBranch, toBranch] = match;
-      if (toBranch === currentBranch && isConventionalBaseBranch(toBranch)) {
+      if (toBranch === currentBranch && isConventionalBaseBranch(toBranch) && branchExists(root, toBranch)) {
         return toBranch;
       }
-      if (toBranch === currentBranch && fromBranch && fromBranch !== 'HEAD' && isConventionalBaseBranch(fromBranch)) {
+      if (toBranch === currentBranch && fromBranch && fromBranch !== 'HEAD' && isConventionalBaseBranch(fromBranch) && branchExists(root, fromBranch)) {
         candidateBaseBranches.push(fromBranch);
       }
     }
@@ -368,9 +391,9 @@ export async function main(): Promise<void> {
   // Resolve project root — scope plans by name unless --plan-dir overrides
   const planName = planDirOverride
     ? undefined
-    : args.subcommand === 'issues'
+    : (args.planName ?? (args.subcommand === 'issues'
       ? undefined
-    : (args.planName ?? resumeTarget?.planName ?? generatePlanName(args.designDoc));
+      : (resumeTarget?.planName ?? generatePlanName(args.designDoc))));
   const paths = getProjectPaths(root, planName);
   const config = await resolveConfig(args, paths.configFile);
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 // ── Hoisted mocks (available inside vi.mock factories) ──
 
@@ -301,6 +302,45 @@ describe('discoverResumeTarget', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('ignores newer legacy checkpoints when selecting a plan-scoped checkpoint', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-legacy-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    mkdirSync(buildDir, { recursive: true });
+
+    const legacy = join(buildDir, '.checkpoint');
+    const scoped = join(buildDir, 'plan-existing.checkpoint');
+    writeFileSync(scoped, 'impl:01:done');
+    writeFileSync(legacy, 'impl:02:done');
+    utimesSync(scoped, new Date('2026-03-07T00:00:00Z'), new Date('2026-03-07T00:00:00Z'));
+    utimesSync(legacy, new Date('2026-03-09T00:00:00Z'), new Date('2026-03-09T00:00:00Z'));
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'plan-existing',
+      checkpointFile: scoped,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('preserves a custom plan directory when a matching root directory exists', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-custom-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    const customPlanDir = join(root, 'chunks');
+    mkdirSync(buildDir, { recursive: true });
+    mkdirSync(customPlanDir, { recursive: true });
+
+    const checkpoint = join(buildDir, 'chunks.checkpoint');
+    writeFileSync(checkpoint, 'impl:01:done');
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'chunks',
+      checkpointFile: checkpoint,
+      planDir: customPlanDir,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('returns undefined when no plan-scoped checkpoints exist', () => {
     const root = join(tmpdir(), `frankenbeast-resume-empty-${Date.now()}`);
     mkdirSync(join(root, '.fbeast', '.build'), { recursive: true });
@@ -313,6 +353,35 @@ describe('discoverResumeTarget', () => {
   it('falls back to main when resume base-branch reflog inference is unavailable', () => {
     const root = join(tmpdir(), `frankenbeast-resume-no-git-${Date.now()}`);
     mkdirSync(root, { recursive: true });
+
+    expect(inferResumeBaseBranch(root)).toBe('main');
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('infers the pre-feature base branch while currently on a feature branch', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-git-feature-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'ignore' });
+    writeFileSync(join(root, 'README.md'), 'test');
+    execFileSync('git', ['add', 'README.md'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+
+    expect(inferResumeBaseBranch(root)).toBe('main');
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('uses the current base branch after checkout returns from a feature branch', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-git-base-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'ignore' });
+    writeFileSync(join(root, 'README.md'), 'test');
+    execFileSync('git', ['add', 'README.md'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', 'main'], { cwd: root, stdio: 'ignore' });
 
     expect(inferResumeBaseBranch(root)).toBe('main');
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -387,6 +387,22 @@ describe('discoverResumeTarget', () => {
 
     rmSync(root, { recursive: true, force: true });
   });
+
+  it('ignores prior feature branches while inferring the resume base branch', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-git-feature-to-feature-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'ignore' });
+    writeFileSync(join(root, 'README.md'), 'test');
+    execFileSync('git', ['add', 'README.md'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', 'main'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'feat/chunk-05'], { cwd: root, stdio: 'ignore' });
+
+    expect(inferResumeBaseBranch(root)).toBe('main');
+
+    rmSync(root, { recursive: true, force: true });
+  });
 });
 
 describe('createStdinIO', () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -71,8 +71,10 @@ const {
     initNonInteractive: false,
   }));
   const mockSessionStart = vi.fn(async () => ({ status: 'completed' as const }));
-  const MockSession = vi.fn(function (this: { start: typeof mockSessionStart }) {
+  const mockSessionRunIssues = vi.fn(async () => ({ status: 'completed' as const }));
+  const MockSession = vi.fn(function (this: { start: typeof mockSessionStart; runIssues: typeof mockSessionRunIssues }) {
     this.start = mockSessionStart;
+    this.runIssues = mockSessionRunIssues;
   });
   const mockStartChatServer = vi.fn(async () => ({
     url: 'http://127.0.0.1:3737',
@@ -369,11 +371,11 @@ describe('discoverResumeTarget', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('falls back to main when resume base-branch reflog inference is unavailable', () => {
+  it('defers to the normal base resolver when resume base-branch reflog inference is unavailable', () => {
     const root = join(tmpdir(), `frankenbeast-resume-no-git-${Date.now()}`);
     mkdirSync(root, { recursive: true });
 
-    expect(inferResumeBaseBranch(root)).toBe('main');
+    expect(inferResumeBaseBranch(root)).toBeUndefined();
 
     rmSync(root, { recursive: true, force: true });
   });
@@ -697,13 +699,64 @@ describe('main() execution', () => {
     await main();
 
     expect(getProjectPaths).toHaveBeenCalledWith(root, 'plan-2026-03-07-pluggable-providers');
-    expect(resolveBaseBranch).not.toHaveBeenCalled();
+    expect(resolveBaseBranch).toHaveBeenCalledWith(root, undefined, expect.any(Object));
     expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
       baseBranch: 'main',
       entryPhase: 'execute',
       resume: true,
       paths: expect.objectContaining({
         plansDir: `${root}/.fbeast/plans/plan-2026-03-07-pluggable-providers`,
+      }),
+    }));
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not scope issue resumes to an unrelated execution checkpoint', async () => {
+    const root = join(tmpdir(), `frankenbeast-main-issues-resume-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    mkdirSync(buildDir, { recursive: true });
+    writeFileSync(join(buildDir, 'plan-2026-03-07-pluggable-providers.checkpoint'), 'impl:04:done');
+
+    mockParseArgs.mockReturnValue({
+      subcommand: 'issues',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: true,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+
+    await main();
+
+    expect(getProjectPaths).toHaveBeenCalledWith(root, undefined);
+    expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
+      entryPhase: 'execute',
+      resume: true,
+      paths: expect.objectContaining({
+        plansDir: `${root}/.fbeast/plans`,
       }),
     }));
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -341,6 +341,25 @@ describe('discoverResumeTarget', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('preserves a unique nested custom plan directory', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-nested-custom-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    const nestedPlanDir = join(root, 'docs', 'chunks');
+    mkdirSync(buildDir, { recursive: true });
+    mkdirSync(nestedPlanDir, { recursive: true });
+
+    const checkpoint = join(buildDir, 'chunks.checkpoint');
+    writeFileSync(checkpoint, 'impl:01:done');
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'chunks',
+      checkpointFile: checkpoint,
+      planDir: nestedPlanDir,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('returns undefined when no plan-scoped checkpoints exist', () => {
     const root = join(tmpdir(), `frankenbeast-resume-empty-${Date.now()}`);
     mkdirSync(join(root, '.fbeast', '.build'), { recursive: true });
@@ -400,6 +419,23 @@ describe('discoverResumeTarget', () => {
     execFileSync('git', ['checkout', '-b', 'feat/chunk-05'], { cwd: root, stdio: 'ignore' });
 
     expect(inferResumeBaseBranch(root)).toBe('main');
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('uses the original conventional base branch after later checkout detours', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-git-original-base-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'ignore' });
+    writeFileSync(join(root, 'README.md'), 'test');
+    execFileSync('git', ['add', 'README.md'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'develop'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', 'main'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+
+    expect(inferResumeBaseBranch(root)).toBe('develop');
 
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -119,11 +119,13 @@ vi.mock('../../../src/cli/args.js', () => ({
 vi.mock('../../../src/cli/project-root.js', () => ({
   resolveProjectRoot: vi.fn((dir: string) => dir),
   generatePlanName: vi.fn(() => 'plan-2026-03-08'),
-  getProjectPaths: vi.fn((root: string) => ({
+  getProjectPaths: vi.fn((root: string, planName?: string) => {
+    const plansDir = planName ? `${root}/.fbeast/plans/${planName}` : `${root}/.fbeast/plans`;
+    return {
     root,
     frankenbeastDir: `${root}/.fbeast`,
     llmCacheDir: `${root}/.fbeast/.cache/llm`,
-    plansDir: `${root}/.fbeast/plans`,
+    plansDir,
     buildDir: `${root}/.fbeast/.build`,
     beastsDir: `${root}/.fbeast/.build/beasts`,
     beastLogsDir: `${root}/.fbeast/.build/beasts/logs`,
@@ -131,10 +133,11 @@ vi.mock('../../../src/cli/project-root.js', () => ({
     checkpointFile: `${root}/.fbeast/.build/.checkpoint`,
     tracesDb: `${root}/.fbeast/.build/build-traces.db`,
     logFile: `${root}/.fbeast/.build/build.log`,
-    designDocFile: `${root}/.fbeast/plans/design.md`,
+    designDocFile: `${plansDir}/design.md`,
     configFile: `${root}/.fbeast/config.json`,
-    llmResponseFile: `${root}/.fbeast/plans/llm-response.json`,
-  })),
+    llmResponseFile: `${plansDir}/llm-response.json`,
+  };
+  }),
   scaffoldFrankenbeast: vi.fn(),
 }));
 
@@ -216,7 +219,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, runDirectCli, shouldForceDirectCliExit } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch } from '../../../src/cli/run.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
 import { createInterface } from 'node:readline';
@@ -236,6 +239,11 @@ describe('resolvePhases', () => {
 
   it('returns execute entry (no exit) for run subcommand', () => {
     const result = resolvePhases({ subcommand: 'run' });
+    expect(result).toEqual({ entryPhase: 'execute' });
+  });
+
+  it('returns execute entry for bare resume', () => {
+    const result = resolvePhases({ resume: true });
     expect(result).toEqual({ entryPhase: 'execute' });
   });
 
@@ -269,6 +277,46 @@ describe('resolvePhases', () => {
       designDoc: '/some/doc.md',
     });
     expect(result).toEqual({ entryPhase: 'execute' });
+  });
+});
+
+describe('discoverResumeTarget', () => {
+  it('selects the newest plan-scoped checkpoint and extracts the plan name', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    mkdirSync(buildDir, { recursive: true });
+
+    const older = join(buildDir, 'plan-older.checkpoint');
+    const newer = join(buildDir, 'plan-2026-03-07-pluggable-providers.checkpoint');
+    writeFileSync(older, 'impl:01:done');
+    writeFileSync(newer, 'impl:04:done');
+    utimesSync(older, new Date('2026-03-07T00:00:00Z'), new Date('2026-03-07T00:00:00Z'));
+    utimesSync(newer, new Date('2026-03-08T00:00:00Z'), new Date('2026-03-08T00:00:00Z'));
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'plan-2026-03-07-pluggable-providers',
+      checkpointFile: newer,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns undefined when no plan-scoped checkpoints exist', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-empty-${Date.now()}`);
+    mkdirSync(join(root, '.fbeast', '.build'), { recursive: true });
+
+    expect(discoverResumeTarget(root)).toBeUndefined();
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('falls back to main when resume base-branch reflog inference is unavailable', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-no-git-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+
+    expect(inferResumeBaseBranch(root)).toBe('main');
+
+    rmSync(root, { recursive: true, force: true });
   });
 });
 
@@ -485,6 +533,60 @@ describe('main() execution', () => {
       entryPhase: 'execute',
       resume: true,
     }));
+  });
+
+  it('auto-detects plan dir and skips base-branch prompt for bare --resume', async () => {
+    const root = join(tmpdir(), `frankenbeast-main-resume-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    mkdirSync(buildDir, { recursive: true });
+    writeFileSync(join(buildDir, 'plan-2026-03-07-pluggable-providers.checkpoint'), 'impl:04:done');
+    vi.mocked(resolveBaseBranch).mockClear();
+
+    mockParseArgs.mockReturnValue({
+      subcommand: undefined,
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: true,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+
+    await main();
+
+    expect(getProjectPaths).toHaveBeenCalledWith(root, 'plan-2026-03-07-pluggable-providers');
+    expect(resolveBaseBranch).not.toHaveBeenCalled();
+    expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
+      baseBranch: 'main',
+      entryPhase: 'execute',
+      resume: true,
+      paths: expect.objectContaining({
+        plansDir: `${root}/.fbeast/plans/plan-2026-03-07-pluggable-providers`,
+      }),
+    }));
+
+    rmSync(root, { recursive: true, force: true });
   });
 
   it('uses config.providers.default when --provider is omitted', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -415,6 +415,27 @@ describe('discoverResumeTarget', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('marks nested custom plan directories as ambiguous when more than one matches', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-ambiguous-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    const firstPlanDir = join(root, 'docs', 'chunks');
+    const secondPlanDir = join(root, 'notes', 'chunks');
+    mkdirSync(buildDir, { recursive: true });
+    mkdirSync(firstPlanDir, { recursive: true });
+    mkdirSync(secondPlanDir, { recursive: true });
+
+    const checkpoint = join(buildDir, 'chunks.checkpoint');
+    writeFileSync(checkpoint, 'impl:01:done');
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'chunks',
+      checkpointFile: checkpoint,
+      ambiguousPlanDir: true,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('returns undefined when no plan-scoped checkpoints exist', () => {
     const root = join(tmpdir(), `frankenbeast-resume-empty-${Date.now()}`);
     mkdirSync(join(root, '.fbeast', '.build'), { recursive: true });
@@ -504,6 +525,7 @@ describe('discoverResumeTarget', () => {
     execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
     execFileSync('git', ['checkout', '-b', 'develop'], { cwd: root, stdio: 'ignore' });
     execFileSync('git', ['checkout', '-b', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['update-ref', 'refs/remotes/origin/develop', 'develop'], { cwd: root, stdio: 'ignore' });
     execFileSync('git', ['branch', '-D', 'develop'], { cwd: root, stdio: 'ignore' });
 
     expect(inferResumeBaseBranch(root)).toBeUndefined();

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -343,12 +343,51 @@ describe('discoverResumeTarget', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('preserves a custom plan directory directly under .fbeast', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-fbeast-custom-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    const customPlanDir = join(root, '.fbeast', 'plans');
+    mkdirSync(buildDir, { recursive: true });
+    mkdirSync(customPlanDir, { recursive: true });
+
+    const checkpoint = join(buildDir, 'plans.checkpoint');
+    writeFileSync(checkpoint, 'impl:01:done');
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'plans',
+      checkpointFile: checkpoint,
+      planDir: customPlanDir,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('preserves a unique nested custom plan directory', () => {
     const root = join(tmpdir(), `frankenbeast-resume-nested-custom-${Date.now()}`);
     const buildDir = join(root, '.fbeast', '.build');
     const nestedPlanDir = join(root, 'docs', 'chunks');
     mkdirSync(buildDir, { recursive: true });
     mkdirSync(nestedPlanDir, { recursive: true });
+
+    const checkpoint = join(buildDir, 'chunks.checkpoint');
+    writeFileSync(checkpoint, 'impl:01:done');
+
+    expect(discoverResumeTarget(root)).toEqual({
+      planName: 'chunks',
+      checkpointFile: checkpoint,
+      planDir: nestedPlanDir,
+    });
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('skips symlinked directories while scanning for nested custom plan dirs', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-symlink-${Date.now()}`);
+    const buildDir = join(root, '.fbeast', '.build');
+    const nestedPlanDir = join(root, 'docs', 'chunks');
+    mkdirSync(buildDir, { recursive: true });
+    mkdirSync(nestedPlanDir, { recursive: true });
+    symlinkSync(root, join(root, 'docs', 'loop'), 'dir');
 
     const checkpoint = join(buildDir, 'chunks.checkpoint');
     writeFileSync(checkpoint, 'impl:01:done');
@@ -438,6 +477,22 @@ describe('discoverResumeTarget', () => {
     execFileSync('git', ['checkout', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
 
     expect(inferResumeBaseBranch(root)).toBe('develop');
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('ignores inferred base branches that no longer exist', () => {
+    const root = join(tmpdir(), `frankenbeast-resume-git-deleted-base-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'ignore' });
+    writeFileSync(join(root, 'README.md'), 'test');
+    execFileSync('git', ['add', 'README.md'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'develop'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-b', 'feat/chunk-04'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['branch', '-D', 'develop'], { cwd: root, stdio: 'ignore' });
+
+    expect(inferResumeBaseBranch(root)).toBeUndefined();
 
     rmSync(root, { recursive: true, force: true });
   });
@@ -757,6 +812,54 @@ describe('main() execution', () => {
       resume: true,
       paths: expect.objectContaining({
         plansDir: `${root}/.fbeast/plans`,
+      }),
+    }));
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('preserves explicit issue plan names', async () => {
+    const root = join(tmpdir(), `frankenbeast-main-issues-plan-name-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+
+    mockParseArgs.mockReturnValue({
+      subcommand: 'issues',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: 'batch-13',
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+
+    await main();
+
+    expect(getProjectPaths).toHaveBeenCalledWith(root, 'batch-13');
+    expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
+      entryPhase: 'execute',
+      paths: expect.objectContaining({
+        plansDir: `${root}/.fbeast/plans/batch-13`,
       }),
     }));
 


### PR DESCRIPTION
## Summary
- make bare `frankenbeast --resume` enter execute mode without requiring `--plan-dir`
- auto-detect the newest plan-scoped checkpoint and reuse its plan name for scoped project paths
- infer the resume base branch from git reflog and skip the interactive base-branch prompt unless `--base-branch` is explicit
- log the detected resume checkpoint for operator visibility

## Tests
- npm run test --workspace packages/franken-orchestrator -- tests/unit/cli/run.test.ts
- npm run test
- npm run typecheck
- npm run build
- npm run lint --workspace packages/franken-orchestrator
- git diff --check

Closes #13