### PR TITLE
fix(security): move chat socket tokens out of URLs

### DIFF
--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -42,7 +42,13 @@ export interface AttachChatWebSocketServerOptions extends ChatSocketControllerOp
   server: HttpServer;
 }
 
-const CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX = 'franken.chat.token.';
+export const CHAT_SOCKET_PROTOCOL = 'franken.chat.v1';
+export const CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX = 'franken.chat.token.';
+
+interface ChatSocketProtocolAuth {
+  hasChatProtocol: boolean;
+  token: string | null;
+}
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -352,19 +358,22 @@ function requestOrigin(request: IncomingMessage): string | null {
   return typeof origin === 'string' ? origin : null;
 }
 
-function extractChatSocketProtocolToken(request: IncomingMessage): string | null {
+function extractChatSocketProtocolAuth(request: IncomingMessage): ChatSocketProtocolAuth {
   const protocols = request.headers['sec-websocket-protocol'];
   const values = Array.isArray(protocols) ? protocols : protocols ? [protocols] : [];
+  let hasChatProtocol = false;
+  let token: string | null = null;
   for (const value of values) {
     for (const protocol of value.split(',')) {
       const trimmed = protocol.trim();
-      if (trimmed.startsWith(CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX)) {
-        const token = trimmed.slice(CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX.length);
-        return token || null;
+      if (trimmed === CHAT_SOCKET_PROTOCOL) {
+        hasChatProtocol = true;
+      } else if (trimmed.startsWith(CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX)) {
+        token = trimmed.slice(CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX.length) || null;
       }
     }
   }
-  return null;
+  return { hasChatProtocol, token };
 }
 
 function closeUnauthorized(
@@ -387,11 +396,12 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
     }
 
     const sessionId = url.searchParams.get('sessionId');
-    const token = extractChatSocketProtocolToken(request);
-    if (!sessionId) {
+    const protocolAuth = extractChatSocketProtocolAuth(request);
+    if (!sessionId || !protocolAuth.hasChatProtocol) {
       closeUnauthorized(socket, 400);
       return;
     }
+    const { token } = protocolAuth;
 
     const auth = controller.connect(
       {
@@ -412,6 +422,7 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
       close: () => socket.destroy(),
       send: () => undefined,
     });
+    request.headers['sec-websocket-protocol'] = CHAT_SOCKET_PROTOCOL;
 
     server.handleUpgrade(request, socket, head, (ws: WebSocket) => {
       const peer = requestToPeer(ws);

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -8,7 +8,6 @@ import type { ChatSession } from '../chat/types.js';
 import type { TurnEvent } from '../chat/turn-runner.js';
 import {
   verifyChatSocketRequest,
-  type VerifyChatSocketRequestOptions,
 } from './ws-chat-auth.js';
 import {
   ClientSocketEventSchema,
@@ -42,6 +41,8 @@ export interface AttachChatWebSocketServerOptions extends ChatSocketControllerOp
   path?: string;
   server: HttpServer;
 }
+
+const CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX = 'franken.chat.token.';
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -351,6 +352,21 @@ function requestOrigin(request: IncomingMessage): string | null {
   return typeof origin === 'string' ? origin : null;
 }
 
+function extractChatSocketProtocolToken(request: IncomingMessage): string | null {
+  const protocols = request.headers['sec-websocket-protocol'];
+  const values = Array.isArray(protocols) ? protocols : protocols ? [protocols] : [];
+  for (const value of values) {
+    for (const protocol of value.split(',')) {
+      const trimmed = protocol.trim();
+      if (trimmed.startsWith(CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX)) {
+        const token = trimmed.slice(CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX.length);
+        return token || null;
+      }
+    }
+  }
+  return null;
+}
+
 function closeUnauthorized(
   socket: Duplex,
   status: number,
@@ -371,7 +387,7 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
     }
 
     const sessionId = url.searchParams.get('sessionId');
-    const token = url.searchParams.get('token');
+    const token = extractChatSocketProtocolToken(request);
     if (!sessionId) {
       closeUnauthorized(socket, 400);
       return;

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -4,6 +4,10 @@ import { randomUUID } from 'node:crypto';
 import { createInterface, type Interface } from 'node:readline';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import { sanitizeChatOutput } from '../chat/output-sanitizer.js';
+import {
+  CHAT_SOCKET_PROTOCOL,
+  CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
+} from '../http/ws-chat-server.js';
 
 interface ManagedNetworkState {
   services?: Array<{
@@ -84,7 +88,10 @@ async function createRemoteSession(target: ManagedChatAttachment, projectId: str
       socketToken: string;
     };
   };
-  const socket = new WebSocket(`${target.wsUrl}?sessionId=${body.data.id}&token=${body.data.socketToken}`);
+  const socket = new WebSocket(
+    `${target.wsUrl}?sessionId=${encodeURIComponent(body.data.id)}`,
+    [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${body.data.socketToken}`],
+  );
   await new Promise<void>((resolve, reject) => {
     socket.addEventListener('open', () => resolve(), { once: true });
     socket.addEventListener('error', () => reject(new Error('Managed chat websocket failed to connect')), { once: true });

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -5,6 +5,10 @@ import { fileURLToPath } from 'node:url';
 import { createBeastServices } from '../../../src/beasts/create-beast-services.js';
 import { startChatServer } from '../../../src/http/chat-server.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
+import {
+  CHAT_SOCKET_PROTOCOL,
+  CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
+} from '../../../src/http/ws-chat-server.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/chat-server');
@@ -60,7 +64,10 @@ describe('chat server bootstrap', () => {
         };
       };
 
-      const socket = new WebSocket(`${server.wsUrl}?sessionId=${body.data.id}&token=${body.data.socketToken}`);
+      const socket = new WebSocket(
+        `${server.wsUrl}?sessionId=${encodeURIComponent(body.data.id)}`,
+        [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${body.data.socketToken}`],
+      );
       await new Promise<void>((resolve, reject) => {
         socket.addEventListener('open', () => resolve(), { once: true });
         socket.addEventListener('error', (event) => reject(event.error ?? new Error('websocket error')), { once: true });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createServer } from 'node:http';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { WebSocket } from 'ws';
 import { ConversationEngine } from '../../../src/chat/conversation-engine.js';
 import { FileSessionStore } from '../../../src/chat/session-store.js';
 import { TurnRunner } from '../../../src/chat/turn-runner.js';
 import { ChatRuntime } from '../../../src/chat/runtime.js';
 import {
   ChatSocketController,
+  attachChatWebSocketServer,
 } from '../../../src/http/ws-chat-server.js';
 import {
   createSessionTokenSecret,
@@ -28,7 +31,96 @@ function createPeer() {
   };
 }
 
+function createTestRuntime(): ChatRuntime {
+  return new ChatRuntime({
+    engine: new ConversationEngine({
+      llm: { complete: vi.fn().mockResolvedValue('Working on it right now.') },
+      projectName: 'proj',
+    }),
+    turnRunner: new TurnRunner({
+      execute: vi.fn().mockResolvedValue({
+        status: 'success',
+        summary: 'Done',
+        filesChanged: [],
+        testsRun: 0,
+        errors: [],
+      }),
+    }),
+  });
+}
+
+function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected TCP listener address');
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function onceSocket(socket: WebSocket, event: 'open' | 'close' | 'error'): Promise<unknown[]> {
+  return new Promise((resolve) => {
+    socket.once(event, (...args: unknown[]) => resolve(args));
+  });
+}
+
 describe('ws chat server', () => {
+  it('accepts upgrade requests with socket tokens in websocket subprotocols', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const httpServer = createServer();
+    attachChatWebSocketServer({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+      server: httpServer,
+    });
+    const port = await listen(httpServer);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}`,
+      ['franken.chat.v1', `franken.chat.token.${token}`],
+    );
+
+    await expect(onceSocket(socket, 'open')).resolves.toEqual([]);
+    expect(socket.protocol).toBe('franken.chat.v1');
+    expect(socket.url).not.toContain(token);
+
+    socket.close();
+    httpServer.close();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('rejects upgrade requests that still pass socket tokens in query strings', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const httpServer = createServer();
+    attachChatWebSocketServer({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+      server: httpServer,
+    });
+    const port = await listen(httpServer);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}&token=${encodeURIComponent(token)}`,
+    );
+
+    await onceSocket(socket, 'error');
+    expect(socket.readyState).toBe(WebSocket.CLOSED);
+
+    httpServer.close();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('emits typing, delta, and complete events for a reply turn', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -9,6 +9,8 @@ import { FileSessionStore } from '../../../src/chat/session-store.js';
 import { TurnRunner } from '../../../src/chat/turn-runner.js';
 import { ChatRuntime } from '../../../src/chat/runtime.js';
 import {
+  CHAT_SOCKET_PROTOCOL,
+  CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
   ChatSocketController,
   attachChatWebSocketServer,
 } from '../../../src/http/ws-chat-server.js';
@@ -84,12 +86,40 @@ describe('ws chat server', () => {
     const port = await listen(httpServer);
     const socket = new WebSocket(
       `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}`,
-      ['franken.chat.v1', `franken.chat.token.${token}`],
+      [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${token}`],
     );
 
     await expect(onceSocket(socket, 'open')).resolves.toEqual([]);
-    expect(socket.protocol).toBe('franken.chat.v1');
+    expect(socket.protocol).toBe(CHAT_SOCKET_PROTOCOL);
     expect(socket.url).not.toContain(token);
+
+    socket.close();
+    httpServer.close();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('does not negotiate token pseudo-protocols when clients send them first', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const httpServer = createServer();
+    attachChatWebSocketServer({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+      server: httpServer,
+    });
+    const port = await listen(httpServer);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}`,
+      [`${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${token}`, CHAT_SOCKET_PROTOCOL],
+    );
+
+    await expect(onceSocket(socket, 'open')).resolves.toEqual([]);
+    expect(socket.protocol).toBe(CHAT_SOCKET_PROTOCOL);
+    expect(socket.protocol).not.toContain(token);
 
     socket.close();
     httpServer.close();

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -16,7 +16,7 @@ class MockWebSocket {
   send = vi.fn();
   close = vi.fn();
 
-  constructor(readonly url: string) {
+  constructor(readonly url: string, readonly protocols?: string | string[]) {
     MockWebSocket.instances.push(this);
   }
 }
@@ -64,6 +64,24 @@ describe('useChatSession error banners', () => {
       code: 'session_init_failed',
       actionLabel: 'Retry session',
     });
+  });
+
+  it('opens websocket connections without putting the socket token in the URL', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    expect(MockWebSocket.instances[0]!.url).toBe('ws://localhost:3000/v1/chat/ws?sessionId=session-1');
+    expect(MockWebSocket.instances[0]!.url).not.toContain('socket-token');
+    expect(MockWebSocket.instances[0]!.protocols).toEqual([
+      'franken.chat.v1',
+      'franken.chat.token.socket-token',
+    ]);
   });
 
   it('turns socket turn errors into visible retry banners', async () => {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -424,7 +424,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setConnectionStatus('connecting');
     readyRef.current = false;
 
-    const socket = new WebSocket(clientRef.current.socketUrl(sessionId, socketToken));
+    const socket = new WebSocket(
+      clientRef.current.socketUrl(sessionId, socketToken),
+      clientRef.current.socketProtocols(socketToken),
+    );
     socketRef.current = socket;
 
     socket.onopen = () => {

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -22,14 +22,20 @@ export type {
 } from '@franken/types';
 export type { ChatSessionResponse as ChatSession } from '@franken/types';
 
-export function toSocketUrl(baseUrl: string, sessionId: string, token: string): string {
+export const CHAT_SOCKET_PROTOCOL = 'franken.chat.v1';
+export const CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX = 'franken.chat.token.';
+
+export function toSocketUrl(baseUrl: string, sessionId: string, _token?: string): string {
   const url = new URL(baseUrl);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   url.pathname = `${url.pathname.replace(/\/$/, '')}/v1/chat/ws`;
   url.search = '';
   url.searchParams.set('sessionId', sessionId);
-  url.searchParams.set('token', token);
   return url.toString();
+}
+
+export function toSocketProtocols(token: string): string[] {
+  return [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${token}`];
 }
 
 export function resolveChatRequestBaseUrl(
@@ -125,8 +131,12 @@ export class ChatApiClient {
     );
   }
 
-  socketUrl(sessionId: string, token: string): string {
+  socketUrl(sessionId: string, token?: string): string {
     return toSocketUrl(this.requestBaseUrl, sessionId, token);
+  }
+
+  socketProtocols(token: string): string[] {
+    return toSocketProtocols(token);
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {

--- a/packages/franken-web/tests/components/app-error-boundary.test.tsx
+++ b/packages/franken-web/tests/components/app-error-boundary.test.tsx
@@ -58,7 +58,7 @@ describe('AppErrorBoundary', () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     expect(writeText.mock.calls[0]?.[0]).toContain('Boom while rendering dashboard');
     expect(writeText.mock.calls[0]?.[0]).toContain('0.1.0-test');
-    expect(screen.getByRole('button', { name: /diagnostics copied/i })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: /diagnostics copied/i })).toBeTruthy();
   });
 
   it('prompts for manual diagnostics when the clipboard API is unavailable', async () => {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -7,6 +7,7 @@ const mockGetSession = vi.fn();
 const mockSendMessage = vi.fn();
 const mockApprove = vi.fn();
 const mockSocketUrl = vi.fn();
+const mockSocketProtocols = vi.fn();
 
 vi.mock('../../src/lib/api', () => ({
   ChatApiClient: vi.fn(function (this: {
@@ -15,12 +16,14 @@ vi.mock('../../src/lib/api', () => ({
     sendMessage: typeof mockSendMessage;
     approve: typeof mockApprove;
     socketUrl: typeof mockSocketUrl;
+    socketProtocols: typeof mockSocketProtocols;
   }) {
     this.createSession = mockCreateSession;
     this.getSession = mockGetSession;
     this.sendMessage = mockSendMessage;
     this.approve = mockApprove;
     this.socketUrl = mockSocketUrl;
+    this.socketProtocols = mockSocketProtocols;
   }),
 }));
 
@@ -28,6 +31,7 @@ class MockWebSocket {
   static instances: MockWebSocket[] = [];
 
   readonly url: string;
+  readonly protocols?: string | string[];
   onopen: ((event: Event) => void) | null = null;
   onmessage: ((event: MessageEvent<string>) => void) | null = null;
   onclose: ((event: CloseEvent) => void) | null = null;
@@ -38,8 +42,9 @@ class MockWebSocket {
     this.readyState = 3;
   });
 
-  constructor(url: string) {
+  constructor(url: string, protocols?: string | string[]) {
     this.url = url;
+    this.protocols = protocols;
     MockWebSocket.instances.push(this);
   }
 
@@ -110,7 +115,8 @@ describe('useChatSession', () => {
       approved: true,
       state: 'active',
     });
-    mockSocketUrl.mockReturnValue('ws://localhost:3000/v1/chat/ws?sessionId=chat-1&token=signed-token');
+    mockSocketUrl.mockReturnValue('ws://localhost:3000/v1/chat/ws?sessionId=chat-1');
+    mockSocketProtocols.mockReturnValue(['franken.chat.v1', 'franken.chat.token.signed-token']);
   });
 
   afterEach(() => {
@@ -126,9 +132,14 @@ describe('useChatSession', () => {
 
     expect(mockCreateSession).toHaveBeenCalledWith('test-proj');
     expect(mockSocketUrl).toHaveBeenCalledWith('chat-1', 'signed-token');
+    expect(mockSocketProtocols).toHaveBeenCalledWith('signed-token');
     expect(MockWebSocket.instances[0]?.url).toBe(
-      'ws://localhost:3000/v1/chat/ws?sessionId=chat-1&token=signed-token',
+      'ws://localhost:3000/v1/chat/ws?sessionId=chat-1',
     );
+    expect(MockWebSocket.instances[0]?.protocols).toEqual([
+      'franken.chat.v1',
+      'franken.chat.token.signed-token',
+    ]);
   });
 
   it('streams assistant messages and updates receipts', async () => {

--- a/packages/franken-web/tests/lib/api.test.ts
+++ b/packages/franken-web/tests/lib/api.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ChatApiClient, resolveChatRequestBaseUrl, resolveChatRequestCredentials } from '../../src/lib/api';
+import {
+  CHAT_SOCKET_PROTOCOL,
+  CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
+  ChatApiClient,
+  resolveChatRequestBaseUrl,
+  resolveChatRequestCredentials,
+} from '../../src/lib/api';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -251,15 +257,24 @@ describe('ChatApiClient', () => {
   });
 
   describe('socketUrl', () => {
-    it('returns the websocket URL for a session', () => {
+    it('returns the websocket URL for a session without leaking the token into the query string', () => {
       const url = client.socketUrl('sess-1', 'signed-token');
-      expect(url).toBe('ws://localhost:3000/v1/chat/ws?sessionId=sess-1&token=signed-token');
+      expect(url).toBe('ws://localhost:3000/v1/chat/ws?sessionId=sess-1');
+      expect(url).not.toContain('signed-token');
+    });
+
+    it('sends the socket token via websocket subprotocols', () => {
+      expect(client.socketProtocols('signed-token')).toEqual([
+        CHAT_SOCKET_PROTOCOL,
+        `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}signed-token`,
+      ]);
     });
 
     it('keeps cross-origin websocket connections on the same-origin proxy', () => {
       const crossOrigin = new ChatApiClient('https://chat-api.example.test');
       const url = crossOrigin.socketUrl('sess-1', 'signed-token');
-      expect(url).toBe('ws://localhost:3000/v1/chat/ws?sessionId=sess-1&token=signed-token');
+      expect(url).toBe('ws://localhost:3000/v1/chat/ws?sessionId=sess-1');
+      expect(url).not.toContain('signed-token');
     });
   });
 


### PR DESCRIPTION
## Summary
- stop appending chat WebSocket socket tokens to browser WebSocket URLs
- send socket tokens via the Sec-WebSocket-Protocol handshake instead
- reject upgrade requests that only provide legacy query-string tokens

## Test Plan
- corepack npm run test --workspace @frankenbeast/web -- tests/lib/api.test.ts src/hooks/use-chat-session.test.tsx
- corepack npm run test --workspace franken-orchestrator -- tests/integration/chat/ws-chat-server.test.ts tests/integration/chat/ws-chat-auth.test.ts
- corepack npm run typecheck --workspace @frankenbeast/web
- corepack npm run build --workspace @frankenbeast/web
- corepack npm run typecheck --workspace franken-orchestrator
- corepack npm run build --workspace franken-orchestrator
- corepack npm run lint --workspace franken-orchestrator (passes with existing warnings)

Closes #569