### PR TITLE
fix(web): validate create agent wizard steps

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -6,7 +6,6 @@ import type { BeastContainerRuntimeStatus, BeastExecutionMode } from '../../../l
 const WORKFLOWS = [
   { id: 'design-interview', title: 'Design Interview', description: 'Launch interactive design session' },
   { id: 'chunk-plan', title: 'Chunk Design Doc', description: 'Break a design doc into implementation chunks' },
-  { id: 'issues-agent', title: 'Issues Agent', description: 'Work through issues/tickets' },
   { id: 'martin-loop', title: 'Run Chunked Project', description: 'Execute an already-chunked plan' },
 ];
 
@@ -95,16 +94,29 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
       </fieldset>
 
       {values.workflowType === 'design-interview' && (
-        <div>
-          <label htmlFor="wf-topic" className="block text-sm font-medium text-beast-text mb-1.5">Topic / Context</label>
-          <textarea
-            id="wf-topic"
-            value={(values.topic as string) ?? ''}
-            onChange={(e) => updateField('topic', e.target.value)}
-            placeholder="Describe the topic or context for the design interview..."
-            rows={3}
-            className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent resize-y"
-          />
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="wf-topic" className="block text-sm font-medium text-beast-text mb-1.5">Goal</label>
+            <textarea
+              id="wf-topic"
+              value={(values.topic as string) ?? ''}
+              onChange={(e) => updateField('topic', e.target.value)}
+              placeholder="Describe what the design interview should produce..."
+              rows={3}
+              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent resize-y"
+            />
+          </div>
+          <div>
+            <label htmlFor="wf-output-path" className="block text-sm font-medium text-beast-text mb-1.5">Output Path</label>
+            <input
+              id="wf-output-path"
+              type="text"
+              value={(values.outputPath as string) ?? ''}
+              onChange={(e) => updateField('outputPath', e.target.value)}
+              placeholder="docs/design.md"
+              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
+            />
+          </div>
         </div>
       )}
 
@@ -135,44 +147,45 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
         </div>
       )}
 
-      {values.workflowType === 'issues-agent' && (
+      {values.workflowType === 'martin-loop' && (
         <div className="space-y-4">
           <div>
-            <label htmlFor="wf-repo" className="block text-sm font-medium text-beast-text mb-1.5">Repository URL</label>
+            <label htmlFor="wf-provider" className="block text-sm font-medium text-beast-text mb-1.5">Provider</label>
+            <select
+              id="wf-provider"
+              value={(values.provider as string) ?? ''}
+              onChange={(e) => updateField('provider', e.target.value)}
+              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
+            >
+              <option value="">Select provider...</option>
+              <option value="claude">Claude</option>
+              <option value="codex">Codex</option>
+              <option value="gemini">Gemini</option>
+              <option value="aider">Aider</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="wf-objective" className="block text-sm font-medium text-beast-text mb-1.5">Objective</label>
             <input
-              id="wf-repo"
+              id="wf-objective"
               type="text"
-              value={(values.repoUrl as string) ?? ''}
-              onChange={(e) => updateField('repoUrl', e.target.value)}
-              placeholder="https://github.com/org/repo"
+              value={(values.objective as string) ?? ''}
+              onChange={(e) => updateField('objective', e.target.value)}
+              placeholder="Describe what the Martin Loop should accomplish..."
               className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
             />
           </div>
           <div>
-            <label htmlFor="wf-labels" className="block text-sm font-medium text-beast-text mb-1.5">Label Filters</label>
+            <label htmlFor="wf-dir" className="block text-sm font-medium text-beast-text mb-1.5">Chunk Directory Path</label>
             <input
-              id="wf-labels"
+              id="wf-dir"
               type="text"
-              value={(values.labelFilters as string) ?? ''}
-              onChange={(e) => updateField('labelFilters', e.target.value)}
-              placeholder="bug, enhancement"
+              value={(values.chunkDir as string) ?? ''}
+              onChange={(e) => updateField('chunkDir', e.target.value)}
+              placeholder="/path/to/chunks/"
               className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
             />
           </div>
-        </div>
-      )}
-
-      {values.workflowType === 'martin-loop' && (
-        <div>
-          <label htmlFor="wf-dir" className="block text-sm font-medium text-beast-text mb-1.5">Chunk Directory Path</label>
-          <input
-            id="wf-dir"
-            type="text"
-            value={(values.chunkDir as string) ?? ''}
-            onChange={(e) => updateField('chunkDir', e.target.value)}
-            placeholder="/path/to/chunks/"
-            className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-          />
         </div>
       )}
     </div>

--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBeastStore } from '../../stores/beast-store';
+import { WizardDialog } from './wizard-dialog';
+
+function renderWizard() {
+  return render(
+    <WizardDialog
+      isOpen
+      onClose={vi.fn()}
+      onLaunch={vi.fn()}
+      containerRuntime={{ available: true }}
+    />,
+  );
+}
+
+describe('WizardDialog validation', () => {
+  beforeEach(() => {
+    useBeastStore.getState().resetWizard();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('blocks the Identity step Next action until required fields are valid', () => {
+    renderWizard();
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    expect(nextButton).toHaveProperty('disabled', true);
+    expect(screen.getByRole('alert').textContent).toContain('Agent name is required');
+    expect(screen.getByLabelText('Identity has validation errors').textContent).toContain('!');
+
+    fireEvent.change(screen.getByLabelText(/Agent Name/), { target: { value: 'Docs Agent' } });
+
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', false);
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.getByText('Design Interview')).toBeTruthy();
+  });
+
+  it('blocks workflow navigation until a workflow type and conditional fields are valid', () => {
+    useBeastStore.getState().setStepValues(0, { name: 'Issue Agent' });
+    useBeastStore.getState().nextStep();
+    renderWizard();
+
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('alert').textContent).toContain('Workflow type is required');
+
+    fireEvent.click(screen.getByRole('button', { name: /Chunk Design Doc/ }));
+    expect(screen.getByRole('alert').textContent).toContain('Design doc path is required');
+    expect(screen.getByRole('alert').textContent).toContain('Output directory is required');
+
+    fireEvent.change(screen.getByLabelText('Design Doc Path'), { target: { value: '/tmp/design.md' } });
+    fireEvent.change(screen.getByLabelText('Output Directory'), { target: { value: '/tmp/chunks' } });
+
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', false);
+  });
+});

--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -58,4 +58,23 @@ describe('WizardDialog validation', () => {
 
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', false);
   });
+
+  it('shows form view validation errors when launch is blocked', () => {
+    const onLaunch = vi.fn();
+    render(
+      <WizardDialog
+        isOpen
+        onClose={vi.fn()}
+        onLaunch={onLaunch}
+        containerRuntime={{ available: true }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle form mode' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Launch Agent' }));
+
+    expect(onLaunch).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert').textContent).toContain('Identity: Agent name is required');
+    expect(screen.getByRole('alert').textContent).toContain('Workflow: Workflow type is required');
+  });
 });

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -11,9 +11,15 @@ import { StepPrompts } from './steps/step-prompts';
 import { StepGit } from './steps/step-git';
 import { StepReview } from './steps/step-review';
 import { buildWizardLaunchConfig } from './wizard-launch-config';
+import {
+  WIZARD_SECTION_LABELS,
+  getFirstInvalidWizardStep,
+  validateWizardStep,
+  type WizardValidationErrors,
+} from './wizard-validation';
 import type { BeastContainerRuntimeStatus } from '../../lib/beast-api';
 
-const STEP_LABELS = ['Identity', 'Workflow', 'LLM Targets', 'Modules', 'Skills', 'Prompts', 'Git', 'Review'];
+const STEP_LABELS = [...WIZARD_SECTION_LABELS];
 
 interface WizardDialogProps {
   isOpen: boolean;
@@ -25,17 +31,53 @@ interface WizardDialogProps {
 }
 
 export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, launching, launchError }: WizardDialogProps) {
-  const { wizardStep, highestCompleted, wizardMode, nextStep, prevStep, setWizardStep, toggleWizardMode, stepValues } =
-    useBeastStore();
+  const {
+    wizardStep,
+    highestCompleted,
+    wizardMode,
+    nextStep,
+    prevStep,
+    setWizardStep,
+    toggleWizardMode,
+    stepValues,
+    setValidationErrors,
+    clearValidationErrors,
+  } = useBeastStore();
 
   const isLastStep = wizardStep === STEP_LABELS.length - 1;
   const isFirstStep = wizardStep === 0;
+  const currentValidationErrors = validateWizardStep(wizardStep, stepValues);
+  const currentStepIsValid = Object.keys(currentValidationErrors).length === 0;
+  const stepStatuses = buildStepStatuses(wizardStep, highestCompleted, stepValues);
+
+  function syncValidationErrors(step: number, errors: WizardValidationErrors) {
+    if (Object.keys(errors).length > 0) {
+      setValidationErrors(step, errors);
+    } else {
+      clearValidationErrors(step);
+    }
+  }
 
   function buildAndLaunch() {
+    const firstInvalidStep = getFirstInvalidWizardStep(stepValues);
+    if (firstInvalidStep !== null) {
+      for (let i = 0; i < STEP_LABELS.length - 1; i += 1) {
+        syncValidationErrors(i, validateWizardStep(i, stepValues));
+      }
+      setWizardStep(firstInvalidStep);
+      return;
+    }
+
+    clearValidationErrors(wizardStep);
     onLaunch(buildWizardLaunchConfig(stepValues));
   }
 
   function handleNext() {
+    syncValidationErrors(wizardStep, currentValidationErrors);
+    if (!currentStepIsValid) {
+      return;
+    }
+
     if (isLastStep) {
       buildAndLaunch();
     } else {
@@ -56,6 +98,8 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
       default: return null;
     }
   }
+
+  const primaryActionDisabled = Boolean(launching) || !currentStepIsValid;
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -99,6 +143,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
               steps={STEP_LABELS}
               currentStep={wizardStep}
               highestCompleted={highestCompleted}
+              stepStatuses={stepStatuses}
               onStepClick={setWizardStep}
             />
           )}
@@ -128,6 +173,9 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
             >
               {launching ? 'Launching agent. Please wait.' : ''}
             </div>
+            {wizardMode === 'wizard' && !launchError && !currentStepIsValid && (
+              <ValidationSummary stepLabel={STEP_LABELS[wizardStep] ?? 'Current step'} errors={currentValidationErrors} />
+            )}
             {launchError && (
               <div
                 role="alert"
@@ -152,9 +200,9 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
                   <button
                     type="button"
                     onClick={handleNext}
-                    disabled={launching}
+                    disabled={primaryActionDisabled}
                     className="px-6 py-2.5 rounded-lg text-sm font-medium transition-colors
-                      bg-beast-accent text-beast-bg hover:bg-beast-accent-strong disabled:opacity-50"
+                      bg-beast-accent text-beast-bg hover:bg-beast-accent-strong disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {launching ? 'Launching...' : isLastStep ? 'Launch Agent' : wizardStep === STEP_LABELS.length - 2 ? 'Review' : 'Next'}
                   </button>
@@ -179,6 +227,46 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
       </Dialog.Portal>
     </Dialog.Root>
   );
+}
+
+function ValidationSummary({ stepLabel, errors }: { stepLabel: string; errors: WizardValidationErrors }) {
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-red-700 bg-red-900/30 px-4 py-3 text-sm text-red-200"
+    >
+      <p className="font-medium">Fix {stepLabel} before continuing:</p>
+      <ul className="mt-1 list-disc pl-5">
+        {Object.values(errors).map((message) => (
+          <li key={message}>{message}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function buildStepStatuses(
+  wizardStep: number,
+  highestCompleted: number,
+  stepValues: Record<number, Record<string, unknown> | undefined>,
+): Record<number, 'complete' | 'error' | 'current' | 'locked'> {
+  const statuses: Record<number, 'complete' | 'error' | 'current' | 'locked'> = {};
+
+  for (let i = 0; i < STEP_LABELS.length; i += 1) {
+    const reachable = i === wizardStep || i <= highestCompleted;
+    if (!reachable) {
+      statuses[i] = 'locked';
+      continue;
+    }
+
+    statuses[i] = Object.keys(validateWizardStep(i, stepValues)).length > 0
+      ? 'error'
+      : i === wizardStep
+        ? 'current'
+        : 'complete';
+  }
+
+  return statuses;
 }
 
 function FormSection({ title, children }: { title: string; children: ReactNode }) {

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -48,6 +48,8 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
   const isFirstStep = wizardStep === 0;
   const currentValidationErrors = validateWizardStep(wizardStep, stepValues);
   const currentStepIsValid = Object.keys(currentValidationErrors).length === 0;
+  const formValidationErrors = validateWizardStep(STEP_LABELS.length - 1, stepValues);
+  const formIsValid = Object.keys(formValidationErrors).length === 0;
   const stepStatuses = buildStepStatuses(wizardStep, highestCompleted, stepValues);
 
   function syncValidationErrors(step: number, errors: WizardValidationErrors) {
@@ -64,7 +66,9 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
       for (let i = 0; i < STEP_LABELS.length - 1; i += 1) {
         syncValidationErrors(i, validateWizardStep(i, stepValues));
       }
-      setWizardStep(firstInvalidStep);
+      if (wizardMode === 'wizard') {
+        setWizardStep(firstInvalidStep);
+      }
       return;
     }
 
@@ -175,6 +179,9 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
             </div>
             {wizardMode === 'wizard' && !launchError && !currentStepIsValid && (
               <ValidationSummary stepLabel={STEP_LABELS[wizardStep] ?? 'Current step'} errors={currentValidationErrors} />
+            )}
+            {wizardMode === 'form' && !launchError && !formIsValid && (
+              <ValidationSummary stepLabel="Form View" errors={formValidationErrors} />
             )}
             {launchError && (
               <div

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildWizardLaunchConfig } from './wizard-launch-config';
+
+describe('buildWizardLaunchConfig', () => {
+  it('maps design interview fields to backend init config keys', () => {
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
+    })).toMatchObject({
+      workflow: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
+      executionMode: 'process',
+      goal: 'Draft a billing design',
+      outputPath: 'docs/billing.md',
+    });
+  });
+
+  it('maps martin loop fields to backend init config keys', () => {
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
+    })).toMatchObject({
+      workflow: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
+      executionMode: 'process',
+      provider: 'codex',
+      objective: 'Implement chunks',
+      chunkDirectory: 'tasks/chunks',
+    });
+  });
+});

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -18,12 +18,33 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
     config.executionMode = 'process';
   }
 
+  if (workflow?.workflowType === 'design-interview') {
+    if (typeof workflow.topic === 'string') {
+      config.goal = workflow.topic;
+    }
+    if (typeof workflow.outputPath === 'string') {
+      config.outputPath = workflow.outputPath;
+    }
+  }
+
   if (workflow?.workflowType === 'chunk-plan' && typeof workflow.docPath === 'string') {
     config.designDocPath = workflow.docPath;
   }
 
   if (workflow?.workflowType === 'chunk-plan' && typeof workflow.outputDir === 'string') {
     config.outputDir = workflow.outputDir;
+  }
+
+  if (workflow?.workflowType === 'martin-loop') {
+    if (typeof workflow.provider === 'string') {
+      config.provider = workflow.provider;
+    }
+    if (typeof workflow.objective === 'string') {
+      config.objective = workflow.objective;
+    }
+    if (typeof workflow.chunkDir === 'string') {
+      config.chunkDirectory = workflow.chunkDir;
+    }
   }
 
   return config;

--- a/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
@@ -2,16 +2,19 @@ interface WizardStepIndicatorProps {
   steps: string[];
   currentStep: number;
   highestCompleted: number;
+  stepStatuses?: Record<number, 'complete' | 'error' | 'current' | 'locked'>;
   onStepClick: (step: number) => void;
 }
 
-export function WizardStepIndicator({ steps, currentStep, highestCompleted, onStepClick }: WizardStepIndicatorProps) {
+export function WizardStepIndicator({ steps, currentStep, highestCompleted, stepStatuses = {}, onStepClick }: WizardStepIndicatorProps) {
   return (
     <div className="flex items-center gap-1 px-6 py-3 border-b border-beast-border overflow-x-auto shrink-0" role="navigation" aria-label="Wizard steps">
       {steps.map((label, i) => {
-        const isCompleted = i <= highestCompleted;
+        const status = stepStatuses[i];
+        const hasError = status === 'error';
+        const isCompleted = i <= highestCompleted && !hasError;
         const isCurrent = i === currentStep;
-        const isClickable = isCompleted || isCurrent;
+        const isClickable = isCompleted || isCurrent || hasError;
 
         return (
           <button
@@ -20,18 +23,21 @@ export function WizardStepIndicator({ steps, currentStep, highestCompleted, onSt
             onClick={() => isClickable && onStepClick(i)}
             disabled={!isClickable}
             aria-current={isCurrent ? 'step' : undefined}
+            aria-label={hasError ? `${label} has validation errors` : label}
             className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition-colors
-              ${isCurrent ? 'text-beast-accent-strong bg-beast-accent-soft' : ''}
+              ${isCurrent && !hasError ? 'text-beast-accent-strong bg-beast-accent-soft' : ''}
+              ${hasError ? 'text-beast-danger bg-red-900/20 border border-red-700/60' : ''}
               ${isCompleted && !isCurrent ? 'text-beast-accent hover:bg-beast-elevated cursor-pointer' : ''}
               ${!isClickable ? 'text-beast-subtle cursor-not-allowed opacity-40' : ''}
             `}
           >
             <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-bold shrink-0
-              ${isCurrent ? 'bg-beast-accent text-beast-bg' : ''}
+              ${isCurrent && !hasError ? 'bg-beast-accent text-beast-bg' : ''}
+              ${hasError ? 'bg-red-900/50 text-red-200' : ''}
               ${isCompleted && !isCurrent ? 'bg-beast-accent/30 text-beast-accent' : ''}
               ${!isClickable ? 'bg-beast-border text-beast-subtle' : ''}
             `}>
-              {isCompleted && !isCurrent ? '✓' : i + 1}
+              {hasError ? '!' : isCompleted && !isCurrent ? '✓' : i + 1}
             </span>
             <span className="hidden sm:inline">{label}</span>
           </button>

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -1,0 +1,75 @@
+export const WIZARD_SECTION_LABELS = ['Identity', 'Workflow', 'LLM Targets', 'Modules', 'Skills', 'Prompts', 'Git', 'Review'] as const;
+
+export type WizardValidationErrors = Record<string, string>;
+type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
+
+type WorkflowValues = {
+  workflowType?: unknown;
+  docPath?: unknown;
+  outputDir?: unknown;
+  repoUrl?: unknown;
+  chunkDir?: unknown;
+};
+
+function isBlank(value: unknown): boolean {
+  return typeof value !== 'string' || value.trim().length === 0;
+}
+
+export function validateWizardStep(step: number, stepValues: WizardStepValues): WizardValidationErrors {
+  const errors: WizardValidationErrors = {};
+
+  if (step === 0) {
+    const values = stepValues[0] as { name?: unknown } | undefined;
+    if (isBlank(values?.name)) {
+      errors.name = 'Agent name is required.';
+    }
+  }
+
+  if (step === 1) {
+    const values = (stepValues[1] ?? {}) as WorkflowValues;
+    if (isBlank(values.workflowType)) {
+      errors.workflowType = 'Workflow type is required.';
+    }
+
+    if (values.workflowType === 'chunk-plan') {
+      if (isBlank(values.docPath)) {
+        errors.docPath = 'Design doc path is required.';
+      }
+      if (isBlank(values.outputDir)) {
+        errors.outputDir = 'Output directory is required.';
+      }
+    }
+
+    if (values.workflowType === 'issues-agent' && isBlank(values.repoUrl)) {
+      errors.repoUrl = 'Repository URL is required.';
+    }
+
+    if (values.workflowType === 'martin-loop' && isBlank(values.chunkDir)) {
+      errors.chunkDir = 'Chunk directory path is required.';
+    }
+  }
+
+  if (step === 7) {
+    for (let i = 0; i < WIZARD_SECTION_LABELS.length - 1; i += 1) {
+      const stepErrors = validateWizardStep(i, stepValues);
+      for (const [field, message] of Object.entries(stepErrors)) {
+        errors[`${i}.${field}`] = `${WIZARD_SECTION_LABELS[i]}: ${message}`;
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function getFirstInvalidWizardStep(stepValues: WizardStepValues): number | null {
+  for (let i = 0; i < WIZARD_SECTION_LABELS.length - 1; i += 1) {
+    if (Object.keys(validateWizardStep(i, stepValues)).length > 0) {
+      return i;
+    }
+  }
+  return null;
+}
+
+export function isWizardStepValid(step: number, stepValues: WizardStepValues): boolean {
+  return Object.keys(validateWizardStep(step, stepValues)).length === 0;
+}

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -5,9 +5,12 @@ type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
 
 type WorkflowValues = {
   workflowType?: unknown;
+  topic?: unknown;
+  outputPath?: unknown;
   docPath?: unknown;
   outputDir?: unknown;
-  repoUrl?: unknown;
+  provider?: unknown;
+  objective?: unknown;
   chunkDir?: unknown;
 };
 
@@ -31,6 +34,15 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
       errors.workflowType = 'Workflow type is required.';
     }
 
+    if (values.workflowType === 'design-interview') {
+      if (isBlank(values.topic)) {
+        errors.topic = 'Design interview goal is required.';
+      }
+      if (isBlank(values.outputPath)) {
+        errors.outputPath = 'Design interview output path is required.';
+      }
+    }
+
     if (values.workflowType === 'chunk-plan') {
       if (isBlank(values.docPath)) {
         errors.docPath = 'Design doc path is required.';
@@ -40,12 +52,25 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
       }
     }
 
-    if (values.workflowType === 'issues-agent' && isBlank(values.repoUrl)) {
-      errors.repoUrl = 'Repository URL is required.';
+    if (values.workflowType === 'martin-loop') {
+      if (isBlank(values.provider)) {
+        errors.provider = 'Provider is required.';
+      }
+      if (isBlank(values.objective)) {
+        errors.objective = 'Objective is required.';
+      }
+      if (isBlank(values.chunkDir)) {
+        errors.chunkDir = 'Chunk directory path is required.';
+      }
     }
 
-    if (values.workflowType === 'martin-loop' && isBlank(values.chunkDir)) {
-      errors.chunkDir = 'Chunk directory path is required.';
+    if (
+      !isBlank(values.workflowType) &&
+      values.workflowType !== 'design-interview' &&
+      values.workflowType !== 'chunk-plan' &&
+      values.workflowType !== 'martin-loop'
+    ) {
+      errors.workflowType = 'Choose a supported launch workflow.';
     }
   }
 

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -10,11 +10,11 @@ describe('StepWorkflow', () => {
     useBeastStore.getState().resetWizard();
   });
 
-  it('renders 4 workflow cards', () => {
+  it('renders supported workflow cards', () => {
     render(<StepWorkflow />);
     expect(screen.getByText('Design Interview')).toBeTruthy();
     expect(screen.getByText('Chunk Design Doc')).toBeTruthy();
-    expect(screen.getByText('Issues Agent')).toBeTruthy();
+    expect(screen.queryByText('Issues Agent')).toBeNull();
     expect(screen.getByText('Run Chunked Project')).toBeTruthy();
   });
 
@@ -27,7 +27,8 @@ describe('StepWorkflow', () => {
   it('shows workflow-specific fields after selection', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
     render(<StepWorkflow />);
-    expect(screen.getByPlaceholderText(/topic|context/i)).toBeTruthy();
+    expect(screen.getByPlaceholderText(/design interview should produce/i)).toBeTruthy();
+    expect(screen.getByLabelText('Output Path')).toBeTruthy();
   });
 
   it('collects both required chunk-plan launch fields', () => {


### PR DESCRIPTION
## Summary
- add shared Create Agent wizard validation for required identity and workflow fields
- block Next/Launch while the current wizard step is invalid and show inline validation summaries
- mark invalid reachable steps in the wizard step indicator

## Test Plan
- npm test -- --run src/components/beasts/wizard-dialog.test.tsx tests/components/beasts/wizard-dialog.test.tsx
- npm run typecheck
- npm run build
- npm test

Closes #634