### PR TITLE
fix(orchestrator): gate provider command overrides

### DIFF
--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -747,6 +747,7 @@ function createObserverFinalize(observer: ObserverDepsBundle): () => Promise<voi
 
 export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
   const config = resolveEffectiveConfig(options);
+  assertTrustedProviderCommandOverrides(options.providersConfig);
   const artifacts = createSessionArtifacts(options);
   clearSessionArtifacts(options, artifacts);
 

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -19,6 +19,7 @@ import { CachedCliLlmClient } from '../cache/cached-cli-llm-client.js';
 import { CritiquePortAdapter } from '../adapters/critique-adapter.js';
 import { bridgeToBeastConfig, bridgeToExistingDeps } from './dep-bridge.js';
 import { createBeastDeps, type ConsolidatedDeps } from './create-beast-deps.js';
+import { assertTrustedProviderCommandOverrides, type ProviderCommandOverridePolicyConfig } from '../config/provider-command-override-policy.js';
 import { GovernorPortAdapter } from '../adapters/governor-adapter.js';
 import type { GovernorPortAdapterDeps } from '../adapters/governor-adapter.js';
 import { IssueFetcher } from '../issues/issue-fetcher.js';
@@ -42,7 +43,7 @@ export interface CliDepOptions {
   budget: number;
   provider: string;
   providers?: string[] | undefined;
-  providersConfig?: Record<string, { command?: string | undefined; model?: string | undefined; extraArgs?: string[] | undefined }> | undefined;
+  providersConfig?: Record<string, ProviderCommandOverridePolicyConfig & { model?: string | undefined; extraArgs?: string[] | undefined }> | undefined;
   noPr: boolean;
   verbose: boolean;
   reset: boolean;
@@ -750,6 +751,7 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
   clearSessionArtifacts(options, artifacts);
 
   const observer = await createObserverDeps(options, config, artifacts);
+  assertTrustedProviderCommandOverrides(options.providersConfig, { logger: observer.logger });
   let finalize = createObserverFinalize(observer);
 
   try {

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -19,7 +19,7 @@ import { CachedCliLlmClient } from '../cache/cached-cli-llm-client.js';
 import { CritiquePortAdapter } from '../adapters/critique-adapter.js';
 import { bridgeToBeastConfig, bridgeToExistingDeps } from './dep-bridge.js';
 import { createBeastDeps, type ConsolidatedDeps } from './create-beast-deps.js';
-import { assertTrustedProviderCommandOverrides, type ProviderCommandOverridePolicyConfig } from '../config/provider-command-override-policy.js';
+import { assertTrustedProviderCommandOverrideEntries, assertTrustedProviderCommandOverrides, type ProviderCommandOverridePolicyConfig } from '../config/provider-command-override-policy.js';
 import { GovernorPortAdapter } from '../adapters/governor-adapter.js';
 import type { GovernorPortAdapterDeps } from '../adapters/governor-adapter.js';
 import { IssueFetcher } from '../issues/issue-fetcher.js';
@@ -36,6 +36,7 @@ import type {
 } from '../deps.js';
 import type { RunConfig } from './run-config-loader.js';
 import type { ProjectPaths } from './project-root.js';
+import type { ProviderConfig } from '../providers/provider-config.js';
 
 export interface CliDepOptions {
   paths: ProjectPaths;
@@ -229,6 +230,18 @@ function resolveEffectiveConfig(options: CliDepOptions): EffectiveCliConfig {
       governor: effectiveModules?.governor ?? (process.env.FRANKENBEAST_MODULE_GOVERNOR !== 'false'),
     },
   };
+}
+
+function consolidatedProviderCommandOverrides(
+  providers: readonly ProviderConfig[] | undefined,
+): Array<readonly [string, ProviderCommandOverridePolicyConfig]> {
+  return providers
+    ?.filter((provider) => provider.type.endsWith('-cli') && Boolean(provider.cliPath))
+    .map((provider) => [provider.type, {
+      cliPath: provider.cliPath,
+      trustCommandOverride: provider.trustCommandOverride,
+      trustedCommandPaths: provider.trustedCommandPaths,
+    }] as const) ?? [];
 }
 
 function createSessionArtifacts(options: CliDepOptions): SessionArtifacts {
@@ -753,6 +766,10 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
 
   const observer = await createObserverDeps(options, config, artifacts);
   assertTrustedProviderCommandOverrides(options.providersConfig, { logger: observer.logger });
+  assertTrustedProviderCommandOverrideEntries(
+    consolidatedProviderCommandOverrides(options.orchestratorConfig?.consolidatedProviders),
+    { logger: observer.logger },
+  );
   let finalize = createObserverFinalize(observer);
 
   try {

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -27,6 +27,7 @@ import { resolveUpstreamRepo } from './upstream-repo.js';
 import type { ChunkDefinition } from './file-writer.js';
 import { CachedCliLlmClient } from '../cache/cached-cli-llm-client.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
+import type { ProviderCommandOverridePolicyConfig } from '../config/provider-command-override-policy.js';
 
 export type SessionPhase = 'interview' | 'plan' | 'execute';
 
@@ -36,7 +37,7 @@ export interface SessionConfig {
   budget: number;
   provider: string;
   providers?: string[] | undefined;
-  providersConfig?: Record<string, { command?: string | undefined; model?: string | undefined; extraArgs?: string[] | undefined }> | undefined;
+  providersConfig?: Record<string, ProviderCommandOverridePolicyConfig & { model?: string | undefined; extraArgs?: string[] | undefined }> | undefined;
   noPr: boolean;
   verbose: boolean;
   reset: boolean;

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -16,6 +16,8 @@ export const ProviderConfigSchema = z.object({
   ]),
   apiKey: z.string().optional(),
   cliPath: z.string().optional(),
+  trustCommandOverride: z.literal(true).optional(),
+  trustedCommandPaths: z.array(z.string()).optional(),
   model: z.string().optional(),
   extraArgs: z.array(z.string()).optional(),
 });
@@ -117,6 +119,21 @@ const BaseOrchestratorConfigSchema = z.object({
 export const OrchestratorConfigSchema = BaseOrchestratorConfigSchema.extend(
   NetworkConfigSchema.shape,
 ).superRefine((config, ctx) => {
+  config.consolidatedProviders?.forEach((provider, index) => {
+    if (!provider.type.endsWith('-cli') || !provider.cliPath) return;
+    for (const message of validateProviderCommandOverride(provider.type, {
+      cliPath: provider.cliPath,
+      trustCommandOverride: provider.trustCommandOverride,
+      trustedCommandPaths: provider.trustedCommandPaths,
+    })) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['consolidatedProviders', index, 'cliPath'],
+        message,
+      });
+    }
+  });
+
   const minDurationMs =
     config.maxCritiqueIterations * MIN_DURATION_MS_PER_CRITIQUE_ITERATION;
   if (config.maxDurationMs < minDurationMs) {

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { NetworkConfigSchema } from '../network/network-config.js';
+import { validateProviderCommandOverride } from './provider-command-override-policy.js';
 
 // Consolidation schemas (moved from run-config-v2.ts)
 
@@ -35,6 +36,8 @@ export const BrainConfigSchema = z.object({
 
 export const ProviderOverrideSchema = z.object({
   command: z.string().optional(),
+  trustCommandOverride: z.literal(true).optional(),
+  trustedCommandPaths: z.array(z.string()).optional(),
   model: z.string().optional(),
   extraArgs: z.array(z.string()).optional(),
 });
@@ -46,6 +49,16 @@ export const ProvidersConfigSchema = z.object({
   fallbackChain: z.array(z.string()).default(['claude', 'codex']),
   /** Per-provider overrides (command, model, extraArgs). */
   overrides: z.record(z.string(), ProviderOverrideSchema).default({}),
+}).superRefine((providers, ctx) => {
+  for (const [name, override] of Object.entries(providers.overrides)) {
+    for (const message of validateProviderCommandOverride(name, override)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['overrides', name, 'command'],
+        message,
+      });
+    }
+  }
 });
 
 const MIN_TOTAL_TOKEN_BUDGET = 10_000;

--- a/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
+++ b/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
@@ -1,0 +1,84 @@
+import { basename, isAbsolute, normalize, sep } from 'node:path';
+
+export interface ProviderCommandOverridePolicyConfig {
+  readonly command?: string | undefined;
+  readonly trustCommandOverride?: boolean | undefined;
+  readonly trustedCommandPaths?: readonly string[] | undefined;
+}
+
+export interface ProviderCommandOverrideAuditLogger {
+  warn(message: string, component?: string): void;
+}
+
+const BUILTIN_PROVIDER_COMMANDS: Record<string, readonly string[]> = {
+  claude: ['claude', 'claude-code'],
+  codex: ['codex'],
+  gemini: ['gemini', 'gemini-cli'],
+  aider: ['aider'],
+};
+
+function allowedCommandNames(provider: string): readonly string[] {
+  return BUILTIN_PROVIDER_COMMANDS[provider] ?? [provider];
+}
+
+function isTrustedPath(command: string, trustedPaths: readonly string[] | undefined): boolean {
+  if (!isAbsolute(command) || !trustedPaths?.length) {
+    return false;
+  }
+
+  const normalizedCommand = normalize(command);
+  return trustedPaths.some((entry) => {
+    if (!isAbsolute(entry)) return false;
+    const normalizedEntry = normalize(entry);
+    return normalizedCommand === normalizedEntry || normalizedCommand.startsWith(`${normalizedEntry}${sep}`);
+  });
+}
+
+export function validateProviderCommandOverride(
+  provider: string,
+  override: ProviderCommandOverridePolicyConfig,
+): string[] {
+  if (!override.command) {
+    return [];
+  }
+
+  const issues: string[] = [];
+  if (override.trustCommandOverride !== true) {
+    issues.push(
+      `providers.overrides.${provider}.command requires trustCommandOverride: true before a repo-configured command override may be used`,
+    );
+  }
+
+  const commandName = basename(override.command);
+  const allowed = allowedCommandNames(provider);
+  if (!allowed.includes(commandName) && !isTrustedPath(override.command, override.trustedCommandPaths)) {
+    issues.push(
+      `providers.overrides.${provider}.command must resolve to an allowed provider binary `
+        + `(${allowed.join(', ')}) or an absolute path under trustedCommandPaths`,
+    );
+  }
+
+  return issues;
+}
+
+export function assertTrustedProviderCommandOverrides(
+  overrides: Record<string, ProviderCommandOverridePolicyConfig> | undefined,
+  options?: { readonly logger?: ProviderCommandOverrideAuditLogger | undefined },
+): void {
+  if (!overrides) return;
+
+  const issues: string[] = [];
+  for (const [provider, override] of Object.entries(overrides)) {
+    issues.push(...validateProviderCommandOverride(provider, override));
+    if (override.command && override.trustCommandOverride === true) {
+      options?.logger?.warn(
+        `SECURITY AUDIT: using trusted provider command override for ${provider}: ${override.command}`,
+        'provider-command-policy',
+      );
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new Error(`Refusing unsafe provider command override: ${issues.join('; ')}`);
+  }
+}

--- a/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
+++ b/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
@@ -2,6 +2,7 @@ import { basename, isAbsolute, normalize, sep } from 'node:path';
 
 export interface ProviderCommandOverridePolicyConfig {
   readonly command?: string | undefined;
+  readonly cliPath?: string | undefined;
   readonly trustCommandOverride?: boolean | undefined;
   readonly trustedCommandPaths?: readonly string[] | undefined;
 }
@@ -17,8 +18,12 @@ const BUILTIN_PROVIDER_COMMANDS: Record<string, readonly string[]> = {
   aider: ['aider'],
 };
 
+function providerNameForType(provider: string): string {
+  return provider.endsWith('-cli') ? provider.slice(0, -'-cli'.length) : provider;
+}
+
 function allowedCommandNames(provider: string): readonly string[] {
-  return BUILTIN_PROVIDER_COMMANDS[provider] ?? [provider];
+  return BUILTIN_PROVIDER_COMMANDS[providerNameForType(provider)] ?? [providerNameForType(provider)];
 }
 
 function isTrustedPath(command: string, trustedPaths: readonly string[] | undefined): boolean {
@@ -38,22 +43,23 @@ export function validateProviderCommandOverride(
   provider: string,
   override: ProviderCommandOverridePolicyConfig,
 ): string[] {
-  if (!override.command) {
+  const command = override.command ?? override.cliPath;
+  if (!command) {
     return [];
   }
 
   const issues: string[] = [];
   if (override.trustCommandOverride !== true) {
     issues.push(
-      `providers.overrides.${provider}.command requires trustCommandOverride: true before a repo-configured command override may be used`,
+      `provider command override for ${provider} requires trustCommandOverride: true before a repo-configured command override may be used`,
     );
   }
 
-  const commandName = basename(override.command);
+  const commandIsBareName = command === basename(command);
   const allowed = allowedCommandNames(provider);
-  if (!allowed.includes(commandName) && !isTrustedPath(override.command, override.trustedCommandPaths)) {
+  if (!(commandIsBareName && allowed.includes(command)) && !isTrustedPath(command, override.trustedCommandPaths)) {
     issues.push(
-      `providers.overrides.${provider}.command must resolve to an allowed provider binary `
+      `provider command override for ${provider} must be a bare allowed provider binary `
         + `(${allowed.join(', ')}) or an absolute path under trustedCommandPaths`,
     );
   }
@@ -70,9 +76,10 @@ export function assertTrustedProviderCommandOverrides(
   const issues: string[] = [];
   for (const [provider, override] of Object.entries(overrides)) {
     issues.push(...validateProviderCommandOverride(provider, override));
-    if (override.command && override.trustCommandOverride === true) {
+    const command = override.command ?? override.cliPath;
+    if (command && override.trustCommandOverride === true) {
       options?.logger?.warn(
-        `SECURITY AUDIT: using trusted provider command override for ${provider}: ${override.command}`,
+        `SECURITY AUDIT: using trusted provider command override for ${provider}: ${command}`,
         'provider-command-policy',
       );
     }

--- a/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
+++ b/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
@@ -1,4 +1,4 @@
-import { basename, isAbsolute, normalize, sep } from 'node:path';
+import { basename, isAbsolute, normalize, parse, sep } from 'node:path';
 
 export interface ProviderCommandOverridePolicyConfig {
   readonly command?: string | undefined;
@@ -34,9 +34,19 @@ function isTrustedPath(command: string, trustedPaths: readonly string[] | undefi
   const normalizedCommand = normalize(command);
   return trustedPaths.some((entry) => {
     if (!isAbsolute(entry)) return false;
-    const normalizedEntry = normalize(entry);
+    const normalizedEntry = normalizeTrustedDirectory(entry);
     return normalizedCommand === normalizedEntry || normalizedCommand.startsWith(`${normalizedEntry}${sep}`);
   });
+}
+
+function normalizeTrustedDirectory(entry: string): string {
+  const normalized = normalize(entry);
+  const root = parse(normalized).root;
+  let trimmed = normalized;
+  while (trimmed.length > root.length && trimmed.endsWith(sep)) {
+    trimmed = trimmed.slice(0, -sep.length);
+  }
+  return trimmed;
 }
 
 export function validateProviderCommandOverride(
@@ -73,8 +83,18 @@ export function assertTrustedProviderCommandOverrides(
 ): void {
   if (!overrides) return;
 
+  assertTrustedProviderCommandOverrideEntries(Object.entries(overrides), options);
+}
+
+export function assertTrustedProviderCommandOverrideEntries(
+  overrides: Iterable<readonly [string, ProviderCommandOverridePolicyConfig]>,
+  options?: { readonly logger?: ProviderCommandOverrideAuditLogger | undefined },
+): void {
+  const entries = Array.from(overrides);
+  if (entries.length === 0) return;
+
   const issues: string[] = [];
-  for (const [provider, override] of Object.entries(overrides)) {
+  for (const [provider, override] of entries) {
     issues.push(...validateProviderCommandOverride(provider, override));
     const command = override.command ?? override.cliPath;
     if (command && override.trustCommandOverride === true) {

--- a/packages/franken-orchestrator/src/providers/provider-config.ts
+++ b/packages/franken-orchestrator/src/providers/provider-config.ts
@@ -19,6 +19,8 @@ export type ProviderType = (typeof PROVIDER_TYPES)[number];
 
 export interface ProviderOverrideConfig {
   readonly command?: string | undefined;
+  readonly trustCommandOverride?: boolean | undefined;
+  readonly trustedCommandPaths?: readonly string[] | undefined;
   readonly model?: string | undefined;
   readonly extraArgs?: readonly string[] | undefined;
 }

--- a/packages/franken-orchestrator/src/providers/provider-config.ts
+++ b/packages/franken-orchestrator/src/providers/provider-config.ts
@@ -30,6 +30,8 @@ export interface ProviderConfig {
   readonly type: ProviderType;
   readonly apiKey?: string | undefined;
   readonly cliPath?: string | undefined;
+  readonly trustCommandOverride?: boolean | undefined;
+  readonly trustedCommandPaths?: readonly string[] | undefined;
   readonly model?: string | undefined;
   readonly extraArgs?: readonly string[] | undefined;
 }

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
@@ -49,7 +49,7 @@ describe('Config loader providers passthrough', () => {
         default: 'gemini',
         fallbackChain: ['gemini', 'claude'],
         overrides: {
-          gemini: { command: 'gemini-cli', model: 'gemini-pro' },
+          gemini: { command: 'gemini-cli', trustCommandOverride: true, model: 'gemini-pro' },
         },
       },
     }));
@@ -59,6 +59,7 @@ describe('Config loader providers passthrough', () => {
     expect(config.providers.fallbackChain).toEqual(['gemini', 'claude']);
     expect(config.providers.overrides['gemini']).toEqual({
       command: 'gemini-cli',
+      trustCommandOverride: true,
       model: 'gemini-pro',
     });
   });

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -69,6 +69,7 @@ describe('bridgeToBeastConfig()', () => {
         providersConfig: {
           aider: {
             command: '/opt/bin/aider',
+            trustCommandOverride: true,
             model: 'gpt-4o',
             extraArgs: ['--yes-always'],
           },
@@ -134,7 +135,7 @@ describe('bridgeToBeastConfig()', () => {
       const config = bridgeToBeastConfig(makeOptions({
         provider: 'claude',
         providersConfig: {
-          claude: { command: '/usr/local/bin/claude' },
+          claude: { command: '/usr/local/bin/claude', trustCommandOverride: true },
         },
       }));
       expect(config.providers).toEqual([
@@ -148,6 +149,7 @@ describe('bridgeToBeastConfig()', () => {
         providersConfig: {
           gemini: {
             command: '/opt/bin/gemini',
+            trustCommandOverride: true,
             model: 'gemini-2.5-pro',
             extraArgs: ['--debug'],
           },
@@ -205,7 +207,7 @@ describe('bridgeToBeastConfig()', () => {
       const config = bridgeToBeastConfig(makeOptions({
         provider: 'codex',
         providersConfig: {
-          claude: { command: '/opt/bin/claude', extraArgs: ['--print'] },
+          claude: { command: '/opt/bin/claude', trustCommandOverride: true, extraArgs: ['--print'] },
         },
         runConfig: {
           provider: 'gemini',
@@ -229,7 +231,7 @@ describe('bridgeToBeastConfig()', () => {
       const config = bridgeToBeastConfig(makeOptions({
         provider: 'aider',
         providersConfig: {
-          aider: { command: '/opt/bin/aider' },
+          aider: { command: '/opt/bin/aider', trustCommandOverride: true },
         },
         runConfig: { model: 'gpt-4o' },
       }));

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -374,7 +374,13 @@ describe('dep-factory provider wiring', () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({
       provider: 'claude',
-      providersConfig: { claude: { command: '/usr/local/bin/claude', trustCommandOverride: true } },
+      providersConfig: {
+        claude: {
+          command: '/usr/local/bin/claude',
+          trustCommandOverride: true,
+          trustedCommandPaths: ['/usr/local/bin'],
+        },
+      },
     });
     await createCliDeps(opts);
     expect(MockCliLlmAdapter).toHaveBeenCalledWith(
@@ -402,7 +408,13 @@ describe('dep-factory provider wiring', () => {
     const opts = makeOpts({
       provider: 'codex',
       providers: ['codex'],
-      providersConfig: { codex: { command: '/usr/local/bin/codex', trustCommandOverride: true } },
+      providersConfig: {
+        codex: {
+          command: '/usr/local/bin/codex',
+          trustCommandOverride: true,
+          trustedCommandPaths: ['/usr/local/bin'],
+        },
+      },
     });
 
     await createCliDeps(opts);

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { getProjectPaths, scaffoldFrankenbeast } from '../../../src/cli/project-root.js';
+import { OrchestratorConfigSchema } from '../../../src/config/orchestrator-config.js';
 import type { CliDepOptions } from '../../../src/cli/dep-factory.js';
 
 // ── Mock heavy dependencies to isolate provider wiring ──
@@ -386,6 +387,33 @@ describe('dep-factory provider wiring', () => {
     expect(MockCliLlmAdapter).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'claude' }),
       expect.objectContaining({ commandOverride: '/usr/local/bin/claude' }),
+    );
+  }, 10_000);
+
+  it('audits trusted command overrides from consolidatedProviders', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    const { BeastLogger } = await import('../../../src/logging/beast-logger.js');
+    const opts = makeOpts({
+      orchestratorConfig: OrchestratorConfigSchema.parse({
+        consolidatedProviders: [
+          {
+            name: 'local-claude',
+            type: 'claude-cli',
+            cliPath: '/usr/local/bin/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/usr/local/bin/'],
+          },
+        ],
+      }),
+    });
+
+    await createCliDeps(opts);
+
+    const loggerInstances = (BeastLogger as unknown as { mock: { instances: Array<{ warn: ReturnType<typeof vi.fn> }> } }).mock.instances;
+    const logger = loggerInstances.at(-1);
+    expect(logger?.warn).toHaveBeenCalledWith(
+      expect.stringContaining('SECURITY AUDIT: using trusted provider command override for claude-cli: /usr/local/bin/claude-wrapper'),
+      'provider-command-policy',
     );
   }, 10_000);
 

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -348,11 +348,33 @@ describe('dep-factory provider wiring', () => {
     );
   });
 
-  it('applies command override from providersConfig', async () => {
+  it('rejects command overrides from providersConfig unless explicitly trusted', async () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({
       provider: 'claude',
-      providersConfig: { claude: { command: '/usr/local/bin/claude' } },
+      providersConfig: { claude: { command: '/tmp/malicious-claude' } },
+    });
+
+    await expect(createCliDeps(opts)).rejects.toThrow(/trustCommandOverride: true/);
+  });
+
+  it('rejects trusted command overrides that do not target the selected provider binary', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    const opts = makeOpts({
+      provider: 'claude',
+      providersConfig: {
+        claude: { command: '/tmp/malicious-shell', trustCommandOverride: true },
+      },
+    });
+
+    await expect(createCliDeps(opts)).rejects.toThrow(/allowed provider binary/);
+  });
+
+  it('applies trusted command override from providersConfig', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    const opts = makeOpts({
+      provider: 'claude',
+      providersConfig: { claude: { command: '/usr/local/bin/claude', trustCommandOverride: true } },
     });
     await createCliDeps(opts);
     expect(MockCliLlmAdapter).toHaveBeenCalledWith(
@@ -380,7 +402,7 @@ describe('dep-factory provider wiring', () => {
     const opts = makeOpts({
       provider: 'codex',
       providers: ['codex'],
-      providersConfig: { codex: { command: '/usr/local/bin/codex' } },
+      providersConfig: { codex: { command: '/usr/local/bin/codex', trustCommandOverride: true } },
     });
 
     await createCliDeps(opts);

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
@@ -27,12 +27,23 @@ describe('OrchestratorConfigSchema providers section', () => {
     expect(config.providers.fallbackChain).toEqual(['gemini', 'aider', 'claude']);
   });
 
-  it('accepts overrides with command, model, and extraArgs', () => {
+  it('rejects provider command overrides without explicit trust', () => {
+    expect(() => OrchestratorConfigSchema.parse({
+      providers: {
+        overrides: {
+          gemini: { command: '/tmp/malicious-gemini' },
+        },
+      },
+    })).toThrow(/trustCommandOverride: true/);
+  });
+
+  it('accepts trusted overrides with command, model, and extraArgs', () => {
     const config = OrchestratorConfigSchema.parse({
       providers: {
         overrides: {
           gemini: {
             command: '/usr/local/bin/gemini-cli',
+            trustCommandOverride: true,
             model: 'gemini-pro',
             extraArgs: ['--temperature', '0.5'],
           },
@@ -44,6 +55,26 @@ describe('OrchestratorConfigSchema providers section', () => {
     expect(gemini!.command).toBe('/usr/local/bin/gemini-cli');
     expect(gemini!.model).toBe('gemini-pro');
     expect(gemini!.extraArgs).toEqual(['--temperature', '0.5']);
+  });
+
+  it('accepts trusted command overrides under trustedCommandPaths', () => {
+    const config = OrchestratorConfigSchema.parse({
+      providers: {
+        overrides: {
+          claude: {
+            command: '/opt/frankenbeast/bin/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/opt/frankenbeast/bin'],
+          },
+        },
+      },
+    });
+
+    expect(config.providers.overrides['claude']).toEqual({
+      command: '/opt/frankenbeast/bin/claude-wrapper',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/opt/frankenbeast/bin'],
+    });
   });
 
   it('accepts overrides with partial fields (all optional)', () => {

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
@@ -37,12 +37,22 @@ describe('OrchestratorConfigSchema providers section', () => {
     })).toThrow(/trustCommandOverride: true/);
   });
 
+  it('rejects provider command path overrides that only match by basename', () => {
+    expect(() => OrchestratorConfigSchema.parse({
+      providers: {
+        overrides: {
+          claude: { command: '/tmp/claude', trustCommandOverride: true },
+        },
+      },
+    })).toThrow(/absolute path under trustedCommandPaths/);
+  });
+
   it('accepts trusted overrides with command, model, and extraArgs', () => {
     const config = OrchestratorConfigSchema.parse({
       providers: {
         overrides: {
           gemini: {
-            command: '/usr/local/bin/gemini-cli',
+            command: 'gemini-cli',
             trustCommandOverride: true,
             model: 'gemini-pro',
             extraArgs: ['--temperature', '0.5'],
@@ -52,7 +62,7 @@ describe('OrchestratorConfigSchema providers section', () => {
     });
     const gemini = config.providers.overrides['gemini'];
     expect(gemini).toBeDefined();
-    expect(gemini!.command).toBe('/usr/local/bin/gemini-cli');
+    expect(gemini!.command).toBe('gemini-cli');
     expect(gemini!.model).toBe('gemini-pro');
     expect(gemini!.extraArgs).toEqual(['--temperature', '0.5']);
   });
@@ -97,6 +107,44 @@ describe('OrchestratorConfigSchema providers section', () => {
       providers: { overrides: {} },
     });
     expect(config.providers.overrides).toEqual({});
+  });
+
+  it('rejects consolidated CLI provider cliPath overrides without trust', () => {
+    expect(() => OrchestratorConfigSchema.parse({
+      consolidatedProviders: [
+        { name: 'local-claude', type: 'claude-cli', cliPath: './tools/claude' },
+      ],
+    })).toThrow(/trustCommandOverride: true/);
+  });
+
+  it('rejects consolidated CLI provider cliPath paths outside trustedCommandPaths', () => {
+    expect(() => OrchestratorConfigSchema.parse({
+      consolidatedProviders: [
+        { name: 'local-claude', type: 'claude-cli', cliPath: '/tmp/claude', trustCommandOverride: true },
+      ],
+    })).toThrow(/absolute path under trustedCommandPaths/);
+  });
+
+  it('accepts trusted consolidated CLI provider cliPath overrides under trustedCommandPaths', () => {
+    const config = OrchestratorConfigSchema.parse({
+      consolidatedProviders: [
+        {
+          name: 'local-claude',
+          type: 'claude-cli',
+          cliPath: '/opt/frankenbeast/bin/claude-wrapper',
+          trustCommandOverride: true,
+          trustedCommandPaths: ['/opt/frankenbeast/bin'],
+        },
+      ],
+    });
+
+    expect(config.consolidatedProviders?.[0]).toEqual({
+      name: 'local-claude',
+      type: 'claude-cli',
+      cliPath: '/opt/frankenbeast/bin/claude-wrapper',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/opt/frankenbeast/bin'],
+    });
   });
 
   it('preserves existing config fields alongside providers', () => {

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
@@ -87,6 +87,42 @@ describe('OrchestratorConfigSchema providers section', () => {
     });
   });
 
+  it('accepts trusted command overrides when trustedCommandPaths has a trailing slash', () => {
+    const config = OrchestratorConfigSchema.parse({
+      providers: {
+        overrides: {
+          claude: {
+            command: '/opt/frankenbeast/bin/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/opt/frankenbeast/bin/'],
+          },
+        },
+      },
+    });
+
+    expect(config.providers.overrides['claude']).toEqual({
+      command: '/opt/frankenbeast/bin/claude-wrapper',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/opt/frankenbeast/bin/'],
+    });
+  });
+
+  it('accepts consolidated CLI provider cliPath overrides when trustedCommandPaths has a trailing slash', () => {
+    const config = OrchestratorConfigSchema.parse({
+      consolidatedProviders: [
+        {
+          name: 'local-claude',
+          type: 'claude-cli',
+          cliPath: '/opt/frankenbeast/bin/claude-wrapper',
+          trustCommandOverride: true,
+          trustedCommandPaths: ['/opt/frankenbeast/bin/'],
+        },
+      ],
+    });
+
+    expect(config.consolidatedProviders?.[0]?.trustedCommandPaths).toEqual(['/opt/frankenbeast/bin/']);
+  });
+
   it('accepts overrides with partial fields (all optional)', () => {
     const config = OrchestratorConfigSchema.parse({
       providers: {


### PR DESCRIPTION
## Summary
- Require explicit `trustCommandOverride: true` for repo/run-config provider command overrides.
- Restrict trusted overrides to known provider binaries or absolute paths under `trustedCommandPaths`.
- Audit-log trusted override use and cover schema/runtime behavior with tests.

## Test Plan
- [x] `npm test -- --run tests/unit/config/orchestrator-config-providers.test.ts tests/unit/cli/config-loader-providers.test.ts tests/unit/cli/dep-factory-providers.test.ts`
- [x] `npm test -- --filter=franken-orchestrator`
- [x] `npm run typecheck -- --filter=franken-orchestrator`
- [x] `npm run build -- --filter=franken-orchestrator`
- [x] `npm run lint --workspace=packages/franken-orchestrator` (passes with existing warnings)

Closes #590
