### PR TITLE
fix(web): fail closed for dashboard SSE auth

### DIFF
--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -28,6 +28,7 @@ function mockCommsRuntime(): CommsRuntimePort {
 function mockSkillManager(): SkillManager {
   return {
     listInstalled: vi.fn().mockReturnValue([]),
+    getEnabledSkills: vi.fn().mockReturnValue([]),
   } as unknown as SkillManager;
 }
 
@@ -40,6 +41,7 @@ function mockProviderRegistry(): ProviderRegistry {
 function buildApp(extra: Partial<ChatAppOptions> = {}): Hono {
   let networkConfig = defaultConfig();
   let securityConfig = resolveSecurityConfig('standard');
+  const skillManager = mockSkillManager();
   return createChatApp({
     sessionStoreDir: join(TMP, 'chat'),
     llm: { complete: vi.fn().mockResolvedValue('hello') },
@@ -62,8 +64,13 @@ function buildApp(extra: Partial<ChatAppOptions> = {}): Hono {
         securityConfig = { ...securityConfig, ...update } as SecurityConfig;
       },
     },
-    skillManager: mockSkillManager(),
+    skillManager,
     providerRegistry: mockProviderRegistry(),
+    dashboardDeps: {
+      skillManager,
+      getSecurityConfig: () => securityConfig,
+      getProviders: () => [],
+    },
     ...extra,
   });
 }
@@ -85,6 +92,8 @@ describe('control-plane operator auth', () => {
       { name: 'network start', path: '/v1/network/start', method: 'POST', body: { target: 'x' } },
       { name: 'security config', path: '/api/security' },
       { name: 'skills list', path: '/api/skills' },
+      { name: 'dashboard snapshot', path: '/api/dashboard' },
+      { name: 'dashboard SSE', path: '/api/dashboard/events' },
       { name: 'comms inbound', path: '/v1/comms/inbound', method: 'POST', body: { channelType: 'slack' } },
       { name: 'comms action', path: '/v1/comms/action', method: 'POST', body: { channelType: 'slack', sessionId: 's', actionId: 'a' } },
     ];
@@ -118,6 +127,20 @@ describe('control-plane operator auth', () => {
       const app = buildApp();
       const res = await app.request('/api/skills', { headers: authHeader });
       expect(res.status).toBe(200);
+    });
+
+    it('dashboard snapshot -> 200 with operator token', async () => {
+      const app = buildApp();
+      const res = await app.request('/api/dashboard', { headers: authHeader });
+      expect(res.status).toBe(200);
+    });
+
+    it('dashboard SSE -> event stream with operator token', async () => {
+      const app = buildApp();
+      const res = await app.request('/api/dashboard/events', { headers: authHeader });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/event-stream');
+      await res.body?.cancel();
     });
 
     it('comms inbound -> accepted with operator token', async () => {

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -165,11 +165,12 @@ describe('DashboardApiClient', () => {
       (globalThis as any).EventSource = MockEventSource;
 
       try {
-        const client = new DashboardApiClient(BASE_URL);
+        const sameOriginBaseUrl = globalThis.location.origin;
+        const client = new DashboardApiClient(sameOriginBaseUrl);
         const onSnapshot = vi.fn();
         const unsub = client.subscribeToDashboard(onSnapshot);
 
-        expect(MockEventSource).toHaveBeenCalledWith(`${BASE_URL}/api/dashboard/events`);
+        expect(MockEventSource).toHaveBeenCalledWith(`${sameOriginBaseUrl}/api/dashboard/events`);
 
         // Simulate a snapshot event
         const snapshot = makeMockSnapshot();
@@ -179,6 +180,29 @@ describe('DashboardApiClient', () => {
         // Unsubscribe
         unsub();
         expect(closeFn).toHaveBeenCalled();
+      } finally {
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
+    it('fails closed instead of opening cross-origin EventSource without bearer auth support', () => {
+      const MockEventSource = vi.fn();
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+
+      try {
+        const client = new DashboardApiClient('https://orchestrator.example.test');
+
+        expect(() => client.subscribeToDashboard(vi.fn())).toThrow(
+          'Refusing to open dashboard SSE across origins',
+        );
+        expect(MockEventSource).not.toHaveBeenCalled();
       } finally {
         if (originalEventSource) {
           globalThis.EventSource = originalEventSource;

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -26,6 +26,21 @@ export interface DashboardSnapshot {
   providers: DashboardProvider[];
 }
 
+function assertDashboardSseCanAuthenticate(url: string): void {
+  const location = globalThis.location;
+  if (!location?.href) {
+    return;
+  }
+
+  const eventSourceUrl = new URL(url, location.href);
+  if (eventSourceUrl.origin !== location.origin) {
+    throw new Error(
+      'Refusing to open dashboard SSE across origins: EventSource cannot attach the operator authorization credential. '
+      + 'Use the same-origin dashboard proxy or configure cookie/ticket auth for dashboard events.',
+    );
+  }
+}
+
 export class DashboardApiClient {
   constructor(private readonly baseUrl: string) {}
 
@@ -61,6 +76,7 @@ export class DashboardApiClient {
     // constructor semantics, then fall back to callable test doubles.
     const EventSourceCtor: any = (globalThis as any).EventSource;
     const url = `${this.baseUrl}/api/dashboard/events`;
+    assertDashboardSseCanAuthenticate(url);
     let eventSource: EventSource;
     try {
       eventSource = new EventSourceCtor(url);


### PR DESCRIPTION
## Summary
- Fail closed before opening dashboard SSE streams across origins, because browser EventSource cannot attach the operator authorization credential.
- Keep same-origin dashboard SSE behavior working.
- Extend control-plane auth coverage so dashboard snapshot and dashboard SSE routes require/pass operator authentication.

## Test Plan
- npm test --workspace @frankenbeast/web
- npm test --workspace franken-orchestrator -- --run tests/integration/http/control-plane-auth.test.ts
- npm run build
- npm run typecheck
- npm run lint --workspace franken-orchestrator (passes with existing warnings)

Closes #623