### PR TITLE
fix(web): remove duplicate review launch action

### DIFF
--- a/packages/franken-web/src/components/beasts/single-page-form.tsx
+++ b/packages/franken-web/src/components/beasts/single-page-form.tsx
@@ -53,7 +53,7 @@ export function SinglePageForm({ onLaunch }: SinglePageFormProps) {
                 </Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Content className="data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp overflow-hidden">
-                {section.Component ? <section.Component /> : <StepReview onLaunch={handleLaunch} />}
+                {section.Component ? <section.Component /> : <StepReview />}
               </Accordion.Content>
             </Accordion.Item>
           ))}

--- a/packages/franken-web/src/components/beasts/steps/step-review.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-review.tsx
@@ -1,17 +1,8 @@
 import type { ReactNode } from 'react';
 import { useBeastStore } from '../../../stores/beast-store';
-import { buildWizardLaunchConfig } from '../wizard-launch-config';
 
-interface StepReviewProps {
-  onLaunch: (config: Record<string, unknown>) => void;
-}
-
-export function StepReview({ onLaunch }: StepReviewProps) {
+export function StepReview() {
   const { stepValues, setWizardStep } = useBeastStore();
-
-  function handleLaunch() {
-    onLaunch(buildWizardLaunchConfig(stepValues));
-  }
 
   const identity = stepValues[0] as { name?: string; description?: string } | undefined;
   const workflow = stepValues[1] as { workflowType?: string } | undefined;
@@ -79,15 +70,6 @@ export function StepReview({ onLaunch }: StepReviewProps) {
         )}
       </ReviewSection>
 
-      <div className="pt-4">
-        <button
-          type="button"
-          onClick={handleLaunch}
-          className="w-full px-4 py-3 rounded-lg bg-beast-accent text-beast-bg font-semibold text-sm hover:bg-beast-accent-strong transition-colors"
-        >
-          Launch
-        </button>
-      </div>
     </div>
   );
 }

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -52,7 +52,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
       case 4: return <StepSkills />;
       case 5: return <StepPrompts />;
       case 6: return <StepGit />;
-      case 7: return <StepReview onLaunch={onLaunch} />;
+      case 7: return <StepReview />;
       default: return null;
     }
   }

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 
 afterEach(cleanup);
@@ -13,13 +13,13 @@ describe('StepReview', () => {
   });
 
   it('renders summary sections from Zustand state', () => {
-    render(<StepReview onLaunch={vi.fn()} />);
+    render(<StepReview />);
     expect(screen.getByText('Test Agent')).toBeTruthy();
     expect(screen.getByText(/design-interview/i)).toBeTruthy();
   });
 
   it('has edit links that call setWizardStep', () => {
-    render(<StepReview onLaunch={vi.fn()} />);
+    render(<StepReview />);
     const editLinks = screen.getAllByText('Edit');
     expect(editLinks.length).toBeGreaterThan(0);
     fireEvent.click(editLinks[0]!);
@@ -27,20 +27,13 @@ describe('StepReview', () => {
     expect(useBeastStore.getState().wizardStep).toBe(0);
   });
 
-  it('launches with the shared wizard config shape for non-default workflows', () => {
-    const onLaunch = vi.fn();
+  it('does not render a launch action inside the review step', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' });
     useBeastStore.getState().setStepValues(2, { defaultProvider: 'codex', defaultModel: 'gpt-5.1' });
-    render(<StepReview onLaunch={onLaunch} />);
-    fireEvent.click(screen.getByText('Launch'));
-    expect(onLaunch).toHaveBeenCalledWith({
-      identity: { name: 'Test Agent', description: 'A test agent' },
-      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
-      executionMode: 'process',
-      designDocPath: 'docs/design.md',
-      outputDir: 'tasks/chunks',
-      llm: { defaultProvider: 'codex', defaultModel: 'gpt-5.1' },
-    });
-    expect(onLaunch.mock.calls[0]?.[0]).not.toHaveProperty('workflow_type');
+    render(<StepReview />);
+
+    expect(screen.queryByRole('button', { name: /launch/i })).toBeNull();
+    expect(screen.getByText('chunk-plan')).toBeTruthy();
+    expect(screen.getByText('codex / gpt-5.1')).toBeTruthy();
   });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -37,6 +37,8 @@ describe('WizardDialog', () => {
     useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
 
     render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={onLaunch} />);
+    expect(screen.getAllByRole('button', { name: /launch/i })).toHaveLength(1);
+
     fireEvent.click(screen.getByText('Launch Agent'));
 
     expect(onLaunch).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- Remove the review-step internal Launch button so the wizard footer is the single canonical launch action
- Keep single-page review rendering non-launching while preserving the form footer Launch button
- Update StepReview/WizardDialog tests to cover no duplicate launch controls and canonical config launch

## Test Plan
- npm run build --workspace @franken/types
- cd packages/franken-web && npm test -- --run tests/components/beasts/steps/step-review.test.tsx tests/components/beasts/wizard-dialog.test.tsx
- cd packages/franken-web && npm run typecheck
- cd packages/franken-web && npm run build
- cd packages/franken-web && npm test

Closes #662