### PR TITLE
fix(web): show actionable chat error banners

### DIFF
--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ActivityPane } from './activity-pane';
+
+describe('ActivityPane', () => {
+  afterEach(() => cleanup());
+
+  it('summarizes turn errors and keeps raw data behind details', () => {
+    render(
+      <ActivityPane
+        events={[
+          {
+            type: 'turn.error',
+            data: { code: 'TOOL_DENIED', message: 'Approval denied by policy.', traceId: 'trace-1' },
+            timestamp: '2026-07-05T00:00:00.000Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('TOOL_DENIED: Approval denied by policy.')).toBeTruthy();
+    expect(screen.getByText('Raw event details')).toBeTruthy();
+    expect(screen.getByText(/"traceId": "trace-1"/)).toBeTruthy();
+  });
+});

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -5,6 +5,28 @@ export interface ActivityPaneProps {
   events: ActivityEvent[];
 }
 
+function summarizeActivity(event: ActivityEvent): string {
+  const data = event.data ?? {};
+  const message = typeof data.message === 'string' ? data.message : undefined;
+  const code = typeof data.code === 'string' ? data.code : undefined;
+  const description = typeof data.description === 'string' ? data.description : undefined;
+
+  if (event.type === 'turn.error') {
+    return [code, message ?? 'Turn failed'].filter(Boolean).join(': ');
+  }
+  if (event.type === 'turn.approval.requested') {
+    return description ? `Approval requested: ${description}` : 'Approval requested.';
+  }
+  if (event.type === 'turn.approval.resolved') {
+    return data.approved === true ? 'Approval granted.' : 'Approval rejected.';
+  }
+  if (message) {
+    return message;
+  }
+
+  return 'Open details to inspect runtime event data.';
+}
+
 export function ActivityPane({ events }: ActivityPaneProps) {
   const endRef = useRef<HTMLDivElement>(null);
 
@@ -25,7 +47,11 @@ export function ActivityPane({ events }: ActivityPaneProps) {
         {events.map((event, index) => (
           <article key={`${event.type}-${event.timestamp}-${index}`} className="activity-event">
             <strong className="activity-event__type">{event.type}</strong>
-            <span className="activity-event__summary">{JSON.stringify(event.data ?? {})}</span>
+            <span className="activity-event__summary">{summarizeActivity(event)}</span>
+            <details className="activity-event__details">
+              <summary>Raw event details</summary>
+              <pre>{JSON.stringify(event.data ?? {}, null, 2)}</pre>
+            </details>
           </article>
         ))}
         <div ref={endRef} />

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import brandMark from '../../../../assets/img/frankenbeast-github-logo-478x72.png';
-import { useChatSession } from '../hooks/use-chat-session';
+import { useChatSession, type ChatErrorBanner } from '../hooks/use-chat-session';
 import { TranscriptPane } from './transcript-pane';
 import { Composer } from './composer';
 import { ActivityPane } from './activity-pane';
@@ -57,6 +57,42 @@ function PlaceholderPage({ routeId }: { routeId: Exclude<RouteId, 'chat'> }) {
       <h1>{route.label}</h1>
       <p>{route.summary}</p>
       <span>Chat is the only live section in this first Frankenbeast dashboard cut.</span>
+    </section>
+  );
+}
+
+function ChatErrorBanners({
+  banners = [],
+  onDismiss = () => undefined,
+  onRetry = () => undefined,
+}: {
+  banners?: ChatErrorBanner[];
+  onDismiss?: (id: string) => void;
+  onRetry?: (id: string) => void;
+}) {
+  if (banners.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="chat-alerts" aria-label="Chat errors" aria-live="assertive">
+      {banners.map((banner) => (
+        <article key={banner.id} className="chat-alert" role="alert">
+          <div className="chat-alert__body">
+            <p className="eyebrow">{banner.code ?? 'chat_error'}</p>
+            <h2>{banner.title}</h2>
+            <p>{banner.message}</p>
+          </div>
+          <div className="chat-alert__actions">
+            <button className="button button--secondary" type="button" onClick={() => onRetry(banner.id)}>
+              {banner.actionLabel}
+            </button>
+            <button className="button button--ghost" type="button" onClick={() => onDismiss(banner.id)}>
+              Dismiss
+            </button>
+          </div>
+        </article>
+      ))}
     </section>
   );
 }
@@ -186,9 +222,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     approve,
     connectionStatus,
     costUsd,
+    dismissError,
+    errorBanners,
     messages,
     pendingApproval,
     projectId: activeProjectId,
+    retryError,
     send,
     sessionId: activeSessionId,
     showTypingIndicator,
@@ -658,6 +697,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 </div>
               </section>
 
+              <ChatErrorBanners banners={errorBanners} onDismiss={dismissError} onRetry={retryError} />
               <TranscriptPane messages={messages} showTypingIndicator={showTypingIndicator} />
               <Composer
                 connectionStatus={connectionStatus}

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -21,7 +21,7 @@ class MockWebSocket {
   }
 }
 
-function sessionResponse() {
+function sessionResponse(overrides: Record<string, unknown> = {}) {
   return {
     data: {
       id: 'session-1',
@@ -31,8 +31,13 @@ function sessionResponse() {
       pendingApproval: null,
       tokenTotals,
       costUsd: 0,
+      ...overrides,
     },
   };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
 }
 
 describe('useChatSession error banners', () => {
@@ -62,7 +67,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('turns socket turn errors into visible retry banners', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(sessionResponse()), { status: 200 })));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -94,6 +99,68 @@ describe('useChatSession error banners', () => {
       message: 'Approval denied by policy.',
       code: 'TOOL_DENIED',
       actionLabel: 'Retry last message',
+    });
+  });
+
+  it('replaces the failed optimistic message when retrying the last message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockWebSocket.instances[0]!.onopen?.();
+    });
+    await act(async () => {
+      await result.current.send('launch beast');
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.error',
+          code: 'TOOL_DENIED',
+          message: 'Approval denied by policy.',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    const retryBanner = result.current.errorBanners[0]!;
+    await act(async () => {
+      result.current.retryError(retryBanner.id);
+    });
+
+    expect(result.current.messages.filter((message) => message.role === 'user')).toHaveLength(1);
+    expect(MockWebSocket.instances[0]!.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not offer message retry when delivery succeeded but transcript refresh failed', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
+      .mockResolvedValueOnce(jsonResponse({ data: { tier: 'cheap' } }))
+      .mockRejectedValueOnce(new Error('refresh failed'));
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    MockWebSocket.instances[0]!.readyState = 0;
+
+    await act(async () => {
+      await result.current.send('launch beast');
+    });
+
+    expect(result.current.errorBanners[0]).toMatchObject({
+      title: 'Message sent; refresh failed',
+      code: 'session_refresh_failed',
+      actionLabel: 'Refresh chat',
     });
   });
 });

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -255,6 +255,38 @@ describe('useChatSession error banners', () => {
     });
   });
 
+  it('does not retry messages or refresh sessions that the server reports as not found', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onopen?.();
+    });
+    await act(async () => {
+      await result.current.send('hello');
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.error',
+          code: 'NOT_FOUND',
+          message: 'Chat session was not found.',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.errorBanners[0]).toMatchObject({
+      code: 'NOT_FOUND',
+      actionLabel: 'Dismiss',
+    });
+  });
+
   it('reconnects when the browser returns online after an offline close', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
     vi.stubGlobal('WebSocket', MockWebSocket);

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -222,4 +222,61 @@ describe('useChatSession error banners', () => {
     });
     expect(result.current.connectionStatus).toBe('connecting');
   });
+
+  it('routes missing-session socket errors to session retry', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onopen?.();
+    });
+    await act(async () => {
+      await result.current.send('hello');
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.error',
+          code: 'NO_SESSION',
+          message: 'Chat session is missing.',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.errorBanners[0]).toMatchObject({
+      code: 'NO_SESSION',
+      actionLabel: 'Retry session',
+    });
+  });
+
+  it('reconnects when the browser returns online after an offline close', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    act(() => {
+      MockWebSocket.instances[0]!.onclose?.();
+    });
+    expect(result.current.connectionStatus).toBe('offline');
+
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+  });
 });

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -163,4 +163,63 @@ describe('useChatSession error banners', () => {
       actionLabel: 'Refresh chat',
     });
   });
+
+  it('does not offer retry for invalid socket payload errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onopen?.();
+    });
+    await act(async () => {
+      await result.current.send('x'.repeat(20_000));
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.error',
+          code: 'INVALID_EVENT',
+          message: 'Message content is too long.',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.errorBanners[0]).toMatchObject({
+      code: 'INVALID_EVENT',
+      actionLabel: 'Dismiss',
+    });
+  });
+
+  it('resets status after a successful reconnect refresh', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'fresh-token' })));
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onerror?.();
+    });
+
+    const retryBanner = result.current.errorBanners[0]!;
+    await act(async () => {
+      result.current.retryError(retryBanner.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('idle');
+    });
+    expect(result.current.connectionStatus).toBe('connecting');
+  });
 });

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useChatSession } from './use-chat-session';
+
+const tokenTotals = { cheap: 0, premiumReasoning: 0, premiumExecution: 0 };
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static readonly OPEN = 1;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  readyState = MockWebSocket.OPEN;
+  send = vi.fn();
+  close = vi.fn();
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+}
+
+function sessionResponse() {
+  return {
+    data: {
+      id: 'session-1',
+      projectId: 'project-1',
+      socketToken: 'socket-token',
+      transcript: [],
+      pendingApproval: null,
+      tokenTotals,
+      costUsd: 0,
+    },
+  };
+}
+
+describe('useChatSession error banners', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    MockWebSocket.instances = [];
+  });
+
+  it('surfaces session init failures with an actionable retry banner', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('HTTP 503')));
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
+    expect(result.current.connectionStatus).toBe('error');
+    expect(result.current.errorBanners[0]).toMatchObject({
+      title: 'Unable to start chat session',
+      message: 'HTTP 503',
+      code: 'session_init_failed',
+      actionLabel: 'Retry session',
+    });
+  });
+
+  it('turns socket turn errors into visible retry banners', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(sessionResponse()), { status: 200 })));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockWebSocket.instances[0]!.onopen?.();
+    });
+    await act(async () => {
+      await result.current.send('launch beast');
+    });
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.error',
+          code: 'TOOL_DENIED',
+          message: 'Approval denied by policy.',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorBanners[0]).toMatchObject({
+      title: 'Turn failed',
+      message: 'Approval denied by policy.',
+      code: 'TOOL_DENIED',
+      actionLabel: 'Retry last message',
+    });
+  });
+});

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -342,6 +342,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setApprovalError(null);
     updateApprovalResolving(false);
     setMessages([]);
+    lastMessageRef.current = null;
     setSessionId(null);
     setSocketToken(null);
     setPendingApproval(null);
@@ -531,11 +532,12 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
               timestamp: payload.timestamp,
             },
           ]);
-          const sessionRecoveryCodes = new Set(['NO_SESSION', 'NOT_FOUND']);
+          const missingSessionCanRefresh = payload.code === 'NO_SESSION';
           const canRetryMessage = Boolean(lastMessageRef.current)
             && payload.code !== 'INVALID_EVENT'
-            && !sessionRecoveryCodes.has(payload.code);
-          const action = sessionRecoveryCodes.has(payload.code)
+            && payload.code !== 'NO_SESSION'
+            && payload.code !== 'NOT_FOUND';
+          const action = missingSessionCanRefresh
             ? 'retry-session'
             : canRetryMessage ? 'retry-message' : 'dismiss';
           addErrorBanner(makeBanner(

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -265,7 +265,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   }, [opts.baseUrl]);
   const readyRef = useRef(false);
   const socketRef = useRef<WebSocket | null>(null);
-  const lastMessageContentRef = useRef<string | null>(null);
+  const lastMessageRef = useRef<{ clientMessageId: string; content: string } | null>(null);
   const errorActionRef = useRef(new Map<string, ChatErrorAction>());
 
   function addErrorBanner(banner: ChatErrorBanner) {
@@ -278,16 +278,43 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setErrorBanners((current) => current.filter((item) => item.id !== id));
   }
 
+  function refreshSession() {
+    if (!sessionId) {
+      setSessionRetrySeed((current) => current + 1);
+      return;
+    }
+
+    void clientRef.current.getSession(sessionId)
+      .then((refreshed) => {
+        setSocketToken(refreshed.socketToken);
+        setMessages(applySessionSnapshot(refreshed));
+        setPendingApproval(refreshed.pendingApproval ?? null);
+        setTokenTotals(refreshed.tokenTotals);
+        setCostUsd(refreshed.costUsd);
+        setConnectionStatus('reconnecting');
+        setSocketGeneration((current) => current + 1);
+      })
+      .catch((error) => {
+        setStatus('error');
+        addErrorBanner(makeBanner(
+          'Unable to refresh chat session',
+          errorMessage(error, 'The chat API did not return a refreshed session.'),
+          'retry-session',
+          'Retry session',
+          'session_refresh_failed',
+        ));
+      });
+  }
+
   function retryError(id: string) {
     const action = errorActionRef.current.get(id);
     dismissError(id);
-    if (action === 'retry-session') {
-      setSessionRetrySeed((current) => current + 1);
-    } else if (action === 'reconnect') {
-      setConnectionStatus('reconnecting');
-      setSocketGeneration((current) => current + 1);
-    } else if (action === 'retry-message' && lastMessageContentRef.current) {
-      void send(lastMessageContentRef.current);
+    if (action === 'retry-session' || action === 'reconnect') {
+      refreshSession();
+    } else if (action === 'retry-message' && lastMessageRef.current) {
+      const { clientMessageId, content } = lastMessageRef.current;
+      setMessages((current) => current.filter((message) => message.id !== clientMessageId));
+      void send(content);
     }
   }
 
@@ -457,8 +484,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           addErrorBanner(makeBanner(
             'Turn failed',
             payload.message,
-            lastMessageContentRef.current ? 'retry-message' : 'dismiss',
-            lastMessageContentRef.current ? 'Retry last message' : 'Dismiss',
+            lastMessageRef.current ? 'retry-message' : 'dismiss',
+            lastMessageRef.current ? 'Retry last message' : 'Dismiss',
             payload.code,
           ));
           setStatus('error');
@@ -504,7 +531,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     const clientMessageId = makeId('user');
-    lastMessageContentRef.current = content;
+    lastMessageRef.current = { clientMessageId, content };
     setErrorBanners((current) => current.filter((item) => item.action !== 'retry-message'));
     setMessages((current) => [
       ...current,
@@ -521,13 +548,24 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     if (!socket || socket.readyState !== 1) {
       try {
         const result = await clientRef.current.sendMessage(sessionId, content);
-        const refreshed = await clientRef.current.getSession(sessionId);
-        setMessages(applySessionSnapshot(refreshed));
-        setPendingApproval(refreshed.pendingApproval ?? null);
-        setTokenTotals(refreshed.tokenTotals);
-        setCostUsd(refreshed.costUsd);
         setTier(result.tier);
-        setStatus('idle');
+        try {
+          const refreshed = await clientRef.current.getSession(sessionId);
+          setMessages(applySessionSnapshot(refreshed));
+          setPendingApproval(refreshed.pendingApproval ?? null);
+          setTokenTotals(refreshed.tokenTotals);
+          setCostUsd(refreshed.costUsd);
+          setStatus('idle');
+        } catch (error) {
+          addErrorBanner(makeBanner(
+            'Message sent; refresh failed',
+            errorMessage(error, 'The message was accepted, but the updated transcript could not be loaded.'),
+            'retry-session',
+            'Refresh chat',
+            'session_refresh_failed',
+          ));
+          setStatus('error');
+        }
       } catch (error) {
         addErrorBanner(makeBanner(
           'Message was not sent',

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -8,8 +8,19 @@ import {
 } from '../lib/api';
 
 export type SessionStatus = 'idle' | 'connecting' | 'sending' | 'streaming' | 'error';
-export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
+export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'offline' | 'error';
 export type MessageReceipt = 'sending' | 'accepted' | 'delivered' | 'read';
+
+export type ChatErrorAction = 'retry-session' | 'reconnect' | 'retry-message' | 'dismiss';
+
+export interface ChatErrorBanner {
+  id: string;
+  title: string;
+  message: string;
+  code?: string;
+  action: ChatErrorAction;
+  actionLabel: string;
+}
 
 export interface ChatMessage {
   id: string;
@@ -39,9 +50,12 @@ export interface UseChatSessionResult {
   approve: (approved: boolean) => Promise<void>;
   connectionStatus: ConnectionStatus;
   costUsd: number;
+  dismissError: (id: string) => void;
+  errorBanners: ChatErrorBanner[];
   messages: ChatMessage[];
   pendingApproval: PendingApproval | null;
   projectId: string;
+  retryError: (id: string) => void;
   send: (content: string) => Promise<void>;
   sessionId: string | null;
   showTypingIndicator: boolean;
@@ -112,6 +126,27 @@ const EMPTY_TOKEN_TOTALS: TokenTotals = {
   premiumReasoning: 0,
   premiumExecution: 0,
 };
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function makeBanner(
+  title: string,
+  message: string,
+  action: ChatErrorAction,
+  actionLabel: string,
+  code?: string,
+): ChatErrorBanner {
+  return {
+    id: makeId('chat-error'),
+    title,
+    message,
+    action,
+    actionLabel,
+    ...(code ? { code } : {}),
+  };
+}
 
 function makeId(prefix: string): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -219,6 +254,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const [status, setStatus] = useState<SessionStatus>('connecting');
   const [tier, setTier] = useState<string | null>(null);
   const [tokenTotals, setTokenTotals] = useState<TokenTotals>(EMPTY_TOKEN_TOTALS);
+  const [errorBanners, setErrorBanners] = useState<ChatErrorBanner[]>([]);
+  const [sessionRetrySeed, setSessionRetrySeed] = useState(0);
 
   const clientRef = useRef(new ChatApiClient(opts.baseUrl));
   // Refresh the client when the baseUrl changes; useRef alone would pin the
@@ -228,6 +265,31 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   }, [opts.baseUrl]);
   const readyRef = useRef(false);
   const socketRef = useRef<WebSocket | null>(null);
+  const lastMessageContentRef = useRef<string | null>(null);
+  const errorActionRef = useRef(new Map<string, ChatErrorAction>());
+
+  function addErrorBanner(banner: ChatErrorBanner) {
+    errorActionRef.current.set(banner.id, banner.action);
+    setErrorBanners((current) => [banner, ...current.filter((item) => item.action !== banner.action)].slice(0, 3));
+  }
+
+  function dismissError(id: string) {
+    errorActionRef.current.delete(id);
+    setErrorBanners((current) => current.filter((item) => item.id !== id));
+  }
+
+  function retryError(id: string) {
+    const action = errorActionRef.current.get(id);
+    dismissError(id);
+    if (action === 'retry-session') {
+      setSessionRetrySeed((current) => current + 1);
+    } else if (action === 'reconnect') {
+      setConnectionStatus('reconnecting');
+      setSocketGeneration((current) => current + 1);
+    } else if (action === 'retry-message' && lastMessageContentRef.current) {
+      void send(lastMessageContentRef.current);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -240,8 +302,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setTier(null);
     setTokenTotals(EMPTY_TOKEN_TOTALS);
     setCostUsd(0);
+    setErrorBanners([]);
+    errorActionRef.current.clear();
     setStatus('connecting');
-    setConnectionStatus('connecting');
+    setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'connecting');
 
     async function init() {
       try {
@@ -261,10 +325,17 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setTokenTotals(session.tokenTotals);
         setCostUsd(session.costUsd);
         setStatus('idle');
-      } catch {
+      } catch (error) {
         if (!cancelled) {
           setStatus('error');
-          setConnectionStatus('error');
+          setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'error');
+          addErrorBanner(makeBanner(
+            'Unable to start chat session',
+            errorMessage(error, 'The chat API did not return a usable session.'),
+            'retry-session',
+            'Retry session',
+            'session_init_failed',
+          ));
         }
       }
     }
@@ -274,7 +345,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     return () => {
       cancelled = true;
     };
-  }, [opts.projectId, opts.sessionId, opts.sessionSeed, opts.baseUrl]);
+  }, [opts.projectId, opts.sessionId, opts.sessionSeed, opts.baseUrl, sessionRetrySeed]);
 
   useEffect(() => {
     if (!sessionId || !socketToken) {
@@ -290,6 +361,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
     socket.onopen = () => {
       setConnectionStatus('connected');
+      setErrorBanners((current) => current.filter((item) => item.action !== 'reconnect'));
     };
 
     socket.onmessage = (event) => {
@@ -382,6 +454,13 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
               timestamp: payload.timestamp,
             },
           ]);
+          addErrorBanner(makeBanner(
+            'Turn failed',
+            payload.message,
+            lastMessageContentRef.current ? 'retry-message' : 'dismiss',
+            lastMessageContentRef.current ? 'Retry last message' : 'Dismiss',
+            payload.code,
+          ));
           setStatus('error');
           return;
         case 'pong':
@@ -392,13 +471,22 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     socket.onerror = () => {
       setConnectionStatus('error');
       setStatus('error');
+      addErrorBanner(makeBanner(
+        'Chat connection error',
+        'The live chat socket failed. Messages may fall back to HTTP while the app reconnects.',
+        'reconnect',
+        'Reconnect',
+        'socket_error',
+      ));
     };
 
     socket.onclose = () => {
       socketRef.current = null;
-      setConnectionStatus('disconnected');
       if (shouldReconnect) {
+        setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'reconnecting');
         setSocketGeneration((current) => current + 1);
+      } else {
+        setConnectionStatus('disconnected');
       }
     };
 
@@ -416,6 +504,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     const clientMessageId = makeId('user');
+    lastMessageContentRef.current = content;
+    setErrorBanners((current) => current.filter((item) => item.action !== 'retry-message'));
     setMessages((current) => [
       ...current,
       {
@@ -438,7 +528,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setCostUsd(refreshed.costUsd);
         setTier(result.tier);
         setStatus('idle');
-      } catch {
+      } catch (error) {
+        addErrorBanner(makeBanner(
+          'Message was not sent',
+          errorMessage(error, 'The fallback chat request failed before the turn could start.'),
+          'retry-message',
+          'Retry last message',
+          'message_send_failed',
+        ));
         setStatus('error');
       }
       return;
@@ -476,7 +573,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);
         setStatus('idle');
-      } catch {
+      } catch (error) {
+        addErrorBanner(makeBanner(
+          'Approval response failed',
+          errorMessage(error, 'The approval response could not be delivered.'),
+          'dismiss',
+          'Dismiss',
+          'approval_failed',
+        ));
         setStatus('error');
       }
       return;
@@ -493,9 +597,12 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     approve,
     connectionStatus,
     costUsd,
+    dismissError,
+    errorBanners,
     messages,
     pendingApproval,
     projectId,
+    retryError,
     send,
     sessionId,
     showTypingIndicator,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -342,6 +342,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setApprovalError(null);
     updateApprovalResolving(false);
     setMessages([]);
+    setSessionId(null);
+    setSocketToken(null);
     setPendingApproval(null);
     setShowTypingIndicator(false);
     setTier(null);
@@ -391,6 +393,20 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       cancelled = true;
     };
   }, [opts.projectId, opts.sessionId, opts.sessionSeed, opts.baseUrl, sessionRetrySeed]);
+
+  useEffect(() => {
+    if (!sessionId || !socketToken || typeof window === 'undefined') {
+      return;
+    }
+
+    function handleOnline() {
+      setConnectionStatus('reconnecting');
+      setSocketGeneration((current) => current + 1);
+    }
+
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+  }, [sessionId, socketToken]);
 
   useEffect(() => {
     if (!sessionId || !socketToken) {
@@ -515,12 +531,18 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
               timestamp: payload.timestamp,
             },
           ]);
-          const canRetryMessage = Boolean(lastMessageRef.current) && payload.code !== 'INVALID_EVENT';
+          const sessionRecoveryCodes = new Set(['NO_SESSION', 'NOT_FOUND']);
+          const canRetryMessage = Boolean(lastMessageRef.current)
+            && payload.code !== 'INVALID_EVENT'
+            && !sessionRecoveryCodes.has(payload.code);
+          const action = sessionRecoveryCodes.has(payload.code)
+            ? 'retry-session'
+            : canRetryMessage ? 'retry-message' : 'dismiss';
           addErrorBanner(makeBanner(
             'Turn failed',
             payload.message,
-            canRetryMessage ? 'retry-message' : 'dismiss',
-            canRetryMessage ? 'Retry last message' : 'Dismiss',
+            action,
+            action === 'retry-session' ? 'Retry session' : canRetryMessage ? 'Retry last message' : 'Dismiss',
             payload.code,
           ));
           setStatus('error');

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -306,6 +306,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setPendingApproval(refreshed.pendingApproval ?? null);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);
+        setStatus('idle');
         setConnectionStatus('reconnecting');
         setSocketGeneration((current) => current + 1);
       })
@@ -393,6 +394,11 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
   useEffect(() => {
     if (!sessionId || !socketToken) {
+      return;
+    }
+
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      setConnectionStatus('offline');
       return;
     }
 
@@ -509,11 +515,12 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
               timestamp: payload.timestamp,
             },
           ]);
+          const canRetryMessage = Boolean(lastMessageRef.current) && payload.code !== 'INVALID_EVENT';
           addErrorBanner(makeBanner(
             'Turn failed',
             payload.message,
-            lastMessageRef.current ? 'retry-message' : 'dismiss',
-            lastMessageRef.current ? 'Retry last message' : 'Dismiss',
+            canRetryMessage ? 'retry-message' : 'dismiss',
+            canRetryMessage ? 'Retry last message' : 'Dismiss',
             payload.code,
           ));
           setStatus('error');
@@ -546,7 +553,11 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setApprovalError('Connection interrupted while resolving approval. Try again if approval is still pending.');
       }
       if (shouldReconnect) {
-        setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'reconnecting');
+        if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+          setConnectionStatus('offline');
+          return;
+        }
+        setConnectionStatus('reconnecting');
         setSocketGeneration((current) => current + 1);
       } else {
         setConnectionStatus('disconnected');

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -448,6 +448,39 @@ button {
   gap: 1rem;
 }
 
+.chat-alerts {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.chat-alert {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.15rem;
+  border: 1px solid rgba(255, 122, 107, 0.38);
+  border-radius: 1.1rem;
+  background: rgba(255, 122, 107, 0.1);
+  color: #ffd0ca;
+}
+
+.chat-alert__body {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chat-alert__body h2 {
+  font-size: 1rem;
+}
+
+.chat-alert__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
 .session-switcher {
   display: flex;
   justify-content: space-between;
@@ -781,6 +814,23 @@ button {
 .activity-event__summary {
   display: block;
   color: var(--text-muted);
+  word-break: break-word;
+}
+
+.activity-event__details {
+  margin-top: 0.55rem;
+  color: var(--text-muted);
+}
+
+.activity-event__details summary {
+  cursor: pointer;
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+}
+
+.activity-event__details pre {
+  margin-top: 0.5rem;
+  white-space: pre-wrap;
   word-break: break-word;
 }
 


### PR DESCRIPTION
## Summary
- add chat-level error banners for session init, socket, approval, and turn failures with retry/reconnect/dismiss actions
- expose reconnecting/offline connection states and keep raw activity event JSON behind expandable details
- add targeted hook and activity pane coverage

## Test Plan
- corepack npm run build --workspace @franken/types
- corepack npm run test --workspace @frankenbeast/web -- src/hooks/use-chat-session.test.tsx src/components/activity-pane.test.tsx
- corepack npm run test --workspace @frankenbeast/web
- corepack npm run typecheck --workspace @frankenbeast/web
- corepack npm run build --workspace @frankenbeast/web

Closes #653