### PR TITLE
fix(web): improve approval pending UX

### DIFF
--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -4,6 +4,9 @@ import type { ChatBeastContext, ExecuteOutcome, TranscriptMessage, TurnOutcome }
 import { sanitizeChatOutput } from './output-sanitizer.js';
 import type { BeastDispatchPort } from './beast-daemon-dispatch-adapter.js';
 import type { BeastExecutionMode } from '../beasts/types.js';
+import type { PendingApproval } from '@franken/types';
+
+type PendingApprovalContext = Omit<PendingApproval, 'description' | 'requestedAt'>;
 
 const SLASH_COMMANDS = new Set([
   '/plan',
@@ -35,6 +38,7 @@ export interface ChatRuntimeResult {
   displayMessages: ChatDisplayMessage[];
   events: TurnEvent[];
   pendingApproval: boolean;
+  pendingApprovalContext?: PendingApprovalContext;
   pendingApprovalDescription?: string;
   providerContext?: {
     provider: string;
@@ -255,6 +259,12 @@ export class ChatRuntime {
   ): Promise<ChatRuntimeResult> {
     const runResult = await this.turnRunner.run(outcome, { sessionId: state.sessionId });
     const pendingApproval = runResult.status === 'pending_approval';
+    const pendingApprovalContext: PendingApprovalContext = {
+      tool: 'execution',
+      command: outcome.taskDescription,
+      risk: 'Requires explicit approval before execution.',
+      sessionId: state.sessionId,
+    };
     const displayKind = pendingApproval ? 'approval' : 'execution';
     const content = pendingApproval
       ? `approval required: ${outcome.taskDescription}`
@@ -270,6 +280,7 @@ export class ChatRuntime {
       {
         events: runResult.events,
         outcome,
+        ...(pendingApproval ? { pendingApprovalContext } : {}),
         ...(pendingApproval ? { pendingApprovalDescription: outcome.taskDescription } : {}),
         state: stateFromRunResult(runResult),
         tier,
@@ -285,6 +296,7 @@ export class ChatRuntime {
       events?: TurnEvent[];
       beastContext?: ChatBeastContext | null | undefined;
       outcome?: TurnOutcome;
+      pendingApprovalContext?: PendingApprovalContext;
       pendingApprovalDescription?: string;
       state?: string;
       tier?: string | null;
@@ -297,6 +309,9 @@ export class ChatRuntime {
       displayMessages,
       events: extra?.events ?? [],
       pendingApproval: state.pendingApproval,
+      ...(extra?.pendingApprovalContext !== undefined
+        ? { pendingApprovalContext: extra.pendingApprovalContext }
+        : {}),
       ...(extra?.pendingApprovalDescription !== undefined
         ? { pendingApprovalDescription: extra.pendingApprovalDescription }
         : {}),

--- a/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
@@ -70,7 +70,11 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
     const routingMetadata = normalizeRoutingMetadata(input.metadata ?? session.routingMetadata);
     const pendingApproval = result.pendingApproval
       ? result.pendingApprovalDescription
-        ? { description: result.pendingApprovalDescription, requestedAt: new Date().toISOString() }
+        ? {
+            description: result.pendingApprovalDescription,
+            requestedAt: new Date().toISOString(),
+            ...result.pendingApprovalContext,
+          }
         : session.state === 'pending_approval' ? session.pendingApproval ?? null : null
       : null;
 

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -114,7 +114,11 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     session.transcript = result.transcript;
     session.state = result.state;
     session.pendingApproval = result.pendingApproval && result.pendingApprovalDescription
-      ? { description: result.pendingApprovalDescription, requestedAt: new Date().toISOString() }
+      ? {
+          description: result.pendingApprovalDescription,
+          requestedAt: new Date().toISOString(),
+          ...result.pendingApprovalContext,
+        }
       : null;
     session.beastContext = result.beastContext ?? null;
     session.updatedAt = new Date().toISOString();

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -227,7 +227,11 @@ export class ChatSocketController {
     session.transcript = result.transcript;
     session.state = result.state;
     session.pendingApproval = result.pendingApproval && result.pendingApprovalDescription
-      ? { description: result.pendingApprovalDescription, requestedAt: nowIso() }
+      ? {
+          description: result.pendingApprovalDescription,
+          requestedAt: nowIso(),
+          ...result.pendingApprovalContext,
+        }
       : null;
     session.beastContext = result.beastContext ?? null;
     session.updatedAt = nowIso();

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -242,6 +242,11 @@ export class ChatSocketController {
         type: 'turn.approval.requested',
         description: session.pendingApproval.description,
         timestamp: session.pendingApproval.requestedAt,
+        ...(session.pendingApproval.tool ? { tool: session.pendingApproval.tool } : {}),
+        ...(session.pendingApproval.command ? { command: session.pendingApproval.command } : {}),
+        ...(session.pendingApproval.risk ? { risk: session.pendingApproval.risk } : {}),
+        ...(session.pendingApproval.affectedFiles ? { affectedFiles: session.pendingApproval.affectedFiles } : {}),
+        ...(session.pendingApproval.sessionId ? { sessionId: session.pendingApproval.sessionId } : {}),
       });
     }
 

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -77,4 +77,67 @@ describe('ws chat server', () => {
 
     rmSync(TMP, { recursive: true, force: true });
   });
+
+  it('emits approval context for execution turns that require approval', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const engine = {
+      processTurn: vi.fn().mockResolvedValue({
+        tier: 'premium_execution',
+        newMessages: [],
+        outcome: {
+          kind: 'execute',
+          taskDescription: 'deploy staging',
+          approvalRequired: true,
+        },
+      }),
+    };
+    const runtime = new ChatRuntime({
+      engine: engine as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({
+        execute: vi.fn(),
+      }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    const connect = controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    });
+    expect(connect.ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-1',
+      content: 'deploy staging',
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.requested',
+      description: 'deploy staging',
+      tool: 'execution',
+      command: 'deploy staging',
+      risk: 'Requires explicit approval before execution.',
+      sessionId: session.id,
+    }));
+    expect(store.get(session.id)?.pendingApproval).toEqual(expect.objectContaining({
+      description: 'deploy staging',
+      tool: 'execution',
+      command: 'deploy staging',
+      risk: 'Requires explicit approval before execution.',
+      sessionId: session.id,
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createChatRuntime } from '../../../src/chat/chat-runtime-factory.js';
+import { ChatRuntime } from '../../../src/chat/runtime.js';
+import { TurnRunner } from '../../../src/chat/turn-runner.js';
 
 describe('chat runtime parity', () => {
   it('preserves CLI continuation semantics through the shared runtime factory', async () => {
@@ -62,5 +64,38 @@ describe('chat runtime parity', () => {
 
     expect(result.displayMessages[0]?.content).toBe('Nothing pending.');
     expect(result.pendingApproval).toBe(false);
+  });
+
+  it('returns approval context for execution turns requiring approval', async () => {
+    const runtime = new ChatRuntime({
+      engine: {
+        processTurn: vi.fn().mockResolvedValue({
+          tier: 'premium_execution',
+          newMessages: [],
+          outcome: {
+            kind: 'execute',
+            taskDescription: 'deploy staging',
+            approvalRequired: true,
+          },
+        }),
+      } as any,
+      turnRunner: new TurnRunner({ execute: vi.fn() }),
+    });
+
+    const result = await runtime.run('deploy staging', {
+      sessionId: 'session-1',
+      pendingApproval: false,
+      projectId: 'test-project',
+      transcript: [],
+    });
+
+    expect(result.pendingApproval).toBe(true);
+    expect(result.pendingApprovalDescription).toBe('deploy staging');
+    expect(result.pendingApprovalContext).toEqual(expect.objectContaining({
+      tool: 'execution',
+      command: 'deploy staging',
+      risk: expect.stringContaining('Requires explicit approval'),
+      sessionId: 'session-1',
+    }));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
@@ -159,6 +159,12 @@ describe('ChatRuntimeCommsAdapter', () => {
       displayMessages: [{ kind: 'approval', content: 'Run dangerous command?' }],
       events: [],
       pendingApproval: true,
+      pendingApprovalContext: {
+        tool: 'execution',
+        command: 'rm -rf /',
+        risk: 'Requires explicit approval before execution.',
+        sessionId: 'sess-1',
+      },
       pendingApprovalDescription: 'rm -rf /',
       state: 'pending_approval',
       tier: null,
@@ -182,6 +188,10 @@ describe('ChatRuntimeCommsAdapter', () => {
       expect.objectContaining({
         pendingApproval: expect.objectContaining({
           description: 'rm -rf /',
+          tool: 'execution',
+          command: 'rm -rf /',
+          risk: 'Requires explicit approval before execution.',
+          sessionId: 'sess-1',
           requestedAt: expect.any(String),
         }),
       }),

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -11,6 +11,11 @@ export interface ApiErrorEnvelope {
 export const PendingApprovalSchema = z.object({
   description: z.string(),
   requestedAt: z.string(),
+  tool: z.string().optional(),
+  command: z.string().optional(),
+  risk: z.string().optional(),
+  affectedFiles: z.array(z.string()).optional(),
+  sessionId: z.string().optional(),
 });
 export type PendingApproval = z.infer<typeof PendingApprovalSchema>;
 

--- a/packages/franken-types/src/comms.ts
+++ b/packages/franken-types/src/comms.ts
@@ -38,6 +38,11 @@ export const ServerSocketEventSchema = z.discriminatedUnion('type', [
     pendingApproval: z.object({
       description: z.string(),
       requestedAt: z.string(),
+      tool: z.string().optional(),
+      command: z.string().optional(),
+      risk: z.string().optional(),
+      affectedFiles: z.array(z.string()).optional(),
+      sessionId: z.string().optional(),
     }).nullable().optional(),
   }).strict(),
   z.object({
@@ -93,6 +98,11 @@ export const ServerSocketEventSchema = z.discriminatedUnion('type', [
     type: z.literal('turn.approval.requested'),
     description: z.string().min(1),
     timestamp: z.string(),
+    tool: z.string().optional(),
+    command: z.string().optional(),
+    risk: z.string().optional(),
+    affectedFiles: z.array(z.string()).optional(),
+    sessionId: z.string().optional(),
   }).strict(),
   z.object({
     type: z.literal('turn.approval.resolved'),

--- a/packages/franken-web/src/components/approval-card.tsx
+++ b/packages/franken-web/src/components/approval-card.tsx
@@ -1,11 +1,61 @@
+import type { PendingApproval } from '../lib/api';
+
 export interface ApprovalCardProps {
   pending: boolean;
-  description: string;
+  approval?: PendingApproval | null;
+  description?: string;
+  resolving?: boolean;
+  error?: string | null;
+  sessionId?: string | null;
   onApprove: () => void;
   onReject: () => void;
 }
 
-export function ApprovalCard({ pending, description, onApprove, onReject }: ApprovalCardProps) {
+function formatRequestedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+interface DetailRowProps {
+  label: string;
+  children: string | string[] | undefined;
+}
+
+function DetailRow({ label, children }: DetailRowProps) {
+  if (!children || (Array.isArray(children) && children.length === 0)) {
+    return null;
+  }
+
+  return (
+    <div className="approval-card__detail">
+      <dt>{label}</dt>
+      <dd>
+        {Array.isArray(children) ? (
+          <ul className="approval-card__file-list">
+            {children.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+        ) : children}
+      </dd>
+    </div>
+  );
+}
+
+export function ApprovalCard({
+  pending,
+  approval,
+  description,
+  resolving = false,
+  error = null,
+  sessionId,
+  onApprove,
+  onReject,
+}: ApprovalCardProps) {
   if (!pending) {
     return (
       <section className="rail-card" aria-label="Pending approval">
@@ -18,16 +68,39 @@ export function ApprovalCard({ pending, description, onApprove, onReject }: Appr
     );
   }
 
+  const approvalDescription = approval?.description ?? description ?? '';
+  const effectiveSessionId = approval?.sessionId ?? sessionId ?? undefined;
+
   return (
-    <section className="rail-card rail-card--approval" aria-label="Pending approval">
+    <section className="rail-card rail-card--approval" aria-label="Pending approval" aria-busy={resolving}>
       <div className="rail-card__header">
         <p className="eyebrow">Approvals</p>
         <h2>Approval Required</h2>
       </div>
-      <p className="approval-card__description">{description}</p>
+      <p className="approval-card__description">{approvalDescription}</p>
+      <dl className="approval-card__details" aria-label="Approval context">
+        <DetailRow label="Tool" children={approval?.tool} />
+        <DetailRow label="Command" children={approval?.command} />
+        <DetailRow label="Risk" children={approval?.risk} />
+        <DetailRow label="Requested" children={approval?.requestedAt ? formatRequestedAt(approval.requestedAt) : undefined} />
+        <DetailRow label="Affected files" children={approval?.affectedFiles} />
+        <DetailRow label="Session" children={effectiveSessionId} />
+      </dl>
+      {resolving ? (
+        <p className="approval-card__status" role="status">
+          Waiting for approval response…
+        </p>
+      ) : null}
+      {error ? (
+        <p className="approval-card__error" role="alert">
+          {error}
+        </p>
+      ) : null}
       <div className="approval-card__actions">
-        <button className="button button--primary" onClick={onApprove}>Approve</button>
-        <button className="button button--secondary" onClick={onReject}>Reject</button>
+        <button className="button button--primary" disabled={resolving} onClick={onApprove}>
+          {resolving ? 'Submitting…' : 'Approve'}
+        </button>
+        <button className="button button--secondary" disabled={resolving} onClick={onReject}>Reject</button>
       </div>
     </section>
   );

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -184,6 +184,8 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const {
     activity,
     approve,
+    approvalError,
+    approvalResolving,
     connectionStatus,
     costUsd,
     messages,
@@ -674,7 +676,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               <ActivityPane events={activity} />
               <ApprovalCard
                 pending={Boolean(pendingApproval)}
+                approval={pendingApproval}
                 description={pendingApproval?.description ?? ''}
+                resolving={approvalResolving}
+                error={approvalError}
+                sessionId={activeSessionId}
                 onApprove={() => {
                   void approve(true);
                 }}

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -37,6 +37,8 @@ export interface UseChatSessionOptions {
 export interface UseChatSessionResult {
   activity: ActivityEvent[];
   approve: (approved: boolean) => Promise<void>;
+  approvalError: string | null;
+  approvalResolving: boolean;
   connectionStatus: ConnectionStatus;
   costUsd: number;
   messages: ChatMessage[];
@@ -93,6 +95,11 @@ type ServerSocketEvent =
     type: 'turn.approval.requested';
     description: string;
     timestamp: string;
+    tool?: string;
+    command?: string;
+    risk?: string;
+    affectedFiles?: string[];
+    sessionId?: string;
   }
   | {
     type: 'turn.approval.resolved';
@@ -207,6 +214,8 @@ function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): Cha
 
 export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResult {
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
+  const [approvalError, setApprovalError] = useState<string | null>(null);
+  const [approvalResolving, setApprovalResolving] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting');
   const [costUsd, setCostUsd] = useState(0);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -227,12 +236,20 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   }, [opts.baseUrl]);
   const readyRef = useRef(false);
   const socketRef = useRef<WebSocket | null>(null);
+  const approvalResolvingRef = useRef(false);
+
+  function updateApprovalResolving(value: boolean): void {
+    approvalResolvingRef.current = value;
+    setApprovalResolving(value);
+  }
 
   useEffect(() => {
     let cancelled = false;
     const client = clientRef.current;
 
     setActivity([]);
+    setApprovalError(null);
+    updateApprovalResolving(false);
     setMessages([]);
     setPendingApproval(null);
     setShowTypingIndicator(false);
@@ -350,7 +367,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setPendingApproval({
             description: payload.description,
             requestedAt: payload.timestamp,
+            ...(payload.tool ? { tool: payload.tool } : {}),
+            ...(payload.command ? { command: payload.command } : {}),
+            ...(payload.risk ? { risk: payload.risk } : {}),
+            ...(payload.affectedFiles ? { affectedFiles: payload.affectedFiles } : {}),
+            ...(payload.sessionId ? { sessionId: payload.sessionId } : {}),
           });
+          setApprovalError(null);
+          updateApprovalResolving(false);
           setActivity((current) => [
             ...current,
             {
@@ -363,6 +387,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           return;
         case 'turn.approval.resolved':
           setPendingApproval(null);
+          setApprovalError(null);
+          updateApprovalResolving(false);
           setActivity((current) => [
             ...current,
             {
@@ -373,6 +399,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           ]);
           return;
         case 'turn.error':
+          updateApprovalResolving(false);
+          setApprovalError(payload.message);
           setActivity((current) => [
             ...current,
             {
@@ -452,10 +480,12 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
   async function approve(approved: boolean): Promise<void> {
     const socket = socketRef.current;
-    if (!sessionId) {
+    if (!sessionId || approvalResolvingRef.current) {
       return;
     }
 
+    setApprovalError(null);
+    updateApprovalResolving(true);
     setStatus('sending');
     if (!socket || socket.readyState !== 1) {
       try {
@@ -474,8 +504,12 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         ]);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);
+        updateApprovalResolving(false);
+        setApprovalError(null);
         setStatus('idle');
-      } catch {
+      } catch (err) {
+        updateApprovalResolving(false);
+        setApprovalError(err instanceof Error ? err.message : 'Approval failed. Try again.');
         setStatus('error');
       }
       return;
@@ -490,6 +524,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   return {
     activity,
     approve,
+    approvalError,
+    approvalResolving,
     connectionStatus,
     costUsd,
     messages,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -417,12 +417,20 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     };
 
     socket.onerror = () => {
+      if (approvalResolvingRef.current) {
+        updateApprovalResolving(false);
+        setApprovalError('Connection interrupted while resolving approval. Try again if approval is still pending.');
+      }
       setConnectionStatus('error');
       setStatus('error');
     };
 
     socket.onclose = () => {
       socketRef.current = null;
+      if (approvalResolvingRef.current) {
+        updateApprovalResolving(false);
+        setApprovalError('Connection interrupted while resolving approval. Try again if approval is still pending.');
+      }
       setConnectionStatus('disconnected');
       if (shouldReconnect) {
         setSocketGeneration((current) => current + 1);

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -788,6 +788,56 @@ button {
   margin-bottom: 0.9rem;
 }
 
+.approval-card__details {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0 0 0.9rem;
+}
+
+.approval-card__detail {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.approval-card__detail dt {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.approval-card__detail dd {
+  margin: 0;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.approval-card__file-list {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.approval-card__status,
+.approval-card__error {
+  margin: 0 0 0.9rem;
+  font-size: 0.9rem;
+}
+
+.approval-card__status {
+  color: var(--text-muted);
+}
+
+.approval-card__error {
+  color: var(--danger);
+}
+
 .approval-card__actions {
   display: flex;
   gap: 0.75rem;

--- a/packages/franken-web/tests/components/approval-card.test.tsx
+++ b/packages/franken-web/tests/components/approval-card.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ApprovalCard } from '../../src/components/approval-card';
+
+afterEach(() => cleanup());
+
+describe('ApprovalCard', () => {
+  it('shows approval context, requested time, and session when available', () => {
+    render(
+      <ApprovalCard
+        pending
+        approval={{
+          description: 'Approve deploy',
+          requestedAt: '2026-03-09T00:00:02Z',
+          tool: 'deploy-agent',
+          command: 'npm run deploy',
+          risk: 'Writes to production',
+          affectedFiles: ['packages/app/src/deploy.ts', 'infra/prod.tf'],
+          sessionId: 'sess-1',
+        }}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Approve deploy')).toBeTruthy();
+    expect(screen.getByText('deploy-agent')).toBeTruthy();
+    expect(screen.getByText('npm run deploy')).toBeTruthy();
+    expect(screen.getByText('Writes to production')).toBeTruthy();
+    expect(screen.getByText('packages/app/src/deploy.ts')).toBeTruthy();
+    expect(screen.getByText('infra/prod.tf')).toBeTruthy();
+    expect(screen.getByText('sess-1')).toBeTruthy();
+    expect(screen.getByText(/Requested/)).toBeTruthy();
+  });
+
+  it('disables actions while resolving and exposes inline errors for retry', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    const { rerender } = render(
+      <ApprovalCard
+        pending
+        approval={{ description: 'Approve deploy', requestedAt: '2026-03-09T00:00:02Z' }}
+        resolving
+        onApprove={onApprove}
+        onReject={onReject}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /submitting/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(onReject).not.toHaveBeenCalled();
+    expect(screen.getByRole('status').textContent).toContain('Waiting for approval response');
+
+    rerender(
+      <ApprovalCard
+        pending
+        approval={{ description: 'Approve deploy', requestedAt: '2026-03-09T00:00:02Z' }}
+        error="Approval failed. Try again."
+        onApprove={onApprove}
+        onReject={onReject}
+      />,
+    );
+
+    expect(screen.getByRole('alert').textContent).toContain('Approval failed. Try again.');
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -294,7 +294,49 @@ describe('useChatSession', () => {
     expect(mockGetSession).toHaveBeenCalledWith('chat-1');
     expect(socket.sent).toHaveLength(0);
     expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.approvalResolving).toBe(false);
+    expect(result.current.approvalError).toBeNull();
     expect(result.current.status).toBe('idle');
+  });
+
+  it('guards against duplicate approval submissions and exposes retryable HTTP failures', async () => {
+    let rejectApproval: (error: Error) => void = () => undefined;
+    mockApprove.mockImplementationOnce(() => new Promise((_resolve, reject) => {
+      rejectApproval = reject;
+    }));
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    act(() => {
+      MockWebSocket.instances[0]!.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+    });
+
+    void act(() => {
+      void result.current.approve(true);
+    });
+    await waitFor(() => {
+      expect(result.current.approvalResolving).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.approve(false);
+    });
+
+    expect(mockApprove).toHaveBeenCalledTimes(1);
+    act(() => rejectApproval(new Error('approval endpoint unavailable')));
+
+    await waitFor(() => {
+      expect(result.current.approvalResolving).toBe(false);
+      expect(result.current.approvalError).toBe('approval endpoint unavailable');
+      expect(result.current.pendingApproval?.description).toBe('Deploy the generated fix');
+    });
   });
 
   it('preserves streamed messages after HTTP approval fallback', async () => {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -339,6 +339,44 @@ describe('useChatSession', () => {
     });
   });
 
+  it('clears approval resolving state after websocket interruption so users can retry', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+    });
+
+    await act(async () => {
+      await result.current.approve(true);
+    });
+
+    expect(socket.sent).toHaveLength(1);
+    expect(result.current.approvalResolving).toBe(true);
+
+    act(() => socket.shutdown());
+
+    await waitFor(() => {
+      expect(result.current.approvalResolving).toBe(false);
+      expect(result.current.approvalError).toContain('Connection interrupted');
+    });
+
+    await act(async () => {
+      await result.current.approve(false);
+    });
+
+    expect(mockApprove).toHaveBeenCalledWith('chat-1', false);
+  });
+
   it('preserves streamed messages after HTTP approval fallback', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 


### PR DESCRIPTION
## Summary
- show approval context fields in the web approval rail, including tool, command, risk, affected files, requested time, and session
- expose approval resolving/error state in the chat hook and disable approval actions while a response is pending
- forward richer approval context over WebSocket session/approval events

## Test Plan
- npm test -- --run tests/components/approval-card.test.tsx tests/hooks/use-chat-session.test.ts
- npm test --workspace @frankenbeast/web
- npm run typecheck
- npm run build
- npm test
- npm run lint (not available: root and @frankenbeast/web define no lint script)

Closes #654