### PR TITLE
fix(web): clarify chat session switcher states

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -43,6 +43,59 @@ const ROUTES: Array<{ id: RouteId; label: string; summary: string; live: boolean
   { id: 'settings', label: 'Settings', summary: 'Operator configuration and launch profiles', live: false },
 ];
 
+function formatSessionCount(count: number): string {
+  return `${count} ${count === 1 ? 'message' : 'messages'}`;
+}
+
+function formatRelativeUpdatedTime(value: string): string {
+  const updatedAt = new Date(value).getTime();
+  if (!Number.isFinite(updatedAt)) {
+    return 'updated time unknown';
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - updatedAt) / 1000));
+  if (elapsedSeconds < 60) {
+    return 'updated just now';
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) {
+    return `updated ${elapsedMinutes}m ago`;
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) {
+    return `updated ${elapsedHours}h ago`;
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 30) {
+    return `updated ${elapsedDays}d ago`;
+  }
+
+  return `updated ${new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
+}
+
+function shortenSessionId(id: string): string {
+  if (id.length <= 14) {
+    return id;
+  }
+
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+function formatSessionOptionLabel(session: ChatSessionSummary): string {
+  const preview = session.preview.trim();
+  const details = [
+    session.state,
+    formatSessionCount(session.messageCount),
+    formatRelativeUpdatedTime(session.updatedAt),
+    shortenSessionId(session.id),
+  ];
+
+  return preview ? `${preview} — ${details.join(' · ')}` : details.join(' · ');
+}
+
 function routeFromHash(hash: string): RouteId {
   const candidate = hash.replace(/^#\/?/, '') as RouteId;
   return ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
@@ -191,6 +244,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>(sessionId);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [chatSessions, setChatSessions] = useState<ChatSessionSummary[]>([]);
+  const [chatSessionsLoading, setChatSessionsLoading] = useState(true);
+  const [chatSessionsError, setChatSessionsError] = useState<string | null>(null);
+  const [chatSessionsRefreshNonce, setChatSessionsRefreshNonce] = useState(0);
   const [beastCatalog, setBeastCatalog] = useState<BeastCatalogEntry[]>([]);
   const [beastAgents, setBeastAgents] = useState<TrackedAgentSummary[]>([]);
   const [beastRuns, setBeastRuns] = useState<BeastRunSummary[]>([]);
@@ -278,22 +334,31 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   useEffect(() => {
     let cancelled = false;
+    setChatSessionsLoading(true);
+    setChatSessionsError(null);
+
     void chatClient.listSessions(projectId)
       .then((sessions) => {
         if (!cancelled) {
           setChatSessions(sessions);
         }
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (!cancelled) {
           setChatSessions([]);
+          setChatSessionsError(error instanceof Error ? error.message : 'Unable to load conversations.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setChatSessionsLoading(false);
         }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [chatClient, projectId, activeSessionId, sessionSeed]);
+  }, [chatClient, projectId, activeSessionId, sessionSeed, chatSessionsRefreshNonce]);
 
   useEffect(() => {
     beastAgentsRef.current = beastAgents;
@@ -671,8 +736,10 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                   <label className="field-stack">
                     <span>Conversation</span>
                     <select
+                      aria-describedby="conversation-status"
                       aria-label="Conversation"
                       className="field-control"
+                      disabled={chatSessionsLoading}
                       onChange={(event) => {
                         const nextId = event.target.value.trim();
                         setSelectedSessionId(nextId || undefined);
@@ -682,11 +749,37 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                       <option value="">Current conversation</option>
                       {chatSessions.map((session) => (
                         <option key={session.id} value={session.id}>
-                          {session.preview ? `${session.id} · ${session.preview}` : session.id}
+                          {formatSessionOptionLabel(session)}
                         </option>
                       ))}
                     </select>
+                    {chatSessionsLoading ? (
+                      <small id="conversation-status" className="field-hint" role="status">
+                        Loading saved conversations…
+                      </small>
+                    ) : chatSessionsError ? (
+                      <small id="conversation-status" className="field-error" role="alert">
+                        Failed to load conversations: {chatSessionsError}
+                      </small>
+                    ) : chatSessions.length === 0 ? (
+                      <small id="conversation-status" className="field-hint">
+                        No saved conversations yet.
+                      </small>
+                    ) : (
+                      <small id="conversation-status" className="field-hint">
+                        {chatSessions.length} saved {chatSessions.length === 1 ? 'conversation' : 'conversations'} available.
+                      </small>
+                    )}
                   </label>
+                  {chatSessionsError ? (
+                    <button
+                      className="button button--secondary button--compact"
+                      onClick={() => setChatSessionsRefreshNonce((current) => current + 1)}
+                      type="button"
+                    >
+                      Retry conversations
+                    </button>
+                  ) : null}
                   <button
                     className="button button--secondary"
                     onClick={() => {

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1024,9 +1024,17 @@ button {
   display: none;
 }
 
+.field-hint,
+.field-error {
+  font-size: 0.82rem;
+}
+
+.field-hint {
+  color: var(--text-subtle);
+}
+
 .field-error {
   color: var(--danger);
-  font-size: 0.82rem;
 }
 
 .beast-card__modules {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -401,6 +401,61 @@ describe('ChatShell', () => {
     expect(screen.getByText('turn.execution.start')).toBeDefined();
   });
 
+  it('labels conversations with preview, state, message count, updated time, and a shortened id', async () => {
+    mockListSessions.mockResolvedValue([
+      {
+        id: 'session-1234567890abcdef',
+        projectId: 'test-project',
+        state: 'awaiting_approval',
+        messageCount: 3,
+        preview: 'Need deploy approval',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', {
+        name: /Need deploy approval — awaiting_approval · 3 messages · updated just now · session-…cdef/,
+      })).toBeDefined();
+      expect(screen.getByText('1 saved conversation available.')).toBeDefined();
+    });
+  });
+
+  it('shows loading, error, and retry states for conversation list failures', async () => {
+    mockListSessions.mockRejectedValueOnce(new Error('session service down'));
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    const conversationSelect = screen.getByLabelText('Conversation') as HTMLSelectElement;
+    expect(conversationSelect.disabled).toBe(true);
+    expect(screen.getByText('Loading saved conversations…')).toBeDefined();
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('session service down');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry conversations' }));
+
+    await waitFor(() => {
+      expect(mockListSessions).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('1 saved conversation available.')).toBeDefined();
+    });
+  });
+
+  it('distinguishes an empty conversation list from a failed load', async () => {
+    mockListSessions.mockResolvedValueOnce([]);
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No saved conversations yet.')).toBeDefined();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+  });
+
   it('fetches network logs when a service is selected on the Network page', async () => {
     window.location.hash = '#/network';
     render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);


### PR DESCRIPTION
## Summary
- add loading, empty, error, and retry states to the chat conversation selector
- label saved conversations with preview, state, message count, relative updated time, and shortened session id
- cover session switcher labels and failure states with component tests

## Test Plan
- npm test -- --run tests/components/chat-shell.test.tsx
- npm run build -w @franken/types
- npm run typecheck -w @frankenbeast/web
- npm run build -w @frankenbeast/web

Closes #655