### PR TITLE
fix(web): make analytics events keyboard-accessible

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -240,11 +240,19 @@ describe('AnalyticsPage', () => {
 
     detailsAction.focus();
     expect(document.activeElement).toBe(detailsAction);
-    fireEvent.keyDown(detailsAction, { key: 'Enter', code: 'Enter' });
     fireEvent.click(detailsAction);
 
     expect(await screen.findByRole('dialog', { name: 'Analytics event detail' })).toBeTruthy();
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(closeButton);
+    });
     expect(client.fetchEventDetail).toHaveBeenCalledWith('governor:1');
+
+    fireEvent.click(closeButton);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(detailsAction);
+    });
   });
 
   it('keeps successful analytics sections visible when one endpoint fails', async () => {

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -221,14 +221,29 @@ describe('AnalyticsPage', () => {
     });
   });
 
-  it('opens a read-only drawer with raw details when a row is selected', async () => {
+  it('opens a read-only drawer from a visible event details action', async () => {
     const client = mockClient();
 
     render(<AnalyticsPage client={client} />);
-    fireEvent.click(await screen.findByText('Denied destructive command'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open details for Denied destructive command' }));
 
     expect(await screen.findByRole('dialog', { name: 'Analytics event detail' })).toBeTruthy();
     expect(screen.getByText('"decision": "denied"')).toBeTruthy();
+    expect(client.fetchEventDetail).toHaveBeenCalledWith('governor:1');
+  });
+
+  it('lets keyboard users open event details with the event action', async () => {
+    const client = mockClient();
+
+    render(<AnalyticsPage client={client} />);
+    const detailsAction = await screen.findByRole('button', { name: 'Open details for Denied destructive command' });
+
+    detailsAction.focus();
+    expect(document.activeElement).toBe(detailsAction);
+    fireEvent.keyDown(detailsAction, { key: 'Enter', code: 'Enter' });
+    fireEvent.click(detailsAction);
+
+    expect(await screen.findByRole('dialog', { name: 'Analytics event detail' })).toBeTruthy();
     expect(client.fetchEventDetail).toHaveBeenCalledWith('governor:1');
   });
 

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -319,16 +319,27 @@ function AnalyticsTable({
                 <th>Tool</th>
                 <th>Outcome</th>
                 <th>Summary</th>
+                <th>Action</th>
               </tr>
             </thead>
             <tbody>
               {events.map((event) => (
-                <tr key={event.id} onClick={() => onSelect(event)}>
+                <tr key={event.id}>
                   <td>{formatTime(event.timestamp)}</td>
                   <td>{event.sessionId ?? '-'}</td>
                   <td>{event.toolName ?? event.source}</td>
                   <td><span className={`analytics-outcome analytics-outcome--${event.severity}`}>{event.outcome}</span></td>
                   <td>{event.summary}</td>
+                  <td>
+                    <button
+                      aria-label={`Open details for ${event.summary}`}
+                      className="analytics-table__details-button"
+                      type="button"
+                      onClick={() => onSelect(event)}
+                    >
+                      Open details
+                    </button>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   AnalyticsApiClient,
   AnalyticsEvent,
@@ -45,6 +45,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [overviewError, setOverviewError] = useState<string | null>(null);
   const [eventsError, setEventsError] = useState<string | null>(null);
   const [isEventsLoading, setIsEventsLoading] = useState(true);
+  const detailTriggerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -113,6 +114,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   );
 
   async function openDetail(event: AnalyticsEvent) {
+    detailTriggerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     setSelectedEvent(event);
     setDetailError(null);
     try {
@@ -120,6 +122,13 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
     } catch (error) {
       setDetailError(error instanceof Error ? error.message : 'Unable to load event detail.');
     }
+  }
+
+  function closeDetail() {
+    const trigger = detailTriggerRef.current;
+    setSelectedEvent(null);
+    setDetailError(null);
+    window.setTimeout(() => trigger?.focus(), 0);
   }
 
   function updateFilter(next: Partial<AnalyticsFilters>) {
@@ -272,10 +281,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
         <DetailDrawer
           detail={selectedEvent}
           error={detailError}
-          onClose={() => {
-            setSelectedEvent(null);
-            setDetailError(null);
-          }}
+          onClose={closeDetail}
           onSessionFilter={(sessionId) => updateFilter({ sessionId })}
         />
       )}
@@ -361,15 +367,21 @@ function DetailDrawer({
   onClose: () => void;
   onSessionFilter: (sessionId: string) => void;
 }) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const rawJson = JSON.stringify(detail.raw, null, 2);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, [detail.id]);
+
   return (
-    <aside aria-label="Analytics event detail" className="analytics-drawer" role="dialog">
+    <aside aria-label="Analytics event detail" aria-modal="true" className="analytics-drawer" role="dialog">
       <div className="analytics-drawer__header">
         <div>
           <p className="eyebrow">{detail.source}</p>
           <h3>{detail.summary}</h3>
         </div>
-        <button className="button button--secondary button--small" type="button" onClick={onClose}>Close</button>
+        <button ref={closeButtonRef} className="button button--secondary button--small" type="button" onClick={onClose}>Close</button>
       </div>
 
       {error && <div className="analytics-alert">{error}</div>}

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -375,7 +375,7 @@ function DetailDrawer({
   }, [detail.id]);
 
   return (
-    <aside aria-label="Analytics event detail" aria-modal="true" className="analytics-drawer" role="dialog">
+    <aside aria-label="Analytics event detail" className="analytics-drawer" role="dialog">
       <div className="analytics-drawer__header">
         <div>
           <p className="eyebrow">{detail.source}</p>

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1257,12 +1257,34 @@ button {
   font-weight: 650;
 }
 
-.analytics-table tbody tr {
-  cursor: pointer;
+.analytics-table tbody tr:hover,
+.analytics-table tbody tr:focus-within {
+  background: rgba(134, 228, 95, 0.08);
 }
 
-.analytics-table tbody tr:hover {
-  background: rgba(134, 228, 95, 0.08);
+.analytics-table__details-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid rgba(134, 228, 95, 0.35);
+  border-radius: 999px;
+  background: rgba(134, 228, 95, 0.12);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.analytics-table__details-button:hover,
+.analytics-table__details-button:focus-visible {
+  border-color: rgba(134, 228, 95, 0.75);
+  background: rgba(134, 228, 95, 0.2);
+  outline: 2px solid rgba(134, 228, 95, 0.45);
+  outline-offset: 2px;
 }
 
 .analytics-table td {


### PR DESCRIPTION
## Summary
- replace click-only analytics event rows with visible Open details buttons
- add focus-within row highlighting and focus-visible button styling
- cover mouse and keyboard-focus access in analytics page tests

## Test Plan
- npm test -- --run src/pages/analytics-page.test.tsx
- npm run build --workspace @franken/types
- npm run typecheck (packages/franken-web)
- npm run build (packages/franken-web)

Closes #631