### PR TITLE
fix(mcp-suite): drop never-used skill_state table from shared schema

### DIFF
--- a/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
@@ -44,7 +44,7 @@ describe('SqliteStore', () => {
     expect(tables).toContain('cost_ledger');
     expect(tables).toContain('governor_log');
     expect(tables).toContain('firewall_log');
-    expect(tables).toContain('skill_state');
+    expect(tables).not.toContain('skill_state');
 
     const walMode = store.db.pragma('journal_mode', { simple: true });
     expect(walMode).toBe('wal');

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -62,13 +62,6 @@ const SCHEMA = `
     matched_patterns TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
-
-  CREATE TABLE IF NOT EXISTS skill_state (
-    name TEXT PRIMARY KEY,
-    enabled INTEGER NOT NULL DEFAULT 1,
-    config TEXT,
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
 `;
 
 export function createSqliteStore(dbPath: string): SqliteStore {


### PR DESCRIPTION
## Summary
The shared SQLite schema created a `skill_state` table that nothing ever writes or reads. The skills adapter is entirely filesystem-based (`.fbeast/skills/` + `config.json`) and never opens the DB; the only occurrence of `skill_state` in the codebase was the `CREATE TABLE` itself. Dead schema misleads operators inspecting `.fbeast/beast.db`.

## Changes
- Removed the `skill_state` CREATE TABLE from `src/shared/sqlite-store.ts`.
- Updated the schema test to assert the table is absent.

## Migration
None needed: the schema uses `CREATE TABLE IF NOT EXISTS` and nothing drops tables, so existing databases keep the orphan table harmlessly.

## Testing
- `npx turbo run test --filter=@fbeast/mcp-suite` — 9/9 tasks green.
- `npx turbo run typecheck --filter=@fbeast/mcp-suite` — green.

The stale walkthrough row attributing `skill_state` to the skills adapter is tracked separately in #515.

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)