### PR TITLE
test(security): cover exposed unsigned webhook startup guard

### DIFF
--- a/docs/adr/016-external-comms-gateway.md
+++ b/docs/adr/016-external-comms-gateway.md
@@ -22,6 +22,7 @@ Each channel integration MUST implement platform-native request verification at 
 - **Slack**: HMAC-SHA256 signature verification with a 5-minute replay protection window.
 - **Generic**: Timing-safe equality checks for all signature comparisons.
 - **Validation**: Strict Zod schema enforcement for all inbound payloads before they reach the gateway logic.
+- **Exposed listeners**: Slack, Discord, and WhatsApp signature verification MUST remain enabled whenever webhook routes are exposed beyond loopback. Any unsigned override is limited to loopback-only local development, and startup must fail closed if an exposed listener would serve those routes unsigned.
 
 ## Consequences
 - **Positive**: Low-latency, streaming feedback on Slack/Discord; shared business logic in `ConversationEngine`; horizontal scalability of the gateway.

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -161,6 +161,56 @@ describe('startChatServer comms pass-through', () => {
     }
   });
 
+  it('fails closed on exposed hosts before disabling Slack, Discord, or WhatsApp signatures', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chat-server-exposed-webhooks-'));
+    tempDirs.push(dir);
+
+    await expect(startChatServer({
+      host: '0.0.0.0',
+      port: 0,
+      sessionStoreDir: '/tmp/chat-server-comms-test',
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      operatorToken: 'operator-token',
+      commsConfig: {
+        orchestrator: {},
+        channels: {
+          slack: {
+            enabled: true,
+            token: 'slack-token',
+            signingSecret: 'slack-signing-secret',
+          },
+          discord: {
+            enabled: true,
+            token: 'discord-token',
+            publicKey: 'discord-public-key',
+          },
+          whatsapp: {
+            enabled: true,
+            accessToken: 'whatsapp-token',
+            phoneNumberId: 'phone-number-id',
+            appSecret: 'whatsapp-app-secret',
+            verifyToken: 'whatsapp-verify-token',
+          },
+        },
+      },
+      networkControl: {
+        root: '/tmp/project',
+        frankenbeastDir: '/tmp/project/.frankenbeast',
+        configFile: join(dir, 'config.json'),
+        getConfig: () => ({
+          security: {
+            profile: 'permissive',
+            webhookSignaturePolicy: 'local-dev-unsigned',
+          },
+        }) as never,
+        setConfig: vi.fn(),
+      },
+    })).rejects.toThrow(/slack, discord, whatsapp webhooks require signature verification/i);
+
+    expect(mockedCreateChatApp).not.toHaveBeenCalled();
+  });
+
   it('allows unsigned external webhooks on loopback-only local development', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chat-server-local-webhooks-'));
     tempDirs.push(dir);


### PR DESCRIPTION
## Summary
- add regression coverage that an exposed chat server fails closed before disabling Slack, Discord, or WhatsApp webhook signatures
- document that unsigned webhook overrides are loopback-only and exposed listeners must fail closed

## Test Plan
- npm run build
- npm run --workspace packages/franken-orchestrator test -- tests/unit/http/chat-server-comms.test.ts tests/unit/http/comms-routes.test.ts tests/integration/http/control-plane-auth.test.ts
- npm run --workspace packages/franken-orchestrator typecheck
- npm run --workspace packages/franken-orchestrator build
- npm run --workspace packages/franken-orchestrator lint

Closes #567