### PR TITLE
fix(security): redact Beast failure stderr tails

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -13,7 +13,7 @@ const REDACTED_SECRET = '[REDACTED]';
 
 function redactFailureStderrLine(line: string): string {
   return line
-    .replace(/(authorization\s*:\s*(?:bearer|basic|bot)\s+)\S+/gi, `$1${REDACTED_SECRET}`)
+    .replace(/((?:"|')?authorization(?:"|')?\s*:\s*(?:"|')?(?:bearer|basic|bot)\s+)[^\s"',;}]+/gi, `$1${REDACTED_SECRET}`)
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, `$1${REDACTED_SECRET}`)
     .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTED_SECRET)
     .replace(/\bgithub_pat_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}_[A-Za-z0-9]{40,}\b/gi, REDACTED_SECRET)
@@ -22,10 +22,10 @@ function redactFailureStderrLine(line: string): string {
     .replace(/\bAIza[0-9A-Za-z_-]{35}\b/g, REDACTED_SECRET)
     .replace(/\bxoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{19,}[A-Za-z0-9]\b/gi, REDACTED_SECRET)
     .replace(
-      /((?:"|')?\b(?:[a-z0-9]+[_-])*(?:password|passwd|pwd|secret|client[_-]?secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url|[a-z0-9]*(?:token|secret|password|apikey|accesskey|webhookurl))\b(?:"|')?\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;}]+)/gi,
+      /((?:"|')?\b(?:[a-z0-9]+[_-])*(?:password|passwd|pwd|secret|client[_-]?secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url|[a-z0-9]*(?:token|secret|password|apikey|accesskey|webhookurl))\b(?:"|')?\s*[=:]\s*)((?:"(?:\\.|[^"\\])*")|(?:'(?:\\.|[^'\\])*')|[^\s,;}]+)/gi,
       `$1${REDACTED_SECRET}`,
     )
-    .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, `$1${REDACTED_SECRET}$2`)
+    .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]*:)[^\s@]+(@)/gi, `$1${REDACTED_SECRET}$2`)
     .replace(
       /https?:\/\/[^\s'"`<>]*(?:hooks\.slack\.com\/services|discord(?:app)?\.com\/api\/webhooks|webhook)[^\s'"`<>]*/gi,
       REDACTED_SECRET,

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -9,6 +9,27 @@ import type { ProcessSupervisorLike } from './process-supervisor.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
 const STDERR_BUFFER_SIZE = 50;
+const REDACTED_SECRET = '[REDACTED]';
+
+function redactFailureStderrLine(line: string): string {
+  return line
+    .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, `$1${REDACTED_SECRET}`)
+    .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, `$1${REDACTED_SECRET}`)
+    .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTED_SECRET)
+    .replace(
+      /(\b(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      `$1${REDACTED_SECRET}`,
+    )
+    .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, `$1${REDACTED_SECRET}$2`)
+    .replace(
+      /https?:\/\/[^\s'"`<>]*(?:hooks\.slack\.com\/services|discord(?:app)?\.com\/api\/webhooks|webhook)[^\s'"`<>]*/gi,
+      REDACTED_SECRET,
+    );
+}
+
+function redactFailureStderrTail(stderrTail: readonly string[]): string[] {
+  return stderrTail.map(redactFailureStderrLine);
+}
 
 function moduleConfigToEnv(config?: ModuleConfig): Record<string, string> {
   if (!config) return {};
@@ -407,6 +428,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     const durationMs = attemptRecord?.startedAt
       ? new Date(finishedAt).getTime() - new Date(attemptRecord.startedAt).getTime()
       : undefined;
+    const redactedStderrTail = code !== 0 ? redactFailureStderrTail(stderrTail) : [];
     const exitEvent = {
       attemptId,
       type: eventType,
@@ -414,7 +436,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         exitCode: code,
         signal,
         ...(durationMs !== undefined ? { durationMs } : {}),
-        ...(code !== 0 ? { lastStderrLines: stderrTail, summary: `Process exited with code ${code}` } : {}),
+        ...(code !== 0 ? { lastStderrLines: redactedStderrTail, summary: `Process exited with code ${code}` } : {}),
       },
       createdAt: finishedAt,
     };

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -19,9 +19,10 @@ function redactFailureStderrLine(line: string): string {
     .replace(/\bgithub_pat_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}_[A-Za-z0-9]{40,}\b/gi, REDACTED_SECRET)
     .replace(/\b(?:gh[opusr])_[A-Za-z0-9_.-]{20,}\b/gi, REDACTED_SECRET)
     .replace(/\bsk-[A-Za-z0-9_-]{15,}[A-Za-z0-9_-]\b/g, REDACTED_SECRET)
+    .replace(/\bAIza[0-9A-Za-z_-]{35}\b/g, REDACTED_SECRET)
     .replace(/\bxoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{19,}[A-Za-z0-9]\b/gi, REDACTED_SECRET)
     .replace(
-      /(\b(?:[a-z0-9]+[_-])*(?:password|passwd|pwd|secret|client[_-]?secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      /((?:"|')?\b(?:[a-z0-9]+[_-])*(?:password|passwd|pwd|secret|client[_-]?secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url|[a-z0-9]*(?:token|secret|password|apikey|accesskey|webhookurl))\b(?:"|')?\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;}]+)/gi,
       `$1${REDACTED_SECRET}`,
     )
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, `$1${REDACTED_SECRET}$2`)
@@ -195,17 +196,18 @@ export class ProcessBeastExecutor implements BeastExecutor {
           }
         },
         onStderr: (line) => {
-          stderrTail.push(line);
+          const redactedLine = redactFailureStderrLine(line);
+          stderrTail.push(redactedLine);
           if (stderrTail.length > STDERR_BUFFER_SIZE) stderrTail.shift();
           if (attemptId) {
             const createdAt = new Date().toISOString();
-            void this.logs.append(run.id, attemptId, 'stderr', line, createdAt);
+            void this.logs.append(run.id, attemptId, 'stderr', redactedLine, createdAt);
             this.options.eventBus?.publish({
               type: 'run.log',
-              data: { runId: run.id, attemptId, stream: 'stderr', line, createdAt },
+              data: { runId: run.id, attemptId, stream: 'stderr', line: redactedLine, createdAt },
             });
           } else {
-            earlyStderrLines.push(line);
+            earlyStderrLines.push(redactedLine);
           }
         },
         onExit: (code, signal) => {

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -13,11 +13,15 @@ const REDACTED_SECRET = '[REDACTED]';
 
 function redactFailureStderrLine(line: string): string {
   return line
-    .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, `$1${REDACTED_SECRET}`)
+    .replace(/(authorization\s*:\s*(?:bearer|basic|bot)\s+)\S+/gi, `$1${REDACTED_SECRET}`)
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, `$1${REDACTED_SECRET}`)
     .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTED_SECRET)
+    .replace(/\bgithub_pat_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}_[A-Za-z0-9]{40,}\b/gi, REDACTED_SECRET)
+    .replace(/\b(?:gh[opusr])_[A-Za-z0-9_.-]{20,}\b/gi, REDACTED_SECRET)
+    .replace(/\bsk-[A-Za-z0-9_-]{15,}[A-Za-z0-9_-]\b/g, REDACTED_SECRET)
+    .replace(/\bxoxb-(?:\d{10,}-){2}[A-Za-z0-9-]{19,}[A-Za-z0-9]\b/gi, REDACTED_SECRET)
     .replace(
-      /(\b(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      /(\b(?:[a-z0-9]+[_-])*(?:password|passwd|pwd|secret|client[_-]?secret|token|api[_-]?key|access[_-]?key|webhook[_-]?url)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/gi,
       `$1${REDACTED_SECRET}`,
     )
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, `$1${REDACTED_SECRET}$2`)

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -707,6 +707,7 @@ describe('ProcessBeastExecutor', () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
       const logs = new BeastLogStore(join(workDir, 'logs'));
+      const appendSpy = vi.spyOn(logs, 'append');
       const eventBus = new BeastEventBus();
       const publishSpy = vi.spyOn(eventBus, 'publish');
       const supervisor = createSupervisorMock();
@@ -720,15 +721,19 @@ describe('ProcessBeastExecutor', () => {
       const standaloneOpenAiKey = `sk-${'standaloneproviderkey1234567890'}`;
       const githubToken = `ghp_${'abcdefghijklmnopqrstuvwxyz123456'}`;
       const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
+      const geminiToken = `AIza${'abcdefghijklmnopqrstuvwxyz123456789'}`;
 
       cb.onStderr('api_key=sk-live-secret-value password=hunter2');
       cb.onStderr('OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz CLIENT_SECRET=client-secret-value');
       cb.onStderr('Authorization: Bot discord-bot-token-value');
       cb.onStderr(`Invalid API key: ${standaloneOpenAiKey} and ${githubToken}`);
       cb.onStderr(`Slack token ${slackToken}`);
+      cb.onStderr(`Google token ${geminiToken}`);
+      cb.onStderr('{"password":"json-password","client_secret":"json-secret","botToken":"camel-token"}');
       cb.onStderr('jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.abc1234567890secret');
       cb.onStderr('posting to https://hooks.slack.com/services/T000/B000/secret-webhook-token');
       cb.onExit(1, null);
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
       const failEvent = repo.listEvents(run.id).find((e) => e.type === 'attempt.failed');
       expect(failEvent).toBeDefined();
@@ -740,10 +745,25 @@ describe('ProcessBeastExecutor', () => {
           'Authorization: Bot [REDACTED]',
           'Invalid API key: [REDACTED] and [REDACTED]',
           'Slack token [REDACTED]',
+          'Google token [REDACTED]',
+          '{"password":[REDACTED],"client_secret":[REDACTED],"botToken":[REDACTED]}',
           'jwt [REDACTED]',
           'posting to [REDACTED]',
         ],
       });
+      expect(appendSpy).toHaveBeenCalledWith(
+        run.id,
+        expect.any(String),
+        'stderr',
+        'api_key=[REDACTED] password=[REDACTED]',
+        expect.any(String),
+      );
+      const publishedLogLines = publishSpy.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.type === 'run.log' && event.data.stream === 'stderr')
+        .map((event) => event.data.line);
+      expect(publishedLogLines).toContain('api_key=[REDACTED] password=[REDACTED]');
+      expect(publishedLogLines).toContain('{"password":[REDACTED],"client_secret":[REDACTED],"botToken":[REDACTED]}');
       const serializedPersistedEvent = JSON.stringify(failEvent);
       expect(serializedPersistedEvent).not.toContain('sk-live-secret-value');
       expect(serializedPersistedEvent).not.toContain('hunter2');
@@ -752,6 +772,10 @@ describe('ProcessBeastExecutor', () => {
       expect(serializedPersistedEvent).not.toContain(standaloneOpenAiKey);
       expect(serializedPersistedEvent).not.toContain(githubToken);
       expect(serializedPersistedEvent).not.toContain(slackToken);
+      expect(serializedPersistedEvent).not.toContain(geminiToken);
+      expect(serializedPersistedEvent).not.toContain('json-password');
+      expect(serializedPersistedEvent).not.toContain('json-secret');
+      expect(serializedPersistedEvent).not.toContain('camel-token');
       expect(serializedPersistedEvent).not.toContain('abc1234567890secret');
       expect(serializedPersistedEvent).not.toContain('secret-webhook-token');
 
@@ -771,6 +795,10 @@ describe('ProcessBeastExecutor', () => {
       expect(serializedPublishedEvent).not.toContain(standaloneOpenAiKey);
       expect(serializedPublishedEvent).not.toContain(githubToken);
       expect(serializedPublishedEvent).not.toContain(slackToken);
+      expect(serializedPublishedEvent).not.toContain(geminiToken);
+      expect(serializedPublishedEvent).not.toContain('json-password');
+      expect(serializedPublishedEvent).not.toContain('json-secret');
+      expect(serializedPublishedEvent).not.toContain('camel-token');
       expect(serializedPublishedEvent).not.toContain('abc1234567890secret');
       expect(serializedPublishedEvent).not.toContain('secret-webhook-token');
     });

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -703,6 +703,53 @@ describe('ProcessBeastExecutor', () => {
       });
     });
 
+    it('redacts secrets from failed attempt stderr tails in repository events and eventBus publishes', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const eventBus = new BeastEventBus();
+      const publishSpy = vi.spyOn(eventBus, 'publish');
+      const supervisor = createSupervisorMock();
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { eventBus });
+      const run = createTestRun(repo);
+
+      await executor.start(run, martinLoopDefinition);
+      const [, callbacks] = supervisor.spawn.mock.calls[0];
+      const cb = callbacks as ProcessCallbacks;
+
+      cb.onStderr('api_key=sk-live-secret-value password=hunter2');
+      cb.onStderr('jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.abc1234567890secret');
+      cb.onStderr('posting to https://hooks.slack.com/services/T000/B000/secret-webhook-token');
+      cb.onExit(1, null);
+
+      const failEvent = repo.listEvents(run.id).find((e) => e.type === 'attempt.failed');
+      expect(failEvent).toBeDefined();
+      expect(failEvent!.payload).toMatchObject({
+        exitCode: 1,
+        lastStderrLines: [
+          'api_key=[REDACTED] password=[REDACTED]',
+          'jwt [REDACTED]',
+          'posting to [REDACTED]',
+        ],
+      });
+      const serializedPersistedEvent = JSON.stringify(failEvent);
+      expect(serializedPersistedEvent).not.toContain('sk-live-secret-value');
+      expect(serializedPersistedEvent).not.toContain('hunter2');
+      expect(serializedPersistedEvent).not.toContain('abc1234567890secret');
+      expect(serializedPersistedEvent).not.toContain('secret-webhook-token');
+
+      const publishedFailure = publishSpy.mock.calls
+        .map(([event]) => event)
+        .find((event) => event.type === 'run.event' && event.data.event.type === 'attempt.failed');
+      expect(publishedFailure).toBeDefined();
+      expect(publishedFailure!.data.event.payload).toMatchObject(failEvent!.payload);
+      const serializedPublishedEvent = JSON.stringify(publishedFailure);
+      expect(serializedPublishedEvent).not.toContain('sk-live-secret-value');
+      expect(serializedPublishedEvent).not.toContain('hunter2');
+      expect(serializedPublishedEvent).not.toContain('abc1234567890secret');
+      expect(serializedPublishedEvent).not.toContain('secret-webhook-token');
+    });
+
     it('marks attempt as failed on signal kill', async () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -717,7 +717,15 @@ describe('ProcessBeastExecutor', () => {
       const [, callbacks] = supervisor.spawn.mock.calls[0];
       const cb = callbacks as ProcessCallbacks;
 
+      const standaloneOpenAiKey = `sk-${'standaloneproviderkey1234567890'}`;
+      const githubToken = `ghp_${'abcdefghijklmnopqrstuvwxyz123456'}`;
+      const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
+
       cb.onStderr('api_key=sk-live-secret-value password=hunter2');
+      cb.onStderr('OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz CLIENT_SECRET=client-secret-value');
+      cb.onStderr('Authorization: Bot discord-bot-token-value');
+      cb.onStderr(`Invalid API key: ${standaloneOpenAiKey} and ${githubToken}`);
+      cb.onStderr(`Slack token ${slackToken}`);
       cb.onStderr('jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.abc1234567890secret');
       cb.onStderr('posting to https://hooks.slack.com/services/T000/B000/secret-webhook-token');
       cb.onExit(1, null);
@@ -728,6 +736,10 @@ describe('ProcessBeastExecutor', () => {
         exitCode: 1,
         lastStderrLines: [
           'api_key=[REDACTED] password=[REDACTED]',
+          'OPENAI_API_KEY=[REDACTED] CLIENT_SECRET=[REDACTED]',
+          'Authorization: Bot [REDACTED]',
+          'Invalid API key: [REDACTED] and [REDACTED]',
+          'Slack token [REDACTED]',
           'jwt [REDACTED]',
           'posting to [REDACTED]',
         ],
@@ -735,17 +747,30 @@ describe('ProcessBeastExecutor', () => {
       const serializedPersistedEvent = JSON.stringify(failEvent);
       expect(serializedPersistedEvent).not.toContain('sk-live-secret-value');
       expect(serializedPersistedEvent).not.toContain('hunter2');
+      expect(serializedPersistedEvent).not.toContain('client-secret-value');
+      expect(serializedPersistedEvent).not.toContain('discord-bot-token-value');
+      expect(serializedPersistedEvent).not.toContain(standaloneOpenAiKey);
+      expect(serializedPersistedEvent).not.toContain(githubToken);
+      expect(serializedPersistedEvent).not.toContain(slackToken);
       expect(serializedPersistedEvent).not.toContain('abc1234567890secret');
       expect(serializedPersistedEvent).not.toContain('secret-webhook-token');
 
       const publishedFailure = publishSpy.mock.calls
         .map(([event]) => event)
-        .find((event) => event.type === 'run.event' && event.data.event.type === 'attempt.failed');
+        .filter((event) => event.type === 'run.event')
+        .find((event) => ((event.data as { event?: { type?: string } }).event?.type === 'attempt.failed')) as
+        | { data: { event: { payload: unknown } } }
+        | undefined;
       expect(publishedFailure).toBeDefined();
       expect(publishedFailure!.data.event.payload).toMatchObject(failEvent!.payload);
       const serializedPublishedEvent = JSON.stringify(publishedFailure);
       expect(serializedPublishedEvent).not.toContain('sk-live-secret-value');
       expect(serializedPublishedEvent).not.toContain('hunter2');
+      expect(serializedPublishedEvent).not.toContain('client-secret-value');
+      expect(serializedPublishedEvent).not.toContain('discord-bot-token-value');
+      expect(serializedPublishedEvent).not.toContain(standaloneOpenAiKey);
+      expect(serializedPublishedEvent).not.toContain(githubToken);
+      expect(serializedPublishedEvent).not.toContain(slackToken);
       expect(serializedPublishedEvent).not.toContain('abc1234567890secret');
       expect(serializedPublishedEvent).not.toContain('secret-webhook-token');
     });

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -730,7 +730,11 @@ describe('ProcessBeastExecutor', () => {
       cb.onStderr(`Slack token ${slackToken}`);
       cb.onStderr(`Google token ${geminiToken}`);
       cb.onStderr('{"password":"json-password","client_secret":"json-secret","botToken":"camel-token"}');
-      cb.onStderr('jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.abc1234567890secret');
+      cb.onStderr('{"password":"abc\\"def","accessToken":"camel-access-token"}');
+      cb.onStderr('redis://:cachepass@localhost:6379/0');
+      cb.onStderr('{"Authorization":"Basic basic-token-value"}');
+      cb.onStderr("headers: {'Authorization': 'Bot object-token-value'}");
+      cb.onStderr('jwt eyJhbG...cret');
       cb.onStderr('posting to https://hooks.slack.com/services/T000/B000/secret-webhook-token');
       cb.onExit(1, null);
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -747,7 +751,11 @@ describe('ProcessBeastExecutor', () => {
           'Slack token [REDACTED]',
           'Google token [REDACTED]',
           '{"password":[REDACTED],"client_secret":[REDACTED],"botToken":[REDACTED]}',
-          'jwt [REDACTED]',
+          '{"password":[REDACTED],"accessToken":[REDACTED]}',
+          'redis://:[REDACTED]@localhost:6379/0',
+          '{"Authorization":"Basic [REDACTED]"}',
+          "headers: {'Authorization': 'Bot [REDACTED]'}",
+          'jwt eyJhbG...cret',
           'posting to [REDACTED]',
         ],
       });
@@ -776,6 +784,11 @@ describe('ProcessBeastExecutor', () => {
       expect(serializedPersistedEvent).not.toContain('json-password');
       expect(serializedPersistedEvent).not.toContain('json-secret');
       expect(serializedPersistedEvent).not.toContain('camel-token');
+      expect(serializedPersistedEvent).not.toContain('abc\\"def');
+      expect(serializedPersistedEvent).not.toContain('camel-access-token');
+      expect(serializedPersistedEvent).not.toContain('cachepass');
+      expect(serializedPersistedEvent).not.toContain('basic-token-value');
+      expect(serializedPersistedEvent).not.toContain('object-token-value');
       expect(serializedPersistedEvent).not.toContain('abc1234567890secret');
       expect(serializedPersistedEvent).not.toContain('secret-webhook-token');
 
@@ -799,6 +812,11 @@ describe('ProcessBeastExecutor', () => {
       expect(serializedPublishedEvent).not.toContain('json-password');
       expect(serializedPublishedEvent).not.toContain('json-secret');
       expect(serializedPublishedEvent).not.toContain('camel-token');
+      expect(serializedPublishedEvent).not.toContain('abc\\"def');
+      expect(serializedPublishedEvent).not.toContain('camel-access-token');
+      expect(serializedPublishedEvent).not.toContain('cachepass');
+      expect(serializedPublishedEvent).not.toContain('basic-token-value');
+      expect(serializedPublishedEvent).not.toContain('object-token-value');
       expect(serializedPublishedEvent).not.toContain('abc1234567890secret');
       expect(serializedPublishedEvent).not.toContain('secret-webhook-token');
     });


### PR DESCRIPTION
## Summary
- Redacts sensitive values from Beast failed-attempt `lastStderrLines` before persisting attempt events.
- Covers repository event storage and `eventBus` publishing for API keys, JWTs, webhook URLs, and password assignments.

## Test Plan
- `npm test -- --run tests/unit/beasts/process-beast-executor.test.ts` (packages/franken-orchestrator)
- `npm run typecheck` (packages/franken-orchestrator)
- `npm run lint` (packages/franken-orchestrator; existing warnings only, no warnings in changed test file)
- `npm run build` (repo root)
- `npm run typecheck` (repo root)

Closes #601