### PR TITLE
fix(web): add recoverable app shell error state

### DIFF
--- a/packages/franken-web/src/components/app-error-boundary.tsx
+++ b/packages/franken-web/src/components/app-error-boundary.tsx
@@ -1,0 +1,127 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type AppErrorBoundaryProps = {
+  children: ReactNode;
+  version: string;
+};
+
+type AppErrorBoundaryState = {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  copied: boolean;
+};
+
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = {
+    error: null,
+    errorInfo: null,
+    copied: false,
+  };
+
+  static getDerivedStateFromError(error: Error): Partial<AppErrorBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ error, errorInfo });
+  }
+
+  private buildDiagnostics(): string {
+    const { error, errorInfo } = this.state;
+    return JSON.stringify(
+      {
+        message: error?.message ?? 'Unknown app-shell error',
+        stack: error?.stack ?? null,
+        componentStack: errorInfo?.componentStack ?? null,
+        version: this.props.version,
+        location: typeof window !== 'undefined' ? window.location.href : null,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+        capturedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    );
+  }
+
+  private copyDiagnostics = async () => {
+    const diagnostics = this.buildDiagnostics();
+
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(diagnostics);
+      this.setState({ copied: true });
+      return;
+    }
+
+    this.setState({ copied: true });
+  };
+
+  private reload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    const { error, copied } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="dashboard-shell app-shell-error" role="alert" aria-live="assertive">
+        <aside className="sidebar app-shell-error__sidebar" aria-label="Frankenbeast recovery shell">
+          <div className="sidebar__brand">
+            <span className="eyebrow">Frankenbeast dashboard</span>
+            <h1>Control plane recovery</h1>
+            <p className="sidebar__tagline">
+              The app shell stayed online after a dashboard render failure.
+            </p>
+          </div>
+          <div className="sidebar__footer">
+            <span className="version-chip">v{this.props.version}</span>
+            <span>Safe mode</span>
+          </div>
+        </aside>
+
+        <main className="app-shell-error__main">
+          <section className="app-shell-error__panel" aria-labelledby="app-shell-error-title">
+            <p className="eyebrow">Recoverable app-shell error</p>
+            <h2 id="app-shell-error-title">The dashboard hit a rendering problem.</h2>
+            <p>
+              Reload the app to try again, or copy diagnostics and include them with the browser console
+              logs when asking for support. The page is not blank, so operators can recover without
+              guessing whether Frankenbeast is still running.
+            </p>
+
+            <dl className="app-shell-error__details">
+              <div>
+                <dt>Error</dt>
+                <dd>{error.message || 'Unknown error'}</dd>
+              </div>
+              <div>
+                <dt>Build</dt>
+                <dd>v{this.props.version}</dd>
+              </div>
+            </dl>
+
+            <div className="app-shell-error__actions">
+              <button type="button" className="primary-action" onClick={this.reload}>
+                Reload dashboard
+              </button>
+              <button type="button" className="secondary-action" onClick={this.copyDiagnostics}>
+                {copied ? 'Diagnostics copied' : 'Copy diagnostics'}
+              </button>
+              <a className="secondary-action" href="https://github.com/djm204/frankenbeast/issues" target="_blank" rel="noreferrer">
+                Open support issues
+              </a>
+            </div>
+
+            <details className="app-shell-error__diagnostics">
+              <summary>View diagnostics</summary>
+              <pre>{this.buildDiagnostics()}</pre>
+            </details>
+          </section>
+        </main>
+      </div>
+    );
+  }
+}

--- a/packages/franken-web/src/components/app-error-boundary.tsx
+++ b/packages/franken-web/src/components/app-error-boundary.tsx
@@ -44,13 +44,55 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
     return 'Unknown app-shell error';
   }
 
+  private safelySerializeThrownValue(value: unknown): unknown {
+    if (value instanceof Error) {
+      return undefined;
+    }
+
+    if (value === undefined) {
+      return null;
+    }
+
+    const seen = new WeakSet<object>();
+
+    try {
+      const serialized = JSON.stringify(value, (_key, nestedValue: unknown) => {
+        if (typeof nestedValue === 'bigint') {
+          return `${nestedValue.toString()}n`;
+        }
+
+        if (typeof nestedValue === 'symbol' || typeof nestedValue === 'function') {
+          return String(nestedValue);
+        }
+
+        if (nestedValue && typeof nestedValue === 'object') {
+          if (seen.has(nestedValue)) {
+            return '[Circular]';
+          }
+
+          seen.add(nestedValue);
+        }
+
+        return nestedValue;
+      });
+
+      return serialized === undefined ? String(value) : JSON.parse(serialized);
+    } catch {
+      try {
+        return String(value);
+      } catch {
+        return Object.prototype.toString.call(value);
+      }
+    }
+  }
+
   private buildDiagnostics(): string {
     const { error, errorInfo } = this.state;
     return JSON.stringify(
       {
         message: this.getErrorMessage(),
         stack: error instanceof Error ? error.stack ?? null : null,
-        thrownValue: error instanceof Error ? undefined : error ?? null,
+        thrownValue: this.safelySerializeThrownValue(error),
         componentStack: errorInfo?.componentStack ?? null,
         version: this.props.version,
         location: typeof window !== 'undefined' ? window.location.href : null,

--- a/packages/franken-web/src/components/app-error-boundary.tsx
+++ b/packages/franken-web/src/components/app-error-boundary.tsx
@@ -134,7 +134,7 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
 
     return (
       <div className="dashboard-shell app-shell-error" role="alert" aria-live="assertive">
-        <aside className="sidebar app-shell-error__sidebar" aria-label="Frankenbeast recovery shell">
+        <aside className="sidebar app-shell-error__sidebar sidebar--open" aria-label="Frankenbeast recovery shell">
           <div className="sidebar__brand">
             <span className="eyebrow">Frankenbeast dashboard</span>
             <h1>Control plane recovery</h1>

--- a/packages/franken-web/src/components/app-error-boundary.tsx
+++ b/packages/franken-web/src/components/app-error-boundary.tsx
@@ -5,33 +5,52 @@ type AppErrorBoundaryProps = {
   version: string;
 };
 
+type CopyStatus = 'idle' | 'copied' | 'manual' | 'failed';
+
 type AppErrorBoundaryState = {
-  error: Error | null;
+  hasError: boolean;
+  error: unknown;
   errorInfo: ErrorInfo | null;
-  copied: boolean;
+  copyStatus: CopyStatus;
 };
 
 export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
   state: AppErrorBoundaryState = {
+    hasError: false,
     error: null,
     errorInfo: null,
-    copied: false,
+    copyStatus: 'idle',
   };
 
-  static getDerivedStateFromError(error: Error): Partial<AppErrorBoundaryState> {
-    return { error };
+  static getDerivedStateFromError(error: unknown): Partial<AppErrorBoundaryState> {
+    return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
     this.setState({ error, errorInfo });
+  }
+
+  private getErrorMessage(): string {
+    const { error } = this.state;
+
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+
+    if (typeof error === 'string' && error.trim()) {
+      return error;
+    }
+
+    return 'Unknown app-shell error';
   }
 
   private buildDiagnostics(): string {
     const { error, errorInfo } = this.state;
     return JSON.stringify(
       {
-        message: error?.message ?? 'Unknown app-shell error',
-        stack: error?.stack ?? null,
+        message: this.getErrorMessage(),
+        stack: error instanceof Error ? error.stack ?? null : null,
+        thrownValue: error instanceof Error ? undefined : error ?? null,
         componentStack: errorInfo?.componentStack ?? null,
         version: this.props.version,
         location: typeof window !== 'undefined' ? window.location.href : null,
@@ -46,13 +65,17 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
   private copyDiagnostics = async () => {
     const diagnostics = this.buildDiagnostics();
 
-    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(diagnostics);
-      this.setState({ copied: true });
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      this.setState({ copyStatus: 'manual' });
       return;
     }
 
-    this.setState({ copied: true });
+    try {
+      await navigator.clipboard.writeText(diagnostics);
+      this.setState({ copyStatus: 'copied' });
+    } catch {
+      this.setState({ copyStatus: 'failed' });
+    }
   };
 
   private reload = () => {
@@ -60,9 +83,10 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
   };
 
   render() {
-    const { error, copied } = this.state;
+    const { hasError, copyStatus } = this.state;
+    const errorMessage = this.getErrorMessage();
 
-    if (!error) {
+    if (!hasError) {
       return this.props.children;
     }
 
@@ -95,7 +119,7 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
             <dl className="app-shell-error__details">
               <div>
                 <dt>Error</dt>
-                <dd>{error.message || 'Unknown error'}</dd>
+                <dd>{errorMessage}</dd>
               </div>
               <div>
                 <dt>Build</dt>
@@ -108,14 +132,20 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
                 Reload dashboard
               </button>
               <button type="button" className="secondary-action" onClick={this.copyDiagnostics}>
-                {copied ? 'Diagnostics copied' : 'Copy diagnostics'}
+                {copyStatus === 'copied'
+                  ? 'Diagnostics copied'
+                  : copyStatus === 'manual'
+                    ? 'Copy manually below'
+                    : copyStatus === 'failed'
+                      ? 'Copy failed — view below'
+                      : 'Copy diagnostics'}
               </button>
               <a className="secondary-action" href="https://github.com/djm204/frankenbeast/issues" target="_blank" rel="noreferrer">
                 Open support issues
               </a>
             </div>
 
-            <details className="app-shell-error__diagnostics">
+            <details className="app-shell-error__diagnostics" open={copyStatus === 'manual' || copyStatus === 'failed'}>
               <summary>View diagnostics</summary>
               <pre>{this.buildDiagnostics()}</pre>
             </details>

--- a/packages/franken-web/src/main.tsx
+++ b/packages/franken-web/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './app';
+import { AppErrorBoundary } from './components/app-error-boundary';
 import './styles/tailwind.css';
 import './styles/app.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AppErrorBoundary version={__FRANKENBEAST_VERSION__}>
+      <App />
+    </AppErrorBoundary>
   </StrictMode>,
 );

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1306,6 +1306,14 @@ button {
     transform: translateX(0);
   }
 
+  .app-shell-error .sidebar {
+    position: relative;
+    inset: auto;
+    width: auto;
+    min-height: auto;
+    transform: none;
+  }
+
   .sidebar__toggle {
     display: inline-flex;
   }

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -69,6 +69,133 @@ button {
   min-height: 100vh;
 }
 
+.app-shell-error {
+  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+}
+
+.app-shell-error__sidebar {
+  min-height: 100vh;
+}
+
+.app-shell-error__sidebar h1 {
+  margin: 0;
+  max-width: 18rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 0.95;
+}
+
+.app-shell-error__main {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 4vw, 4rem);
+}
+
+.app-shell-error__panel {
+  width: min(100%, 58rem);
+  display: grid;
+  gap: 1.35rem;
+  padding: clamp(1.4rem, 3vw, 2.5rem);
+  border: 1px solid rgba(255, 122, 107, 0.42);
+  border-radius: 1.6rem;
+  background:
+    linear-gradient(180deg, rgba(255, 122, 107, 0.12), transparent 38%),
+    var(--bg-panel);
+  box-shadow: var(--shadow);
+}
+
+.app-shell-error__panel h2 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.app-shell-error__panel p {
+  margin: 0;
+  max-width: 46rem;
+  color: var(--text-muted);
+}
+
+.app-shell-error__details {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+}
+
+.app-shell-error__details div {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.app-shell-error__details dt {
+  color: var(--text-subtle);
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.app-shell-error__details dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.app-shell-error__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.72rem 1rem;
+  border-radius: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.primary-action {
+  border: 1px solid rgba(181, 255, 129, 0.36);
+  background: var(--control-bg-primary);
+  color: var(--text);
+  box-shadow: var(--control-shadow);
+}
+
+.secondary-action {
+  border: 1px solid var(--control-border);
+  background: var(--control-bg);
+  color: var(--text-muted);
+}
+
+.app-shell-error__diagnostics {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.app-shell-error__diagnostics summary {
+  cursor: pointer;
+  padding: 0.9rem 1rem;
+  color: var(--accent-strong);
+}
+
+.app-shell-error__diagnostics pre {
+  max-height: 18rem;
+  margin: 0;
+  overflow: auto;
+  padding: 0 1rem 1rem;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+}
+
 .eyebrow {
   font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 0.72rem;

--- a/packages/franken-web/tests/components/app-error-boundary.test.tsx
+++ b/packages/franken-web/tests/components/app-error-boundary.test.tsx
@@ -11,6 +11,10 @@ function ThrowsNull(): ReactElement {
   throw null;
 }
 
+function ThrowsBigInt(): ReactElement {
+  throw 1n;
+}
+
 describe('AppErrorBoundary', () => {
   afterEach(() => {
     cleanup();
@@ -87,5 +91,18 @@ describe('AppErrorBoundary', () => {
 
     expect(screen.getByRole('alert')).toBeTruthy();
     expect(screen.getByText('Unknown app-shell error')).toBeTruthy();
+  });
+
+  it('keeps diagnostics renderable when the thrown value is not JSON-serializable by default', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <AppErrorBoundary version="0.1.0-test">
+        <ThrowsBigInt />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/"thrownValue": "1n"/)).toBeTruthy();
   });
 });

--- a/packages/franken-web/tests/components/app-error-boundary.test.tsx
+++ b/packages/franken-web/tests/components/app-error-boundary.test.tsx
@@ -7,6 +7,10 @@ function BrokenDashboard(): ReactElement {
   throw new Error('Boom while rendering dashboard');
 }
 
+function ThrowsNull(): ReactElement {
+  throw null;
+}
+
 describe('AppErrorBoundary', () => {
   afterEach(() => {
     cleanup();
@@ -51,5 +55,37 @@ describe('AppErrorBoundary', () => {
     expect(writeText.mock.calls[0]?.[0]).toContain('Boom while rendering dashboard');
     expect(writeText.mock.calls[0]?.[0]).toContain('0.1.0-test');
     expect(screen.getByRole('button', { name: /diagnostics copied/i })).toBeTruthy();
+  });
+
+  it('prompts for manual diagnostics when the clipboard API is unavailable', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(
+      <AppErrorBoundary version="0.1.0-test">
+        <BrokenDashboard />
+      </AppErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /copy diagnostics/i }));
+
+    expect(await screen.findByRole('button', { name: /copy manually below/i })).toBeTruthy();
+    expect(screen.getByText(/view diagnostics/i).closest('details')?.hasAttribute('open')).toBe(true);
+  });
+
+  it('shows the recovery shell even when the thrown value is falsy', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <AppErrorBoundary version="0.1.0-test">
+        <ThrowsNull />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText('Unknown app-shell error')).toBeTruthy();
   });
 });

--- a/packages/franken-web/tests/components/app-error-boundary.test.tsx
+++ b/packages/franken-web/tests/components/app-error-boundary.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { AppErrorBoundary } from '../../src/components/app-error-boundary';
+
+function BrokenDashboard(): ReactElement {
+  throw new Error('Boom while rendering dashboard');
+}
+
+describe('AppErrorBoundary', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows a recoverable shell instead of leaving the root blank when the app crashes', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <AppErrorBoundary version="0.1.0-test">
+        <BrokenDashboard />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText('Control plane recovery')).toBeTruthy();
+    expect(screen.getByText('The dashboard hit a rendering problem.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reload dashboard/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /copy diagnostics/i })).toBeTruthy();
+    expect(screen.getByText('Boom while rendering dashboard')).toBeTruthy();
+    expect(document.body.textContent).toContain('Recoverable app-shell error');
+  });
+
+  it('copies diagnostics for support without hiding the recovery UI', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <AppErrorBoundary version="0.1.0-test">
+        <BrokenDashboard />
+      </AppErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /copy diagnostics/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0]?.[0]).toContain('Boom while rendering dashboard');
+    expect(writeText.mock.calls[0]?.[0]).toContain('0.1.0-test');
+    expect(screen.getByRole('button', { name: /diagnostics copied/i })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the React dashboard in an app-shell error boundary
- show a recoverable safe-mode panel with reload, diagnostics copy, build/version info, and support link
- cover render crashes and diagnostics copy with focused web tests

## Test Plan
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web test
- npm --prefix packages/franken-web run build
- git diff --check

Closes #626