### PR TITLE
fix(web): surface dashboard operation failures

### DIFF
--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -88,12 +88,14 @@ describe('DashboardApiClient', () => {
   });
 
   describe('updateSecurityProfile', () => {
-    it('sends PATCH with profile value', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+    it('sends PATCH with profile value and returns resolved security config', async () => {
+      const security = { ...makeMockSnapshot().security, profile: 'strict', requireApproval: 'all' };
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => security });
 
       const client = new DashboardApiClient(BASE_URL);
-      await client.updateSecurityProfile('strict');
+      const result = await client.updateSecurityProfile('strict');
 
+      expect(result).toEqual(security);
       expect(globalThis.fetch).toHaveBeenCalledWith(
         `${BASE_URL}/api/security`,
         {

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -44,13 +44,14 @@ export class DashboardApiClient {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
   }
 
-  async updateSecurityProfile(profile: string): Promise<void> {
+  async updateSecurityProfile(profile: string): Promise<DashboardSecurity> {
     const res = await fetch(`${this.baseUrl}/api/security`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ profile }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as DashboardSecurity;
   }
 
   // NOTE: EventSource cannot attach an Authorization header. Browser clients

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DashboardPage } from './dashboard-page';
+import type { DashboardApiClient, DashboardSnapshot } from '../lib/dashboard-api';
+import { useDashboardStore } from '../stores/dashboard-store';
+
+const snapshot: DashboardSnapshot = {
+  skills: [
+    { name: 'shell', enabled: false, hasContext: false, mcpServerCount: 0 },
+  ],
+  security: {
+    profile: 'standard',
+    injectionDetection: true,
+    piiMasking: true,
+    outputValidation: true,
+  },
+  providers: [
+    { name: 'openai', type: 'llm', available: true, failoverOrder: 1 },
+  ],
+};
+
+function mockClient(overrides: Partial<DashboardApiClient> = {}): DashboardApiClient {
+  return {
+    fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    toggleSkill: vi.fn().mockResolvedValue(undefined),
+    updateSecurityProfile: vi.fn().mockResolvedValue(undefined),
+    subscribeToDashboard: vi.fn().mockReturnValue(() => undefined),
+    ...overrides,
+  } as unknown as DashboardApiClient;
+}
+
+describe('DashboardPage', () => {
+  afterEach(() => {
+    cleanup();
+    useDashboardStore.getState().reset();
+  });
+
+  it('shows a load failure with a retry action instead of hiding it in the console', async () => {
+    const client = mockClient({
+      fetchSnapshot: vi.fn()
+        .mockRejectedValueOnce(new Error('HTTP 503'))
+        .mockResolvedValueOnce(snapshot),
+    });
+
+    render(<DashboardPage client={client} />);
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to load dashboard. HTTP 503');
+    expect(screen.getByRole('button', { name: 'Retry loading dashboard' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading dashboard' }));
+
+    expect(await screen.findByRole('switch', { name: 'Enable shell' })).toBeTruthy();
+    expect(screen.queryByText(/Unable to load dashboard/)).toBeNull();
+    expect(client.fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('rolls back a failed skill toggle and offers a retry', async () => {
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockRejectedValueOnce(new Error('HTTP 500'))
+        .mockResolvedValueOnce(undefined),
+    });
+
+    render(<DashboardPage client={client} />);
+    const toggle = await screen.findByRole('switch', { name: 'Enable shell' });
+    fireEvent.click(toggle);
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not enable shell; the switch was rolled back. HTTP 500');
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry enabling shell' }));
+
+    await waitFor(() => {
+      expect(client.toggleSkill).toHaveBeenLastCalledWith('shell', true);
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+    });
+    expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+  });
+
+  it('rolls back a failed security profile save and offers a retry', async () => {
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockRejectedValueOnce(new Error('HTTP 409'))
+        .mockResolvedValueOnce(undefined),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not save security profile strict; the previous profile was restored. HTTP 409');
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('standard');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry saving strict' }));
+
+    await waitFor(() => {
+      expect(client.updateSecurityProfile).toHaveBeenLastCalledWith('strict');
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+    });
+    expect(screen.queryByText(/Could not save security profile/)).toBeNull();
+  });
+});

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -29,6 +29,17 @@ function mockClient(overrides: Partial<DashboardApiClient> = {}): DashboardApiCl
   } as unknown as DashboardApiClient;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('DashboardPage', () => {
   afterEach(() => {
     cleanup();
@@ -101,5 +112,45 @@ describe('DashboardPage', () => {
       expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
     });
     expect(screen.queryByText(/Could not save security profile/)).toBeNull();
+  });
+
+  it('does not roll back a newer skill toggle when an older request fails late', async () => {
+    const firstToggle = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(firstToggle.promise)
+        .mockResolvedValueOnce(undefined),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
+
+    firstToggle.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+    expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+  });
+
+  it('does not restore an older security profile after a newer save starts', async () => {
+    const firstSave = deferred<void>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockReturnValueOnce(firstSave.promise)
+        .mockResolvedValueOnce(undefined),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+
+    firstSave.reject(new Error('HTTP 409'));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('permissive');
+    });
+    expect(screen.queryByText(/Could not save security profile strict/)).toBeNull();
   });
 });

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -604,6 +604,66 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('ignores a failed skill mutation when a server snapshot removed that pending skill', async () => {
+    const failedEnable = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const client = mockClient({
+      toggleSkill: vi.fn().mockReturnValue(failedEnable.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    pushSnapshot({ ...snapshot, skills: [] });
+    failedEnable.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Retry enabling shell' })).toBeNull();
+    });
+  });
+
+  it('clears mutation errors when switching dashboard clients', async () => {
+    const failedEnable = deferred<void>();
+    const firstClient = mockClient({ toggleSkill: vi.fn().mockReturnValue(failedEnable.promise) });
+    const nextClient = mockClient();
+    const { rerender } = render(<DashboardPage client={firstClient} />);
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    failedEnable.reject(new Error('HTTP 500'));
+    expect(await screen.findByText(/Could not enable shell/)).toBeTruthy();
+
+    rerender(<DashboardPage client={nextClient} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+    });
+  });
+
+  it('handles skill names that collide with object prototype properties', async () => {
+    const failedToggle = deferred<void>();
+    const prototypeNameSnapshot: DashboardSnapshot = {
+      ...snapshot,
+      skills: [{ name: 'toString', enabled: false, hasContext: false, mcpServerCount: 0 }],
+    };
+    const client = mockClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(prototypeNameSnapshot),
+      toggleSkill: vi.fn().mockReturnValue(failedToggle.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable toString' }));
+    failedToggle.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable toString' }).getAttribute('aria-checked')).toBe('false');
+      expect(screen.getByText(/Could not enable toString/)).toBeTruthy();
+    });
+  });
+
   it('ignores snapshots from a superseded dashboard client subscription', async () => {
     let pushStaleSnapshot!: (nextSnapshot: DashboardSnapshot) => void;
     const firstClient = mockClient({

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -463,6 +463,123 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('applies an earlier successful skill toggle after a newer overlapping toggle fails first', async () => {
+    const successfulEnable = deferred<void>();
+    const failedDisable = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(successfulEnable.promise)
+        .mockReturnValueOnce(failedDisable.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
+
+    failedDisable.reject(new Error('HTTP 500'));
+    successfulEnable.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('applies an earlier successful security profile save after a newer overlapping save fails first', async () => {
+    const successfulStrictSave = deferred<void>();
+    const failedPermissiveSave = deferred<void>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockReturnValueOnce(successfulStrictSave.promise)
+        .mockReturnValueOnce(failedPermissiveSave.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+
+    failedPermissiveSave.reject(new Error('HTTP 409'));
+    successfulStrictSave.resolve(undefined);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+    });
+  });
+
+  it('does not show a failed skill mutation alert after a snapshot confirms the requested state', async () => {
+    const failedEnable = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const client = mockClient({
+      toggleSkill: vi.fn().mockReturnValue(failedEnable.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    pushSnapshot({
+      ...snapshot,
+      skills: [{ name: 'shell', enabled: true, hasContext: false, mcpServerCount: 0 }],
+    });
+    failedEnable.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+      expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+    });
+  });
+
+  it('does not show a failed security save alert after a snapshot confirms the requested profile', async () => {
+    const failedStrictSave = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const client = mockClient({
+      updateSecurityProfile: vi.fn().mockReturnValue(failedStrictSave.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    pushSnapshot({ ...snapshot, security: { ...snapshot.security, profile: 'strict' } });
+    failedStrictSave.reject(new Error('HTTP 409'));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+      expect(screen.queryByText(/Could not save security profile/)).toBeNull();
+    });
+  });
+
+  it('preserves unrelated optimistic skill updates when confirming one skill', async () => {
+    const successfulShellToggle = deferred<void>();
+    const pendingGithubToggle = deferred<void>();
+    const multiSkillSnapshot: DashboardSnapshot = {
+      ...snapshot,
+      skills: [
+        { name: 'shell', enabled: false, hasContext: false, mcpServerCount: 0 },
+        { name: 'github', enabled: false, hasContext: false, mcpServerCount: 0 },
+      ],
+    };
+    const client = mockClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(multiSkillSnapshot),
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(successfulShellToggle.promise)
+        .mockReturnValueOnce(pendingGithubToggle.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable github' }));
+    successfulShellToggle.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+      expect(screen.getByRole('switch', { name: 'Disable github' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
   it('ignores snapshots from a superseded dashboard client subscription', async () => {
     let pushStaleSnapshot!: (nextSnapshot: DashboardSnapshot) => void;
     const firstClient = mockClient({

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -689,10 +689,42 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('clears retry alerts when an older skill toggle confirms the failed latest state', async () => {
+    const firstEnable = deferred<void>();
+    const secondDisable = deferred<void>();
+    const failedFinalEnable = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(firstEnable.promise)
+        .mockReturnValueOnce(secondDisable.promise)
+        .mockReturnValueOnce(failedFinalEnable.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+
+    failedFinalEnable.reject(new Error('HTTP 500'));
+    firstEnable.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+      expect(screen.queryByRole('button', { name: 'Retry enabling shell' })).toBeNull();
+    });
+  });
+
   it('retains the retry alert for a failed latest security save when an older save later succeeds', async () => {
-    const firstStrictSave = deferred<void>();
-    const secondPermissiveSave = deferred<void>();
-    const failedFinalStrictSave = deferred<void>();
+    const firstStrictSave = deferred<DashboardSnapshot['security']>();
+    const secondPermissiveSave = deferred<DashboardSnapshot['security']>();
+    const failedFinalStrictSave = deferred<DashboardSnapshot['security']>();
+    const permissiveSecurity: DashboardSnapshot['security'] = {
+      profile: 'permissive',
+      injectionDetection: false,
+      piiMasking: false,
+      outputValidation: false,
+      requireApproval: 'none',
+    };
     const client = mockClient({
       updateSecurityProfile: vi.fn()
         .mockReturnValueOnce(firstStrictSave.promise)
@@ -706,11 +738,40 @@ describe('DashboardPage', () => {
     fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'strict' } });
 
     failedFinalStrictSave.reject(new Error('HTTP 409'));
-    secondPermissiveSave.resolve(undefined);
+    secondPermissiveSave.resolve(permissiveSecurity);
 
     await waitFor(() => {
       expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('permissive');
+      expect(screen.getByText('Injection Detection: [off]')).toBeTruthy();
+      expect(screen.getByText('PII Masking: [off]')).toBeTruthy();
+      expect(screen.getByText('Output Validation: [off]')).toBeTruthy();
+      expect(screen.getByText('Approval Required: none')).toBeTruthy();
       expect(screen.getByRole('button', { name: 'Retry saving strict' })).toBeTruthy();
+    });
+  });
+
+  it('clears retry alerts when an older security save confirms the failed latest profile', async () => {
+    const firstStrictSave = deferred<DashboardSnapshot['security']>();
+    const secondPermissiveSave = deferred<DashboardSnapshot['security']>();
+    const failedFinalStrictSave = deferred<DashboardSnapshot['security']>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockReturnValueOnce(firstStrictSave.promise)
+        .mockReturnValueOnce(secondPermissiveSave.promise)
+        .mockReturnValueOnce(failedFinalStrictSave.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'strict' } });
+
+    failedFinalStrictSave.reject(new Error('HTTP 409'));
+    firstStrictSave.resolve({ ...snapshot.security, profile: 'strict', requireApproval: 'all' });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+      expect(screen.queryByRole('button', { name: 'Retry saving strict' })).toBeNull();
     });
   });
 

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -664,6 +664,56 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('retains the retry alert for a failed latest skill toggle when an older toggle later succeeds', async () => {
+    const firstEnable = deferred<void>();
+    const secondDisable = deferred<void>();
+    const failedFinalEnable = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(firstEnable.promise)
+        .mockReturnValueOnce(secondDisable.promise)
+        .mockReturnValueOnce(failedFinalEnable.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+
+    failedFinalEnable.reject(new Error('HTTP 500'));
+    secondDisable.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+      expect(screen.getByRole('button', { name: 'Retry enabling shell' })).toBeTruthy();
+    });
+  });
+
+  it('retains the retry alert for a failed latest security save when an older save later succeeds', async () => {
+    const firstStrictSave = deferred<void>();
+    const secondPermissiveSave = deferred<void>();
+    const failedFinalStrictSave = deferred<void>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockReturnValueOnce(firstStrictSave.promise)
+        .mockReturnValueOnce(secondPermissiveSave.promise)
+        .mockReturnValueOnce(failedFinalStrictSave.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'strict' } });
+
+    failedFinalStrictSave.reject(new Error('HTTP 409'));
+    secondPermissiveSave.resolve(undefined);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('permissive');
+      expect(screen.getByRole('button', { name: 'Retry saving strict' })).toBeTruthy();
+    });
+  });
+
   it('ignores snapshots from a superseded dashboard client subscription', async () => {
     let pushStaleSnapshot!: (nextSnapshot: DashboardSnapshot) => void;
     const firstClient = mockClient({

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -278,4 +278,103 @@ describe('DashboardPage', () => {
     });
     expect(screen.queryByText(/Unable to load dashboard/)).toBeNull();
   });
+
+  it('preserves an earlier successful skill toggle when a newer overlapping toggle fails', async () => {
+    const successfulEnable = deferred<void>();
+    const failedDisable = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(successfulEnable.promise)
+        .mockReturnValueOnce(failedDisable.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
+
+    successfulEnable.resolve(undefined);
+    failedDisable.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('preserves an earlier successful profile save when a newer overlapping save fails', async () => {
+    const successfulStrictSave = deferred<void>();
+    const failedPermissiveSave = deferred<void>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockReturnValueOnce(successfulStrictSave.promise)
+        .mockReturnValueOnce(failedPermissiveSave.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+
+    successfulStrictSave.resolve(undefined);
+    failedPermissiveSave.reject(new Error('HTTP 409'));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+    });
+  });
+
+  it('does not overwrite a newer SSE skill snapshot when an older toggle succeeds late', async () => {
+    const successfulEnable = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const client = mockClient({
+      toggleSkill: vi.fn().mockReturnValue(successfulEnable.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (snapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    pushSnapshot(snapshot);
+    successfulEnable.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+  });
+
+  it('does not overwrite a newer SSE profile snapshot when an older save succeeds late', async () => {
+    const successfulStrictSave = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const client = mockClient({
+      updateSecurityProfile: vi.fn().mockReturnValue(successfulStrictSave.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (snapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    pushSnapshot({ ...snapshot, security: { ...snapshot.security, profile: 'permissive' } });
+    successfulStrictSave.resolve(undefined);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('permissive');
+    });
+  });
+
+  it('uses a cached dashboard as the rollback baseline when refresh fails on remount', async () => {
+    useDashboardStore.getState().setSnapshot(snapshot);
+    const client = mockClient({
+      fetchSnapshot: vi.fn().mockRejectedValue(new Error('HTTP 503')),
+      toggleSkill: vi.fn().mockRejectedValue(new Error('HTTP 500')),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+  });
 });

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -216,4 +216,66 @@ describe('DashboardPage', () => {
       expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('standard');
     });
   });
+
+  it('preserves a successful skill toggle as the confirmed rollback baseline', async () => {
+    const failedDisable = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockReturnValueOnce(failedDisable.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+    });
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Disable shell' }));
+    failedDisable.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('preserves a successful profile save as the confirmed rollback baseline', async () => {
+    const failedPermissiveSave = deferred<void>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockReturnValueOnce(failedPermissiveSave.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+    });
+
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+    failedPermissiveSave.reject(new Error('HTTP 409'));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+    });
+  });
+
+  it('leaves the populated dashboard usable when a refresh fails after confirmed data exists', async () => {
+    const initialClient = mockClient();
+    const refreshedClient = mockClient({ fetchSnapshot: vi.fn().mockRejectedValue(new Error('HTTP 503')) });
+    const { rerender } = render(<DashboardPage client={initialClient} />);
+
+    expect(await screen.findByRole('switch', { name: 'Enable shell' })).toBeTruthy();
+
+    rerender(<DashboardPage client={refreshedClient} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading dashboard...')).toBeNull();
+      expect(screen.getByRole('switch', { name: 'Enable shell' })).toBeTruthy();
+    });
+    expect(screen.queryByText(/Unable to load dashboard/)).toBeNull();
+  });
 });

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DashboardPage } from './dashboard-page';
 import type { DashboardApiClient, DashboardSnapshot } from '../lib/dashboard-api';
@@ -293,6 +293,11 @@ describe('DashboardPage', () => {
     fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
 
     successfulEnable.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+
     failedDisable.reject(new Error('HTTP 500'));
 
     await waitFor(() => {
@@ -375,6 +380,108 @@ describe('DashboardPage', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+  });
+
+  it('retries a failed skill mutation toward the requested state without flipping current server state', async () => {
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockRejectedValueOnce(new Error('HTTP 500'))
+        .mockResolvedValueOnce(undefined),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    expect(await screen.findByRole('button', { name: 'Retry enabling shell' })).toBeTruthy();
+
+    act(() => {
+      useDashboardStore.getState().setSkillEnabled('shell', true);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry enabling shell' }));
+
+    await waitFor(() => {
+      expect(client.toggleSkill).toHaveBeenLastCalledWith('shell', true);
+      expect(screen.getByRole('switch', { name: 'Disable shell' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('ignores stale mutation failures from a previous dashboard client', async () => {
+    const staleToggle = deferred<void>();
+    const firstClient = mockClient({
+      toggleSkill: vi.fn().mockReturnValue(staleToggle.promise),
+    });
+    const nextClient = mockClient();
+    const { rerender } = render(<DashboardPage client={firstClient} />);
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    rerender(<DashboardPage client={nextClient} />);
+    await screen.findByRole('switch', { name: 'Enable shell' });
+
+    staleToggle.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+  });
+
+  it('preserves newer snapshot fields when rolling back one failed skill mutation', async () => {
+    const failedShellToggle = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const multiSkillSnapshot: DashboardSnapshot = {
+      ...snapshot,
+      skills: [
+        { name: 'shell', enabled: false, hasContext: false, mcpServerCount: 0 },
+        { name: 'github', enabled: false, hasContext: false, mcpServerCount: 0 },
+      ],
+    };
+    const client = mockClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(multiSkillSnapshot),
+      toggleSkill: vi.fn().mockReturnValue(failedShellToggle.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    pushSnapshot({
+      ...multiSkillSnapshot,
+      skills: [
+        { name: 'shell', enabled: false, hasContext: false, mcpServerCount: 0 },
+        { name: 'github', enabled: true, hasContext: false, mcpServerCount: 0 },
+      ],
+    });
+
+    failedShellToggle.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+      expect(screen.getByRole('switch', { name: 'Disable github' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('ignores snapshots from a superseded dashboard client subscription', async () => {
+    let pushStaleSnapshot!: (nextSnapshot: DashboardSnapshot) => void;
+    const firstClient = mockClient({
+      subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
+        pushStaleSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+    const nextClient = mockClient();
+    const { rerender } = render(<DashboardPage client={firstClient} />);
+
+    expect(await screen.findByRole('switch', { name: 'Enable shell' })).toBeTruthy();
+    rerender(<DashboardPage client={nextClient} />);
+    await screen.findByRole('switch', { name: 'Enable shell' });
+
+    pushStaleSnapshot({ ...snapshot, security: { ...snapshot.security, profile: 'strict' } });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('standard');
     });
   });
 });

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -24,7 +24,7 @@ function mockClient(overrides: Partial<DashboardApiClient> = {}): DashboardApiCl
     fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
     toggleSkill: vi.fn().mockResolvedValue(undefined),
     updateSecurityProfile: vi.fn().mockResolvedValue(undefined),
-    subscribeToDashboard: vi.fn().mockReturnValue(() => undefined),
+    subscribeToDashboard: vi.fn().mockResolvedValue(() => undefined),
     ...overrides,
   } as unknown as DashboardApiClient;
 }
@@ -160,7 +160,7 @@ describe('DashboardPage', () => {
       fetchSnapshot: vi.fn().mockReturnValue(initialFetch.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (snapshot: DashboardSnapshot) => void) => {
         onSnapshot(snapshot);
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -333,7 +333,7 @@ describe('DashboardPage', () => {
       toggleSkill: vi.fn().mockReturnValue(successfulEnable.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (snapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -354,7 +354,7 @@ describe('DashboardPage', () => {
       updateSecurityProfile: vi.fn().mockReturnValue(successfulStrictSave.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (snapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -441,7 +441,7 @@ describe('DashboardPage', () => {
       toggleSkill: vi.fn().mockReturnValue(failedShellToggle.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -512,7 +512,7 @@ describe('DashboardPage', () => {
       toggleSkill: vi.fn().mockReturnValue(failedEnable.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -537,7 +537,7 @@ describe('DashboardPage', () => {
       updateSecurityProfile: vi.fn().mockReturnValue(failedStrictSave.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -587,7 +587,7 @@ describe('DashboardPage', () => {
       toggleSkill: vi.fn().mockReturnValue(failedEnable.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -611,7 +611,7 @@ describe('DashboardPage', () => {
       toggleSkill: vi.fn().mockReturnValue(failedEnable.promise),
       subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
         pushSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
 
@@ -780,7 +780,7 @@ describe('DashboardPage', () => {
     const firstClient = mockClient({
       subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
         pushStaleSnapshot = onSnapshot;
-        return () => undefined;
+        return Promise.resolve(() => undefined);
       }),
     });
     const nextClient = mockClient();

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -580,6 +580,30 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('clears stale skill mutation errors when a server snapshot removes that skill', async () => {
+    const failedEnable = deferred<void>();
+    let pushSnapshot!: (snapshot: DashboardSnapshot) => void;
+    const client = mockClient({
+      toggleSkill: vi.fn().mockReturnValue(failedEnable.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (nextSnapshot: DashboardSnapshot) => void) => {
+        pushSnapshot = onSnapshot;
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    failedEnable.reject(new Error('HTTP 500'));
+    expect(await screen.findByText(/Could not enable shell/)).toBeTruthy();
+
+    pushSnapshot({ ...snapshot, skills: [] });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Could not enable shell/)).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Retry enabling shell' })).toBeNull();
+    });
+  });
+
   it('ignores snapshots from a superseded dashboard client subscription', async () => {
     let pushStaleSnapshot!: (nextSnapshot: DashboardSnapshot) => void;
     const firstClient = mockClient({

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -76,7 +76,7 @@ describe('DashboardPage', () => {
     const toggle = await screen.findByRole('switch', { name: 'Enable shell' });
     fireEvent.click(toggle);
 
-    expect((await screen.findByRole('alert')).textContent).toContain('Could not enable shell; the switch was rolled back. HTTP 500');
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not enable shell; the switch was restored to the latest confirmed dashboard state. HTTP 500');
     await waitFor(() => {
       expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
     });
@@ -100,7 +100,7 @@ describe('DashboardPage', () => {
     render(<DashboardPage client={client} />);
     fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
 
-    expect((await screen.findByRole('alert')).textContent).toContain('Could not save security profile strict; the previous profile was restored. HTTP 409');
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not save security profile strict; the profile was restored to the latest confirmed dashboard state. HTTP 409');
     await waitFor(() => {
       expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('standard');
     });
@@ -152,5 +152,68 @@ describe('DashboardPage', () => {
       expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('permissive');
     });
     expect(screen.queryByText(/Could not save security profile strict/)).toBeNull();
+  });
+
+  it('keeps an SSE snapshot authoritative when the initial fetch fails late', async () => {
+    const initialFetch = deferred<DashboardSnapshot>();
+    const client = mockClient({
+      fetchSnapshot: vi.fn().mockReturnValue(initialFetch.promise),
+      subscribeToDashboard: vi.fn((onSnapshot: (snapshot: DashboardSnapshot) => void) => {
+        onSnapshot(snapshot);
+        return () => undefined;
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    expect(await screen.findByRole('switch', { name: 'Enable shell' })).toBeTruthy();
+
+    initialFetch.reject(new Error('HTTP 503'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Unable to load dashboard/)).toBeNull();
+      expect(screen.getByRole('switch', { name: 'Enable shell' })).toBeTruthy();
+    });
+  });
+
+  it('restores the last confirmed skill baseline when overlapping toggles both fail', async () => {
+    const firstToggle = deferred<void>();
+    const secondToggle = deferred<void>();
+    const client = mockClient({
+      toggleSkill: vi.fn()
+        .mockReturnValueOnce(firstToggle.promise)
+        .mockReturnValueOnce(secondToggle.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    fireEvent.click(await screen.findByRole('switch', { name: 'Disable shell' }));
+
+    secondToggle.reject(new Error('HTTP 500'));
+    firstToggle.reject(new Error('HTTP 500'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'Enable shell' }).getAttribute('aria-checked')).toBe('false');
+    });
+  });
+
+  it('restores the last confirmed security profile when overlapping saves both fail', async () => {
+    const firstSave = deferred<void>();
+    const secondSave = deferred<void>();
+    const client = mockClient({
+      updateSecurityProfile: vi.fn()
+        .mockReturnValueOnce(firstSave.promise)
+        .mockReturnValueOnce(secondSave.promise),
+    });
+
+    render(<DashboardPage client={client} />);
+    fireEvent.change(await screen.findByLabelText('Profile:'), { target: { value: 'strict' } });
+    fireEvent.change(screen.getByLabelText('Profile:'), { target: { value: 'permissive' } });
+
+    secondSave.reject(new Error('HTTP 409'));
+    firstSave.reject(new Error('HTTP 409'));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('standard');
+    });
   });
 });

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -61,7 +61,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     setSkillErrors((currentErrors) => Object.fromEntries(
       Object.entries(currentErrors).filter(([name, error]) => {
         const skill = snapshot.skills.find((candidate) => candidate.name === name);
-        return !skill || skill.enabled !== error.enabled;
+        return Boolean(skill && skill.enabled !== error.enabled);
       }),
     ));
     setSecurityError((currentError) => (

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -3,7 +3,7 @@ import { useDashboardStore } from '../stores/dashboard-store';
 import { SkillCatalogBrowser } from '../components/skills/skill-catalog-browser';
 import { SecurityPanel } from '../components/security/security-panel';
 import { ProviderPanel } from '../components/providers/provider-panel';
-import type { DashboardApiClient, DashboardSnapshot } from '../lib/dashboard-api';
+import type { DashboardApiClient, DashboardSecurity, DashboardSnapshot } from '../lib/dashboard-api';
 
 interface DashboardPageProps {
   client: DashboardApiClient;
@@ -83,15 +83,22 @@ export function DashboardPage({ client }: DashboardPageProps) {
     if (applyToStore) setSkillEnabled(name, enabled);
   }, [setSkillEnabled]);
 
-  const confirmSecurityProfile = useCallback((profile: string, applyToStore = true) => {
+  const confirmSecurityProfile = useCallback((confirmedSecurity: DashboardSecurity, applyToStore = true) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
     confirmedSnapshotRef.current = {
       ...confirmedSnapshot,
-      security: { ...confirmedSnapshot.security, profile },
+      security: confirmedSecurity,
     };
-    if (applyToStore) setSecurityProfile(profile);
-  }, [setSecurityProfile]);
+    if (applyToStore) {
+      const currentSnapshot = useDashboardStore.getState();
+      setSnapshot({
+        skills: currentSnapshot.skills,
+        security: confirmedSecurity,
+        providers: currentSnapshot.providers,
+      });
+    }
+  }, [setSnapshot]);
 
   const restoreSkillState = useCallback((name: string) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
@@ -106,9 +113,15 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [setSnapshot]);
 
   const restoreSecurityProfile = useCallback(() => {
-    const confirmedProfile = confirmedSnapshotRef.current?.security.profile;
-    if (confirmedProfile) setSecurityProfile(confirmedProfile);
-  }, [setSecurityProfile]);
+    const confirmedSecurity = confirmedSnapshotRef.current?.security;
+    if (!confirmedSecurity) return;
+    const currentSnapshot = useDashboardStore.getState();
+    setSnapshot({
+      skills: currentSnapshot.skills,
+      security: confirmedSecurity,
+      providers: currentSnapshot.providers,
+    });
+  }, [setSnapshot]);
 
   const loadSnapshot = useCallback(() => {
     const sequence = loadSequenceRef.current + 1;
@@ -194,7 +207,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
         if (isLatestSkillRequest) {
           skillMutationSequenceRef.current.delete(name);
           const failedSkillRequest = failedSkillMutationSequenceRef.current.get(name);
-          if (!failedSkillRequest || failedSkillRequest.sequence <= sequence) {
+          if (!failedSkillRequest || failedSkillRequest.sequence <= sequence || failedSkillRequest.enabled === enabled) {
             failedSkillMutationSequenceRef.current.delete(name);
             setSkillErrors((currentErrors) => {
               const { [name]: _cleared, ...remainingErrors } = currentErrors;
@@ -238,7 +251,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     setSecurityProfile(profile);
     setSecurityError(null);
     client.updateSecurityProfile(profile)
-      .then(() => {
+      .then((confirmedSecurity) => {
         if (!mountedRef.current) return;
         if (clientGenerationRef.current !== clientGeneration) return;
         if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
@@ -246,10 +259,10 @@ export function DashboardPage({ client }: DashboardPageProps) {
         confirmedSecurityMutationSequenceRef.current = sequence;
         const latestSecurityRequest = securityMutationSequenceRef.current;
         const isLatestSecurityRequest = latestSecurityRequest === 0 || latestSecurityRequest === sequence;
-        confirmSecurityProfile(profile, isLatestSecurityRequest);
+        confirmSecurityProfile(confirmedSecurity ?? { ...confirmedSnapshotRef.current!.security, profile }, isLatestSecurityRequest);
         if (isLatestSecurityRequest) {
           securityMutationSequenceRef.current = 0;
-          if (!failedSecurityMutationSequenceRef.current || failedSecurityMutationSequenceRef.current.sequence <= sequence) {
+          if (!failedSecurityMutationSequenceRef.current || failedSecurityMutationSequenceRef.current.sequence <= sequence || failedSecurityMutationSequenceRef.current.profile === profile) {
             failedSecurityMutationSequenceRef.current = null;
             setSecurityError(null);
           }

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -56,6 +56,26 @@ export function DashboardPage({ client }: DashboardPageProps) {
     if (confirmedSnapshot) applyConfirmedSnapshot(confirmedSnapshot);
   }, [applyConfirmedSnapshot]);
 
+  const confirmSkillState = useCallback((name: string, enabled: boolean) => {
+    const confirmedSnapshot = confirmedSnapshotRef.current;
+    if (!confirmedSnapshot) return;
+    applyConfirmedSnapshot({
+      ...confirmedSnapshot,
+      skills: confirmedSnapshot.skills.map((skill) => (
+        skill.name === name ? { ...skill, enabled } : skill
+      )),
+    });
+  }, [applyConfirmedSnapshot]);
+
+  const confirmSecurityProfile = useCallback((profile: string) => {
+    const confirmedSnapshot = confirmedSnapshotRef.current;
+    if (!confirmedSnapshot) return;
+    applyConfirmedSnapshot({
+      ...confirmedSnapshot,
+      security: { ...confirmedSnapshot.security, profile },
+    });
+  }, [applyConfirmedSnapshot]);
+
   const loadSnapshot = useCallback(() => {
     const sequence = loadSequenceRef.current + 1;
     loadSequenceRef.current = sequence;
@@ -68,7 +88,10 @@ export function DashboardPage({ client }: DashboardPageProps) {
       })
       .catch((error) => {
         if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
-        if (confirmedSnapshotRef.current) return;
+        if (confirmedSnapshotRef.current) {
+          setLoading(false);
+          return;
+        }
         setLoadError(`Unable to load dashboard. ${describeError(error)}`);
         setLoading(false);
       });
@@ -105,31 +128,41 @@ export function DashboardPage({ client }: DashboardPageProps) {
     skillMutationSequenceRef.current[name] = sequence;
     toggleSkill(name);
     setSkillError(null);
-    client.toggleSkill(name, enabled).catch((error) => {
-      if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
-      restoreConfirmedSnapshot();
-      setSkillError({
-        name,
-        enabled,
-        message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was restored to the latest confirmed dashboard state. ${describeError(error)}`,
+    client.toggleSkill(name, enabled)
+      .then(() => {
+        if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
+        confirmSkillState(name, enabled);
+      })
+      .catch((error) => {
+        if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
+        restoreConfirmedSnapshot();
+        setSkillError({
+          name,
+          enabled,
+          message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was restored to the latest confirmed dashboard state. ${describeError(error)}`,
+        });
       });
-    });
-  }, [client, restoreConfirmedSnapshot, toggleSkill]);
+  }, [client, confirmSkillState, restoreConfirmedSnapshot, toggleSkill]);
 
   const handleSecurityProfileChange = useCallback((profile: string) => {
     const sequence = securityMutationSequenceRef.current + 1;
     securityMutationSequenceRef.current = sequence;
     setSecurityProfile(profile);
     setSecurityError(null);
-    client.updateSecurityProfile(profile).catch((error) => {
-      if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
-      restoreConfirmedSnapshot();
-      setSecurityError({
-        profile,
-        message: `Could not save security profile ${profile}; the profile was restored to the latest confirmed dashboard state. ${describeError(error)}`,
+    client.updateSecurityProfile(profile)
+      .then(() => {
+        if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
+        confirmSecurityProfile(profile);
+      })
+      .catch((error) => {
+        if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
+        restoreConfirmedSnapshot();
+        setSecurityError({
+          profile,
+          message: `Could not save security profile ${profile}; the profile was restored to the latest confirmed dashboard state. ${describeError(error)}`,
+        });
       });
-    });
-  }, [client, restoreConfirmedSnapshot, setSecurityProfile]);
+  }, [client, confirmSecurityProfile, restoreConfirmedSnapshot, setSecurityProfile]);
 
   if (loading) return <div className="dashboard-loading">Loading dashboard...</div>;
 

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -36,20 +36,30 @@ export function DashboardPage({ client }: DashboardPageProps) {
     setLoading,
   } = useDashboardStore();
   const mountedRef = useRef(false);
+  const loadSequenceRef = useRef(0);
+  const skillMutationSequenceRef = useRef<Record<string, number>>({});
+  const securityMutationSequenceRef = useRef(0);
+  const skillsRef = useRef(skills);
+  const securityProfileRef = useRef(security?.profile);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [skillError, setSkillError] = useState<SkillMutationError | null>(null);
   const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
 
+  useEffect(() => { skillsRef.current = skills; }, [skills]);
+  useEffect(() => { securityProfileRef.current = security?.profile; }, [security?.profile]);
+
   const loadSnapshot = useCallback(() => {
+    const sequence = loadSequenceRef.current + 1;
+    loadSequenceRef.current = sequence;
     setLoadError(null);
     setLoading(true);
     client.fetchSnapshot()
       .then((snap) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
         setSnapshot(snap);
       })
       .catch((error) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
         setLoadError(`Unable to load dashboard. ${describeError(error)}`);
         setLoading(false);
       });
@@ -82,11 +92,14 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [client, loadSnapshot, setSnapshot]);
 
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
+    const sequence = (skillMutationSequenceRef.current[name] ?? 0) + 1;
+    skillMutationSequenceRef.current[name] = sequence;
     toggleSkill(name);
     setSkillError(null);
     client.toggleSkill(name, enabled).catch((error) => {
-      if (!mountedRef.current) return;
-      toggleSkill(name);
+      if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
+      const currentSkill = skillsRef.current.find((skill) => skill.name === name);
+      if (currentSkill?.enabled === enabled) toggleSkill(name);
       setSkillError({
         name,
         enabled,
@@ -96,18 +109,20 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [client, toggleSkill]);
 
   const handleSecurityProfileChange = useCallback((profile: string) => {
-    const previousProfile = security?.profile;
+    const sequence = securityMutationSequenceRef.current + 1;
+    securityMutationSequenceRef.current = sequence;
+    const previousProfile = securityProfileRef.current;
     setSecurityProfile(profile);
     setSecurityError(null);
     client.updateSecurityProfile(profile).catch((error) => {
-      if (!mountedRef.current) return;
-      if (previousProfile) setSecurityProfile(previousProfile);
+      if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
+      if (previousProfile && securityProfileRef.current === profile) setSecurityProfile(previousProfile);
       setSecurityError({
         profile,
         message: `Could not save security profile ${profile}; the previous profile was restored. ${describeError(error)}`,
       });
     });
-  }, [client, security?.profile, setSecurityProfile]);
+  }, [client, setSecurityProfile]);
 
   if (loading) return <div className="dashboard-loading">Loading dashboard...</div>;
 

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -38,7 +38,9 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const mountedRef = useRef(false);
   const clientGenerationRef = useRef(0);
   const loadSequenceRef = useRef(0);
+  const issuedSkillMutationSequenceRef = useRef<Record<string, number>>({});
   const skillMutationSequenceRef = useRef<Record<string, number>>({});
+  const issuedSecurityMutationSequenceRef = useRef(0);
   const securityMutationSequenceRef = useRef(0);
   const confirmedSnapshotRef = useRef<DashboardSnapshot | null>(null);
   const serverSnapshotVersionRef = useRef(0);
@@ -48,14 +50,14 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const [skillErrors, setSkillErrors] = useState<Record<string, SkillMutationError>>({});
   const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
 
-  const setConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot, applyToStore = true) => {
+  const setConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot) => {
     confirmedSnapshotRef.current = snapshot;
-    if (applyToStore) setSnapshot(snapshot);
-  }, [setSnapshot]);
+  }, []);
 
   const applyServerSnapshot = useCallback((snapshot: DashboardSnapshot) => {
     serverSnapshotVersionRef.current += 1;
     setConfirmedSnapshot(snapshot);
+    setSnapshot(snapshot);
     setSkillErrors((currentErrors) => Object.fromEntries(
       Object.entries(currentErrors).filter(([name, error]) => {
         const skill = snapshot.skills.find((candidate) => candidate.name === name);
@@ -70,22 +72,24 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const confirmSkillState = useCallback((name: string, enabled: boolean, applyToStore = true) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
-    setConfirmedSnapshot({
+    confirmedSnapshotRef.current = {
       ...confirmedSnapshot,
       skills: confirmedSnapshot.skills.map((skill) => (
         skill.name === name ? { ...skill, enabled } : skill
       )),
-    }, applyToStore);
-  }, [setConfirmedSnapshot]);
+    };
+    if (applyToStore) setSkillEnabled(name, enabled);
+  }, [setSkillEnabled]);
 
   const confirmSecurityProfile = useCallback((profile: string, applyToStore = true) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
-    setConfirmedSnapshot({
+    confirmedSnapshotRef.current = {
       ...confirmedSnapshot,
       security: { ...confirmedSnapshot.security, profile },
-    }, applyToStore);
-  }, [setConfirmedSnapshot]);
+    };
+    if (applyToStore) setSecurityProfile(profile);
+  }, [setSecurityProfile]);
 
   const restoreSkillState = useCallback((name: string) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
@@ -158,7 +162,8 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [applyServerSnapshot, client, loadSnapshot, setConfirmedSnapshot]);
 
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
-    const sequence = (skillMutationSequenceRef.current[name] ?? 0) + 1;
+    const sequence = (issuedSkillMutationSequenceRef.current[name] ?? 0) + 1;
+    issuedSkillMutationSequenceRef.current[name] = sequence;
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
     const clientGeneration = clientGenerationRef.current;
     skillMutationSequenceRef.current[name] = sequence;
@@ -174,11 +179,28 @@ export function DashboardPage({ client }: DashboardPageProps) {
         if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
         if (sequence < (confirmedSkillMutationSequenceRef.current[name] ?? 0)) return;
         confirmedSkillMutationSequenceRef.current[name] = sequence;
-        const isLatestSkillRequest = skillMutationSequenceRef.current[name] === sequence;
+        const latestSkillRequest = skillMutationSequenceRef.current[name];
+        const isLatestSkillRequest = latestSkillRequest === undefined || latestSkillRequest === sequence;
         confirmSkillState(name, enabled, isLatestSkillRequest);
+        if (isLatestSkillRequest) {
+          delete skillMutationSequenceRef.current[name];
+          setSkillErrors((currentErrors) => {
+            const { [name]: _cleared, ...remainingErrors } = currentErrors;
+            return remainingErrors;
+          });
+        }
       })
       .catch((error) => {
         if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || skillMutationSequenceRef.current[name] !== sequence) return;
+        delete skillMutationSequenceRef.current[name];
+        const confirmedSkill = confirmedSnapshotRef.current?.skills.find((skill) => skill.name === name);
+        if (confirmedSkill?.enabled === enabled) {
+          setSkillErrors((currentErrors) => {
+            const { [name]: _cleared, ...remainingErrors } = currentErrors;
+            return remainingErrors;
+          });
+          return;
+        }
         restoreSkillState(name);
         setSkillErrors((currentErrors) => ({
           ...currentErrors,
@@ -192,7 +214,8 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [client, confirmSkillState, restoreSkillState, setSkillEnabled]);
 
   const handleSecurityProfileChange = useCallback((profile: string) => {
-    const sequence = securityMutationSequenceRef.current + 1;
+    const sequence = issuedSecurityMutationSequenceRef.current + 1;
+    issuedSecurityMutationSequenceRef.current = sequence;
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
     const clientGeneration = clientGenerationRef.current;
     securityMutationSequenceRef.current = sequence;
@@ -205,11 +228,21 @@ export function DashboardPage({ client }: DashboardPageProps) {
         if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
         if (sequence < confirmedSecurityMutationSequenceRef.current) return;
         confirmedSecurityMutationSequenceRef.current = sequence;
-        const isLatestSecurityRequest = securityMutationSequenceRef.current === sequence;
+        const latestSecurityRequest = securityMutationSequenceRef.current;
+        const isLatestSecurityRequest = latestSecurityRequest === 0 || latestSecurityRequest === sequence;
         confirmSecurityProfile(profile, isLatestSecurityRequest);
+        if (isLatestSecurityRequest) {
+          securityMutationSequenceRef.current = 0;
+          setSecurityError(null);
+        }
       })
       .catch((error) => {
         if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || securityMutationSequenceRef.current !== sequence) return;
+        securityMutationSequenceRef.current = 0;
+        if (confirmedSnapshotRef.current?.security.profile === profile) {
+          setSecurityError(null);
+          return;
+        }
         restoreSecurityProfile();
         setSecurityError({
           profile,

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -40,8 +40,10 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const loadSequenceRef = useRef(0);
   const issuedSkillMutationSequenceRef = useRef(new Map<string, number>());
   const skillMutationSequenceRef = useRef(new Map<string, number>());
+  const failedSkillMutationSequenceRef = useRef(new Map<string, { sequence: number; enabled: boolean }>());
   const issuedSecurityMutationSequenceRef = useRef(0);
   const securityMutationSequenceRef = useRef(0);
+  const failedSecurityMutationSequenceRef = useRef<{ sequence: number; profile: string } | null>(null);
   const confirmedSnapshotRef = useRef<DashboardSnapshot | null>(null);
   const serverSnapshotVersionRef = useRef(0);
   const confirmedSkillMutationSequenceRef = useRef(new Map<string, number>());
@@ -137,6 +139,8 @@ export function DashboardPage({ client }: DashboardPageProps) {
     clientGenerationRef.current += 1;
     skillMutationSequenceRef.current.clear();
     securityMutationSequenceRef.current = 0;
+    failedSkillMutationSequenceRef.current.clear();
+    failedSecurityMutationSequenceRef.current = null;
     setSkillErrors({});
     setSecurityError(null);
     const subscriptionGeneration = clientGenerationRef.current;
@@ -171,6 +175,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
     const clientGeneration = clientGenerationRef.current;
     skillMutationSequenceRef.current.set(name, sequence);
+    failedSkillMutationSequenceRef.current.delete(name);
     setSkillEnabled(name, enabled);
     setSkillErrors((currentErrors) => {
       const { [name]: _cleared, ...remainingErrors } = currentErrors;
@@ -188,10 +193,14 @@ export function DashboardPage({ client }: DashboardPageProps) {
         confirmSkillState(name, enabled, isLatestSkillRequest);
         if (isLatestSkillRequest) {
           skillMutationSequenceRef.current.delete(name);
-          setSkillErrors((currentErrors) => {
-            const { [name]: _cleared, ...remainingErrors } = currentErrors;
-            return remainingErrors;
-          });
+          const failedSkillRequest = failedSkillMutationSequenceRef.current.get(name);
+          if (!failedSkillRequest || failedSkillRequest.sequence <= sequence) {
+            failedSkillMutationSequenceRef.current.delete(name);
+            setSkillErrors((currentErrors) => {
+              const { [name]: _cleared, ...remainingErrors } = currentErrors;
+              return remainingErrors;
+            });
+          }
         }
       })
       .catch((error) => {
@@ -199,6 +208,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
         skillMutationSequenceRef.current.delete(name);
         const confirmedSkill = confirmedSnapshotRef.current?.skills.find((skill) => skill.name === name);
         if (!confirmedSkill || confirmedSkill.enabled === enabled) {
+          failedSkillMutationSequenceRef.current.delete(name);
           setSkillErrors((currentErrors) => {
             const { [name]: _cleared, ...remainingErrors } = currentErrors;
             return remainingErrors;
@@ -206,6 +216,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
           return;
         }
         restoreSkillState(name);
+        failedSkillMutationSequenceRef.current.set(name, { sequence, enabled });
         setSkillErrors((currentErrors) => ({
           ...currentErrors,
           [name]: {
@@ -223,6 +234,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
     const clientGeneration = clientGenerationRef.current;
     securityMutationSequenceRef.current = sequence;
+    failedSecurityMutationSequenceRef.current = null;
     setSecurityProfile(profile);
     setSecurityError(null);
     client.updateSecurityProfile(profile)
@@ -237,17 +249,22 @@ export function DashboardPage({ client }: DashboardPageProps) {
         confirmSecurityProfile(profile, isLatestSecurityRequest);
         if (isLatestSecurityRequest) {
           securityMutationSequenceRef.current = 0;
-          setSecurityError(null);
+          if (!failedSecurityMutationSequenceRef.current || failedSecurityMutationSequenceRef.current.sequence <= sequence) {
+            failedSecurityMutationSequenceRef.current = null;
+            setSecurityError(null);
+          }
         }
       })
       .catch((error) => {
         if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || securityMutationSequenceRef.current !== sequence) return;
         securityMutationSequenceRef.current = 0;
         if (confirmedSnapshotRef.current?.security.profile === profile) {
+          failedSecurityMutationSequenceRef.current = null;
           setSecurityError(null);
           return;
         }
         restoreSecurityProfile();
+        failedSecurityMutationSequenceRef.current = { sequence, profile };
         setSecurityError({
           profile,
           message: `Could not save security profile ${profile}; the profile was restored to the latest confirmed dashboard state. ${describeError(error)}`,

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDashboardStore } from '../stores/dashboard-store';
 import { SkillCatalogBrowser } from '../components/skills/skill-catalog-browser';
 import { SecurityPanel } from '../components/security/security-panel';
@@ -9,43 +9,141 @@ interface DashboardPageProps {
   client: DashboardApiClient;
 }
 
+interface SkillMutationError {
+  name: string;
+  enabled: boolean;
+  message: string;
+}
+
+interface SecurityMutationError {
+  profile: string;
+  message: string;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
 export function DashboardPage({ client }: DashboardPageProps) {
-  const { skills, security, providers, loading, setSnapshot, toggleSkill, setSecurityProfile } =
-    useDashboardStore();
+  const {
+    skills,
+    security,
+    providers,
+    loading,
+    setSnapshot,
+    toggleSkill,
+    setSecurityProfile,
+    setLoading,
+  } = useDashboardStore();
+  const mountedRef = useRef(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [skillError, setSkillError] = useState<SkillMutationError | null>(null);
+  const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
+
+  const loadSnapshot = useCallback(() => {
+    setLoadError(null);
+    setLoading(true);
+    client.fetchSnapshot()
+      .then((snap) => {
+        if (!mountedRef.current) return;
+        setSnapshot(snap);
+      })
+      .catch((error) => {
+        if (!mountedRef.current) return;
+        setLoadError(`Unable to load dashboard. ${describeError(error)}`);
+        setLoading(false);
+      });
+  }, [client, setLoading, setSnapshot]);
 
   useEffect(() => {
     // Note: SSE snapshot events replace full store state. If the server pushes
     // a snapshot while an optimistic update is in-flight, the server state wins.
     // Currently only the initial snapshot is pushed (heartbeats carry no data).
-    let stale = false;
-    client.fetchSnapshot()
-      .then((snap) => { if (!stale) setSnapshot(snap); })
-      .catch(console.error);
+    mountedRef.current = true;
+    loadSnapshot();
     let unsub: (() => void) | undefined;
-    client.subscribeToDashboard((snap) => { if (!stale) setSnapshot(snap); })
+    client.subscribeToDashboard((snap) => {
+      if (!mountedRef.current) return;
+      setLoadError(null);
+      setSnapshot(snap);
+    })
       .then((nextUnsub) => {
-        if (stale) {
+        if (!mountedRef.current) {
           nextUnsub();
           return;
         }
         unsub = nextUnsub;
       })
-      .catch(console.error);
-    return () => { stale = true; unsub?.(); };
-  }, [client]); // eslint-disable-line react-hooks/exhaustive-deps — setSnapshot is stable (Zustand v5)
+      .catch((error) => {
+        if (!mountedRef.current) return;
+        setLoadError(`Unable to stream dashboard updates. ${describeError(error)}`);
+      });
+    return () => { mountedRef.current = false; unsub?.(); };
+  }, [client, loadSnapshot, setSnapshot]);
+
+  const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
+    toggleSkill(name);
+    setSkillError(null);
+    client.toggleSkill(name, enabled).catch((error) => {
+      if (!mountedRef.current) return;
+      toggleSkill(name);
+      setSkillError({
+        name,
+        enabled,
+        message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was rolled back. ${describeError(error)}`,
+      });
+    });
+  }, [client, toggleSkill]);
+
+  const handleSecurityProfileChange = useCallback((profile: string) => {
+    const previousProfile = security?.profile;
+    setSecurityProfile(profile);
+    setSecurityError(null);
+    client.updateSecurityProfile(profile).catch((error) => {
+      if (!mountedRef.current) return;
+      if (previousProfile) setSecurityProfile(previousProfile);
+      setSecurityError({
+        profile,
+        message: `Could not save security profile ${profile}; the previous profile was restored. ${describeError(error)}`,
+      });
+    });
+  }, [client, security?.profile, setSecurityProfile]);
 
   if (loading) return <div className="dashboard-loading">Loading dashboard...</div>;
 
   return (
     <div className="dashboard-page">
       <h2>Dashboard</h2>
+      {(loadError || skillError || securityError) && (
+        <section className="dashboard-alerts" aria-label="Dashboard errors" aria-live="assertive">
+          {loadError && (
+            <div className="analytics-alert dashboard-alert" role="alert">
+              <span>{loadError}</span>
+              <button type="button" onClick={loadSnapshot}>Retry loading dashboard</button>
+            </div>
+          )}
+          {skillError && (
+            <div className="analytics-alert dashboard-alert" role="alert">
+              <span>{skillError.message}</span>
+              <button type="button" onClick={() => handleToggleSkill(skillError.name, skillError.enabled)}>
+                Retry {skillError.enabled ? 'enabling' : 'disabling'} {skillError.name}
+              </button>
+            </div>
+          )}
+          {securityError && (
+            <div className="analytics-alert dashboard-alert" role="alert">
+              <span>{securityError.message}</span>
+              <button type="button" onClick={() => handleSecurityProfileChange(securityError.profile)}>
+                Retry saving {securityError.profile}
+              </button>
+            </div>
+          )}
+        </section>
+      )}
       <div className="dashboard-page__grid">
         <SkillCatalogBrowser
           skills={skills}
-          onToggle={(name, enabled) => {
-            toggleSkill(name);
-            client.toggleSkill(name, enabled).catch(console.error);
-          }}
+          onToggle={handleToggleSkill}
         />
         {security && (
           <SecurityPanel
@@ -54,10 +152,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
             piiMasking={security.piiMasking}
             outputValidation={security.outputValidation}
             requireApproval={security.requireApproval}
-            onProfileChange={(profile) => {
-              setSecurityProfile(profile);
-              client.updateSecurityProfile(profile).catch(console.error);
-            }}
+            onProfileChange={handleSecurityProfileChange}
           />
         )}
         <ProviderPanel providers={providers} />

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -3,7 +3,7 @@ import { useDashboardStore } from '../stores/dashboard-store';
 import { SkillCatalogBrowser } from '../components/skills/skill-catalog-browser';
 import { SecurityPanel } from '../components/security/security-panel';
 import { ProviderPanel } from '../components/providers/provider-panel';
-import type { DashboardApiClient } from '../lib/dashboard-api';
+import type { DashboardApiClient, DashboardSnapshot } from '../lib/dashboard-api';
 
 interface DashboardPageProps {
   client: DashboardApiClient;
@@ -39,14 +39,22 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const loadSequenceRef = useRef(0);
   const skillMutationSequenceRef = useRef<Record<string, number>>({});
   const securityMutationSequenceRef = useRef(0);
-  const skillsRef = useRef(skills);
-  const securityProfileRef = useRef(security?.profile);
+  const confirmedSnapshotRef = useRef<DashboardSnapshot | null>(null);
+  const confirmedSnapshotVersionRef = useRef(0);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [skillError, setSkillError] = useState<SkillMutationError | null>(null);
   const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
 
-  useEffect(() => { skillsRef.current = skills; }, [skills]);
-  useEffect(() => { securityProfileRef.current = security?.profile; }, [security?.profile]);
+  const applyConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot) => {
+    confirmedSnapshotRef.current = snapshot;
+    confirmedSnapshotVersionRef.current += 1;
+    setSnapshot(snapshot);
+  }, [setSnapshot]);
+
+  const restoreConfirmedSnapshot = useCallback(() => {
+    const confirmedSnapshot = confirmedSnapshotRef.current;
+    if (confirmedSnapshot) applyConfirmedSnapshot(confirmedSnapshot);
+  }, [applyConfirmedSnapshot]);
 
   const loadSnapshot = useCallback(() => {
     const sequence = loadSequenceRef.current + 1;
@@ -56,14 +64,15 @@ export function DashboardPage({ client }: DashboardPageProps) {
     client.fetchSnapshot()
       .then((snap) => {
         if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
-        setSnapshot(snap);
+        applyConfirmedSnapshot(snap);
       })
       .catch((error) => {
         if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
+        if (confirmedSnapshotRef.current) return;
         setLoadError(`Unable to load dashboard. ${describeError(error)}`);
         setLoading(false);
       });
-  }, [client, setLoading, setSnapshot]);
+  }, [applyConfirmedSnapshot, client, setLoading]);
 
   useEffect(() => {
     // Note: SSE snapshot events replace full store state. If the server pushes
@@ -75,7 +84,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     client.subscribeToDashboard((snap) => {
       if (!mountedRef.current) return;
       setLoadError(null);
-      setSnapshot(snap);
+      applyConfirmedSnapshot(snap);
     })
       .then((nextUnsub) => {
         if (!mountedRef.current) {
@@ -89,7 +98,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
         setLoadError(`Unable to stream dashboard updates. ${describeError(error)}`);
       });
     return () => { mountedRef.current = false; unsub?.(); };
-  }, [client, loadSnapshot, setSnapshot]);
+  }, [applyConfirmedSnapshot, client, loadSnapshot]);
 
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
     const sequence = (skillMutationSequenceRef.current[name] ?? 0) + 1;
@@ -98,31 +107,29 @@ export function DashboardPage({ client }: DashboardPageProps) {
     setSkillError(null);
     client.toggleSkill(name, enabled).catch((error) => {
       if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
-      const currentSkill = skillsRef.current.find((skill) => skill.name === name);
-      if (currentSkill?.enabled === enabled) toggleSkill(name);
+      restoreConfirmedSnapshot();
       setSkillError({
         name,
         enabled,
-        message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was rolled back. ${describeError(error)}`,
+        message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was restored to the latest confirmed dashboard state. ${describeError(error)}`,
       });
     });
-  }, [client, toggleSkill]);
+  }, [client, restoreConfirmedSnapshot, toggleSkill]);
 
   const handleSecurityProfileChange = useCallback((profile: string) => {
     const sequence = securityMutationSequenceRef.current + 1;
     securityMutationSequenceRef.current = sequence;
-    const previousProfile = securityProfileRef.current;
     setSecurityProfile(profile);
     setSecurityError(null);
     client.updateSecurityProfile(profile).catch((error) => {
       if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
-      if (previousProfile && securityProfileRef.current === profile) setSecurityProfile(previousProfile);
+      restoreConfirmedSnapshot();
       setSecurityError({
         profile,
-        message: `Could not save security profile ${profile}; the previous profile was restored. ${describeError(error)}`,
+        message: `Could not save security profile ${profile}; the profile was restored to the latest confirmed dashboard state. ${describeError(error)}`,
       });
     });
-  }, [client, setSecurityProfile]);
+  }, [client, restoreConfirmedSnapshot, setSecurityProfile]);
 
   if (loading) return <div className="dashboard-loading">Loading dashboard...</div>;
 

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -31,11 +31,12 @@ export function DashboardPage({ client }: DashboardPageProps) {
     providers,
     loading,
     setSnapshot,
-    toggleSkill,
+    setSkillEnabled,
     setSecurityProfile,
     setLoading,
   } = useDashboardStore();
   const mountedRef = useRef(false);
+  const clientGenerationRef = useRef(0);
   const loadSequenceRef = useRef(0);
   const skillMutationSequenceRef = useRef<Record<string, number>>({});
   const securityMutationSequenceRef = useRef(0);
@@ -44,25 +45,29 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const confirmedSkillMutationSequenceRef = useRef<Record<string, number>>({});
   const confirmedSecurityMutationSequenceRef = useRef(0);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [skillError, setSkillError] = useState<SkillMutationError | null>(null);
+  const [skillErrors, setSkillErrors] = useState<Record<string, SkillMutationError>>({});
   const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
 
-  const setConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot) => {
+  const setConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot, applyToStore = true) => {
     confirmedSnapshotRef.current = snapshot;
-    setSnapshot(snapshot);
+    if (applyToStore) setSnapshot(snapshot);
   }, [setSnapshot]);
 
   const applyServerSnapshot = useCallback((snapshot: DashboardSnapshot) => {
     serverSnapshotVersionRef.current += 1;
     setConfirmedSnapshot(snapshot);
+    setSkillErrors((currentErrors) => Object.fromEntries(
+      Object.entries(currentErrors).filter(([name, error]) => {
+        const skill = snapshot.skills.find((candidate) => candidate.name === name);
+        return !skill || skill.enabled !== error.enabled;
+      }),
+    ));
+    setSecurityError((currentError) => (
+      currentError && snapshot.security.profile === currentError.profile ? null : currentError
+    ));
   }, [setConfirmedSnapshot]);
 
-  const restoreConfirmedSnapshot = useCallback(() => {
-    const confirmedSnapshot = confirmedSnapshotRef.current;
-    if (confirmedSnapshot) setConfirmedSnapshot(confirmedSnapshot);
-  }, [setConfirmedSnapshot]);
-
-  const confirmSkillState = useCallback((name: string, enabled: boolean) => {
+  const confirmSkillState = useCallback((name: string, enabled: boolean, applyToStore = true) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
     setConfirmedSnapshot({
@@ -70,17 +75,34 @@ export function DashboardPage({ client }: DashboardPageProps) {
       skills: confirmedSnapshot.skills.map((skill) => (
         skill.name === name ? { ...skill, enabled } : skill
       )),
-    });
+    }, applyToStore);
   }, [setConfirmedSnapshot]);
 
-  const confirmSecurityProfile = useCallback((profile: string) => {
+  const confirmSecurityProfile = useCallback((profile: string, applyToStore = true) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
     setConfirmedSnapshot({
       ...confirmedSnapshot,
       security: { ...confirmedSnapshot.security, profile },
-    });
+    }, applyToStore);
   }, [setConfirmedSnapshot]);
+
+  const restoreSkillState = useCallback((name: string) => {
+    const confirmedSnapshot = confirmedSnapshotRef.current;
+    const confirmedSkill = confirmedSnapshot?.skills.find((skill) => skill.name === name);
+    if (!confirmedSnapshot || !confirmedSkill) return;
+    const currentSnapshot = useDashboardStore.getState();
+    setSnapshot({
+      skills: currentSnapshot.skills.map((skill) => (skill.name === name ? confirmedSkill : skill)),
+      security: currentSnapshot.security ?? confirmedSnapshot.security,
+      providers: currentSnapshot.providers,
+    });
+  }, [setSnapshot]);
+
+  const restoreSecurityProfile = useCallback(() => {
+    const confirmedProfile = confirmedSnapshotRef.current?.security.profile;
+    if (confirmedProfile) setSecurityProfile(confirmedProfile);
+  }, [setSecurityProfile]);
 
   const loadSnapshot = useCallback(() => {
     const sequence = loadSequenceRef.current + 1;
@@ -108,6 +130,8 @@ export function DashboardPage({ client }: DashboardPageProps) {
     // a snapshot while an optimistic update is in-flight, the server state wins.
     // Currently only the initial snapshot is pushed (heartbeats carry no data).
     mountedRef.current = true;
+    clientGenerationRef.current += 1;
+    const subscriptionGeneration = clientGenerationRef.current;
     if (!confirmedSnapshotRef.current && security) {
       setConfirmedSnapshot({ skills, security, providers });
     }
@@ -115,6 +139,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     let unsub: (() => void) | undefined;
     client.subscribeToDashboard((snap) => {
       if (!mountedRef.current) return;
+      if (clientGenerationRef.current !== subscriptionGeneration) return;
       setLoadError(null);
       applyServerSnapshot(snap);
     })
@@ -135,58 +160,70 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
     const sequence = (skillMutationSequenceRef.current[name] ?? 0) + 1;
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
+    const clientGeneration = clientGenerationRef.current;
     skillMutationSequenceRef.current[name] = sequence;
-    toggleSkill(name);
-    setSkillError(null);
+    setSkillEnabled(name, enabled);
+    setSkillErrors((currentErrors) => {
+      const { [name]: _cleared, ...remainingErrors } = currentErrors;
+      return remainingErrors;
+    });
     client.toggleSkill(name, enabled)
       .then(() => {
         if (!mountedRef.current) return;
+        if (clientGenerationRef.current !== clientGeneration) return;
         if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
         if (sequence < (confirmedSkillMutationSequenceRef.current[name] ?? 0)) return;
         confirmedSkillMutationSequenceRef.current[name] = sequence;
-        confirmSkillState(name, enabled);
+        const isLatestSkillRequest = skillMutationSequenceRef.current[name] === sequence;
+        confirmSkillState(name, enabled, isLatestSkillRequest);
       })
       .catch((error) => {
-        if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
-        restoreConfirmedSnapshot();
-        setSkillError({
-          name,
-          enabled,
-          message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was restored to the latest confirmed dashboard state. ${describeError(error)}`,
-        });
+        if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || skillMutationSequenceRef.current[name] !== sequence) return;
+        restoreSkillState(name);
+        setSkillErrors((currentErrors) => ({
+          ...currentErrors,
+          [name]: {
+            name,
+            enabled,
+            message: `Could not ${enabled ? 'enable' : 'disable'} ${name}; the switch was restored to the latest confirmed dashboard state. ${describeError(error)}`,
+          },
+        }));
       });
-  }, [client, confirmSkillState, restoreConfirmedSnapshot, toggleSkill]);
+  }, [client, confirmSkillState, restoreSkillState, setSkillEnabled]);
 
   const handleSecurityProfileChange = useCallback((profile: string) => {
     const sequence = securityMutationSequenceRef.current + 1;
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
+    const clientGeneration = clientGenerationRef.current;
     securityMutationSequenceRef.current = sequence;
     setSecurityProfile(profile);
     setSecurityError(null);
     client.updateSecurityProfile(profile)
       .then(() => {
         if (!mountedRef.current) return;
+        if (clientGenerationRef.current !== clientGeneration) return;
         if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
         if (sequence < confirmedSecurityMutationSequenceRef.current) return;
         confirmedSecurityMutationSequenceRef.current = sequence;
-        confirmSecurityProfile(profile);
+        const isLatestSecurityRequest = securityMutationSequenceRef.current === sequence;
+        confirmSecurityProfile(profile, isLatestSecurityRequest);
       })
       .catch((error) => {
-        if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
-        restoreConfirmedSnapshot();
+        if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || securityMutationSequenceRef.current !== sequence) return;
+        restoreSecurityProfile();
         setSecurityError({
           profile,
           message: `Could not save security profile ${profile}; the profile was restored to the latest confirmed dashboard state. ${describeError(error)}`,
         });
       });
-  }, [client, confirmSecurityProfile, restoreConfirmedSnapshot, setSecurityProfile]);
+  }, [client, confirmSecurityProfile, restoreSecurityProfile, setSecurityProfile]);
 
   if (loading) return <div className="dashboard-loading">Loading dashboard...</div>;
 
   return (
     <div className="dashboard-page">
       <h2>Dashboard</h2>
-      {(loadError || skillError || securityError) && (
+      {(loadError || Object.keys(skillErrors).length > 0 || securityError) && (
         <section className="dashboard-alerts" aria-label="Dashboard errors" aria-live="assertive">
           {loadError && (
             <div className="analytics-alert dashboard-alert" role="alert">
@@ -194,14 +231,14 @@ export function DashboardPage({ client }: DashboardPageProps) {
               <button type="button" onClick={loadSnapshot}>Retry loading dashboard</button>
             </div>
           )}
-          {skillError && (
-            <div className="analytics-alert dashboard-alert" role="alert">
+          {Object.values(skillErrors).map((skillError) => (
+            <div className="analytics-alert dashboard-alert" role="alert" key={skillError.name}>
               <span>{skillError.message}</span>
               <button type="button" onClick={() => handleToggleSkill(skillError.name, skillError.enabled)}>
                 Retry {skillError.enabled ? 'enabling' : 'disabling'} {skillError.name}
               </button>
             </div>
-          )}
+          ))}
           {securityError && (
             <div className="analytics-alert dashboard-alert" role="alert">
               <span>{securityError.message}</span>

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -38,13 +38,13 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const mountedRef = useRef(false);
   const clientGenerationRef = useRef(0);
   const loadSequenceRef = useRef(0);
-  const issuedSkillMutationSequenceRef = useRef<Record<string, number>>({});
-  const skillMutationSequenceRef = useRef<Record<string, number>>({});
+  const issuedSkillMutationSequenceRef = useRef(new Map<string, number>());
+  const skillMutationSequenceRef = useRef(new Map<string, number>());
   const issuedSecurityMutationSequenceRef = useRef(0);
   const securityMutationSequenceRef = useRef(0);
   const confirmedSnapshotRef = useRef<DashboardSnapshot | null>(null);
   const serverSnapshotVersionRef = useRef(0);
-  const confirmedSkillMutationSequenceRef = useRef<Record<string, number>>({});
+  const confirmedSkillMutationSequenceRef = useRef(new Map<string, number>());
   const confirmedSecurityMutationSequenceRef = useRef(0);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [skillErrors, setSkillErrors] = useState<Record<string, SkillMutationError>>({});
@@ -135,6 +135,10 @@ export function DashboardPage({ client }: DashboardPageProps) {
     // Currently only the initial snapshot is pushed (heartbeats carry no data).
     mountedRef.current = true;
     clientGenerationRef.current += 1;
+    skillMutationSequenceRef.current.clear();
+    securityMutationSequenceRef.current = 0;
+    setSkillErrors({});
+    setSecurityError(null);
     const subscriptionGeneration = clientGenerationRef.current;
     if (!confirmedSnapshotRef.current && security) {
       setConfirmedSnapshot({ skills, security, providers });
@@ -162,11 +166,11 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [applyServerSnapshot, client, loadSnapshot, setConfirmedSnapshot]);
 
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
-    const sequence = (issuedSkillMutationSequenceRef.current[name] ?? 0) + 1;
-    issuedSkillMutationSequenceRef.current[name] = sequence;
+    const sequence = (issuedSkillMutationSequenceRef.current.get(name) ?? 0) + 1;
+    issuedSkillMutationSequenceRef.current.set(name, sequence);
     const serverSnapshotVersion = serverSnapshotVersionRef.current;
     const clientGeneration = clientGenerationRef.current;
-    skillMutationSequenceRef.current[name] = sequence;
+    skillMutationSequenceRef.current.set(name, sequence);
     setSkillEnabled(name, enabled);
     setSkillErrors((currentErrors) => {
       const { [name]: _cleared, ...remainingErrors } = currentErrors;
@@ -177,13 +181,13 @@ export function DashboardPage({ client }: DashboardPageProps) {
         if (!mountedRef.current) return;
         if (clientGenerationRef.current !== clientGeneration) return;
         if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
-        if (sequence < (confirmedSkillMutationSequenceRef.current[name] ?? 0)) return;
-        confirmedSkillMutationSequenceRef.current[name] = sequence;
-        const latestSkillRequest = skillMutationSequenceRef.current[name];
+        if (sequence < (confirmedSkillMutationSequenceRef.current.get(name) ?? 0)) return;
+        confirmedSkillMutationSequenceRef.current.set(name, sequence);
+        const latestSkillRequest = skillMutationSequenceRef.current.get(name);
         const isLatestSkillRequest = latestSkillRequest === undefined || latestSkillRequest === sequence;
         confirmSkillState(name, enabled, isLatestSkillRequest);
         if (isLatestSkillRequest) {
-          delete skillMutationSequenceRef.current[name];
+          skillMutationSequenceRef.current.delete(name);
           setSkillErrors((currentErrors) => {
             const { [name]: _cleared, ...remainingErrors } = currentErrors;
             return remainingErrors;
@@ -191,10 +195,10 @@ export function DashboardPage({ client }: DashboardPageProps) {
         }
       })
       .catch((error) => {
-        if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || skillMutationSequenceRef.current[name] !== sequence) return;
-        delete skillMutationSequenceRef.current[name];
+        if (!mountedRef.current || clientGenerationRef.current !== clientGeneration || skillMutationSequenceRef.current.get(name) !== sequence) return;
+        skillMutationSequenceRef.current.delete(name);
         const confirmedSkill = confirmedSnapshotRef.current?.skills.find((skill) => skill.name === name);
-        if (confirmedSkill?.enabled === enabled) {
+        if (!confirmedSkill || confirmedSkill.enabled === enabled) {
           setSkillErrors((currentErrors) => {
             const { [name]: _cleared, ...remainingErrors } = currentErrors;
             return remainingErrors;

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -40,51 +40,57 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const skillMutationSequenceRef = useRef<Record<string, number>>({});
   const securityMutationSequenceRef = useRef(0);
   const confirmedSnapshotRef = useRef<DashboardSnapshot | null>(null);
-  const confirmedSnapshotVersionRef = useRef(0);
+  const serverSnapshotVersionRef = useRef(0);
+  const confirmedSkillMutationSequenceRef = useRef<Record<string, number>>({});
+  const confirmedSecurityMutationSequenceRef = useRef(0);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [skillError, setSkillError] = useState<SkillMutationError | null>(null);
   const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
 
-  const applyConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot) => {
+  const setConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot) => {
     confirmedSnapshotRef.current = snapshot;
-    confirmedSnapshotVersionRef.current += 1;
     setSnapshot(snapshot);
   }, [setSnapshot]);
 
+  const applyServerSnapshot = useCallback((snapshot: DashboardSnapshot) => {
+    serverSnapshotVersionRef.current += 1;
+    setConfirmedSnapshot(snapshot);
+  }, [setConfirmedSnapshot]);
+
   const restoreConfirmedSnapshot = useCallback(() => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
-    if (confirmedSnapshot) applyConfirmedSnapshot(confirmedSnapshot);
-  }, [applyConfirmedSnapshot]);
+    if (confirmedSnapshot) setConfirmedSnapshot(confirmedSnapshot);
+  }, [setConfirmedSnapshot]);
 
   const confirmSkillState = useCallback((name: string, enabled: boolean) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
-    applyConfirmedSnapshot({
+    setConfirmedSnapshot({
       ...confirmedSnapshot,
       skills: confirmedSnapshot.skills.map((skill) => (
         skill.name === name ? { ...skill, enabled } : skill
       )),
     });
-  }, [applyConfirmedSnapshot]);
+  }, [setConfirmedSnapshot]);
 
   const confirmSecurityProfile = useCallback((profile: string) => {
     const confirmedSnapshot = confirmedSnapshotRef.current;
     if (!confirmedSnapshot) return;
-    applyConfirmedSnapshot({
+    setConfirmedSnapshot({
       ...confirmedSnapshot,
       security: { ...confirmedSnapshot.security, profile },
     });
-  }, [applyConfirmedSnapshot]);
+  }, [setConfirmedSnapshot]);
 
   const loadSnapshot = useCallback(() => {
     const sequence = loadSequenceRef.current + 1;
     loadSequenceRef.current = sequence;
     setLoadError(null);
-    setLoading(true);
+    if (!confirmedSnapshotRef.current) setLoading(true);
     client.fetchSnapshot()
       .then((snap) => {
         if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
-        applyConfirmedSnapshot(snap);
+        applyServerSnapshot(snap);
       })
       .catch((error) => {
         if (!mountedRef.current || loadSequenceRef.current !== sequence) return;
@@ -95,19 +101,22 @@ export function DashboardPage({ client }: DashboardPageProps) {
         setLoadError(`Unable to load dashboard. ${describeError(error)}`);
         setLoading(false);
       });
-  }, [applyConfirmedSnapshot, client, setLoading]);
+  }, [applyServerSnapshot, client, setLoading]);
 
   useEffect(() => {
     // Note: SSE snapshot events replace full store state. If the server pushes
     // a snapshot while an optimistic update is in-flight, the server state wins.
     // Currently only the initial snapshot is pushed (heartbeats carry no data).
     mountedRef.current = true;
+    if (!confirmedSnapshotRef.current && security) {
+      setConfirmedSnapshot({ skills, security, providers });
+    }
     loadSnapshot();
     let unsub: (() => void) | undefined;
     client.subscribeToDashboard((snap) => {
       if (!mountedRef.current) return;
       setLoadError(null);
-      applyConfirmedSnapshot(snap);
+      applyServerSnapshot(snap);
     })
       .then((nextUnsub) => {
         if (!mountedRef.current) {
@@ -121,16 +130,20 @@ export function DashboardPage({ client }: DashboardPageProps) {
         setLoadError(`Unable to stream dashboard updates. ${describeError(error)}`);
       });
     return () => { mountedRef.current = false; unsub?.(); };
-  }, [applyConfirmedSnapshot, client, loadSnapshot]);
+  }, [applyServerSnapshot, client, loadSnapshot, setConfirmedSnapshot]);
 
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
     const sequence = (skillMutationSequenceRef.current[name] ?? 0) + 1;
+    const serverSnapshotVersion = serverSnapshotVersionRef.current;
     skillMutationSequenceRef.current[name] = sequence;
     toggleSkill(name);
     setSkillError(null);
     client.toggleSkill(name, enabled)
       .then(() => {
-        if (!mountedRef.current || skillMutationSequenceRef.current[name] !== sequence) return;
+        if (!mountedRef.current) return;
+        if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
+        if (sequence < (confirmedSkillMutationSequenceRef.current[name] ?? 0)) return;
+        confirmedSkillMutationSequenceRef.current[name] = sequence;
         confirmSkillState(name, enabled);
       })
       .catch((error) => {
@@ -146,12 +159,16 @@ export function DashboardPage({ client }: DashboardPageProps) {
 
   const handleSecurityProfileChange = useCallback((profile: string) => {
     const sequence = securityMutationSequenceRef.current + 1;
+    const serverSnapshotVersion = serverSnapshotVersionRef.current;
     securityMutationSequenceRef.current = sequence;
     setSecurityProfile(profile);
     setSecurityError(null);
     client.updateSecurityProfile(profile)
       .then(() => {
-        if (!mountedRef.current || securityMutationSequenceRef.current !== sequence) return;
+        if (!mountedRef.current) return;
+        if (serverSnapshotVersionRef.current !== serverSnapshotVersion) return;
+        if (sequence < confirmedSecurityMutationSequenceRef.current) return;
+        confirmedSecurityMutationSequenceRef.current = sequence;
         confirmSecurityProfile(profile);
       })
       .catch((error) => {

--- a/packages/franken-web/src/stores/dashboard-store.ts
+++ b/packages/franken-web/src/stores/dashboard-store.ts
@@ -9,6 +9,7 @@ interface DashboardStore {
 
   setSnapshot: (snapshot: { skills: DashboardSkill[]; security: DashboardSecurity; providers: DashboardProvider[] }) => void;
   toggleSkill: (name: string) => void;
+  setSkillEnabled: (name: string, enabled: boolean) => void;
   setSecurityProfile: (profile: string) => void;
   setLoading: (loading: boolean) => void;
   reset: () => void;
@@ -36,6 +37,13 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
     set((s) => ({
       skills: s.skills.map((sk) =>
         sk.name === name ? { ...sk, enabled: !sk.enabled } : sk,
+      ),
+    })),
+
+  setSkillEnabled: (name, enabled) =>
+    set((s) => ({
+      skills: s.skills.map((sk) =>
+        sk.name === name ? { ...sk, enabled } : sk,
       ),
     })),
 

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1434,6 +1434,23 @@ button {
   color: #ffd0ca;
 }
 
+.dashboard-alerts {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.dashboard-alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.dashboard-alert button {
+  flex: none;
+}
+
 .analytics-summary-region {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- Adds visible dashboard error alerts for initial snapshot load failures with a retry action.
- Rolls back failed skill toggles and security profile changes while explaining the rollback inline.
- Adds focused DashboardPage coverage for load retry, skill retry, and security profile retry flows.

## Test Plan
- `cd packages/franken-web && npm test -- --run src/pages/dashboard-page.test.tsx`
- `cd packages/franken-web && npm test` (after root build generated workspace package outputs)
- `cd packages/franken-web && npm run typecheck`
- `npm run build`

Closes #627
