### PR TITLE
fix(security): constrain chunk-plan design doc path

### DIFF
--- a/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import type { BeastDefinition } from '../types.js';
 import { resolveCliEntrypoint } from './resolve-cli-entrypoint.js';
 
@@ -11,7 +11,7 @@ function resolveContainedConfigPath(fieldName: string, projectRoot: string | und
   const root = resolve(projectRoot);
   const target = isAbsolute(requested) ? resolve(requested) : resolve(root, requested);
   const rel = relative(root, target);
-  if (rel === '..' || rel.startsWith('../') || isAbsolute(rel)) {
+  if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('../') || rel.startsWith('..\\') || isAbsolute(rel)) {
     throw new Error(`${fieldName} resolves outside project root: ${requested}`);
   }
 

--- a/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
@@ -1,6 +1,22 @@
 import { z } from 'zod';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type { BeastDefinition } from '../types.js';
 import { resolveCliEntrypoint } from './resolve-cli-entrypoint.js';
+
+function resolveContainedConfigPath(fieldName: string, projectRoot: string | undefined, requested: string): string {
+  if (!projectRoot) {
+    return requested;
+  }
+
+  const root = resolve(projectRoot);
+  const target = isAbsolute(requested) ? resolve(requested) : resolve(root, requested);
+  const rel = relative(root, target);
+  if (rel === '..' || rel.startsWith('../') || isAbsolute(rel)) {
+    throw new Error(`${fieldName} resolves outside project root: ${requested}`);
+  }
+
+  return target;
+}
 
 export const chunkPlanDefinition: BeastDefinition = {
   id: 'chunk-plan',
@@ -27,17 +43,26 @@ export const chunkPlanDefinition: BeastDefinition = {
       required: true,
     },
   ],
-  buildProcessSpec: (config) => ({
-    command: process.execPath,
-    args: [
-      resolveCliEntrypoint(),
-      'plan',
-      '--design-doc', String(config.designDocPath),
-      '--output-dir', String(config.outputDir),
-    ],
-    env: { FRANKENBEAST_SPAWNED: '1' },
-    cwd: String(config.projectRoot ?? process.env.FBEAST_ROOT ?? process.cwd()),
-  }),
+  buildProcessSpec: (config) => {
+    const projectRoot = String(config.projectRoot ?? process.env.FBEAST_ROOT ?? process.cwd());
+    const designDocPath = resolveContainedConfigPath(
+      'designDocPath',
+      projectRoot,
+      String(config.designDocPath),
+    );
+
+    return {
+      command: process.execPath,
+      args: [
+        resolveCliEntrypoint(),
+        'plan',
+        '--design-doc', designDocPath,
+        '--output-dir', String(config.outputDir),
+      ],
+      env: { FRANKENBEAST_SPAWNED: '1' },
+      cwd: projectRoot,
+    };
+  },
   telemetryLabels: {
     family: 'chunk-plan',
   },

--- a/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
@@ -1,15 +1,24 @@
 import { z } from 'zod';
+import { realpathSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import type { BeastDefinition } from '../types.js';
 import { resolveCliEntrypoint } from './resolve-cli-entrypoint.js';
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
 
 function resolveContainedConfigPath(fieldName: string, projectRoot: string | undefined, requested: string): string {
   if (!projectRoot) {
     return requested;
   }
 
-  const root = resolve(projectRoot);
-  const target = isAbsolute(requested) ? resolve(requested) : resolve(root, requested);
+  const root = canonicalPath(projectRoot);
+  const target = canonicalPath(isAbsolute(requested) ? requested : resolve(root, requested));
   const rel = relative(root, target);
   if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('../') || rel.startsWith('..\\') || isAbsolute(rel)) {
     throw new Error(`${fieldName} resolves outside project root: ${requested}`);

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -1,5 +1,5 @@
 import { readFileSync, mkdirSync, realpathSync } from 'node:fs';
-import { isAbsolute, relative, resolve, join } from 'node:path';
+import { isAbsolute, relative, resolve, join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { BeastLoop } from '../beast-loop.js';
@@ -36,7 +36,7 @@ function resolveContainedExistingPath(projectRoot: string, requestedPath: string
   const requested = isAbsolute(requestedPath) ? requestedPath : resolve(root, requestedPath);
   const target = realpathSync(requested);
   const rel = relative(root, target);
-  if (rel === '..' || rel.startsWith('../') || isAbsolute(rel)) {
+  if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('../') || rel.startsWith('..\\') || isAbsolute(rel)) {
     throw new Error(`${fieldName} resolves outside project root: ${requestedPath}`);
   }
 

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -1,5 +1,5 @@
-import { readFileSync, mkdirSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { readFileSync, mkdirSync, realpathSync } from 'node:fs';
+import { isAbsolute, relative, resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { BeastLoop } from '../beast-loop.js';
@@ -30,6 +30,18 @@ import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import type { ProviderCommandOverridePolicyConfig } from '../config/provider-command-override-policy.js';
 
 export type SessionPhase = 'interview' | 'plan' | 'execute';
+
+function resolveContainedExistingPath(projectRoot: string, requestedPath: string, fieldName: string): string {
+  const root = realpathSync(resolve(projectRoot));
+  const requested = isAbsolute(requestedPath) ? requestedPath : resolve(root, requestedPath);
+  const target = realpathSync(requested);
+  const rel = relative(root, target);
+  if (rel === '..' || rel.startsWith('../') || isAbsolute(rel)) {
+    throw new Error(`${fieldName} resolves outside project root: ${requestedPath}`);
+  }
+
+  return target;
+}
 
 export interface SessionConfig {
   paths: ProjectPaths;
@@ -293,7 +305,8 @@ export class Session {
     let designContent: string;
     if (designDocPath) {
       try {
-        designContent = readFileSync(designDocPath, 'utf-8');
+        const safeDesignDocPath = resolveContainedExistingPath(paths.root, designDocPath, 'designDocPath');
+        designContent = readFileSync(safeDesignDocPath, 'utf-8');
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
           throw new Error(

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -33,7 +33,7 @@ export type SessionPhase = 'interview' | 'plan' | 'execute';
 
 function resolveContainedExistingPath(projectRoot: string, requestedPath: string, fieldName: string): string {
   const root = realpathSync(resolve(projectRoot));
-  const requested = isAbsolute(requestedPath) ? requestedPath : resolve(root, requestedPath);
+  const requested = isAbsolute(requestedPath) ? requestedPath : resolve(process.cwd(), requestedPath);
   const target = realpathSync(requested);
   const rel = relative(root, target);
   if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('../') || rel.startsWith('..\\') || isAbsolute(rel)) {

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { chunkPlanDefinition } from '../../../../src/beasts/definitions/chunk-plan-definition.js';
 import { parseArgs } from '../../../../src/cli/args.js';
 
@@ -60,6 +62,29 @@ describe('chunkPlanDefinition', () => {
       expect(() => chunkPlanDefinition.buildProcessSpec(config)).toThrow(
         /designDocPath.*outside project root/,
       );
+    });
+
+    it('allows designDocPath values inside a symlinked projectRoot', () => {
+      const testDir = mkdtempSync(resolve(tmpdir(), 'fb-chunk-plan-'));
+      const realRoot = resolve(testDir, 'project');
+      const linkRoot = resolve(testDir, 'project-link');
+      const designPath = resolve(realRoot, 'docs', 'design.md');
+
+      try {
+        mkdirSync(resolve(realRoot, 'docs'), { recursive: true });
+        writeFileSync(designPath, '# Design');
+        symlinkSync(realRoot, linkRoot, 'dir');
+
+        const spec = chunkPlanDefinition.buildProcessSpec({
+          ...validConfig,
+          projectRoot: linkRoot,
+          designDocPath: designPath,
+        });
+
+        expect(spec.args[spec.args.indexOf('--design-doc') + 1]).toBe(designPath);
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
     });
 
     it('falls back to process.cwd() when projectRoot is not provided', () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
 import { chunkPlanDefinition } from '../../../../src/beasts/definitions/chunk-plan-definition.js';
 import { parseArgs } from '../../../../src/cli/args.js';
 
 describe('chunkPlanDefinition', () => {
   const validConfig = {
-    designDocPath: '/tmp/design.md',
+    designDocPath: 'docs/design.md',
     outputDir: '/tmp/chunks-out',
   };
 
@@ -28,7 +29,7 @@ describe('chunkPlanDefinition', () => {
       const spec = chunkPlanDefinition.buildProcessSpec(validConfig);
       const idx = spec.args.indexOf('--design-doc');
       expect(idx).toBeGreaterThan(-1);
-      expect(spec.args[idx + 1]).toBe('/tmp/design.md');
+      expect(spec.args[idx + 1]).toBe(resolve(process.cwd(), 'docs/design.md'));
     });
 
     it('passes --output-dir flag with value', () => {
@@ -47,6 +48,18 @@ describe('chunkPlanDefinition', () => {
       const config = { ...validConfig, projectRoot: '/home/user/project' };
       const spec = chunkPlanDefinition.buildProcessSpec(config);
       expect(spec.cwd).toBe('/home/user/project');
+    });
+
+    it('rejects designDocPath values that escape projectRoot', () => {
+      const config = {
+        ...validConfig,
+        projectRoot: '/home/user/project',
+        designDocPath: '../secret.md',
+      };
+
+      expect(() => chunkPlanDefinition.buildProcessSpec(config)).toThrow(
+        /designDocPath.*outside project root/,
+      );
     });
 
     it('falls back to process.cwd() when projectRoot is not provided', () => {

--- a/packages/franken-orchestrator/tests/unit/cli/session.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session.test.ts
@@ -380,6 +380,26 @@ describe('Session', () => {
       rmSync(outsidePath, { force: true });
     });
 
+    it('resolves relative designDocPath from the invoking cwd before containment', async () => {
+      const { Session } = await import('../../../src/cli/session.js');
+      const originalCwd = process.cwd();
+      const config = makeConfig({ entryPhase: 'plan', exitAfter: 'plan' });
+      const nestedDir = resolve(config.paths.root, 'docs');
+      mkdirSync(nestedDir, { recursive: true });
+      writeFileSync(resolve(nestedDir, 'design.md'), '# Nested Design');
+
+      try {
+        process.chdir(nestedDir);
+        config.designDocPath = 'design.md';
+
+        await new Session(config).start();
+
+        expect(mockReadDesignDoc).not.toHaveBeenCalled();
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
     it('throws friendly ENOENT error when designDocPath file is missing', async () => {
       const { Session } = await import('../../../src/cli/session.js');
       const missingPath = resolve(tmpdir(), `nonexistent-design-${Date.now()}.md`);

--- a/packages/franken-orchestrator/tests/unit/cli/session.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session.test.ts
@@ -353,22 +353,31 @@ describe('Session', () => {
 
     it('uses designDocPath when provided (--design-doc flag)', async () => {
       const { Session } = await import('../../../src/cli/session.js');
-      const testDir = resolve(tmpdir(), `fb-test-design-${Date.now()}`);
-      mkdirSync(testDir, { recursive: true });
-      const designPath = resolve(testDir, 'custom-design.md');
+      const config = makeConfig({ entryPhase: 'plan', exitAfter: 'plan' });
+      const designPath = resolve(config.paths.root, 'custom-design.md');
       writeFileSync(designPath, '# Custom Design');
 
-      const config = makeConfig({
-        entryPhase: 'plan',
-        exitAfter: 'plan',
-        designDocPath: designPath,
-      });
+      config.designDocPath = designPath;
       await new Session(config).start();
 
       // readDesignDoc should NOT be called when designDocPath is provided
       expect(mockReadDesignDoc).not.toHaveBeenCalled();
 
-      rmSync(testDir, { recursive: true, force: true });
+      rmSync(designPath, { force: true });
+    });
+
+    it('rejects designDocPath values outside the project root', async () => {
+      const { Session } = await import('../../../src/cli/session.js');
+      const config = makeConfig({ entryPhase: 'plan', exitAfter: 'plan' });
+      const outsidePath = resolve(config.paths.root, '..', `outside-design-${Date.now()}.md`);
+      writeFileSync(outsidePath, '# Outside Design');
+      config.designDocPath = outsidePath;
+
+      await expect(new Session(config).start()).rejects.toThrow(
+        /designDocPath.*outside project root/,
+      );
+
+      rmSync(outsidePath, { force: true });
     });
 
     it('throws friendly ENOENT error when designDocPath file is missing', async () => {


### PR DESCRIPTION
## Summary
- constrain chunk-plan Beast `designDocPath` values to paths under the project root before spawning the planner CLI
- enforce realpath-based containment in the CLI before reading an explicit `--design-doc`
- add regression coverage for traversal/out-of-root design docs

## Test Plan
- `npm run test --workspace franken-orchestrator -- tests/unit/beasts/definitions/chunk-plan-definition.test.ts tests/unit/cli/session.test.ts`
- `npm run build`
- `npm run test --workspace franken-orchestrator`
- `npm run typecheck --workspace franken-orchestrator`
- `npm run build --workspace franken-orchestrator`
- `npm run lint --workspace franken-orchestrator` (passes with existing warnings)
- `git diff --check`

Closes #570
