### PR TITLE
fix(security): redact Beast startup log lines

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -11,7 +11,7 @@ import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, Beas
 const STDERR_BUFFER_SIZE = 50;
 const REDACTED_SECRET = '[REDACTED]';
 
-function redactFailureStderrLine(line: string): string {
+function redactBeastLogLine(line: string): string {
   return line
     .replace(/((?:"|')?authorization(?:"|')?\s*:\s*(?:"|')?(?:bearer|basic|bot)\s+)[^\s"',;}]+/gi, `$1${REDACTED_SECRET}`)
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, `$1${REDACTED_SECRET}`)
@@ -33,7 +33,7 @@ function redactFailureStderrLine(line: string): string {
 }
 
 function redactFailureStderrTail(stderrTail: readonly string[]): string[] {
-  return stderrTail.map(redactFailureStderrLine);
+  return stderrTail.map(redactBeastLogLine);
 }
 
 function moduleConfigToEnv(config?: ModuleConfig): Record<string, string> {
@@ -184,19 +184,20 @@ export class ProcessBeastExecutor implements BeastExecutor {
     try {
       handle = await this.supervisor.spawn(spawnedSpec, {
         onStdout: (line) => {
+          const redactedLine = redactBeastLogLine(line);
           if (attemptId) {
             const createdAt = new Date().toISOString();
-            void this.logs.append(run.id, attemptId, 'stdout', line, createdAt);
+            void this.logs.append(run.id, attemptId, 'stdout', redactedLine, createdAt);
             this.options.eventBus?.publish({
               type: 'run.log',
-              data: { runId: run.id, attemptId, stream: 'stdout', line, createdAt },
+              data: { runId: run.id, attemptId, stream: 'stdout', line: redactedLine, createdAt },
             });
           } else {
-            earlyStdoutLines.push(line);
+            earlyStdoutLines.push(redactedLine);
           }
         },
         onStderr: (line) => {
-          const redactedLine = redactFailureStderrLine(line);
+          const redactedLine = redactBeastLogLine(line);
           stderrTail.push(redactedLine);
           if (stderrTail.length > STDERR_BUFFER_SIZE) stderrTail.shift();
           if (attemptId) {

--- a/packages/franken-orchestrator/test/execution/process-beast-executor-redaction.test.ts
+++ b/packages/franken-orchestrator/test/execution/process-beast-executor-redaction.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { ProcessBeastExecutor } from '../../src/beasts/execution/process-beast-executor.js';
+import type { ProcessCallbacks, ProcessSupervisorLike } from '../../src/beasts/execution/process-supervisor.js';
+import type { BeastLogStore } from '../../src/beasts/events/beast-log-store.js';
+import type { BeastEventBus } from '../../src/beasts/events/beast-event-bus.js';
+import type { SQLiteBeastRepository } from '../../src/beasts/repository/sqlite-beast-repository.js';
+import type { BeastDefinition, BeastRun, BeastRunAttempt, BeastRunEvent } from '../../src/beasts/types.js';
+
+type LogEntry = {
+  runId: string;
+  attemptId: string;
+  stream: 'stdout' | 'stderr';
+  message: string;
+};
+
+type PublishedEvent = {
+  type: string;
+  data: Record<string, unknown>;
+};
+
+function createRun(): BeastRun {
+  return {
+    id: 'run-early-redaction',
+    definitionId: 'test-beast',
+    definitionVersion: 1,
+    status: 'queued',
+    executionMode: 'process',
+    configSnapshot: {},
+    dispatchedBy: 'api',
+    dispatchedByUser: 'test',
+    createdAt: '2026-07-05T00:00:00.000Z',
+    attemptCount: 0,
+  };
+}
+
+function createDefinition(): BeastDefinition {
+  return {
+    id: 'test-beast',
+    version: 1,
+    label: 'Test Beast',
+    description: 'Test definition',
+    executionModeDefault: 'process',
+    configSchema: {} as BeastDefinition['configSchema'],
+    interviewPrompts: [],
+    buildProcessSpec: () => ({ command: 'node', args: ['beast.js'], cwd: process.cwd() }),
+    telemetryLabels: {},
+  };
+}
+
+function createRepository() {
+  const attempts = new Map<string, BeastRunAttempt>();
+  const events: Array<Omit<BeastRunEvent, 'id' | 'runId' | 'sequence'>> = [];
+  return {
+    events,
+    createAttempt(runId: string, fields: Omit<BeastRunAttempt, 'id' | 'runId' | 'attemptNumber'>): BeastRunAttempt {
+      const attempt: BeastRunAttempt = {
+        id: 'attempt-1',
+        runId,
+        attemptNumber: 1,
+        ...fields,
+      };
+      attempts.set(attempt.id, attempt);
+      return attempt;
+    },
+    getAttempt(attemptId: string): BeastRunAttempt | undefined {
+      return attempts.get(attemptId);
+    },
+    updateAttempt(attemptId: string, fields: Partial<BeastRunAttempt>): BeastRunAttempt {
+      const current = attempts.get(attemptId);
+      if (!current) throw new Error(`missing attempt ${attemptId}`);
+      const updated = { ...current, ...fields };
+      attempts.set(attemptId, updated);
+      return updated;
+    },
+    updateRun: () => {},
+    appendEvent(_runId: string, event: Omit<BeastRunEvent, 'id' | 'runId' | 'sequence'>): void {
+      events.push(event);
+    },
+  };
+}
+
+describe('ProcessBeastExecutor log redaction', () => {
+  it('redacts early stdout and stderr before flushing them to durable logs and events', async () => {
+    const rawStdoutSecret = `${'sk'}-${'12345678901234567890'}`;
+    const rawStderrSecret = `${'ghp'}_${'abcdefghijklmnopqrstuvwxyz1234567890'}`;
+    const logs: LogEntry[] = [];
+    const publishedEvents: PublishedEvent[] = [];
+    const repository = createRepository();
+    const logStore = {
+      async append(
+        runId: string,
+        attemptId: string,
+        stream: 'stdout' | 'stderr',
+        message: string,
+      ): Promise<void> {
+        logs.push({ runId, attemptId, stream, message });
+      },
+    } as BeastLogStore;
+    const eventBus = {
+      publish(event: PublishedEvent): void {
+        publishedEvents.push(event);
+      },
+    } as BeastEventBus;
+    const supervisor: ProcessSupervisorLike = {
+      async spawn(_spec, callbacks: ProcessCallbacks) {
+        callbacks.onStdout(`booting with OPENAI_API_KEY=${rawStdoutSecret}`);
+        callbacks.onStderr(`failed Authorization: Bearer ${rawStderrSecret}`);
+        return { pid: 4242 };
+      },
+      async stop() {},
+      async kill() {},
+    };
+
+    const executor = new ProcessBeastExecutor(
+      repository as unknown as SQLiteBeastRepository,
+      logStore,
+      supervisor,
+      { eventBus },
+    );
+
+    await executor.start(createRun(), createDefinition());
+
+    const stdoutLog = logs.find((entry) => entry.stream === 'stdout')?.message ?? '';
+    const stderrLog = logs.find((entry) => entry.stream === 'stderr')?.message ?? '';
+    const publishedLogLines = publishedEvents
+      .filter((event) => event.type === 'run.log')
+      .map((event) => String(event.data.line));
+
+    expect(stdoutLog).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(stderrLog).toContain('Authorization: Bearer [REDACTED]');
+    expect([...logs.map((entry) => entry.message), ...publishedLogLines].join('\n')).not.toContain(rawStdoutSecret);
+    expect([...logs.map((entry) => entry.message), ...publishedLogLines].join('\n')).not.toContain(rawStderrSecret);
+  });
+});


### PR DESCRIPTION
## Summary
- Redacts Beast process stdout with the same centralized log redactor already used for stderr.
- Stores early stdout/stderr buffers only after redaction, so startup output cannot bypass durable log/event masking.
- Adds a targeted ProcessBeastExecutor regression test for early startup log flushing.

## Test Plan
- npm --workspace packages/franken-orchestrator test -- --run test/execution/process-beast-executor-redaction.test.ts
- npm run typecheck
- npm --workspace packages/franken-orchestrator run lint (passes with existing warnings)
- npm --workspace packages/franken-orchestrator test
- npm run build

Closes #600
