### PR TITLE
docs: align walkthrough-mcp-suite with registered tools and real behavior

### DIFF
--- a/docs/walkthrough-mcp-suite.md
+++ b/docs/walkthrough-mcp-suite.md
@@ -6,7 +6,7 @@ fbeast works with any MCP-compatible AI assistant client. Currently supported:
 |--------|-----------|-------|
 | Claude Code | `.claude/` | ✅ PreToolUse / PostToolUse (generated shell scripts) |
 | Gemini CLI | `.gemini/` | ✅ BeforeTool / AfterTool (shell scripts) |
-| Codex CLI | `codex mcp add` | ✅ PreToolUse / PostToolUse (shell scripts) |
+| Codex CLI | `.codex/config.toml` (written directly) | ✅ PreToolUse / PostToolUse (shell scripts) |
 
 Beast mode (`fbeast mcp beast`) is provider-agnostic: `anthropic-api`, `codex-cli`, `claude-cli`.
 
@@ -249,7 +249,7 @@ Only two tools in its tool list:
 ### Usage pattern
 
 1. Agent calls `search_tools` to find a tool by name (e.g., "tools for memory")
-2. Returns matching lightweight tool metadata (name and short description)
+2. Returns matching tool metadata — name, description, and full input schema (so the agent can call the tool without a second lookup)
 3. Agent calls `execute_tool` with the tool name and arguments
 4. Proxy server dispatches to the appropriate handler and returns the result
 
@@ -271,8 +271,11 @@ Once installed, Claude Code has access to these tools:
 | `fbeast_memory_forget` | memory | Delete a working memory entry |
 | `fbeast_plan_decompose` | planner | Break a task into a DAG of steps |
 | `fbeast_plan_status` | planner | Get current plan status |
+| `fbeast_plan_validate` | planner | Check a stored plan for issues (cycles, missing deps) |
 | `fbeast_critique_evaluate` | critique | Score output quality (0–1), suggest improvements |
+| `fbeast_critique_compare` | critique | Compare two outputs against the same criteria |
 | `fbeast_firewall_scan` | firewall | Scan input for prompt injection |
+| `fbeast_firewall_scan_file` | firewall | Scan a file on disk for prompt injection |
 | `fbeast_observer_log` | observer | Log a tool call event to the audit trail |
 | `fbeast_observer_log_cost` | observer | Record LLM token usage and cost for a call |
 | `fbeast_observer_cost` | observer | Get cost summary by model |
@@ -340,7 +343,6 @@ All MCP servers, hooks, and beast runs share `.fbeast/beast.db` (WAL mode,
 | `governor_log` | governor adapter (`fbeast-governor`), pre-tool hook |
 | `firewall_log` | firewall adapter (`fbeast-firewall`) |
 | `plans` | planner adapter (`fbeast-planner`) |
-| `skill_state` | skills adapter (`fbeast-skills`) |
 | `beast_runs` | `SQLiteBeastRepository` (beast mode) |
 | `beast_run_attempts` | `SQLiteBeastRepository` |
 | `beast_run_events` | `SQLiteBeastRepository` |

--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -43,7 +43,7 @@ export function createMemoryServer(deps: MemoryServerDeps, options: CreateMcpSer
     },
     {
       name: 'fbeast_memory_store',
-      description: 'Store a memory entry. Upserts by key.',
+      description: 'Store a memory entry. Working memory upserts by key; episodic entries are appended as new events.',
       inputSchema: {
         type: 'object',
         properties: {


### PR DESCRIPTION
## Summary
Walkthrough truthfulness fixes from the 2026-07-04 docs-vs-reality audit (#515). Written against post-fix reality: the `denied` governor_log claim became true via #581, and the `skill_state` row removal matches #546.

## Corrections
- **MCP Tools Reference**: added the three registered-but-undocumented tools — `fbeast_plan_validate`, `fbeast_critique_compare`, `fbeast_firewall_scan_file` (verified in `tool-registry.ts`; 20 tools total, now consistent with the package README).
- **Client table**: Codex CLI is configured by writing `.codex/config.toml` directly (`init.ts` never runs `codex mcp add`; only `get`/`remove` are used for migration/uninstall).
- **Proxy usage**: `search_tools` deliberately returns each match's full input schema (PR #446) — replaced the stale "lightweight metadata (name and short description)" promise.
- **Shared Database Layout**: dropped the `skill_state` row (table never written; removed from schema in #546).
- **`fbeast_memory_store` description** (one code string): "Upserts by key" was only true for working memory — episodic entries are appended unconditionally (`brain-adapter.ts`). Description now says so.

Note: the python3 prerequisite concern from the audit is addressed separately in #668 (hooks now parse with node), so no prerequisite note is needed here.

## Testing
`npx turbo run test typecheck --filter=@fbeast/mcp-suite` — green (description string is metadata only; no behavior change).

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)