### PR TITLE
fix(security): ticket dashboard SSE streams

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -19,6 +19,7 @@ export class SseConnectionTicketStore {
     this.ttlMs = options?.ttlMs ?? 30_000;
     const cleanupMs = options?.cleanupIntervalMs ?? 60_000;
     this.cleanupInterval = setInterval(() => this.cleanup(), cleanupMs);
+    this.cleanupInterval.unref?.();
   }
 
   issue(token: string): string {

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -28,6 +28,7 @@ import type { SkillManager } from '../skills/skill-manager.js';
 import type { ProviderRegistry } from '../providers/provider-registry.js';
 import { createSkillRoutes } from './routes/skill-routes.js';
 import { createDashboardRoutes, type DashboardRouteDeps } from './routes/dashboard-routes.js';
+import { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
 import { createAnalyticsRoutes, type AnalyticsRouteDeps } from './routes/analytics-routes.js';
 
 export interface ChatAppOptions {
@@ -169,13 +170,20 @@ export function createChatApp(opts: ChatAppOptions): Hono {
       }
       return requireAuth()(c, next);
     });
+    app.use('/api/dashboard', requireAuth());
+    app.use('/api/dashboard/*', async (c, next) => {
+      if (new URL(c.req.url).pathname === '/api/dashboard/events') {
+        await next();
+        return;
+      }
+      return requireAuth()(c, next);
+    });
     for (const base of [
       '/v1/chat',
       '/v1/network',
       '/v1/comms',
       '/api/security',
       '/api/skills',
-      '/api/dashboard',
       '/api/analytics',
     ]) {
       app.use(base, requireAuth());
@@ -249,7 +257,11 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     }));
   }
   if (opts.dashboardDeps) {
-    app.route('/api/dashboard', createDashboardRoutes(opts.dashboardDeps));
+    app.route('/api/dashboard', createDashboardRoutes({
+      ...opts.dashboardDeps,
+      operatorToken: effectiveOperatorToken,
+      ticketStore: opts.dashboardDeps.ticketStore ?? new SseConnectionTicketStore(),
+    }));
   }
   if (opts.analyticsDeps) {
     app.route('/api/analytics', createAnalyticsRoutes(opts.analyticsDeps));

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
+import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 import type { SkillManager } from '../../skills/skill-manager.js';
 import type { SecurityConfig } from '../../middleware/security-profiles.js';
 
@@ -10,6 +11,8 @@ export interface DashboardRouteDeps {
   skillManager: SkillManager;
   getSecurityConfig: () => SecurityConfig;
   getProviders: () => Array<{ name: string; type: string; available: boolean; failoverOrder: number }>;
+  operatorToken?: string | undefined;
+  ticketStore?: SseConnectionTicketStore | undefined;
 }
 
 function buildSnapshot(deps: DashboardRouteDeps) {
@@ -30,14 +33,35 @@ function buildSnapshot(deps: DashboardRouteDeps) {
 
 export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   const app = new Hono();
+  const ticketStore = deps.ticketStore;
+  const operatorToken = deps.operatorToken;
 
   // GET /api/dashboard — aggregated snapshot of all dashboard state
   app.get('/', (c) => {
     return c.json(buildSnapshot(deps));
   });
 
-  // GET /api/dashboard/events — SSE stream for real-time dashboard updates
+  // POST /api/dashboard/events/ticket — authenticated callers mint a one-shot
+  // short-lived ticket before EventSource opens the SSE stream. EventSource
+  // cannot attach bearer headers, and raw streams are rejected below.
+  app.post('/events/ticket', (c) => {
+    if (!operatorToken) {
+      return c.json({ ticket: null });
+    }
+    if (!ticketStore) {
+      return c.json({ error: { code: 'UNAVAILABLE', message: 'Dashboard SSE tickets are not configured' } }, 503);
+    }
+
+    return c.json({ ticket: ticketStore.issue(operatorToken) });
+  });
+
+  // GET /api/dashboard/events — ticket-authenticated SSE stream for real-time dashboard updates
   app.get('/events', (c) => {
+    const ticket = c.req.query('ticket');
+    if (operatorToken && (!ticketStore || !ticket || !ticketStore.validate(ticket, operatorToken))) {
+      return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+    }
+
     return streamSSE(c, async (stream) => {
       let lastSnapshot = JSON.stringify(buildSnapshot(deps));
 

--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -135,12 +135,25 @@ describe('control-plane operator auth', () => {
       expect(res.status).toBe(200);
     });
 
-    it('dashboard SSE -> event stream with operator token', async () => {
+    it('dashboard SSE -> mints a ticket with operator token, then streams without bearer auth', async () => {
       const app = buildApp();
-      const res = await app.request('/api/dashboard/events', { headers: authHeader });
+      const ticketRes = await app.request('/api/dashboard/events/ticket', {
+        method: 'POST',
+        headers: authHeader,
+      });
+      expect(ticketRes.status).toBe(200);
+      const { ticket } = await ticketRes.json() as { ticket: string };
+
+      const res = await app.request(`/api/dashboard/events?ticket=${ticket}`);
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toContain('text/event-stream');
       await res.body?.cancel();
+    });
+
+    it('dashboard SSE rejects bearer-auth streams without a one-shot ticket', async () => {
+      const app = buildApp();
+      const res = await app.request('/api/dashboard/events', { headers: authHeader });
+      expect(res.status).toBe(401);
     });
 
     it('comms inbound -> accepted with operator token', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
 import { createDashboardRoutes, type DashboardRouteDeps } from '../../../src/http/routes/dashboard-routes.js';
+
+let ticketStore: SseConnectionTicketStore | undefined;
 
 function createMockDeps(): DashboardRouteDeps {
   return {
@@ -32,10 +35,17 @@ function createMockDeps(): DashboardRouteDeps {
     getProviders: vi.fn().mockReturnValue([
       { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
     ]),
+    operatorToken: 'dashboard-token',
+    ticketStore: ticketStore = new SseConnectionTicketStore(),
   };
 }
 
 describe('dashboard routes', () => {
+  afterEach(() => {
+    ticketStore?.destroy();
+    ticketStore = undefined;
+  });
+
   describe('GET /', () => {
     it('returns aggregated dashboard state', async () => {
       const deps = createMockDeps();
@@ -86,18 +96,72 @@ describe('dashboard routes', () => {
   });
 
   describe('GET /events', () => {
-    it('returns SSE content-type', async () => {
+    it('POST /events/ticket returns a short-lived stream ticket', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
+
+      const res = await app.request('/events/ticket', { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { ticket?: string };
+      expect(body.ticket).toBeTruthy();
+    });
+
+    it('rejects raw streams without a ticket', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+
       const res = await app.request('/events');
 
+      expect(res.status).toBe(401);
+    });
+
+    it('preserves unauthenticated local-dev streams when no operator token is configured', async () => {
+      const deps = createMockDeps();
+      deps.operatorToken = undefined;
+      deps.ticketStore = undefined;
+      const app = createDashboardRoutes(deps);
+
+      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+      expect(ticketRes.status).toBe(200);
+      expect(await ticketRes.json()).toEqual({ ticket: null });
+
+      const res = await app.request('/events');
       expect(res.headers.get('content-type')).toContain('text/event-stream');
+      await res.body?.cancel();
+    });
+
+    it('returns SSE content-type with a valid ticket', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+      const { ticket } = await ticketRes.json() as { ticket: string };
+
+      const res = await app.request(`/events?ticket=${ticket}`);
+      expect(res.headers.get('content-type')).toContain('text/event-stream');
+      await res.body?.cancel();
+    });
+
+    it('rejects a reused stream ticket', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+      const { ticket } = await ticketRes.json() as { ticket: string };
+
+      const first = await app.request(`/events?ticket=${ticket}`);
+      expect(first.status).toBe(200);
+      await first.body?.cancel();
+
+      const second = await app.request(`/events?ticket=${ticket}`);
+      expect(second.status).toBe(401);
     });
 
     it('sends initial snapshot event in the stream', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
-      const res = await app.request('/events');
+      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+      const { ticket } = await ticketRes.json() as { ticket: string };
+      const res = await app.request(`/events?ticket=${ticket}`);
 
       // Read partial stream — the SSE connection stays open, so we read
       // chunks until we have enough data for the initial snapshot.
@@ -133,7 +197,9 @@ describe('dashboard routes', () => {
         const deps = createMockDeps();
         const providers = deps.getProviders as ReturnType<typeof vi.fn>;
         const app = createDashboardRoutes(deps);
-        const res = await app.request('/events');
+        const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+        const { ticket } = await ticketRes.json() as { ticket: string };
+        const res = await app.request(`/events?ticket=${ticket}`);
 
         const reader = res.body!.getReader();
         const decoder = new TextDecoder();
@@ -167,7 +233,9 @@ describe('dashboard routes', () => {
         const deps = createMockDeps();
         const providers = deps.getProviders as ReturnType<typeof vi.fn>;
         const app = createDashboardRoutes(deps);
-        const res = await app.request('/events');
+        const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+        const { ticket } = await ticketRes.json() as { ticket: string };
+        const res = await app.request(`/events?ticket=${ticket}`);
         const reader = res.body!.getReader();
 
         await reader.read();

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -250,6 +250,59 @@ describe('DashboardApiClient', () => {
       }
     });
 
+    it('retries ticket minting failures during reconnect', async () => {
+      vi.useFakeTimers();
+      const closeFns = [vi.fn(), vi.fn()];
+      const listeners: Array<Record<string, (event: { data?: string }) => void>> = [];
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data?: string }) => void) => void;
+        close?: () => void;
+      }) {
+        const index = listeners.length;
+        listeners[index] = {};
+        this.addEventListener = vi.fn((type: string, handler: (event: { data?: string }) => void) => {
+          listeners[index]![type] = handler;
+        });
+        this.close = closeFns[index];
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-1' }) })
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-2' }) });
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const unsub = await client.subscribeToDashboard(vi.fn());
+
+        listeners[0]!.error!({});
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(errorSpy).toHaveBeenCalledWith(expect.any(Error));
+        expect(MockEventSource).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+        expect(MockEventSource).toHaveBeenNthCalledWith(2, `${BASE_URL}/api/dashboard/events?ticket=ticket-2`);
+
+        unsub();
+        expect(closeFns[1]).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        errorSpy.mockRestore();
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
     it('opens the local loopback stream without a ticket when auth is disabled', async () => {
       const closeFn = vi.fn();
       const MockEventSource = vi.fn(function (this: {

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -146,7 +146,7 @@ describe('DashboardApiClient', () => {
   });
 
   describe('subscribeToDashboard', () => {
-    it('creates EventSource and returns unsubscribe function', () => {
+    it('mints a short-lived ticket before opening EventSource', async () => {
       const closeFn = vi.fn();
       const listeners: Record<string, (event: { data: string }) => void> = {};
 
@@ -163,14 +163,24 @@ describe('DashboardApiClient', () => {
       const originalEventSource = globalThis.EventSource;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ticket: 'dashboard-ticket' }),
+      });
 
       try {
         const sameOriginBaseUrl = globalThis.location.origin;
         const client = new DashboardApiClient(sameOriginBaseUrl);
         const onSnapshot = vi.fn();
-        const unsub = client.subscribeToDashboard(onSnapshot);
+        const unsub = await client.subscribeToDashboard(onSnapshot);
 
-        expect(MockEventSource).toHaveBeenCalledWith(`${sameOriginBaseUrl}/api/dashboard/events`);
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          `${sameOriginBaseUrl}/api/dashboard/events/ticket`,
+          expect.objectContaining({ method: 'POST' }),
+        );
+        const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1] as RequestInit;
+        expect(new Headers(init.headers).has('authorization')).toBe(false);
+        expect(MockEventSource).toHaveBeenCalledWith(`${sameOriginBaseUrl}/api/dashboard/events?ticket=dashboard-ticket`);
 
         // Simulate a snapshot event
         const snapshot = makeMockSnapshot();
@@ -190,18 +200,101 @@ describe('DashboardApiClient', () => {
       }
     });
 
-    it('fails closed instead of opening cross-origin EventSource without bearer auth support', () => {
+    it('mints a fresh one-shot ticket after EventSource errors', async () => {
+      vi.useFakeTimers();
+      const closeFns = [vi.fn(), vi.fn()];
+      const listeners: Array<Record<string, (event: { data?: string }) => void>> = [];
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data?: string }) => void) => void;
+        close?: () => void;
+      }) {
+        const index = listeners.length;
+        listeners[index] = {};
+        this.addEventListener = vi.fn((type: string, handler: (event: { data?: string }) => void) => {
+          listeners[index]![type] = handler;
+        });
+        this.close = closeFns[index];
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-1' }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-2' }) });
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const unsub = await client.subscribeToDashboard(vi.fn());
+
+        listeners[0]!.error!({});
+        expect(closeFns[0]).toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(MockEventSource).toHaveBeenNthCalledWith(1, `${BASE_URL}/api/dashboard/events?ticket=ticket-1`);
+        expect(MockEventSource).toHaveBeenNthCalledWith(2, `${BASE_URL}/api/dashboard/events?ticket=ticket-2`);
+
+        unsub();
+        expect(closeFns[1]).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
+    it('opens the local loopback stream without a ticket when auth is disabled', async () => {
+      const closeFn = vi.fn();
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data?: string }) => void) => void;
+        close?: typeof closeFn;
+      }) {
+        this.addEventListener = vi.fn();
+        this.close = closeFn;
+      });
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ticket: null }),
+      });
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const unsub = await client.subscribeToDashboard(vi.fn());
+
+        expect(MockEventSource).toHaveBeenCalledWith(`${BASE_URL}/api/dashboard/events`);
+        unsub();
+        expect(closeFn).toHaveBeenCalled();
+      } finally {
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
+    it('does not open EventSource when ticket minting fails', async () => {
       const MockEventSource = vi.fn();
       const originalEventSource = globalThis.EventSource;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
 
       try {
         const client = new DashboardApiClient('https://orchestrator.example.test');
 
-        expect(() => client.subscribeToDashboard(vi.fn())).toThrow(
-          'Refusing to open dashboard SSE across origins',
-        );
+        await expect(client.subscribeToDashboard(vi.fn())).rejects.toThrow('HTTP 401');
         expect(MockEventSource).not.toHaveBeenCalled();
       } finally {
         if (originalEventSource) {

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -66,6 +66,17 @@ export class DashboardApiClient {
       eventSource = undefined;
     };
 
+    const scheduleReconnect = () => {
+      if (closed || reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        void connect().catch((err) => {
+          console.error(err);
+          scheduleReconnect();
+        });
+      }, 1_000);
+    };
+
     const connect = async () => {
       const ticketRes = await fetch(`${this.baseUrl}/api/dashboard/events/ticket`, { method: 'POST' });
       if (!ticketRes.ok) throw new Error(`HTTP ${ticketRes.status}`);
@@ -92,11 +103,7 @@ export class DashboardApiClient {
       });
       nextEventSource.addEventListener('error', () => {
         closeActiveSource();
-        if (closed) return;
-        reconnectTimer = setTimeout(() => {
-          reconnectTimer = undefined;
-          void connect().catch(console.error);
-        }, 1_000);
+        scheduleReconnect();
       });
     };
 

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -26,21 +26,6 @@ export interface DashboardSnapshot {
   providers: DashboardProvider[];
 }
 
-function assertDashboardSseCanAuthenticate(url: string): void {
-  const location = globalThis.location;
-  if (!location?.href) {
-    return;
-  }
-
-  const eventSourceUrl = new URL(url, location.href);
-  if (eventSourceUrl.origin !== location.origin) {
-    throw new Error(
-      'Refusing to open dashboard SSE across origins: EventSource cannot attach the operator authorization credential. '
-      + 'Use the same-origin dashboard proxy or configure cookie/ticket auth for dashboard events.',
-    );
-  }
-}
-
 export class DashboardApiClient {
   constructor(private readonly baseUrl: string) {}
 
@@ -68,26 +53,59 @@ export class DashboardApiClient {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
   }
 
-  // NOTE: EventSource cannot attach an Authorization header. Keep dashboard
-  // browser clients on same-origin/BFF routes; do not put long-lived operator
-  // credentials in URLs, headers, or bundle-visible env values.
-  subscribeToDashboard(onSnapshot: (snapshot: DashboardSnapshot) => void): () => void {
-    // EventSource may be mocked as a plain function in tests; prefer browser
-    // constructor semantics, then fall back to callable test doubles.
-    const EventSourceCtor: any = (globalThis as any).EventSource;
-    const url = `${this.baseUrl}/api/dashboard/events`;
-    assertDashboardSseCanAuthenticate(url);
-    let eventSource: EventSource;
-    try {
-      eventSource = new EventSourceCtor(url);
-    } catch {
-      eventSource = EventSourceCtor(url);
-    }
-    eventSource.addEventListener('snapshot', (event: any) => {
-      const snapshot = JSON.parse(event.data) as DashboardSnapshot;
-      onSnapshot(snapshot);
-    });
-    return () => eventSource.close();
+  // NOTE: EventSource cannot attach an Authorization header. Browser clients
+  // first mint a short-lived, one-shot stream ticket with normal authenticated
+  // fetch, then put only that ticket in the EventSource URL.
+  async subscribeToDashboard(onSnapshot: (snapshot: DashboardSnapshot) => void): Promise<() => void> {
+    let eventSource: EventSource | undefined;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let closed = false;
+
+    const closeActiveSource = () => {
+      eventSource?.close();
+      eventSource = undefined;
+    };
+
+    const connect = async () => {
+      const ticketRes = await fetch(`${this.baseUrl}/api/dashboard/events/ticket`, { method: 'POST' });
+      if (!ticketRes.ok) throw new Error(`HTTP ${ticketRes.status}`);
+      const { ticket } = await ticketRes.json() as { ticket?: string | null };
+
+      if (closed) return;
+
+      // EventSource may be mocked as a plain function in tests; prefer browser
+      // constructor semantics, then fall back to callable test doubles.
+      const EventSourceCtor: any = (globalThis as any).EventSource;
+      const url = ticket
+        ? `${this.baseUrl}/api/dashboard/events?${new URLSearchParams({ ticket }).toString()}`
+        : `${this.baseUrl}/api/dashboard/events`;
+      let nextEventSource: EventSource;
+      try {
+        nextEventSource = new EventSourceCtor(url);
+      } catch {
+        nextEventSource = EventSourceCtor(url);
+      }
+      eventSource = nextEventSource;
+      nextEventSource.addEventListener('snapshot', (event: any) => {
+        const snapshot = JSON.parse(event.data) as DashboardSnapshot;
+        onSnapshot(snapshot);
+      });
+      nextEventSource.addEventListener('error', () => {
+        closeActiveSource();
+        if (closed) return;
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = undefined;
+          void connect().catch(console.error);
+        }, 1_000);
+      });
+    };
+
+    await connect();
+    return () => {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      closeActiveSource();
+    };
   }
 
 }

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -21,8 +21,17 @@ export function DashboardPage({ client }: DashboardPageProps) {
     client.fetchSnapshot()
       .then((snap) => { if (!stale) setSnapshot(snap); })
       .catch(console.error);
-    const unsub = client.subscribeToDashboard((snap) => { if (!stale) setSnapshot(snap); });
-    return () => { stale = true; unsub(); };
+    let unsub: (() => void) | undefined;
+    client.subscribeToDashboard((snap) => { if (!stale) setSnapshot(snap); })
+      .then((nextUnsub) => {
+        if (stale) {
+          nextUnsub();
+          return;
+        }
+        unsub = nextUnsub;
+      })
+      .catch(console.error);
+    return () => { stale = true; unsub?.(); };
   }, [client]); // eslint-disable-line react-hooks/exhaustive-deps — setSnapshot is stable (Zustand v5)
 
   if (loading) return <div className="dashboard-loading">Loading dashboard...</div>;

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -182,7 +182,7 @@ const mockDashboardSnapshot = {
 const mockDashboardFetchSnapshot = vi.fn().mockResolvedValue(mockDashboardSnapshot);
 const mockDashboardToggleSkill = vi.fn().mockResolvedValue(undefined);
 const mockDashboardUpdateSecurityProfile = vi.fn().mockResolvedValue(undefined);
-const mockDashboardSubscribe = vi.fn().mockReturnValue(vi.fn());
+const mockDashboardSubscribe = vi.fn().mockResolvedValue(vi.fn());
 
 vi.mock('../../src/hooks/use-chat-session.js', () => ({
   useChatSession: () => ({
@@ -422,7 +422,7 @@ afterEach(() => {
   mockDashboardUpdateSecurityProfile.mockReset();
   mockDashboardUpdateSecurityProfile.mockResolvedValue(undefined);
   mockDashboardSubscribe.mockReset();
-  mockDashboardSubscribe.mockReturnValue(vi.fn());
+  mockDashboardSubscribe.mockResolvedValue(vi.fn());
   mockGetRun.mockReset();
   mockGetRun.mockResolvedValue({
     run: {


### PR DESCRIPTION
## Summary
- add a dashboard SSE ticket endpoint that mints short-lived one-shot stream credentials after normal operator-authenticated fetch
- require dashboard EventSource streams to present a valid ticket, rejecting raw unauthenticated streams
- update the dashboard browser client to mint a ticket before opening EventSource and handle async unsubscribe setup

## Test Plan
- npm run test --workspace @frankenbeast/web -- --run src/lib/dashboard-api.test.ts
- npm run test --workspace franken-orchestrator -- --run tests/unit/http/dashboard-routes.test.ts tests/integration/http/control-plane-auth.test.ts
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web
- npm run build --workspace franken-planner && npm run typecheck --workspace franken-orchestrator && npm run build --workspace franken-orchestrator
- npm run lint (franken-orchestrator; exits 0 with existing warnings)

Closes #622