### PR TITLE
fix(web): show review summary in agent form view

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -77,4 +77,20 @@ describe('WizardDialog validation', () => {
     expect(screen.getByRole('alert').textContent).toContain('Identity: Agent name is required');
     expect(screen.getByRole('alert').textContent).toContain('Workflow: Workflow type is required');
   });
+
+  it('includes the review summary in form view before the launch action', () => {
+    useBeastStore.getState().setStepValues(0, { name: 'Reviewable Agent' });
+    useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
+
+    renderWizard();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle form mode' }));
+
+    const reviewHeading = screen.getByRole('heading', { name: 'Review' });
+    const launchButton = screen.getByRole('button', { name: 'Launch Agent' });
+
+    expect(reviewHeading.compareDocumentPosition(launchButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Reviewable Agent')).toBeTruthy();
+    expect(screen.getByText('design-interview')).toBeTruthy();
+  });
 });

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -163,6 +163,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
                 <FormSection title="Skills"><StepSkills /></FormSection>
                 <FormSection title="Prompts"><StepPrompts /></FormSection>
                 <FormSection title="Git"><StepGit /></FormSection>
+                <FormSection title="Review"><StepReview /></FormSection>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Render the Create Agent Review summary in Form View before the footer launch CTA
- Add a regression test asserting the form review summary appears before Launch Agent

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @frankenbeast/web
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web

Closes #635