### PR TITLE
fix(web): preserve transcript and activity scroll

### DIFF
--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -1,9 +1,18 @@
-import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActivityPane } from './activity-pane';
 
+function setScrollMetrics(element: Element, metrics: { scrollHeight: number; scrollTop: number; clientHeight: number }) {
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: metrics.scrollHeight });
+  Object.defineProperty(element, 'scrollTop', { configurable: true, value: metrics.scrollTop });
+  Object.defineProperty(element, 'clientHeight', { configurable: true, value: metrics.clientHeight });
+}
+
 describe('ActivityPane', () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
   it('summarizes turn errors and keeps raw data behind details', () => {
     render(
@@ -21,5 +30,34 @@ describe('ActivityPane', () => {
     expect(screen.getByText('TOOL_DENIED: Approval denied by policy.')).toBeTruthy();
     expect(screen.getByText('Raw event details')).toBeTruthy();
     expect(screen.getByText(/"traceId": "trace-1"/)).toBeTruthy();
+  });
+
+  it('preserves scroll position and offers a jump button when new activity arrives while scrolled up', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView });
+    const firstEvent = { type: 'turn.started', data: { message: 'Started' }, timestamp: '2026-07-05T00:00:00.000Z' };
+    const { container, rerender } = render(<ActivityPane events={[firstEvent]} />);
+    scrollIntoView.mockClear();
+
+    const list = container.querySelector('.activity-list');
+    expect(list).toBeTruthy();
+    setScrollMetrics(list!, { scrollHeight: 900, scrollTop: 120, clientHeight: 300 });
+    fireEvent.scroll(list!);
+
+    rerender(
+      <ActivityPane
+        events={[
+          firstEvent,
+          { type: 'turn.completed', data: { message: 'Done' }, timestamp: '2026-07-05T00:00:01.000Z' },
+        ]}
+      />,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    const jumpButton = screen.getByRole('button', { name: /new activity/i });
+    expect(jumpButton).toBeTruthy();
+
+    fireEvent.click(jumpButton);
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
   });
 });

--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -115,4 +115,13 @@ describe('ActivityPane', () => {
 
     expect(screen.queryByRole('button', { name: /new activity/i })).toBeNull();
   });
+
+  it('does not auto-scroll an empty activity rail', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView });
+
+    render(<ActivityPane events={[]} />);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
 });

--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -60,4 +60,18 @@ describe('ActivityPane', () => {
     fireEvent.click(jumpButton);
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
   });
+
+  it('does not show a jump button when the user scrolls up before new activity arrives', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: vi.fn() });
+    const { container } = render(
+      <ActivityPane events={[{ type: 'turn.started', data: { message: 'Started' }, timestamp: '2026-07-05T00:00:00.000Z' }]} />,
+    );
+
+    const list = container.querySelector('.activity-list');
+    expect(list).toBeTruthy();
+    setScrollMetrics(list!, { scrollHeight: 900, scrollTop: 120, clientHeight: 300 });
+    fireEvent.scroll(list!);
+
+    expect(screen.queryByRole('button', { name: /new activity/i })).toBeNull();
+  });
 });

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -215,7 +215,7 @@ export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
             </li>
           );
         })}
-        <li ref={endRef} className="activity-list__sentinel" aria-hidden="true" />
+        {events.length > 0 && <li ref={endRef} className="activity-list__sentinel" aria-hidden="true" />}
       </ol>
       {hasNewItems && (
         <button className="scroll-jump-button" type="button" onClick={() => scrollToLatest()}>

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
 import type { ActivityEvent } from '../hooks/use-chat-session';
+import { usePinnedScroll } from './use-pinned-scroll';
 
 export interface ActivityPaneProps {
   events: ActivityEvent[];
@@ -28,13 +28,7 @@ function summarizeActivity(event: ActivityEvent): string {
 }
 
 export function ActivityPane({ events }: ActivityPaneProps) {
-  const endRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (typeof endRef.current?.scrollIntoView === 'function') {
-      endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
-    }
-  }, [events.length]);
+  const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll(events.length);
 
   return (
     <section className="rail-card" aria-label="Activity">
@@ -43,7 +37,7 @@ export function ActivityPane({ events }: ActivityPaneProps) {
         <h2>Runtime Events</h2>
       </div>
       {events.length === 0 && <p className="rail-card__empty">Waiting for execution events.</p>}
-      <div className="activity-list">
+      <div ref={containerRef} className="activity-list" onScroll={handleScroll}>
         {events.map((event, index) => (
           <article key={`${event.type}-${event.timestamp}-${index}`} className="activity-event">
             <strong className="activity-event__type">{event.type}</strong>
@@ -56,6 +50,11 @@ export function ActivityPane({ events }: ActivityPaneProps) {
         ))}
         <div ref={endRef} />
       </div>
+      {hasNewItems && (
+        <button className="scroll-jump-button" type="button" onClick={() => scrollToLatest()}>
+          New activity — jump to latest
+        </button>
+      )}
     </section>
   );
 }

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -3,6 +3,7 @@ import { usePinnedScroll } from './use-pinned-scroll';
 
 export interface ActivityPaneProps {
   events: ActivityEvent[];
+  resetKey?: unknown;
 }
 
 function summarizeActivity(event: ActivityEvent): string {
@@ -27,8 +28,8 @@ function summarizeActivity(event: ActivityEvent): string {
   return 'Open details to inspect runtime event data.';
 }
 
-export function ActivityPane({ events }: ActivityPaneProps) {
-  const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll(events.length);
+export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
+  const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll(events.length, resetKey);
 
   return (
     <section className="rail-card" aria-label="Activity">

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -908,6 +908,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                     }
                   }).catch(() => undefined);
                 }}
+                resetKey={`${activeProjectId}:${activeSessionId ?? selectedSessionId ?? 'new'}:${sessionSeed}`}
                 retryDisabled={status !== 'idle' && status !== 'error'}
                 showTypingIndicator={showTypingIndicator}
               />
@@ -923,7 +924,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
             <aside className="chat-page__rail">
               <CostBadge tier={tier ?? 'pending'} tokenTotals={tokenTotals} costUsd={costUsd} />
-              <ActivityPane events={activity} />
+              <ActivityPane events={activity} resetKey={`${activeProjectId}:${activeSessionId ?? selectedSessionId ?? 'new'}:${sessionSeed}`} />
               <ApprovalCard
                 pending={Boolean(pendingApproval)}
                 approval={pendingApproval}

--- a/packages/franken-web/src/components/transcript-pane.tsx
+++ b/packages/franken-web/src/components/transcript-pane.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
 import type { ChatMessage } from '../hooks/use-chat-session';
+import { usePinnedScroll } from './use-pinned-scroll';
 
 export interface TranscriptPaneProps {
   messages: ChatMessage[];
@@ -9,13 +9,9 @@ export interface TranscriptPaneProps {
 }
 
 export function TranscriptPane({ messages, onRetryMessage, retryDisabled = false, showTypingIndicator }: TranscriptPaneProps) {
-  const endRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (typeof endRef.current?.scrollIntoView === 'function') {
-      endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
-    }
-  }, [messages.length, showTypingIndicator]);
+  const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll(
+    `${messages.length}:${showTypingIndicator}`,
+  );
 
   return (
     <section className="transcript-pane" aria-label="Transcript">
@@ -27,7 +23,7 @@ export function TranscriptPane({ messages, onRetryMessage, retryDisabled = false
         <p className="transcript-pane__meta">CLI-parity conversation stream with live execution telemetry.</p>
       </div>
 
-      <div className="transcript-pane__body">
+      <div ref={containerRef} className="transcript-pane__body" onScroll={handleScroll}>
         {messages.length === 0 && (
           <div className="empty-state">
             <p>No messages yet.</p>
@@ -68,6 +64,11 @@ export function TranscriptPane({ messages, onRetryMessage, retryDisabled = false
 
         <div ref={endRef} />
       </div>
+      {hasNewItems && (
+        <button className="scroll-jump-button" type="button" onClick={() => scrollToLatest()}>
+          New messages — jump to latest
+        </button>
+      )}
     </section>
   );
 }

--- a/packages/franken-web/src/components/transcript-pane.tsx
+++ b/packages/franken-web/src/components/transcript-pane.tsx
@@ -4,13 +4,16 @@ import { usePinnedScroll } from './use-pinned-scroll';
 export interface TranscriptPaneProps {
   messages: ChatMessage[];
   onRetryMessage?: (messageId: string) => void;
+  resetKey?: unknown;
   retryDisabled?: boolean;
   showTypingIndicator: boolean;
 }
 
-export function TranscriptPane({ messages, onRetryMessage, retryDisabled = false, showTypingIndicator }: TranscriptPaneProps) {
+export function TranscriptPane({ messages, onRetryMessage, resetKey, retryDisabled = false, showTypingIndicator }: TranscriptPaneProps) {
+  const lastMessage = messages.at(-1);
   const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll(
-    `${messages.length}:${showTypingIndicator}`,
+    `${messages.length}:${lastMessage?.id ?? ''}:${lastMessage?.content.length ?? 0}:${lastMessage?.receipt ?? ''}:${showTypingIndicator}`,
+    resetKey,
   );
 
   return (

--- a/packages/franken-web/src/components/use-pinned-scroll.ts
+++ b/packages/franken-web/src/components/use-pinned-scroll.ts
@@ -50,7 +50,7 @@ export function usePinnedScroll<ContainerElement extends HTMLElement = HTMLDivEl
     }
 
     if (isPinnedToBottom) {
-      scrollToLatest();
+      scrollToLatest('auto');
     } else if (tokenChanged) {
       setHasNewItems(true);
     }

--- a/packages/franken-web/src/components/use-pinned-scroll.ts
+++ b/packages/franken-web/src/components/use-pinned-scroll.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const NEAR_BOTTOM_PX = 48;
+
+function isNearBottom(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= NEAR_BOTTOM_PX;
+}
+
+export function usePinnedScroll(updateToken: unknown) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
+  const [hasNewItems, setHasNewItems] = useState(false);
+
+  const scrollToLatest = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    if (typeof endRef.current?.scrollIntoView === 'function') {
+      endRef.current.scrollIntoView({ behavior, block: 'end' });
+    }
+    setIsPinnedToBottom(true);
+    setHasNewItems(false);
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const pinned = isNearBottom(container);
+    setIsPinnedToBottom(pinned);
+    if (pinned) {
+      setHasNewItems(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isPinnedToBottom) {
+      scrollToLatest();
+    } else {
+      setHasNewItems(true);
+    }
+  }, [isPinnedToBottom, scrollToLatest, updateToken]);
+
+  return {
+    containerRef,
+    endRef,
+    hasNewItems,
+    handleScroll,
+    scrollToLatest,
+  };
+}

--- a/packages/franken-web/src/components/use-pinned-scroll.ts
+++ b/packages/franken-web/src/components/use-pinned-scroll.ts
@@ -9,6 +9,7 @@ function isNearBottom(element: HTMLElement): boolean {
 export function usePinnedScroll(updateToken: unknown) {
   const containerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const previousUpdateTokenRef = useRef(updateToken);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
   const [hasNewItems, setHasNewItems] = useState(false);
 
@@ -34,9 +35,12 @@ export function usePinnedScroll(updateToken: unknown) {
   }, []);
 
   useEffect(() => {
+    const tokenChanged = !Object.is(previousUpdateTokenRef.current, updateToken);
+    previousUpdateTokenRef.current = updateToken;
+
     if (isPinnedToBottom) {
       scrollToLatest();
-    } else {
+    } else if (tokenChanged) {
       setHasNewItems(true);
     }
   }, [isPinnedToBottom, scrollToLatest, updateToken]);

--- a/packages/franken-web/src/components/use-pinned-scroll.ts
+++ b/packages/franken-web/src/components/use-pinned-scroll.ts
@@ -6,10 +6,11 @@ function isNearBottom(element: HTMLElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= NEAR_BOTTOM_PX;
 }
 
-export function usePinnedScroll(updateToken: unknown) {
+export function usePinnedScroll(updateToken: unknown, resetToken: unknown = undefined) {
   const containerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const previousUpdateTokenRef = useRef(updateToken);
+  const previousResetTokenRef = useRef(resetToken);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
   const [hasNewItems, setHasNewItems] = useState(false);
 
@@ -35,15 +36,22 @@ export function usePinnedScroll(updateToken: unknown) {
   }, []);
 
   useEffect(() => {
+    const resetChanged = !Object.is(previousResetTokenRef.current, resetToken);
     const tokenChanged = !Object.is(previousUpdateTokenRef.current, updateToken);
+    previousResetTokenRef.current = resetToken;
     previousUpdateTokenRef.current = updateToken;
+
+    if (resetChanged) {
+      scrollToLatest('auto');
+      return;
+    }
 
     if (isPinnedToBottom) {
       scrollToLatest();
     } else if (tokenChanged) {
       setHasNewItems(true);
     }
-  }, [isPinnedToBottom, scrollToLatest, updateToken]);
+  }, [isPinnedToBottom, resetToken, scrollToLatest, updateToken]);
 
   return {
     containerRef,

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -500,6 +500,7 @@ button {
   position: relative;
   display: flex;
   flex-direction: column;
+  height: clamp(32rem, 58vh, 44rem);
   min-height: 32rem;
   overflow: hidden;
 }
@@ -518,9 +519,11 @@ button {
 }
 
 .transcript-pane__body {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-height: 0;
   padding: 1.25rem 1.25rem 1.5rem;
   overflow: auto;
 }

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -497,6 +497,7 @@ button {
 }
 
 .transcript-pane {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 32rem;
@@ -522,6 +523,25 @@ button {
   gap: 1rem;
   padding: 1.25rem 1.25rem 1.5rem;
   overflow: auto;
+}
+
+.scroll-jump-button {
+  align-self: center;
+  margin: 0.75rem auto 1rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid rgba(134, 228, 95, 0.4);
+  border-radius: 999px;
+  background: rgba(134, 228, 95, 0.16);
+  color: var(--accent-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.scroll-jump-button:hover,
+.scroll-jump-button:focus-visible {
+  background: rgba(134, 228, 95, 0.24);
 }
 
 .message-card {

--- a/packages/franken-web/tests/components/transcript-pane.test.tsx
+++ b/packages/franken-web/tests/components/transcript-pane.test.tsx
@@ -1,8 +1,17 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TranscriptPane } from '../../src/components/transcript-pane.js';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function setScrollMetrics(element: Element, metrics: { scrollHeight: number; scrollTop: number; clientHeight: number }) {
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: metrics.scrollHeight });
+  Object.defineProperty(element, 'scrollTop', { configurable: true, value: metrics.scrollTop });
+  Object.defineProperty(element, 'clientHeight', { configurable: true, value: metrics.clientHeight });
+}
 
 describe('TranscriptPane', () => {
   it('renders messages with role labels', () => {
@@ -47,5 +56,35 @@ describe('TranscriptPane', () => {
     ];
     render(<TranscriptPane messages={messages} showTypingIndicator={false} />);
     expect(screen.queryByText(/cheap|premium/i)).toBeNull();
+  });
+
+  it('preserves scroll position and offers a jump button when new messages arrive while scrolled up', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView });
+    const firstMessage = { id: 'u1', role: 'user' as const, content: 'Original', timestamp: new Date().toISOString() };
+    const { container, rerender } = render(<TranscriptPane messages={[firstMessage]} showTypingIndicator={false} />);
+    scrollIntoView.mockClear();
+
+    const body = container.querySelector('.transcript-pane__body');
+    expect(body).toBeTruthy();
+    setScrollMetrics(body!, { scrollHeight: 1000, scrollTop: 100, clientHeight: 300 });
+    fireEvent.scroll(body!);
+
+    rerender(
+      <TranscriptPane
+        messages={[
+          firstMessage,
+          { id: 'a1', role: 'assistant' as const, content: 'New reply', timestamp: new Date().toISOString() },
+        ]}
+        showTypingIndicator={false}
+      />,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    const jumpButton = screen.getByRole('button', { name: /new messages/i });
+    expect(jumpButton).toBeTruthy();
+
+    fireEvent.click(jumpButton);
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
   });
 });

--- a/packages/franken-web/tests/components/transcript-pane.test.tsx
+++ b/packages/franken-web/tests/components/transcript-pane.test.tsx
@@ -104,4 +104,48 @@ describe('TranscriptPane', () => {
 
     expect(screen.queryByRole('button', { name: /new messages/i })).toBeNull();
   });
+
+  it('follows streamed content changes for the existing last message while pinned', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView });
+    const { rerender } = render(
+      <TranscriptPane
+        messages={[{ id: 'a1', role: 'assistant' as const, content: 'Chunk', timestamp: new Date().toISOString() }]}
+        showTypingIndicator={false}
+      />,
+    );
+    scrollIntoView.mockClear();
+
+    rerender(
+      <TranscriptPane
+        messages={[{ id: 'a1', role: 'assistant' as const, content: 'Chunk plus more streamed text', timestamp: new Date().toISOString() }]}
+        showTypingIndicator={false}
+      />,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
+  });
+
+  it('resets pinned scroll state when the conversation changes', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView });
+    const { container, rerender } = render(
+      <TranscriptPane
+        messages={[{ id: 'u1', role: 'user' as const, content: 'Old session', timestamp: new Date().toISOString() }]}
+        resetKey="session-1"
+        showTypingIndicator={false}
+      />,
+    );
+
+    const body = container.querySelector('.transcript-pane__body');
+    expect(body).toBeTruthy();
+    setScrollMetrics(body!, { scrollHeight: 1000, scrollTop: 100, clientHeight: 300 });
+    fireEvent.scroll(body!);
+    scrollIntoView.mockClear();
+
+    rerender(<TranscriptPane messages={[]} resetKey="session-2" showTypingIndicator={false} />);
+
+    expect(screen.queryByRole('button', { name: /new messages/i })).toBeNull();
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'end' });
+  });
 });

--- a/packages/franken-web/tests/components/transcript-pane.test.tsx
+++ b/packages/franken-web/tests/components/transcript-pane.test.tsx
@@ -87,4 +87,21 @@ describe('TranscriptPane', () => {
     fireEvent.click(jumpButton);
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
   });
+
+  it('does not show a jump button when the user scrolls up before new messages arrive', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: vi.fn() });
+    const { container } = render(
+      <TranscriptPane
+        messages={[{ id: 'u1', role: 'user' as const, content: 'Original', timestamp: new Date().toISOString() }]}
+        showTypingIndicator={false}
+      />,
+    );
+
+    const body = container.querySelector('.transcript-pane__body');
+    expect(body).toBeTruthy();
+    setScrollMetrics(body!, { scrollHeight: 1000, scrollTop: 100, clientHeight: 300 });
+    fireEvent.scroll(body!);
+
+    expect(screen.queryByRole('button', { name: /new messages/i })).toBeNull();
+  });
 });

--- a/packages/franken-web/tests/components/transcript-pane.test.tsx
+++ b/packages/franken-web/tests/components/transcript-pane.test.tsx
@@ -123,7 +123,7 @@ describe('TranscriptPane', () => {
       />,
     );
 
-    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'end' });
   });
 
   it('resets pinned scroll state when the conversation changes', () => {


### PR DESCRIPTION
## Summary
- Preserve transcript and activity scroll position when operators have scrolled up from the live tail
- Add shared pinned-scroll behavior with jump-to-latest buttons for new messages/activity
- Cover both panes with regression tests

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @frankenbeast/web -- --run tests/components/transcript-pane.test.tsx src/components/activity-pane.test.tsx
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web
- npm run test --workspace @frankenbeast/web

Closes #629