### PR TITLE
fix(web): explain disabled composer states

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -229,6 +229,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     messages,
     pendingApproval,
     projectId: activeProjectId,
+    reconnect,
     retryError,
     send,
     sessionId: activeSessionId,
@@ -704,6 +705,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               <Composer
                 connectionStatus={connectionStatus}
                 disabled={status === 'connecting' || status === 'sending' || status === 'streaming'}
+                onReconnect={reconnect}
                 onSend={(content) => {
                   void send(content);
                 }}

--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -4,12 +4,84 @@ import type { ConnectionStatus, SessionStatus } from '../hooks/use-chat-session'
 export interface ComposerProps {
   connectionStatus: ConnectionStatus;
   disabled: boolean;
+  onReconnect?: () => void;
   onSend: (content: string) => void;
   status: SessionStatus;
 }
 
-export function Composer({ connectionStatus, disabled, onSend, status }: ComposerProps) {
+function connectionStatusLabel(connectionStatus: ConnectionStatus): string {
+  switch (connectionStatus) {
+    case 'connected':
+      return 'Connected';
+    case 'connecting':
+      return 'Connecting to chat';
+    case 'reconnecting':
+      return 'Reconnecting to chat';
+    case 'disconnected':
+      return 'Chat disconnected';
+    case 'offline':
+      return 'Browser offline';
+    case 'error':
+      return 'Connection error';
+  }
+}
+
+function sessionStatusLabel(status: SessionStatus): string {
+  switch (status) {
+    case 'idle':
+      return 'Ready to dispatch';
+    case 'connecting':
+      return 'Preparing chat session';
+    case 'sending':
+      return 'Sending message';
+    case 'streaming':
+      return 'Assistant is responding';
+    case 'error':
+      return 'Chat needs attention';
+  }
+}
+
+function disabledReason(status: SessionStatus): string | null {
+  switch (status) {
+    case 'connecting':
+      return 'Dispatch is disabled while the chat session connects.';
+    case 'sending':
+      return 'Dispatch is disabled while your previous message is being sent.';
+    case 'streaming':
+      return 'Dispatch is disabled while Frankenbeast is responding.';
+    default:
+      return null;
+  }
+}
+
+function connectionHelp(connectionStatus: ConnectionStatus): string | null {
+  switch (connectionStatus) {
+    case 'connecting':
+      return 'Connecting to live chat. Dispatch will unlock when the session is ready.';
+    case 'reconnecting':
+      return 'Reconnecting to live chat. Messages may use the HTTP fallback if needed.';
+    case 'disconnected':
+      return 'Live chat is disconnected. Try reconnecting before sending time-sensitive work.';
+    case 'offline':
+      return 'Your browser is offline. Reconnect to the network, then try reconnecting chat.';
+    case 'error':
+      return 'The live chat connection hit an error. Try reconnecting.';
+    default:
+      return null;
+  }
+}
+
+function canRetryConnection(connectionStatus: ConnectionStatus): boolean {
+  return connectionStatus === 'disconnected' || connectionStatus === 'offline' || connectionStatus === 'error';
+}
+
+export function Composer({ connectionStatus, disabled, onReconnect, onSend, status }: ComposerProps) {
   const [value, setValue] = useState('');
+  const helpText = disabledReason(status)
+    ?? connectionHelp(connectionStatus)
+    ?? 'Type a message, then press Dispatch or Ctrl+Enter to send.';
+  const liveStatus = `${connectionStatusLabel(connectionStatus)}. ${sessionStatusLabel(status)}.`;
+  const showReconnect = canRetryConnection(connectionStatus);
 
   function submitCurrentValue() {
     if (disabled) {
@@ -35,6 +107,8 @@ export function Composer({ connectionStatus, disabled, onSend, status }: Compose
       <label className="composer__field">
         <span className="eyebrow">Dispatch Input</span>
         <textarea
+          aria-describedby="composer-help composer-live-status"
+          aria-disabled={disabled ? 'true' : undefined}
           className="field-control composer__textarea"
           value={value}
           onChange={(event) => setValue(event.target.value)}
@@ -48,15 +122,26 @@ export function Composer({ connectionStatus, disabled, onSend, status }: Compose
           aria-label="Message input"
           rows={3}
         />
+        <span className="composer__help" id="composer-help">
+          {helpText}
+        </span>
       </label>
       <div className="composer__footer">
-        <p className="composer__status">
-          <span>{connectionStatus}</span>
-          <span>{status}</span>
+        <p className="composer__status" id="composer-live-status" role="status" aria-live="polite" aria-atomic="true">
+          <span>{connectionStatusLabel(connectionStatus)}</span>
+          <span>{sessionStatusLabel(status)}</span>
+          <span className="composer__status-message">{liveStatus}</span>
         </p>
-        <button className="button button--primary" type="submit" disabled={disabled}>
-          Dispatch
-        </button>
+        <div className="composer__actions">
+          {showReconnect ? (
+            <button className="button button--secondary" type="button" onClick={onReconnect}>
+              Try reconnecting
+            </button>
+          ) : null}
+          <button className="button button--primary" type="submit" disabled={disabled}>
+            Dispatch
+          </button>
+        </div>
       </div>
     </form>
   );

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -57,6 +57,7 @@ export interface UseChatSessionResult {
   messages: ChatMessage[];
   pendingApproval: PendingApproval | null;
   projectId: string;
+  reconnect: () => void;
   retryError: (id: string) => void;
   send: (content: string) => Promise<void>;
   sessionId: string | null;
@@ -719,6 +720,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     messages,
     pendingApproval,
     projectId,
+    reconnect: refreshSession,
     retryError,
     send,
     sessionId,

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -660,6 +660,12 @@ button {
   min-height: 8rem;
 }
 
+.composer__help {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 .button {
   position: relative;
   display: inline-flex;
@@ -761,6 +767,25 @@ button {
   color: var(--text-muted);
   font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 0.82rem;
+}
+
+.composer__status-message {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.composer__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.65rem;
 }
 
 .rail-card {

--- a/packages/franken-web/tests/components/composer.test.tsx
+++ b/packages/franken-web/tests/components/composer.test.tsx
@@ -33,6 +33,34 @@ describe('Composer', () => {
     expect(button).toHaveProperty('disabled', true);
   });
 
+  it('explains why dispatch is disabled and marks the textarea for assistive tech', () => {
+    render(<Composer onSend={vi.fn()} disabled={true} connectionStatus="connected" status="streaming" />);
+
+    const input = screen.getByRole('textbox');
+    expect(input.getAttribute('aria-disabled')).toBe('true');
+    expect(input.getAttribute('aria-describedby')).toContain('composer-help');
+    expect(screen.getByText('Dispatch is disabled while Frankenbeast is responding.')).toBeTruthy();
+  });
+
+  it('announces connection and session states in a live status region', () => {
+    render(<Composer onSend={vi.fn()} disabled={false} connectionStatus="reconnecting" status="idle" />);
+
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+    expect(liveRegion.textContent).toContain('Reconnecting to chat');
+    expect(liveRegion.textContent).toContain('Ready to dispatch');
+  });
+
+  it('shows a reconnect affordance when the chat is disconnected', () => {
+    const onReconnect = vi.fn();
+    render(<Composer onSend={vi.fn()} onReconnect={onReconnect} disabled={false} connectionStatus="disconnected" status="idle" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try reconnecting' }));
+
+    expect(onReconnect).toHaveBeenCalledOnce();
+    expect(screen.getByText('Live chat is disconnected. Try reconnecting before sending time-sensitive work.')).toBeTruthy();
+  });
+
   it('does not call onSend with empty input', () => {
     const onSend = vi.fn();
     render(<Composer onSend={onSend} disabled={false} connectionStatus="connected" status="idle" />);


### PR DESCRIPTION
## Summary
- add composer helper copy that explains disabled dispatch states
- announce readable connection/session state changes with a polite live region
- add a Try reconnecting affordance for disconnected/offline/error chat states

## Test Plan
- npm test -- --run tests/components/composer.test.tsx
- npm run build --workspace @franken/types && npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web
- npm test --workspace @frankenbeast/web

Closes #628