### PR TITLE
fix(security): fail closed for unsigned exposed webhooks

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -185,6 +185,31 @@ function createCommsRuntimeAdapter(
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
 
+function enabledSignedExternalWebhookChannels(commsConfig: CommsConfig | undefined): string[] {
+  if (!commsConfig) {
+    return [];
+  }
+
+  const channels = commsConfig.channels;
+  const enabledChannels: string[] = [];
+  if (channels.slack?.enabled && channels.slack.token && channels.slack.signingSecret) {
+    enabledChannels.push('slack');
+  }
+  if (channels.discord?.enabled && channels.discord.token && channels.discord.publicKey) {
+    enabledChannels.push('discord');
+  }
+  if (
+    channels.whatsapp?.enabled
+    && channels.whatsapp.accessToken
+    && channels.whatsapp.phoneNumberId
+    && channels.whatsapp.appSecret
+    && channels.whatsapp.verifyToken
+  ) {
+    enabledChannels.push('whatsapp');
+  }
+  return enabledChannels;
+}
+
 export async function startChatServer(options: StartChatServerOptions): Promise<ChatServerHandle> {
   const host = options.host ?? DEFAULT_HOST;
   const port = options.port ?? DEFAULT_PORT;
@@ -224,6 +249,20 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       + 'or bind to a loopback host. Pass allowUnauthenticatedChatForTests in tests.',
     );
   }
+  const securityConfig = options.networkControl
+    ? createNetworkSecurityConfigAdapter(options.networkControl)
+    : undefined;
+  const webhookSignaturePolicy = securityConfig?.getSecurityConfig().webhookSignaturePolicy ?? 'required';
+  const unsignedExternalWebhookChannels = webhookSignaturePolicy === 'local-dev-unsigned'
+    ? enabledSignedExternalWebhookChannels(options.commsConfig)
+    : [];
+  if (isExposed && unsignedExternalWebhookChannels.length > 0) {
+    throw new Error(
+      `Refusing to start chat-server on ${host} with unsigned external webhooks enabled: `
+      + `${unsignedExternalWebhookChannels.join(', ')} webhooks require signature verification when the listener is exposed. `
+      + 'Set security.webhookSignaturePolicy to "required" or bind to a loopback-only local-dev host.',
+    );
+  }
   const tokenSecret = createSessionTokenSecret();
   const sessionStore = resolveChatServerSessionStore(options);
   const runtime = createChatRuntime({
@@ -253,9 +292,6 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ?? (options.commsConfig
       ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName)
       : undefined);
-  const securityConfig = options.networkControl
-    ? createNetworkSecurityConfigAdapter(options.networkControl)
-    : undefined;
   const app = createChatApp({
     sessionStore,
     engine: runtime.engine,

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import process from 'node:process';
 
 vi.mock('../../../src/http/chat-app.js', () => {
   const { Hono } = require('hono') as typeof import('hono');
@@ -113,6 +114,88 @@ describe('startChatServer comms pass-through', () => {
     const writtenConfig = await readFile(configFile, 'utf-8');
     expect(writtenConfig).toContain('"webhookSignaturePolicy": "required"');
     expect(writtenConfig).toContain('"customRules"');
+  });
+
+  it('fails closed when managed mode exposes unsigned external webhooks', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chat-server-unsigned-webhooks-'));
+    tempDirs.push(dir);
+    const previous = process.env['FRANKENBEAST_NETWORK_MANAGED'];
+    process.env['FRANKENBEAST_NETWORK_MANAGED'] = '1';
+    try {
+      await expect(startChatServer({
+        host: '127.0.0.1',
+        port: 0,
+        sessionStoreDir: '/tmp/chat-server-comms-test',
+        llm: { complete: vi.fn().mockResolvedValue('ok') },
+        projectName: 'test',
+        operatorToken: 'operator-token',
+        commsConfig: {
+          orchestrator: {},
+          channels: {
+            slack: {
+              enabled: true,
+              token: 'slack-token',
+              signingSecret: 'slack-signing-secret',
+            },
+          },
+        },
+        networkControl: {
+          root: '/tmp/project',
+          frankenbeastDir: '/tmp/project/.frankenbeast',
+          configFile: join(dir, 'config.json'),
+          getConfig: () => ({
+            security: {
+              profile: 'permissive',
+              webhookSignaturePolicy: 'local-dev-unsigned',
+            },
+          }) as never,
+          setConfig: vi.fn(),
+        },
+      })).rejects.toThrow(/unsigned external webhooks/i);
+    } finally {
+      if (previous === undefined) {
+        delete process.env['FRANKENBEAST_NETWORK_MANAGED'];
+      } else {
+        process.env['FRANKENBEAST_NETWORK_MANAGED'] = previous;
+      }
+    }
+  });
+
+  it('allows unsigned external webhooks on loopback-only local development', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chat-server-local-webhooks-'));
+    tempDirs.push(dir);
+
+    handle = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir: '/tmp/chat-server-comms-test',
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      commsConfig: {
+        orchestrator: {},
+        channels: {
+          slack: {
+            enabled: true,
+            token: 'slack-token',
+            signingSecret: 'slack-signing-secret',
+          },
+        },
+      },
+      networkControl: {
+        root: '/tmp/project',
+        frankenbeastDir: '/tmp/project/.frankenbeast',
+        configFile: join(dir, 'config.json'),
+        getConfig: () => ({
+          security: {
+            profile: 'permissive',
+            webhookSignaturePolicy: 'local-dev-unsigned',
+          },
+        }) as never,
+        setConfig: vi.fn(),
+      },
+    });
+
+    expect(mockedCreateChatApp).toHaveBeenCalledOnce();
   });
 
   it('creates a chat-runtime comms adapter when commsConfig is provided without a runtime', async () => {


### PR DESCRIPTION
## Summary
- fail chat-server startup when an exposed listener would run Slack/Discord/WhatsApp webhooks under local-dev unsigned signature policy
- keep loopback-only local development allowed
- add targeted chat-server comms tests for managed/exposed fail-closed behavior

## Test Plan
- npm test -- tests/unit/http/chat-server-comms.test.ts
- npm run typecheck
- npm run build
- npm run lint (passes with existing warnings)

Closes #611