### PR TITLE
fix(web): confirm destructive beast actions

### DIFF
--- a/packages/franken-web/src/pages/beast-dispatch-page.tsx
+++ b/packages/franken-web/src/pages/beast-dispatch-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import type {
   BeastCatalogEntry,
   BeastExecutionMode,
@@ -98,6 +99,55 @@ function canStartAgent(agent: TrackedAgentSummary): boolean {
 
 function canRestartAgent(agent: TrackedAgentSummary): boolean {
   return agent.status === 'running' || canStartAgent(agent);
+}
+
+function ConfirmedAgentActionButton({
+  action,
+  confirmLabel,
+  consequence,
+  objectName,
+  onConfirm,
+}: {
+  action: 'Stop' | 'Delete' | 'Kill';
+  confirmLabel: string;
+  consequence: string;
+  objectName: string;
+  onConfirm(): void;
+}) {
+  return (
+    <AlertDialog.Root>
+      <AlertDialog.Trigger asChild>
+        <button
+          aria-label={`${action} ${objectName} with confirmation`}
+          className="button button--secondary button--compact"
+          type="button"
+        >
+          {action} {objectName}
+        </button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className="beast-confirm-dialog__overlay" />
+        <AlertDialog.Content className="beast-confirm-dialog">
+          <AlertDialog.Title className="beast-confirm-dialog__title">
+            {confirmLabel}
+          </AlertDialog.Title>
+          <AlertDialog.Description className="beast-confirm-dialog__description">
+            {consequence}
+          </AlertDialog.Description>
+          <div className="beast-confirm-dialog__actions">
+            <AlertDialog.Cancel asChild>
+              <button autoFocus className="button button--secondary" type="button">Cancel</button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <button className="button button--primary" onClick={onConfirm} type="button">
+                {confirmLabel}
+              </button>
+            </AlertDialog.Action>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
 }
 
 export function BeastDispatchPage(props: BeastDispatchPageProps) {
@@ -382,7 +432,13 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
                 </div>
                 <div className="beast-run-row__actions">
                   {canStopAgent(agent) && (
-                    <button className="button button--secondary button--compact" onClick={() => props.onStop(agent.id)} type="button">Stop {agent.id}</button>
+                    <ConfirmedAgentActionButton
+                      action="Stop"
+                      confirmLabel={`Stop ${agent.id}`}
+                      consequence={`This interrupts ${agent.id} and may leave its current work incomplete until you start or resume it.`}
+                      objectName={agent.id}
+                      onConfirm={() => props.onStop(agent.id)}
+                    />
                   )}
                   {canStartAgent(agent) && (
                     <button className="button button--secondary button--compact" onClick={() => props.onStart(agent.id)} type="button">Start {agent.id}</button>
@@ -394,10 +450,22 @@ export function BeastDispatchPage(props: BeastDispatchPageProps) {
                     <button className="button button--secondary button--compact" onClick={() => props.onResume(agent.id)} type="button">Resume {agent.id}</button>
                   )}
                   {agent.status === 'stopped' && (
-                    <button className="button button--secondary button--compact" onClick={() => props.onDelete(agent.id)} type="button">Delete {agent.id}</button>
+                    <ConfirmedAgentActionButton
+                      action="Delete"
+                      confirmLabel={`Delete ${agent.id}`}
+                      consequence={`This removes ${agent.id} from tracked agents. Its saved metadata and row will no longer be available from this list.`}
+                      objectName={agent.id}
+                      onConfirm={() => props.onDelete(agent.id)}
+                    />
                   )}
                   {agent.status === 'running' && linkedRunId && (
-                    <button className="button button--secondary button--compact" onClick={() => props.onKill(linkedRunId)} type="button">Kill {linkedRunId}</button>
+                    <ConfirmedAgentActionButton
+                      action="Kill"
+                      confirmLabel={`Kill run ${linkedRunId}`}
+                      consequence={`This force-terminates linked run ${linkedRunId} for ${agent.id}. Logs or in-progress output may be lost.`}
+                      objectName={linkedRunId}
+                      onConfirm={() => props.onKill(linkedRunId)}
+                    />
                   )}
                 </div>
               </article>

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -980,6 +980,44 @@ button {
   gap: 0.6rem;
 }
 
+.beast-confirm-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.58);
+}
+
+.beast-confirm-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 61;
+  width: min(92vw, 28rem);
+  transform: translate(-50%, -50%);
+  display: grid;
+  gap: 1rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(255, 122, 107, 0.36);
+  border-radius: 1rem;
+  background: var(--bg-panel);
+  box-shadow: var(--shadow);
+}
+
+.beast-confirm-dialog__title {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.beast-confirm-dialog__description {
+  color: var(--text-muted);
+}
+
+.beast-confirm-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
 .beast-detail {
   display: grid;
   gap: 1rem;

--- a/packages/franken-web/tests/pages/beast-dispatch-page.test.tsx
+++ b/packages/franken-web/tests/pages/beast-dispatch-page.test.tsx
@@ -1,7 +1,22 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { BeastCatalogEntry } from '../../src/lib/beast-api';
+import type { BeastCatalogEntry, TrackedAgentSummary } from '../../src/lib/beast-api';
 import { BeastDispatchPage } from '../../src/pages/beast-dispatch-page';
+
+function agent(overrides: Partial<TrackedAgentSummary>): TrackedAgentSummary {
+  return {
+    id: 'agent-1',
+    definitionId: 'reviewer',
+    status: 'running',
+    source: 'catalog',
+    createdByUser: 'operator',
+    initAction: { kind: 'design-interview', command: 'fbeast run reviewer', config: {} },
+    initConfig: {},
+    createdAt: '2026-07-05T00:00:00.000Z',
+    updatedAt: '2026-07-05T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 const catalog: BeastCatalogEntry[] = [
   {
@@ -74,5 +89,51 @@ describe('BeastDispatchPage', () => {
     expect(audienceErrorId).toBeTruthy();
     expect(document.getElementById(designFileErrorId ?? '')?.textContent).toBe('This field is required.');
     expect(document.getElementById(audienceErrorId ?? '')?.textContent).toBe('This field is required.');
+  });
+
+  it('requires confirmation with consequence copy before stopping an agent', () => {
+    const onStop = vi.fn();
+    renderDispatchPage({ agents: [agent({ id: 'agent-stop', status: 'running' })], catalog: [], onStop });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop agent-stop with confirmation' }));
+
+    expect(onStop).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog', { name: 'Stop agent-stop' })).toBeTruthy();
+    expect(screen.getByText(/may leave its current work incomplete/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop agent-stop' }));
+
+    expect(onStop).toHaveBeenCalledWith('agent-stop');
+  });
+
+  it('requires confirmation with consequence copy before deleting a stopped agent', () => {
+    const onDelete = vi.fn();
+    renderDispatchPage({ agents: [agent({ id: 'agent-delete', status: 'stopped' })], catalog: [], onDelete });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent-delete with confirmation' }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog', { name: 'Delete agent-delete' })).toBeTruthy();
+    expect(screen.getByText(/removes agent-delete from tracked agents/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent-delete' }));
+
+    expect(onDelete).toHaveBeenCalledWith('agent-delete');
+  });
+
+  it('requires confirmation with consequence copy before killing a linked run', () => {
+    const onKill = vi.fn();
+    renderDispatchPage({ agents: [agent({ id: 'agent-kill', status: 'running', dispatchRunId: 'run-123' })], catalog: [], onKill });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill run-123 with confirmation' }));
+
+    expect(onKill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog', { name: 'Kill run run-123' })).toBeTruthy();
+    expect(screen.getByText(/logs or in-progress output may be lost/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill run run-123' }));
+
+    expect(onKill).toHaveBeenCalledWith('run-123');
   });
 });


### PR DESCRIPTION
## Summary
- Wrap tracked-agent Stop, Delete, and Kill row actions in confirmation dialogs
- Add consequence copy naming the affected agent/run and keep Cancel as the safe default
- Cover Stop/Delete/Kill confirmation flow with Beast dispatch page tests

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @frankenbeast/web -- beast-dispatch-page.test.tsx
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web
- npm run test --workspace @frankenbeast/web

Closes #637