### PR TITLE
fix(web): mount dashboard overview route

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -22,6 +22,8 @@ import { NetworkApiClient, type NetworkConfigResponse, type NetworkStatusRespons
 import { BeastsPage } from '../pages/beasts-page';
 import { AnalyticsApiClient } from '../lib/analytics-api';
 import { AnalyticsPage } from '../pages/analytics-page';
+import { DashboardApiClient } from '../lib/dashboard-api';
+import { DashboardPage } from '../pages/dashboard-page';
 
 export interface ChatShellProps {
   baseUrl: string;
@@ -30,9 +32,11 @@ export interface ChatShellProps {
   version: string;
 }
 
-type RouteId = 'chat' | 'beasts' | 'network' | 'sessions' | 'analytics' | 'costs' | 'safety' | 'settings';
+type RouteId = 'dashboard' | 'chat' | 'beasts' | 'network' | 'sessions' | 'analytics' | 'costs' | 'safety' | 'settings';
+type PlaceholderRouteId = Exclude<RouteId, 'dashboard' | 'chat' | 'beasts' | 'network' | 'analytics'>;
 
 const ROUTES: Array<{ id: RouteId; label: string; summary: string; live: boolean }> = [
+  { id: 'dashboard', label: 'Overview', summary: 'Snapshot controls for skills, security, and providers', live: true },
   { id: 'chat', label: 'Chat', summary: 'Live CLI-parity operator console', live: true },
   { id: 'beasts', label: 'Beasts', summary: 'Dispatch, inspect, and control tracked beast runs', live: true },
   { id: 'network', label: 'Network', summary: 'Service controls and operator config', live: true },
@@ -107,7 +111,7 @@ function routeFromHash(hash: string): RouteId {
   return ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
 }
 
-function PlaceholderPage({ routeId }: { routeId: Exclude<RouteId, 'chat'> }) {
+function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {
   const route = ROUTES.find((item) => item.id === routeId)!;
 
   return (
@@ -316,6 +320,10 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   );
   const analyticsClient = useMemo(
     () => new AnalyticsApiClient(baseUrl),
+    [baseUrl],
+  );
+  const dashboardClient = useMemo(
+    () => new DashboardApiClient(baseUrl),
     [baseUrl],
   );
   const beastClient = useMemo(
@@ -788,7 +796,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           </dl>
         </header>
 
-        {route === 'chat' ? (
+        {route === 'dashboard' ? (
+          <main className="dashboard-overview-page">
+            <DashboardPage client={dashboardClient} />
+          </main>
+        ) : route === 'chat' ? (
           <main className="chat-page">
             <section className="chat-page__main">
               <section className="session-switcher rail-card">

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ChatShell } from '../../src/components/chat-shell.js';
+import { useDashboardStore } from '../../src/stores/dashboard-store.js';
 
 const mockListSessions = vi.fn().mockResolvedValue([
   {
@@ -163,6 +164,25 @@ const mockNetworkGetLogs = vi.fn().mockResolvedValue({ logs: ['chat log line'] }
 const mockNetworkStart = vi.fn().mockResolvedValue(undefined);
 const mockNetworkStop = vi.fn().mockResolvedValue(undefined);
 const mockNetworkRestart = vi.fn().mockResolvedValue(undefined);
+const mockDashboardSnapshot = {
+  skills: [
+    { name: 'github', enabled: true, hasContext: false, mcpServerCount: 1 },
+  ],
+  security: {
+    profile: 'standard',
+    injectionDetection: true,
+    piiMasking: true,
+    outputValidation: true,
+    requireApproval: 'destructive',
+  },
+  providers: [
+    { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
+  ],
+};
+const mockDashboardFetchSnapshot = vi.fn().mockResolvedValue(mockDashboardSnapshot);
+const mockDashboardToggleSkill = vi.fn().mockResolvedValue(undefined);
+const mockDashboardUpdateSecurityProfile = vi.fn().mockResolvedValue(undefined);
+const mockDashboardSubscribe = vi.fn().mockReturnValue(vi.fn());
 
 vi.mock('../../src/hooks/use-chat-session.js', () => ({
   useChatSession: () => ({
@@ -270,11 +290,26 @@ vi.mock('../../src/lib/network-api.js', () => ({
   }),
 }));
 
+vi.mock('../../src/lib/dashboard-api.js', () => ({
+  DashboardApiClient: vi.fn(function (this: {
+    fetchSnapshot: ReturnType<typeof vi.fn>;
+    toggleSkill: ReturnType<typeof vi.fn>;
+    updateSecurityProfile: ReturnType<typeof vi.fn>;
+    subscribeToDashboard: ReturnType<typeof vi.fn>;
+  }) {
+    this.fetchSnapshot = mockDashboardFetchSnapshot;
+    this.toggleSkill = mockDashboardToggleSkill;
+    this.updateSecurityProfile = mockDashboardUpdateSecurityProfile;
+    this.subscribeToDashboard = mockDashboardSubscribe;
+  }),
+}));
+
 afterEach(() => {
   cleanup();
   window.location.hash = '';
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  useDashboardStore.getState().reset();
   latestBeastEventHandlers = null;
   mockSubscribeToEvents.mockImplementation((handlers: Record<string, (event: unknown) => void>) => {
     latestBeastEventHandlers = handlers;
@@ -380,6 +415,14 @@ afterEach(() => {
   mockNetworkStop.mockResolvedValue(undefined);
   mockNetworkRestart.mockReset();
   mockNetworkRestart.mockResolvedValue(undefined);
+  mockDashboardFetchSnapshot.mockReset();
+  mockDashboardFetchSnapshot.mockResolvedValue(mockDashboardSnapshot);
+  mockDashboardToggleSkill.mockReset();
+  mockDashboardToggleSkill.mockResolvedValue(undefined);
+  mockDashboardUpdateSecurityProfile.mockReset();
+  mockDashboardUpdateSecurityProfile.mockResolvedValue(undefined);
+  mockDashboardSubscribe.mockReset();
+  mockDashboardSubscribe.mockReturnValue(vi.fn());
   mockGetRun.mockReset();
   mockGetRun.mockResolvedValue({
     run: {
@@ -405,10 +448,28 @@ describe('ChatShell', () => {
 
     expect(footer?.textContent).toContain('v0.9.0');
     expect(brand?.textContent).not.toContain('v0.9.0');
+    expect(nav?.textContent).toContain('Overview');
     expect(nav?.textContent).toContain('Chat');
     expect(nav?.textContent).toContain('Beasts');
     expect(nav?.textContent).toContain('Sessions');
     expect(nav?.textContent).toContain('Analytics');
+  });
+
+  it('mounts the dashboard overview as a first-class navigation route', async () => {
+    window.location.hash = '#/dashboard';
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    expect(screen.getByRole('link', { name: /Overview/ })).toHaveProperty('hash', '#/dashboard');
+    expect(screen.getAllByText('Snapshot controls for skills, security, and providers').length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(mockDashboardFetchSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockDashboardSubscribe).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('github')).toBeDefined();
+      expect(screen.getByText('Injection Detection: [on]')).toBeDefined();
+      expect(screen.getByText('claude')).toBeDefined();
+    });
   });
 
   it('renders the chat workspace inside the dashboard shell', () => {


### PR DESCRIPTION
## Summary
- Adds the implemented dashboard overview as a live first-class sidebar route at `#/dashboard`
- Wires `DashboardPage` to the existing same-origin `DashboardApiClient` from the shell
- Covers the route with a ChatShell regression test

## Test Plan
- `npm run build --workspace @franken/types`
- `npm test --workspace @frankenbeast/web -- --run tests/components/chat-shell.test.tsx`
- `npm run typecheck --workspace @frankenbeast/web`
- `npm run build --workspace @frankenbeast/web`
- `npm test --workspace @frankenbeast/web`

Closes #647