### PR TITLE
fix(orchestrator): redact configured Beast log secrets

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -10,9 +10,60 @@ import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, Beas
 
 const STDERR_BUFFER_SIZE = 50;
 const REDACTED_SECRET = '[REDACTED]';
+const MIN_CONFIGURED_SECRET_LENGTH = 6;
 
-function redactBeastLogLine(line: string): string {
-  return line
+const SENSITIVE_CONFIG_KEY_PATTERN = /(?:^|[_\-.])(?:password|passwd|pwd|secret|client[_\-.]?secret|token|api[_\-.]?key|access[_\-.]?key|auth|credential|webhook[_\-.]?url)(?:$|[_\-.])/i;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isConfiguredSecretKey(key: string): boolean {
+  return SENSITIVE_CONFIG_KEY_PATTERN.test(key);
+}
+
+function addConfiguredSecretValue(secrets: Set<string>, value: unknown): void {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (trimmed.length < MIN_CONFIGURED_SECRET_LENGTH) return;
+  secrets.add(trimmed);
+}
+
+function collectConfiguredSecretsFromObject(
+  input: unknown,
+  secrets: Set<string>,
+  path: string[] = [],
+): void {
+  if (!input || typeof input !== 'object') return;
+  if (Array.isArray(input)) {
+    for (const item of input) collectConfiguredSecretsFromObject(item, secrets, path);
+    return;
+  }
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    const nextPath = [...path, key];
+    if (isConfiguredSecretKey(nextPath.join('.'))) {
+      addConfiguredSecretValue(secrets, value);
+    }
+    collectConfiguredSecretsFromObject(value, secrets, nextPath);
+  }
+}
+
+function collectConfiguredSecretValues(...sources: readonly unknown[]): readonly string[] {
+  const secrets = new Set<string>();
+  for (const source of sources) collectConfiguredSecretsFromObject(source, secrets);
+  return [...secrets].sort((a, b) => b.length - a.length);
+}
+
+function redactConfiguredSecretValues(line: string, configuredSecrets: readonly string[]): string {
+  let redacted = line;
+  for (const secret of configuredSecrets) {
+    redacted = redacted.replace(new RegExp(escapeRegExp(secret), 'g'), REDACTED_SECRET);
+  }
+  return redacted;
+}
+
+function redactBeastLogLine(line: string, configuredSecrets: readonly string[] = []): string {
+  return redactConfiguredSecretValues(line, configuredSecrets)
     .replace(/((?:"|')?authorization(?:"|')?\s*:\s*(?:"|')?(?:bearer|basic|bot)\s+)[^\s"',;}]+/gi, `$1${REDACTED_SECRET}`)
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, `$1${REDACTED_SECRET}`)
     .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTED_SECRET)
@@ -32,8 +83,8 @@ function redactBeastLogLine(line: string): string {
     );
 }
 
-function redactFailureStderrTail(stderrTail: readonly string[]): string[] {
-  return stderrTail.map(redactBeastLogLine);
+function redactFailureStderrTail(stderrTail: readonly string[], configuredSecrets: readonly string[]): string[] {
+  return stderrTail.map(line => redactBeastLogLine(line, configuredSecrets));
 }
 
 function moduleConfigToEnv(config?: ModuleConfig): Record<string, string> {
@@ -172,6 +223,13 @@ export class ProcessBeastExecutor implements BeastExecutor {
       },
     };
     const spawnedSpec = this.options.transformSpec?.(run, processSpec, mergedSpec) ?? mergedSpec;
+    const configuredSecrets = collectConfiguredSecretValues(
+      run.configSnapshot,
+      processSpec.env,
+      isolatedSpec.env,
+      mergedSpec.env,
+      spawnedSpec.env,
+    );
 
     // eslint-disable-next-line prefer-const -- reassigned after attempt creation (line 162)
     let attemptId: string | undefined;
@@ -184,7 +242,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     try {
       handle = await this.supervisor.spawn(spawnedSpec, {
         onStdout: (line) => {
-          const redactedLine = redactBeastLogLine(line);
+          const redactedLine = redactBeastLogLine(line, configuredSecrets);
           if (attemptId) {
             const createdAt = new Date().toISOString();
             void this.logs.append(run.id, attemptId, 'stdout', redactedLine, createdAt);
@@ -197,7 +255,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
           }
         },
         onStderr: (line) => {
-          const redactedLine = redactBeastLogLine(line);
+          const redactedLine = redactBeastLogLine(line, configuredSecrets);
           stderrTail.push(redactedLine);
           if (stderrTail.length > STDERR_BUFFER_SIZE) stderrTail.shift();
           if (attemptId) {
@@ -213,7 +271,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         },
         onExit: (code, signal) => {
           if (attemptId) {
-            this.handleProcessExit(run.id, attemptId, code, signal, [...stderrTail]);
+            this.handleProcessExit(run.id, attemptId, code, signal, [...stderrTail], configuredSecrets);
           } else {
             earlyExit = { code, signal };
           }
@@ -311,7 +369,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     // Flush early exit if process died before attemptId was set
     let flushedEarlyExit = false;
     if (earlyExit) {
-      this.handleProcessExit(run.id, attemptId, earlyExit.code, earlyExit.signal, [...stderrTail]);
+      this.handleProcessExit(run.id, attemptId, earlyExit.code, earlyExit.signal, [...stderrTail], configuredSecrets);
       flushedEarlyExit = true;
     }
 
@@ -393,6 +451,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     code: number | null,
     signal: string | null,
     stderrTail: string[],
+    configuredSecrets: readonly string[],
   ): void {
     // Skip if attempt is already in a terminal state (e.g., finishAttempt already ran from stop/kill)
     const currentAttempt = this.repository.getAttempt(attemptId);
@@ -435,7 +494,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     const durationMs = attemptRecord?.startedAt
       ? new Date(finishedAt).getTime() - new Date(attemptRecord.startedAt).getTime()
       : undefined;
-    const redactedStderrTail = code !== 0 ? redactFailureStderrTail(stderrTail) : [];
+    const redactedStderrTail = code !== 0 ? redactFailureStderrTail(stderrTail, configuredSecrets) : [];
     const exitEvent = {
       attemptId,
       type: eventType,

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -12,21 +12,23 @@ const STDERR_BUFFER_SIZE = 50;
 const REDACTED_SECRET = '[REDACTED]';
 const MIN_CONFIGURED_SECRET_LENGTH = 6;
 
-const SENSITIVE_CONFIG_KEY_PATTERN = /(?:^|[_\-.])(?:password|passwd|pwd|secret|client[_\-.]?secret|token|api[_\-.]?key|access[_\-.]?key|auth|credential|webhook[_\-.]?url)(?:$|[_\-.])/i;
+const SENSITIVE_CONFIG_KEY_PATTERN = /(?:password|passwd|pwd|secret|clientsecret|token|apikey|accesskey|privatekey|auth|credential|webhookurl)/i;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isConfiguredSecretKey(key: string): boolean {
-  return SENSITIVE_CONFIG_KEY_PATTERN.test(key);
+  return SENSITIVE_CONFIG_KEY_PATTERN.test(key.replace(/[_\-.]/g, ''));
 }
 
 function addConfiguredSecretValue(secrets: Set<string>, value: unknown): void {
   if (typeof value !== 'string') return;
-  const trimmed = value.trim();
-  if (trimmed.length < MIN_CONFIGURED_SECRET_LENGTH) return;
-  secrets.add(trimmed);
+  const fragments = value.split(/\r?\n/);
+  for (const fragment of fragments) {
+    const trimmed = fragment.trim();
+    if (trimmed.length >= MIN_CONFIGURED_SECRET_LENGTH) secrets.add(trimmed);
+  }
 }
 
 function collectConfiguredSecretsFromObject(
@@ -34,6 +36,8 @@ function collectConfiguredSecretsFromObject(
   secrets: Set<string>,
   path: string[] = [],
 ): void {
+  const currentPathIsSensitive = path.length > 0 && isConfiguredSecretKey(path.join('.'));
+  if (currentPathIsSensitive) addConfiguredSecretValue(secrets, input);
   if (!input || typeof input !== 'object') return;
   if (Array.isArray(input)) {
     for (const item of input) collectConfiguredSecretsFromObject(item, secrets, path);

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -547,6 +547,85 @@ describe('ProcessBeastExecutor', () => {
       );
     });
 
+    it('redacts configured secret values from stdout, stderr, persisted logs, and streamed log events', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const appendSpy = vi.spyOn(logs, 'append');
+      const eventBus = new BeastEventBus();
+      const publishSpy = vi.spyOn(eventBus, 'publish');
+      const supervisor = createSupervisorMock();
+      const envSecret = 'configured-env-secret-12345';
+      const configSecret = 'configured-webhook-secret-67890';
+      const visibleValue = 'visible-nonsecret-value';
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { eventBus });
+      const run = repo.createRun({
+        definitionId: 'test-beast',
+        definitionVersion: 1,
+        executionMode: 'process',
+        configSnapshot: {
+          webhookUrl: configSecret,
+          normalOutput: visibleValue,
+        },
+        dispatchedBy: 'cli',
+        dispatchedByUser: 'pfk',
+        createdAt: '2026-03-10T00:00:00.000Z',
+      });
+      const definition: BeastDefinition = {
+        ...createDefinitionWithCwd(workDir),
+        buildProcessSpec: () => ({
+          command: 'node',
+          args: ['agent.js'],
+          cwd: workDir,
+          env: { SERVICE_TOKEN: envSecret, NORMAL_OUTPUT: visibleValue },
+        }),
+      };
+
+      const attempt = await executor.start(run, definition);
+      const [, callbacks] = supervisor.spawn.mock.calls[0];
+      const cb = callbacks as ProcessCallbacks;
+
+      cb.onStdout(`stdout ${envSecret} ${visibleValue}`);
+      cb.onStderr(`stderr ${configSecret} ${visibleValue}`);
+      cb.onExit(1, null);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(appendSpy).toHaveBeenCalledWith(
+        run.id,
+        attempt.id,
+        'stdout',
+        `stdout [REDACTED] ${visibleValue}`,
+        expect.any(String),
+      );
+      expect(appendSpy).toHaveBeenCalledWith(
+        run.id,
+        attempt.id,
+        'stderr',
+        `stderr [REDACTED] ${visibleValue}`,
+        expect.any(String),
+      );
+      const failEvent = repo.listEvents(run.id).find((e) => e.type === 'attempt.failed');
+      expect(failEvent!.payload).toMatchObject({
+        lastStderrLines: [`stderr [REDACTED] ${visibleValue}`],
+      });
+      const publishedLogLines = publishSpy.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.type === 'run.log')
+        .map((event) => event.data.line);
+      expect(publishedLogLines).toContain(`stdout [REDACTED] ${visibleValue}`);
+      expect(publishedLogLines).toContain(`stderr [REDACTED] ${visibleValue}`);
+      const persistedLogLines = (await logs.read(run.id, attempt.id)).join('\n');
+      expect(persistedLogLines).toContain(`stdout [REDACTED] ${visibleValue}`);
+      expect(persistedLogLines).toContain(`stderr [REDACTED] ${visibleValue}`);
+      expect(persistedLogLines).not.toContain(envSecret);
+      expect(persistedLogLines).not.toContain(configSecret);
+
+      const serializedPersistedEvents = JSON.stringify(repo.listEvents(run.id));
+      expect(serializedPersistedEvents).not.toContain(envSecret);
+      expect(serializedPersistedEvents).not.toContain(configSecret);
+      expect(serializedPersistedEvents).toContain(visibleValue);
+    });
+
     it('publishes early buffered lines to eventBus after attempt creation', async () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -557,6 +557,9 @@ describe('ProcessBeastExecutor', () => {
       const supervisor = createSupervisorMock();
       const envSecret = 'configured-env-secret-12345';
       const configSecret = 'configured-webhook-secret-67890';
+      const camelCaseSecret = 'configured-camel-case-token-24680';
+      const multilineSecretLine = 'configured-multiline-secret-line-13579';
+      const arraySecret = 'configured-array-token-97531';
       const visibleValue = 'visible-nonsecret-value';
       const executor = new ProcessBeastExecutor(repo, logs, supervisor, { eventBus });
       const run = repo.createRun({
@@ -565,6 +568,9 @@ describe('ProcessBeastExecutor', () => {
         executionMode: 'process',
         configSnapshot: {
           webhookUrl: configSecret,
+          signingSecret: camelCaseSecret,
+          apiKey: [`prefix-${arraySecret}`],
+          privateKey: `-----BEGIN PRIVATE KEY-----\n${multilineSecretLine}\n-----END PRIVATE KEY-----`,
           normalOutput: visibleValue,
         },
         dispatchedBy: 'cli',
@@ -585,8 +591,8 @@ describe('ProcessBeastExecutor', () => {
       const [, callbacks] = supervisor.spawn.mock.calls[0];
       const cb = callbacks as ProcessCallbacks;
 
-      cb.onStdout(`stdout ${envSecret} ${visibleValue}`);
-      cb.onStderr(`stderr ${configSecret} ${visibleValue}`);
+      cb.onStdout(`stdout ${envSecret} ${camelCaseSecret} ${multilineSecretLine} ${visibleValue}`);
+      cb.onStderr(`stderr ${configSecret} prefix-${arraySecret} ${visibleValue}`);
       cb.onExit(1, null);
       await new Promise((r) => setTimeout(r, 10));
 
@@ -594,35 +600,41 @@ describe('ProcessBeastExecutor', () => {
         run.id,
         attempt.id,
         'stdout',
-        `stdout [REDACTED] ${visibleValue}`,
+        `stdout [REDACTED] [REDACTED] [REDACTED] ${visibleValue}`,
         expect.any(String),
       );
       expect(appendSpy).toHaveBeenCalledWith(
         run.id,
         attempt.id,
         'stderr',
-        `stderr [REDACTED] ${visibleValue}`,
+        `stderr [REDACTED] [REDACTED] ${visibleValue}`,
         expect.any(String),
       );
       const failEvent = repo.listEvents(run.id).find((e) => e.type === 'attempt.failed');
       expect(failEvent!.payload).toMatchObject({
-        lastStderrLines: [`stderr [REDACTED] ${visibleValue}`],
+        lastStderrLines: [`stderr [REDACTED] [REDACTED] ${visibleValue}`],
       });
       const publishedLogLines = publishSpy.mock.calls
         .map(([event]) => event)
         .filter((event) => event.type === 'run.log')
         .map((event) => event.data.line);
-      expect(publishedLogLines).toContain(`stdout [REDACTED] ${visibleValue}`);
-      expect(publishedLogLines).toContain(`stderr [REDACTED] ${visibleValue}`);
+      expect(publishedLogLines).toContain(`stdout [REDACTED] [REDACTED] [REDACTED] ${visibleValue}`);
+      expect(publishedLogLines).toContain(`stderr [REDACTED] [REDACTED] ${visibleValue}`);
       const persistedLogLines = (await logs.read(run.id, attempt.id)).join('\n');
-      expect(persistedLogLines).toContain(`stdout [REDACTED] ${visibleValue}`);
-      expect(persistedLogLines).toContain(`stderr [REDACTED] ${visibleValue}`);
+      expect(persistedLogLines).toContain(`stdout [REDACTED] [REDACTED] [REDACTED] ${visibleValue}`);
+      expect(persistedLogLines).toContain(`stderr [REDACTED] [REDACTED] ${visibleValue}`);
       expect(persistedLogLines).not.toContain(envSecret);
       expect(persistedLogLines).not.toContain(configSecret);
+      expect(persistedLogLines).not.toContain(camelCaseSecret);
+      expect(persistedLogLines).not.toContain(multilineSecretLine);
+      expect(persistedLogLines).not.toContain(arraySecret);
 
       const serializedPersistedEvents = JSON.stringify(repo.listEvents(run.id));
       expect(serializedPersistedEvents).not.toContain(envSecret);
       expect(serializedPersistedEvents).not.toContain(configSecret);
+      expect(serializedPersistedEvents).not.toContain(camelCaseSecret);
+      expect(serializedPersistedEvents).not.toContain(multilineSecretLine);
+      expect(serializedPersistedEvents).not.toContain(arraySecret);
       expect(serializedPersistedEvents).toContain(visibleValue);
     });
 


### PR DESCRIPTION
## Summary
- Redacts configured secret values from Beast stdout/stderr before append and event streaming.
- Applies the same configured-secret redaction to failure stderr tails persisted in run events.
- Adds regression coverage for stdout, stderr, streamed log events, persisted log files, and `lastStderrLines`.

## Test Plan
- `npm run test -- tests/unit/beasts/process-beast-executor.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint` (passes with existing warnings)

Closes #568
