### PR TITLE
fix(web): render activity timeline entries

### DIFF
--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -19,7 +19,40 @@ describe('ActivityPane', () => {
     );
 
     expect(screen.getByText('TOOL_DENIED: Approval denied by policy.')).toBeTruthy();
+    expect(screen.getByText('Error')).toBeTruthy();
+    expect(screen.getByText('Jul 5, 2026, 12:00 AM')).toBeTruthy();
     expect(screen.getByText('Raw event details')).toBeTruthy();
     expect(screen.getByText(/"traceId": "trace-1"/)).toBeTruthy();
+  });
+
+  it('renders runtime activity as a readable timeline with status chips and artifact links', () => {
+    render(
+      <ActivityPane
+        events={[
+          {
+            type: 'turn.execution.start',
+            data: { message: 'Running plan', runId: 'run-42', sessionId: 'session-7' },
+            timestamp: '2026-07-05T01:02:03.000Z',
+          },
+          {
+            type: 'turn.approval.requested',
+            data: { description: 'Run npm test', risk: 'medium', artifactPath: '/tmp/report.md' },
+            timestamp: '2026-07-05T01:03:04.000Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('list')).toBeTruthy();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText('Execution started')).toBeTruthy();
+    expect(screen.getByText('Running plan')).toBeTruthy();
+    expect(screen.getByText('Approval needed')).toBeTruthy();
+    expect(screen.getByText('Needs review')).toBeTruthy();
+    expect(screen.getByText('Medium risk')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Session session-7' }).getAttribute('href')).toBe('#/sessions/session-7');
+    expect(screen.getByRole('link', { name: 'Run run-42' }).getAttribute('href')).toBe('#/runs/run-42');
+    expect(screen.getByRole('link', { name: 'Artifact /tmp/report.md' }).getAttribute('href')).toBe('#/artifacts?path=%2Ftmp%2Freport.md');
+    expect(screen.queryByText('{"message":"Running plan"}')).toBeNull();
   });
 });

--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -31,7 +31,7 @@ describe('ActivityPane', () => {
         events={[
           {
             type: 'turn.execution.start',
-            data: { message: 'Running plan', runId: 'run-42', sessionId: 'session-7' },
+            data: { taskDescription: 'Deploy agent', runId: 'run-42', sessionId: 'session-7' },
             timestamp: '2026-07-05T01:02:03.000Z',
           },
           {
@@ -39,20 +39,28 @@ describe('ActivityPane', () => {
             data: { description: 'Run npm test', risk: 'medium', artifactPath: '/tmp/report.md' },
             timestamp: '2026-07-05T01:03:04.000Z',
           },
+          {
+            type: 'turn.execution.complete',
+            data: { status: 'failed', summary: 'Tests failed' },
+            timestamp: '2026-07-05T01:04:05.000Z',
+          },
         ]}
       />,
     );
 
     expect(screen.getByRole('list')).toBeTruthy();
-    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
     expect(screen.getByText('Execution started')).toBeTruthy();
-    expect(screen.getByText('Running plan')).toBeTruthy();
+    expect(screen.getByText('Deploy agent')).toBeTruthy();
     expect(screen.getByText('Approval needed')).toBeTruthy();
     expect(screen.getByText('Needs review')).toBeTruthy();
     expect(screen.getByText('Medium risk')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Session session-7' }).getAttribute('href')).toBe('#/sessions/session-7');
-    expect(screen.getByRole('link', { name: 'Run run-42' }).getAttribute('href')).toBe('#/runs/run-42');
-    expect(screen.getByRole('link', { name: 'Artifact /tmp/report.md' }).getAttribute('href')).toBe('#/artifacts?path=%2Ftmp%2Freport.md');
-    expect(screen.queryByText('{"message":"Running plan"}')).toBeNull();
+    expect(screen.getByText('Execution complete')).toBeTruthy();
+    expect(screen.getByText('Failed')).toBeTruthy();
+    expect(screen.getByText('Tests failed')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Session session-7' }).getAttribute('href')).toBe('#/sessions');
+    expect(screen.getByRole('link', { name: 'Run run-42' }).getAttribute('href')).toBe('#/beasts');
+    expect(screen.getByText('Artifact /tmp/report.md')).toBeTruthy();
+    expect(screen.queryByText('{"taskDescription":"Deploy agent"}')).toBeNull();
   });
 });

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -5,11 +5,106 @@ export interface ActivityPaneProps {
   events: ActivityEvent[];
 }
 
+type ActivitySeverity = 'info' | 'success' | 'warning' | 'error';
+
+interface ActivityLink {
+  label: string;
+  href: string;
+}
+
+interface ActivityViewModel {
+  title: string;
+  summary: string;
+  status: string;
+  severity: ActivitySeverity;
+  links: ActivityLink[];
+}
+
+const TYPE_TITLES: Record<string, string> = {
+  'turn.execution.start': 'Execution started',
+  'turn.execution.progress': 'Execution update',
+  'turn.execution.complete': 'Execution complete',
+  'turn.approval.requested': 'Approval needed',
+  'turn.approval.resolved': 'Approval resolved',
+  'turn.error': 'Turn failed',
+};
+
+function stringValue(data: Record<string, unknown>, key: string): string | undefined {
+  const value = data[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function formatActivityTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function humanizeEventType(type: string): string {
+  return type
+    .split('.')
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function titleForActivity(type: string): string {
+  return TYPE_TITLES[type] ?? humanizeEventType(type);
+}
+
+function statusForActivity(event: ActivityEvent, data: Record<string, unknown>): string {
+  if (event.type === 'turn.error') {
+    return 'Error';
+  }
+  if (event.type === 'turn.approval.requested') {
+    return 'Needs review';
+  }
+  if (event.type === 'turn.approval.resolved') {
+    return data.approved === true ? 'Approved' : 'Rejected';
+  }
+  if (event.type === 'turn.execution.complete') {
+    return 'Complete';
+  }
+  if (event.type === 'turn.execution.start') {
+    return 'Started';
+  }
+  if (event.type === 'turn.execution.progress') {
+    return 'In progress';
+  }
+
+  return 'Event';
+}
+
+function severityForActivity(event: ActivityEvent, data: Record<string, unknown>): ActivitySeverity {
+  if (event.type === 'turn.error' || data.approved === false) {
+    return 'error';
+  }
+  if (event.type === 'turn.approval.requested') {
+    return 'warning';
+  }
+  if (event.type === 'turn.execution.complete' || data.approved === true) {
+    return 'success';
+  }
+
+  return 'info';
+}
+
 function summarizeActivity(event: ActivityEvent): string {
   const data = event.data ?? {};
-  const message = typeof data.message === 'string' ? data.message : undefined;
-  const code = typeof data.code === 'string' ? data.code : undefined;
-  const description = typeof data.description === 'string' ? data.description : undefined;
+  const message = stringValue(data, 'message');
+  const code = stringValue(data, 'code');
+  const description = stringValue(data, 'description');
+  const summary = stringValue(data, 'summary');
 
   if (event.type === 'turn.error') {
     return [code, message ?? 'Turn failed'].filter(Boolean).join(': ');
@@ -20,11 +115,53 @@ function summarizeActivity(event: ActivityEvent): string {
   if (event.type === 'turn.approval.resolved') {
     return data.approved === true ? 'Approval granted.' : 'Approval rejected.';
   }
+  if (summary) {
+    return summary;
+  }
   if (message) {
     return message;
   }
 
   return 'Open details to inspect runtime event data.';
+}
+
+function riskLabel(data: Record<string, unknown>): string | undefined {
+  const risk = stringValue(data, 'risk');
+  if (!risk) {
+    return undefined;
+  }
+
+  return `${risk.charAt(0).toUpperCase()}${risk.slice(1)} risk`;
+}
+
+function activityLinks(data: Record<string, unknown>): ActivityLink[] {
+  const links: ActivityLink[] = [];
+  const sessionId = stringValue(data, 'sessionId');
+  const runId = stringValue(data, 'runId');
+  const artifactPath = stringValue(data, 'artifactPath') ?? stringValue(data, 'artifact');
+
+  if (sessionId) {
+    links.push({ label: `Session ${sessionId}`, href: `#/sessions/${encodeURIComponent(sessionId)}` });
+  }
+  if (runId) {
+    links.push({ label: `Run ${runId}`, href: `#/runs/${encodeURIComponent(runId)}` });
+  }
+  if (artifactPath) {
+    links.push({ label: `Artifact ${artifactPath}`, href: `#/artifacts?path=${encodeURIComponent(artifactPath)}` });
+  }
+
+  return links;
+}
+
+function viewModelForActivity(event: ActivityEvent): ActivityViewModel {
+  const data = event.data ?? {};
+  return {
+    title: titleForActivity(event.type),
+    summary: summarizeActivity(event),
+    status: statusForActivity(event, data),
+    severity: severityForActivity(event, data),
+    links: activityLinks(data),
+  };
 }
 
 export function ActivityPane({ events }: ActivityPaneProps) {
@@ -43,19 +180,36 @@ export function ActivityPane({ events }: ActivityPaneProps) {
         <h2>Runtime Events</h2>
       </div>
       {events.length === 0 && <p className="rail-card__empty">Waiting for execution events.</p>}
-      <div className="activity-list">
-        {events.map((event, index) => (
-          <article key={`${event.type}-${event.timestamp}-${index}`} className="activity-event">
-            <strong className="activity-event__type">{event.type}</strong>
-            <span className="activity-event__summary">{summarizeActivity(event)}</span>
-            <details className="activity-event__details">
-              <summary>Raw event details</summary>
-              <pre>{JSON.stringify(event.data ?? {}, null, 2)}</pre>
-            </details>
-          </article>
-        ))}
+      <ol className="activity-list" aria-label="Runtime activity timeline">
+        {events.map((event, index) => {
+          const viewModel = viewModelForActivity(event);
+          const risk = riskLabel(event.data ?? {});
+          return (
+            <li key={`${event.type}-${event.timestamp}-${index}`} className={`activity-event activity-event--${viewModel.severity}`}>
+              <div className="activity-event__meta">
+                <span className={`activity-event__chip activity-event__chip--${viewModel.severity}`}>{viewModel.status}</span>
+                <time dateTime={event.timestamp}>{formatActivityTime(event.timestamp)}</time>
+              </div>
+              <h3 className="activity-event__title">{viewModel.title}</h3>
+              <span className="activity-event__type">{event.type}</span>
+              <p className="activity-event__summary">{viewModel.summary}</p>
+              {(risk || viewModel.links.length > 0) && (
+                <div className="activity-event__context" aria-label={`${viewModel.title} context`}>
+                  {risk && <span className="activity-event__risk">{risk}</span>}
+                  {viewModel.links.map((link) => (
+                    <a key={`${link.label}-${link.href}`} href={link.href}>{link.label}</a>
+                  ))}
+                </div>
+              )}
+              <details className="activity-event__details">
+                <summary>Raw event details</summary>
+                <pre>{JSON.stringify(event.data ?? {}, null, 2)}</pre>
+              </details>
+            </li>
+          );
+        })}
         <div ref={endRef} />
-      </div>
+      </ol>
     </section>
   );
 }

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -9,7 +9,7 @@ type ActivitySeverity = 'info' | 'success' | 'warning' | 'error';
 
 interface ActivityLink {
   label: string;
-  href: string;
+  href?: string;
 }
 
 interface ActivityViewModel {
@@ -73,7 +73,7 @@ function statusForActivity(event: ActivityEvent, data: Record<string, unknown>):
     return data.approved === true ? 'Approved' : 'Rejected';
   }
   if (event.type === 'turn.execution.complete') {
-    return 'Complete';
+    return data.status === 'failed' ? 'Failed' : 'Complete';
   }
   if (event.type === 'turn.execution.start') {
     return 'Started';
@@ -86,7 +86,7 @@ function statusForActivity(event: ActivityEvent, data: Record<string, unknown>):
 }
 
 function severityForActivity(event: ActivityEvent, data: Record<string, unknown>): ActivitySeverity {
-  if (event.type === 'turn.error' || data.approved === false) {
+  if (event.type === 'turn.error' || data.approved === false || data.status === 'failed') {
     return 'error';
   }
   if (event.type === 'turn.approval.requested') {
@@ -105,6 +105,7 @@ function summarizeActivity(event: ActivityEvent): string {
   const code = stringValue(data, 'code');
   const description = stringValue(data, 'description');
   const summary = stringValue(data, 'summary');
+  const taskDescription = stringValue(data, 'taskDescription');
 
   if (event.type === 'turn.error') {
     return [code, message ?? 'Turn failed'].filter(Boolean).join(': ');
@@ -120,6 +121,9 @@ function summarizeActivity(event: ActivityEvent): string {
   }
   if (message) {
     return message;
+  }
+  if (taskDescription) {
+    return taskDescription;
   }
 
   return 'Open details to inspect runtime event data.';
@@ -141,13 +145,13 @@ function activityLinks(data: Record<string, unknown>): ActivityLink[] {
   const artifactPath = stringValue(data, 'artifactPath') ?? stringValue(data, 'artifact');
 
   if (sessionId) {
-    links.push({ label: `Session ${sessionId}`, href: `#/sessions/${encodeURIComponent(sessionId)}` });
+    links.push({ label: `Session ${sessionId}`, href: '#/sessions' });
   }
   if (runId) {
-    links.push({ label: `Run ${runId}`, href: `#/runs/${encodeURIComponent(runId)}` });
+    links.push({ label: `Run ${runId}`, href: '#/beasts' });
   }
   if (artifactPath) {
-    links.push({ label: `Artifact ${artifactPath}`, href: `#/artifacts?path=${encodeURIComponent(artifactPath)}` });
+    links.push({ label: `Artifact ${artifactPath}` });
   }
 
   return links;
@@ -165,7 +169,7 @@ function viewModelForActivity(event: ActivityEvent): ActivityViewModel {
 }
 
 export function ActivityPane({ events }: ActivityPaneProps) {
-  const endRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
     if (typeof endRef.current?.scrollIntoView === 'function') {
@@ -185,7 +189,11 @@ export function ActivityPane({ events }: ActivityPaneProps) {
           const viewModel = viewModelForActivity(event);
           const risk = riskLabel(event.data ?? {});
           return (
-            <li key={`${event.type}-${event.timestamp}-${index}`} className={`activity-event activity-event--${viewModel.severity}`}>
+            <li
+              key={`${event.type}-${event.timestamp}-${index}`}
+              ref={index === events.length - 1 ? endRef : undefined}
+              className={`activity-event activity-event--${viewModel.severity}`}
+            >
               <div className="activity-event__meta">
                 <span className={`activity-event__chip activity-event__chip--${viewModel.severity}`}>{viewModel.status}</span>
                 <time dateTime={event.timestamp}>{formatActivityTime(event.timestamp)}</time>
@@ -197,7 +205,9 @@ export function ActivityPane({ events }: ActivityPaneProps) {
                 <div className="activity-event__context" aria-label={`${viewModel.title} context`}>
                   {risk && <span className="activity-event__risk">{risk}</span>}
                   {viewModel.links.map((link) => (
-                    <a key={`${link.label}-${link.href}`} href={link.href}>{link.label}</a>
+                    link.href
+                      ? <a key={`${link.label}-${link.href}`} href={link.href}>{link.label}</a>
+                      : <span key={link.label} className="activity-event__context-label">{link.label}</span>
                   ))}
                 </div>
               )}
@@ -208,7 +218,6 @@ export function ActivityPane({ events }: ActivityPaneProps) {
             </li>
           );
         })}
-        <div ref={endRef} />
       </ol>
     </section>
   );

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -120,6 +120,44 @@ describe('useChatSession error banners', () => {
     });
   });
 
+  it('preserves approval metadata on activity events for readable timeline chips', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.approval.requested',
+          description: 'Run npm test',
+          risk: 'medium',
+          tool: 'terminal',
+          command: 'npm test',
+          affectedFiles: ['packages/franken-web/src/components/activity-pane.tsx'],
+          sessionId: 'session-1',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.activity[0]).toMatchObject({
+      type: 'turn.approval.requested',
+      data: {
+        description: 'Run npm test',
+        risk: 'medium',
+        tool: 'terminal',
+        command: 'npm test',
+        affectedFiles: ['packages/franken-web/src/components/activity-pane.tsx'],
+        sessionId: 'session-1',
+      },
+    });
+  });
+
   it('replaces the failed optimistic message when retrying the last message', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
     vi.stubGlobal('WebSocket', MockWebSocket);

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -646,7 +646,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
             ...current,
             {
               type: payload.type,
-              data: { description: payload.description },
+              data: {
+                description: payload.description,
+                ...(payload.tool ? { tool: payload.tool } : {}),
+                ...(payload.command ? { command: payload.command } : {}),
+                ...(payload.risk ? { risk: payload.risk } : {}),
+                ...(payload.affectedFiles ? { affectedFiles: payload.affectedFiles } : {}),
+                ...(payload.sessionId ? { sessionId: payload.sessionId } : {}),
+              },
               timestamp: payload.timestamp,
             },
           ]);

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1079,8 +1079,13 @@ button {
   font-size: 0.82rem;
 }
 
-.activity-event__context a {
+.activity-event__context a,
+.activity-event__context-label {
   color: var(--accent-strong);
+}
+
+.activity-event__context-label {
+  overflow-wrap: anywhere;
 }
 
 .activity-event__details {

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -986,7 +986,10 @@ button {
   flex-direction: column;
   gap: 0.75rem;
   max-height: 18rem;
+  margin: 0;
+  padding: 0;
   overflow: auto;
+  list-style: none;
 }
 
 .activity-event {
@@ -996,16 +999,97 @@ button {
   background: rgba(255, 255, 255, 0.025);
 }
 
+.activity-event--error {
+  border-color: rgba(248, 113, 113, 0.55);
+}
+
+.activity-event--warning {
+  border-color: rgba(251, 191, 36, 0.55);
+}
+
+.activity-event--success {
+  border-color: rgba(74, 222, 128, 0.45);
+}
+
+.activity-event__meta,
+.activity-event__context {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.activity-event__meta {
+  margin-bottom: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.activity-event__chip,
+.activity-event__risk {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.12rem 0.48rem;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.activity-event__chip--error {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #fecaca;
+}
+
+.activity-event__chip--warning {
+  border-color: rgba(251, 191, 36, 0.55);
+  color: #fde68a;
+}
+
+.activity-event__chip--success {
+  border-color: rgba(74, 222, 128, 0.45);
+  color: #bbf7d0;
+}
+
+.activity-event__title {
+  margin: 0 0 0.15rem;
+  font-size: 0.98rem;
+}
+
 .activity-event__type {
   display: block;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.35rem;
   font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
   color: var(--accent-strong);
+  font-size: 0.78rem;
 }
 
 .activity-event__summary {
   display: block;
+  margin: 0;
   color: var(--text-muted);
+  word-break: break-word;
+}
+
+.activity-event__context {
+  margin-top: 0.65rem;
+  font-size: 0.82rem;
+}
+
+.activity-event__context a {
+  color: var(--accent-strong);
+}
+
+.activity-event__details {
+  margin-top: 0.65rem;
+}
+
+.activity-event__details pre {
+  overflow: auto;
+  white-space: pre-wrap;
   word-break: break-word;
 }
 


### PR DESCRIPTION
## Summary
- Render runtime activity as timeline list items with human-readable titles, timestamps, and severity/status chips.
- Preserve raw JSON behind expandable details while adding session/run/artifact links when event data includes them.
- Add regression coverage for readable runtime activity entries.

## Test Plan
- npm test -- activity-pane.test.tsx
- npm run build --workspace @franken/types
- npm run typecheck
- npm run build
- npm test

Closes #630