### PR TITLE
fix(orchestrator): harden verify command execution

### DIFF
--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type { MartinLoopConfig, MartinLoopResult, IterationResult, CliSkillConfig, MergeResult } from './cli-types.js';
 import type { SkillInput, SkillResult, ICheckpointStore, ILogger } from '../deps.js';
 import type { MartinLoop } from './martin-loop.js';
@@ -165,6 +165,44 @@ function safeReplayJson(value: unknown): string {
 type CommitMessageFn = (diffStat: string, objective: string) => Promise<string | null>;
 const BUDGET_POLL_INTERVAL_MS = 100;
 
+type VerifyCommandSpec = {
+  readonly command: string;
+  readonly args: readonly string[];
+};
+
+const ALLOWED_VERIFY_COMMANDS = new Map<string, VerifyCommandSpec>([
+  ['npx tsc --noEmit', { command: process.platform === 'win32' ? 'npx.cmd' : 'npx', args: ['tsc', '--noEmit'] }],
+  ['npm run typecheck', { command: process.platform === 'win32' ? 'npm.cmd' : 'npm', args: ['run', 'typecheck'] }],
+  ['npm run build', { command: process.platform === 'win32' ? 'npm.cmd' : 'npm', args: ['run', 'build'] }],
+  ['npm run lint', { command: process.platform === 'win32' ? 'npm.cmd' : 'npm', args: ['run', 'lint'] }],
+  ['npm test', { command: process.platform === 'win32' ? 'npm.cmd' : 'npm', args: ['test'] }],
+  ['npm run test', { command: process.platform === 'win32' ? 'npm.cmd' : 'npm', args: ['run', 'test'] }],
+]);
+
+/**
+ * Verification commands intentionally use a small exact whitelist and execFileSync.
+ * The verifyCommand option can come from caller-controlled configuration, so never
+ * pass it to a shell or parse arbitrary command text.
+ */
+function normalizeVerifyCommand(verifyCommand: string): VerifyCommandSpec {
+  const normalized = verifyCommand.trim().replace(/\s+/g, ' ');
+  const spec = ALLOWED_VERIFY_COMMANDS.get(normalized);
+  if (!spec) {
+    throw new Error(`Unsafe verifyCommand rejected: ${verifyCommand}`);
+  }
+  return spec;
+}
+
+function runVerifyCommand(verifyCommand: string, cwd: string): void {
+  const spec = normalizeVerifyCommand(verifyCommand);
+  execFileSync(spec.command, [...spec.args], {
+    encoding: 'utf-8',
+    cwd,
+    stdio: 'pipe',
+    shell: false,
+  });
+}
+
 type DefaultMartinConfig = Pick<MartinLoopConfig, 'provider'> & Partial<Pick<
   MartinLoopConfig,
   'command' | 'providers' | 'planName' | 'sessionStore' | 'snapshotStore' | 'renderer' | 'compactor' | 'contextUsage'
@@ -209,11 +247,7 @@ export class CliSkillExecutor {
 
     if (this.verifyCommand) {
       try {
-        execSync(this.verifyCommand, {
-          encoding: 'utf-8',
-          cwd: this.git.getWorkingDir(),
-          stdio: 'pipe',
-        });
+        runVerifyCommand(this.verifyCommand, this.git.getWorkingDir());
       } catch {
         // Verification failed — reset to last known good commit
         const lastHash = checkpoint.lastCommit(taskId, stage);

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -199,7 +199,10 @@ function runVerifyCommand(verifyCommand: string, cwd: string): void {
     encoding: 'utf-8',
     cwd,
     stdio: 'pipe',
-    shell: false,
+    // Windows requires cmd.exe to launch npm/npx .cmd shims. This remains safe
+    // because verifyCommand is matched against exact hard-coded commands above;
+    // caller-provided command text is never passed through the shell.
+    shell: process.platform === 'win32',
   });
 }
 

--- a/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
+++ b/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { runExecution } from '../../src/phases/execution.js';
 import { BeastContext } from '../../src/context/franken-context.js';
 import {
@@ -13,7 +13,7 @@ import type { ICheckpointStore, SkillInput, SkillResult } from '../../src/deps.j
 import type { CliSkillExecutor } from '../../src/skills/cli-skill-executor.js';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 function makeCheckpoint(overrides: Partial<ICheckpointStore> = {}): ICheckpointStore {
@@ -494,14 +494,14 @@ describe('CliSkillExecutor.recoverDirtyFiles', () => {
     };
   }
 
-  const mockedExecSync = vi.mocked(execSync);
+  const mockedExecFileSync = vi.mocked(execFileSync);
 
   function mockVerifyPass(): void {
-    mockedExecSync.mockImplementation(() => 'ok');
+    mockedExecFileSync.mockImplementation(() => 'ok');
   }
 
   function mockVerifyFail(): void {
-    mockedExecSync.mockImplementation(() => {
+    mockedExecFileSync.mockImplementation(() => {
       throw new Error('verify failed');
     });
   }
@@ -526,7 +526,7 @@ describe('CliSkillExecutor.recoverDirtyFiles', () => {
     git.getStatus.mockReturnValue('M src/file.ts');
     mockVerifyPass();
     const { CliSkillExecutor } = await import('../../src/skills/cli-skill-executor.js');
-    const executor = new CliSkillExecutor(makeMockMartin() as any, git as any, makeMockObserver(), 'echo ok');
+    const executor = new CliSkillExecutor(makeMockMartin() as any, git as any, makeMockObserver(), 'npx tsc --noEmit');
 
     const checkpoint = makeCheckpoint({ lastCommit: vi.fn(() => 'abc123') });
     const result = await executor.recoverDirtyFiles('t1', 'impl', checkpoint, makeLogger());
@@ -541,7 +541,7 @@ describe('CliSkillExecutor.recoverDirtyFiles', () => {
     git.getStatus.mockReturnValue('M src/file.ts');
     mockVerifyPass();
     const { CliSkillExecutor } = await import('../../src/skills/cli-skill-executor.js');
-    const executor = new CliSkillExecutor(makeMockMartin() as any, git as any, makeMockObserver(), 'echo ok');
+    const executor = new CliSkillExecutor(makeMockMartin() as any, git as any, makeMockObserver(), 'npx tsc --noEmit');
 
     const checkpoint = makeCheckpoint({ lastCommit: vi.fn(() => 'abc123') });
     const result = await executor.recoverDirtyFiles('impl:11_rate_limit_resilience', 'impl', checkpoint, makeLogger());

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -586,6 +586,28 @@ describe('CliSkillExecutor', () => {
     });
   });
 
+  describe('verify command safety', () => {
+    it('rejects shell metacharacters instead of executing injected verify commands', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'verify-command-injection-'));
+      const marker = join(root, 'pwned');
+      git.getWorkingDir.mockReturnValue(root);
+      git.getStatus.mockReturnValue(' M src/file.ts');
+
+      const checkpoint = makeCheckpoint({ lastCommit: vi.fn(() => 'safe123') });
+      const executor = harness.executor({
+        verifyCommand: `${process.execPath} -e "process.exit(0)" ; ${process.execPath} -e "require('node:fs').writeFileSync('${marker}', 'pwned')"`,
+      });
+
+      await expect(executor.recoverDirtyFiles('impl:11_rate_limit_resilience', 'impl', checkpoint, makeLogger()))
+        .resolves.toBe('reset');
+
+      expect(git.resetHard).toHaveBeenCalledWith('safe123');
+      expect(git.autoCommit).not.toHaveBeenCalled();
+      expect(() => rmSync(marker)).toThrow();
+      rmSync(root, { recursive: true, force: true });
+    });
+  });
+
   describe('chunk session recovery metadata', () => {
     it('records the last known good commit on the chunk session during recovery', async () => {
       const root = mkdtempSync(join(tmpdir(), 'chunk-recovery-'));


### PR DESCRIPTION
## Summary
- Replaces arbitrary shell-based verifyCommand execution with an exact whitelist resolved to executable + args.
- Runs allowed verify commands through execFileSync; Windows uses the npm/npx shim-compatible launch path only after exact whitelist matching.
- Adds regression coverage proving shell metacharacter injection is rejected and not executed.

## Test Plan
- npm test -- tests/unit/skills/cli-skill-executor.test.ts
- npm test -- tests/unit/execution-checkpoint.test.ts tests/unit/skills/cli-skill-executor.test.ts
- npx turbo run typecheck --filter=franken-orchestrator
- npx turbo run build --filter=franken-orchestrator
- npx turbo run test --filter=franken-orchestrator
- npm run lint (0 errors, existing warnings only)
- git diff --check

Closes #521
