### PR TITLE
fix(web): upgrade network log viewer

### DIFF
--- a/packages/franken-web/src/components/network-logs-panel.tsx
+++ b/packages/franken-web/src/components/network-logs-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 interface NetworkLogsPanelProps {
   logs: string[];
@@ -44,6 +44,7 @@ export function NetworkLogsPanel({
   const [levelFilter, setLevelFilter] = useState<LogLevel | 'all'>('all');
   const [wrapLines, setWrapLines] = useState(true);
   const [tailLogs, setTailLogs] = useState(true);
+  const logListRef = useRef<HTMLOListElement | null>(null);
 
   const loggableServices = services.filter((service) => !service.inProcess || service.hostServiceId);
   const parsedLogs = useMemo(() => logs.map((line, index) => ({ ...parseLogLine(line), index, line })), [logs]);
@@ -61,6 +62,22 @@ export function NetworkLogsPanel({
     ? `${logs.length} ${logs.length === 1 ? 'entry' : 'entries'}`
     : `${visibleLogs.length} of ${logs.length} entries`;
   const downloadName = `${selectedServiceId || 'network'}-network.log`;
+
+  useEffect(() => {
+    if (!tailLogs || !logListRef.current) {
+      return;
+    }
+
+    if (typeof logListRef.current.scrollTo === 'function') {
+      logListRef.current.scrollTo({
+        top: logListRef.current.scrollHeight,
+        behavior: 'smooth',
+      });
+      return;
+    }
+
+    logListRef.current.scrollTop = logListRef.current.scrollHeight;
+  }, [tailLogs, visibleText]);
 
   function copyVisibleLogs() {
     if (!visibleText) {
@@ -159,7 +176,11 @@ export function NetworkLogsPanel({
               </a>
             </div>
             {visibleLogs.length > 0 ? (
-              <ol className={`network-logs__lines${wrapLines ? ' network-logs__lines--wrap' : ''}${tailLogs ? ' network-logs__lines--tail' : ''}`} aria-label="Visible network logs">
+              <ol
+                ref={logListRef}
+                className={`network-logs__lines${wrapLines ? ' network-logs__lines--wrap' : ''}${tailLogs ? ' network-logs__lines--tail' : ''}`}
+                aria-label="Visible network logs"
+              >
                 {visibleLogs.map((log) => (
                   <li className={`network-logs__line network-logs__line--${log.level}`} key={`${log.index}:${log.line}`}>
                     <span className="network-logs__line-number">{log.index + 1}</span>

--- a/packages/franken-web/src/components/network-logs-panel.tsx
+++ b/packages/franken-web/src/components/network-logs-panel.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from 'react';
+
 interface NetworkLogsPanelProps {
   logs: string[];
   services: Array<{ id: string; status: string; inProcess?: boolean; hostServiceId?: string }>;
@@ -5,6 +7,29 @@ interface NetworkLogsPanelProps {
   isLoading?: boolean;
   error?: string | null;
   onSelectService(serviceId: string): void;
+}
+
+type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal' | 'unknown';
+
+const LOG_LEVELS: Array<LogLevel | 'all'> = ['all', 'trace', 'debug', 'info', 'warn', 'error', 'fatal', 'unknown'];
+
+const TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2}(?:T|\s)\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)/;
+const LEVEL_PATTERN = /\b(trace|debug|info|warn|warning|error|fatal)\b/i;
+
+function parseLogLine(line: string) {
+  const timestamp = line.match(TIMESTAMP_PATTERN)?.[1];
+  const rawLevel = line.match(LEVEL_PATTERN)?.[1]?.toLowerCase();
+  const level: LogLevel = rawLevel === 'warning'
+    ? 'warn'
+    : rawLevel === 'trace' || rawLevel === 'debug' || rawLevel === 'info' || rawLevel === 'warn' || rawLevel === 'error' || rawLevel === 'fatal'
+      ? rawLevel
+      : 'unknown';
+
+  return { level, timestamp };
+}
+
+function buildDownloadHref(lines: string[]) {
+  return `data:text/plain;charset=utf-8,${encodeURIComponent(lines.join('\n'))}`;
 }
 
 export function NetworkLogsPanel({
@@ -15,12 +40,44 @@ export function NetworkLogsPanel({
   error = null,
   onSelectService,
 }: NetworkLogsPanelProps) {
+  const [query, setQuery] = useState('');
+  const [levelFilter, setLevelFilter] = useState<LogLevel | 'all'>('all');
+  const [wrapLines, setWrapLines] = useState(true);
+  const [tailLogs, setTailLogs] = useState(true);
+
   const loggableServices = services.filter((service) => !service.inProcess || service.hostServiceId);
+  const parsedLogs = useMemo(() => logs.map((line, index) => ({ ...parseLogLine(line), index, line })), [logs]);
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleLogs = useMemo(
+    () => parsedLogs.filter((log) => {
+      const matchesQuery = normalizedQuery.length === 0 || log.line.toLowerCase().includes(normalizedQuery);
+      const matchesLevel = levelFilter === 'all' || log.level === levelFilter;
+      return matchesQuery && matchesLevel;
+    }),
+    [levelFilter, normalizedQuery, parsedLogs],
+  );
+  const visibleText = visibleLogs.map((log) => log.line).join('\n');
+  const totalLabel = visibleLogs.length === logs.length
+    ? `${logs.length} ${logs.length === 1 ? 'entry' : 'entries'}`
+    : `${visibleLogs.length} of ${logs.length} entries`;
+  const downloadName = `${selectedServiceId || 'network'}-network.log`;
+
+  function copyVisibleLogs() {
+    if (!visibleText) {
+      return;
+    }
+
+    void navigator.clipboard?.writeText(visibleText);
+  }
 
   return (
     <section className="rail-card network-logs">
-      <div className="rail-card__header">
-        <p className="eyebrow">Logs</p>
+      <div className="rail-card__header network-logs__header">
+        <div>
+          <p className="eyebrow">Logs</p>
+          <h2>Operational log viewer</h2>
+        </div>
+        {!isLoading && !error && logs.length > 0 ? <span className="network-logs__count">{totalLabel}</span> : null}
       </div>
       <label className="field-stack">
         <span>Service logs</span>
@@ -39,10 +96,87 @@ export function NetworkLogsPanel({
         </select>
       </label>
       <div className="network-logs__list">
-        {isLoading ? <p>Loading logs...</p> : null}
-        {!isLoading && error ? <p role="alert">{error}</p> : null}
-        {!isLoading && !error && logs.length > 0 ? logs.map((log, index) => <code key={`${index}:${log}`}>{log}</code>) : null}
-        {!isLoading && !error && logs.length === 0 ? <p>{selectedServiceId ? 'No logs found.' : 'No logs selected.'}</p> : null}
+        {isLoading ? <p>Loading logs for the selected service...</p> : null}
+        {!isLoading && error ? <p role="alert">Could not load logs. Check whether the service is running, then refresh. {error}</p> : null}
+        {!isLoading && !error && logs.length > 0 ? (
+          <div className="network-logs__viewer">
+            <div className="network-logs__toolbar" aria-label="Log viewer controls">
+              <label className="field-stack network-logs__search">
+                <span>Search</span>
+                <input
+                  aria-label="Search logs"
+                  className="field-control"
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Filter visible logs"
+                  type="search"
+                  value={query}
+                />
+              </label>
+              <label className="field-stack network-logs__level">
+                <span>Level</span>
+                <select
+                  aria-label="Log level"
+                  className="field-control"
+                  onChange={(event) => setLevelFilter(event.target.value as LogLevel | 'all')}
+                  value={levelFilter}
+                >
+                  {LOG_LEVELS.map((level) => (
+                    <option key={level} value={level}>{level === 'all' ? 'All levels' : level}</option>
+                  ))}
+                </select>
+              </label>
+              <button
+                aria-pressed={tailLogs}
+                className="button button--secondary button--small"
+                onClick={() => setTailLogs((value) => !value)}
+                type="button"
+              >
+                {tailLogs ? 'Tail live logs' : 'Paused'}
+              </button>
+              <label className="network-logs__toggle">
+                <input
+                  aria-label="Wrap log lines"
+                  checked={wrapLines}
+                  onChange={(event) => setWrapLines(event.target.checked)}
+                  type="checkbox"
+                />
+                <span>Wrap</span>
+              </label>
+              <button
+                className="button button--secondary button--small"
+                disabled={visibleLogs.length === 0}
+                onClick={copyVisibleLogs}
+                type="button"
+              >
+                Copy visible logs
+              </button>
+              <a
+                className="button button--secondary button--small"
+                download={downloadName}
+                href={buildDownloadHref(visibleLogs.map((log) => log.line))}
+              >
+                Download visible logs
+              </a>
+            </div>
+            {visibleLogs.length > 0 ? (
+              <ol className={`network-logs__lines${wrapLines ? ' network-logs__lines--wrap' : ''}${tailLogs ? ' network-logs__lines--tail' : ''}`} aria-label="Visible network logs">
+                {visibleLogs.map((log) => (
+                  <li className={`network-logs__line network-logs__line--${log.level}`} key={`${log.index}:${log.line}`}>
+                    <span className="network-logs__line-number">{log.index + 1}</span>
+                    <span className="network-logs__badge">{log.level}</span>
+                    {log.timestamp ? <time dateTime={log.timestamp}>{log.timestamp}</time> : null}
+                    <code>{log.line}</code>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p>No logs match the current search and level filters.</p>
+            )}
+          </div>
+        ) : null}
+        {!isLoading && !error && logs.length === 0 ? (
+          <p>{selectedServiceId ? 'No logs are available yet. Refresh after the service emits output, or pick another service.' : 'Select a service to inspect its operational logs.'}</p>
+        ) : null}
       </div>
     </section>
   );

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -742,6 +742,123 @@ button {
   font-size: 1.05rem;
 }
 
+.network-logs__header,
+.network-logs__toolbar,
+.network-logs__line,
+.network-logs__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.network-logs__header,
+.network-logs__toolbar {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.network-logs__count {
+  padding: 0.22rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.network-logs__list,
+.network-logs__viewer {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.network-logs__search {
+  flex: 1 1 12rem;
+}
+
+.network-logs__level {
+  flex: 0 0 8.5rem;
+}
+
+.network-logs__toggle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.network-logs__lines {
+  display: grid;
+  gap: 0.35rem;
+  max-height: 24rem;
+  margin: 0;
+  padding: 0.55rem;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 0.95rem;
+  background: rgba(0, 0, 0, 0.18);
+  list-style: none;
+}
+
+.network-logs__lines--tail {
+  scroll-behavior: smooth;
+}
+
+.network-logs__line {
+  align-items: flex-start;
+  padding: 0.45rem 0.55rem;
+  border-left: 3px solid var(--border);
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.025);
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.network-logs__line code {
+  min-width: 0;
+  white-space: pre;
+  overflow-wrap: normal;
+}
+
+.network-logs__lines--wrap .network-logs__line code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.network-logs__line-number,
+.network-logs__badge,
+.network-logs__line time {
+  flex: 0 0 auto;
+  color: var(--text-subtle);
+}
+
+.network-logs__badge {
+  min-width: 4.8rem;
+  padding: 0.12rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.network-logs__line--info {
+  border-left-color: #7dd3fc;
+}
+
+.network-logs__line--warn {
+  border-left-color: #fbbf24;
+}
+
+.network-logs__line--error,
+.network-logs__line--fatal {
+  border-left-color: var(--danger);
+}
+
+.network-logs__line--debug,
+.network-logs__line--trace {
+  border-left-color: var(--accent);
+}
+
 .cost-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -246,6 +246,10 @@ describe('NetworkPage', () => {
   });
 
   it('upgrades network logs into a searchable operational viewer', () => {
+    const scrollTo = vi.fn();
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    HTMLElement.prototype.scrollTo = scrollTo;
+
     render(
       <NetworkPage
         config={baseConfig}
@@ -270,6 +274,7 @@ describe('NetworkPage', () => {
     expect(screen.getByRole('button', { name: 'Copy visible logs' })).toBeDefined();
     expect(screen.getByRole('link', { name: 'Download visible logs' }).getAttribute('download')).toBe('chat-server-network.log');
     expect(screen.getByRole('button', { name: 'Tail live logs' }).getAttribute('aria-pressed')).toBe('true');
+    expect(scrollTo).toHaveBeenCalled();
     expect((screen.getByLabelText('Wrap log lines') as HTMLInputElement).checked).toBe(true);
 
     const errorLine = screen.getByText(/failed to bind port/).closest('li');
@@ -285,5 +290,7 @@ describe('NetworkPage', () => {
     fireEvent.change(screen.getByLabelText('Log level'), { target: { value: 'warn' } });
 
     expect(screen.getByText('No logs match the current search and level filters.')).toBeDefined();
+
+    HTMLElement.prototype.scrollTo = originalScrollTo;
   });
 });

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -244,4 +244,46 @@ describe('NetworkPage', () => {
     expect(screen.queryByRole('option', { name: 'orphan-in-process (running)' })).toBeNull();
     expect(screen.getByRole('option', { name: 'comms-gateway (running)' })).toBeDefined();
   });
+
+  it('upgrades network logs into a searchable operational viewer', () => {
+    render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[
+          '2026-07-05T07:00:00Z INFO chat-server ready',
+          '2026-07-05T07:01:00Z ERROR failed to bind port',
+          'WARN retrying connection to dashboard',
+        ]}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={vi.fn()}
+        onSelectLogService={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        selectedLogServiceId="chat-server"
+        services={[{ id: 'chat-server', status: 'running' }]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    expect(screen.getByText('3 entries')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Copy visible logs' })).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Download visible logs' }).getAttribute('download')).toBe('chat-server-network.log');
+    expect(screen.getByRole('button', { name: 'Tail live logs' }).getAttribute('aria-pressed')).toBe('true');
+    expect((screen.getByLabelText('Wrap log lines') as HTMLInputElement).checked).toBe(true);
+
+    const errorLine = screen.getByText(/failed to bind port/).closest('li');
+    expect(errorLine?.getAttribute('class')).toContain('network-logs__line--error');
+    expect(errorLine?.querySelector('time')?.getAttribute('dateTime')).toBe('2026-07-05T07:01:00Z');
+
+    fireEvent.change(screen.getByLabelText('Search logs'), { target: { value: 'failed' } });
+
+    expect(screen.getByText('1 of 3 entries')).toBeDefined();
+    expect(screen.getByText(/failed to bind port/)).toBeDefined();
+    expect(screen.queryByText(/chat-server ready/)).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Log level'), { target: { value: 'warn' } });
+
+    expect(screen.getByText('No logs match the current search and level filters.')).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- Replace raw Network log code lines with an operational viewer
- Add search, level filtering, copy/download, wrap, and tail/pause controls
- Highlight timestamps and log severity with actionable loading/empty/error copy

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm test -- tests/components/network-page.test.tsx -t "upgrades network logs"
- npm test -- tests/components/network-page.test.tsx
- npm test -- tests/components/chat-shell.test.tsx -t "network logs"
- npm run typecheck (packages/franken-web)
- npm run build (packages/franken-web)
- npm test (packages/franken-web)

Closes #658