### PR TITLE
fix(governor): make trigger evaluators actually fire and 'denied' reachable

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -40,11 +40,19 @@ import * as readline from 'node:readline/promises';
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 const readlineAdapter = { question: (prompt: string) => rl.question(prompt) };
 
-// Wire up the governor with triggers
+// Wire up the governor with triggers. SkillTrigger and BudgetTrigger need
+// context sources: skillMetadata supplies HITL/destructive flags for the
+// rationale's selectedTool, and budgetState supplies the circuit-breaker
+// state. A trigger whose source is missing is skipped (it cannot fire).
 const governor = createGovernor({
   readline: readlineAdapter,
   memoryPort: { recordDecision: async (trace) => console.log('Audit:', trace) },
   evaluators: [new BudgetTrigger(), new SkillTrigger()],
+  skillMetadata: {
+    getSkillMetadata: (skillId) =>
+      skillId === 'deploy-prod' ? { requiresHitl: true, isDestructive: true } : undefined,
+  },
+  budgetState: { getBudgetState: () => ({ tripped: false, spendUsd: 0, limitUsd: 50 }) },
   projectId: 'my-project',
   operatorName: 'alice',
 });
@@ -58,6 +66,8 @@ const result = await governor.verifyRationale({
   timestamp: new Date(),
 });
 
+// 'deploy-prod' is flagged destructive above, so the SkillTrigger fires and
+// the operator is prompted; a rejection (or non-TTY default) lands here:
 if (result.verdict === 'approved') {
   console.log('Proceeding with execution');
 } else {

--- a/packages/franken-governor/src/gateway/governor-critique-adapter.ts
+++ b/packages/franken-governor/src/gateway/governor-critique-adapter.ts
@@ -5,7 +5,28 @@ import type { ApprovalChannel } from './approval-channel.js';
 import { ApprovalGateway, type AuditRecorder } from './approval-gateway.js';
 import type { SignatureVerifier } from '../security/signature-verifier.js';
 import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
+import { BudgetTrigger, type BudgetTriggerContext } from '../triggers/budget-trigger.js';
+import { SkillTrigger, type SkillTriggerContext } from '../triggers/skill-trigger.js';
 import type { RationaleBlock, VerificationResult } from '@franken/types';
+
+/** Governance flags for a skill, looked up by the adapter per rationale. */
+export interface SkillGovernanceMetadata {
+  readonly requiresHitl: boolean;
+  readonly isDestructive: boolean;
+}
+
+/**
+ * Source of skill governance metadata (e.g. a skill registry). Returning
+ * `undefined` means the skill is unknown and the SkillTrigger is skipped.
+ */
+export interface SkillMetadataSource {
+  getSkillMetadata(skillId: string): SkillGovernanceMetadata | undefined;
+}
+
+/** Source of the current budget circuit-breaker state (e.g. MOD-05 observer). */
+export interface BudgetStateSource {
+  getBudgetState(): BudgetTriggerContext;
+}
 
 export interface GovernorCritiqueAdapterDeps {
   readonly channel: ApprovalChannel;
@@ -14,12 +35,29 @@ export interface GovernorCritiqueAdapterDeps {
   readonly projectId: string;
   readonly config?: GovernorConfig;
   readonly signatureVerifier?: SignatureVerifier;
+  /**
+   * Supplies HITL/destructive flags for `rationale.selectedTool`. Without it a
+   * registered SkillTrigger is skipped (its context cannot be constructed).
+   */
+  readonly skillMetadata?: SkillMetadataSource;
+  /**
+   * Supplies the budget circuit-breaker state. Without it a registered
+   * BudgetTrigger is skipped (its context cannot be constructed).
+   */
+  readonly budgetState?: BudgetStateSource;
 }
+
+/** Sentinel result for an evaluator whose context cannot be constructed. */
+type TriggerContext = { readonly skip: true } | { readonly skip: false; readonly context: unknown };
+
+const SKIP: TriggerContext = { skip: true };
 
 export class GovernorCritiqueAdapter {
   private readonly gateway: ApprovalGateway;
   private readonly evaluators: ReadonlyArray<TriggerEvaluator>;
   private readonly projectId: string;
+  private readonly skillMetadata: SkillMetadataSource | undefined;
+  private readonly budgetState: BudgetStateSource | undefined;
 
   constructor(deps: GovernorCritiqueAdapterDeps) {
     this.gateway = new ApprovalGateway({
@@ -30,6 +68,8 @@ export class GovernorCritiqueAdapter {
     });
     this.evaluators = deps.evaluators;
     this.projectId = deps.projectId;
+    this.skillMetadata = deps.skillMetadata;
+    this.budgetState = deps.budgetState;
   }
 
   async verifyRationale(rationale: RationaleBlock): Promise<VerificationResult> {
@@ -68,9 +108,42 @@ export class GovernorCritiqueAdapter {
 
   private evaluateTriggers(rationale: RationaleBlock): TriggerResult {
     for (const evaluator of this.evaluators) {
-      const result = evaluator.evaluate(rationale);
+      const triggerContext = this.buildTriggerContext(evaluator, rationale);
+      // Explicit skip: the evaluator's typed context cannot be constructed
+      // from the rationale + injected sources, so it must not be fed a
+      // RationaleBlock it was never typed for (see issue #490).
+      if (triggerContext.skip) continue;
+      const result = evaluator.evaluate(triggerContext.context);
       if (result.triggered) return result;
     }
     return { triggered: false, triggerId: 'none' };
+  }
+
+  /**
+   * Builds the evaluator's typed context. Built-in SkillTrigger/BudgetTrigger
+   * instances get real contexts derived from the rationale's selected tool and
+   * the injected sources; any other evaluator receives the RationaleBlock and
+   * must be typed to accept it.
+   */
+  private buildTriggerContext(evaluator: TriggerEvaluator, rationale: RationaleBlock): TriggerContext {
+    if (evaluator instanceof SkillTrigger) {
+      const skillId = rationale.selectedTool;
+      if (skillId === undefined) return SKIP;
+      const metadata = this.skillMetadata?.getSkillMetadata(skillId);
+      if (metadata === undefined) return SKIP;
+      const context: SkillTriggerContext = {
+        skillId,
+        requiresHitl: metadata.requiresHitl,
+        isDestructive: metadata.isDestructive,
+      };
+      return { skip: false, context };
+    }
+
+    if (evaluator instanceof BudgetTrigger) {
+      if (this.budgetState === undefined) return SKIP;
+      return { skip: false, context: this.budgetState.getBudgetState() };
+    }
+
+    return { skip: false, context: rationale };
   }
 }

--- a/packages/franken-governor/src/gateway/governor-factory.ts
+++ b/packages/franken-governor/src/gateway/governor-factory.ts
@@ -1,4 +1,9 @@
-import { GovernorCritiqueAdapter, type GovernorCritiqueAdapterDeps } from './governor-critique-adapter.js';
+import {
+  GovernorCritiqueAdapter,
+  type BudgetStateSource,
+  type GovernorCritiqueAdapterDeps,
+  type SkillMetadataSource,
+} from './governor-critique-adapter.js';
 import { GovernorAuditRecorder } from '../audit/audit-recorder.js';
 import { CliChannel, type ReadlineAdapter } from '../channels/cli-channel.js';
 import type { GovernorMemoryPort } from '../audit/governor-memory-port.js';
@@ -12,6 +17,10 @@ export interface CreateGovernorOptions {
   readonly projectId?: string;
   readonly operatorName?: string;
   readonly config?: Partial<GovernorConfig>;
+  /** Skill governance flags for SkillTrigger contexts (e.g. a skill registry). */
+  readonly skillMetadata?: SkillMetadataSource;
+  /** Budget circuit-breaker state for BudgetTrigger contexts (e.g. MOD-05). */
+  readonly budgetState?: BudgetStateSource;
 }
 
 export function createGovernor(options: CreateGovernorOptions): GovernorCritiqueAdapter {
@@ -33,5 +42,7 @@ export function createGovernor(options: CreateGovernorOptions): GovernorCritique
     evaluators: options.evaluators ?? [],
     projectId: options.projectId ?? 'default',
     config,
+    ...(options.skillMetadata ? { skillMetadata: options.skillMetadata } : {}),
+    ...(options.budgetState ? { budgetState: options.budgetState } : {}),
   });
 }

--- a/packages/franken-governor/src/gateway/index.ts
+++ b/packages/franken-governor/src/gateway/index.ts
@@ -2,7 +2,12 @@ export type { ApprovalChannel } from './approval-channel.js';
 export { ApprovalGateway } from './approval-gateway.js';
 export type { AuditRecorder, ApprovalGatewayDeps } from './approval-gateway.js';
 export { GovernorCritiqueAdapter } from './governor-critique-adapter.js';
-export type { GovernorCritiqueAdapterDeps } from './governor-critique-adapter.js';
+export type {
+  BudgetStateSource,
+  GovernorCritiqueAdapterDeps,
+  SkillGovernanceMetadata,
+  SkillMetadataSource,
+} from './governor-critique-adapter.js';
 export { createGovernor } from './governor-factory.js';
 export type { CreateGovernorOptions } from './governor-factory.js';
 export { ApprovalWaiterRegistry } from './approval-waiter-registry.js';

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -42,7 +42,12 @@ export type { ApprovalChannel } from './gateway/index.js';
 export { ApprovalGateway } from './gateway/index.js';
 export type { AuditRecorder, ApprovalGatewayDeps } from './gateway/index.js';
 export { GovernorCritiqueAdapter } from './gateway/index.js';
-export type { GovernorCritiqueAdapterDeps } from './gateway/index.js';
+export type {
+  BudgetStateSource,
+  GovernorCritiqueAdapterDeps,
+  SkillGovernanceMetadata,
+  SkillMetadataSource,
+} from './gateway/index.js';
 export { createGovernor } from './gateway/index.js';
 export type { CreateGovernorOptions } from './gateway/index.js';
 export { ApprovalWaiterRegistry } from './gateway/index.js';

--- a/packages/franken-governor/src/triggers/skill-trigger.ts
+++ b/packages/franken-governor/src/triggers/skill-trigger.ts
@@ -23,7 +23,9 @@ export class SkillTrigger implements TriggerEvaluator<SkillTriggerContext> {
       triggered: true,
       triggerId: this.triggerId,
       reason: `Skill '${context.skillId}' ${reasons.join(' and ')}`,
-      severity: 'high',
+      // Destructive skills are critical (downstream policy maps 'critical' to a
+      // hard denial); HITL-only skills are high (review/approval required).
+      severity: context.isDestructive ? 'critical' : 'high',
     };
   }
 }

--- a/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GovernorCritiqueAdapter } from '../../../src/gateway/governor-critique-adapter.js';
+import type { SkillMetadataSource } from '../../../src/gateway/governor-critique-adapter.js';
 import type { ApprovalRequest, ApprovalOutcome } from '../../../src/core/types.js';
 import type { ApprovalChannel } from '../../../src/gateway/approval-channel.js';
 import type { TriggerEvaluator } from '../../../src/triggers/trigger-evaluator.js';
 import type { TriggerResult } from '../../../src/core/types.js';
+import { BudgetTrigger } from '../../../src/triggers/budget-trigger.js';
+import { SkillTrigger } from '../../../src/triggers/skill-trigger.js';
 
 interface RationaleBlock {
   taskId: string;
@@ -154,5 +157,175 @@ describe('GovernorCritiqueAdapter', () => {
     await adapter.verifyRationale(makeRationale());
     expect(channel.requestApproval).not.toHaveBeenCalled();
     expect(auditRecorder.record).not.toHaveBeenCalled();
+  });
+});
+
+describe('GovernorCritiqueAdapter per-trigger context construction (issue #490)', () => {
+  function makeSkillMetadataSource(
+    metadata: Record<string, { requiresHitl: boolean; isDestructive: boolean }>,
+  ): SkillMetadataSource {
+    return { getSkillMetadata: (skillId) => metadata[skillId] };
+  }
+
+  it('a destructive skill produces a non-approved verdict through verifyRationale', async () => {
+    const channel = makeFakeChannel('REGEN');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new SkillTrigger()],
+      projectId: 'proj-001',
+      skillMetadata: makeSkillMetadataSource({
+        'deploy-prod': { requiresHitl: false, isDestructive: true },
+      }),
+    });
+
+    const result = await adapter.verifyRationale(makeRationale({ selectedTool: 'deploy-prod' }));
+
+    expect(channel.requestApproval).toHaveBeenCalledOnce();
+    expect(result.verdict).toBe('rejected');
+    const request = vi.mocked(channel.requestApproval).mock.calls[0]![0] as ApprovalRequest;
+    expect(request.trigger.triggerId).toBe('skill');
+    expect(request.trigger.severity).toBe('critical');
+    expect(request.trigger.reason).toContain('deploy-prod');
+  });
+
+  it('a HITL-requiring skill produces a non-approved verdict through verifyRationale', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new SkillTrigger()],
+      projectId: 'proj-001',
+      skillMetadata: makeSkillMetadataSource({
+        'deploy-prod': { requiresHitl: true, isDestructive: false },
+      }),
+    });
+
+    const result = await adapter.verifyRationale(makeRationale({ selectedTool: 'deploy-prod' }));
+
+    expect(channel.requestApproval).toHaveBeenCalledOnce();
+    expect(result.verdict).toBe('rejected');
+  });
+
+  it('a benign skill does not fire the SkillTrigger', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new SkillTrigger()],
+      projectId: 'proj-001',
+      skillMetadata: makeSkillMetadataSource({
+        'read-docs': { requiresHitl: false, isDestructive: false },
+      }),
+    });
+
+    const result = await adapter.verifyRationale(makeRationale({ selectedTool: 'read-docs' }));
+
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('a tripped budget produces a non-approved verdict through verifyRationale', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new BudgetTrigger()],
+      projectId: 'proj-001',
+      budgetState: { getBudgetState: () => ({ tripped: true, limitUsd: 50, spendUsd: 52.3 }) },
+    });
+
+    const result = await adapter.verifyRationale(makeRationale());
+
+    expect(channel.requestApproval).toHaveBeenCalledOnce();
+    expect(result.verdict).toBe('rejected');
+    const request = vi.mocked(channel.requestApproval).mock.calls[0]![0] as ApprovalRequest;
+    expect(request.trigger.triggerId).toBe('budget');
+    expect(request.trigger.severity).toBe('critical');
+  });
+
+  it('an untripped budget does not fire the BudgetTrigger', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new BudgetTrigger()],
+      projectId: 'proj-001',
+      budgetState: { getBudgetState: () => ({ tripped: false, limitUsd: 50, spendUsd: 1 }) },
+    });
+
+    const result = await adapter.verifyRationale(makeRationale());
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('skips a SkillTrigger when no skill metadata source is injected', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new SkillTrigger()],
+      projectId: 'proj-001',
+    });
+
+    const result = await adapter.verifyRationale(makeRationale({ selectedTool: 'deploy-prod' }));
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('skips a SkillTrigger when the rationale has no selectedTool or the skill is unknown', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new SkillTrigger()],
+      projectId: 'proj-001',
+      skillMetadata: makeSkillMetadataSource({
+        'deploy-prod': { requiresHitl: true, isDestructive: true },
+      }),
+    });
+
+    const noTool = makeRationale();
+    delete noTool.selectedTool;
+    expect(await adapter.verifyRationale(noTool)).toEqual({ verdict: 'approved' });
+
+    const unknownSkill = await adapter.verifyRationale(makeRationale({ selectedTool: 'unknown-skill' }));
+    expect(unknownSkill).toEqual({ verdict: 'approved' });
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('skips a BudgetTrigger when no budget state source is injected', async () => {
+    const channel = makeFakeChannel('ABORT');
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [new BudgetTrigger()],
+      projectId: 'proj-001',
+    });
+
+    const result = await adapter.verifyRationale(makeRationale());
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('still passes the rationale to custom evaluators', async () => {
+    const seen: unknown[] = [];
+    const custom: TriggerEvaluator = {
+      triggerId: 'custom',
+      evaluate: (context) => {
+        seen.push(context);
+        return { triggered: false, triggerId: 'custom' };
+      },
+    };
+    const adapter = new GovernorCritiqueAdapter({
+      channel: makeFakeChannel(),
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [custom],
+      projectId: 'proj-001',
+    });
+
+    const rationale = makeRationale();
+    await adapter.verifyRationale(rationale);
+    expect(seen).toEqual([rationale]);
   });
 });

--- a/packages/franken-governor/tests/unit/triggers/skill-trigger.test.ts
+++ b/packages/franken-governor/tests/unit/triggers/skill-trigger.test.ts
@@ -40,10 +40,21 @@ describe('SkillTrigger', () => {
     }
   });
 
-  it('sets severity to high when triggered', () => {
+  it('sets severity to high when HITL is required but skill is not destructive', () => {
     const result = trigger.evaluate(makeSkillContext({ requiresHitl: true }));
-    if (result.triggered) {
-      expect(result.severity).toBe('high');
-    }
+    expect(result.triggered).toBe(true);
+    expect(result.severity).toBe('high');
+  });
+
+  it('sets severity to critical when the skill is destructive', () => {
+    const result = trigger.evaluate(makeSkillContext({ isDestructive: true }));
+    expect(result.triggered).toBe(true);
+    expect(result.severity).toBe('critical');
+  });
+
+  it('sets severity to critical when destructive and HITL-requiring', () => {
+    const result = trigger.evaluate(makeSkillContext({ requiresHitl: true, isDestructive: true }));
+    expect(result.triggered).toBe(true);
+    expect(result.severity).toBe('critical');
   });
 });

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -32,20 +32,27 @@ describe('GovernorAdapter', () => {
     expect(result.decision).toBe('approved');
   });
 
-  it('flags a destructive fbeast tool (fbeast_memory_forget) on the SHARED path', async () => {
+  it('denies a destructive fbeast tool (fbeast_memory_forget) on the SHARED path', async () => {
     // The word heuristic does not catch "forget"; classification lives in the
     // shared governor so every caller (hook, fbeast_governor_check, central
-    // gate, governor_log) gets the same non-approved decision for a benign key.
+    // gate, governor_log) gets the same 'denied' decision for a benign key.
     const governor = createGovernorAdapter(tracked(tmpDbPath()));
     const result = await governor.check({ action: 'fbeast_memory_forget', context: '{"key":"note"}' });
-    expect(result.decision).not.toBe('approved');
-    expect(result.decision).toBe('review_recommended');
+    expect(result.decision).toBe('denied');
   });
 
-  it('still flags raw destructive patterns (rm -rf)', async () => {
+  it('denies raw destructive patterns (rm -rf)', async () => {
     const governor = createGovernorAdapter(tracked(tmpDbPath()));
     const result = await governor.check({ action: 'rm -rf /data', context: '{}' });
-    expect(result.decision).not.toBe('approved');
+    expect(result.decision).toBe('denied');
+  });
+
+  it('denies when the dangerous pattern is only in the context payload', async () => {
+    const governor = createGovernorAdapter(tracked(tmpDbPath()));
+    // 'rm -rf' is in DANGEROUS_PATTERNS; the tool name alone is benign.
+    // (Word-order variants like 'push --force' are #475's split-flag scope.)
+    const result = await governor.check({ action: 'run_shell', context: 'rm -rf /var/data' });
+    expect(result.decision).toBe('denied');
   });
 
   it('exempts non-executing tools on the SHARED path even with dangerous-looking payload', async () => {

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -93,6 +93,9 @@ const triggerRegistry = new TriggerRegistry([skillTrigger]);
 function mapSeverityToDecision(
   severity: TriggerSeverity | undefined,
 ): GovernorCheckResult['decision'] {
+  // SkillTrigger emits 'critical' for destructive matches (dangerous patterns
+  // and DESTRUCTIVE_ACTIONS), so destructive actions map to a hard 'denied';
+  // lower severities (e.g. HITL-only 'high') stay 'review_recommended'.
   if (severity === 'critical') return 'denied';
   return 'review_recommended';
 }

--- a/packages/franken-mcp-suite/src/integration/full-cycle.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/full-cycle.integration.test.ts
@@ -106,7 +106,7 @@ describe('full-cycle integration', () => {
         `SELECT decision FROM governor_log WHERE action = 'rm -rf /data' ORDER BY id DESC LIMIT 1`,
       ).get() as { decision: string } | undefined;
       raw.close();
-      expect(['denied', 'review_recommended']).toContain(row?.decision);
+      expect(row?.decision).toBe('denied');
     }
 
     // ── 4. Post-tool hook — real observer writes to audit_trail ──────────────


### PR DESCRIPTION
## Summary
Two governance defects from the 2026-07-04 docs-vs-reality audit, both verified live at HEAD before fixing.

### #490 — triggers never fired
`GovernorCritiqueAdapter.evaluateTriggers` passed the raw `RationaleBlock` to every evaluator, but `SkillTrigger` reads `requiresHitl`/`isDestructive` and `BudgetTrigger` reads `tripped` — none exist on `RationaleBlock`, so both always returned `triggered: false` and the gate always approved. The generic erasure of `TriggerEvaluator<T>` hid the mismatch.

**Fix:** the adapter now constructs per-trigger contexts:
- `SkillTrigger` → `{skillId, requiresHitl, isDestructive}` derived from `rationale.selectedTool` via a new injectable `SkillMetadataSource`.
- `BudgetTrigger` → circuit-breaker state from a new injectable `BudgetStateSource`.
- A trigger whose context cannot be constructed is **skipped explicitly** (documented) instead of being fed a mistyped object; custom evaluators still receive the `RationaleBlock`.
- `createGovernor` accepts the two optional sources; additive API only — the mcp-suite call path that constructs `SkillTriggerContext` directly is untouched.
- Governor README Quick Start now wires the sources, so its `Blocked` branch is actually reachable (it previously could never fire).

### #491 — 'denied' unreachable
`mapSeverityToDecision` (mcp-suite governor adapter) returns `denied` only for severity `critical`, but `SkillTrigger` always emitted `high` — so `rm -rf` produced `review_recommended`, contradicting the walkthrough's documented `denied`.

**Fix:** `SkillTrigger` emits `critical` for destructive skills (`high` remains for HITL-only), making destructive/dangerous-pattern matches map to a hard `denied` across the shared governor path (hooks, public check tool, central ADR-038 gate). The full-cycle integration test assertion is tightened from `['denied','review_recommended']` to exactly `'denied'`; a payload-only dangerous command (`run_shell` + `rm -rf …`) is also asserted `denied`. Word-order pattern variants (e.g. `push --force`) remain #475's scope.

## Testing
- New `GovernorCritiqueAdapter` suite: destructive skill → rejected, HITL skill → rejected, benign → approved, tripped budget → rejected, untripped → approved, explicit-skip cases (no source / no selectedTool / unknown skill).
- `npx turbo run test typecheck --filter=@franken/governor --filter=@fbeast/mcp-suite --force` — 12/12 tasks green.

Closes #490
Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)