### PR TITLE
fix(security): reject non-loopback plaintext endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,6 @@ jobs:
 
       - run: npm run test:root -- tests/workspaces.test.ts
 
+      - run: npm run lint:security
+
       - run: npx turbo run build test lint

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
+    "lint:security": "node scripts/check-plain-http.mjs",
     "test": "turbo run test",
     "test:root": "vitest run",
     "test:root:watch": "vitest",

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -52,7 +52,7 @@ import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
 import { CommsConfigSchema, type CommsConfig } from '../comms/config/comms-config.js';
-import { localPlaintextOrSecureEndpoint } from '../network/network-url.js';
+import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } from '../network/network-url.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -753,7 +753,12 @@ export async function main(): Promise<void> {
         dbPath: join(paths.frankenbeastDir, 'beast.db'),
       });
       const commsConfig = await buildChatServerCommsConfig(config, bootSecretStore, root);
-      const explicitBeastDaemonUrl = process.env.FRANKENBEAST_BEAST_DAEMON_URL;
+      const explicitBeastDaemonUrl = process.env.FRANKENBEAST_BEAST_DAEMON_URL
+        ? assertLocalPlaintextOrSecureHttpUrl(
+            process.env.FRANKENBEAST_BEAST_DAEMON_URL,
+            'FRANKENBEAST_BEAST_DAEMON_URL',
+          )
+        : undefined;
       const localBeastServices = beastOperatorToken && !explicitBeastDaemonUrl
         ? createBeastServices({
             beastsDb: join(paths.frankenbeastDir, 'beast.db'),

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -52,6 +52,7 @@ import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
 import { CommsConfigSchema, type CommsConfig } from '../comms/config/comms-config.js';
+import { localPlaintextOrSecureEndpoint } from '../network/network-url.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -267,13 +268,12 @@ export function resolveDashboardAllowedOrigins(config: OrchestratorConfig): stri
   }
 
   const { host, port } = config.dashboard;
-  const originHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
-  const origins = [`http://${originHost}:${port}`];
+  const origins = [localPlaintextOrSecureEndpoint(host, port)];
   if (host === '127.0.0.1' || host === '::1' || host === '[::1]' || host === '0.0.0.0') {
-    origins.push(`http://localhost:${port}`);
+    origins.push(localPlaintextOrSecureEndpoint('localhost', port));
   }
   if (host === '0.0.0.0') {
-    origins.push(`http://127.0.0.1:${port}`);
+    origins.push(localPlaintextOrSecureEndpoint('127.0.0.1', port));
   }
   return origins;
 }

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { NetworkConfigSchema } from '../network/network-config.js';
+import { NetworkConfigFieldsSchema, validateNetworkConfig } from '../network/network-config.js';
 import { validateProviderCommandOverride } from './provider-command-override-policy.js';
 
 // Consolidation schemas (moved from run-config-v2.ts)
@@ -135,8 +135,10 @@ const BaseOrchestratorConfigSchema = z.object({
 });
 
 export const OrchestratorConfigSchema = BaseOrchestratorConfigSchema.extend(
-  NetworkConfigSchema.shape,
+  NetworkConfigFieldsSchema.shape,
 ).superRefine((config, ctx) => {
+  validateNetworkConfig(config, ctx);
+
   config.consolidatedProviders?.forEach((provider, index) => {
     if (!provider.type.endsWith('-cli') || !provider.cliPath) return;
     for (const message of validateProviderCommandOverride(provider.type, {

--- a/packages/franken-orchestrator/src/http/beast-daemon-server.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-server.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { Hono } from 'hono';
 import { createBeastServices, type BeastServiceBundle, type BeastServicePaths } from '../beasts/create-beast-services.js';
+import { isLoopbackHost } from '../network/network-config.js';
 import { localPlaintextOrSecureEndpoint } from '../network/network-url.js';
 import { createBeastDaemonApp } from './beast-daemon-app.js';
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
@@ -36,6 +37,9 @@ export function defaultBeastDaemonPidFile(root: string): string {
 export async function startBeastDaemon(options: StartBeastDaemonOptions): Promise<BeastDaemonHandle> {
   const host = options.host ?? DEFAULT_HOST;
   const port = options.port ?? DEFAULT_PORT;
+  if (!isLoopbackHost(host)) {
+    throw new Error(`Refusing to start beast daemon on non-loopback host ${host}; terminate TLS in a separate reverse proxy for non-local deployments.`);
+  }
   const pidFile = options.pidFile ?? defaultBeastDaemonPidFile(options.root);
   await claimPidFile(pidFile);
 

--- a/packages/franken-orchestrator/src/http/beast-daemon-server.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-server.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { Hono } from 'hono';
 import { createBeastServices, type BeastServiceBundle, type BeastServicePaths } from '../beasts/create-beast-services.js';
+import { localPlaintextOrSecureEndpoint } from '../network/network-url.js';
 import { createBeastDaemonApp } from './beast-daemon-app.js';
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
 
@@ -76,7 +77,7 @@ export async function startBeastDaemon(options: StartBeastDaemonOptions): Promis
     throw new Error('Beast daemon did not bind to a TCP address');
   }
 
-  const url = `http://${host}:${address.port}`;
+  const url = localPlaintextOrSecureEndpoint(host, address.port);
 
   return {
     app,

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -23,6 +23,7 @@ import type { SkillManager } from '../skills/skill-manager.js';
 import type { ProviderRegistry } from '../providers/provider-registry.js';
 import type { DashboardRouteDeps } from './routes/dashboard-routes.js';
 import type { AnalyticsRouteDeps } from './routes/analytics-routes.js';
+import { isLoopbackHost } from '../network/network-config.js';
 import { localPlaintextOrSecureEndpoint, localPlaintextOrSecureWebSocketUrl } from '../network/network-url.js';
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
 import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
@@ -184,8 +185,6 @@ function createCommsRuntimeAdapter(
   });
 }
 
-const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
-
 function enabledSignedExternalWebhookChannels(commsConfig: CommsConfig | undefined): string[] {
   if (!commsConfig) {
     return [];
@@ -215,6 +214,9 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
   const host = options.host ?? DEFAULT_HOST;
   const port = options.port ?? DEFAULT_PORT;
   const path = options.path ?? DEFAULT_WS_PATH;
+  if (!isLoopbackHost(host)) {
+    throw new Error(`Refusing to start chat-server on non-loopback host ${host}; terminate TLS in a separate reverse proxy for non-local deployments.`);
+  }
 
   // Fail closed: refuse to expose /v1/chat/* without an operator token when
   // the server is exposed (managed-network mode OR non-loopback host).
@@ -242,7 +244,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
   }
   const effectiveOperatorToken = configuredTokens[0];
   const isManaged = process.env['FRANKENBEAST_NETWORK_MANAGED'] === '1';
-  const isExposed = isManaged || !LOOPBACK_HOSTS.has(host);
+  const isExposed = isManaged || !isLoopbackHost(host);
   if (isExposed && !effectiveOperatorToken && !options.allowUnauthenticatedChatForTests) {
     throw new Error(
       `Refusing to start chat-server on ${host} without an operator token: `

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -23,6 +23,7 @@ import type { SkillManager } from '../skills/skill-manager.js';
 import type { ProviderRegistry } from '../providers/provider-registry.js';
 import type { DashboardRouteDeps } from './routes/dashboard-routes.js';
 import type { AnalyticsRouteDeps } from './routes/analytics-routes.js';
+import { localPlaintextOrSecureEndpoint, localPlaintextOrSecureWebSocketUrl } from '../network/network-url.js';
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
 import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
 
@@ -337,8 +338,8 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     throw new Error('Chat server did not bind to a TCP address');
   }
 
-  const url = `http://${host}:${address.port}`;
-  const wsUrl = `ws://${host}:${address.port}${path}`;
+  const url = localPlaintextOrSecureEndpoint(host, address.port);
+  const wsUrl = localPlaintextOrSecureWebSocketUrl(host, address.port, path);
 
   return {
     app,

--- a/packages/franken-orchestrator/src/http/http-server-utils.ts
+++ b/packages/franken-orchestrator/src/http/http-server-utils.ts
@@ -32,7 +32,9 @@ export async function handleHonoHttpRequest(app: Hono, request: IncomingMessage,
 
 function toRequest(request: IncomingMessage): Request {
   const host = request.headers.host ?? `${DEFAULT_HOST}:${DEFAULT_PORT}`;
-  const url = new URL(request.url ?? '/', `http://${host}`);
+  const baseUrl = new URL('http://localhost');
+  baseUrl.host = host;
+  const url = new URL(request.url ?? '/', baseUrl);
   const method = request.method ?? 'GET';
   const headers = new Headers();
   const abortController = new AbortController();

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -8,7 +8,7 @@ import {
   CHAT_SOCKET_PROTOCOL,
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
 } from '../http/ws-chat-server.js';
-import { localPlaintextOrSecureEndpoint } from './network-url.js';
+import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } from './network-url.js';
 
 interface ManagedNetworkState {
   services?: Array<{
@@ -50,7 +50,9 @@ export async function resolveManagedChatAttachment(
   const fetchImpl = options.fetchImpl ?? fetch;
   const state = await loadNetworkState(options.frankenbeastDir);
   const stateUrl = state?.services?.find((service) => service.id === 'chat-server')?.url;
-  const baseUrl = stateUrl ?? localPlaintextOrSecureEndpoint(options.config.chat.host, options.config.chat.port);
+  const baseUrl = stateUrl
+    ? assertLocalPlaintextOrSecureHttpUrl(stateUrl, 'Persisted chat-server URL')
+    : localPlaintextOrSecureEndpoint(options.config.chat.host, options.config.chat.port);
   const healthResponse = await fetchImpl(`${baseUrl}/health`);
   if (!healthResponse.ok) {
     return undefined;

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -8,6 +8,7 @@ import {
   CHAT_SOCKET_PROTOCOL,
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
 } from '../http/ws-chat-server.js';
+import { localPlaintextOrSecureEndpoint } from './network-url.js';
 
 interface ManagedNetworkState {
   services?: Array<{
@@ -49,7 +50,7 @@ export async function resolveManagedChatAttachment(
   const fetchImpl = options.fetchImpl ?? fetch;
   const state = await loadNetworkState(options.frankenbeastDir);
   const stateUrl = state?.services?.find((service) => service.id === 'chat-server')?.url;
-  const baseUrl = stateUrl ?? `http://${options.config.chat.host}:${options.config.chat.port}`;
+  const baseUrl = stateUrl ?? localPlaintextOrSecureEndpoint(options.config.chat.host, options.config.chat.port);
   const healthResponse = await fetchImpl(`${baseUrl}/health`);
   if (!healthResponse.ok) {
     return undefined;

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -3,6 +3,39 @@ import { z } from 'zod';
 const HostSchema = z.string().min(1).default('127.0.0.1');
 const PortSchema = z.number().int().min(1).max(65_535);
 
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase().replace(/^\[|\]$/g, '');
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || normalized === '0:0:0:0:0:0:0:1'
+    || normalized === '0.0.0.0'
+    || normalized === '::'
+    || normalized === '127.0.0.1'
+    || normalized.startsWith('127.');
+}
+
+function isLocalPlaintextOrSecureUrl(value: string, secureProtocols: string[], localProtocols: string[]): boolean {
+  try {
+    const parsed = new URL(value);
+    if (secureProtocols.includes(parsed.protocol)) {
+      return true;
+    }
+    return localProtocols.includes(parsed.protocol) && isLoopbackHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+const LocalHttpOrHttpsUrlSchema = z.string().url().refine(
+  (value) => isLocalPlaintextOrSecureUrl(value, ['https:'], ['http:']),
+  { message: 'Must use https:// unless the URL targets a loopback-only development host.' },
+);
+
+const LocalWsOrWssUrlSchema = z.string().url().refine(
+  (value) => isLocalPlaintextOrSecureUrl(value, ['wss:'], ['ws:']),
+  { message: 'Must use wss:// unless the URL targets a loopback-only development host.' },
+);
+
 export const NetworkModeSchema = z.enum(['secure', 'insecure']);
 
 const LEGACY_BACKEND_MAP: Record<string, string> = {
@@ -39,7 +72,7 @@ export const DashboardServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
   host: HostSchema,
   port: PortSchema.default(5173),
-  apiUrl: z.string().url().default('http://127.0.0.1:3737'),
+  apiUrl: LocalHttpOrHttpsUrlSchema.default('http://127.0.0.1:3737'),
 });
 
 export const SlackChannelConfigSchema = z.object({
@@ -73,7 +106,7 @@ export const CommsServiceConfigSchema = z.object({
   enabled: z.boolean().default(false),
   host: HostSchema,
   port: PortSchema.default(3200),
-  orchestratorWsUrl: z.string().url().default('ws://127.0.0.1:3737/v1/chat/ws'),
+  orchestratorWsUrl: LocalWsOrWssUrlSchema.default('ws://127.0.0.1:3737/v1/chat/ws'),
   orchestratorTokenRef: z.string().min(1).optional(),
   slack: SlackChannelConfigSchema.default({}),
   discord: DiscordChannelConfigSchema.default({}),

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -157,13 +157,64 @@ export const CommsServiceConfigSchema = z.object({
   );
 });
 
-export const NetworkConfigSchema = z.object({
+function hasEnabledCommsChannel(comms: z.infer<typeof CommsServiceConfigSchema>): boolean {
+  return comms.slack.enabled
+    || comms.discord.enabled
+    || comms.telegram.enabled
+    || comms.whatsapp.enabled;
+}
+
+const loopbackOnlyMessage = 'Managed service hosts must be loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.';
+
+export const NetworkConfigFieldsSchema = z.object({
   network: NetworkOperatorConfigSchema.default({}),
   beastsDaemon: BeastDaemonServiceConfigSchema.default({}),
   chat: ChatServiceConfigSchema.default({}),
   dashboard: DashboardServiceConfigSchema.default({}),
   comms: CommsServiceConfigSchema.default({}),
 });
+
+export function validateNetworkConfig(value: z.infer<typeof NetworkConfigFieldsSchema>, ctx: z.RefinementCtx): void {
+  const commsActive = value.comms.enabled || hasEnabledCommsChannel(value.comms);
+  const dashboardActive = value.dashboard.enabled;
+  const chatActive = value.chat.enabled || dashboardActive || commsActive;
+  const beastsDaemonActive = value.beastsDaemon.enabled || chatActive;
+
+  if (beastsDaemonActive && !isLoopbackHost(value.beastsDaemon.host)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['beastsDaemon', 'host'], message: loopbackOnlyMessage });
+  }
+  if (chatActive && !isLoopbackHost(value.chat.host)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['chat', 'host'], message: loopbackOnlyMessage });
+  }
+  if (dashboardActive) {
+    if (!isLoopbackHost(value.dashboard.host)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['dashboard', 'host'], message: loopbackOnlyMessage });
+    }
+    requireLocalPlaintextOrSecureUrl(
+      ctx,
+      'dashboard.apiUrl',
+      value.dashboard.apiUrl,
+      ['https:'],
+      ['http:'],
+      'Must use https:// unless the URL targets a loopback-only development host.',
+    );
+  }
+  if (commsActive) {
+    if (!isLoopbackHost(value.comms.host)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['comms', 'host'], message: loopbackOnlyMessage });
+    }
+    requireLocalPlaintextOrSecureUrl(
+      ctx,
+      'comms.orchestratorWsUrl',
+      value.comms.orchestratorWsUrl,
+      ['wss:'],
+      ['ws:'],
+      'Must use wss:// unless the URL targets a loopback-only development host.',
+    );
+  }
+}
+
+export const NetworkConfigSchema = NetworkConfigFieldsSchema.superRefine(validateNetworkConfig);
 
 export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
 export type NetworkMode = z.infer<typeof NetworkModeSchema>;

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+const HostSchema = z.string().min(1).default('127.0.0.1');
 const PortSchema = z.number().int().min(1).max(65_535);
 
 export function isLoopbackHost(host: string): boolean {
@@ -15,10 +16,28 @@ export function isLoopbackHost(host: string): boolean {
   return normalized.split('.').every((part) => Number(part) >= 0 && Number(part) <= 255);
 }
 
-const LocalServiceHostSchema = z.string().min(1).refine(
-  isLoopbackHost,
-  { message: 'Managed service hosts must be loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.' },
-).default('127.0.0.1');
+function requireLoopbackServiceHost(ctx: z.RefinementCtx, host: string): void {
+  if (!isLoopbackHost(host)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['host'],
+      message: 'Managed service hosts must be loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.',
+    });
+  }
+}
+
+function requireLocalPlaintextOrSecureUrl(
+  ctx: z.RefinementCtx,
+  path: string,
+  value: string,
+  secureProtocols: string[],
+  localProtocols: string[],
+  message: string,
+): void {
+  if (!isLocalPlaintextOrSecureUrl(value, secureProtocols, localProtocols)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: [path], message });
+  }
+}
 
 function isLocalPlaintextOrSecureUrl(value: string, secureProtocols: string[], localProtocols: string[]): boolean {
   try {
@@ -32,15 +51,7 @@ function isLocalPlaintextOrSecureUrl(value: string, secureProtocols: string[], l
   }
 }
 
-const LocalHttpOrHttpsUrlSchema = z.string().url().refine(
-  (value) => isLocalPlaintextOrSecureUrl(value, ['https:'], ['http:']),
-  { message: 'Must use https:// unless the URL targets a loopback-only development host.' },
-);
-
-const LocalWsOrWssUrlSchema = z.string().url().refine(
-  (value) => isLocalPlaintextOrSecureUrl(value, ['wss:'], ['ws:']),
-  { message: 'Must use wss:// unless the URL targets a loopback-only development host.' },
-);
+const UrlSchema = z.string().url();
 
 export const NetworkModeSchema = z.enum(['secure', 'insecure']);
 
@@ -63,22 +74,37 @@ export const NetworkOperatorConfigSchema = z.object({
 
 export const ChatServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  host: LocalServiceHostSchema,
+  host: HostSchema,
   port: PortSchema.default(3737),
   model: z.string().min(1).default('claude-sonnet-4-6'),
+}).superRefine((value, ctx) => {
+  if (value.enabled) requireLoopbackServiceHost(ctx, value.host);
 });
 
 export const BeastDaemonServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  host: LocalServiceHostSchema,
+  host: HostSchema,
   port: PortSchema.default(4050),
+}).superRefine((value, ctx) => {
+  if (value.enabled) requireLoopbackServiceHost(ctx, value.host);
 });
 
 export const DashboardServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  host: LocalServiceHostSchema,
+  host: HostSchema,
   port: PortSchema.default(5173),
-  apiUrl: LocalHttpOrHttpsUrlSchema.default('http://127.0.0.1:3737'),
+  apiUrl: UrlSchema.default('http://127.0.0.1:3737'),
+}).superRefine((value, ctx) => {
+  if (!value.enabled) return;
+  requireLoopbackServiceHost(ctx, value.host);
+  requireLocalPlaintextOrSecureUrl(
+    ctx,
+    'apiUrl',
+    value.apiUrl,
+    ['https:'],
+    ['http:'],
+    'Must use https:// unless the URL targets a loopback-only development host.',
+  );
 });
 
 export const SlackChannelConfigSchema = z.object({
@@ -110,14 +136,25 @@ export const WhatsAppChannelConfigSchema = z.object({
 
 export const CommsServiceConfigSchema = z.object({
   enabled: z.boolean().default(false),
-  host: LocalServiceHostSchema,
+  host: HostSchema,
   port: PortSchema.default(3200),
-  orchestratorWsUrl: LocalWsOrWssUrlSchema.default('ws://127.0.0.1:3737/v1/chat/ws'),
+  orchestratorWsUrl: UrlSchema.default('ws://127.0.0.1:3737/v1/chat/ws'),
   orchestratorTokenRef: z.string().min(1).optional(),
   slack: SlackChannelConfigSchema.default({}),
   discord: DiscordChannelConfigSchema.default({}),
   telegram: TelegramChannelConfigSchema.default({}),
   whatsapp: WhatsAppChannelConfigSchema.default({}),
+}).superRefine((value, ctx) => {
+  if (!value.enabled) return;
+  requireLoopbackServiceHost(ctx, value.host);
+  requireLocalPlaintextOrSecureUrl(
+    ctx,
+    'orchestratorWsUrl',
+    value.orchestratorWsUrl,
+    ['wss:'],
+    ['ws:'],
+    'Must use wss:// unless the URL targets a loopback-only development host.',
+  );
 });
 
 export const NetworkConfigSchema = z.object({

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -1,18 +1,24 @@
 import { z } from 'zod';
 
-const HostSchema = z.string().min(1).default('127.0.0.1');
 const PortSchema = z.number().int().min(1).max(65_535);
 
 export function isLoopbackHost(host: string): boolean {
   const normalized = host.toLowerCase().replace(/^\[|\]$/g, '');
-  return normalized === 'localhost'
+  if (normalized === 'localhost'
     || normalized === '::1'
-    || normalized === '0:0:0:0:0:0:0:1'
-    || normalized === '0.0.0.0'
-    || normalized === '::'
-    || normalized === '127.0.0.1'
-    || normalized.startsWith('127.');
+    || normalized === '0:0:0:0:0:0:0:1') {
+    return true;
+  }
+  if (!/^127(?:\.\d{1,3}){3}$/.test(normalized)) {
+    return false;
+  }
+  return normalized.split('.').every((part) => Number(part) >= 0 && Number(part) <= 255);
 }
+
+const LocalServiceHostSchema = z.string().min(1).refine(
+  isLoopbackHost,
+  { message: 'Managed service hosts must be loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.' },
+).default('127.0.0.1');
 
 function isLocalPlaintextOrSecureUrl(value: string, secureProtocols: string[], localProtocols: string[]): boolean {
   try {
@@ -57,20 +63,20 @@ export const NetworkOperatorConfigSchema = z.object({
 
 export const ChatServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  host: HostSchema,
+  host: LocalServiceHostSchema,
   port: PortSchema.default(3737),
   model: z.string().min(1).default('claude-sonnet-4-6'),
 });
 
 export const BeastDaemonServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  host: HostSchema,
+  host: LocalServiceHostSchema,
   port: PortSchema.default(4050),
 });
 
 export const DashboardServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  host: HostSchema,
+  host: LocalServiceHostSchema,
   port: PortSchema.default(5173),
   apiUrl: LocalHttpOrHttpsUrlSchema.default('http://127.0.0.1:3737'),
 });
@@ -104,7 +110,7 @@ export const WhatsAppChannelConfigSchema = z.object({
 
 export const CommsServiceConfigSchema = z.object({
   enabled: z.boolean().default(false),
-  host: HostSchema,
+  host: LocalServiceHostSchema,
   port: PortSchema.default(3200),
   orchestratorWsUrl: LocalWsOrWssUrlSchema.default('ws://127.0.0.1:3737/v1/chat/ws'),
   orchestratorTokenRef: z.string().min(1).optional(),

--- a/packages/franken-orchestrator/src/network/network-url.ts
+++ b/packages/franken-orchestrator/src/network/network-url.ts
@@ -1,7 +1,10 @@
 import { isLoopbackHost } from './network-config.js';
 
 export function localPlaintextOrSecureEndpoint(host: string, port: number): string {
-  const protocol = isLoopbackHost(host) ? 'http' : 'https';
+  if (!isLoopbackHost(host)) {
+    throw new Error(`Managed service host ${host} is not loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.`);
+  }
+  const protocol = 'http';
   const bracketedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
   return `${protocol}://` + `${bracketedHost}:${port}`;
 }
@@ -11,7 +14,10 @@ export function localPlaintextOrSecureHealthUrl(host: string, port: number, path
 }
 
 export function localPlaintextOrSecureWebSocketUrl(host: string, port: number, path: string): string {
-  const protocol = isLoopbackHost(host) ? 'ws' : 'wss';
+  if (!isLoopbackHost(host)) {
+    throw new Error(`Managed service host ${host} is not loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.`);
+  }
+  const protocol = 'ws';
   const bracketedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
   return `${protocol}://` + `${bracketedHost}:${port}${path}`;
 }

--- a/packages/franken-orchestrator/src/network/network-url.ts
+++ b/packages/franken-orchestrator/src/network/network-url.ts
@@ -1,0 +1,17 @@
+import { isLoopbackHost } from './network-config.js';
+
+export function localPlaintextOrSecureEndpoint(host: string, port: number): string {
+  const protocol = isLoopbackHost(host) ? 'http' : 'https';
+  const bracketedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+  return `${protocol}://` + `${bracketedHost}:${port}`;
+}
+
+export function localPlaintextOrSecureHealthUrl(host: string, port: number, path = '/health'): string {
+  return `${localPlaintextOrSecureEndpoint(host, port)}${path}`;
+}
+
+export function localPlaintextOrSecureWebSocketUrl(host: string, port: number, path: string): string {
+  const protocol = isLoopbackHost(host) ? 'ws' : 'wss';
+  const bracketedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+  return `${protocol}://` + `${bracketedHost}:${port}${path}`;
+}

--- a/packages/franken-orchestrator/src/network/network-url.ts
+++ b/packages/franken-orchestrator/src/network/network-url.ts
@@ -1,5 +1,13 @@
 import { isLoopbackHost } from './network-config.js';
 
+export function assertLocalPlaintextOrSecureHttpUrl(url: string, source: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === 'https:' || (parsed.protocol === 'http:' && isLoopbackHost(parsed.hostname))) {
+    return url;
+  }
+  throw new Error(`${source} must use https:// unless it targets a loopback-only development host.`);
+}
+
 export function localPlaintextOrSecureEndpoint(host: string, port: number): string {
   if (!isLoopbackHost(host)) {
     throw new Error(`Managed service host ${host} is not loopback-only; terminate TLS in a separate reverse proxy for non-local deployments.`);

--- a/packages/franken-orchestrator/src/network/services/beasts-daemon-service.ts
+++ b/packages/franken-orchestrator/src/network/services/beasts-daemon-service.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorConfig } from '../../config/orchestrator-config.js';
+import { localPlaintextOrSecureEndpoint, localPlaintextOrSecureHealthUrl } from '../network-url.js';
 import type { NetworkServiceDefinition } from '../network-registry.js';
 
 export const beastsDaemonService: NetworkServiceDefinition = {
@@ -13,8 +14,8 @@ export const beastsDaemonService: NetworkServiceDefinition = {
   buildRuntimeConfig: (config: OrchestratorConfig, context) => ({
     host: config.beastsDaemon.host,
     port: config.beastsDaemon.port,
-    url: `http://${config.beastsDaemon.host}:${config.beastsDaemon.port}`,
-    healthUrl: `http://${config.beastsDaemon.host}:${config.beastsDaemon.port}/health`,
+    url: localPlaintextOrSecureEndpoint(config.beastsDaemon.host, config.beastsDaemon.port),
+    healthUrl: localPlaintextOrSecureHealthUrl(config.beastsDaemon.host, config.beastsDaemon.port),
     serviceIdentity: 'beasts-daemon',
     process: {
       command: 'npm',
@@ -33,7 +34,10 @@ export const beastsDaemonService: NetworkServiceDefinition = {
       cwd: context.repoRoot,
       env: {
         FRANKENBEAST_NETWORK_MANAGED: '1',
-        FRANKENBEAST_BEAST_DAEMON_URL: `http://${config.beastsDaemon.host}:${config.beastsDaemon.port}`,
+        FRANKENBEAST_BEAST_DAEMON_URL: localPlaintextOrSecureEndpoint(
+          config.beastsDaemon.host,
+          config.beastsDaemon.port,
+        ),
       },
     },
   }),

--- a/packages/franken-orchestrator/src/network/services/chat-server-service.ts
+++ b/packages/franken-orchestrator/src/network/services/chat-server-service.ts
@@ -1,4 +1,9 @@
 import type { OrchestratorConfig } from '../../config/orchestrator-config.js';
+import {
+  localPlaintextOrSecureEndpoint,
+  localPlaintextOrSecureHealthUrl,
+  localPlaintextOrSecureWebSocketUrl,
+} from '../network-url.js';
 import type { NetworkServiceDefinition } from '../network-registry.js';
 
 export const chatServerService: NetworkServiceDefinition = {
@@ -13,9 +18,9 @@ export const chatServerService: NetworkServiceDefinition = {
   buildRuntimeConfig: (config: OrchestratorConfig, context) => ({
     host: config.chat.host,
     port: config.chat.port,
-    url: `http://${config.chat.host}:${config.chat.port}`,
-    healthUrl: `http://${config.chat.host}:${config.chat.port}/health`,
-    wsUrl: `ws://${config.chat.host}:${config.chat.port}/v1/chat/ws`,
+    url: localPlaintextOrSecureEndpoint(config.chat.host, config.chat.port),
+    healthUrl: localPlaintextOrSecureHealthUrl(config.chat.host, config.chat.port),
+    wsUrl: localPlaintextOrSecureWebSocketUrl(config.chat.host, config.chat.port, '/v1/chat/ws'),
     serviceIdentity: 'chat-server',
     suppressManagedBanner: true,
     model: config.chat.model,
@@ -38,7 +43,10 @@ export const chatServerService: NetworkServiceDefinition = {
       cwd: context.repoRoot,
       env: {
         FRANKENBEAST_NETWORK_MANAGED: '1',
-        FRANKENBEAST_BEAST_DAEMON_URL: `http://${config.beastsDaemon.host}:${config.beastsDaemon.port}`,
+        FRANKENBEAST_BEAST_DAEMON_URL: localPlaintextOrSecureEndpoint(
+          config.beastsDaemon.host,
+          config.beastsDaemon.port,
+        ),
       },
     },
   }),

--- a/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
+++ b/packages/franken-orchestrator/src/network/services/comms-gateway-service.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorConfig } from '../../config/orchestrator-config.js';
+import { localPlaintextOrSecureEndpoint, localPlaintextOrSecureHealthUrl } from '../network-url.js';
 import type { NetworkServiceDefinition } from '../network-registry.js';
 
 function hasEnabledChannels(config: OrchestratorConfig): boolean {
@@ -31,8 +32,8 @@ export const commsGatewayService: NetworkServiceDefinition = {
   buildRuntimeConfig: (config: OrchestratorConfig) => ({
     host: config.chat.host,
     port: config.chat.port,
-    url: `http://${config.chat.host}:${config.chat.port}`,
-    healthUrl: `http://${config.chat.host}:${config.chat.port}/comms/health`,
+    url: localPlaintextOrSecureEndpoint(config.chat.host, config.chat.port),
+    healthUrl: localPlaintextOrSecureHealthUrl(config.chat.host, config.chat.port, '/comms/health'),
     orchestratorWsUrl: config.comms.orchestratorWsUrl,
     channels: {
       slack: config.comms.slack.enabled,

--- a/packages/franken-orchestrator/src/network/services/dashboard-web-service.ts
+++ b/packages/franken-orchestrator/src/network/services/dashboard-web-service.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorConfig } from '../../config/orchestrator-config.js';
+import { localPlaintextOrSecureEndpoint } from '../network-url.js';
 import type { NetworkServiceDefinition } from '../network-registry.js';
 
 export const dashboardWebService: NetworkServiceDefinition = {
@@ -13,7 +14,7 @@ export const dashboardWebService: NetworkServiceDefinition = {
   buildRuntimeConfig: (config: OrchestratorConfig, context) => ({
     host: config.dashboard.host,
     port: config.dashboard.port,
-    url: `http://${config.dashboard.host}:${config.dashboard.port}`,
+    url: localPlaintextOrSecureEndpoint(config.dashboard.host, config.dashboard.port),
     serviceIdentity: 'dashboard-web',
     apiUrl: config.dashboard.apiUrl,
     process: {
@@ -34,7 +35,10 @@ export const dashboardWebService: NetworkServiceDefinition = {
         FRANKENBEAST_CONFIG_FILE: context.configFile ?? '',
         VITE_API_URL: '',
         VITE_API_PROXY_TARGET: config.dashboard.apiUrl,
-        VITE_BEAST_API_PROXY_TARGET: `http://${config.beastsDaemon.host}:${config.beastsDaemon.port}`,
+        VITE_BEAST_API_PROXY_TARGET: localPlaintextOrSecureEndpoint(
+          config.beastsDaemon.host,
+          config.beastsDaemon.port,
+        ),
       },
     },
   }),

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -218,4 +218,17 @@ describe('beast daemon', () => {
 
     expect(existsSync(paths.pidFile)).toBe(false);
   });
+
+  it('rejects non-loopback hosts before claiming the pid file', async () => {
+    const paths = await makePaths();
+
+    await expect(startBeastDaemon({
+      ...paths,
+      host: '0.0.0.0',
+      operatorToken,
+      port: 0,
+    })).rejects.toThrow(/non-loopback host/);
+
+    expect(existsSync(paths.pidFile)).toBe(false);
+  });
 });

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -282,7 +282,7 @@ describe('chat server bootstrap', () => {
     beastServices.dispose();
   });
 
-  it('refuses to start on a non-loopback host without an operator token', async () => {
+  it('refuses to start on a non-loopback host before binding', async () => {
     mkdirSync(TMP, { recursive: true });
     await expect(startChatServer({
       host: '0.0.0.0',
@@ -290,7 +290,8 @@ describe('chat server bootstrap', () => {
       sessionStoreDir: TMP,
       llm: { complete: vi.fn().mockResolvedValue('') },
       projectName: 'test-project',
-    })).rejects.toThrow(/operator token/i);
+      operatorToken: 'shared-token',
+    })).rejects.toThrow(/non-loopback host/);
   });
 
   it('starts on loopback without a token (dev mode)', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -90,4 +90,26 @@ describe('resolveManagedChatAttachment', () => {
 
     expect(attachment).toBeUndefined();
   });
+
+  it('rejects persisted non-loopback plaintext chat URLs before healthcheck', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-chat-attach-'));
+    const frankenbeastDir = join(workDir, '.fbeast');
+    await mkdir(join(frankenbeastDir, 'network'), { recursive: true });
+    await writeFile(join(frankenbeastDir, 'network', 'state.json'), JSON.stringify({
+      services: [
+        {
+          id: 'chat-server',
+          url: 'http://internal-service:3737',
+        },
+      ],
+    }));
+
+    await expect(resolveManagedChatAttachment({
+      config: defaultConfig(),
+      frankenbeastDir,
+      fetchImpl: async () => {
+        throw new Error('healthcheck should not run for rejected persisted URL');
+      },
+    })).rejects.toThrow(/https:\/\//);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -577,7 +577,7 @@ describe('resolveDashboardAllowedOrigins', () => {
         port: 5173,
         apiUrl: 'http://127.0.0.1:3737',
       },
-    } as never)).toEqual(['http://dashboard.example.com:5173']);
+    } as never)).toEqual(['https://dashboard.example.com:5173']);
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -558,26 +558,26 @@ describe('resolveDashboardAllowedOrigins', () => {
     } as never)).toEqual(['http://[::1]:5173', 'http://localhost:5173']);
   });
 
-  it('adds usable loopback aliases for wildcard dashboard binds', () => {
-    expect(resolveDashboardAllowedOrigins({
+  it('rejects wildcard dashboard binds when deriving browser origins', () => {
+    expect(() => resolveDashboardAllowedOrigins({
       dashboard: {
         enabled: true,
         host: '0.0.0.0',
         port: 5173,
         apiUrl: 'http://127.0.0.1:3737',
       },
-    } as never)).toEqual(['http://0.0.0.0:5173', 'http://localhost:5173', 'http://127.0.0.1:5173']);
+    } as never)).toThrow(/loopback-only/);
   });
 
-  it('does not add a localhost alias for non-loopback dashboard hosts', () => {
-    expect(resolveDashboardAllowedOrigins({
+  it('rejects non-loopback dashboard hosts when deriving browser origins', () => {
+    expect(() => resolveDashboardAllowedOrigins({
       dashboard: {
         enabled: true,
         host: 'dashboard.example.com',
         port: 5173,
         apiUrl: 'http://127.0.0.1:3737',
       },
-    } as never)).toEqual(['https://dashboard.example.com:5173']);
+    } as never)).toThrow(/loopback-only/);
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1398,6 +1398,44 @@ describe('main() execution', () => {
     }));
   });
 
+  it('rejects non-loopback plaintext explicit beast daemon URLs before proxying', async () => {
+    process.env.FRANKENBEAST_BEAST_DAEMON_URL = 'http://internal-service:4050';
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: '/mock/project',
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    } as never);
+
+    await expect(main()).rejects.toThrow(/FRANKENBEAST_BEAST_DAEMON_URL must use https:\/\//i);
+    expect(mockStartChatServer).not.toHaveBeenCalled();
+  });
+
   it('dispatches beasts-daemon without creating a Session or REPL', async () => {
     mockParseArgs.mockReturnValue({
       subcommand: 'beasts-daemon',

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -132,5 +132,15 @@ describe('OrchestratorConfig', () => {
       expect(result.maxCritiqueIterations).toBe(1);
       expect(result.minCritiqueScore).toBe(0);
     });
+
+    it('applies network plaintext endpoint validation to the full orchestrator config', () => {
+      expect(() => OrchestratorConfigSchema.parse({
+        chat: { enabled: false, host: '0.0.0.0' },
+      })).toThrow(/loopback-only/);
+
+      expect(() => OrchestratorConfigSchema.parse({
+        comms: { slack: { enabled: true }, orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws' },
+      })).toThrow(/wss:\/\//);
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -161,52 +161,62 @@ describe('startChatServer comms pass-through', () => {
     }
   });
 
-  it('fails closed on exposed hosts before disabling Slack, Discord, or WhatsApp signatures', async () => {
+  it('fails closed on managed-network hosts before disabling Slack, Discord, or WhatsApp signatures', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chat-server-exposed-webhooks-'));
     tempDirs.push(dir);
+    const previous = process.env['FRANKENBEAST_NETWORK_MANAGED'];
+    process.env['FRANKENBEAST_NETWORK_MANAGED'] = '1';
 
-    await expect(startChatServer({
-      host: '0.0.0.0',
-      port: 0,
-      sessionStoreDir: '/tmp/chat-server-comms-test',
-      llm: { complete: vi.fn().mockResolvedValue('ok') },
-      projectName: 'test',
-      operatorToken: 'operator-token',
-      commsConfig: {
-        orchestrator: {},
-        channels: {
-          slack: {
-            enabled: true,
-            token: 'slack-token',
-            signingSecret: 'slack-signing-secret',
-          },
-          discord: {
-            enabled: true,
-            token: 'discord-token',
-            publicKey: 'discord-public-key',
-          },
-          whatsapp: {
-            enabled: true,
-            accessToken: 'whatsapp-token',
-            phoneNumberId: 'phone-number-id',
-            appSecret: 'whatsapp-app-secret',
-            verifyToken: 'whatsapp-verify-token',
+    try {
+      await expect(startChatServer({
+        host: '127.0.0.1',
+        port: 0,
+        sessionStoreDir: '/tmp/chat-server-comms-test',
+        llm: { complete: vi.fn().mockResolvedValue('ok') },
+        projectName: 'test',
+        operatorToken: 'operator-token',
+        commsConfig: {
+          orchestrator: {},
+          channels: {
+            slack: {
+              enabled: true,
+              token: 'slack-token',
+              signingSecret: 'slack-signing-secret',
+            },
+            discord: {
+              enabled: true,
+              token: 'discord-token',
+              publicKey: 'discord-public-key',
+            },
+            whatsapp: {
+              enabled: true,
+              accessToken: 'whatsapp-token',
+              phoneNumberId: 'phone-number-id',
+              appSecret: 'whatsapp-app-secret',
+              verifyToken: 'whatsapp-verify-token',
+            },
           },
         },
-      },
-      networkControl: {
-        root: '/tmp/project',
-        frankenbeastDir: '/tmp/project/.frankenbeast',
-        configFile: join(dir, 'config.json'),
-        getConfig: () => ({
-          security: {
-            profile: 'permissive',
-            webhookSignaturePolicy: 'local-dev-unsigned',
-          },
-        }) as never,
-        setConfig: vi.fn(),
-      },
-    })).rejects.toThrow(/slack, discord, whatsapp webhooks require signature verification/i);
+        networkControl: {
+          root: '/tmp/project',
+          frankenbeastDir: '/tmp/project/.frankenbeast',
+          configFile: join(dir, 'config.json'),
+          getConfig: () => ({
+            security: {
+              profile: 'permissive',
+              webhookSignaturePolicy: 'local-dev-unsigned',
+            },
+          }) as never,
+          setConfig: vi.fn(),
+        },
+      })).rejects.toThrow(/slack, discord, whatsapp webhooks require signature verification/i);
+    } finally {
+      if (previous === undefined) {
+        delete process.env['FRANKENBEAST_NETWORK_MANAGED'];
+      } else {
+        process.env['FRANKENBEAST_NETWORK_MANAGED'] = previous;
+      }
+    }
 
     expect(mockedCreateChatApp).not.toHaveBeenCalled();
   });

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -109,7 +109,7 @@ describe('network-registry', () => {
     })).toThrow(/https:\/\//);
 
     expect(() => NetworkConfigSchema.parse({
-      comms: { orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws' },
+      comms: { enabled: true, orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws' },
     })).toThrow(/wss:\/\//);
 
     expect(() => NetworkConfigSchema.parse({
@@ -130,6 +130,21 @@ describe('network-registry', () => {
     expect(() => NetworkConfigSchema.parse({
       beastsDaemon: { host: '0.0.0.0' },
     })).toThrow(/loopback-only/);
+  });
+
+  it('does not validate disabled service endpoint settings', () => {
+    expect(NetworkConfigSchema.parse({
+      dashboard: {
+        enabled: false,
+        host: '0.0.0.0',
+        apiUrl: 'http://internal-service:3737',
+      },
+      comms: {
+        enabled: false,
+        host: '0.0.0.0',
+        orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws',
+      },
+    }).dashboard.enabled).toBe(false);
   });
 
   it('projects runtime config for each service', () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -113,6 +113,10 @@ describe('network-registry', () => {
     })).toThrow(/wss:\/\//);
 
     expect(() => NetworkConfigSchema.parse({
+      comms: { slack: { enabled: true }, orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws' },
+    })).toThrow(/wss:\/\//);
+
+    expect(() => NetworkConfigSchema.parse({
       dashboard: { apiUrl: 'http://127.attacker.example:3737' },
     })).toThrow(/https:\/\//);
 
@@ -129,6 +133,10 @@ describe('network-registry', () => {
 
     expect(() => NetworkConfigSchema.parse({
       beastsDaemon: { host: '0.0.0.0' },
+    })).toThrow(/loopback-only/);
+
+    expect(() => NetworkConfigSchema.parse({
+      chat: { host: '0.0.0.0' },
     })).toThrow(/loopback-only/);
   });
 

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -112,10 +112,24 @@ describe('network-registry', () => {
       comms: { orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws' },
     })).toThrow(/wss:\/\//);
 
+    expect(() => NetworkConfigSchema.parse({
+      dashboard: { apiUrl: 'http://127.attacker.example:3737' },
+    })).toThrow(/https:\/\//);
+
     expect(NetworkConfigSchema.parse({
       dashboard: { apiUrl: 'https://internal-service:3737' },
       comms: { orchestratorWsUrl: 'wss://internal-service:3737/v1/chat/ws' },
     }).dashboard.apiUrl).toBe('https://internal-service:3737');
+  });
+
+  it('rejects non-loopback managed service hosts', () => {
+    expect(() => NetworkConfigSchema.parse({
+      dashboard: { host: 'dashboard.example.com' },
+    })).toThrow(/loopback-only/);
+
+    expect(() => NetworkConfigSchema.parse({
+      beastsDaemon: { host: '0.0.0.0' },
+    })).toThrow(/loopback-only/);
   });
 
   it('projects runtime config for each service', () => {
@@ -157,24 +171,13 @@ describe('network-registry', () => {
     });
   });
 
-  it('uses HTTPS for non-loopback dashboard and Beast proxy endpoints', () => {
+  it('refuses to project managed services on non-loopback hosts', () => {
     const config = defaultConfig();
     config.dashboard.host = 'dashboard.example.com';
     config.dashboard.apiUrl = 'https://api.example.com';
     config.beastsDaemon.host = 'beast.example.com';
 
-    const dashboard = resolveNetworkServices(config, context)
-      .find((service) => service.id === 'dashboard-web');
-
-    expect(dashboard?.runtimeConfig).toMatchObject({
-      url: 'https://dashboard.example.com:5173',
-      process: {
-        env: {
-          VITE_API_PROXY_TARGET: 'https://api.example.com',
-          VITE_BEAST_API_PROXY_TARGET: 'https://beast.example.com:4050',
-        },
-      },
-    });
+    expect(() => resolveNetworkServices(config, context)).toThrow(/loopback-only/);
   });
 
   it('forwards an explicit config path to spawned chat servers', () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
+import { NetworkConfigSchema } from '../../../src/network/network-config.js';
 import { createNetworkRegistry, filterNetworkServices, resolveNetworkServices } from '../../../src/network/network-registry.js';
 
 describe('network-registry', () => {
@@ -102,6 +103,21 @@ describe('network-registry', () => {
     expect(services.map((service) => service.id)).toEqual(['beasts-daemon', 'chat-server', 'dashboard-web']);
   });
 
+  it('rejects non-loopback plaintext dashboard and comms endpoints', () => {
+    expect(() => NetworkConfigSchema.parse({
+      dashboard: { apiUrl: 'http://internal-service:3737' },
+    })).toThrow(/https:\/\//);
+
+    expect(() => NetworkConfigSchema.parse({
+      comms: { orchestratorWsUrl: 'ws://internal-service:3737/v1/chat/ws' },
+    })).toThrow(/wss:\/\//);
+
+    expect(NetworkConfigSchema.parse({
+      dashboard: { apiUrl: 'https://internal-service:3737' },
+      comms: { orchestratorWsUrl: 'wss://internal-service:3737/v1/chat/ws' },
+    }).dashboard.apiUrl).toBe('https://internal-service:3737');
+  });
+
   it('projects runtime config for each service', () => {
     const config = defaultConfig();
     config.chat.port = 4242;
@@ -136,6 +152,26 @@ describe('network-registry', () => {
           VITE_API_URL: '',
           VITE_API_PROXY_TARGET: 'http://127.0.0.1:4242',
           VITE_BEAST_API_PROXY_TARGET: 'http://127.0.0.1:4050',
+        },
+      },
+    });
+  });
+
+  it('uses HTTPS for non-loopback dashboard and Beast proxy endpoints', () => {
+    const config = defaultConfig();
+    config.dashboard.host = 'dashboard.example.com';
+    config.dashboard.apiUrl = 'https://api.example.com';
+    config.beastsDaemon.host = 'beast.example.com';
+
+    const dashboard = resolveNetworkServices(config, context)
+      .find((service) => service.id === 'dashboard-web');
+
+    expect(dashboard?.runtimeConfig).toMatchObject({
+      url: 'https://dashboard.example.com:5173',
+      process: {
+        env: {
+          VITE_API_PROXY_TARGET: 'https://api.example.com',
+          VITE_BEAST_API_PROXY_TARGET: 'https://beast.example.com:4050',
         },
       },
     });

--- a/packages/franken-web/tests/vite-config.test.ts
+++ b/packages/franken-web/tests/vite-config.test.ts
@@ -16,6 +16,8 @@ describe('vite dev proxy configuration', () => {
 
   it('injects the operator token only in the server-side dev proxy after an origin check', () => {
     expect(CONFIG_SOURCE).toContain("'/v1': withServerSideOperatorAuth(proxyTarget, proxyOperatorToken, { ws: true })");
+    expect(CONFIG_SOURCE).toContain('assertSecureProxyTarget(\'VITE_API_PROXY_TARGET\', proxyTarget)');
+    expect(CONFIG_SOURCE).toContain('assertSecureProxyTarget(\'VITE_BEAST_API_PROXY_TARGET\', beastProxyTarget)');
     expect(CONFIG_SOURCE).toContain('command === \'serve\'');
     expect(CONFIG_SOURCE).toContain('assertNoBrowserOperatorToken(loadProxyEnv(loadEnv, mode, repoRootDir, process.cwd()))');
     expect(CONFIG_SOURCE).toContain('await loadProxyOperatorToken(loadEnv, mode, repoRootDir, process.cwd())');

--- a/packages/franken-web/tests/vite-env.test.ts
+++ b/packages/franken-web/tests/vite-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { loadProxyOperatorToken, type EnvLoader } from '../vite-env';
+import { assertSecureProxyTarget, loadProxyOperatorToken, type EnvLoader } from '../vite-env';
 
 const ROOT = '/repo';
 const PKG = '/repo/packages/franken-web';
@@ -10,6 +10,22 @@ function loaderFor(byDir: Record<string, Record<string, string>>): EnvLoader {
 }
 
 const noSecretStoreToken = async () => '';
+
+describe('assertSecureProxyTarget', () => {
+  it('allows HTTPS proxy targets', () => {
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'https://api.example.com')).not.toThrow();
+  });
+
+  it('allows loopback HTTP targets for local development only', () => {
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://127.0.0.1:3737')).not.toThrow();
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://localhost:3737')).not.toThrow();
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://[::1]:3737')).not.toThrow();
+  });
+
+  it('rejects non-loopback plain HTTP proxy targets', () => {
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://internal-service')).toThrow(/https:\/\//);
+  });
+});
 
 describe('loadProxyOperatorToken', () => {
   it('reads FRANKENBEAST_BEAST_OPERATOR_TOKEN from the repo-root env file for the server proxy', async () => {

--- a/packages/franken-web/tests/vite-env.test.ts
+++ b/packages/franken-web/tests/vite-env.test.ts
@@ -24,6 +24,8 @@ describe('assertSecureProxyTarget', () => {
 
   it('rejects non-loopback plain HTTP proxy targets', () => {
     expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://internal-service')).toThrow(/https:\/\//);
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://127.attacker.example:3737')).toThrow(/https:\/\//);
+    expect(() => assertSecureProxyTarget('VITE_API_PROXY_TARGET', 'http://0.0.0.0:3737')).toThrow(/https:\/\//);
   });
 });
 

--- a/packages/franken-web/vite-env.ts
+++ b/packages/franken-web/vite-env.ts
@@ -37,6 +37,38 @@ export function assertNoBrowserOperatorToken(env: Record<string, string>): void 
   }
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || normalized === '0:0:0:0:0:0:0:1'
+    || normalized === '0.0.0.0'
+    || normalized === '::'
+    || normalized === '127.0.0.1'
+    || normalized.startsWith('127.');
+}
+
+export function assertSecureProxyTarget(name: string, target: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    throw new Error(`${name} must be an absolute URL.`);
+  }
+
+  if (parsed.protocol === 'https:') {
+    return;
+  }
+
+  if (parsed.protocol === 'http:' && isLoopbackHostname(parsed.hostname)) {
+    return;
+  }
+
+  throw new Error(
+    `${name} must use https:// unless it targets a loopback-only development host. Refusing insecure proxy target: ${target}`,
+  );
+}
+
 export async function resolveSecretStoreOperatorToken(rootDir: string, configPath?: string): Promise<string> {
   try {
     const resolvedConfigPath = configPath

--- a/packages/franken-web/vite-env.ts
+++ b/packages/franken-web/vite-env.ts
@@ -39,13 +39,15 @@ export function assertNoBrowserOperatorToken(env: Record<string, string>): void 
 
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  return normalized === 'localhost'
+  if (normalized === 'localhost'
     || normalized === '::1'
-    || normalized === '0:0:0:0:0:0:0:1'
-    || normalized === '0.0.0.0'
-    || normalized === '::'
-    || normalized === '127.0.0.1'
-    || normalized.startsWith('127.');
+    || normalized === '0:0:0:0:0:0:0:1') {
+    return true;
+  }
+  if (!/^127(?:\.\d{1,3}){3}$/.test(normalized)) {
+    return false;
+  }
+  return normalized.split('.').every((part) => Number(part) >= 0 && Number(part) <= 255);
 }
 
 export function assertSecureProxyTarget(name: string, target: string): void {

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 import { readFileSync } from 'node:fs';
 import type { IncomingMessage } from 'node:http';
 import { fileURLToPath } from 'node:url';
-import { assertNoBrowserOperatorToken, loadProxyEnv, loadProxyOperatorToken } from './vite-env';
+import { assertNoBrowserOperatorToken, assertSecureProxyTarget, loadProxyEnv, loadProxyOperatorToken } from './vite-env';
 
 type ServerSideProxyConfig = Record<string, string | ProxyOptions>;
 
@@ -84,6 +84,8 @@ export default defineConfig(async ({ command, mode }) => {
   assertNoBrowserOperatorToken(loadProxyEnv(loadEnv, mode, repoRootDir, process.cwd()));
   const proxyTarget = env.VITE_API_PROXY_TARGET || 'http://127.0.0.1:3737';
   const beastProxyTarget = env.VITE_BEAST_API_PROXY_TARGET || proxyTarget;
+  assertSecureProxyTarget('VITE_API_PROXY_TARGET', proxyTarget);
+  assertSecureProxyTarget('VITE_BEAST_API_PROXY_TARGET', beastProxyTarget);
   const proxyOperatorToken = command === 'serve'
     ? await loadProxyOperatorToken(loadEnv, mode, repoRootDir, process.cwd())
     : '';

--- a/scripts/check-plain-http.mjs
+++ b/scripts/check-plain-http.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const root = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const scannedExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const scanRoots = ['packages', 'scripts'];
+const ignoredPathParts = new Set([
+  'node_modules',
+  'dist',
+  'coverage',
+  '.turbo',
+  '.vite',
+  'test',
+  'tests',
+  '__tests__',
+  'fixtures',
+]);
+
+function extensionOf(path) {
+  const match = /\.[^.]+$/.exec(path);
+  return match?.[0] ?? '';
+}
+
+function shouldScan(path) {
+  const rel = relative(root, path);
+  const parts = rel.split('/');
+  if (parts.some((part) => ignoredPathParts.has(part))) {
+    return false;
+  }
+  if (/\.(test|spec)\.[cm]?[jt]sx?$/.test(path)) {
+    return false;
+  }
+  return scannedExtensions.has(extensionOf(path));
+}
+
+function isAllowedLocalPlaintext(urlText) {
+  try {
+    const parsed = new URL(urlText);
+    const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    return parsed.protocol === 'http:' && (
+      host === 'localhost'
+      || host === '::1'
+      || host === '0:0:0:0:0:0:0:1'
+      || host === '0.0.0.0'
+      || host === '::'
+      || host === '127.0.0.1'
+      || host.startsWith('127.')
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function* walk(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!ignoredPathParts.has(entry.name)) {
+        yield* walk(fullPath);
+      }
+      continue;
+    }
+    if (entry.isFile() && shouldScan(fullPath)) {
+      yield fullPath;
+    }
+  }
+}
+
+const findings = [];
+for (const scanRoot of scanRoots) {
+  for await (const file of walk(join(root, scanRoot))) {
+    const content = await readFile(file, 'utf8');
+    const lines = content.split(/\r?\n/);
+    for (const [index, line] of lines.entries()) {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+        continue;
+      }
+      for (const match of line.matchAll(/http:\/\/[^\s'"`)>}]+/g)) {
+        const url = match[0];
+        if (url.includes('${')) {
+          continue;
+        }
+        if (!isAllowedLocalPlaintext(url)) {
+          findings.push(`${relative(root, file)}:${index + 1}: ${url}`);
+        }
+      }
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error('Plain HTTP URLs are only allowed for loopback-only local development targets. Use HTTPS/WSS for non-loopback endpoints.');
+  for (const finding of findings) {
+    console.error(`- ${finding}`);
+  }
+  process.exit(1);
+}
+
+console.log('No non-loopback plain HTTP URLs found in production JavaScript/TypeScript sources.');

--- a/scripts/check-plain-http.mjs
+++ b/scripts/check-plain-http.mjs
@@ -63,7 +63,7 @@ function literalUrlFromMatch(value) {
     const parsed = new URL(prefix);
     return `${parsed.protocol}//${parsed.host}`;
   } catch {
-    return undefined;
+    return value;
   }
 }
 

--- a/scripts/check-plain-http.mjs
+++ b/scripts/check-plain-http.mjs
@@ -38,17 +38,32 @@ function isAllowedLocalPlaintext(urlText) {
   try {
     const parsed = new URL(urlText);
     const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
-    return parsed.protocol === 'http:' && (
-      host === 'localhost'
-      || host === '::1'
-      || host === '0:0:0:0:0:0:0:1'
-      || host === '0.0.0.0'
-      || host === '::'
-      || host === '127.0.0.1'
-      || host.startsWith('127.')
-    );
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'ws:') {
+      return false;
+    }
+    if (host === 'localhost' || host === '::1' || host === '0:0:0:0:0:0:0:1') {
+      return true;
+    }
+    if (!/^127(?:\.\d{1,3}){3}$/.test(host)) {
+      return false;
+    }
+    return host.split('.').every((part) => Number(part) >= 0 && Number(part) <= 255);
   } catch {
     return false;
+  }
+}
+
+function literalUrlFromMatch(value) {
+  const interpolationIndex = value.indexOf('${');
+  if (interpolationIndex === -1) {
+    return value;
+  }
+  const prefix = value.slice(0, interpolationIndex);
+  try {
+    const parsed = new URL(prefix);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return undefined;
   }
 }
 
@@ -85,9 +100,9 @@ for (const scanRoot of scanRoots) {
       if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
         continue;
       }
-      for (const match of line.matchAll(/http:\/\/[^\s'"`)>}]+/g)) {
-        const url = match[0];
-        if (url.includes('${')) {
+      for (const match of line.matchAll(/(?:http|ws):\/\/[^\s'"`)>]+/g)) {
+        const url = literalUrlFromMatch(match[0]);
+        if (!url) {
           continue;
         }
         if (!isAllowedLocalPlaintext(url)) {


### PR DESCRIPTION
## Summary
- Reject non-loopback plaintext `VITE_API_PROXY_TARGET`/`VITE_BEAST_API_PROXY_TARGET` values in the Vite server-side proxy.
- Validate network config URLs so non-loopback dashboard/comms endpoints must use HTTPS/WSS, while loopback HTTP/WS remains allowed for local development.
- Add a security lint script that fails on non-loopback plain HTTP URLs in production JS/TS sources.

## Test Plan
- npm run lint:security
- npm --workspace @frankenbeast/web test -- vite-env.test.ts vite-config.test.ts
- npx vitest run tests/unit/network/network-registry.test.ts tests/unit/cli/run.test.ts --root packages/franken-orchestrator
- npm --workspace @frankenbeast/web run typecheck
- npm --workspace franken-orchestrator run typecheck
- npm --workspace @frankenbeast/web run build
- npm --workspace franken-orchestrator run build

Closes #516
