### PR TITLE
fix(web): keep closed mobile sidebar out of focus

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -84,6 +84,12 @@ function shortenSessionId(id: string): string {
   return `${id.slice(0, 8)}…${id.slice(-4)}`;
 }
 
+function getSidebarFocusableElements(sidebar: HTMLElement): HTMLElement[] {
+  return Array.from(
+    sidebar.querySelectorAll<HTMLElement>('a[href]:not(.sidebar__focus-guard), button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not(.sidebar__focus-guard)'),
+  );
+}
+
 function formatSessionOptionLabel(session: ChatSessionSummary): string {
   const preview = session.preview.trim();
   const details = [
@@ -241,6 +247,10 @@ function buildInitAction(
 export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellProps) {
   const [route, setRoute] = useState<RouteId>(() => routeFromHash(window.location.hash));
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isMobileSidebar, setIsMobileSidebar] = useState(() => window.matchMedia?.('(max-width: 920px)').matches ?? false);
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const sidebarToggleRef = useRef<HTMLButtonElement | null>(null);
+  const wasSidebarOpenRef = useRef(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>(sessionId);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [chatSessions, setChatSessions] = useState<ChatSessionSummary[]>([]);
@@ -610,17 +620,66 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   }, []);
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia?.('(max-width: 920px)');
+    if (!mediaQuery) return;
+
+    const updateMobileSidebarState = () => setIsMobileSidebar(mediaQuery.matches);
+    updateMobileSidebarState();
+    mediaQuery.addEventListener('change', updateMobileSidebarState);
+    return () => mediaQuery.removeEventListener('change', updateMobileSidebarState);
+  }, []);
+
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
-        setIsSidebarOpen(false);
+        closeSidebar();
       }
     }
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [isSidebarOpen]);
+
+  useEffect(() => {
+    const sidebar = sidebarRef.current;
+    if (!isMobileSidebar || !isSidebarOpen || !sidebar) {
+      if (wasSidebarOpenRef.current && !isSidebarOpen) {
+        sidebarToggleRef.current?.focus();
+      }
+      wasSidebarOpenRef.current = isSidebarOpen;
+      return;
+    }
+
+    const focusableElements = getSidebarFocusableElements(sidebar);
+    const firstFocusableElement = focusableElements[0];
+
+    firstFocusableElement?.focus();
+    wasSidebarOpenRef.current = true;
+  }, [isMobileSidebar, isSidebarOpen]);
 
   const activeRoute = ROUTES.find((item) => item.id === route) ?? ROUTES[0]!;
+  const isSidebarHidden = isMobileSidebar && !isSidebarOpen;
+  const sidebarHiddenAttributes: Record<string, string> = isSidebarHidden ? { 'aria-hidden': 'true', inert: '' } : {};
+  const focusGuardTabIndex = isMobileSidebar && isSidebarOpen ? 0 : -1;
+
+  function closeSidebar() {
+    setIsSidebarOpen(false);
+    window.setTimeout(() => sidebarToggleRef.current?.focus(), 0);
+  }
+
+  function focusFirstSidebarControl() {
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return;
+    getSidebarFocusableElements(sidebar)[0]?.focus();
+  }
+
+  function focusLastSidebarControl() {
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return;
+    getSidebarFocusableElements(sidebar).at(-1)?.focus();
+  }
 
   return (
     <div className={`dashboard-shell ${isSidebarOpen ? 'dashboard-shell--nav-open' : ''}`}>
@@ -628,16 +687,19 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         aria-hidden={!isSidebarOpen}
         aria-label="Close navigation overlay"
         className={`sidebar-backdrop ${isSidebarOpen ? 'sidebar-backdrop--visible' : ''}`}
-        onClick={() => setIsSidebarOpen(false)}
+        onClick={closeSidebar}
         tabIndex={isSidebarOpen ? 0 : -1}
         type="button"
       />
 
       <aside
+        {...sidebarHiddenAttributes}
         aria-label="Primary"
         className={`sidebar ${isSidebarOpen ? 'sidebar--open' : ''}`}
         id="dashboard-sidebar"
+        ref={sidebarRef}
       >
+        <span className="sidebar__focus-guard" onFocus={focusLastSidebarControl} tabIndex={focusGuardTabIndex} />
         <div className="sidebar__header">
           <div className="sidebar__brand">
             <img src={brandMark} alt="Frankenbeast" />
@@ -649,7 +711,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           <button
             aria-label="Close navigation menu"
             className="button button--secondary button--compact sidebar__close"
-            onClick={() => setIsSidebarOpen(false)}
+            onClick={closeSidebar}
             type="button"
           >
             Close
@@ -678,6 +740,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             <span className="version-chip">v{version}</span>
           </div>
         </div>
+        <span className="sidebar__focus-guard" onFocus={focusFirstSidebarControl} tabIndex={focusGuardTabIndex} />
       </aside>
 
       <div className="workspace-shell">
@@ -689,6 +752,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               aria-label="Open navigation menu"
               className="button button--secondary button--compact sidebar__toggle"
               onClick={() => setIsSidebarOpen(true)}
+              ref={sidebarToggleRef}
               type="button"
             >
               Menu

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -241,9 +241,17 @@ button {
 .sidebar__header,
 .sidebar__brand,
 .sidebar__nav,
-.sidebar__footer {
+.sidebar__footer,
+.sidebar__focus-guard {
   position: relative;
   z-index: 1;
+}
+
+.sidebar__focus-guard {
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
 }
 
 .sidebar__header {

--- a/packages/franken-web/src/vite-env.d.ts
+++ b/packages/franken-web/src/vite-env.d.ts
@@ -1,3 +1,13 @@
 /// <reference types="vite/client" />
 
-declare const __FRANKENBEAST_VERSION__: string;
+import 'react';
+
+declare module 'react' {
+  interface HTMLAttributes<T> {
+    inert?: '' | boolean | undefined;
+  }
+}
+
+declare global {
+  const __FRANKENBEAST_VERSION__: string;
+}

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -260,6 +260,7 @@ vi.mock('../../src/lib/network-api.js', () => ({
 afterEach(() => {
   cleanup();
   window.location.hash = '';
+  vi.unstubAllGlobals();
   vi.clearAllMocks();
   latestBeastEventHandlers = null;
   mockSubscribeToEvents.mockImplementation((handlers: Record<string, (event: unknown) => void>) => {
@@ -545,21 +546,59 @@ describe('ChatShell', () => {
     expect(topbar?.textContent).toContain('test-project');
   });
 
-  it('exposes an accessible mobile navigation drawer toggle', () => {
-    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+  it('exposes an accessible mobile navigation drawer toggle', async () => {
+    const mediaQueryList = {
+      matches: true,
+      media: '(max-width: 920px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mediaQueryList));
+
+    const { container } = render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
 
     const toggle = screen.getByRole('button', { name: 'Open navigation menu' });
+    const sidebar = container.querySelector<HTMLElement>('#dashboard-sidebar');
 
     expect(toggle.getAttribute('aria-controls')).toBe('dashboard-sidebar');
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(toggle.getAttribute('class')).toContain('button');
+    expect(sidebar?.getAttribute('aria-hidden')).toBe('true');
+    expect(sidebar?.hasAttribute('inert')).toBe(true);
 
     fireEvent.click(toggle);
 
+    const openSidebar = container.querySelector<HTMLElement>('#dashboard-sidebar');
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(openSidebar?.getAttribute('aria-hidden')).toBeNull();
+    expect(openSidebar?.hasAttribute('inert')).toBe(false);
     expect(screen.getByRole('button', { name: 'Close navigation menu' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Dispatch' }).getAttribute('class')).toContain('button--primary');
     expect(screen.getByRole('button', { name: 'Reject' }).getAttribute('class')).toContain('button--secondary');
+
+    const closeButton = screen.getByRole('button', { name: 'Close navigation menu' });
+    await waitFor(() => expect(document.activeElement).toBe(closeButton));
+
+    const sidebarLinks = Array.from(openSidebar?.querySelectorAll<HTMLAnchorElement>('a[href]') ?? []);
+    const lastSidebarLink = sidebarLinks.at(-1);
+    const focusGuards = Array.from(openSidebar?.querySelectorAll<HTMLElement>('.sidebar__focus-guard') ?? []);
+
+    lastSidebarLink?.focus();
+    focusGuards[1]?.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    closeButton.focus();
+    focusGuards[0]?.focus();
+    expect(document.activeElement).toBe(lastSidebarLink);
+
+    fireEvent.click(closeButton);
+    await waitFor(() => expect(document.activeElement).toBe(toggle));
+    expect(sidebar?.getAttribute('aria-hidden')).toBe('true');
+    expect(sidebar?.hasAttribute('inert')).toBe(true);
   });
 
   it('renders agent list on the beasts page', async () => {


### PR DESCRIPTION
## Summary
- mark the mobile sidebar inert and aria-hidden while closed so offscreen links cannot receive focus
- focus the close control when the drawer opens, loop mobile drawer focus with focus guards, and restore focus to Menu when it closes
- extend the ChatShell accessibility test for closed/open mobile drawer focus behavior

## Test Plan
- npm test -- --run tests/components/chat-shell.test.tsx --reporter=dot
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web

Closes #649