### PR TITLE
fix(web): mark stale analytics metrics during filter loads

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -101,6 +101,66 @@ describe('AnalyticsPage', () => {
     });
   });
 
+  it('marks summary metrics as updating instead of silently showing stale filter values', async () => {
+    const client = mockClient();
+    let resolveFilteredSummary!: (summary: Awaited<ReturnType<AnalyticsApiClient['fetchSummary']>>) => void;
+    let resolveFilteredSessions!: (sessions: Awaited<ReturnType<AnalyticsApiClient['fetchSessions']>>) => void;
+    vi.mocked(client.fetchSummary)
+      .mockResolvedValueOnce({
+        totalEvents: 3,
+        uniqueSessions: 2,
+        denialCount: 1,
+        errorCount: 1,
+        failureCount: 0,
+        securityDetectionCount: 1,
+        tokenTotals: { prompt: 100, completion: 50, total: 150 },
+        costTotals: { usd: 0.25 },
+      })
+      .mockReturnValueOnce(new Promise((resolve) => {
+        resolveFilteredSummary = resolve;
+      }));
+    vi.mocked(client.fetchSessions)
+      .mockResolvedValueOnce([
+        { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
+      ])
+      .mockReturnValueOnce(new Promise((resolve) => {
+        resolveFilteredSessions = resolve;
+      }));
+
+    render(<AnalyticsPage client={client} />);
+
+    expect(await screen.findByText('Total Events')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Metrics last updated for Last 24h.')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Session'), { target: { value: 'session-a' } });
+
+    expect(screen.getByText('Updating metrics for Session session-a · Last 24h...')).toBeTruthy();
+    expect(screen.getByText('Showing previous metric values until refreshed.')).toBeTruthy();
+    expect(screen.getByLabelText('Analytics summary').getAttribute('aria-busy')).toBe('true');
+    expect(screen.getByText('3')).toBeTruthy();
+
+    resolveFilteredSummary({
+      totalEvents: 1,
+      uniqueSessions: 1,
+      denialCount: 0,
+      errorCount: 0,
+      failureCount: 0,
+      securityDetectionCount: 0,
+      tokenTotals: { prompt: 40, completion: 10, total: 50 },
+      costTotals: { usd: 0.1 },
+    });
+    resolveFilteredSessions([
+      { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 1, failureCount: 0 },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Analytics summary').getAttribute('aria-busy')).toBe('false');
+      expect(screen.getByText('Metrics last updated for Session session-a · Last 24h.')).toBeTruthy();
+    });
+  });
+
   it('navigates event pages and exposes disabled pagination states', async () => {
     const client = mockClient();
     let resolveSecondPage!: (page: AnalyticsEventPage) => void;

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -191,6 +191,8 @@ describe('AnalyticsPage', () => {
     expect(await screen.findByText('summary timeout')).toBeTruthy();
     expect(screen.getByText('Metric values are still from Last 24h; refresh for Session session-a · Last 24h failed or is incomplete.')).toBeTruthy();
     expect(screen.getByText('Showing previous metric values until refreshed.')).toBeTruthy();
+    expect(screen.queryByText('Updating')).toBeNull();
+    expect(screen.getAllByText('Stale').length).toBeGreaterThan(0);
     expect(screen.getByLabelText('Analytics summary').getAttribute('aria-busy')).toBe('false');
     expect(screen.getByText('3')).toBeTruthy();
   });

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -161,6 +161,40 @@ describe('AnalyticsPage', () => {
     });
   });
 
+  it('keeps prior metric values marked stale when a filtered summary refresh fails', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchSummary)
+      .mockResolvedValueOnce({
+        totalEvents: 3,
+        uniqueSessions: 2,
+        denialCount: 1,
+        errorCount: 1,
+        failureCount: 0,
+        securityDetectionCount: 1,
+        tokenTotals: { prompt: 100, completion: 50, total: 150 },
+        costTotals: { usd: 0.25 },
+      })
+      .mockRejectedValueOnce(new Error('summary timeout'));
+    vi.mocked(client.fetchSessions)
+      .mockResolvedValueOnce([
+        { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
+      ]);
+
+    render(<AnalyticsPage client={client} />);
+    await screen.findByText('Metrics last updated for Last 24h.');
+
+    fireEvent.change(screen.getByLabelText('Session'), { target: { value: 'session-a' } });
+
+    expect(await screen.findByText('summary timeout')).toBeTruthy();
+    expect(screen.getByText('Metric values are still from Last 24h; refresh for Session session-a · Last 24h failed or is incomplete.')).toBeTruthy();
+    expect(screen.getByText('Showing previous metric values until refreshed.')).toBeTruthy();
+    expect(screen.getByLabelText('Analytics summary').getAttribute('aria-busy')).toBe('false');
+    expect(screen.getByText('3')).toBeTruthy();
+  });
+
   it('navigates event pages and exposes disabled pagination states', async () => {
     const client = mockClient();
     let resolveSecondPage!: (page: AnalyticsEventPage) => void;

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -47,6 +47,8 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [detailError, setDetailError] = useState<string | null>(null);
   const [overviewError, setOverviewError] = useState<string | null>(null);
   const [eventsError, setEventsError] = useState<string | null>(null);
+  const [isOverviewLoading, setIsOverviewLoading] = useState(true);
+  const [overviewLastUpdatedFilter, setOverviewLastUpdatedFilter] = useState<string | null>(null);
   const [isEventsLoading, setIsEventsLoading] = useState(true);
   const [pendingFocusEventId, setPendingFocusEventId] = useState<string | null>(null);
   const detailTriggerRef = useRef<HTMLElement | null>(null);
@@ -58,6 +60,8 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   useEffect(() => {
     let cancelled = false;
     setOverviewError(null);
+    setIsOverviewLoading(true);
+    const requestedFilterLabel = describeFilters(filters);
 
     void Promise.allSettled([
       client.fetchSummary(filters),
@@ -74,6 +78,8 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
         setSessions(sessionsResult.value);
       }
       setOverviewError(errors.length > 0 ? errors.join('; ') : null);
+      setOverviewLastUpdatedFilter(requestedFilterLabel);
+      setIsOverviewLoading(false);
     });
 
     return () => {
@@ -112,6 +118,15 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const canGoPrevious = currentPage > 1 && !isEventsLoading;
   const canGoNext = currentPage < totalPages && !isEventsLoading;
   const loadError = [overviewError, eventsError].filter(Boolean).join('; ') || null;
+  const currentFilterLabel = describeFilters(filters);
+  const hasStaleOverview = isOverviewLoading && (summary !== null || sessions.length > 0);
+  const overviewStatus = isOverviewLoading
+    ? hasStaleOverview
+      ? `Updating metrics for ${currentFilterLabel}...`
+      : `Loading metrics for ${currentFilterLabel}...`
+    : overviewLastUpdatedFilter
+      ? `Metrics last updated for ${overviewLastUpdatedFilter}.`
+      : null;
   const activityEvents = useMemo(
     () => events.filter((event) => event.outcome === 'approved' && event.source !== 'governor'),
     [events],
@@ -205,17 +220,30 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 
       {loadError && <div className="analytics-alert">{loadError}</div>}
 
-      <section className="analytics-summary-grid" aria-label="Analytics summary">
-        <MetricCard label="Total Events" value={summary?.totalEvents ?? 0} />
-        <MetricCard label="Sessions" value={summary?.uniqueSessions ?? 0} />
-        <MetricCard label="Denials" value={summary?.denialCount ?? 0} tone="danger" />
-        <MetricCard label="Errors" value={(summary?.errorCount ?? 0) + (summary?.failureCount ?? 0)} tone="danger" />
-        <MetricCard label="Detections" value={summary?.securityDetectionCount ?? 0} tone="warning" />
-        <MetricCard label="Tokens" value={summary?.tokenTotals.total ?? 0} />
-        <MetricCard label="Cost" value={`$${(summary?.costTotals.usd ?? 0).toFixed(2)}`} />
+      <section className="analytics-summary-region" aria-busy={isOverviewLoading} aria-label="Analytics summary">
+        {overviewStatus && (
+          <div className="analytics-summary-status" role="status">
+            <span>{overviewStatus}</span>
+            {hasStaleOverview && <span>Showing previous metric values until refreshed.</span>}
+          </div>
+        )}
+        <div className="analytics-summary-grid">
+          <MetricCard label="Total Events" value={summary?.totalEvents ?? '—'} isStale={hasStaleOverview} />
+          <MetricCard label="Sessions" value={summary?.uniqueSessions ?? '—'} isStale={hasStaleOverview} />
+          <MetricCard label="Denials" value={summary?.denialCount ?? '—'} tone="danger" isStale={hasStaleOverview} />
+          <MetricCard
+            label="Errors"
+            value={summary ? summary.errorCount + summary.failureCount : '—'}
+            tone="danger"
+            isStale={hasStaleOverview}
+          />
+          <MetricCard label="Detections" value={summary?.securityDetectionCount ?? '—'} tone="warning" isStale={hasStaleOverview} />
+          <MetricCard label="Tokens" value={summary?.tokenTotals.total ?? '—'} isStale={hasStaleOverview} />
+          <MetricCard label="Cost" value={summary ? `$${summary.costTotals.usd.toFixed(2)}` : '—'} isStale={hasStaleOverview} />
+        </div>
       </section>
 
-      <section className="analytics-filter-bar" aria-label="Analytics filters">
+      <section className="analytics-filter-bar" aria-busy={isOverviewLoading} aria-label="Analytics filters">
         <label className="field-stack">
           <span>Session</span>
           <select
@@ -291,6 +319,8 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
             ))}
           </select>
         </label>
+
+        {isOverviewLoading && <div className="analytics-filter-status">Refreshing session options...</div>}
       </section>
 
       <section className="analytics-pagination" aria-label="Analytics pagination">
@@ -346,13 +376,34 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   );
 }
 
-function MetricCard({ label, value, tone }: { label: string; value: string | number; tone?: 'danger' | 'warning' }) {
+function MetricCard({
+  isStale = false,
+  label,
+  tone,
+  value,
+}: {
+  isStale?: boolean;
+  label: string;
+  value: string | number;
+  tone?: 'danger' | 'warning';
+}) {
   return (
-    <article className={`analytics-metric ${tone ? `analytics-metric--${tone}` : ''}`}>
+    <article className={`analytics-metric ${tone ? `analytics-metric--${tone}` : ''} ${isStale ? 'analytics-metric--stale' : ''}`}>
       <span>{label}</span>
       <strong>{value}</strong>
+      {isStale && <small>Updating</small>}
     </article>
   );
+}
+
+function describeFilters(filters: AnalyticsFilters): string {
+  const parts: string[] = [];
+  if (filters.sessionId) parts.push(`Session ${filters.sessionId}`);
+  if (filters.toolQuery) parts.push(`Tool ${filters.toolQuery}`);
+  if (filters.outcome) parts.push(`Outcome ${filters.outcome}`);
+  const windowLabel = TIME_WINDOWS.find((window) => window.value === (filters.timeWindow ?? '24h'))?.label ?? filters.timeWindow ?? 'Last 24h';
+  parts.push(windowLabel);
+  return parts.join(' · ');
 }
 
 function AnalyticsTable({

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -48,7 +48,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [overviewError, setOverviewError] = useState<string | null>(null);
   const [eventsError, setEventsError] = useState<string | null>(null);
   const [isOverviewLoading, setIsOverviewLoading] = useState(true);
-  const [overviewLastUpdatedFilter, setOverviewLastUpdatedFilter] = useState<string | null>(null);
+  const [summaryFilter, setSummaryFilter] = useState<string | null>(null);
   const [isEventsLoading, setIsEventsLoading] = useState(true);
   const [pendingFocusEventId, setPendingFocusEventId] = useState<string | null>(null);
   const detailTriggerRef = useRef<HTMLElement | null>(null);
@@ -73,12 +73,12 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
         .map((result) => result.reason instanceof Error ? result.reason.message : 'Unable to load analytics.');
       if (summaryResult.status === 'fulfilled') {
         setSummary(summaryResult.value);
+        setSummaryFilter(requestedFilterLabel);
       }
       if (sessionsResult.status === 'fulfilled') {
         setSessions(sessionsResult.value);
       }
       setOverviewError(errors.length > 0 ? errors.join('; ') : null);
-      setOverviewLastUpdatedFilter(requestedFilterLabel);
       setIsOverviewLoading(false);
     });
 
@@ -119,13 +119,16 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const canGoNext = currentPage < totalPages && !isEventsLoading;
   const loadError = [overviewError, eventsError].filter(Boolean).join('; ') || null;
   const currentFilterLabel = describeFilters(filters);
-  const hasStaleOverview = isOverviewLoading && (summary !== null || sessions.length > 0);
+  const isSummaryStale = summary !== null && summaryFilter !== null && summaryFilter !== currentFilterLabel;
+  const hasStaleOverview = (isOverviewLoading && summary !== null) || isSummaryStale;
   const overviewStatus = isOverviewLoading
     ? hasStaleOverview
       ? `Updating metrics for ${currentFilterLabel}...`
       : `Loading metrics for ${currentFilterLabel}...`
-    : overviewLastUpdatedFilter
-      ? `Metrics last updated for ${overviewLastUpdatedFilter}.`
+    : isSummaryStale && summaryFilter
+      ? `Metric values are still from ${summaryFilter}; refresh for ${currentFilterLabel} failed or is incomplete.`
+      : summaryFilter
+        ? `Metrics last updated for ${summaryFilter}.`
       : null;
   const activityEvents = useMemo(
     () => events.filter((event) => event.outcome === 'approved' && event.source !== 'governor'),

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -121,6 +121,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const currentFilterLabel = describeFilters(filters);
   const isSummaryStale = summary !== null && summaryFilter !== null && summaryFilter !== currentFilterLabel;
   const hasStaleOverview = (isOverviewLoading && summary !== null) || isSummaryStale;
+  const metricStatusLabel = isOverviewLoading ? 'Updating' : 'Stale';
   const overviewStatus = isOverviewLoading
     ? hasStaleOverview
       ? `Updating metrics for ${currentFilterLabel}...`
@@ -231,18 +232,19 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
           </div>
         )}
         <div className="analytics-summary-grid">
-          <MetricCard label="Total Events" value={summary?.totalEvents ?? '—'} isStale={hasStaleOverview} />
-          <MetricCard label="Sessions" value={summary?.uniqueSessions ?? '—'} isStale={hasStaleOverview} />
-          <MetricCard label="Denials" value={summary?.denialCount ?? '—'} tone="danger" isStale={hasStaleOverview} />
+          <MetricCard label="Total Events" value={summary?.totalEvents ?? '—'} isStale={hasStaleOverview} staleLabel={metricStatusLabel} />
+          <MetricCard label="Sessions" value={summary?.uniqueSessions ?? '—'} isStale={hasStaleOverview} staleLabel={metricStatusLabel} />
+          <MetricCard label="Denials" value={summary?.denialCount ?? '—'} tone="danger" isStale={hasStaleOverview} staleLabel={metricStatusLabel} />
           <MetricCard
             label="Errors"
             value={summary ? summary.errorCount + summary.failureCount : '—'}
             tone="danger"
             isStale={hasStaleOverview}
+            staleLabel={metricStatusLabel}
           />
-          <MetricCard label="Detections" value={summary?.securityDetectionCount ?? '—'} tone="warning" isStale={hasStaleOverview} />
-          <MetricCard label="Tokens" value={summary?.tokenTotals.total ?? '—'} isStale={hasStaleOverview} />
-          <MetricCard label="Cost" value={summary ? `$${summary.costTotals.usd.toFixed(2)}` : '—'} isStale={hasStaleOverview} />
+          <MetricCard label="Detections" value={summary?.securityDetectionCount ?? '—'} tone="warning" isStale={hasStaleOverview} staleLabel={metricStatusLabel} />
+          <MetricCard label="Tokens" value={summary?.tokenTotals.total ?? '—'} isStale={hasStaleOverview} staleLabel={metricStatusLabel} />
+          <MetricCard label="Cost" value={summary ? `$${summary.costTotals.usd.toFixed(2)}` : '—'} isStale={hasStaleOverview} staleLabel={metricStatusLabel} />
         </div>
       </section>
 
@@ -382,11 +384,13 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 function MetricCard({
   isStale = false,
   label,
+  staleLabel = 'Stale',
   tone,
   value,
 }: {
   isStale?: boolean;
   label: string;
+  staleLabel?: string;
   value: string | number;
   tone?: 'danger' | 'warning';
 }) {
@@ -394,7 +398,7 @@ function MetricCard({
     <article className={`analytics-metric ${tone ? `analytics-metric--${tone}` : ''} ${isStale ? 'analytics-metric--stale' : ''}`}>
       <span>{label}</span>
       <strong>{value}</strong>
-      {isStale && <small>Updating</small>}
+      {isStale && <small>{staleLabel}</small>}
     </article>
   );
 }

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1089,6 +1089,25 @@ button {
   color: #ffd0ca;
 }
 
+.analytics-summary-region {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.analytics-summary-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.analytics-summary-status span:first-child {
+  color: var(--text);
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
 .analytics-summary-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(7rem, 1fr));
@@ -1099,7 +1118,7 @@ button {
   min-height: 6.25rem;
   display: grid;
   align-content: space-between;
-  gap: 0.75rem;
+  gap: 0.5rem;
   padding: 0.9rem 1rem;
   border-radius: 1rem;
 }
@@ -1121,6 +1140,24 @@ button {
 
 .analytics-metric--warning {
   border-color: rgba(255, 205, 86, 0.36);
+}
+
+.analytics-metric--stale {
+  border-color: rgba(124, 179, 255, 0.45);
+  background: rgba(124, 179, 255, 0.08);
+}
+
+.analytics-metric small {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.analytics-filter-status {
+  grid-column: 1 / -1;
+  color: var(--text-muted);
+  font-size: 0.82rem;
 }
 
 .analytics-filter-bar {


### PR DESCRIPTION
## Summary
- add scoped analytics summary loading/stale state during filter changes
- show last-updated filter context and keep prior metric values visibly marked while refreshing
- add regression coverage for filter-scoped metric loading state

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @frankenbeast/web
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web

Closes #656