### PR TITLE
fix(cli): pass provider override extra args

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -26,6 +26,7 @@ type CliTransformed = {
 type ProviderOverride = {
   command?: string | undefined;
   model?: string | undefined;
+  extraArgs?: readonly string[] | undefined;
 };
 
 type LlmReplayRecorder = (record: {
@@ -171,6 +172,7 @@ export class CliLlmAdapter implements IAdapter {
           model: activeModel,
           chatMode,
           sessionContinue,
+          extraArgs: this.resolveExtraArgs(activeProvider),
         }),
         env: provider.filterEnv(this.captureEnv()),
         prompt,
@@ -293,6 +295,10 @@ export class CliLlmAdapter implements IAdapter {
       return this.opts.model ?? requestModel;
     }
     return undefined;
+  }
+
+  private resolveExtraArgs(name: string): readonly string[] | undefined {
+    return this.opts.providerOverrides?.[name]?.extraArgs;
   }
 
   private captureEnv(): Record<string, string> {

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -248,6 +248,25 @@ describe('CliLlmAdapter', () => {
         expect(calls[0]!.cmd).toBe('/usr/local/bin/claude-custom');
       });
 
+      it('passes configured provider override extraArgs to the selected provider argv', async () => {
+        const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providerOverrides: {
+              claude: { extraArgs: ['--temperature', '0.5'] },
+            },
+          },
+          spawnFn,
+        );
+
+        await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+        expect(calls[0]!.args).toContain('--temperature');
+        expect(calls[0]!.args[calls[0]!.args.indexOf('--temperature') + 1]).toBe('0.5');
+      });
+
       it('builds args via provider.buildArgs() and pipes prompt via stdin', async () => {
         const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
         const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);


### PR DESCRIPTION
## Summary
- Pass provider override extraArgs into the CLI provider buildArgs call on the main CliLlmAdapter execute path.
- Add regression coverage proving configured extra args reach spawned Claude CLI argv.

## Test Plan
- npm test -- tests/unit/adapters/cli-llm-adapter.test.ts
- npm run typecheck
- npm run lint (0 errors; existing warnings remain)
- npm run build

Closes #671