### PR TITLE
fix(web): announce create agent launch state

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -120,16 +120,14 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
 
           {/* Footer */}
           <div className="flex flex-col gap-3 px-8 py-5 border-t border-beast-border shrink-0">
-            {launching && !launchError && (
-              <div
-                role="status"
-                aria-live="polite"
-                aria-atomic="true"
-                className="sr-only"
-              >
-                Launching agent. Please wait.
-              </div>
-            )}
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="sr-only"
+            >
+              {launching ? 'Launching agent. Please wait.' : ''}
+            </div>
             {launchError && (
               <div
                 role="alert"

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -64,7 +64,6 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
         <Dialog.Content
           className="fixed top-[10vh] left-[12vw] w-[76vw] h-[80vh] bg-beast-panel border border-beast-border
             rounded-2xl z-[70] flex flex-col shadow-2xl shadow-black/40"
-          aria-busy={launching || undefined}
           aria-describedby={undefined}
         >
           {/* Header */}

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -64,6 +64,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
         <Dialog.Content
           className="fixed top-[10vh] left-[12vw] w-[76vw] h-[80vh] bg-beast-panel border border-beast-border
             rounded-2xl z-[70] flex flex-col shadow-2xl shadow-black/40"
+          aria-busy={launching || undefined}
           aria-describedby={undefined}
         >
           {/* Header */}
@@ -120,12 +121,25 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
 
           {/* Footer */}
           <div className="flex flex-col gap-3 px-8 py-5 border-t border-beast-border shrink-0">
+            {launching && !launchError && (
+              <div
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                className="sr-only"
+              >
+                Launching agent. Please wait.
+              </div>
+            )}
             {launchError && (
-              <div className="px-4 py-3 rounded-lg bg-red-900/30 border border-red-700 text-red-300 text-sm">
+              <div
+                role="alert"
+                className="px-4 py-3 rounded-lg bg-red-900/30 border border-red-700 text-red-300 text-sm"
+              >
                 {launchError}
               </div>
             )}
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between" aria-busy={launching || undefined}>
               {wizardMode === 'wizard' ? (
                 <>
                   <button

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -49,4 +49,19 @@ describe('WizardDialog', () => {
       outputDir: 'tasks/chunks',
     });
   });
+
+  it('announces launch progress and marks the dialog busy while launching', () => {
+    render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} launching={true} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-busy')).toBe('true');
+    expect(screen.getByRole('status').textContent).toContain('Launching agent');
+  });
+
+  it('announces launch errors as alerts', () => {
+    render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} launchError="Agent launch failed" />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Agent launch failed');
+  });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -50,11 +50,11 @@ describe('WizardDialog', () => {
     });
   });
 
-  it('announces launch progress and marks the dialog busy while launching', () => {
+  it('announces launch progress and marks launch controls busy while launching', () => {
     render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} launching={true} />);
 
-    const dialog = screen.getByRole('dialog');
-    expect(dialog.getAttribute('aria-busy')).toBe('true');
+    const launchButton = screen.getByRole('button', { name: /launching/i });
+    expect(launchButton.closest('[aria-busy="true"]')).toBeTruthy();
     expect(screen.getByRole('status').textContent).toContain('Launching agent');
   });
 

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -50,6 +50,12 @@ describe('WizardDialog', () => {
     });
   });
 
+  it('keeps the launch progress status region mounted before launching', () => {
+    render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} />);
+
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
+
   it('announces launch progress and marks launch controls busy while launching', () => {
     render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} launching={true} />);
 


### PR DESCRIPTION
## Summary
- Add an off-screen polite status live region while Create Agent launch is in progress.
- Mark the Create Agent dialog/footer busy while launching.
- Render launch failures with `role="alert"` so assistive tech announces them.

## Test Plan
- `npm run build --workspace @franken/types`
- `npm run test --workspace @frankenbeast/web -- tests/components/beasts/wizard-dialog.test.tsx`
- `npm run typecheck --workspace @frankenbeast/web`
- `npm run build --workspace @frankenbeast/web`

Closes #660
