### PR TITLE
fix(api): share web DTO contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10320,6 +10320,7 @@
       "name": "@frankenbeast/web",
       "version": "0.1.0",
       "dependencies": {
+        "@franken/types": "*",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/franken-orchestrator/src/chat/types.ts
+++ b/packages/franken-orchestrator/src/chat/types.ts
@@ -1,4 +1,15 @@
-import { z } from 'zod';
+import {
+  ChatBeastContextSchema,
+  ChatSessionResponseSchema,
+  TokenTotalsSchema,
+  TranscriptMessageSchema,
+} from '@franken/types';
+import type {
+  ChatBeastContext,
+  ChatSessionResponse,
+  TranscriptMessage,
+  TurnOutcome,
+} from '@franken/types';
 
 // --- Const enums ---
 
@@ -20,73 +31,15 @@ export type IntentClassValue = (typeof IntentClass)[keyof typeof IntentClass];
 
 // --- TurnOutcome discriminated union (kind discriminant) ---
 
-export interface ReplyOutcome {
-  kind: 'reply';
-  content: string;
-  modelTier: string;
-}
-
-export interface ClarifyOutcome {
-  kind: 'clarify';
-  question: string;
-  options: string[];
-}
-
-export interface PlanOutcome {
-  kind: 'plan';
-  planSummary: string;
-  chunkCount: number;
-}
-
-export interface ExecuteOutcome {
-  kind: 'execute';
-  taskDescription: string;
-  approvalRequired: boolean;
-}
-
-export type TurnOutcome = ReplyOutcome | ClarifyOutcome | PlanOutcome | ExecuteOutcome;
-
-export const ChatBeastContextSchema = z.object({
-  agentId: z.string().min(1).optional(),
-  definitionId: z.string().min(1),
-  interviewSessionId: z.string().min(1),
-  executionMode: z.enum(['process', 'container']).optional(),
-  status: z.enum(['interviewing']),
-});
-export type ChatBeastContext = z.infer<typeof ChatBeastContextSchema>;
+export type ReplyOutcome = Extract<TurnOutcome, { kind: 'reply' }>;
+export type ClarifyOutcome = Extract<TurnOutcome, { kind: 'clarify' }>;
+export type PlanOutcome = Extract<TurnOutcome, { kind: 'plan' }>;
+export type ExecuteOutcome = Extract<TurnOutcome, { kind: 'execute' }>;
+export type { ChatBeastContext, TranscriptMessage, TurnOutcome };
 
 // --- Zod schemas ---
 
-export const TranscriptMessageSchema = z.object({
-  id: z.string().optional(),
-  role: z.enum(['user', 'assistant', 'system']),
-  content: z.string(),
-  timestamp: z.string(),
-  modelTier: z.string().optional(),
-  tokens: z.number().nonnegative().optional(),
-  costUsd: z.number().nonnegative().optional(),
-});
-export type TranscriptMessage = z.infer<typeof TranscriptMessageSchema>;
+export { ChatBeastContextSchema, TranscriptMessageSchema, TokenTotalsSchema };
 
-export const TokenTotalsSchema = z.object({
-  cheap: z.number().nonnegative(),
-  premiumReasoning: z.number().nonnegative(),
-  premiumExecution: z.number().nonnegative(),
-});
-
-export const ChatSessionSchema = z.object({
-  id: z.string(),
-  projectId: z.string(),
-  transcript: z.array(TranscriptMessageSchema),
-  state: z.string(),
-  pendingApproval: z.object({
-    description: z.string(),
-    requestedAt: z.string(),
-  }).nullable().optional(),
-  beastContext: ChatBeastContextSchema.nullable().optional(),
-  tokenTotals: TokenTotalsSchema,
-  costUsd: z.number().nonnegative(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-});
-export type ChatSession = z.infer<typeof ChatSessionSchema>;
+export const ChatSessionSchema = ChatSessionResponseSchema.omit({ socketToken: true });
+export type ChatSession = Omit<ChatSessionResponse, 'socketToken'>;

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -4,6 +4,14 @@ import type { ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
 import type { ChatRuntime } from '../../chat/runtime.js';
 import type { TurnRunner } from '../../chat/turn-runner.js';
+import type {
+  ApiDataEnvelope,
+  ApproveResult,
+  ChatSessionResponse,
+  ChatSessionSummary,
+  MessageResult,
+  TurnOutcome,
+} from '@franken/types';
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 
@@ -36,6 +44,13 @@ function getSessionOrThrow(store: ISessionStore, id: string) {
   return session;
 }
 
+function sessionResponse(
+  session: NonNullable<ReturnType<ISessionStore['get']>>,
+  socketToken: string,
+): ChatSessionResponse {
+  return { ...session, socketToken };
+}
+
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
   const { sessionStore, runtime, turnRunner, issueSocketToken } = deps;
   const app = new Hono();
@@ -51,12 +66,15 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const body = await parseJsonBody(c);
     const { projectId } = validateBody(CreateSessionBody, body);
     const session = sessionStore.create(projectId);
-    return c.json({ data: { ...session, socketToken: issueSocketToken(session.id) } }, 201);
+    const response = {
+      data: sessionResponse(session, issueSocketToken(session.id)),
+    } satisfies ApiDataEnvelope<ChatSessionResponse>;
+    return c.json(response, 201);
   });
 
   app.get('/v1/chat/sessions', (c) => {
     const projectId = c.req.query('projectId');
-    const sessions = sessionStore.listSessions(projectId).map((session) => ({
+    const sessions: ChatSessionSummary[] = sessionStore.listSessions(projectId).map((session) => ({
       id: session.id,
       projectId: session.projectId,
       state: session.state,
@@ -65,14 +83,16 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
     }));
-    return c.json({ data: { sessions } });
+    return c.json({ data: { sessions } } satisfies ApiDataEnvelope<{ sessions: ChatSessionSummary[] }>);
   });
 
   // Get session
   app.get('/v1/chat/sessions/:id', (c) => {
     const id = c.req.param('id');
     const session = getSessionOrThrow(sessionStore, id);
-    return c.json({ data: { ...session, socketToken: issueSocketToken(session.id) } });
+    return c.json({
+      data: sessionResponse(session, issueSocketToken(session.id)),
+    } satisfies ApiDataEnvelope<ChatSessionResponse>);
   });
 
   // Submit message
@@ -100,13 +120,20 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     session.updatedAt = new Date().toISOString();
     sessionStore.save(session);
 
-    return c.json({
+    const outcome: TurnOutcome = result.outcome ?? {
+      kind: 'reply',
+      content: result.displayMessages.map((message) => message.content).join('\n'),
+      modelTier: result.tier ?? 'unknown',
+    };
+
+    const response = {
       data: {
-        outcome: result.outcome,
-        tier: result.tier,
+        outcome,
+        tier: result.tier ?? 'unknown',
         state: session.state,
       },
-    });
+    } satisfies ApiDataEnvelope<MessageResult>;
+    return c.json(response);
   });
 
   // SSE stream
@@ -123,7 +150,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     session.updatedAt = new Date().toISOString();
     sessionStore.save(session);
 
-    return c.json({ data: { id: session.id, approved, state: session.state } });
+    return c.json({ data: { id: session.id, approved, state: session.state } } satisfies ApiDataEnvelope<ApproveResult>);
   });
 
   return app;

--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -11,6 +11,7 @@ import { redactSensitiveConfig } from '../../network/network-secrets.js';
 import { NetworkStateStore } from '../../network/network-state-store.js';
 import { NetworkSupervisor } from '../../network/network-supervisor.js';
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
+import type { ApiDataEnvelope, NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
 import {
   healthcheckNetworkService,
   preflightNetworkService,
@@ -58,19 +59,18 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
     const supervisor = createSupervisor(deps.frankenbeastDir);
     const status = await supervisor.status();
     const services = resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root });
-    return c.json({
-      data: {
-        ...status,
-        services: status.services.map((service) => {
-          const resolved = services.find((candidate) => candidate.id === service.id);
-          return {
-            ...service,
-            explanation: resolved?.explanation,
-            url: resolved?.runtimeConfig.url,
-          };
-        }),
-      },
-    });
+    const response: NetworkStatusResponse = {
+      ...status,
+      services: status.services.map((service) => {
+        const resolved = services.find((candidate) => candidate.id === service.id);
+        return {
+          ...service,
+          ...(resolved?.explanation !== undefined ? { explanation: resolved.explanation } : {}),
+          ...(resolved?.runtimeConfig.url !== undefined ? { url: resolved.runtimeConfig.url } : {}),
+        };
+      }),
+    };
+    return c.json({ data: response } satisfies ApiDataEnvelope<NetworkStatusResponse>);
   });
 
   app.post('/v1/network/up', async (c) => {
@@ -139,7 +139,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   });
 
   app.get('/v1/network/config', (c) => {
-    return c.json({ data: redactSensitiveConfig(deps.getConfig()) });
+    return c.json({ data: redactSensitiveConfig(deps.getConfig()) } satisfies ApiDataEnvelope<NetworkConfigResponse>);
   });
 
   app.post('/v1/network/config', async (c) => {
@@ -150,7 +150,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
     deps.setConfig(nextConfig);
     await mkdir(dirname(deps.configFile), { recursive: true });
     await writeFile(deps.configFile, JSON.stringify(nextConfig, null, 2), 'utf-8');
-    return c.json({ data: redactSensitiveConfig(nextConfig) });
+    return c.json({ data: redactSensitiveConfig(nextConfig) } satisfies ApiDataEnvelope<NetworkConfigResponse>);
   });
 
   return app;

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -1,0 +1,332 @@
+import { z } from 'zod';
+
+export interface ApiDataEnvelope<T> {
+  data: T;
+}
+
+export interface ApiErrorEnvelope {
+  error: { code: string; message: string; details?: unknown };
+}
+
+export const PendingApprovalSchema = z.object({
+  description: z.string(),
+  requestedAt: z.string(),
+});
+export type PendingApproval = z.infer<typeof PendingApprovalSchema>;
+
+export const TranscriptMessageSchema = z.object({
+  id: z.string().optional(),
+  role: z.enum(['user', 'assistant', 'system']),
+  content: z.string(),
+  timestamp: z.string(),
+  modelTier: z.string().optional(),
+  tokens: z.number().nonnegative().optional(),
+  costUsd: z.number().nonnegative().optional(),
+});
+export type TranscriptMessage = z.infer<typeof TranscriptMessageSchema>;
+
+export const TokenTotalsSchema = z.object({
+  cheap: z.number().nonnegative(),
+  premiumReasoning: z.number().nonnegative(),
+  premiumExecution: z.number().nonnegative(),
+});
+export type TokenTotals = z.infer<typeof TokenTotalsSchema>;
+
+export const ChatBeastContextSchema = z.object({
+  agentId: z.string().min(1).optional(),
+  definitionId: z.string().min(1),
+  interviewSessionId: z.string().min(1),
+  executionMode: z.enum(['process', 'container']).optional(),
+  status: z.enum(['interviewing']),
+});
+export type ChatBeastContext = z.infer<typeof ChatBeastContextSchema>;
+
+export const ChatSessionResponseSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  transcript: z.array(TranscriptMessageSchema),
+  state: z.string(),
+  pendingApproval: PendingApprovalSchema.nullable().optional(),
+  beastContext: ChatBeastContextSchema.nullable().optional(),
+  socketToken: z.string(),
+  tokenTotals: TokenTotalsSchema,
+  costUsd: z.number().nonnegative(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type ChatSessionResponse = z.infer<typeof ChatSessionResponseSchema>;
+
+export const ChatSessionSummarySchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  state: z.string(),
+  messageCount: z.number().int().nonnegative(),
+  preview: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type ChatSessionSummary = z.infer<typeof ChatSessionSummarySchema>;
+
+export const TurnOutcomeSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('reply'), content: z.string(), modelTier: z.string() }),
+  z.object({ kind: z.literal('clarify'), question: z.string(), options: z.array(z.string()) }),
+  z.object({ kind: z.literal('plan'), planSummary: z.string(), chunkCount: z.number().int().nonnegative() }),
+  z.object({ kind: z.literal('execute'), taskDescription: z.string(), approvalRequired: z.boolean() }),
+]);
+export type TurnOutcome = z.infer<typeof TurnOutcomeSchema>;
+
+export const MessageResultSchema = z.object({
+  outcome: TurnOutcomeSchema,
+  tier: z.string(),
+  state: z.string(),
+});
+export type MessageResult = z.infer<typeof MessageResultSchema>;
+
+export const ApproveResultSchema = z.object({
+  id: z.string(),
+  approved: z.boolean(),
+  state: z.string(),
+});
+export type ApproveResult = z.infer<typeof ApproveResultSchema>;
+
+export interface BeastInterviewPrompt {
+  key: string;
+  prompt: string;
+  kind: 'string' | 'boolean' | 'file' | 'directory';
+  required?: boolean;
+  options?: readonly string[];
+}
+
+export type BeastExecutionMode = 'process' | 'container';
+
+export interface BeastContainerRuntimeStatus {
+  available: boolean;
+  reason?: string;
+}
+
+export interface BeastCatalogEntry {
+  id: string;
+  version?: number;
+  label: string;
+  description: string;
+  executionModeDefault: BeastExecutionMode;
+  containerRuntime?: BeastContainerRuntimeStatus;
+  interviewPrompts: readonly BeastInterviewPrompt[];
+}
+
+export interface BeastRunSummary {
+  id: string;
+  trackedAgentId?: string;
+  definitionId: string;
+  definitionVersion?: number;
+  status: string;
+  executionMode: BeastExecutionMode;
+  configSnapshot?: Readonly<Record<string, unknown>>;
+  dispatchedBy: string;
+  dispatchedByUser: string;
+  attemptCount: number;
+  currentAttemptId?: string;
+  stopReason?: string;
+  latestExitCode?: number;
+  containerId?: unknown;
+  containerName?: unknown;
+  containerRuntime?: unknown;
+  image?: unknown;
+  containerImage?: unknown;
+  containerNetwork?: unknown;
+  resourceSnapshot?: unknown;
+  resources?: unknown;
+  workspaceHostPath?: unknown;
+  workspaceContainerPath?: unknown;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  lastHeartbeatAt?: string;
+}
+
+export interface BeastRunEvent {
+  id: string;
+  runId: string;
+  attemptId?: string;
+  sequence: number;
+  type: string;
+  payload: Readonly<Record<string, unknown>>;
+  createdAt: string;
+}
+
+export interface BeastRunAttempt {
+  id: string;
+  runId: string;
+  attemptNumber: number;
+  status: string;
+  pid?: number;
+  startedAt?: string;
+  finishedAt?: string;
+  exitCode?: number;
+  stopReason?: string;
+  executorMetadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface BeastRunDetail {
+  run: BeastRunSummary;
+  attempts: BeastRunAttempt[];
+  events: BeastRunEvent[];
+  logs: string[];
+}
+
+export interface BeastSseSnapshot {
+  agents?: Array<Partial<TrackedAgentSummary> & { id: string }>;
+}
+
+export interface BeastSseAgentStatusEvent {
+  agentId: string;
+  status: string;
+  updatedAt?: string;
+}
+
+export interface BeastSseAgentEvent {
+  agentId: string;
+  event: Omit<TrackedAgentEvent, 'id' | 'agentId' | 'sequence'> & Partial<TrackedAgentEvent>;
+}
+
+export interface BeastSseRunStatusEvent {
+  runId: string;
+  status: string;
+  updatedAt?: string;
+}
+
+export interface BeastSseRunLogEvent {
+  eventId?: string;
+  runId: string;
+  attemptId?: string;
+  stream?: 'stdout' | 'stderr';
+  line: string;
+  createdAt?: string;
+}
+
+export interface BeastSseRunEvent {
+  runId: string;
+  event: Record<string, unknown>;
+}
+
+export interface BeastEventHandlers {
+  snapshot?: (snapshot: BeastSseSnapshot) => void;
+  agentStatus?: (event: BeastSseAgentStatusEvent) => void;
+  agentEvent?: (event: BeastSseAgentEvent) => void;
+  runStatus?: (event: BeastSseRunStatusEvent) => void;
+  runLog?: (event: BeastSseRunLogEvent) => void;
+  runEvent?: (event: BeastSseRunEvent) => void;
+  error?: (error: Error) => void;
+}
+
+export interface TrackedAgentInitAction {
+  kind: 'design-interview' | 'chunk-plan' | 'martin-loop';
+  command: string;
+  config: Readonly<Record<string, unknown>>;
+  chatSessionId?: string;
+}
+
+export interface ModuleConfig {
+  firewall?: boolean;
+  skills?: boolean;
+  memory?: boolean;
+  planner?: boolean;
+  critique?: boolean;
+  governor?: boolean;
+  heartbeat?: boolean;
+}
+
+export const MODULE_CONFIG_KEYS: readonly (keyof ModuleConfig)[] = [
+  'firewall', 'skills', 'memory', 'planner', 'critique', 'governor', 'heartbeat',
+] as const;
+
+export interface TrackedAgentSummary {
+  id: string;
+  name?: string;
+  definitionId: string;
+  status: string;
+  source: string;
+  createdByUser: string;
+  initAction: TrackedAgentInitAction;
+  initConfig: Readonly<Record<string, unknown>>;
+  moduleConfig?: ModuleConfig;
+  executionMode?: BeastExecutionMode;
+  chatSessionId?: string;
+  dispatchRunId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TrackedAgentEvent {
+  id: string;
+  agentId: string;
+  sequence: number;
+  level: 'info' | 'warning' | 'error';
+  type: string;
+  message: string;
+  payload: Readonly<Record<string, unknown>>;
+  createdAt: string;
+}
+
+export interface TrackedAgentDetail {
+  agent: TrackedAgentSummary;
+  events: TrackedAgentEvent[];
+}
+
+export interface AgentLlmConfig {
+  default?: { provider: string; model: string };
+  overrides?: Record<string, { provider: string; model: string }>;
+}
+
+export interface AgentGitConfig {
+  preset: 'one-shot' | 'feature-branch' | 'feature-branch-worktree' | 'yolo-main' | 'custom';
+  baseBranch: string;
+  branchPattern: string;
+  prCreation: boolean;
+  prTemplate?: string;
+  commitConvention: 'conventional' | 'freeform';
+  mergeStrategy: 'merge' | 'squash' | 'rebase';
+}
+
+export interface AgentDeepModuleConfig {
+  firewall?: { ruleSet?: string; customRules?: string };
+  memory?: { backend?: string; retentionPolicy?: string };
+  planner?: { maxDagDepth?: number; parallelTaskLimit?: number };
+  critique?: { maxIterations?: number; severityThreshold?: string };
+  governor?: { approvalMode?: string; escalationRules?: string };
+  heartbeat?: { reflectionInterval?: number; llmOverride?: { provider: string; model: string } };
+}
+
+export interface ExtendedAgentCreateInput {
+  name: string;
+  description?: string;
+  definitionId: string;
+  initAction: TrackedAgentInitAction;
+  moduleConfig?: ModuleConfig;
+  deepModuleConfig?: AgentDeepModuleConfig;
+  llmConfig?: AgentLlmConfig;
+  gitConfig?: AgentGitConfig;
+  skills?: string[];
+  promptText?: string;
+  promptFiles?: Array<{ name: string; content: string; tokens: number }>;
+}
+
+export interface NetworkServiceStatus {
+  id: string;
+  status: string;
+  explanation?: string;
+  url?: string;
+}
+
+export interface NetworkStatusResponse {
+  mode?: string;
+  secureBackend?: string;
+  services: NetworkServiceStatus[];
+}
+
+export interface NetworkConfigResponse {
+  network: { mode: string; secureBackend?: string };
+  chat: { model: string; enabled: boolean; host?: string; port?: number };
+  dashboard?: { enabled?: boolean; host?: string; port?: number; apiUrl?: string };
+  comms?: { enabled?: boolean };
+}

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -90,6 +90,9 @@ export {
   SkillCatalogEntrySchema,
 } from './provider.js';
 
+// Web/API contract DTOs
+export * from './api-contracts.js';
+
 // Skill schemas
 export type { McpConfig, SkillInfo, SkillToolManifest } from './skill.js';
 export {

--- a/packages/franken-types/tests/api-contracts.test.ts
+++ b/packages/franken-types/tests/api-contracts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ChatSessionResponseSchema,
+  MessageResultSchema,
+  MODULE_CONFIG_KEYS,
+  type ApiDataEnvelope,
+  type NetworkStatusResponse,
+} from '../src/api-contracts.js';
+
+describe('web/API contracts', () => {
+  it('validates chat session DTOs consumed by the web client', () => {
+    const session = ChatSessionResponseSchema.parse({
+      id: 'sess-1',
+      projectId: 'proj-1',
+      transcript: [{ role: 'user', content: 'hello', timestamp: '2026-03-09T00:00:00.000Z' }],
+      state: 'active',
+      socketToken: 'socket-token',
+      tokenTotals: { cheap: 1, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0.01,
+      createdAt: '2026-03-09T00:00:00.000Z',
+      updatedAt: '2026-03-09T00:00:01.000Z',
+    });
+
+    expect(session.socketToken).toBe('socket-token');
+    expect(session.transcript[0]?.role).toBe('user');
+  });
+
+  it('validates chat turn result DTOs', () => {
+    const result = MessageResultSchema.parse({
+      outcome: { kind: 'execute', taskDescription: 'Run tests', approvalRequired: true },
+      tier: 'premium_execution',
+      state: 'pending_approval',
+    });
+
+    expect(result.outcome.kind).toBe('execute');
+  });
+
+  it('exposes envelope and network DTOs for route clients', () => {
+    const envelope: ApiDataEnvelope<NetworkStatusResponse> = {
+      data: {
+        mode: 'local',
+        services: [{ id: 'chat-server', status: 'started', url: 'http://127.0.0.1:3737' }],
+      },
+    };
+
+    expect(envelope.data.services[0]?.id).toBe('chat-server');
+    expect(MODULE_CONFIG_KEYS).toContain('planner');
+  });
+});

--- a/packages/franken-web/package.json
+++ b/packages/franken-web/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@franken/types": "*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -1,68 +1,26 @@
-export interface PendingApproval {
-  description: string;
-  requestedAt: string;
-}
+import type {
+  ApiDataEnvelope,
+  ApiErrorEnvelope,
+  ApproveResult,
+  ChatSessionResponse as ChatSession,
+  ChatSessionSummary,
+  MessageResult,
+  PendingApproval,
+  TokenTotals,
+  TranscriptMessage,
+  TurnOutcome,
+} from '@franken/types';
 
-export interface TranscriptMessage {
-  id?: string;
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-  timestamp: string;
-  modelTier?: string;
-  tokens?: number;
-  costUsd?: number;
-}
-
-export interface TokenTotals {
-  cheap: number;
-  premiumReasoning: number;
-  premiumExecution: number;
-}
-
-export interface ChatSession {
-  id: string;
-  projectId: string;
-  transcript: TranscriptMessage[];
-  state: string;
-  pendingApproval?: PendingApproval | null;
-  socketToken: string;
-  tokenTotals: TokenTotals;
-  costUsd: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface ChatSessionSummary {
-  id: string;
-  projectId: string;
-  state: string;
-  messageCount: number;
-  preview: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export type TurnOutcome =
-  | { kind: 'reply'; content: string; modelTier: string }
-  | { kind: 'clarify'; question: string; options: string[] }
-  | { kind: 'plan'; planSummary: string; chunkCount: number }
-  | { kind: 'execute'; taskDescription: string; approvalRequired: boolean };
-
-export interface MessageResult {
-  outcome: TurnOutcome;
-  tier: string;
-  state: string;
-}
-
-export interface ApproveResult {
-  id: string;
-  approved: boolean;
-  state: string;
-}
-
-interface ApiErrorEnvelope {
-  error: { code: string; message: string; details?: unknown };
-}
+export type {
+  ApproveResult,
+  ChatSessionSummary,
+  MessageResult,
+  PendingApproval,
+  TokenTotals,
+  TranscriptMessage,
+  TurnOutcome,
+} from '@franken/types';
+export type { ChatSessionResponse as ChatSession } from '@franken/types';
 
 export function toSocketUrl(baseUrl: string, sessionId: string, token: string): string {
   const url = new URL(baseUrl);
@@ -160,7 +118,7 @@ export class ChatApiClient {
       throw new Error(message);
     }
 
-    const body = (await res.json()) as { data: T };
+    const body = (await res.json()) as ApiDataEnvelope<T>;
     return body.data;
   }
 }

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -1,195 +1,49 @@
-export interface BeastInterviewPrompt {
-  key: string;
-  prompt: string;
-  kind: 'string' | 'boolean' | 'file' | 'directory';
-  required?: boolean;
-  options?: readonly string[];
-}
+import { MODULE_CONFIG_KEYS } from '@franken/types';
+import type {
+  ApiDataEnvelope,
+  BeastCatalogEntry,
+  BeastContainerRuntimeStatus,
+  BeastInterviewPrompt,
+  BeastEventHandlers,
+  BeastExecutionMode,
+  BeastRunDetail,
+  BeastRunSummary,
+  BeastSseAgentEvent,
+  BeastSseAgentStatusEvent,
+  BeastSseRunEvent,
+  BeastSseRunLogEvent,
+  BeastSseRunStatusEvent,
+  BeastSseSnapshot,
+  ExtendedAgentCreateInput,
+  ModuleConfig,
+  TrackedAgentDetail,
+  TrackedAgentEvent,
+  TrackedAgentInitAction,
+  TrackedAgentSummary,
+} from '@franken/types';
 
-export type BeastExecutionMode = 'process' | 'container';
-
-export interface BeastContainerRuntimeStatus {
-  available: boolean;
-  reason?: string;
-}
-
-export interface BeastCatalogEntry {
-  id: string;
-  version?: number;
-  label: string;
-  description: string;
-  executionModeDefault: BeastExecutionMode;
-  containerRuntime?: BeastContainerRuntimeStatus;
-  interviewPrompts: BeastInterviewPrompt[];
-}
-
-export interface BeastRunSummary {
-  id: string;
-  trackedAgentId?: string;
-  definitionId: string;
-  status: string;
-  executionMode: 'process' | 'container';
-  dispatchedBy: string;
-  dispatchedByUser: string;
-  attemptCount: number;
-  currentAttemptId?: string;
-  stopReason?: string;
-  containerId?: string;
-  containerName?: string;
-  containerRuntime?: string;
-  image?: string;
-  containerImage?: string;
-  containerNetwork?: string;
-  resourceSnapshot?: Record<string, unknown>;
-  resources?: Record<string, unknown>;
-  workspaceHostPath?: string;
-  workspaceContainerPath?: string;
-  createdAt: string;
-}
-
-export interface BeastRunDetail {
-  run: BeastRunSummary;
-  attempts: Array<Record<string, unknown>>;
-  events: Array<{ id: string; runId: string; sequence: number; type: string; payload: Record<string, unknown>; createdAt: string }>;
-  logs: string[];
-}
-
-export interface BeastSseSnapshot {
-  agents?: Array<Partial<TrackedAgentSummary> & { id: string }>;
-}
-
-export interface BeastSseAgentStatusEvent {
-  agentId: string;
-  status: string;
-  updatedAt?: string;
-}
-
-export interface BeastSseAgentEvent {
-  agentId: string;
-  event: Omit<TrackedAgentEvent, 'id' | 'agentId' | 'sequence'> & Partial<TrackedAgentEvent>;
-}
-
-export interface BeastSseRunStatusEvent {
-  runId: string;
-  status: string;
-  updatedAt?: string;
-}
-
-export interface BeastSseRunLogEvent {
-  eventId?: string;
-  runId: string;
-  attemptId?: string;
-  stream?: 'stdout' | 'stderr';
-  line: string;
-  createdAt?: string;
-}
-
-export interface BeastSseRunEvent {
-  runId: string;
-  event: Record<string, unknown>;
-}
-
-export interface BeastEventHandlers {
-  snapshot?: (snapshot: BeastSseSnapshot) => void;
-  agentStatus?: (event: BeastSseAgentStatusEvent) => void;
-  agentEvent?: (event: BeastSseAgentEvent) => void;
-  runStatus?: (event: BeastSseRunStatusEvent) => void;
-  runLog?: (event: BeastSseRunLogEvent) => void;
-  runEvent?: (event: BeastSseRunEvent) => void;
-  error?: (error: Error) => void;
-}
-
-export interface TrackedAgentInitAction {
-  kind: 'design-interview' | 'chunk-plan' | 'martin-loop';
-  command: string;
-  config: Record<string, unknown>;
-  chatSessionId?: string;
-}
-
-export interface ModuleConfig {
-  firewall?: boolean;
-  skills?: boolean;
-  memory?: boolean;
-  planner?: boolean;
-  critique?: boolean;
-  governor?: boolean;
-  heartbeat?: boolean;
-}
-
-export const MODULE_CONFIG_KEYS: readonly (keyof ModuleConfig)[] = [
-  'firewall', 'skills', 'memory', 'planner', 'critique', 'governor', 'heartbeat',
-] as const;
-
-export interface TrackedAgentSummary {
-  id: string;
-  name?: string;
-  definitionId: string;
-  status: string;
-  source: string;
-  createdByUser: string;
-  initAction: TrackedAgentInitAction;
-  initConfig: Record<string, unknown>;
-  moduleConfig?: ModuleConfig;
-  executionMode?: BeastExecutionMode;
-  chatSessionId?: string;
-  dispatchRunId?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface TrackedAgentEvent {
-  id: string;
-  agentId: string;
-  sequence: number;
-  level: 'info' | 'warning' | 'error';
-  type: string;
-  message: string;
-  payload: Record<string, unknown>;
-  createdAt: string;
-}
-
-export interface TrackedAgentDetail {
-  agent: TrackedAgentSummary;
-  events: TrackedAgentEvent[];
-}
-
-export interface AgentLlmConfig {
-  default?: { provider: string; model: string };
-  overrides?: Record<string, { provider: string; model: string }>;
-}
-
-export interface AgentGitConfig {
-  preset: 'one-shot' | 'feature-branch' | 'feature-branch-worktree' | 'yolo-main' | 'custom';
-  baseBranch: string;
-  branchPattern: string;
-  prCreation: boolean;
-  prTemplate?: string;
-  commitConvention: 'conventional' | 'freeform';
-  mergeStrategy: 'merge' | 'squash' | 'rebase';
-}
-
-export interface AgentDeepModuleConfig {
-  firewall?: { ruleSet?: string; customRules?: string };
-  memory?: { backend?: string; retentionPolicy?: string };
-  planner?: { maxDagDepth?: number; parallelTaskLimit?: number };
-  critique?: { maxIterations?: number; severityThreshold?: string };
-  governor?: { approvalMode?: string; escalationRules?: string };
-  heartbeat?: { reflectionInterval?: number; llmOverride?: { provider: string; model: string } };
-}
-
-export interface ExtendedAgentCreateInput {
-  name: string;
-  description?: string;
-  definitionId: string;
-  initAction: TrackedAgentInitAction;
-  moduleConfig?: ModuleConfig;
-  deepModuleConfig?: AgentDeepModuleConfig;
-  llmConfig?: AgentLlmConfig;
-  gitConfig?: AgentGitConfig;
-  skills?: string[];
-  promptText?: string;
-  promptFiles?: Array<{ name: string; content: string; tokens: number }>;
-}
+export { MODULE_CONFIG_KEYS } from '@franken/types';
+export type {
+  BeastCatalogEntry,
+  BeastContainerRuntimeStatus,
+  BeastInterviewPrompt,
+  BeastEventHandlers,
+  BeastExecutionMode,
+  BeastRunDetail,
+  BeastRunSummary,
+  BeastSseAgentEvent,
+  BeastSseAgentStatusEvent,
+  BeastSseRunEvent,
+  BeastSseRunLogEvent,
+  BeastSseRunStatusEvent,
+  BeastSseSnapshot,
+  ExtendedAgentCreateInput,
+  ModuleConfig,
+  TrackedAgentDetail,
+  TrackedAgentEvent,
+  TrackedAgentInitAction,
+  TrackedAgentSummary,
+} from '@franken/types';
 
 export class BeastApiClient {
   constructor(
@@ -409,7 +263,7 @@ export class BeastApiClient {
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {
-    const body = await this.requestRaw<{ data: T }>(path, init);
+    const body = await this.requestRaw<ApiDataEnvelope<T>>(path, init);
     return body.data;
   }
 

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -1,15 +1,6 @@
-export interface NetworkStatusResponse {
-  mode?: string;
-  secureBackend?: string;
-  services: Array<{ id: string; status: string; explanation?: string; url?: string }>;
-}
+import type { ApiDataEnvelope, NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
 
-export interface NetworkConfigResponse {
-  network: { mode: string; secureBackend?: string };
-  chat: { model: string; enabled: boolean; host?: string; port?: number };
-  dashboard?: { enabled?: boolean; host?: string; port?: number; apiUrl?: string };
-  comms?: { enabled?: boolean };
-}
+export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
 
 export class NetworkApiClient {
   constructor(
@@ -66,7 +57,7 @@ export class NetworkApiClient {
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const body = await response.json() as { data: T };
+    const body = await response.json() as ApiDataEnvelope<T>;
     return body.data;
   }
 }

--- a/tasks/resolve-issues-375-progress.md
+++ b/tasks/resolve-issues-375-progress.md
@@ -1,0 +1,22 @@
+# Resolve issue #375 progress
+
+- [x] Read Kanban context, parent handoff, PM/root blackboard, and shared lessons.
+- [x] Refresh live GitHub issue/PR state; issue #375 is open and no duplicate open PR exists.
+- [x] Create isolated worktree `/home/pfkagent/dev/resolve-wt/issue-375` and branch `resolve/issue-375-api-contracts` from `origin/main`.
+- [x] Inspect duplicated web/API DTO definitions and existing shared type packages.
+- [x] Implement scoped shared DTO fix in `@franken/types` for chat, beast, and network API envelopes/DTOs.
+- [x] Update web chat/beast/network API clients to import/re-export shared DTOs instead of local duplicates.
+- [x] Update orchestrator chat/network response code and chat persisted schemas to use shared DTO contracts.
+- [x] Add tests proving shared API contract schemas and envelope types are consumable.
+- [x] Run full typecheck/build and targeted tests. Full `npm test` has unrelated flaky timeout in `@franken/critique` safety test; isolated retry of that test passed.
+- [ ] Commit, push, and open exactly one PR with `Closes #375`.
+- [ ] Run current-head GitHub Codex review loop and address findings.
+- [ ] Merge only after CI and Codex are clean, then update shared lessons and complete/block Kanban.
+
+Verification so far:
+- PASS `npm run typecheck`
+- PASS `npm run build`
+- PASS `npm test --workspace @franken/types -- tests/api-contracts.test.ts`
+- PASS `npm test --workspace @frankenbeast/web -- tests/lib/api.test.ts tests/lib/beast-api.test.ts src/lib/network-api.test.ts`
+- PASS `npm test --workspace packages/franken-orchestrator -- tests/unit/chat/types.test.ts`
+- FAIL then PASS-on-isolated-retry: `npm test` failed only in `@franken/critique` test `SafetyEvaluator > allows disjoint and deterministic repeated alternatives` due 5000ms timeout; `npm test --workspace @franken/critique -- tests/unit/evaluators/safety.test.ts -t "allows disjoint and deterministic repeated alternatives"` passed.


### PR DESCRIPTION
## Summary
- add shared API envelope and DTO contracts in `@franken/types` for chat, beast, and network surfaces
- update web chat/beast/network API clients to import and re-export shared contract types instead of maintaining local duplicates
- wire orchestrator chat/network route responses and persisted chat schemas to the shared contracts

Closes #375

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test --workspace @franken/types -- tests/api-contracts.test.ts`
- `npm test --workspace @frankenbeast/web -- tests/lib/api.test.ts tests/lib/beast-api.test.ts src/lib/network-api.test.ts`
- `npm test --workspace packages/franken-orchestrator -- tests/unit/chat/types.test.ts`
- `npm test --workspace @franken/critique -- tests/unit/evaluators/safety.test.ts -t "allows disjoint and deterministic repeated alternatives"`

Note: full `npm test` was run and failed only because `@franken/critique` test `SafetyEvaluator > allows disjoint and deterministic repeated alternatives` timed out at 5000ms during the full parallel run; the same test passed when retried directly as listed above.