### PR TITLE
fix(orchestrator): preserve MCP skill HITL metadata

### DIFF
--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -28,14 +28,14 @@ export class SkillManagerAdapter implements ISkillsModule {
       const descriptors: SkillDescriptor[] = [];
 
       if (isServerAliasExecutable(name, tools)) {
-        descriptors.push(createDescriptor(name, name));
+        descriptors.push(createDescriptor(name, name, undefined, aliasToolFor(name, tools)?.requiresHitl ?? false));
       }
 
       for (const tool of tools) {
         if (tool.name !== name) {
-          descriptors.push(createDescriptor(tool.name, tool.name, name));
+          descriptors.push(createDescriptor(tool.name, tool.name, name, tool.requiresHitl ?? false));
         }
-        descriptors.push(createDescriptor(namespacedToolId(name, tool.name), tool.name, name));
+        descriptors.push(createDescriptor(namespacedToolId(name, tool.name), tool.name, name, tool.requiresHitl ?? false));
       }
 
       return descriptors;
@@ -52,12 +52,12 @@ export class SkillManagerAdapter implements ISkillsModule {
   }
 }
 
-function createDescriptor(id: string, name: string, parentSkillId?: string): SkillDescriptor {
+function createDescriptor(id: string, name: string, parentSkillId: string | undefined, requiresHitl: boolean): SkillDescriptor {
   return {
     id,
     name,
     ...(parentSkillId ? { parentSkillId } : {}),
-    requiresHitl: false,
+    requiresHitl,
     executionType: 'mcp',
   };
 }
@@ -71,4 +71,12 @@ function isServerAliasExecutable(
   tools: ReturnType<SkillManager['readTools']>,
 ): boolean {
   return tools.length === 0 || tools.length === 1 || tools.some(tool => tool.name === skillName);
+}
+
+function aliasToolFor(
+  skillName: string,
+  tools: ReturnType<SkillManager['readTools']>,
+): ReturnType<SkillManager['readTools']>[number] | undefined {
+  if (tools.length === 1) return tools[0];
+  return tools.find(tool => tool.name === skillName);
 }

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -42,6 +42,24 @@ describe('MCP execution adapters', () => {
       .toEqual(['query', 'search/query', 'summarize', 'search/summarize']);
   });
 
+  it('SkillManagerAdapter preserves requiresHitl metadata from tool manifests', () => {
+    const skillsDir = mkdtempSync(join(tmpdir(), 'franken-skills-'));
+    mkdirSync(join(skillsDir, 'github'));
+    writeFileSync(join(skillsDir, 'github', 'mcp.json'), JSON.stringify({ mcpServers: { github: { command: 'github' } } }));
+    writeFileSync(join(skillsDir, 'github', 'tools.json'), JSON.stringify([
+      { name: 'create_issue', description: 'Create issue', inputSchema: {}, requiresHitl: true },
+      { name: 'list_repos', description: 'List repos', inputSchema: {} },
+    ]));
+    const manager = new SkillManager(skillsDir, new Set(['github']));
+    const adapter = new SkillManagerAdapter(manager);
+
+    expect(adapter.getAvailableSkills()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'create_issue', requiresHitl: true, executionType: 'mcp' }),
+      expect.objectContaining({ id: 'github/create_issue', requiresHitl: true, executionType: 'mcp' }),
+      expect.objectContaining({ id: 'list_repos', requiresHitl: false, executionType: 'mcp' }),
+    ]));
+  });
+
   it('SkillManagerAdapter keeps server aliases only when they resolve to one tool', () => {
     const skillsDir = mkdtempSync(join(tmpdir(), 'franken-skills-'));
     mkdirSync(join(skillsDir, 'memory'));

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -89,6 +89,8 @@ export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  /** True when using this tool requires human approval before execution. */
+  requiresHitl?: boolean | undefined;
 }
 
 // --- Stream Events ---
@@ -163,6 +165,7 @@ export const ToolDefinitionSchema = z.object({
   name: z.string().min(1),
   description: z.string(),
   inputSchema: z.record(z.unknown()),
+  requiresHitl: z.boolean().optional(),
 });
 
 export const TokenUsageSchema = z.object({

--- a/packages/franken-types/tests/skill.test.ts
+++ b/packages/franken-types/tests/skill.test.ts
@@ -121,7 +121,7 @@ describe('SkillInfoSchema', () => {
 describe('SkillToolManifestSchema', () => {
   it('validates array of tool definitions', () => {
     const manifest: SkillToolManifest = [
-      { name: 'create_issue', description: 'Create an issue', inputSchema: { type: 'object' } },
+      { name: 'create_issue', description: 'Create an issue', inputSchema: { type: 'object' }, requiresHitl: true },
       { name: 'list_repos', description: 'List repos', inputSchema: {} },
     ];
     expect(SkillToolManifestSchema.parse(manifest)).toEqual(manifest);


### PR DESCRIPTION
## Summary
- Preserve optional requiresHitl metadata on MCP tool manifests in @franken/types.
- Propagate tool-level HITL metadata through SkillManagerAdapter descriptors, including namespaced MCP tool IDs and single-tool aliases.
- Add targeted coverage for MCP descriptor HITL preservation and tool manifest validation.

## Test Plan
- npm test -- tests/unit/adapters/mcp-execution-adapters.test.ts (packages/franken-orchestrator)
- npm test -- tests/unit/cli/dep-factory-providers.test.ts (packages/franken-orchestrator)
- npm test -- tests/skill.test.ts (packages/franken-types)
- npm run build
- npm run typecheck
- npm run lint --workspace=packages/franken-orchestrator (passes with existing warnings)

Note: full npm test currently fails in @franken/critique tests/unit/evaluators/safety.test.ts on an existing timeout unrelated to this change; the same targeted critique test reproduces the timeout.

Closes #21