### PR TITLE
fix(web): improve network config save feedback

### DIFF
--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -20,10 +20,13 @@ interface NetworkConfigFormState {
   commsEnabled: boolean;
 }
 
+const NETWORK_MODES = ['secure', 'insecure'] as const;
+const SECURE_BACKENDS = ['local-encrypted', 'os-keychain', '1password', 'bitwarden'] as const;
+
 function formStateFromConfig(config: NetworkConfigResponse): NetworkConfigFormState {
   return {
     networkMode: config.network.mode,
-    secureBackend: config.network.secureBackend ?? '',
+    secureBackend: config.network.secureBackend ?? 'local-encrypted',
     chatEnabled: config.chat.enabled,
     chatModel: config.chat.model,
     chatHost: config.chat.host ?? '',
@@ -64,33 +67,107 @@ function buildAssignments(current: NetworkConfigFormState, initial: NetworkConfi
     .map(([key, value]) => assignment(key, value));
 }
 
+function validatePort(label: string, value: string): string | null {
+  const trimmed = value.trim();
+  const parsed = Number(trimmed);
+  if (!/^\d+$/.test(trimmed) || !Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) {
+    return `${label} must be between 1 and 65535.`;
+  }
+  return null;
+}
+
+function validateUrl(label: string, value: string): string | null {
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return `${label} must be an HTTP or HTTPS URL.`;
+    }
+  } catch {
+    return `${label} must be a valid URL.`;
+  }
+  return null;
+}
+
+function validateForm(state: NetworkConfigFormState): string[] {
+  const errors: string[] = [];
+  if (!NETWORK_MODES.includes(state.networkMode as (typeof NETWORK_MODES)[number])) {
+    errors.push('Network mode must be secure or insecure.');
+  }
+  if (!SECURE_BACKENDS.includes(state.secureBackend as (typeof SECURE_BACKENDS)[number])) {
+    errors.push('Secure backend must be local-encrypted, os-keychain, 1password, or bitwarden.');
+  }
+  if (!state.chatModel.trim()) {
+    errors.push('Chat model is required.');
+  }
+  if (!state.chatHost.trim()) {
+    errors.push('Chat host is required.');
+  }
+  const chatPortError = validatePort('Chat port', state.chatPort);
+  if (chatPortError) {
+    errors.push(chatPortError);
+  }
+  const shouldValidateDashboard = state.dashboardEnabled
+    || Boolean(state.dashboardHost.trim())
+    || Boolean(state.dashboardPort.trim())
+    || Boolean(state.dashboardApiUrl.trim());
+  if (shouldValidateDashboard) {
+    if (!state.dashboardHost.trim()) {
+      errors.push('Dashboard host is required.');
+    }
+    const dashboardPortError = validatePort('Dashboard port', state.dashboardPort);
+    if (dashboardPortError) {
+      errors.push(dashboardPortError);
+    }
+    if (state.dashboardApiUrl.trim()) {
+      const apiUrlError = validateUrl('Dashboard API URL', state.dashboardApiUrl);
+      if (apiUrlError) {
+        errors.push(apiUrlError);
+      }
+    }
+  }
+  return errors;
+}
+
 export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps) {
   const initialState = useMemo(() => formStateFromConfig(config), [config]);
   const [formState, setFormState] = useState<NetworkConfigFormState>(initialState);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const assignments = buildAssignments(formState, initialState);
+  const validationErrors = validateForm(formState);
+  const canSave = assignments.length > 0 && validationErrors.length === 0 && !isSaving;
 
   useEffect(() => {
     setFormState(initialState);
     setError(null);
+    setSuccess(null);
   }, [initialState]);
 
   function update<K extends keyof NetworkConfigFormState>(key: K, value: NetworkConfigFormState[K]) {
     setFormState((current) => ({ ...current, [key]: value }));
+    setError(null);
+    setSuccess(null);
   }
 
   async function save() {
+    if (!canSave) {
+      return;
+    }
     setIsSaving(true);
     setError(null);
+    setSuccess(null);
     try {
       await onSave(assignments);
+      setSuccess('Saved network config changes.');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to save network config.');
     } finally {
       setIsSaving(false);
     }
   }
+
+  const alertMessage = error ?? (assignments.length > 0 ? validationErrors[0] : null);
 
   return (
     <section className="rail-card network-config-editor">
@@ -100,24 +177,26 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
 
       <label className="network-config-editor__field">
         <span>Network mode</span>
-        <input
+        <select
           aria-label="Network mode"
           className="field-control"
-          type="text"
           value={formState.networkMode}
           onChange={(event) => update('networkMode', event.target.value)}
-        />
+        >
+          {NETWORK_MODES.map((mode) => <option key={mode} value={mode}>{mode}</option>)}
+        </select>
       </label>
 
       <label className="network-config-editor__field">
         <span>Secure backend</span>
-        <input
+        <select
           aria-label="Secure backend"
           className="field-control"
-          type="text"
           value={formState.secureBackend}
           onChange={(event) => update('secureBackend', event.target.value)}
-        />
+        >
+          {SECURE_BACKENDS.map((backend) => <option key={backend} value={backend}>{backend}</option>)}
+        </select>
       </label>
 
       <label className="network-config-editor__field network-config-editor__field--checkbox">
@@ -156,6 +235,7 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
         <span>Chat port</span>
         <input
           aria-label="Chat port"
+          aria-invalid={validationErrors.some((message) => message.startsWith('Chat port')) ? true : undefined}
           className="field-control"
           inputMode="numeric"
           type="number"
@@ -189,6 +269,7 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
         <span>Dashboard port</span>
         <input
           aria-label="Dashboard port"
+          aria-invalid={validationErrors.some((message) => message.startsWith('Dashboard port')) ? true : undefined}
           className="field-control"
           inputMode="numeric"
           type="number"
@@ -201,8 +282,9 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
         <span>Dashboard API URL</span>
         <input
           aria-label="Dashboard API URL"
+          aria-invalid={validationErrors.some((message) => message.startsWith('Dashboard API URL')) ? true : undefined}
           className="field-control"
-          type="text"
+          type="url"
           value={formState.dashboardApiUrl}
           onChange={(event) => update('dashboardApiUrl', event.target.value)}
         />
@@ -218,9 +300,21 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
         <span>Comms enabled</span>
       </label>
 
-      {error && <p role="alert">{error}</p>}
+      <div className="network-config-editor__pending" aria-live="polite">
+        <h3>Pending config changes</h3>
+        {assignments.length > 0 ? (
+          <ul>
+            {assignments.map((item) => <li key={item}><code>{item}</code></li>)}
+          </ul>
+        ) : (
+          <p>No pending config changes.</p>
+        )}
+      </div>
 
-      <button className="button button--primary" type="button" disabled={isSaving} onClick={() => { void save(); }}>
+      {alertMessage && <p className="network-config-editor__alert" role="alert">{alertMessage}</p>}
+      {success && <p className="network-config-editor__success" role="status">{success}</p>}
+
+      <button className="button button--primary" type="button" disabled={!canSave} onClick={() => { void save(); }}>
         {isSaving ? 'Saving…' : 'Save config'}
       </button>
     </section>

--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -118,7 +118,9 @@ function validateForm(state: NetworkConfigFormState): string[] {
     if (dashboardPortError) {
       errors.push(dashboardPortError);
     }
-    if (state.dashboardApiUrl.trim()) {
+    if (!state.dashboardApiUrl.trim()) {
+      errors.push('Dashboard API URL is required.');
+    } else {
       const apiUrlError = validateUrl('Dashboard API URL', state.dashboardApiUrl);
       if (apiUrlError) {
         errors.push(apiUrlError);
@@ -141,7 +143,6 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
   useEffect(() => {
     setFormState(initialState);
     setError(null);
-    setSuccess(null);
   }, [initialState]);
 
   function update<K extends keyof NetworkConfigFormState>(key: K, value: NetworkConfigFormState[K]) {

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -780,6 +780,76 @@ button {
   font-size: 1.05rem;
 }
 
+.network-config-editor {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.network-config-editor__field {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.network-config-editor__field--checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--text);
+}
+
+.network-config-editor__pending {
+  padding: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.network-config-editor__pending h3 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+}
+
+.network-config-editor__pending ul {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.network-config-editor__pending p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.network-config-editor__pending code {
+  color: var(--accent-strong);
+}
+
+.network-config-editor__alert,
+.network-config-editor__success {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.9rem;
+}
+
+.network-config-editor__alert {
+  border: 1px solid rgba(255, 126, 126, 0.32);
+  background: rgba(255, 126, 126, 0.1);
+  color: var(--danger);
+}
+
+.network-config-editor__success {
+  border: 1px solid rgba(134, 228, 95, 0.28);
+  background: rgba(134, 228, 95, 0.12);
+  color: var(--accent-strong);
+}
+
+.field-control[aria-invalid='true'] {
+  border-color: rgba(255, 126, 126, 0.58);
+}
+
 .network-logs__header,
 .network-logs__toolbar,
 .network-logs__line,

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -129,6 +129,12 @@ describe('NetworkPage', () => {
     expect(onSaveConfig).not.toHaveBeenCalled();
 
     fireEvent.change(screen.getByLabelText('Dashboard port'), { target: { value: '5173' } });
+    fireEvent.change(screen.getByLabelText('Dashboard API URL'), { target: { value: '' } });
+
+    expect(saveButton).toHaveProperty('disabled', true);
+    expect(screen.getByRole('alert').textContent).toContain('Dashboard API URL is required.');
+
+    fireEvent.change(screen.getByLabelText('Dashboard API URL'), { target: { value: 'http://localhost:3737' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
 
     expect(screen.getByText('Pending config changes')).toBeDefined();
@@ -136,10 +142,10 @@ describe('NetworkPage', () => {
     expect(saveButton).toHaveProperty('disabled', false);
   });
 
-  it('shows success feedback after network config changes save', async () => {
+  it('shows success feedback after network config changes save and the refreshed config arrives', async () => {
     const onSaveConfig = vi.fn().mockResolvedValue(undefined);
 
-    render(
+    const { rerender } = render(
       <NetworkPage
         config={baseConfig}
         logs={[]}
@@ -159,6 +165,26 @@ describe('NetworkPage', () => {
 
     await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Saved network config changes.'));
     expect(onSaveConfig).toHaveBeenCalledWith(['dashboard.apiUrl=http://localhost:3737']);
+
+    rerender(
+      <NetworkPage
+        config={{
+          ...baseConfig,
+          dashboard: { ...baseConfig.dashboard!, apiUrl: 'http://localhost:3737' },
+        }}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    expect(screen.getByRole('status').textContent).toContain('Saved network config changes.');
   });
 
   it('updates editor values when fetched config props change', () => {

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -36,7 +36,7 @@ describe('NetworkPage', () => {
       />,
     );
 
-    expect(screen.getByText('secure')).toBeDefined();
+    expect(screen.getAllByText('secure').length).toBeGreaterThan(0);
     expect(screen.getByText('chat-server')).toBeDefined();
     expect(screen.getByText('/tmp/chat-server.log')).toBeDefined();
     expect(screen.getByDisplayValue('claude-sonnet-4-6')).toBeDefined();
@@ -80,7 +80,7 @@ describe('NetworkPage', () => {
     await waitFor(() => expect(screen.getByText('Stopped chat-server.')).toBeDefined());
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat-server' }));
     await waitFor(() => expect(screen.getByText('Restarted chat-server.')).toBeDefined());
-    fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'hybrid' } });
+    fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'insecure' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
     fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });
     fireEvent.change(screen.getByLabelText('Dashboard port'), { target: { value: '5173' } });
@@ -91,12 +91,74 @@ describe('NetworkPage', () => {
     expect(onStop).toHaveBeenCalledWith('chat-server');
     expect(onRestart).toHaveBeenCalledWith('chat-server');
     expect(onSaveConfig).toHaveBeenCalledWith([
-      'network.mode=hybrid',
+      'network.mode=insecure',
       'chat.model=gpt-5',
       'chat.host=0.0.0.0',
       'dashboard.port=5173',
       'comms.enabled=true',
     ]);
+  });
+
+  it('keeps Save disabled until valid config changes are pending and previews assignments', () => {
+    const onSaveConfig = vi.fn();
+
+    render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    const saveButton = screen.getByRole('button', { name: 'Save config' });
+    expect(saveButton).toHaveProperty('disabled', true);
+    expect(screen.getByText('No pending config changes.')).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText('Dashboard port'), { target: { value: '70000' } });
+
+    expect(saveButton).toHaveProperty('disabled', true);
+    expect(screen.getByRole('alert').textContent).toContain('Dashboard port must be between 1 and 65535.');
+    fireEvent.click(saveButton);
+    expect(onSaveConfig).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Dashboard port'), { target: { value: '5173' } });
+    fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
+
+    expect(screen.getByText('Pending config changes')).toBeDefined();
+    expect(screen.getByText('chat.model=gpt-5')).toBeDefined();
+    expect(saveButton).toHaveProperty('disabled', false);
+  });
+
+  it('shows success feedback after network config changes save', async () => {
+    const onSaveConfig = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Dashboard API URL'), { target: { value: 'http://localhost:3737' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
+
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Saved network config changes.'));
+    expect(onSaveConfig).toHaveBeenCalledWith(['dashboard.apiUrl=http://localhost:3737']);
   });
 
   it('updates editor values when fetched config props change', () => {
@@ -123,7 +185,7 @@ describe('NetworkPage', () => {
     rerender(
       <NetworkPage
         config={{
-          network: { mode: 'hybrid', secureBackend: 'remote-vault' },
+          network: { mode: 'insecure', secureBackend: 'os-keychain' },
           chat: { model: 'fetched-model', enabled: false, host: '0.0.0.0', port: 4747 },
           dashboard: { enabled: true, host: 'localhost', port: 5173, apiUrl: 'http://localhost:4747' },
           comms: { enabled: true },
@@ -141,8 +203,8 @@ describe('NetworkPage', () => {
     );
 
     expect(screen.getByDisplayValue('fetched-model')).toBeDefined();
-    expect(screen.getByDisplayValue('hybrid')).toBeDefined();
-    expect(screen.getByDisplayValue('remote-vault')).toBeDefined();
+    expect(screen.getByDisplayValue('insecure')).toBeDefined();
+    expect(screen.getByDisplayValue('os-keychain')).toBeDefined();
     expect((screen.getByLabelText('Chat enabled') as HTMLInputElement).checked).toBe(false);
     expect((screen.getByLabelText('Comms enabled') as HTMLInputElement).checked).toBe(true);
   });


### PR DESCRIPTION
## Summary
- disables Network config Save until valid pending changes exist
- adds pending assignment preview plus success/error feedback for saves
- constrains network mode and secure backend inputs and validates ports/URLs before submit

## Test Plan
- npm run test --workspace @frankenbeast/web -- tests/components/network-page.test.tsx tests/components/chat-shell.test.tsx
- npm run test --workspace @frankenbeast/web
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web

Closes #638