### PR TITLE
fix(security): decouple webhook signature policy

### DIFF
--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -8,6 +8,8 @@ import {
   buildMiddlewareChain,
   resolveSecurityConfig,
   type SecurityProfile,
+  type SecurityRule,
+  type WebhookSignaturePolicy,
 } from '../middleware/security-profiles.js';
 import { SkillManager } from '../skills/skill-manager.js';
 import { SkillConfigStore } from '../skills/skill-config-store.js';
@@ -46,9 +48,11 @@ export interface BeastDepsConfig {
     injectionDetection?: boolean;
     piiMasking?: boolean;
     outputValidation?: boolean;
+    webhookSignaturePolicy?: WebhookSignaturePolicy;
     allowedDomains?: string[];
     maxTokenBudget?: number;
     requireApproval?: 'all' | 'destructive' | 'none';
+    customRules?: SecurityRule[];
   };
   brain?: {
     dbPath?: string;

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -99,9 +99,11 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
           ...(config.security.injectionDetection !== undefined ? { injectionDetection: config.security.injectionDetection } : {}),
           ...(config.security.piiMasking !== undefined ? { piiMasking: config.security.piiMasking } : {}),
           ...(config.security.outputValidation !== undefined ? { outputValidation: config.security.outputValidation } : {}),
+          ...(config.security.webhookSignaturePolicy ? { webhookSignaturePolicy: config.security.webhookSignaturePolicy } : {}),
           ...(config.security.allowedDomains ? { allowedDomains: config.security.allowedDomains } : {}),
           ...(config.security.maxTokenBudget !== undefined ? { maxTokenBudget: config.security.maxTokenBudget } : {}),
           ...(config.security.requireApproval ? { requireApproval: config.security.requireApproval } : {}),
+          ...(config.security.customRules ? { customRules: config.security.customRules } : {}),
         }
       : { profile: securityProfile },
     brain: {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -47,7 +47,7 @@ import {
   stopNetworkService,
 } from '../network/network-supervisor-runtime.js';
 import type { ISecretStore } from '../network/secret-store.js';
-import { resolveSecurityConfig } from '../middleware/security-profiles.js';
+import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
 import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
@@ -276,6 +276,22 @@ export function resolveDashboardAllowedOrigins(config: OrchestratorConfig): stri
     origins.push(`http://127.0.0.1:${port}`);
   }
   return origins;
+}
+
+function resolveConfigSecurity(config: OrchestratorConfig): SecurityConfig {
+  const security = config.security;
+  const overrides: Partial<Omit<SecurityConfig, 'profile'>> = {};
+  if (security?.injectionDetection !== undefined) overrides.injectionDetection = security.injectionDetection;
+  if (security?.piiMasking !== undefined) overrides.piiMasking = security.piiMasking;
+  if (security?.outputValidation !== undefined) overrides.outputValidation = security.outputValidation;
+  if (security?.webhookSignaturePolicy !== undefined) {
+    overrides.webhookSignaturePolicy = security.webhookSignaturePolicy;
+  }
+  if (security?.allowedDomains !== undefined) overrides.allowedDomains = security.allowedDomains;
+  if (security?.maxTokenBudget !== undefined) overrides.maxTokenBudget = security.maxTokenBudget;
+  if (security?.requireApproval !== undefined) overrides.requireApproval = security.requireApproval;
+  if (security?.customRules !== undefined) overrides.customRules = security.customRules;
+  return resolveSecurityConfig(security?.profile ?? 'standard', overrides);
 }
 
 interface ChatSurfaceDeps {
@@ -794,7 +810,7 @@ export async function main(): Promise<void> {
           ? {
               dashboardDeps: {
                 skillManager,
-                getSecurityConfig: () => resolveSecurityConfig('standard'),
+                getSecurityConfig: () => resolveConfigSecurity(mutableConfig),
                 getProviders: () => providerRegistry.getProviders().map((p, i) => ({
                   name: p.name, type: p.type, available: true, failoverOrder: i,
                 })),

--- a/packages/franken-orchestrator/src/cli/security-cli.ts
+++ b/packages/franken-orchestrator/src/cli/security-cli.ts
@@ -79,6 +79,9 @@ export async function handleSecurityCommand(deps: SecurityCommandDeps): Promise<
         ...(currentSecurity?.outputValidation !== undefined
           ? { outputValidation: currentSecurity.outputValidation }
           : {}),
+        ...(currentSecurity?.webhookSignaturePolicy !== undefined
+          ? { webhookSignaturePolicy: currentSecurity.webhookSignaturePolicy }
+          : {}),
         ...(currentSecurity?.allowedDomains !== undefined ? { allowedDomains: currentSecurity.allowedDomains } : {}),
         ...(currentSecurity?.maxTokenBudget !== undefined ? { maxTokenBudget: currentSecurity.maxTokenBudget } : {}),
         ...(currentSecurity?.requireApproval !== undefined ? { requireApproval: currentSecurity.requireApproval } : {}),
@@ -88,6 +91,7 @@ export async function handleSecurityCommand(deps: SecurityCommandDeps): Promise<
       print(`  Injection Detection: ${config.injectionDetection ? 'on' : 'off'}`);
       print(`  PII Masking: ${config.piiMasking ? 'on' : 'off'}`);
       print(`  Output Validation: ${config.outputValidation ? 'on' : 'off'}`);
+      print(`  Webhook Signature Policy: ${config.webhookSignaturePolicy}`);
       return;
     }
     case 'set': {

--- a/packages/franken-orchestrator/src/comms/channels/discord/discord-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/discord/discord-router.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { discordSignatureMiddleware } from '../../security/discord-signature.js';
 import { DiscordInteractionSchema, DiscordInteractionType } from './discord-schemas.js';
 import type { ChatGateway } from '../../gateway/chat-gateway.js';
@@ -8,16 +8,20 @@ export interface DiscordRouterOptions {
   gateway: ChatGateway;
   sessionMapper: SessionMapper;
   publicKey: string;
-  verifySignature?: boolean;
+  verifySignature?: boolean | ((c: Context) => boolean);
 }
 
 export function discordRouter(options: DiscordRouterOptions) {
   const { gateway, sessionMapper, publicKey } = options;
   const app = new Hono();
 
-  if (options.verifySignature !== false) {
-    app.use('*', discordSignatureMiddleware({ publicKey }));
-  }
+  const verify = discordSignatureMiddleware({ publicKey });
+  app.use('*', async (c, next) => {
+    if (!shouldVerifySignature(options.verifySignature, c)) {
+      return next();
+    }
+    return verify(c, next);
+  });
 
   app.post('/interactions', async (c) => {
     const body = await c.req.json();
@@ -85,4 +89,11 @@ export function discordRouter(options: DiscordRouterOptions) {
   });
 
   return app;
+}
+
+function shouldVerifySignature(verifySignature: DiscordRouterOptions['verifySignature'], c: Context): boolean {
+  if (typeof verifySignature === 'function') {
+    return verifySignature(c);
+  }
+  return verifySignature !== false;
 }

--- a/packages/franken-orchestrator/src/comms/channels/slack/slack-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/slack/slack-router.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { slackSignatureMiddleware } from '../../security/slack-signature.js';
 import { SlackEventBaseSchema, SlackInteractionSchema } from './slack-schemas.js';
 import type { ChatGateway } from '../../gateway/chat-gateway.js';
@@ -8,16 +8,20 @@ export interface SlackRouterOptions {
   gateway: ChatGateway;
   sessionMapper: SessionMapper;
   signingSecret: string;
-  verifySignature?: boolean;
+  verifySignature?: boolean | ((c: Context) => boolean);
 }
 
 export function slackRouter(options: SlackRouterOptions) {
   const { gateway, sessionMapper, signingSecret } = options;
   const app = new Hono();
 
-  if (options.verifySignature !== false) {
-    app.use('*', slackSignatureMiddleware({ signingSecret }));
-  }
+  const verify = slackSignatureMiddleware({ signingSecret });
+  app.use('*', async (c, next) => {
+    if (!shouldVerifySignature(options.verifySignature, c)) {
+      return next();
+    }
+    return verify(c, next);
+  });
 
   // Events API: https://api.slack.com/events-api
   app.post('/events', async (c) => {
@@ -89,4 +93,11 @@ export function slackRouter(options: SlackRouterOptions) {
   });
 
   return app;
+}
+
+function shouldVerifySignature(verifySignature: SlackRouterOptions['verifySignature'], c: Context): boolean {
+  if (typeof verifySignature === 'function') {
+    return verifySignature(c);
+  }
+  return verifySignature !== false;
 }

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context, type Next } from 'hono';
 import { whatsappSignatureMiddleware } from '../../security/whatsapp-signature.js';
 import { WhatsAppWebhookSchema } from './whatsapp-schemas.js';
 import type { ChatGateway } from '../../gateway/chat-gateway.js';
@@ -9,7 +9,7 @@ export interface WhatsAppRouterOptions {
   sessionMapper: SessionMapper;
   appSecret: string;
   verifyToken: string;
-  verifySignature?: boolean;
+  verifySignature?: boolean | ((c: Context) => boolean);
 }
 
 export function whatsappRouter(options: WhatsAppRouterOptions) {
@@ -29,9 +29,13 @@ export function whatsappRouter(options: WhatsAppRouterOptions) {
   });
 
   // Incoming messages: Meta sends a POST request with signatures
-  const whatsappMiddleware = options.verifySignature !== false
-    ? whatsappSignatureMiddleware({ appSecret })
-    : async (_c: any, next: () => Promise<void>) => next();
+  const verify = whatsappSignatureMiddleware({ appSecret });
+  const whatsappMiddleware = async (c: Context, next: Next) => {
+    if (!shouldVerifySignature(options.verifySignature, c)) {
+      return next();
+    }
+    return verify(c, next);
+  };
   app.post('/webhook', whatsappMiddleware, async (c) => {
     const body = await c.req.json();
     const parsed = WhatsAppWebhookSchema.parse(body);
@@ -78,4 +82,11 @@ export function whatsappRouter(options: WhatsAppRouterOptions) {
   });
 
   return app;
+}
+
+function shouldVerifySignature(verifySignature: WhatsAppRouterOptions['verifySignature'], c: Context): boolean {
+  if (typeof verifySignature === 'function') {
+    return verifySignature(c);
+  }
+  return verifySignature !== false;
 }

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -22,9 +22,18 @@ export const ProviderConfigSchema = z.object({
   extraArgs: z.array(z.string()).optional(),
 });
 
+const RegexPatternSchema = z.string().min(1).refine((pattern) => {
+  try {
+    new RegExp(pattern, 'i');
+    return true;
+  } catch {
+    return false;
+  }
+}, { message: 'pattern must be a valid regular expression' });
+
 export const SecurityRuleInputSchema = z.object({
   name: z.string().min(1),
-  pattern: z.string().min(1),
+  pattern: RegexPatternSchema,
   action: z.enum(['block', 'warn', 'log']),
   target: z.enum(['request', 'response', 'both']),
 });

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -27,6 +27,7 @@ export const SecurityConfigInputSchema = z.object({
   injectionDetection: z.boolean().optional(),
   piiMasking: z.boolean().optional(),
   outputValidation: z.boolean().optional(),
+  webhookSignaturePolicy: z.enum(['required', 'local-dev-unsigned']).optional(),
   allowedDomains: z.array(z.string()).optional(),
   maxTokenBudget: z.number().positive().optional(),
   requireApproval: z.enum(['all', 'destructive', 'none']).optional(),

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -22,6 +22,13 @@ export const ProviderConfigSchema = z.object({
   extraArgs: z.array(z.string()).optional(),
 });
 
+export const SecurityRuleInputSchema = z.object({
+  name: z.string().min(1),
+  pattern: z.string().min(1),
+  action: z.enum(['block', 'warn', 'log']),
+  target: z.enum(['request', 'response', 'both']),
+});
+
 export const SecurityConfigInputSchema = z.object({
   profile: z.enum(['strict', 'standard', 'permissive']).optional(),
   injectionDetection: z.boolean().optional(),
@@ -31,6 +38,7 @@ export const SecurityConfigInputSchema = z.object({
   allowedDomains: z.array(z.string()).optional(),
   maxTokenBudget: z.number().positive().optional(),
   requireApproval: z.enum(['all', 'destructive', 'none']).optional(),
+  customRules: z.array(SecurityRuleInputSchema).optional(),
 });
 
 export const BrainConfigSchema = z.object({

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -221,7 +221,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
       runtime: opts.commsRuntime,
     };
     if (opts.securityConfig) {
-      commsRoutesOpts.webhookSignaturePolicy = opts.securityConfig.getSecurityConfig().webhookSignaturePolicy;
+      commsRoutesOpts.getWebhookSignaturePolicy = () => opts.securityConfig!.getSecurityConfig().webhookSignaturePolicy;
     }
     app.route('/', commsRoutes(commsRoutesOpts));
   }

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -221,7 +221,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
       runtime: opts.commsRuntime,
     };
     if (opts.securityConfig) {
-      commsRoutesOpts.securityProfile = opts.securityConfig.getSecurityConfig().profile;
+      commsRoutesOpts.webhookSignaturePolicy = opts.securityConfig.getSecurityConfig().webhookSignaturePolicy;
     }
     app.route('/', commsRoutes(commsRoutesOpts));
   }

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -23,6 +23,7 @@ import type { ProviderRegistry } from '../providers/provider-registry.js';
 import type { DashboardRouteDeps } from './routes/dashboard-routes.js';
 import type { AnalyticsRouteDeps } from './routes/analytics-routes.js';
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
+import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
 
 export interface StartChatServerOptions {
   host?: string;
@@ -251,6 +252,9 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ?? (options.commsConfig
       ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName)
       : undefined);
+  const securityConfig = options.networkControl
+    ? createNetworkSecurityConfigAdapter(options.networkControl)
+    : undefined;
   const app = createChatApp({
     sessionStore,
     engine: runtime.engine,
@@ -261,6 +265,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
     ...(options.beastControl ? { beastControl: options.beastControl } : {}),
     ...(options.networkControl ? { networkControl: options.networkControl } : {}),
+    ...(securityConfig ? { securityConfig } : {}),
     ...(options.commsConfig ? { commsConfig: options.commsConfig } : {}),
     ...(commsRuntime ? { commsRuntime } : {}),
     ...(options.skillManager ? { skillManager: options.skillManager } : {}),
@@ -312,6 +317,38 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       const closedServer = closeHttpServer(server);
       server.closeAllConnections();
       await closedServer;
+    },
+  };
+}
+
+function createNetworkSecurityConfigAdapter(networkControl: NonNullable<StartChatServerOptions['networkControl']>): {
+  getSecurityConfig: () => SecurityConfig;
+  setSecurityConfig: (config: Partial<SecurityConfig>) => void;
+} {
+  return {
+    getSecurityConfig: () => {
+      const security = networkControl.getConfig().security;
+      const overrides: Partial<Omit<SecurityConfig, 'profile'>> = {};
+      if (security?.injectionDetection !== undefined) overrides.injectionDetection = security.injectionDetection;
+      if (security?.piiMasking !== undefined) overrides.piiMasking = security.piiMasking;
+      if (security?.outputValidation !== undefined) overrides.outputValidation = security.outputValidation;
+      if (security?.webhookSignaturePolicy !== undefined) {
+        overrides.webhookSignaturePolicy = security.webhookSignaturePolicy;
+      }
+      if (security?.allowedDomains !== undefined) overrides.allowedDomains = security.allowedDomains;
+      if (security?.maxTokenBudget !== undefined) overrides.maxTokenBudget = security.maxTokenBudget;
+      if (security?.requireApproval !== undefined) overrides.requireApproval = security.requireApproval;
+      return resolveSecurityConfig(security?.profile ?? 'standard', overrides);
+    },
+    setSecurityConfig: (config) => {
+      const current = networkControl.getConfig();
+      networkControl.setConfig({
+        ...current,
+        security: {
+          ...current.security,
+          ...config,
+        },
+      });
     },
   };
 }

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -339,6 +339,7 @@ function createNetworkSecurityConfigAdapter(networkControl: NonNullable<StartCha
       if (security?.allowedDomains !== undefined) overrides.allowedDomains = security.allowedDomains;
       if (security?.maxTokenBudget !== undefined) overrides.maxTokenBudget = security.maxTokenBudget;
       if (security?.requireApproval !== undefined) overrides.requireApproval = security.requireApproval;
+      if (security?.customRules !== undefined) overrides.customRules = security.customRules;
       return resolveSecurityConfig(security?.profile ?? 'standard', overrides);
     },
     setSecurityConfig: (config) => {

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -1,7 +1,8 @@
 import { createServer, type Server as HttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { Hono } from 'hono';
 import type { ILlmClient } from '@franken/types';
 import { FileSessionStore, type ISessionStore } from '../chat/session-store.js';
@@ -342,13 +343,16 @@ function createNetworkSecurityConfigAdapter(networkControl: NonNullable<StartCha
     },
     setSecurityConfig: (config) => {
       const current = networkControl.getConfig();
-      networkControl.setConfig({
+      const next = {
         ...current,
         security: {
           ...current.security,
           ...config,
         },
-      });
+      };
+      networkControl.setConfig(next);
+      mkdirSync(dirname(networkControl.configFile), { recursive: true });
+      writeFileSync(networkControl.configFile, `${JSON.stringify(next, null, 2)}\n`, 'utf-8');
     },
   };
 }

--- a/packages/franken-orchestrator/src/http/http-server-utils.ts
+++ b/packages/franken-orchestrator/src/http/http-server-utils.ts
@@ -5,6 +5,7 @@ import type { Hono } from 'hono';
 
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 3737;
+const TRUSTED_REMOTE_ADDRESS_HEADER = 'x-frankenbeast-remote-address';
 
 export async function handleHonoHttpRequest(app: Hono, request: IncomingMessage, response: ServerResponse): Promise<void> {
   try {
@@ -57,6 +58,10 @@ function toRequest(request: IncomingMessage): Request {
     }
     headers.set(key, value);
   }
+
+  // Set after copying request headers so clients cannot spoof the trusted peer
+  // address consumed by security-sensitive route guards.
+  headers.set(TRUSTED_REMOTE_ADDRESS_HEADER, request.socket.remoteAddress ?? '');
 
   if (method === 'GET' || method === 'HEAD') {
     return new Request(url, { method, headers, signal: abortController.signal });

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { ChatGateway } from '../../comms/gateway/chat-gateway.js';
 import { SessionMapper } from '../../comms/core/session-mapper.js';
 import { slackRouter } from '../../comms/channels/slack/slack-router.js';
@@ -20,6 +20,7 @@ export interface CommsRoutesOptions {
   config: CommsConfig;
   runtime?: CommsRuntimePort;
   webhookSignaturePolicy?: WebhookSignaturePolicy;
+  getWebhookSignaturePolicy?: () => WebhookSignaturePolicy;
 }
 
 export function commsRoutes(options: CommsRoutesOptions): Hono {
@@ -34,23 +35,28 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   }
 
   const gateway = new ChatGateway(runtime);
-  const webhookSignaturePolicy = options.webhookSignaturePolicy ?? 'required';
-  const verifySignature = webhookSignaturePolicy === 'required';
+  const getWebhookSignaturePolicy = options.getWebhookSignaturePolicy
+    ?? (() => options.webhookSignaturePolicy ?? 'required');
+  const shouldVerifySignature = (c: Context) => {
+    const policy = getWebhookSignaturePolicy();
+    return policy !== 'local-dev-unsigned' || !isLoopbackWebhookRequest(c.req.raw);
+  };
 
-  if (!verifySignature) {
+  if (getWebhookSignaturePolicy() === 'local-dev-unsigned') {
     console.warn('[comms] Webhook signature verification disabled for loopback-only local development');
   }
 
   const app = new Hono();
 
-  if (!verifySignature) {
-    app.use('/webhooks/*', async (c, next) => {
-      if (!isLoopbackWebhookRequest(c.req.raw)) {
-        return c.json({ error: 'Unsigned webhooks are only allowed on loopback hosts' }, 403);
+  app.use('/webhooks/*', async (c, next) => {
+    if (getWebhookSignaturePolicy() === 'local-dev-unsigned') {
+      if (isLoopbackWebhookRequest(c.req.raw)) {
+        return next();
       }
-      return next();
-    });
-  }
+      return c.json({ error: 'Unsigned webhooks are only allowed on loopback hosts' }, 403);
+    }
+    return next();
+  });
 
   app.get('/comms/health', (c) => c.json({ status: 'ok' }));
 
@@ -62,7 +68,7 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
       gateway,
       sessionMapper,
       signingSecret: slack.signingSecret,
-      verifySignature,
+      verifySignature: shouldVerifySignature,
     }));
   }
 
@@ -74,7 +80,7 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
       gateway,
       sessionMapper,
       publicKey: discord.publicKey,
-      verifySignature,
+      verifySignature: shouldVerifySignature,
     }));
   }
 
@@ -101,7 +107,7 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
       sessionMapper,
       appSecret: whatsapp.appSecret,
       verifyToken: whatsapp.verifyToken,
-      verifySignature,
+      verifySignature: shouldVerifySignature,
     }));
   }
 
@@ -121,15 +127,33 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
 }
 
 function isLoopbackWebhookRequest(request: Request): boolean {
+  const hostname = new URL(request.url).hostname;
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  const realIp = request.headers.get('x-real-ip');
   const trustedRemoteAddress = request.headers.get(TRUSTED_REMOTE_ADDRESS_HEADER);
+
   if (trustedRemoteAddress !== null) {
-    return isLoopbackAddress(trustedRemoteAddress);
+    return isLoopbackAddress(trustedRemoteAddress)
+      && isLoopbackAddress(hostname)
+      && isForwardedForLoopback(forwardedFor)
+      && (realIp === null || isLoopbackAddress(realIp));
   }
 
   // Unit tests call Hono directly and therefore do not have an IncomingMessage
   // socket. In real Node HTTP traffic http-server-utils sets the trusted peer
   // address header above, after overwriting any client-supplied value.
-  return isLoopbackAddress(new URL(request.url).hostname);
+  return isLoopbackAddress(hostname);
+}
+
+function isForwardedForLoopback(forwardedFor: string | null): boolean {
+  if (forwardedFor === null) {
+    return true;
+  }
+  return forwardedFor
+    .split(',')
+    .map((address) => address.trim())
+    .filter(Boolean)
+    .every(isLoopbackAddress);
 }
 
 function isLoopbackAddress(address: string): boolean {

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -48,16 +48,6 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
 
   const app = new Hono();
 
-  app.use('/webhooks/*', async (c, next) => {
-    if (getWebhookSignaturePolicy() === 'local-dev-unsigned') {
-      if (isLoopbackWebhookRequest(c.req.raw)) {
-        return next();
-      }
-      return c.json({ error: 'Unsigned webhooks are only allowed on loopback hosts' }, 403);
-    }
-    return next();
-  });
-
   app.get('/comms/health', (c) => c.json({ status: 'ok' }));
 
   const slack = config.channels.slack;

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -12,12 +12,12 @@ import { WhatsAppAdapter } from '../../comms/channels/whatsapp/whatsapp-adapter.
 import type { CommsConfig } from '../../comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../../comms/core/comms-runtime-port.js';
 
-import type { SecurityProfile } from '../../middleware/security-profiles.js';
+import type { WebhookSignaturePolicy } from '../../middleware/security-profiles.js';
 
 export interface CommsRoutesOptions {
   config: CommsConfig;
   runtime?: CommsRuntimePort;
-  securityProfile?: SecurityProfile;
+  webhookSignaturePolicy?: WebhookSignaturePolicy;
 }
 
 export function commsRoutes(options: CommsRoutesOptions): Hono {
@@ -32,13 +32,23 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   }
 
   const gateway = new ChatGateway(runtime);
-  const verifySignature = options.securityProfile !== 'permissive';
+  const webhookSignaturePolicy = options.webhookSignaturePolicy ?? 'required';
+  const verifySignature = webhookSignaturePolicy === 'required';
 
   if (!verifySignature) {
-    console.warn('[comms] Webhook signature verification disabled (security profile: permissive)');
+    console.warn('[comms] Webhook signature verification disabled for loopback-only local development');
   }
 
   const app = new Hono();
+
+  if (!verifySignature) {
+    app.use('/webhooks/*', async (c, next) => {
+      if (!isLoopbackWebhookRequest(c.req.url)) {
+        return c.json({ error: 'Unsigned webhooks are only allowed on loopback hosts' }, 403);
+      }
+      return next();
+    });
+  }
 
   app.get('/comms/health', (c) => c.json({ status: 'ok' }));
 
@@ -106,4 +116,11 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   });
 
   return app;
+}
+
+function isLoopbackWebhookRequest(url: string): boolean {
+  const hostname = new URL(url).hostname.toLowerCase();
+  return hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname === '::1';
 }

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -14,6 +14,8 @@ import type { CommsRuntimePort } from '../../comms/core/comms-runtime-port.js';
 
 import type { WebhookSignaturePolicy } from '../../middleware/security-profiles.js';
 
+const TRUSTED_REMOTE_ADDRESS_HEADER = 'x-frankenbeast-remote-address';
+
 export interface CommsRoutesOptions {
   config: CommsConfig;
   runtime?: CommsRuntimePort;
@@ -43,7 +45,7 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
 
   if (!verifySignature) {
     app.use('/webhooks/*', async (c, next) => {
-      if (!isLoopbackWebhookRequest(c.req.url)) {
+      if (!isLoopbackWebhookRequest(c.req.raw)) {
         return c.json({ error: 'Unsigned webhooks are only allowed on loopback hosts' }, 403);
       }
       return next();
@@ -118,9 +120,22 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   return app;
 }
 
-function isLoopbackWebhookRequest(url: string): boolean {
-  const hostname = new URL(url).hostname.toLowerCase();
-  return hostname === 'localhost'
-    || hostname === '127.0.0.1'
-    || hostname === '::1';
+function isLoopbackWebhookRequest(request: Request): boolean {
+  const trustedRemoteAddress = request.headers.get(TRUSTED_REMOTE_ADDRESS_HEADER);
+  if (trustedRemoteAddress !== null) {
+    return isLoopbackAddress(trustedRemoteAddress);
+  }
+
+  // Unit tests call Hono directly and therefore do not have an IncomingMessage
+  // socket. In real Node HTTP traffic http-server-utils sets the trusted peer
+  // address header above, after overwriting any client-supplied value.
+  return isLoopbackAddress(new URL(request.url).hostname);
+}
+
+function isLoopbackAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  return normalized === 'localhost'
+    || normalized === '127.0.0.1'
+    || normalized === '::1'
+    || normalized === '::ffff:127.0.0.1';
 }

--- a/packages/franken-orchestrator/src/http/routes/security-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/security-routes.ts
@@ -47,7 +47,11 @@ export function createSecurityRoutes(deps: {
     ) as Partial<SecurityConfig>;
 
     if (parsed.profile) {
-      const resolved = resolveSecurityConfig(parsed.profile, parsed);
+      const current = deps.getSecurityConfig();
+      const resolved = resolveSecurityConfig(parsed.profile, {
+        webhookSignaturePolicy: current.webhookSignaturePolicy,
+        ...parsed,
+      });
       // Reject strict profile without allowedDomains
       if (
         resolved.profile === 'strict' &&

--- a/packages/franken-orchestrator/src/http/routes/security-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/security-routes.ts
@@ -19,6 +19,7 @@ export function createSecurityRoutes(deps: {
       config.injectionDetection !== defaults.injectionDetection ||
       config.piiMasking !== defaults.piiMasking ||
       config.outputValidation !== defaults.outputValidation ||
+      config.webhookSignaturePolicy !== defaults.webhookSignaturePolicy ||
       config.requireApproval !== defaults.requireApproval;
     return c.json({ ...config, isCustomized });
   });

--- a/packages/franken-orchestrator/src/middleware/security-profiles.ts
+++ b/packages/franken-orchestrator/src/middleware/security-profiles.ts
@@ -28,6 +28,15 @@ export interface SecurityConfig {
   customRules?: SecurityRule[];
 }
 
+const RegexPatternSchema = z.string().min(1).refine((pattern) => {
+  try {
+    new RegExp(pattern, 'i');
+    return true;
+  } catch {
+    return false;
+  }
+}, { message: 'pattern must be a valid regular expression' });
+
 export const SecurityConfigSchema = z.object({
   profile: z.enum(['strict', 'standard', 'permissive']),
   injectionDetection: z.boolean(),
@@ -41,7 +50,7 @@ export const SecurityConfigSchema = z.object({
     .array(
       z.object({
         name: z.string().min(1),
-        pattern: z.string().min(1),
+        pattern: RegexPatternSchema,
         action: z.enum(['block', 'warn', 'log']),
         target: z.enum(['request', 'response', 'both']),
       }),

--- a/packages/franken-orchestrator/src/middleware/security-profiles.ts
+++ b/packages/franken-orchestrator/src/middleware/security-profiles.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { MiddlewareChain, type LlmMiddleware } from './llm-middleware.js';
+import { MiddlewareChain } from './llm-middleware.js';
 import { InjectionDetectionMiddleware } from './injection-detection.js';
 import { PiiMaskingMiddleware } from './pii-masking.js';
 import { OutputValidationMiddleware } from './output-validation.js';
@@ -7,6 +7,7 @@ import { CustomRuleMiddleware } from './custom-rule.js';
 import { DomainAllowlistMiddleware } from './domain-allowlist.js';
 
 export type SecurityProfile = 'strict' | 'standard' | 'permissive';
+export type WebhookSignaturePolicy = 'required' | 'local-dev-unsigned';
 
 export interface SecurityRule {
   name: string;
@@ -20,6 +21,7 @@ export interface SecurityConfig {
   injectionDetection: boolean;
   piiMasking: boolean;
   outputValidation: boolean;
+  webhookSignaturePolicy: WebhookSignaturePolicy;
   allowedDomains?: string[];
   maxTokenBudget?: number;
   requireApproval: 'all' | 'destructive' | 'none';
@@ -31,6 +33,7 @@ export const SecurityConfigSchema = z.object({
   injectionDetection: z.boolean(),
   piiMasking: z.boolean(),
   outputValidation: z.boolean(),
+  webhookSignaturePolicy: z.enum(['required', 'local-dev-unsigned']),
   allowedDomains: z.array(z.string()).optional(),
   maxTokenBudget: z.number().positive().optional(),
   requireApproval: z.enum(['all', 'destructive', 'none']),
@@ -52,6 +55,7 @@ export const PROFILE_DEFAULTS: Record<SecurityProfile, SecurityConfig> = {
     injectionDetection: true,
     piiMasking: true,
     outputValidation: true,
+    webhookSignaturePolicy: 'required',
     allowedDomains: [],
     requireApproval: 'all',
   },
@@ -60,6 +64,7 @@ export const PROFILE_DEFAULTS: Record<SecurityProfile, SecurityConfig> = {
     injectionDetection: true,
     piiMasking: true,
     outputValidation: true,
+    webhookSignaturePolicy: 'required',
     requireApproval: 'destructive',
   },
   permissive: {
@@ -67,6 +72,7 @@ export const PROFILE_DEFAULTS: Record<SecurityProfile, SecurityConfig> = {
     injectionDetection: false,
     piiMasking: false,
     outputValidation: true,
+    webhookSignaturePolicy: 'required',
     requireApproval: 'none',
   },
 };

--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -206,5 +206,44 @@ describe('control-plane operator auth', () => {
       const bodyText = await res.text();
       expect(bodyText).not.toContain('Operator authentication is required');
     });
+
+    it('keeps webhook signatures required for permissive security profiles unless an explicit local override is set', async () => {
+      let networkConfig = defaultConfig();
+      const app = createChatApp({
+        sessionStoreDir: join(TMP, 'chat'),
+        llm: { complete: vi.fn().mockResolvedValue('hello') },
+        projectName: 'control-plane-auth',
+        operatorToken: OPERATOR_TOKEN,
+        networkControl: {
+          root: TMP,
+          frankenbeastDir: TMP,
+          configFile: join(TMP, 'config.json'),
+          getConfig: () => networkConfig,
+          setConfig: (next) => {
+            networkConfig = next;
+          },
+        },
+        commsConfig: {
+          orchestrator: {},
+          channels: {
+            slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+          },
+        } as CommsConfig,
+        commsRuntime: mockCommsRuntime(),
+        securityConfig: {
+          getSecurityConfig: () => resolveSecurityConfig('permissive'),
+          setSecurityConfig: vi.fn(),
+        },
+      });
+
+      const res = await app.request('/webhooks/slack/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'url_verification', challenge: 'ok' }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Missing security headers' });
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/integration/middleware/security-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/middleware/security-routes.test.ts
@@ -56,6 +56,26 @@ describe('Security API routes', () => {
     expect(body.requireApproval).toBe('none');
   });
 
+  it('PATCH /api/security with profile preserves explicit webhook signature policy', async () => {
+    const app = createTestApp();
+    const policyRes = await app.request('/api/security', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ webhookSignaturePolicy: 'local-dev-unsigned' }),
+    });
+    expect(policyRes.status).toBe(200);
+
+    const profileRes = await app.request('/api/security', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: 'permissive' }),
+    });
+    expect(profileRes.status).toBe(200);
+    const body = await profileRes.json();
+    expect(body.profile).toBe('permissive');
+    expect(body.webhookSignaturePolicy).toBe('local-dev-unsigned');
+  });
+
   it('PATCH /api/security with individual override', async () => {
     const app = createTestApp();
     const res = await app.request('/api/security', {

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -305,6 +305,27 @@ describe('bridgeToBeastConfig()', () => {
       expect(config.security?.profile).toBe('strict');
     });
 
+    it('passes webhook policy and custom rules through config.security', () => {
+      const customRules = [
+        { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+      ];
+      const orchestratorConfig = {
+        security: {
+          profile: 'standard',
+          webhookSignaturePolicy: 'local-dev-unsigned',
+          customRules,
+        },
+      } as any;
+
+      const config = bridgeToBeastConfig(makeOptions({}), orchestratorConfig);
+
+      expect(config.security).toEqual(expect.objectContaining({
+        profile: 'standard',
+        webhookSignaturePolicy: 'local-dev-unsigned',
+        customRules,
+      }));
+    });
+
     it('uses config.brain.dbPath when provided', () => {
       const orchestratorConfig = { brain: { dbPath: '/custom/brain.db' } } as any;
       const config = bridgeToBeastConfig(makeOptions({}), orchestratorConfig);

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1001,6 +1001,43 @@ describe('main() execution', () => {
 
   it('dispatches chat-server without creating a Session or REPL', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(loadConfig).mockResolvedValueOnce({
+      maxCritiqueIterations: 3,
+      maxDurationMs: 600_000,
+      enableTracing: false,
+      enableHeartbeat: false,
+      minCritiqueScore: 0.7,
+      maxTotalTokens: 100_000,
+      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      security: {
+        profile: 'permissive',
+        webhookSignaturePolicy: 'local-dev-unsigned',
+        customRules: [{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }],
+      },
+      network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+      comms: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 3200,
+        orchestratorWsUrl: 'ws://127.0.0.1:3737/v1/chat/ws',
+        slack: { enabled: false },
+        discord: { enabled: false },
+        telegram: { enabled: false },
+        whatsapp: { enabled: false },
+      },
+    } as any);
+    mockCreateCliDeps.mockResolvedValueOnce({
+      deps: {},
+      cliLlmAdapter: { name: 'chat-adapter' },
+      observerBridge: {},
+      logger: {},
+      finalize: mockFinalize,
+      skillManager: {},
+      providerRegistry: { getProviders: vi.fn(() => []) },
+    } as any);
     mockParseArgs.mockReturnValue({
       subcommand: 'chat-server',
       networkAction: undefined,
@@ -1050,6 +1087,12 @@ describe('main() execution', () => {
       beastControl: expect.objectContaining({
         operatorToken: 'dashboard-operator-token',
       }),
+    }));
+    const startOptions = (mockStartChatServer.mock.calls as any[])[0][0];
+    expect(startOptions.dashboardDeps?.getSecurityConfig()).toEqual(expect.objectContaining({
+      profile: 'permissive',
+      webhookSignaturePolicy: 'local-dev-unsigned',
+      customRules: [{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }],
     }));
     expect(MockSession).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3737'));

--- a/packages/franken-orchestrator/tests/unit/cli/security-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/security-cli.test.ts
@@ -14,6 +14,7 @@ describe('handleSecurityCommand()', () => {
     expect(print).toHaveBeenCalledWith(expect.stringContaining('Injection Detection'));
     expect(print).toHaveBeenCalledWith(expect.stringContaining('PII Masking'));
     expect(print).toHaveBeenCalledWith(expect.stringContaining('Output Validation'));
+    expect(print).toHaveBeenCalledWith('  Webhook Signature Policy: required');
   });
 
   it('defaults to standard profile when none provided', async () => {
@@ -89,7 +90,7 @@ describe('handleSecurityCommand()', () => {
 
     await handleSecurityCommand({
       action: 'status',
-      currentSecurity: { profile: 'permissive', piiMasking: true },
+      currentSecurity: { profile: 'permissive', piiMasking: true, webhookSignaturePolicy: 'local-dev-unsigned' },
       print,
     });
 
@@ -97,6 +98,7 @@ describe('handleSecurityCommand()', () => {
     expect(print).toHaveBeenCalledWith('  Injection Detection: off');
     expect(print).toHaveBeenCalledWith('  PII Masking: on');
     expect(print).toHaveBeenCalledWith('  Output Validation: on');
+    expect(print).toHaveBeenCalledWith('  Webhook Signature Policy: local-dev-unsigned');
   });
 
   it('preserves existing config and security settings when setting profile', async () => {

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -47,6 +47,30 @@ describe('OrchestratorConfig', () => {
       expect(result.success).toBe(false);
     });
 
+    it('accepts security custom rules in config', () => {
+      const result = OrchestratorConfigSchema.parse({
+        security: {
+          customRules: [
+            { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+          ],
+        },
+      });
+
+      expect(result.security?.customRules).toEqual([
+        { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+      ]);
+    });
+
+    it('rejects malformed security custom rules', () => {
+      const result = OrchestratorConfigSchema.safeParse({
+        security: {
+          customRules: [{ name: '', pattern: 'secret', action: 'block', target: 'request' }],
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
     it('rejects out-of-range critique iterations', () => {
       expect(() =>
         OrchestratorConfigSchema.parse({ maxCritiqueIterations: 0 }),

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -64,7 +64,7 @@ describe('OrchestratorConfig', () => {
     it('rejects malformed security custom rules', () => {
       const result = OrchestratorConfigSchema.safeParse({
         security: {
-          customRules: [{ name: '', pattern: 'secret', action: 'block', target: 'request' }],
+          customRules: [{ name: 'bad-regex', pattern: '[', action: 'block', target: 'request' }],
         },
       });
 

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -25,6 +25,28 @@ describe('OrchestratorConfig', () => {
       expect(result.enableHeartbeat).toBe(false); // secure default preserved
     });
 
+    it('accepts explicit local-only webhook signature override in security config', () => {
+      const result = OrchestratorConfigSchema.parse({
+        security: {
+          profile: 'permissive',
+          webhookSignaturePolicy: 'local-dev-unsigned',
+        },
+      });
+
+      expect(result.security?.profile).toBe('permissive');
+      expect(result.security?.webhookSignaturePolicy).toBe('local-dev-unsigned');
+    });
+
+    it('rejects invalid webhook signature policies', () => {
+      const result = OrchestratorConfigSchema.safeParse({
+        security: {
+          webhookSignaturePolicy: 'disabled',
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
     it('rejects out-of-range critique iterations', () => {
       expect(() =>
         OrchestratorConfigSchema.parse({ maxCritiqueIterations: 0 }),

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -63,6 +63,36 @@ describe('startChatServer comms pass-through', () => {
     expect(opts).toHaveProperty('commsRuntime', commsRuntime);
   });
 
+  it('passes network security config to createChatApp so comms can read webhook policy', async () => {
+    let config = {
+      security: {
+        profile: 'permissive' as const,
+        webhookSignaturePolicy: 'local-dev-unsigned' as const,
+      },
+    };
+
+    handle = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir: '/tmp/chat-server-comms-test',
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      commsConfig: { orchestrator: {}, channels: {} },
+      networkControl: {
+        root: '/tmp/project',
+        frankenbeastDir: '/tmp/project/.frankenbeast',
+        configFile: '/tmp/project/.frankenbeast/config.json',
+        getConfig: () => config,
+        setConfig: (next) => {
+          config = next as typeof config;
+        },
+      },
+    });
+
+    const opts = mockedCreateChatApp.mock.calls[0]![0];
+    expect(opts.securityConfig?.getSecurityConfig().webhookSignaturePolicy).toBe('local-dev-unsigned');
+  });
+
   it('creates a chat-runtime comms adapter when commsConfig is provided without a runtime', async () => {
     const commsConfig: CommsConfig = {
       orchestrator: {},

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -71,6 +71,7 @@ describe('startChatServer comms pass-through', () => {
       security: {
         profile: 'strict' | 'standard' | 'permissive';
         webhookSignaturePolicy: 'required' | 'local-dev-unsigned';
+        customRules?: Array<{ name: string; pattern: string; action: 'block' | 'warn' | 'log'; target: 'request' | 'response' | 'both' }>;
       };
     } = {
       security: {
@@ -100,9 +101,18 @@ describe('startChatServer comms pass-through', () => {
     const opts = mockedCreateChatApp.mock.calls[0]![0];
     expect(opts.securityConfig?.getSecurityConfig().webhookSignaturePolicy).toBe('local-dev-unsigned');
 
-    opts.securityConfig?.setSecurityConfig({ webhookSignaturePolicy: 'required' });
+    opts.securityConfig?.setSecurityConfig({
+      webhookSignaturePolicy: 'required',
+      customRules: [{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }],
+    });
     expect(config.security.webhookSignaturePolicy).toBe('required');
-    await expect(readFile(configFile, 'utf-8')).resolves.toContain('"webhookSignaturePolicy": "required"');
+    expect(config.security.customRules).toEqual([{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }]);
+    expect(opts.securityConfig?.getSecurityConfig().customRules).toEqual([
+      { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+    ]);
+    const writtenConfig = await readFile(configFile, 'utf-8');
+    expect(writtenConfig).toContain('"webhookSignaturePolicy": "required"');
+    expect(writtenConfig).toContain('"customRules"');
   });
 
   it('creates a chat-runtime comms adapter when commsConfig is provided without a runtime', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -64,10 +64,18 @@ describe('startChatServer comms pass-through', () => {
   });
 
   it('passes network security config to createChatApp so comms can read webhook policy', async () => {
-    let config = {
+    const dir = await mkdtemp(join(tmpdir(), 'chat-server-security-config-'));
+    tempDirs.push(dir);
+    const configFile = join(dir, 'config.json');
+    let config: {
       security: {
-        profile: 'permissive' as const,
-        webhookSignaturePolicy: 'local-dev-unsigned' as const,
+        profile: 'strict' | 'standard' | 'permissive';
+        webhookSignaturePolicy: 'required' | 'local-dev-unsigned';
+      };
+    } = {
+      security: {
+        profile: 'permissive',
+        webhookSignaturePolicy: 'local-dev-unsigned',
       },
     };
 
@@ -81,8 +89,8 @@ describe('startChatServer comms pass-through', () => {
       networkControl: {
         root: '/tmp/project',
         frankenbeastDir: '/tmp/project/.frankenbeast',
-        configFile: '/tmp/project/.frankenbeast/config.json',
-        getConfig: () => config,
+        configFile,
+        getConfig: () => config as never,
         setConfig: (next) => {
           config = next as typeof config;
         },
@@ -91,6 +99,10 @@ describe('startChatServer comms pass-through', () => {
 
     const opts = mockedCreateChatApp.mock.calls[0]![0];
     expect(opts.securityConfig?.getSecurityConfig().webhookSignaturePolicy).toBe('local-dev-unsigned');
+
+    opts.securityConfig?.setSecurityConfig({ webhookSignaturePolicy: 'required' });
+    expect(config.security.webhookSignaturePolicy).toBe('required');
+    await expect(readFile(configFile, 'utf-8')).resolves.toContain('"webhookSignaturePolicy": "required"');
   });
 
   it('creates a chat-runtime comms adapter when commsConfig is provided without a runtime', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -159,6 +159,47 @@ describe('commsRoutes', () => {
     });
     expect(spoofedHost.status).toBe(403);
     expect(await spoofedHost.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+
+    const proxiedExternal = await app.request('https://public.example/webhooks/slack/events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-frankenbeast-remote-address': '127.0.0.1',
+        'x-forwarded-for': '203.0.113.10',
+      },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'blocked' }),
+    });
+    expect(proxiedExternal.status).toBe(403);
+    expect(await proxiedExternal.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+  });
+
+  it('re-evaluates webhook signature policy for each request', async () => {
+    let webhookSignaturePolicy: 'required' | 'local-dev-unsigned' = 'local-dev-unsigned';
+    const app = commsRoutes({
+      config: minimalConfig({
+        channels: {
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+        },
+      }),
+      runtime: mockRuntime(),
+      getWebhookSignaturePolicy: () => webhookSignaturePolicy,
+    });
+
+    const localUnsigned = await app.request('http://localhost/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'ok' }),
+    });
+    expect(localUnsigned.status).toBe(200);
+
+    webhookSignaturePolicy = 'required';
+    const nowRequired = await app.request('http://localhost/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'blocked' }),
+    });
+    expect(nowRequired.status).toBe(401);
+    expect(await nowRequired.json()).toEqual({ error: 'Missing security headers' });
   });
 
   it('throws when runtime is not provided', () => {

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -128,6 +128,37 @@ describe('commsRoutes', () => {
     });
     expect(external.status).toBe(403);
     expect(await external.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+
+    const trustedIpv6Loopback = await app.request('http://[::1]/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'ipv6-ok' }),
+    });
+    expect(trustedIpv6Loopback.status).toBe(200);
+    expect(await trustedIpv6Loopback.json()).toEqual({ challenge: 'ipv6-ok' });
+  });
+
+  it('uses the trusted remote address instead of the client-controlled host for unsigned webhooks', async () => {
+    const app = commsRoutes({
+      config: minimalConfig({
+        channels: {
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+        },
+      }),
+      runtime: mockRuntime(),
+      webhookSignaturePolicy: 'local-dev-unsigned',
+    });
+
+    const spoofedHost = await app.request('http://localhost/webhooks/slack/events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-frankenbeast-remote-address': '203.0.113.10',
+      },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'blocked' }),
+    });
+    expect(spoofedHost.status).toBe(403);
+    expect(await spoofedHost.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
   });
 
   it('throws when runtime is not provided', () => {

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -126,8 +126,8 @@ describe('commsRoutes', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'url_verification', challenge: 'ok' }),
     });
-    expect(external.status).toBe(403);
-    expect(await external.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+    expect(external.status).toBe(401);
+    expect(await external.json()).toEqual({ error: 'Missing security headers' });
 
     const trustedIpv6Loopback = await app.request('http://[::1]/webhooks/slack/events', {
       method: 'POST',
@@ -138,7 +138,7 @@ describe('commsRoutes', () => {
     expect(await trustedIpv6Loopback.json()).toEqual({ challenge: 'ipv6-ok' });
   });
 
-  it('uses the trusted remote address instead of the client-controlled host for unsigned webhooks', async () => {
+  it('requires signatures when trusted remote address or proxy headers show external traffic', async () => {
     const app = commsRoutes({
       config: minimalConfig({
         channels: {
@@ -157,8 +157,8 @@ describe('commsRoutes', () => {
       },
       body: JSON.stringify({ type: 'url_verification', challenge: 'blocked' }),
     });
-    expect(spoofedHost.status).toBe(403);
-    expect(await spoofedHost.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+    expect(spoofedHost.status).toBe(401);
+    expect(await spoofedHost.json()).toEqual({ error: 'Missing security headers' });
 
     const proxiedExternal = await app.request('https://public.example/webhooks/slack/events', {
       method: 'POST',
@@ -169,8 +169,8 @@ describe('commsRoutes', () => {
       },
       body: JSON.stringify({ type: 'url_verification', challenge: 'blocked' }),
     });
-    expect(proxiedExternal.status).toBe(403);
-    expect(await proxiedExternal.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+    expect(proxiedExternal.status).toBe(401);
+    expect(await proxiedExternal.json()).toEqual({ error: 'Missing security headers' });
   });
 
   it('re-evaluates webhook signature policy for each request', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -82,6 +82,54 @@ describe('commsRoutes', () => {
     expect(res.status).toBe(404);
   });
 
+  it('requires webhook signatures by default even when the security profile is permissive elsewhere', async () => {
+    const app = commsRoutes({
+      config: minimalConfig({
+        channels: {
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+        },
+      }),
+      runtime: mockRuntime(),
+    });
+
+    const res = await app.request('/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'ok' }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Missing security headers' });
+  });
+
+  it('allows unsigned webhooks only for the explicit loopback development policy', async () => {
+    const app = commsRoutes({
+      config: minimalConfig({
+        channels: {
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+        },
+      }),
+      runtime: mockRuntime(),
+      webhookSignaturePolicy: 'local-dev-unsigned',
+    });
+
+    const local = await app.request('http://localhost/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'ok' }),
+    });
+    expect(local.status).toBe(200);
+    expect(await local.json()).toEqual({ challenge: 'ok' });
+
+    const external = await app.request('https://example.com/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'url_verification', challenge: 'ok' }),
+    });
+    expect(external.status).toBe(403);
+    expect(await external.json()).toEqual({ error: 'Unsigned webhooks are only allowed on loopback hosts' });
+  });
+
   it('throws when runtime is not provided', () => {
     expect(() => commsRoutes({ config: minimalConfig() })).toThrow('CommsRuntimePort');
   });

--- a/packages/franken-orchestrator/tests/unit/middleware/security-profiles.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/security-profiles.test.ts
@@ -4,7 +4,6 @@ import {
   resolveSecurityConfig,
   buildMiddlewareChain,
   type SecurityConfig,
-  type SecurityProfile,
   SecurityConfigSchema,
 } from '../../../src/middleware/security-profiles.js';
 
@@ -15,6 +14,7 @@ describe('SecurityProfiles', () => {
       expect(s.injectionDetection).toBe(true);
       expect(s.piiMasking).toBe(true);
       expect(s.outputValidation).toBe(true);
+      expect(s.webhookSignaturePolicy).toBe('required');
       expect(s.requireApproval).toBe('all');
     });
 
@@ -23,14 +23,16 @@ describe('SecurityProfiles', () => {
       expect(s.injectionDetection).toBe(true);
       expect(s.piiMasking).toBe(true);
       expect(s.outputValidation).toBe(true);
+      expect(s.webhookSignaturePolicy).toBe('required');
       expect(s.requireApproval).toBe('destructive');
     });
 
-    it('permissive only enables output validation', () => {
+    it('permissive only relaxes LLM middleware and approvals', () => {
       const s = PROFILE_DEFAULTS.permissive;
       expect(s.injectionDetection).toBe(false);
       expect(s.piiMasking).toBe(false);
       expect(s.outputValidation).toBe(true);
+      expect(s.webhookSignaturePolicy).toBe('required');
       expect(s.requireApproval).toBe('none');
     });
   });
@@ -65,6 +67,14 @@ describe('SecurityProfiles', () => {
         customRules: [{ name: 'no-sql', pattern: 'DROP TABLE', action: 'block', target: 'request' }],
       });
       expect(config.customRules).toHaveLength(1);
+    });
+
+    it('allows an explicit local-only webhook signature override independent of profile', () => {
+      const config = resolveSecurityConfig('permissive', {
+        webhookSignaturePolicy: 'local-dev-unsigned',
+      });
+      expect(config.profile).toBe('permissive');
+      expect(config.webhookSignaturePolicy).toBe('local-dev-unsigned');
     });
   });
 
@@ -108,6 +118,7 @@ describe('SecurityProfiles', () => {
         injectionDetection: true,
         piiMasking: true,
         outputValidation: true,
+        webhookSignaturePolicy: 'required',
         requireApproval: 'destructive',
       };
       expect(SecurityConfigSchema.parse(config)).toEqual(config);
@@ -115,7 +126,13 @@ describe('SecurityProfiles', () => {
 
     it('rejects invalid profile', () => {
       expect(() =>
-        SecurityConfigSchema.parse({ profile: 'invalid', injectionDetection: true, piiMasking: true, outputValidation: true, requireApproval: 'all' }),
+        SecurityConfigSchema.parse({ profile: 'invalid', injectionDetection: true, piiMasking: true, outputValidation: true, webhookSignaturePolicy: 'required', requireApproval: 'all' }),
+      ).toThrow();
+    });
+
+    it('rejects invalid webhook signature policy', () => {
+      expect(() =>
+        SecurityConfigSchema.parse({ profile: 'standard', injectionDetection: true, piiMasking: true, outputValidation: true, webhookSignaturePolicy: 'disabled', requireApproval: 'destructive' }),
       ).toThrow();
     });
 
@@ -125,6 +142,7 @@ describe('SecurityProfiles', () => {
         injectionDetection: true,
         piiMasking: true,
         outputValidation: true,
+        webhookSignaturePolicy: 'local-dev-unsigned',
         requireApproval: 'all',
         allowedDomains: ['github.com'],
         maxTokenBudget: 50000,

--- a/packages/franken-orchestrator/tests/unit/middleware/security-profiles.test.ts
+++ b/packages/franken-orchestrator/tests/unit/middleware/security-profiles.test.ts
@@ -149,5 +149,18 @@ describe('SecurityProfiles', () => {
       };
       expect(SecurityConfigSchema.parse(config)).toEqual(config);
     });
+
+    it('rejects invalid custom rule regex patterns', () => {
+      const config: SecurityConfig = {
+        profile: 'standard',
+        injectionDetection: true,
+        piiMasking: true,
+        outputValidation: true,
+        webhookSignaturePolicy: 'required',
+        requireApproval: 'destructive',
+        customRules: [{ name: 'bad-regex', pattern: '[', action: 'block', target: 'request' }],
+      };
+      expect(() => SecurityConfigSchema.parse(config)).toThrow('pattern must be a valid regular expression');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- decouple provider webhook signature verification from the broad `permissive` security profile
- add explicit `webhookSignaturePolicy` security config with secure default `required`
- permit unsigned webhook requests only via the explicit `local-dev-unsigned` policy and only for loopback-host requests

## Test Plan
- `npm run build --workspace @franken/types`
- `npm run build --workspace franken-brain`
- `npm run build --workspace franken-planner`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @frankenbeast/observer`
- `npm test --workspace franken-orchestrator -- tests/unit/middleware/security-profiles.test.ts tests/unit/http/comms-routes.test.ts tests/unit/config/orchestrator-config.test.ts tests/integration/http/control-plane-auth.test.ts`
- `npm run typecheck --workspace franken-orchestrator`
- `npm run build --workspace franken-orchestrator`
- `npm run lint --workspace franken-orchestrator` (passes with existing warnings)
- `git diff --check`

Closes #612
