### PR TITLE
fix(web): show network service action feedback

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -952,7 +952,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             }}
             onRestart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
-              void client.restart(serviceId).then(() => client.getStatus()).then(setNetworkStatus).catch(() => undefined);
+              return client.restart(serviceId).then(() => client.getStatus()).then(setNetworkStatus);
             }}
             onSaveConfig={(assignments) => {
               const client = new NetworkApiClient(baseUrl);
@@ -995,11 +995,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             }}
             onStart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
-              void client.start(serviceId).then(() => client.getStatus()).then(setNetworkStatus).catch(() => undefined);
+              return client.start(serviceId).then(() => client.getStatus()).then(setNetworkStatus);
             }}
             onStop={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
-              void client.stop(serviceId).then(() => client.getStatus()).then(setNetworkStatus).catch(() => undefined);
+              return client.stop(serviceId).then(() => client.getStatus()).then(setNetworkStatus);
             }}
             selectedLogServiceId={selectedNetworkLogServiceId}
             services={networkStatus.services}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -952,7 +952,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             }}
             onRestart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
-              return client.restart(serviceId).then(() => client.getStatus()).then(setNetworkStatus);
+              return client.restart(serviceId).then(() => {
+                void client.getStatus().then(setNetworkStatus).catch(() => undefined);
+              });
             }}
             onSaveConfig={(assignments) => {
               const client = new NetworkApiClient(baseUrl);
@@ -995,11 +997,15 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             }}
             onStart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
-              return client.start(serviceId).then(() => client.getStatus()).then(setNetworkStatus);
+              return client.start(serviceId).then(() => {
+                void client.getStatus().then(setNetworkStatus).catch(() => undefined);
+              });
             }}
             onStop={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
-              return client.stop(serviceId).then(() => client.getStatus()).then(setNetworkStatus);
+              return client.stop(serviceId).then(() => {
+                void client.getStatus().then(setNetworkStatus).catch(() => undefined);
+              });
             }}
             selectedLogServiceId={selectedNetworkLogServiceId}
             services={networkStatus.services}

--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 interface NetworkServiceItem {
   id: string;
   status: string;
@@ -9,10 +11,23 @@ interface NetworkServiceItem {
 
 interface NetworkServiceListProps {
   services: NetworkServiceItem[];
-  onStart(serviceId: string): void;
-  onStop(serviceId: string): void;
-  onRestart(serviceId: string): void;
+  onStart(serviceId: string): Promise<void> | void;
+  onStop(serviceId: string): Promise<void> | void;
+  onRestart(serviceId: string): Promise<void> | void;
 }
+
+type ServiceAction = 'start' | 'stop' | 'restart';
+
+interface ServiceActionState {
+  status: 'pending' | 'success' | 'error';
+  message: string;
+}
+
+const actionLabels: Record<ServiceAction, { present: string; past: string }> = {
+  start: { present: 'Starting', past: 'Started' },
+  stop: { present: 'Stopping', past: 'Stopped' },
+  restart: { present: 'Restarting', past: 'Restarted' },
+};
 
 export function NetworkServiceList({
   services,
@@ -20,6 +35,42 @@ export function NetworkServiceList({
   onStop,
   onRestart,
 }: NetworkServiceListProps) {
+  const [actionStateByService, setActionStateByService] = useState<Record<string, ServiceActionState>>({});
+
+  const runAction = (serviceId: string, action: ServiceAction, callback: (serviceId: string) => Promise<void> | void) => {
+    const current = actionStateByService[serviceId];
+    if (current?.status === 'pending') {
+      return;
+    }
+    setActionStateByService((states) => ({
+      ...states,
+      [serviceId]: {
+        status: 'pending',
+        message: `${actionLabels[action].present} ${serviceId}…`,
+      },
+    }));
+    void Promise.resolve(callback(serviceId))
+      .then(() => {
+        setActionStateByService((states) => ({
+          ...states,
+          [serviceId]: {
+            status: 'success',
+            message: `${actionLabels[action].past} ${serviceId}.`,
+          },
+        }));
+      })
+      .catch((error: unknown) => {
+        const detail = error instanceof Error ? error.message : 'Action failed.';
+        setActionStateByService((states) => ({
+          ...states,
+          [serviceId]: {
+            status: 'error',
+            message: `Unable to ${action} ${serviceId}: ${detail}`,
+          },
+        }));
+      });
+  };
+
   return (
     <section className="rail-card network-services">
       <div className="rail-card__header">
@@ -27,7 +78,9 @@ export function NetworkServiceList({
       </div>
       <div className="network-services__list">
         {services.map((service) => {
-          const disableInProcessControls = Boolean(service.inProcess);
+          const actionState = actionStateByService[service.id];
+          const hasPendingAction = actionState?.status === 'pending';
+          const disableInProcessControls = Boolean(service.inProcess) || hasPendingAction;
           return (
           <article key={service.id} className="network-services__item">
             <div>
@@ -37,11 +90,19 @@ export function NetworkServiceList({
               {service.explanation && <span>{service.explanation}</span>}
               {service.url && <small>{service.url}</small>}
               {service.channels && <small>{Object.entries(service.channels).map(([name, enabled]) => `${name}:${enabled ? 'on' : 'off'}`).join(' ')}</small>}
+              {actionState && (
+                <small
+                  aria-live="polite"
+                  role={actionState.status === 'error' ? 'alert' : undefined}
+                >
+                  {actionState.message}
+                </small>
+              )}
             </div>
             <div className="network-services__actions">
-              <button className="button button--secondary button--small" type="button" onClick={() => onStart(service.id)} aria-label={`Start ${service.id}`}>Start</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => onStop(service.id)} aria-label={`Stop ${service.id}`} disabled={disableInProcessControls}>Stop</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => onRestart(service.id)} aria-label={`Restart ${service.id}`} disabled={disableInProcessControls}>Restart</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service.id, 'start', onStart)} aria-label={`Start ${service.id}`} disabled={hasPendingAction}>Start</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service.id, 'stop', onStop)} aria-label={`Stop ${service.id}`} disabled={disableInProcessControls}>Stop</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service.id, 'restart', onRestart)} aria-label={`Restart ${service.id}`} disabled={disableInProcessControls}>Restart</button>
             </div>
           </article>
           );

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -13,9 +13,9 @@ interface NetworkPageProps {
   logsError?: string | null;
   config: NetworkConfigResponse;
   onRefresh(): void;
-  onStart(serviceId: string): void;
-  onStop(serviceId: string): void;
-  onRestart(serviceId: string): void;
+  onStart(serviceId: string): Promise<void> | void;
+  onStop(serviceId: string): Promise<void> | void;
+  onRestart(serviceId: string): Promise<void> | void;
   onSaveConfig(assignments: string[]): Promise<void> | void;
   onSelectLogService(serviceId: string): void;
 }

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -601,10 +601,34 @@ describe('ChatShell', () => {
 
     await waitFor(() => {
       expect(mockNetworkStart).toHaveBeenCalledWith('chat-server');
-      expect(mockNetworkGetStatus).toHaveBeenCalledTimes(2);
-      expect(screen.getByText('running')).toBeDefined();
       expect(screen.getByText('Started chat-server.')).toBeDefined();
     });
+    await waitFor(() => {
+      expect(mockNetworkGetStatus).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('running')).toBeDefined();
+    });
+  });
+
+  it('keeps service action success feedback when the follow-up status refresh fails', async () => {
+    window.location.hash = '#/network';
+    mockNetworkGetStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      })
+      .mockRejectedValueOnce(new Error('status endpoint unavailable'));
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
+
+    await waitFor(() => {
+      expect(mockNetworkRestart).toHaveBeenCalledWith('chat-server');
+      expect(screen.getByText('Restarted chat-server.')).toBeDefined();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+    await waitFor(() => expect(mockNetworkGetStatus).toHaveBeenCalledTimes(2));
   });
 
   it('shows connection and session status in the top bar', () => {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -160,6 +160,9 @@ const mockNetworkGetConfig = vi.fn().mockResolvedValue({
   chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
 });
 const mockNetworkGetLogs = vi.fn().mockResolvedValue({ logs: ['chat log line'] });
+const mockNetworkStart = vi.fn().mockResolvedValue(undefined);
+const mockNetworkStop = vi.fn().mockResolvedValue(undefined);
+const mockNetworkRestart = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../src/hooks/use-chat-session.js', () => ({
   useChatSession: () => ({
@@ -250,10 +253,20 @@ vi.mock('../../src/lib/beast-api.js', () => ({
 }));
 
 vi.mock('../../src/lib/network-api.js', () => ({
-  NetworkApiClient: vi.fn(function (this: { getStatus: ReturnType<typeof vi.fn>; getConfig: ReturnType<typeof vi.fn>; getLogs: ReturnType<typeof vi.fn> }) {
+  NetworkApiClient: vi.fn(function (this: {
+    getStatus: ReturnType<typeof vi.fn>;
+    getConfig: ReturnType<typeof vi.fn>;
+    getLogs: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    restart: ReturnType<typeof vi.fn>;
+  }) {
     this.getStatus = mockNetworkGetStatus;
     this.getConfig = mockNetworkGetConfig;
     this.getLogs = mockNetworkGetLogs;
+    this.start = mockNetworkStart;
+    this.stop = mockNetworkStop;
+    this.restart = mockNetworkRestart;
   }),
 }));
 
@@ -360,6 +373,12 @@ afterEach(() => {
   });
   mockNetworkGetLogs.mockReset();
   mockNetworkGetLogs.mockResolvedValue({ logs: ['chat log line'] });
+  mockNetworkStart.mockReset();
+  mockNetworkStart.mockResolvedValue(undefined);
+  mockNetworkStop.mockReset();
+  mockNetworkStop.mockResolvedValue(undefined);
+  mockNetworkRestart.mockReset();
+  mockNetworkRestart.mockResolvedValue(undefined);
   mockGetRun.mockReset();
   mockGetRun.mockResolvedValue({
     run: {
@@ -533,6 +552,58 @@ describe('ChatShell', () => {
     await waitFor(() => {
       expect(screen.queryByText('current log line')).toBeNull();
       expect(screen.getByRole('alert').textContent).toContain('log endpoint failed');
+    });
+  });
+
+  it('shows pending and failure feedback for network service actions', async () => {
+    window.location.hash = '#/network';
+    let rejectStart!: (error: Error) => void;
+    mockNetworkStart.mockImplementationOnce(() => new Promise((_, reject) => {
+      rejectStart = reject;
+    }));
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    const startButton = await screen.findByRole('button', { name: 'Start chat-server' });
+
+    fireEvent.click(startButton);
+    fireEvent.click(startButton);
+
+    expect(mockNetworkStart).toHaveBeenCalledTimes(1);
+    expect(startButton).toHaveProperty('disabled', true);
+    expect(screen.getByText('Starting chat-server…')).toBeDefined();
+
+    rejectStart(new Error('service manager unreachable'));
+
+    await waitFor(() => {
+      expect(startButton).toHaveProperty('disabled', false);
+      expect(screen.getByRole('alert').textContent).toContain('Unable to start chat-server: service manager unreachable');
+    });
+  });
+
+  it('shows success feedback and refreshes status after network service actions complete', async () => {
+    window.location.hash = '#/network';
+    mockNetworkGetStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'stopped' }],
+      })
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      });
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start chat-server' }));
+
+    await waitFor(() => {
+      expect(mockNetworkStart).toHaveBeenCalledWith('chat-server');
+      expect(mockNetworkGetStatus).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('running')).toBeDefined();
+      expect(screen.getByText('Started chat-server.')).toBeDefined();
     });
   });
 

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -46,10 +46,10 @@ describe('NetworkPage', () => {
     expect(screen.getByRole('button', { name: 'Save config' }).getAttribute('class')).toContain('button--primary');
   });
 
-  it('invokes service controls and saves all changed config assignments atomically', () => {
-    const onStart = vi.fn();
-    const onStop = vi.fn();
-    const onRestart = vi.fn();
+  it('invokes service controls and saves all changed config assignments atomically', async () => {
+    const onStart = vi.fn().mockResolvedValue(undefined);
+    const onStop = vi.fn().mockResolvedValue(undefined);
+    const onRestart = vi.fn().mockResolvedValue(undefined);
     const onSaveConfig = vi.fn();
 
     render(
@@ -75,8 +75,11 @@ describe('NetworkPage', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Start chat-server' }));
+    await waitFor(() => expect(screen.getByText('Started chat-server.')).toBeDefined());
     fireEvent.click(screen.getByRole('button', { name: 'Stop chat-server' }));
+    await waitFor(() => expect(screen.getByText('Stopped chat-server.')).toBeDefined());
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat-server' }));
+    await waitFor(() => expect(screen.getByText('Restarted chat-server.')).toBeDefined());
     fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'hybrid' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
     fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });


### PR DESCRIPTION
## Summary
- track per-service Network action pending, success, and error state in the service list
- disable duplicate row actions while a service control request is in flight
- return Network action promises so failures surface inline and successful actions refresh status

## Test Plan
- npm test -- tests/components/chat-shell.test.tsx tests/components/network-page.test.tsx
- npm run typecheck
- npm run build

Closes #650