### PR TITLE
fix(web): guard disabled composer submissions

### DIFF
--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -12,6 +12,10 @@ export function Composer({ connectionStatus, disabled, onSend, status }: Compose
   const [value, setValue] = useState('');
 
   function submitCurrentValue() {
+    if (disabled) {
+      return;
+    }
+
     const trimmed = value.trim();
     if (!trimmed) {
       return;

--- a/packages/franken-web/tests/components/composer.test.tsx
+++ b/packages/franken-web/tests/components/composer.test.tsx
@@ -74,6 +74,28 @@ describe('Composer', () => {
     expect(onSend).toHaveBeenCalledWith('keyboard send');
   });
 
+  it('does not send on Ctrl+Enter while dispatch is disabled', () => {
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} disabled={true} connectionStatus="connected" status="sending" />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'blocked keyboard send' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', ctrlKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not submit the form while dispatch is disabled', () => {
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} disabled={true} connectionStatus="connected" status="sending" />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'blocked form send' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it('submit button has a label', () => {
     render(<Composer onSend={vi.fn()} disabled={false} connectionStatus="connected" status="idle" />);
     const button = screen.getByRole('button');


### PR DESCRIPTION
## Summary
- Guard the shared Composer submit path when Dispatch is disabled.
- Add regression coverage for disabled Ctrl+Enter and disabled form submit paths.

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @frankenbeast/web -- tests/components/composer.test.tsx
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web
- npm test --workspace @frankenbeast/web

Closes #651
