### PR TITLE
feat(orchestrator): isolate beast processes in git worktrees

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -50,6 +50,10 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
       onRunStatusChange: (runId: string) => runService.notifyRunStatusChange(runId),
       eventBus,
       runConfigDir,
+      worktreeIsolation: {
+        enabled: true,
+        projectRoot,
+      },
     }),
     container: new ContainerBeastExecutor({
       repository,

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 export type GitRunner = (args: readonly string[], cwd: string) => string;
 
@@ -15,6 +15,7 @@ export interface GitWorktreeIsolationConfig {
 export interface BeastWorktreeAllocation {
   readonly agentId: string;
   readonly branchName: string;
+  readonly executionCwd: string;
   readonly projectRoot: string;
   readonly worktreePath: string;
 }
@@ -39,6 +40,24 @@ function branchExists(runGit: GitRunner, projectRoot: string, branchName: string
   return runGit(['branch', '--list', branchName], projectRoot).length > 0;
 }
 
+function isGitRepository(runGit: GitRunner, projectRoot: string): boolean {
+  try {
+    return runGit(['rev-parse', '--is-inside-work-tree'], projectRoot) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function isolatedExecutionCwd(projectRoot: string, worktreePath: string, baseCwd: string | undefined): string {
+  if (!baseCwd) return worktreePath;
+  const resolvedBaseCwd = resolve(baseCwd);
+  const relativeBaseCwd = relative(projectRoot, resolvedBaseCwd);
+  if (!relativeBaseCwd || relativeBaseCwd.startsWith('..') || isAbsolute(relativeBaseCwd)) {
+    return worktreePath;
+  }
+  return join(worktreePath, relativeBaseCwd);
+}
+
 export function createBeastWorktree(
   config: GitWorktreeIsolationConfig | undefined,
   agentId: string,
@@ -53,11 +72,14 @@ export function createBeastWorktree(
   const branchName = `${config.branchPrefix ?? DEFAULT_BRANCH_PREFIX}${safeAgentId}`;
   const runGit = config.runGit ?? defaultRunGit;
 
+  if (!isGitRepository(runGit, projectRoot)) return undefined;
+
   mkdirSync(worktreesRoot, { recursive: true });
 
   const allocation: BeastWorktreeAllocation = {
     agentId: safeAgentId,
     branchName,
+    executionCwd: isolatedExecutionCwd(projectRoot, worktreePath, baseCwd),
     projectRoot,
     worktreePath,
   };

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -15,7 +15,9 @@ export interface GitWorktreeIsolationConfig {
 export interface BeastWorktreeAllocation {
   readonly agentId: string;
   readonly branchName: string;
+  readonly created: boolean;
   readonly executionCwd: string;
+  readonly gitTopLevel: string;
   readonly projectRoot: string;
   readonly worktreePath: string;
 }
@@ -48,10 +50,14 @@ function isGitRepository(runGit: GitRunner, projectRoot: string): boolean {
   }
 }
 
-function isolatedExecutionCwd(projectRoot: string, worktreePath: string, baseCwd: string | undefined): string {
+function gitTopLevel(runGit: GitRunner, projectRoot: string): string {
+  return resolve(runGit(['rev-parse', '--show-toplevel'], projectRoot));
+}
+
+function isolatedExecutionCwd(gitRoot: string, worktreePath: string, baseCwd: string | undefined): string {
   if (!baseCwd) return worktreePath;
   const resolvedBaseCwd = resolve(baseCwd);
-  const relativeBaseCwd = relative(projectRoot, resolvedBaseCwd);
+  const relativeBaseCwd = relative(gitRoot, resolvedBaseCwd);
   if (!relativeBaseCwd || relativeBaseCwd.startsWith('..') || isAbsolute(relativeBaseCwd)) {
     return worktreePath;
   }
@@ -73,18 +79,22 @@ export function createBeastWorktree(
   const runGit = config.runGit ?? defaultRunGit;
 
   if (!isGitRepository(runGit, projectRoot)) return undefined;
+  const root = gitTopLevel(runGit, projectRoot);
 
   mkdirSync(worktreesRoot, { recursive: true });
+  const alreadyExists = existsSync(worktreePath);
 
   const allocation: BeastWorktreeAllocation = {
     agentId: safeAgentId,
     branchName,
-    executionCwd: isolatedExecutionCwd(projectRoot, worktreePath, baseCwd),
+    created: !alreadyExists,
+    executionCwd: isolatedExecutionCwd(root, worktreePath, baseCwd),
+    gitTopLevel: root,
     projectRoot,
     worktreePath,
   };
 
-  if (existsSync(worktreePath)) {
+  if (alreadyExists) {
     return allocation;
   }
 

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+export type GitRunner = (args: readonly string[], cwd: string) => string;
+
+export interface GitWorktreeIsolationConfig {
+  readonly enabled: boolean;
+  readonly projectRoot?: string | undefined;
+  readonly worktreesDir?: string | undefined;
+  readonly branchPrefix?: string | undefined;
+  readonly runGit?: GitRunner | undefined;
+}
+
+export interface BeastWorktreeAllocation {
+  readonly agentId: string;
+  readonly branchName: string;
+  readonly projectRoot: string;
+  readonly worktreePath: string;
+}
+
+const DEFAULT_WORKTREES_DIR = join('.frankenbeast', '.worktrees');
+const DEFAULT_BRANCH_PREFIX = 'beast/';
+
+function defaultRunGit(args: readonly string[], cwd: string): string {
+  return execFileSync('git', [...args], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function sanitizeAgentId(id: string): string {
+  const safe = id.replace(/[^a-zA-Z0-9_.-]/g, '-').replace(/^-+|-+$/g, '');
+  return safe.length > 0 ? safe : 'agent';
+}
+
+function branchExists(runGit: GitRunner, projectRoot: string, branchName: string): boolean {
+  return runGit(['branch', '--list', branchName], projectRoot).length > 0;
+}
+
+export function createBeastWorktree(
+  config: GitWorktreeIsolationConfig | undefined,
+  agentId: string,
+  baseCwd: string | undefined,
+): BeastWorktreeAllocation | undefined {
+  if (!config?.enabled) return undefined;
+
+  const safeAgentId = sanitizeAgentId(agentId);
+  const projectRoot = resolve(config.projectRoot ?? baseCwd ?? process.env.FBEAST_ROOT ?? process.cwd());
+  const worktreesRoot = resolve(projectRoot, config.worktreesDir ?? DEFAULT_WORKTREES_DIR);
+  const worktreePath = join(worktreesRoot, safeAgentId);
+  const branchName = `${config.branchPrefix ?? DEFAULT_BRANCH_PREFIX}${safeAgentId}`;
+  const runGit = config.runGit ?? defaultRunGit;
+
+  mkdirSync(worktreesRoot, { recursive: true });
+
+  const allocation: BeastWorktreeAllocation = {
+    agentId: safeAgentId,
+    branchName,
+    projectRoot,
+    worktreePath,
+  };
+
+  if (existsSync(worktreePath)) {
+    return allocation;
+  }
+
+  if (branchExists(runGit, projectRoot, branchName)) {
+    runGit(['worktree', 'add', worktreePath, branchName], projectRoot);
+  } else {
+    runGit(['worktree', 'add', '-b', branchName, worktreePath], projectRoot);
+  }
+
+  return allocation;
+}
+
+export function removeBeastWorktree(allocation: BeastWorktreeAllocation, runGit: GitRunner = defaultRunGit): void {
+  if (existsSync(allocation.worktreePath)) {
+    runGit(['worktree', 'remove', '--force', allocation.worktreePath], allocation.projectRoot);
+  }
+  if (branchExists(runGit, allocation.projectRoot, allocation.branchName)) {
+    runGit(['branch', '-D', allocation.branchName], allocation.projectRoot);
+  }
+}

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -1,10 +1,10 @@
-import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { cpSync, existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { BeastLogStore } from '../events/beast-log-store.js';
 import type { BeastEventBus } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import type { BeastExecutor, StopOptions } from './beast-executor.js';
-import { createBeastWorktree, type GitWorktreeIsolationConfig } from './git-worktree-isolation.js';
+import { createBeastWorktree, removeBeastWorktree, type GitWorktreeIsolationConfig } from './git-worktree-isolation.js';
 import type { ProcessSupervisorLike } from './process-supervisor.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
@@ -20,6 +20,30 @@ function moduleConfigToEnv(config?: ModuleConfig): Record<string, string> {
     }
   }
   return env;
+}
+
+function materializeRuntimeDirectory(
+  configSnapshot: Readonly<Record<string, unknown>>,
+  key: string,
+  sourceRoot: string | undefined,
+  targetRoot: string | undefined,
+): void {
+  if (!sourceRoot || !targetRoot) return;
+  const value = configSnapshot[key];
+  if (typeof value !== 'string' || isAbsolute(value)) return;
+  const source = resolve(sourceRoot, value);
+  const target = resolve(targetRoot, value);
+  if (!existsSync(source) || existsSync(target)) return;
+  mkdirSync(dirname(target), { recursive: true });
+  cpSync(source, target, { recursive: true });
+}
+
+function materializeIgnoredRuntimeState(
+  configSnapshot: Readonly<Record<string, unknown>>,
+  sourceRoot: string | undefined,
+  targetRoot: string | undefined,
+): void {
+  materializeRuntimeDirectory(configSnapshot, 'chunkDirectory', sourceRoot, targetRoot);
 }
 
 export interface ProcessBeastExecutorOptions {
@@ -60,10 +84,13 @@ export class ProcessBeastExecutor implements BeastExecutor {
       run.trackedAgentId ?? run.id,
       processSpec.cwd,
     );
+    if (worktree) {
+      materializeIgnoredRuntimeState(run.configSnapshot, processSpec.cwd, worktree.executionCwd);
+    }
     const isolatedSpec = worktree
       ? {
           ...processSpec,
-          cwd: worktree.worktreePath,
+          cwd: worktree.executionCwd,
           env: {
             ...processSpec.env,
             FRANKENBEAST_WORKTREE_PATH: worktree.worktreePath,
@@ -164,11 +191,14 @@ export class ProcessBeastExecutor implements BeastExecutor {
         data: { runId: run.id, event: spawnFailedEvent },
       });
 
-      // Clean up config file written before spawn
+      // Clean up config file and worktree allocation written before spawn
       const configPath = this.configFilePaths.get(run.id);
       if (configPath) {
         try { unlinkSync(configPath); } catch { /* already removed */ }
         this.configFilePaths.delete(run.id);
+      }
+      if (worktree) {
+        try { removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit); } catch { /* cleanup best effort */ }
       }
 
       this.options.eventBus?.publish({
@@ -195,6 +225,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
               worktreePath: worktree.worktreePath,
               worktreeBranch: worktree.branchName,
               worktreeAgentId: worktree.agentId,
+              worktreeExecutionCwd: worktree.executionCwd,
               worktreeProjectRoot: worktree.projectRoot,
             }
           : {}),

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -1,5 +1,5 @@
 import { cpSync, existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { BeastLogStore } from '../events/beast-log-store.js';
 import type { BeastEventBus } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
@@ -22,28 +22,38 @@ function moduleConfigToEnv(config?: ModuleConfig): Record<string, string> {
   return env;
 }
 
-function materializeRuntimeDirectory(
-  configSnapshot: Readonly<Record<string, unknown>>,
-  key: string,
-  sourceRoot: string | undefined,
-  targetRoot: string | undefined,
-): void {
-  if (!sourceRoot || !targetRoot) return;
-  const value = configSnapshot[key];
-  if (typeof value !== 'string' || isAbsolute(value)) return;
-  const source = resolve(sourceRoot, value);
-  const target = resolve(targetRoot, value);
-  if (!existsSync(source) || existsSync(target)) return;
-  mkdirSync(dirname(target), { recursive: true });
-  cpSync(source, target, { recursive: true });
+function remapRuntimePath(value: string, sourceRoot: string | undefined, targetRoot: string | undefined): string {
+  if (!sourceRoot || !targetRoot) return value;
+  const source = isAbsolute(value) ? resolve(value) : resolve(sourceRoot, value);
+  const relativeSource = relative(resolve(sourceRoot), source);
+  if (relativeSource.startsWith('..') || isAbsolute(relativeSource)) return value;
+  const target = resolve(targetRoot, relativeSource);
+  if (existsSync(source) && !existsSync(target)) {
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(source, target, { recursive: true });
+  }
+  return isAbsolute(value) ? target : value;
 }
 
-function materializeIgnoredRuntimeState(
+function remapRuntimeConfigSnapshot(
   configSnapshot: Readonly<Record<string, unknown>>,
   sourceRoot: string | undefined,
   targetRoot: string | undefined,
-): void {
-  materializeRuntimeDirectory(configSnapshot, 'chunkDirectory', sourceRoot, targetRoot);
+): Readonly<Record<string, unknown>> {
+  const chunkDirectory = configSnapshot.chunkDirectory;
+  if (typeof chunkDirectory !== 'string') return configSnapshot;
+  const remappedChunkDirectory = remapRuntimePath(chunkDirectory, sourceRoot, targetRoot);
+  return remappedChunkDirectory === chunkDirectory
+    ? configSnapshot
+    : { ...configSnapshot, chunkDirectory: remappedChunkDirectory };
+}
+
+function remapAbsoluteRuntimeArgs(
+  args: readonly string[],
+  sourceRoot: string | undefined,
+  targetRoot: string | undefined,
+): readonly string[] {
+  return args.map((arg) => isAbsolute(arg) ? remapRuntimePath(arg, sourceRoot, targetRoot) : arg);
 }
 
 export interface ProcessBeastExecutorOptions {
@@ -79,17 +89,21 @@ export class ProcessBeastExecutor implements BeastExecutor {
   async start(run: BeastRun, definition: BeastDefinition): Promise<BeastRunAttempt> {
     const processSpec = definition.buildProcessSpec(run.configSnapshot);
     const moduleEnv = moduleConfigToEnv(run.configSnapshot.modules as ModuleConfig | undefined);
-    const worktree = createBeastWorktree(
-      this.options.worktreeIsolation,
-      run.trackedAgentId ?? run.id,
-      processSpec.cwd,
-    );
-    if (worktree) {
-      materializeIgnoredRuntimeState(run.configSnapshot, processSpec.cwd, worktree.executionCwd);
-    }
+    this.supervisor.validateCwd?.(processSpec.cwd);
+    const worktree = run.trackedAgentId
+      ? createBeastWorktree(
+          this.options.worktreeIsolation,
+          run.trackedAgentId,
+          processSpec.cwd,
+        )
+      : undefined;
+    const isolatedConfigSnapshot = worktree
+      ? remapRuntimeConfigSnapshot(run.configSnapshot, processSpec.cwd, worktree.executionCwd)
+      : run.configSnapshot;
     const isolatedSpec = worktree
       ? {
           ...processSpec,
+          args: remapAbsoluteRuntimeArgs(processSpec.args, processSpec.cwd, worktree.executionCwd),
           cwd: worktree.executionCwd,
           env: {
             ...processSpec.env,
@@ -98,7 +112,6 @@ export class ProcessBeastExecutor implements BeastExecutor {
           },
         }
       : processSpec;
-    this.supervisor.validateCwd?.(isolatedSpec.cwd);
 
     // Write configSnapshot to a JSON file for the spawned process to load
     const configDir = resolve(
@@ -107,7 +120,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     );
     mkdirSync(configDir, { recursive: true });
     const configFilePath = join(configDir, `${run.id}.json`);
-    writeFileSync(configFilePath, JSON.stringify(run.configSnapshot, null, 2));
+    writeFileSync(configFilePath, JSON.stringify(isolatedConfigSnapshot, null, 2));
     this.configFilePaths.set(run.id, configFilePath);
 
     const mergedSpec = {
@@ -197,8 +210,8 @@ export class ProcessBeastExecutor implements BeastExecutor {
         try { unlinkSync(configPath); } catch { /* already removed */ }
         this.configFilePaths.delete(run.id);
       }
-      if (worktree) {
-        try { removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit); } catch { /* cleanup best effort */ }
+      if (worktree?.created) {
+        try { removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit); } catch { /* best effort */ }
       }
 
       this.options.eventBus?.publish({
@@ -224,6 +237,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
               worktreeIsolation: true,
               worktreePath: worktree.worktreePath,
               worktreeBranch: worktree.branchName,
+              worktreeCreated: worktree.created,
               worktreeAgentId: worktree.agentId,
               worktreeExecutionCwd: worktree.executionCwd,
               worktreeProjectRoot: worktree.projectRoot,

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -35,25 +35,39 @@ function remapRuntimePath(value: string, sourceRoot: string | undefined, targetR
   return isAbsolute(value) ? target : value;
 }
 
+const RUNTIME_CONFIG_PATH_FIELDS = ['chunkDirectory', 'designDocPath', 'outputDir'] as const;
+const RUNTIME_PATH_ARG_FLAGS = new Set(['--plan-dir', '--design-doc', '--output-dir']);
+
 function remapRuntimeConfigSnapshot(
   configSnapshot: Readonly<Record<string, unknown>>,
   sourceRoot: string | undefined,
   targetRoot: string | undefined,
 ): Readonly<Record<string, unknown>> {
-  const chunkDirectory = configSnapshot.chunkDirectory;
-  if (typeof chunkDirectory !== 'string') return configSnapshot;
-  const remappedChunkDirectory = remapRuntimePath(chunkDirectory, sourceRoot, targetRoot);
-  return remappedChunkDirectory === chunkDirectory
-    ? configSnapshot
-    : { ...configSnapshot, chunkDirectory: remappedChunkDirectory };
+  let changed = false;
+  const remapped: Record<string, unknown> = { ...configSnapshot };
+  for (const key of RUNTIME_CONFIG_PATH_FIELDS) {
+    const value = configSnapshot[key];
+    if (typeof value !== 'string') continue;
+    const remappedValue = remapRuntimePath(value, sourceRoot, targetRoot);
+    if (remappedValue !== value) {
+      remapped[key] = remappedValue;
+      changed = true;
+    }
+  }
+  return changed ? remapped : configSnapshot;
 }
 
-function remapAbsoluteRuntimeArgs(
+function remapRuntimePathArgs(
   args: readonly string[],
   sourceRoot: string | undefined,
   targetRoot: string | undefined,
 ): readonly string[] {
-  return args.map((arg) => isAbsolute(arg) ? remapRuntimePath(arg, sourceRoot, targetRoot) : arg);
+  return args.map((arg, index) => {
+    const previous = index > 0 ? args[index - 1] : undefined;
+    return previous && RUNTIME_PATH_ARG_FLAGS.has(previous)
+      ? remapRuntimePath(arg, sourceRoot, targetRoot)
+      : arg;
+  });
 }
 
 export interface ProcessBeastExecutorOptions {
@@ -103,7 +117,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     const isolatedSpec = worktree
       ? {
           ...processSpec,
-          args: remapAbsoluteRuntimeArgs(processSpec.args, processSpec.cwd, worktree.executionCwd),
+          args: remapRuntimePathArgs(processSpec.args, processSpec.cwd, worktree.executionCwd),
           cwd: worktree.executionCwd,
           env: {
             ...processSpec.env,

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -4,6 +4,7 @@ import { BeastLogStore } from '../events/beast-log-store.js';
 import type { BeastEventBus } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import type { BeastExecutor, StopOptions } from './beast-executor.js';
+import { createBeastWorktree, type GitWorktreeIsolationConfig } from './git-worktree-isolation.js';
 import type { ProcessSupervisorLike } from './process-supervisor.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
@@ -37,6 +38,7 @@ export interface ProcessBeastExecutorOptions {
     spawnedSpec: BeastProcessSpec,
     handle: { pid: number },
   ) => Readonly<Record<string, unknown>>;
+  worktreeIsolation?: GitWorktreeIsolationConfig | undefined;
 }
 
 export class ProcessBeastExecutor implements BeastExecutor {
@@ -53,12 +55,28 @@ export class ProcessBeastExecutor implements BeastExecutor {
   async start(run: BeastRun, definition: BeastDefinition): Promise<BeastRunAttempt> {
     const processSpec = definition.buildProcessSpec(run.configSnapshot);
     const moduleEnv = moduleConfigToEnv(run.configSnapshot.modules as ModuleConfig | undefined);
-    this.supervisor.validateCwd?.(processSpec.cwd);
+    const worktree = createBeastWorktree(
+      this.options.worktreeIsolation,
+      run.trackedAgentId ?? run.id,
+      processSpec.cwd,
+    );
+    const isolatedSpec = worktree
+      ? {
+          ...processSpec,
+          cwd: worktree.worktreePath,
+          env: {
+            ...processSpec.env,
+            FRANKENBEAST_WORKTREE_PATH: worktree.worktreePath,
+            FRANKENBEAST_WORKTREE_BRANCH: worktree.branchName,
+          },
+        }
+      : processSpec;
+    this.supervisor.validateCwd?.(isolatedSpec.cwd);
 
     // Write configSnapshot to a JSON file for the spawned process to load
     const configDir = resolve(
       this.options.runConfigDir ??
-      join(processSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd(), '.fbeast', '.build', 'run-configs'),
+      join(isolatedSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd(), '.fbeast', '.build', 'run-configs'),
     );
     mkdirSync(configDir, { recursive: true });
     const configFilePath = join(configDir, `${run.id}.json`);
@@ -66,9 +84,9 @@ export class ProcessBeastExecutor implements BeastExecutor {
     this.configFilePaths.set(run.id, configFilePath);
 
     const mergedSpec = {
-      ...processSpec,
+      ...isolatedSpec,
       env: {
-        ...processSpec.env,
+        ...isolatedSpec.env,
         ...moduleEnv,
         FRANKENBEAST_RUN_CONFIG: configFilePath,
       },
@@ -171,6 +189,15 @@ export class ProcessBeastExecutor implements BeastExecutor {
         backend: 'process',
         command: processSpec.command,
         args: [...processSpec.args],
+        ...(worktree
+          ? {
+              worktreeIsolation: true,
+              worktreePath: worktree.worktreePath,
+              worktreeBranch: worktree.branchName,
+              worktreeAgentId: worktree.agentId,
+              worktreeProjectRoot: worktree.projectRoot,
+            }
+          : {}),
       },
     });
 

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -156,6 +156,7 @@ export class AgentService {
     return {
       agentId: worktreeAgentId,
       branchName,
+      executionCwd: typeof metadata.worktreeExecutionCwd === 'string' ? metadata.worktreeExecutionCwd : worktreePath,
       projectRoot,
       worktreePath,
     };

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -156,7 +156,9 @@ export class AgentService {
     return {
       agentId: worktreeAgentId,
       branchName,
+      created: true,
       executionCwd: typeof metadata.worktreeExecutionCwd === 'string' ? metadata.worktreeExecutionCwd : worktreePath,
+      gitTopLevel: projectRoot,
       projectRoot,
       worktreePath,
     };

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -6,11 +6,6 @@ import type {
   TrackedAgentInitAction,
 } from '../types.js';
 import { UnknownTrackedAgentError } from '../errors.js';
-import {
-  removeBeastWorktree,
-  type BeastWorktreeAllocation,
-  type GitRunner,
-} from '../execution/git-worktree-isolation.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 
 export interface CreateTrackedAgentRequest {
@@ -40,10 +35,6 @@ export interface UpdateTrackedAgentRequest {
   readonly moduleConfig?: ModuleConfig | undefined;
 }
 
-export interface AgentServiceOptions {
-  readonly runGit?: GitRunner | undefined;
-}
-
 export interface TrackedAgentDetail {
   readonly agent: TrackedAgent;
   readonly events: TrackedAgentEvent[];
@@ -53,7 +44,6 @@ export class AgentService {
   constructor(
     private readonly repository: SQLiteBeastRepository,
     private readonly now: () => string = () => new Date().toISOString(),
-    private readonly options: AgentServiceOptions = {},
   ) {}
 
   createAgent(request: CreateTrackedAgentRequest): TrackedAgent {
@@ -111,10 +101,6 @@ export class AgentService {
     if (agent.status !== 'stopped') {
       throw new Error(`Tracked agent '${agentId}' is not stopped`);
     }
-    const allocation = this.worktreeAllocationFor(agent);
-    if (allocation) {
-      removeBeastWorktree(allocation, this.options.runGit);
-    }
     return this.repository.updateTrackedAgent(agentId, {
       status: 'deleted',
       updatedAt: this.now(),
@@ -131,37 +117,6 @@ export class AgentService {
       ...(request.moduleConfig !== undefined ? { moduleConfig: request.moduleConfig } : {}),
       updatedAt: this.now(),
     });
-  }
-
-  private worktreeAllocationFor(agent: TrackedAgent): BeastWorktreeAllocation | undefined {
-    if (!agent.dispatchRunId) return undefined;
-    const attempt = [...this.repository.listAttempts(agent.dispatchRunId)].reverse()
-      .find((entry) => entry.executorMetadata?.worktreeIsolation === true);
-    const metadata = attempt?.executorMetadata;
-    if (!metadata) return undefined;
-
-    const worktreePath = metadata.worktreePath;
-    const branchName = metadata.worktreeBranch;
-    const projectRoot = metadata.worktreeProjectRoot;
-    const worktreeAgentId = metadata.worktreeAgentId;
-    if (
-      typeof worktreePath !== 'string' ||
-      typeof branchName !== 'string' ||
-      typeof projectRoot !== 'string' ||
-      typeof worktreeAgentId !== 'string'
-    ) {
-      return undefined;
-    }
-
-    return {
-      agentId: worktreeAgentId,
-      branchName,
-      created: true,
-      executionCwd: typeof metadata.worktreeExecutionCwd === 'string' ? metadata.worktreeExecutionCwd : worktreePath,
-      gitTopLevel: projectRoot,
-      projectRoot,
-      worktreePath,
-    };
   }
 }
 

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -6,6 +6,11 @@ import type {
   TrackedAgentInitAction,
 } from '../types.js';
 import { UnknownTrackedAgentError } from '../errors.js';
+import {
+  removeBeastWorktree,
+  type BeastWorktreeAllocation,
+  type GitRunner,
+} from '../execution/git-worktree-isolation.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 
 export interface CreateTrackedAgentRequest {
@@ -35,6 +40,10 @@ export interface UpdateTrackedAgentRequest {
   readonly moduleConfig?: ModuleConfig | undefined;
 }
 
+export interface AgentServiceOptions {
+  readonly runGit?: GitRunner | undefined;
+}
+
 export interface TrackedAgentDetail {
   readonly agent: TrackedAgent;
   readonly events: TrackedAgentEvent[];
@@ -44,6 +53,7 @@ export class AgentService {
   constructor(
     private readonly repository: SQLiteBeastRepository,
     private readonly now: () => string = () => new Date().toISOString(),
+    private readonly options: AgentServiceOptions = {},
   ) {}
 
   createAgent(request: CreateTrackedAgentRequest): TrackedAgent {
@@ -101,6 +111,10 @@ export class AgentService {
     if (agent.status !== 'stopped') {
       throw new Error(`Tracked agent '${agentId}' is not stopped`);
     }
+    const allocation = this.worktreeAllocationFor(agent);
+    if (allocation) {
+      removeBeastWorktree(allocation, this.options.runGit);
+    }
     return this.repository.updateTrackedAgent(agentId, {
       status: 'deleted',
       updatedAt: this.now(),
@@ -117,6 +131,34 @@ export class AgentService {
       ...(request.moduleConfig !== undefined ? { moduleConfig: request.moduleConfig } : {}),
       updatedAt: this.now(),
     });
+  }
+
+  private worktreeAllocationFor(agent: TrackedAgent): BeastWorktreeAllocation | undefined {
+    if (!agent.dispatchRunId) return undefined;
+    const attempt = [...this.repository.listAttempts(agent.dispatchRunId)].reverse()
+      .find((entry) => entry.executorMetadata?.worktreeIsolation === true);
+    const metadata = attempt?.executorMetadata;
+    if (!metadata) return undefined;
+
+    const worktreePath = metadata.worktreePath;
+    const branchName = metadata.worktreeBranch;
+    const projectRoot = metadata.worktreeProjectRoot;
+    const worktreeAgentId = metadata.worktreeAgentId;
+    if (
+      typeof worktreePath !== 'string' ||
+      typeof branchName !== 'string' ||
+      typeof projectRoot !== 'string' ||
+      typeof worktreeAgentId !== 'string'
+    ) {
+      return undefined;
+    }
+
+    return {
+      agentId: worktreeAgentId,
+      branchName,
+      projectRoot,
+      worktreePath,
+    };
   }
 }
 

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -96,6 +97,55 @@ describe('AgentService', () => {
     expect(linked.dispatchRunId).toBe(run.id);
     expect(detail.agent.dispatchRunId).toBe(run.id);
     expect(detail.events).toEqual([event]);
+  });
+
+  it('removes tracked worktree allocation when soft-deleting a stopped agent', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-agent-service-'));
+    const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const runGit = vi.fn((_args: readonly string[]) => 'beast/agent-cleanup');
+    const service = new AgentService(repository, () => '2026-03-11T00:00:00.000Z', { runGit });
+    const worktreePath = join(workDir, '.frankenbeast', '.worktrees', 'agent-cleanup');
+    mkdirSync(worktreePath, { recursive: true });
+
+    const agent = service.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: { chunkDirectory: 'docs/chunks' },
+      },
+      initConfig: { chunkDirectory: 'docs/chunks' },
+    });
+    const run = repository.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-11T00:00:00.000Z',
+    });
+    repository.createAttempt(run.id, {
+      status: 'stopped',
+      executorMetadata: {
+        worktreeIsolation: true,
+        worktreePath,
+        worktreeBranch: 'beast/agent-cleanup',
+        worktreeAgentId: 'agent-cleanup',
+        worktreeProjectRoot: workDir,
+      },
+    });
+    service.linkRun(agent.id, run.id);
+    service.updateAgent(agent.id, { status: 'stopped' });
+
+    service.softDeleteAgent(agent.id);
+
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', worktreePath], workDir);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', 'beast/agent-cleanup'], workDir);
   });
 
   it('hides soft-deleted tracked agents from list and detail lookups', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { existsSync, mkdirSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -99,11 +99,10 @@ describe('AgentService', () => {
     expect(detail.events).toEqual([event]);
   });
 
-  it('removes tracked worktree allocation when soft-deleting a stopped agent', async () => {
+  it('preserves tracked worktree state when soft-deleting a stopped agent', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-agent-service-'));
     const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
-    const runGit = vi.fn((_args: readonly string[]) => 'beast/agent-cleanup');
-    const service = new AgentService(repository, () => '2026-03-11T00:00:00.000Z', { runGit });
+    const service = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
     const worktreePath = join(workDir, '.frankenbeast', '.worktrees', 'agent-cleanup');
     mkdirSync(worktreePath, { recursive: true });
 
@@ -144,8 +143,6 @@ describe('AgentService', () => {
     service.softDeleteAgent(agent.id);
 
     expect(existsSync(worktreePath)).toBe(true);
-    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', worktreePath], workDir);
-    expect(runGit).toHaveBeenCalledWith(['branch', '-D', 'beast/agent-cleanup'], workDir);
   });
 
   it('hides soft-deleted tracked agents from list and detail lookups', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -9,6 +9,7 @@ import { martinLoopDefinition } from '../../../src/beasts/definitions/martin-loo
 import { ProcessBeastExecutor } from '../../../src/beasts/execution/process-beast-executor.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import type { ProcessCallbacks } from '../../../src/beasts/execution/process-supervisor.js';
+import type { BeastDefinition } from '../../../src/beasts/types.js';
 
 function createTestRun(repo: SQLiteBeastRepository) {
   return repo.createRun({
@@ -31,6 +32,25 @@ function createSupervisorMock() {
     spawn: vi.fn(async (_spec: unknown, _callbacks: unknown) => ({ pid: 4242 })),
     stop: vi.fn(async () => {}),
     kill: vi.fn(async () => {}),
+  };
+}
+
+function createDefinitionWithCwd(cwd: string): BeastDefinition {
+  return {
+    id: 'test-beast',
+    version: 1,
+    label: 'Test Beast',
+    description: 'Test definition',
+    executionModeDefault: 'process',
+    configSchema: martinLoopDefinition.configSchema,
+    interviewPrompts: [],
+    buildProcessSpec: () => ({
+      command: 'node',
+      args: ['agent.js'],
+      cwd,
+      env: { EXISTING_ENV: '1' },
+    }),
+    telemetryLabels: { family: 'test' },
   };
 }
 
@@ -96,6 +116,65 @@ describe('ProcessBeastExecutor', () => {
         type: 'attempt.started',
       }),
     ]);
+  });
+
+  it('creates an isolated git worktree and spawns the process inside it when enabled', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = createSupervisorMock();
+    const runGit = vi.fn((_args: readonly string[]) => '');
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: {
+        enabled: true,
+        projectRoot: workDir,
+        runGit,
+      },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const attempt = await executor.start(run, createDefinitionWithCwd(workDir));
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    const expectedBranch = `beast/${agent.id}`;
+    expect(runGit).toHaveBeenCalledWith(['branch', '--list', expectedBranch], workDir);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'add', '-b', expectedBranch, expectedWorktree], workDir);
+    expect(supervisor.spawn).toHaveBeenCalledTimes(1);
+    const [spawnedSpec] = supervisor.spawn.mock.calls[0];
+    expect(spawnedSpec).toMatchObject({
+      cwd: expectedWorktree,
+      env: expect.objectContaining({
+        EXISTING_ENV: '1',
+        FRANKENBEAST_WORKTREE_PATH: expectedWorktree,
+        FRANKENBEAST_WORKTREE_BRANCH: expectedBranch,
+      }),
+    });
+    expect(attempt.executorMetadata).toMatchObject({
+      worktreeIsolation: true,
+      worktreePath: expectedWorktree,
+      worktreeBranch: expectedBranch,
+      worktreeAgentId: agent.id,
+      worktreeProjectRoot: workDir,
+    });
   });
 
   it('stops the current attempt without deleting the run row', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -123,11 +123,15 @@ describe('ProcessBeastExecutor', () => {
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = createSupervisorMock();
-    const runGit = vi.fn((args: readonly string[]) => args[0] === 'rev-parse' ? 'true' : '');
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      return '';
+    });
     const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
       worktreeIsolation: {
         enabled: true,
-        projectRoot: workDir,
+        projectRoot: workDir!,
         runGit,
       },
     });
@@ -173,6 +177,7 @@ describe('ProcessBeastExecutor', () => {
       worktreeIsolation: true,
       worktreePath: expectedWorktree,
       worktreeBranch: expectedBranch,
+      worktreeCreated: true,
       worktreeAgentId: agent.id,
       worktreeExecutionCwd: expectedWorktree,
       worktreeProjectRoot: workDir,
@@ -184,9 +189,46 @@ describe('ProcessBeastExecutor', () => {
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = createSupervisorMock();
-    const runGit = vi.fn(() => { throw new Error('not a git repository'); });
+    const runGit = vi.fn((_args: readonly string[]): string => { throw new Error('not a git repository'); });
     const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
-      worktreeIsolation: { enabled: true, projectRoot: workDir, runGit },
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await executor.start(run, createDefinitionWithCwd(workDir));
+
+    const [spawnedSpec] = supervisor.spawn.mock.calls[0];
+    expect(spawnedSpec).toMatchObject({ cwd: workDir });
+    expect(runGit).toHaveBeenCalledWith(['rev-parse', '--is-inside-work-tree'], workDir);
+  });
+
+  it('skips worktree isolation for ad-hoc runs without a tracked agent', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = createSupervisorMock();
+    const runGit = vi.fn((_args: readonly string[]) => 'true');
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
     });
     const run = createTestRun(repo);
 
@@ -194,7 +236,7 @@ describe('ProcessBeastExecutor', () => {
 
     const [spawnedSpec] = supervisor.spawn.mock.calls[0];
     expect(spawnedSpec).toMatchObject({ cwd: workDir });
-    expect(runGit).toHaveBeenCalledWith(['rev-parse', '--is-inside-work-tree'], workDir);
+    expect(runGit).not.toHaveBeenCalled();
   });
 
   it('preserves subdirectory cwd and materializes ignored runtime plan state in the worktree', async () => {
@@ -206,9 +248,13 @@ describe('ProcessBeastExecutor', () => {
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = createSupervisorMock();
-    const runGit = vi.fn((args: readonly string[]) => args[0] === 'rev-parse' ? 'true' : '');
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      return '';
+    });
     const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
-      worktreeIsolation: { enabled: true, projectRoot: workDir, runGit },
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
     });
     const agent = repo.createTrackedAgent({
       definitionId: 'martin-loop',
@@ -249,13 +295,14 @@ describe('ProcessBeastExecutor', () => {
       stop: vi.fn(async () => {}),
       kill: vi.fn(async () => {}),
     };
-    const runGit = vi.fn((args: readonly string[]) => {
-      if (args[0] === 'rev-parse') return 'true';
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
       if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
       return '';
     });
     const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
-      worktreeIsolation: { enabled: true, projectRoot: workDir, runGit },
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
     });
     const agent = repo.createTrackedAgent({
       definitionId: 'test-beast',

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -123,7 +123,7 @@ describe('ProcessBeastExecutor', () => {
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = createSupervisorMock();
-    const runGit = vi.fn((_args: readonly string[]) => '');
+    const runGit = vi.fn((args: readonly string[]) => args[0] === 'rev-parse' ? 'true' : '');
     const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
       worktreeIsolation: {
         enabled: true,
@@ -156,6 +156,7 @@ describe('ProcessBeastExecutor', () => {
 
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
     const expectedBranch = `beast/${agent.id}`;
+    expect(runGit).toHaveBeenCalledWith(['rev-parse', '--is-inside-work-tree'], workDir);
     expect(runGit).toHaveBeenCalledWith(['branch', '--list', expectedBranch], workDir);
     expect(runGit).toHaveBeenCalledWith(['worktree', 'add', '-b', expectedBranch, expectedWorktree], workDir);
     expect(supervisor.spawn).toHaveBeenCalledTimes(1);
@@ -173,8 +174,115 @@ describe('ProcessBeastExecutor', () => {
       worktreePath: expectedWorktree,
       worktreeBranch: expectedBranch,
       worktreeAgentId: agent.id,
+      worktreeExecutionCwd: expectedWorktree,
       worktreeProjectRoot: workDir,
     });
+  });
+
+  it('falls back to the original cwd when worktree isolation is enabled outside a git repository', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = createSupervisorMock();
+    const runGit = vi.fn(() => { throw new Error('not a git repository'); });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir, runGit },
+    });
+    const run = createTestRun(repo);
+
+    await executor.start(run, createDefinitionWithCwd(workDir));
+
+    const [spawnedSpec] = supervisor.spawn.mock.calls[0];
+    expect(spawnedSpec).toMatchObject({ cwd: workDir });
+    expect(runGit).toHaveBeenCalledWith(['rev-parse', '--is-inside-work-tree'], workDir);
+  });
+
+  it('preserves subdirectory cwd and materializes ignored runtime plan state in the worktree', async () => {
+    workDir = await createTempWorkDir();
+    const projectCwd = join(workDir, 'packages', 'demo');
+    const sourcePlanDir = join(projectCwd, '.fbeast', 'plans', 'plan-1');
+    mkdirSync(sourcePlanDir, { recursive: true });
+    writeFileSync(join(sourcePlanDir, 'chunk.md'), 'plan chunk');
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = createSupervisorMock();
+    const runGit = vi.fn((args: readonly string[]) => args[0] === 'rev-parse' ? 'true' : '');
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { chunkDirectory: '.fbeast/plans/plan-1' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await executor.start(run, createDefinitionWithCwd(projectCwd));
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    const expectedExecutionCwd = join(expectedWorktree, 'packages', 'demo');
+    const [spawnedSpec] = supervisor.spawn.mock.calls[0];
+    expect(spawnedSpec).toMatchObject({ cwd: expectedExecutionCwd });
+    expect(readFileSync(join(expectedExecutionCwd, '.fbeast', 'plans', 'plan-1', 'chunk.md'), 'utf-8')).toBe('plan chunk');
+  });
+
+  it('removes a worktree allocation when process spawning fails before attempt creation', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = {
+      spawn: vi.fn(async () => { throw new Error('spawn failed'); }),
+      stop: vi.fn(async () => {}),
+      kill: vi.fn(async () => {}),
+    };
+    const runGit = vi.fn((args: readonly string[]) => {
+      if (args[0] === 'rev-parse') return 'true';
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await expect(executor.start(run, createDefinitionWithCwd(workDir))).rejects.toThrow('spawn failed');
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
   });
 
   it('stops the current attempt without deleting the run row', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -239,12 +239,19 @@ describe('ProcessBeastExecutor', () => {
     expect(runGit).not.toHaveBeenCalled();
   });
 
-  it('preserves subdirectory cwd and materializes ignored runtime plan state in the worktree', async () => {
+  it('preserves subdirectory cwd and materializes ignored runtime paths in the worktree', async () => {
     workDir = await createTempWorkDir();
     const projectCwd = join(workDir, 'packages', 'demo');
     const sourcePlanDir = join(projectCwd, '.fbeast', 'plans', 'plan-1');
+    const sourceDesignDoc = join(projectCwd, '.fbeast', 'designs', 'design.md');
+    const sourceOutputDir = join(projectCwd, '.fbeast', 'outputs', 'plan-1');
+    const originalCliEntrypoint = join(workDir, 'packages', 'franken-orchestrator', 'dist', 'cli', 'run.js');
     mkdirSync(sourcePlanDir, { recursive: true });
+    mkdirSync(join(projectCwd, '.fbeast', 'designs'), { recursive: true });
+    mkdirSync(sourceOutputDir, { recursive: true });
     writeFileSync(join(sourcePlanDir, 'chunk.md'), 'plan chunk');
+    writeFileSync(sourceDesignDoc, 'design doc');
+    writeFileSync(join(sourceOutputDir, 'result.md'), 'existing result');
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const supervisor = createSupervisorMock();
@@ -271,19 +278,61 @@ describe('ProcessBeastExecutor', () => {
       definitionId: 'martin-loop',
       definitionVersion: 1,
       executionMode: 'process',
-      configSnapshot: { chunkDirectory: '.fbeast/plans/plan-1' },
+      configSnapshot: {
+        chunkDirectory: '.fbeast/plans/plan-1',
+        designDocPath: sourceDesignDoc,
+        outputDir: sourceOutputDir,
+      },
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'pfk',
       createdAt: '2026-03-10T00:00:00.000Z',
     });
+    const definition: BeastDefinition = {
+      ...createDefinitionWithCwd(projectCwd),
+      buildProcessSpec: () => ({
+        command: 'node',
+        args: [
+          originalCliEntrypoint,
+          '--design-doc',
+          sourceDesignDoc,
+          '--plan-dir',
+          '.fbeast/plans/plan-1',
+          '--output-dir',
+          sourceOutputDir,
+        ],
+        cwd: projectCwd,
+        env: { EXISTING_ENV: '1' },
+      }),
+    };
 
-    await executor.start(run, createDefinitionWithCwd(projectCwd));
+    await executor.start(run, definition);
 
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
     const expectedExecutionCwd = join(expectedWorktree, 'packages', 'demo');
+    const expectedDesignDoc = join(expectedExecutionCwd, '.fbeast', 'designs', 'design.md');
+    const expectedOutputDir = join(expectedExecutionCwd, '.fbeast', 'outputs', 'plan-1');
     const [spawnedSpec] = supervisor.spawn.mock.calls[0];
-    expect(spawnedSpec).toMatchObject({ cwd: expectedExecutionCwd });
+    expect(spawnedSpec).toMatchObject({
+      cwd: expectedExecutionCwd,
+      args: [
+        originalCliEntrypoint,
+        '--design-doc',
+        expectedDesignDoc,
+        '--plan-dir',
+        '.fbeast/plans/plan-1',
+        '--output-dir',
+        expectedOutputDir,
+      ],
+    });
     expect(readFileSync(join(expectedExecutionCwd, '.fbeast', 'plans', 'plan-1', 'chunk.md'), 'utf-8')).toBe('plan chunk');
+    expect(readFileSync(expectedDesignDoc, 'utf-8')).toBe('design doc');
+    expect(readFileSync(join(expectedOutputDir, 'result.md'), 'utf-8')).toBe('existing result');
+    const configPath = (spawnedSpec as { env: Record<string, string> }).env.FRANKENBEAST_RUN_CONFIG;
+    expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toMatchObject({
+      chunkDirectory: '.fbeast/plans/plan-1',
+      designDocPath: expectedDesignDoc,
+      outputDir: expectedOutputDir,
+    });
   });
 
   it('removes a worktree allocation when process spawning fails before attempt creation', async () => {


### PR DESCRIPTION
## Summary
- add Git worktree allocation/removal helpers for beast process executions
- run process beasts from per-agent worktrees and expose worktree metadata/env vars
- clean up recorded worktrees when stopped tracked agents are soft-deleted

## Test Plan
- npm test -- --run tests/unit/beasts/process-beast-executor.test.ts tests/unit/beasts/agent-service.test.ts
- npx turbo run typecheck --filter=franken-orchestrator
- npx turbo run build --filter=franken-orchestrator
- npx turbo run lint --filter=franken-orchestrator (passes with existing warnings)

Closes #494