### PR TITLE
fix(web): remove Vite operator token bridge

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -213,7 +213,10 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     app.all('/v1/beasts/*', async (c) => proxyToBeastDaemon(c.req.raw, opts.beastDaemon!, proxyOperatorToken));
   }
   if (opts.networkControl) {
-    app.route('/', networkRoutes(opts.networkControl));
+    app.route('/', networkRoutes({
+      ...opts.networkControl,
+      ...(effectiveOperatorToken ? { operatorToken: effectiveOperatorToken } : {}),
+    }));
   }
   if (opts.commsConfig && opts.commsRuntime) {
     const commsRoutesOpts: Parameters<typeof commsRoutes>[0] = {

--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -5,7 +5,7 @@ import { join, dirname } from 'node:path';
 import { spawn } from 'node:child_process';
 import { OrchestratorConfigSchema, type OrchestratorConfig } from '../../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../../network/network-config-paths.js';
-import { filterNetworkServices, resolveNetworkServices } from '../../network/network-registry.js';
+import { filterNetworkServices, resolveNetworkServices, type NetworkRegistryContext } from '../../network/network-registry.js';
 import { NetworkLogStore } from '../../network/network-logs.js';
 import { redactSensitiveConfig } from '../../network/network-secrets.js';
 import { NetworkStateStore } from '../../network/network-state-store.js';
@@ -31,6 +31,7 @@ export interface NetworkRoutesDeps {
   root: string;
   frankenbeastDir: string;
   configFile: string;
+  operatorToken?: string;
   getConfig(): OrchestratorConfig;
   setConfig(config: OrchestratorConfig): void;
 }
@@ -52,13 +53,21 @@ function createSupervisor(frankenbeastDir: string): NetworkSupervisor {
   });
 }
 
+function resolveNetworkContext(deps: NetworkRoutesDeps): NetworkRegistryContext {
+  const operatorToken = deps.operatorToken?.trim();
+  return {
+    repoRoot: deps.root,
+    ...(operatorToken ? { operatorToken } : {}),
+  };
+}
+
 export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   const app = new Hono();
 
   app.get('/v1/network/status', async (c) => {
     const supervisor = createSupervisor(deps.frankenbeastDir);
     const status = await supervisor.status();
-    const services = resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root });
+    const services = resolveNetworkServices(deps.getConfig(), resolveNetworkContext(deps));
     const response: NetworkStatusResponse = {
       ...status,
       services: status.services.map((service) => {
@@ -75,7 +84,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
 
   app.post('/v1/network/up', async (c) => {
     const supervisor = createSupervisor(deps.frankenbeastDir);
-    const services = resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root });
+    const services = resolveNetworkServices(deps.getConfig(), resolveNetworkContext(deps));
     const state = await supervisor.up({
       services,
       detached: true,
@@ -95,7 +104,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
     const services = filterNetworkServices(
-      resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root }),
+      resolveNetworkServices(deps.getConfig(), resolveNetworkContext(deps)),
       body.target,
     );
     const state = await supervisor.up({
@@ -119,7 +128,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
     const supervisor = createSupervisor(deps.frankenbeastDir);
     await supervisor.stop(body.target);
     const services = filterNetworkServices(
-      resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root }),
+      resolveNetworkServices(deps.getConfig(), resolveNetworkContext(deps)),
       body.target,
     );
     const state = await supervisor.up({

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -12,6 +12,7 @@ export interface NetworkRegistryContext {
   repoRoot: string;
   configFile?: string | undefined;
   configOverrides?: string[] | undefined;
+  operatorToken?: string | undefined;
 }
 
 export interface NetworkServiceRuntimeConfig {

--- a/packages/franken-orchestrator/src/network/services/dashboard-web-service.ts
+++ b/packages/franken-orchestrator/src/network/services/dashboard-web-service.ts
@@ -32,6 +32,7 @@ export const dashboardWebService: NetworkServiceDefinition = {
       cwd: context.repoRoot,
       env: {
         FRANKENBEAST_CONFIG_FILE: context.configFile ?? '',
+        ...(context.operatorToken ? { FRANKENBEAST_BEAST_OPERATOR_TOKEN: context.operatorToken } : {}),
         VITE_API_URL: '',
         VITE_API_PROXY_TARGET: config.dashboard.apiUrl,
         VITE_BEAST_API_PROXY_TARGET: `http://${config.beastsDaemon.host}:${config.beastsDaemon.port}`,

--- a/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
@@ -2,14 +2,24 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { startNetworkService } from '../../../src/network/network-supervisor-runtime.js';
+import type { ResolvedNetworkService } from '../../../src/network/network-registry.js';
 import { createChatApp } from '../../../src/http/chat-app.js';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
+
+vi.mock('../../../src/network/network-supervisor-runtime.js', () => ({
+  startNetworkService: vi.fn(async () => ({ pid: 12345 })),
+  stopNetworkService: vi.fn(async () => undefined),
+  healthcheckNetworkService: vi.fn(async () => true),
+  preflightNetworkService: vi.fn(async () => ({ action: 'start' })),
+}));
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/network-routes');
 
 describe('network routes', () => {
   afterEach(() => {
+    vi.clearAllMocks();
     rmSync(TMP, { recursive: true, force: true });
   });
 
@@ -44,5 +54,39 @@ describe('network routes', () => {
     const configResponse = await app.request('/v1/network/config');
     const body = await configResponse.json() as { data: { network: { mode: string } } };
     expect(body.data.network.mode).toBe('insecure');
+  });
+
+  it('passes the effective operator token into dashboard launches', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const config = defaultConfig();
+    const app = createChatApp({
+      sessionStoreDir: join(TMP, 'chat'),
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'network-project',
+      operatorToken: 'effective-token',
+      networkControl: {
+        root: TMP,
+        frankenbeastDir: TMP,
+        configFile: join(TMP, 'config.json'),
+        getConfig: () => config,
+        setConfig: vi.fn(),
+      },
+    });
+
+    const response = await app.request('/v1/network/start', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer effective-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ target: 'dashboard-web' }),
+    });
+
+    expect(response.status).toBe(200);
+    const startedServices = vi.mocked(startNetworkService).mock.calls
+      .map(([service]) => service as ResolvedNetworkService);
+    const dashboard = startedServices.find((service) => service.id === 'dashboard-web');
+    expect(dashboard?.runtimeConfig.process?.env?.FRANKENBEAST_BEAST_OPERATOR_TOKEN)
+      .toBe('effective-token');
   });
 });

--- a/packages/franken-web/tests/vite-config.test.ts
+++ b/packages/franken-web/tests/vite-config.test.ts
@@ -26,11 +26,14 @@ describe('vite dev proxy configuration', () => {
     expect(CONFIG_SOURCE).not.toContain('operatorProxy(');
   });
 
-  it('allows browser-proven same-origin requests and requires loopback for unmarked requests', () => {
+  it('requires same-origin browser requests to carry a trusted origin', () => {
     expect(CONFIG_SOURCE).toContain('isLoopbackRemoteAddress(req.socket.remoteAddress)');
     expect(CONFIG_SOURCE).toContain('if (!isLoopbackRemoteAddress(req.socket.remoteAddress))');
-    expect(CONFIG_SOURCE).toContain('if (!originValue && !fetchSiteValue)');
-    expect(CONFIG_SOURCE).toContain("fetchSiteValue === 'same-origin'");
+    expect(CONFIG_SOURCE).toContain("if (fetchSiteValue && !['none', 'same-origin'].includes(fetchSiteValue))");
+    expect(CONFIG_SOURCE).toContain('if (!originValue)');
+    expect(CONFIG_SOURCE).toContain('return false');
+    expect(CONFIG_SOURCE).not.toContain('if (!originValue && !fetchSiteValue)');
+    expect(CONFIG_SOURCE).not.toContain("fetchSiteValue === 'same-origin'");
   });
 
   it('uses the same server-side proxy for dev and preview serving', () => {

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -33,12 +33,8 @@ function isSameOriginProxyRequest(req: IncomingMessage): boolean {
 
   const origin = req.headers.origin;
   const originValue = Array.isArray(origin) ? origin[0] : origin;
-  if (!originValue && !fetchSiteValue) {
-    return isLoopbackRemoteAddress(req.socket.remoteAddress);
-  }
   if (!originValue) {
-    return fetchSiteValue === 'same-origin'
-      || isLoopbackRemoteAddress(req.socket.remoteAddress);
+    return false;
   }
 
   const host = req.headers.host;


### PR DESCRIPTION
## Summary
- remove the Vite config bridge that mapped the server-side operator token into `import.meta.env.VITE_BEAST_OPERATOR_TOKEN`
- fail franken-web dev/build startup when `VITE_BEAST_OPERATOR_TOKEN` is set so long-lived operator credentials are not bundled
- allow same-origin Beast API clients to run without a browser token and update docs/tests around server-side token handling

## Test Plan
- npm --workspace @franken/types run build
- npm --workspace @frankenbeast/web test -- --run tests/vite-env.test.ts tests/vite-config.test.ts tests/lib/beast-api.test.ts
- npm --workspace @frankenbeast/web run typecheck
- npm --workspace @frankenbeast/web run build
- VITE_BEAST_OPERATOR_TOKEN=secret npm --workspace @frankenbeast/web run build (expected failure)
- npm --workspace @frankenbeast/web test

Closes #597