### PR TITLE
fix(web): associate beast dispatch errors with fields

### DIFF
--- a/packages/franken-web/src/pages/beast-dispatch-page.tsx
+++ b/packages/franken-web/src/pages/beast-dispatch-page.tsx
@@ -40,8 +40,12 @@ function buildInitialFormState(catalog: BeastCatalogEntry[]): FormState {
   ]));
 }
 
-function buildPromptId(definition: BeastCatalogEntry, prompt: BeastInterviewPrompt): string {
-  return `${definition.label} ${prompt.key}`;
+function buildPromptControlId(definition: BeastCatalogEntry, prompt: BeastInterviewPrompt): string {
+  return `${definition.id}-${prompt.key}-field`;
+}
+
+function buildPromptErrorId(definition: BeastCatalogEntry, prompt: BeastInterviewPrompt): string {
+  return `${definition.id}-${prompt.key}-error`;
 }
 
 function isBrowserFakePath(value: string): boolean {
@@ -102,6 +106,7 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
   const [executionModes, setExecutionModes] = useState<ExecutionModeState>({});
   const [errors, setErrors] = useState<FormErrors>({});
   const pickerRefs = useRef<Record<string, HTMLInputElement | null>>({});
+  const fieldRefs = useRef<Record<string, HTMLInputElement | HTMLSelectElement | null>>({});
 
   useEffect(() => {
     setForms((current) => {
@@ -158,6 +163,10 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
       [definition.id]: nextErrors,
     }));
     if (Object.keys(nextErrors).length > 0) {
+      const firstInvalidPrompt = definition.interviewPrompts.find((prompt) => nextErrors[prompt.key]);
+      if (firstInvalidPrompt) {
+        fieldRefs.current[`${definition.id}:${firstInvalidPrompt.key}`]?.focus();
+      }
       return;
     }
     const toggles = moduleToggles[definition.id];
@@ -226,19 +235,25 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
               </fieldset>
               <div className="beast-card__form">
                 {definition.interviewPrompts.map((prompt) => {
-                  const inputId = buildPromptId(definition, prompt);
+                  const inputId = buildPromptControlId(definition, prompt);
+                  const errorId = buildPromptErrorId(definition, prompt);
                   const inputValue = forms[definition.id]?.[prompt.key] ?? '';
                   const error = errors[definition.id]?.[prompt.key];
 
                   return (
-                    <label className="field-stack" key={prompt.key}>
+                    <label className="field-stack" htmlFor={inputId} key={prompt.key}>
                       <span>{prompt.prompt}</span>
                       {prompt.options && prompt.options.length > 0 ? (
                         <select
-                          aria-label={inputId}
+                          aria-describedby={error ? errorId : undefined}
+                          aria-invalid={error ? true : undefined}
                           className="field-control"
                           disabled={props.disabled}
+                          id={inputId}
                           onChange={(event) => updateField(definition.id, prompt, event.target.value)}
+                          ref={(element) => {
+                            fieldRefs.current[`${definition.id}:${prompt.key}`] = element;
+                          }}
                           value={inputValue}
                         >
                           <option value="">Select</option>
@@ -249,11 +264,16 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
                       ) : prompt.kind === 'directory' ? (
                         <div className="beast-path-picker">
                           <input
-                            aria-label={inputId}
+                            aria-describedby={error ? errorId : undefined}
+                            aria-invalid={error ? true : undefined}
                             className="field-control"
                             disabled={props.disabled}
+                            id={inputId}
                             onChange={(event) => updateField(definition.id, prompt, event.target.value)}
                             placeholder="path/to/chunks"
+                            ref={(element) => {
+                              fieldRefs.current[`${definition.id}:${prompt.key}`] = element;
+                            }}
                             type="text"
                             value={inputValue}
                           />
@@ -283,16 +303,21 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
                         </div>
                       ) : (
                         <input
-                          aria-label={inputId}
+                          aria-describedby={error ? errorId : undefined}
+                          aria-invalid={error ? true : undefined}
                           className="field-control"
                           disabled={props.disabled}
+                          id={inputId}
                           onChange={(event) => updateField(definition.id, prompt, event.target.value)}
                           placeholder={prompt.kind === 'file' ? 'path/to/design.md' : undefined}
+                          ref={(element) => {
+                            fieldRefs.current[`${definition.id}:${prompt.key}`] = element;
+                          }}
                           type="text"
                           value={inputValue}
                         />
                       )}
-                      {error && <small className="field-error">{error}</small>}
+                      {error && <small className="field-error" id={errorId}>{error}</small>}
                     </label>
                   );
                 })}

--- a/packages/franken-web/tests/pages/beast-dispatch-page.test.tsx
+++ b/packages/franken-web/tests/pages/beast-dispatch-page.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BeastCatalogEntry } from '../../src/lib/beast-api';
+import { BeastDispatchPage } from '../../src/pages/beast-dispatch-page';
+
+const catalog: BeastCatalogEntry[] = [
+  {
+    id: 'design-interview',
+    label: 'Design Interview',
+    description: 'Collects design details',
+    executionModeDefault: 'process',
+    interviewPrompts: [
+      {
+        key: 'designFile',
+        prompt: 'Design file path',
+        kind: 'file',
+        required: true,
+      },
+      {
+        key: 'audience',
+        prompt: 'Target audience',
+        kind: 'string',
+        required: true,
+        options: ['Developers', 'Designers'],
+      },
+    ],
+  },
+];
+
+function renderDispatchPage(overrides: Partial<React.ComponentProps<typeof BeastDispatchPage>> = {}) {
+  return render(
+    <BeastDispatchPage
+      agentDetail={null}
+      agents={[]}
+      catalog={catalog}
+      disabled={false}
+      error={null}
+      onDelete={vi.fn()}
+      onDispatch={vi.fn()}
+      onKill={vi.fn()}
+      onRefresh={vi.fn()}
+      onRestart={vi.fn()}
+      onResume={vi.fn()}
+      onSelectAgent={vi.fn()}
+      onStart={vi.fn()}
+      onStop={vi.fn()}
+      selectedAgentId={null}
+      {...overrides}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe('BeastDispatchPage', () => {
+  it('labels dispatch prompt controls with prompt text and connects validation errors to the invalid fields', () => {
+    const onDispatch = vi.fn();
+    renderDispatchPage({ onDispatch });
+
+    const designFileInput = screen.getByLabelText('Design file path');
+    const audienceSelect = screen.getByLabelText('Target audience');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Launch Design Interview' }));
+
+    expect(onDispatch).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(designFileInput);
+    expect(designFileInput.getAttribute('aria-invalid')).toBe('true');
+    expect(audienceSelect.getAttribute('aria-invalid')).toBe('true');
+
+    const designFileErrorId = designFileInput.getAttribute('aria-describedby');
+    const audienceErrorId = audienceSelect.getAttribute('aria-describedby');
+
+    expect(designFileErrorId).toBeTruthy();
+    expect(audienceErrorId).toBeTruthy();
+    expect(document.getElementById(designFileErrorId ?? '')?.textContent).toBe('This field is required.');
+    expect(document.getElementById(audienceErrorId ?? '')?.textContent).toBe('This field is required.');
+  });
+});


### PR DESCRIPTION
## Summary
- add stable ids for Beast dispatch prompt fields and validation messages
- connect field errors with aria-describedby / aria-invalid
- focus the first invalid prompt after a failed launch attempt
- cover the accessibility behavior with a targeted web test

## Test Plan
- npm test --workspace @frankenbeast/web -- --run tests/pages/beast-dispatch-page.test.tsx
- npm test --workspace @frankenbeast/web
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web

Closes #659