### PR TITLE
fix(orchestrator): handle missing provider CLIs

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -6,7 +6,12 @@ import {
   type ICliProvider,
   type ProviderRegistry,
 } from '../skills/providers/cli-provider.js';
-import { classifyCommandFailure, parseResetTimeText, type CommandFailure } from '../errors/command-failure.js';
+import {
+  classifyCommandFailure,
+  commandFailureFromExecError,
+  parseResetTimeText,
+  type CommandFailure,
+} from '../errors/command-failure.js';
 
 type CliCacheSessionHint = {
   key: string;
@@ -165,18 +170,54 @@ export class CliLlmAdapter implements IAdapter {
           content: prompt,
         });
       }
-      const result = await this.spawnSingle({
-        cmd: this.resolveCommand(activeProvider),
-        args: provider.buildArgs({
-          maxTurns,
-          model: activeModel,
-          chatMode,
-          sessionContinue,
-          extraArgs: this.resolveExtraArgs(activeProvider),
-        }),
-        env: provider.filterEnv(this.captureEnv()),
-        prompt,
-      });
+      const activeCommand = this.resolveCommand(activeProvider);
+      let result: { stdout: string; stderr: string; exitCode: number };
+      try {
+        result = await this.spawnSingle({
+          cmd: activeCommand,
+          args: provider.buildArgs({
+            maxTurns,
+            model: activeModel,
+            chatMode,
+            sessionContinue,
+            extraArgs: this.resolveExtraArgs(activeProvider),
+          }),
+          env: provider.filterEnv(this.captureEnv()),
+          prompt,
+        });
+      } catch (error) {
+        if (requestId) {
+          this.responseSessions.delete(requestId);
+        }
+
+        const failure = commandFailureFromExecError({
+          tool: 'llm',
+          provider: activeProvider,
+          command: activeCommand,
+          error,
+          detectRateLimit: (text) => provider.isRateLimited(text),
+          parseRetryAfterMs: (text) => {
+            const providerMs = provider.parseRetryAfter(text);
+            if (providerMs !== undefined) {
+              return providerMs;
+            }
+            const parsed = parseResetTimeText(text);
+            return parsed.sleepSeconds >= 0 ? parsed.sleepSeconds * 1000 : undefined;
+          },
+        });
+
+        if (failure.kind === 'spawn_error') {
+          exhaustedProviders.set(activeProvider, failure);
+          const nextProvider = providers.find((name) => !exhaustedProviders.has(name));
+          if (nextProvider) {
+            activeProvider = nextProvider;
+            continue;
+          }
+          throw new Error(buildNoCliProvidersAvailableSummary(exhaustedProviders), { cause: failure });
+        }
+
+        throw new Error(failure.summary, { cause: failure });
+      }
 
       if (result.exitCode === 0) {
         if (requestId) {
@@ -208,7 +249,7 @@ export class CliLlmAdapter implements IAdapter {
       const failure = classifyCommandFailure({
         tool: 'llm',
         provider: activeProvider,
-        command: this.resolveCommand(activeProvider),
+        command: activeCommand,
         exitCode: result.exitCode,
         stdout: result.stdout,
         stderr: result.stderr,
@@ -424,6 +465,20 @@ function normalizeProviderChain(
 ): string[] {
   const ordered = [selectedProvider, ...(providers ?? [])];
   return [...new Set(ordered.filter((name) => name.length > 0))];
+}
+
+function buildNoCliProvidersAvailableSummary(exhaustedProviders: Map<string, CommandFailure>): string {
+  const attempted = [...exhaustedProviders.entries()]
+    .map(([provider, failure]) => {
+      const code = typeof failure.details?.code === 'string' ? ` (${failure.details.code})` : '';
+      return `${provider}: ${failure.command}${code}`;
+    })
+    .join(', ');
+  return [
+    'No configured LLM provider CLI is available.',
+    attempted ? `Tried: ${attempted}.` : '',
+    'Install one of: claude, codex, gemini, aider; or configure a provider command override.',
+  ].filter(Boolean).join(' ');
 }
 
 function defaultSleep(durationMs: number): Promise<void> {

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -213,6 +213,13 @@ export class CliLlmAdapter implements IAdapter {
             activeProvider = nextProvider;
             continue;
           }
+          if (hasRateLimitedProvider(exhaustedProviders)) {
+            const sleepMs = this.resolveSleepMs(exhaustedProviders);
+            await sleepFn(sleepMs);
+            exhaustedProviders.clear();
+            activeProvider = initialProvider;
+            continue;
+          }
           throw new Error(buildNoCliProvidersAvailableSummary(exhaustedProviders), { cause: failure });
         }
 
@@ -465,6 +472,10 @@ function normalizeProviderChain(
 ): string[] {
   const ordered = [selectedProvider, ...(providers ?? [])];
   return [...new Set(ordered.filter((name) => name.length > 0))];
+}
+
+function hasRateLimitedProvider(exhaustedProviders: Map<string, CommandFailure>): boolean {
+  return [...exhaustedProviders.values()].some((failure) => failure.rateLimited);
 }
 
 function buildNoCliProvidersAvailableSummary(exhaustedProviders: Map<string, CommandFailure>): string {

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -439,7 +439,8 @@ export class CliLlmAdapter implements IAdapter {
         // Don't keep the event loop alive waiting on the hard-kill fallback;
         // short-lived invocations should exit promptly after a timeout reject.
         hardKillTimer.unref();
-        settle(() => reject(new Error(`CLI timeout after ${this.opts.timeoutMs}ms`)));
+        const error = Object.assign(new Error(`CLI timeout after ${this.opts.timeoutMs}ms`), { code: 'ETIMEDOUT' });
+        settle(() => reject(error));
       }, this.opts.timeoutMs);
 
       child.on('close', (code) => {

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -585,6 +585,11 @@ function createCliExecutorDeps(
     : undefined;
 
   const override = options.providersConfig?.[config.provider];
+  const providerCommands = Object.fromEntries(
+    Object.entries(options.providersConfig ?? {})
+      .filter(([, providerOverride]) => typeof providerOverride.command === 'string' && providerOverride.command.length > 0)
+      .map(([providerName, providerOverride]) => [providerName, providerOverride.command as string]),
+  );
   const executorObserverDeps: ObserverDeps = config.enableTracing
     ? observer.observerBridge.observerDeps
     : observer.observerBridge.disabledObserverDeps;
@@ -620,6 +625,7 @@ function createCliExecutorDeps(
         }),
       providers: options.providers,
       ...(override?.command ? { command: override.command } : {}),
+      ...(Object.keys(providerCommands).length > 0 ? { providerCommands } : {}),
     },
   );
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -308,6 +308,58 @@ function resolveSelectedProvider(args: CliArgs, config: OrchestratorConfig): str
   return args.providerSpecified ? args.provider : config.providers.default;
 }
 
+export interface ProviderCliAvailability {
+  readonly provider: string;
+  readonly command: string;
+  readonly available: boolean;
+}
+
+export function checkProviderCliAvailability(
+  selectedProvider: string,
+  fallbackChain: readonly string[],
+  overrides: OrchestratorConfig['providers']['overrides'] = {},
+): ProviderCliAvailability[] {
+  const registry = createDefaultRegistry();
+  const providerNames = [...new Set([selectedProvider, ...fallbackChain].filter(Boolean))];
+  return providerNames.map((provider) => {
+    const command = overrides?.[provider]?.command ?? registry.get(provider).command;
+    return {
+      provider,
+      command,
+      available: isCommandAvailable(command),
+    };
+  });
+}
+
+export function assertAnyProviderCliAvailable(
+  selectedProvider: string,
+  fallbackChain: readonly string[],
+  overrides: OrchestratorConfig['providers']['overrides'] = {},
+): void {
+  const report = checkProviderCliAvailability(selectedProvider, fallbackChain, overrides);
+  if (report.some((entry) => entry.available)) {
+    return;
+  }
+
+  const attempted = report
+    .map((entry) => `${entry.provider} (${entry.command})`)
+    .join(', ');
+  throw new Error(
+    'No configured LLM provider CLI is available. '
+      + `Checked: ${attempted || 'none'}. `
+      + 'Install one of: claude, codex, gemini, aider; or configure providers.overrides.<provider>.command.',
+  );
+}
+
+function isCommandAvailable(command: string): boolean {
+  try {
+    execFileSync('/bin/sh', ['-c', 'command -v "$1"', 'sh', command], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function resolveBeastOperatorToken(
   root: string,
   options?: { secretStore?: ISecretStore | undefined; config?: OrchestratorConfig | undefined } | undefined,
@@ -860,6 +912,11 @@ export async function main(): Promise<void> {
   // Determine phases
   const { entryPhase, exitAfter } = resolvePhases(args);
   const provider = resolveSelectedProvider(args, config);
+  assertAnyProviderCliAvailable(
+    provider,
+    args.providers ?? config.providers.fallbackChain,
+    config.providers.overrides,
+  );
 
   // Create and run session
   // Precedence: CLI args > config file > defaults

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -2,7 +2,7 @@
 
 import { mkdir, open, readFile, writeFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
-import { existsSync, lstatSync, readdirSync, statSync } from 'node:fs';
+import { accessSync, constants, existsSync, lstatSync, readdirSync, statSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
@@ -26,7 +26,7 @@ import { createCliDeps } from './dep-factory.js';
 import { createDefaultRegistry } from '../skills/providers/cli-provider.js';
 import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
 import { CliLlmAdapter } from '../adapters/cli-llm-adapter.js';
-import { basename, dirname, join, resolve as resolvePath } from 'node:path';
+import { basename, delimiter, dirname, join, resolve as resolvePath } from 'node:path';
 import { tmpdir } from 'node:os';
 import { startChatServer } from '../http/chat-server.js';
 import { createSqliteAnalyticsService } from '../analytics/sqlite-analytics-service.js';
@@ -53,6 +53,7 @@ import { createBeastServices } from '../beasts/create-beast-services.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
 import { CommsConfigSchema, type CommsConfig } from '../comms/config/comms-config.js';
 import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } from '../network/network-url.js';
+import { loadRunConfigFromEnv, type RunConfig } from './run-config-loader.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -308,6 +309,12 @@ function resolveSelectedProvider(args: CliArgs, config: OrchestratorConfig): str
   return args.providerSpecified ? args.provider : config.providers.default;
 }
 
+function resolveEffectivePreflightProvider(selectedProvider: string, runConfig: RunConfig | undefined): string {
+  return runConfig?.llmConfig?.default?.provider
+    ?? runConfig?.provider
+    ?? selectedProvider;
+}
+
 export interface ProviderCliAvailability {
   readonly provider: string;
   readonly command: string;
@@ -352,8 +359,32 @@ export function assertAnyProviderCliAvailable(
 }
 
 function isCommandAvailable(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    return canExecuteCommand(trimmed);
+  }
+
+  const pathEntries = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  const extensions = process.platform === 'win32'
+    ? (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+    : [''];
+  const candidates = process.platform === 'win32' && extensions.some((ext) => trimmed.toLowerCase().endsWith(ext.toLowerCase()))
+    ? [trimmed]
+    : extensions.map((ext) => `${trimmed}${ext}`);
+
+  return pathEntries.some((dir) => candidates.some((candidate) => canExecuteCommand(join(dir, candidate))));
+}
+
+function canExecuteCommand(candidate: string): boolean {
   try {
-    execFileSync('/bin/sh', ['-c', 'command -v "$1"', 'sh', command], { stdio: 'ignore' });
+    if (process.platform === 'win32') {
+      return existsSync(candidate);
+    }
+    accessSync(candidate, constants.X_OK);
     return true;
   } catch {
     return false;
@@ -912,8 +943,10 @@ export async function main(): Promise<void> {
   // Determine phases
   const { entryPhase, exitAfter } = resolvePhases(args);
   const provider = resolveSelectedProvider(args, config);
+  const runConfig = loadRunConfigFromEnv();
+  const preflightProvider = resolveEffectivePreflightProvider(provider, runConfig);
   assertAnyProviderCliAvailable(
-    provider,
+    preflightProvider,
     args.providers ?? config.providers.fallbackChain,
     config.providers.overrides,
   );

--- a/packages/franken-orchestrator/src/errors/command-failure.ts
+++ b/packages/franken-orchestrator/src/errors/command-failure.ts
@@ -119,6 +119,26 @@ export function commandFailureFromExecError(options: CommandFailureFromExecError
   const exitCode = readExecExitCode(options.error);
   const code = readExecCode(options.error);
 
+  if (code === 'ETIMEDOUT') {
+    return classifyCommandFailure({
+      tool: options.tool,
+      command: options.command,
+      ...(options.provider ? { provider: options.provider } : {}),
+      exitCode: exitCode ?? 1,
+      timedOut: true,
+      stdout,
+      stderr,
+      normalizedOutput: options.normalizedOutput,
+      detectRateLimit: options.detectRateLimit,
+      parseRetryAfterMs: options.parseRetryAfterMs,
+      details: {
+        ...(options.details ?? {}),
+        code,
+        message,
+      },
+    });
+  }
+
   if (exitCode === undefined && code) {
     return {
       kind: 'spawn_error',

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -75,13 +75,19 @@ export class ProviderRegistry {
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
     let lastError: Error | undefined;
+    const unavailableProviders: string[] = [];
+    let attemptedProviders = 0;
 
     for (let i = 0; i < this.providers.length; i++) {
       const providerIndex =
         (this.currentProviderIndex + i) % this.providers.length;
       const provider = this.providers[providerIndex]!;
 
-      if (!(await provider.isAvailable())) continue;
+      if (!(await provider.isAvailable())) {
+        unavailableProviders.push(provider.name);
+        continue;
+      }
+      attemptedProviders++;
 
       let effectiveRequest = request;
       if (i > 0) {
@@ -176,9 +182,13 @@ export class ProviderRegistry {
       timestamp: new Date().toISOString(),
     });
 
+    const exhaustionReason = attemptedProviders === 0
+      ? `No providers available. Checked: ${unavailableProviders.join(', ')}. `
+        + 'Install or authenticate at least one configured provider CLI, or configure provider overrides.'
+      : `All providers exhausted. Last error: ${lastError?.message ?? 'unknown'}. `;
+
     throw new Error(
-      `All providers exhausted. Last error: ${lastError?.message ?? 'unknown'}. ` +
-        `Brain state checkpointed for recovery.`,
+      exhaustionReason + 'Brain state checkpointed for recovery.',
     );
   }
 

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -394,6 +394,11 @@ export class CliSkillExecutor {
       },
       onSpawnError: (provider: string, error: string) => {
         this.logger?.error('MartinLoop: provider spawn error', { chunkId, provider, error }, 'martin');
+        const currentCost = this.computeCurrentCost();
+        const budgetResult = this.observer.breaker.check(currentCost);
+        if (budgetResult.tripped) {
+          abortForBudget(budgetResult);
+        }
         config.martin?.onSpawnError?.(provider, error);
       },
       onProviderTimeout: (provider: string, timeoutMs: number) => {

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -388,7 +388,7 @@ export class CliSkillExecutor {
         );
         config.martin?.onProviderAttempt?.(provider, iteration, renderedPrompt);
       },
-      onProviderSwitch: (fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset') => {
+      onProviderSwitch: (fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset' | 'spawn-error') => {
         this.logger?.warn('MartinLoop: provider switch', { chunkId, fromProvider, toProvider, reason }, 'martin');
         config.martin?.onProviderSwitch?.(fromProvider, toProvider, reason);
       },

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -208,7 +208,7 @@ function runVerifyCommand(verifyCommand: string, cwd: string): void {
 
 type DefaultMartinConfig = Pick<MartinLoopConfig, 'provider'> & Partial<Pick<
   MartinLoopConfig,
-  'command' | 'providers' | 'planName' | 'sessionStore' | 'snapshotStore' | 'renderer' | 'compactor' | 'contextUsage'
+  'command' | 'providerCommands' | 'providers' | 'planName' | 'sessionStore' | 'snapshotStore' | 'renderer' | 'compactor' | 'contextUsage'
 >>;
 
 export class CliSkillExecutor {

--- a/packages/franken-orchestrator/src/skills/cli-types.ts
+++ b/packages/franken-orchestrator/src/skills/cli-types.ts
@@ -32,6 +32,7 @@ export interface MartinLoopConfig {
   readonly maxTurns: number;
   readonly provider: string;
   readonly command?: string | undefined;
+  readonly providerCommands?: Readonly<Record<string, string>> | undefined;
   readonly timeoutMs: number;
   readonly workingDir?: string | undefined;
   readonly abortSignal?: AbortSignal | undefined;

--- a/packages/franken-orchestrator/src/skills/cli-types.ts
+++ b/packages/franken-orchestrator/src/skills/cli-types.ts
@@ -54,7 +54,7 @@ export interface MartinLoopConfig {
   readonly onIteration?: ((iteration: number, result: IterationResult) => void) | undefined;
   readonly onSleep?: ((durationMs: number, source: string) => void) | undefined;
   readonly onProviderAttempt?: ((provider: string, iteration: number, renderedPrompt?: string) => void) | undefined;
-  readonly onProviderSwitch?: ((fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset') => void) | undefined;
+  readonly onProviderSwitch?: ((fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset' | 'spawn-error') => void) | undefined;
   readonly onSpawnError?: ((provider: string, error: string) => void) | undefined;
   readonly onProviderTimeout?: ((provider: string, timeoutMs: number) => void) | undefined;
   /** @internal Injected sleep function for testing — do not use in production. */

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -270,7 +270,9 @@ function spawnIteration(
       return;
     }
 
-    const cmd = config.command ?? provider.command;
+    const cmd = config.providerCommands?.[provider.name]
+      ?? (provider.name === config.provider ? config.command : undefined)
+      ?? provider.command;
     const providerArgs = provider.buildArgs({ maxTurns: config.maxTurns, sessionContinue });
     const prompt = (promptOverride ?? config.prompt) + NO_COMMIT_CONSTRAINT;
     const args = provider.supportsStreamJson()

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -459,6 +459,9 @@ export class MartinLoop {
       try {
         result = await spawnIteration(config, resolved, renderedPrompt, sessionContinue);
       } catch (error) {
+        if (config.abortSignal?.aborted) {
+          throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+        }
         if (isAbortError(error)) {
           throw error;
         }

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -478,6 +478,7 @@ export class MartinLoop {
         const msg = error instanceof Error ? error.message : String(error);
         config.onSpawnError?.(activeProvider, msg);
         if (failure.kind === 'spawn_error') {
+          iteration--;
           exhaustedProviders.set(activeProvider, failure);
           const nextProvider = providers.find(p => !exhaustedProviders.has(p));
           if (nextProvider) {

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -22,7 +22,7 @@ import type { ICliProvider } from './providers/cli-provider.js';
 import { ProviderRegistry, createDefaultRegistry } from './providers/cli-provider.js';
 import { tryExtractTextFromNode } from './providers/index.js';
 import { createChunkSession, createChunkTranscriptEntry, type ChunkSession } from '../session/chunk-session.js';
-import { classifyCommandFailure, parseResetTimeText, type CommandFailure } from '../errors/command-failure.js';
+import { classifyCommandFailure, commandFailureFromExecError, parseResetTimeText, type CommandFailure } from '../errors/command-failure.js';
 
 export function parseResetTime(stderr: string, stdout: string): { sleepSeconds: number; source: string } {
   return parseResetTimeText(`${stderr}\n${stdout}`);
@@ -460,8 +460,87 @@ export class MartinLoop {
         if (isAbortError(error)) {
           throw error;
         }
+        const failure = commandFailureFromExecError({
+          tool: 'llm',
+          provider: activeProvider,
+          command: resolved.command,
+          error,
+          detectRateLimit: (text) => resolved.isRateLimited(text),
+          parseRetryAfterMs: (text) => {
+            const providerMs = resolved.parseRetryAfter(text);
+            if (providerMs !== undefined) {
+              return providerMs;
+            }
+            const parsed = parseResetTimeText(text);
+            return parsed.sleepSeconds >= 0 ? parsed.sleepSeconds * 1000 : undefined;
+          },
+        });
         const msg = error instanceof Error ? error.message : String(error);
         config.onSpawnError?.(activeProvider, msg);
+        if (failure.kind === 'spawn_error') {
+          exhaustedProviders.set(activeProvider, failure);
+          const nextProvider = providers.find(p => !exhaustedProviders.has(p));
+          if (nextProvider) {
+            config.onProviderSwitch?.(activeProvider, nextProvider, 'spawn-error');
+            activeProvider = nextProvider;
+            if (chunkSession) {
+              chunkSession = {
+                ...chunkSession,
+                activeProvider,
+                updatedAt: new Date().toISOString(),
+              };
+              config.sessionStore?.save(chunkSession);
+            }
+            continue;
+          }
+
+          const rateLimitedFailures = [...exhaustedProviders.entries()]
+            .filter(([, data]) => data.rateLimited);
+          if (rateLimitedFailures.length > 0) {
+            let shortestSleep = Infinity;
+            let shortestSource = 'unknown';
+            for (const [providerName, data] of rateLimitedFailures) {
+              if (data.retryAfterMs !== undefined) {
+                const sleepSeconds = data.retryAfterMs / 1000;
+                if (sleepSeconds >= 0 && sleepSeconds < shortestSleep) {
+                  shortestSleep = sleepSeconds;
+                  shortestSource = `${providerName} parseRetryAfter`;
+                }
+                continue;
+              }
+
+              const parsed = parseResetTime(data.stderr, data.stdout);
+              if (parsed.sleepSeconds >= 0 && parsed.sleepSeconds < shortestSleep) {
+                shortestSleep = parsed.sleepSeconds;
+                shortestSource = parsed.source;
+              }
+            }
+
+            const sleepMs = shortestSleep === Infinity ? 120_000 : shortestSleep * 1000;
+            const sleepSource = shortestSleep === Infinity ? 'unknown' : shortestSource;
+            config.onSleep?.(sleepMs, sleepSource);
+            await sleepWithAbort(sleepMs, sleepFn, config.abortSignal);
+            pendingSleepMs = sleepMs;
+            exhaustedProviders.clear();
+            if (activeProvider !== initialProvider) {
+              config.onProviderSwitch?.(activeProvider, initialProvider, 'post-sleep-reset');
+            }
+            activeProvider = initialProvider;
+            if (chunkSession) {
+              chunkSession = {
+                ...chunkSession,
+                activeProvider,
+                updatedAt: new Date().toISOString(),
+              };
+              config.sessionStore?.save(chunkSession);
+            }
+            continue;
+          }
+
+          throw new Error(
+            `No configured LLM provider CLI is available. Install or configure one of: ${providers.join(', ')}. Last error: ${failure.summary}`,
+          );
+        }
         continue;
       }
 

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -482,6 +482,9 @@ export class MartinLoop {
         });
         const msg = error instanceof Error ? error.message : String(error);
         config.onSpawnError?.(activeProvider, msg);
+        if (config.abortSignal?.aborted) {
+          throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+        }
         if (failure.kind === 'spawn_error') {
           iteration--;
           exhaustedProviders.set(activeProvider, failure);

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -641,6 +641,33 @@ describe('CliLlmAdapter', () => {
         expect(calls[2]!.cmd).toBe('claude');
       });
 
+      it('retries a rate-limited provider when later fallback provider CLI is missing', async () => {
+        const sleepFn = vi.fn(async () => {});
+        const { spawnFn, calls } = createQueuedSpawn([
+          { stderr: 'retry-after: 5', exitCode: 1 },
+          { error: Object.assign(new Error('spawn codex ENOENT'), { code: 'ENOENT' }) },
+          { stdout: 'claude recovered', exitCode: 0 },
+        ]);
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providers: ['claude', 'codex'],
+            _sleepFn: sleepFn,
+          } as never,
+          spawnFn,
+        );
+
+        const result = await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+        expect(result).toBe('claude recovered');
+        expect(sleepFn).toHaveBeenCalledWith(5_000);
+        expect(calls).toHaveLength(3);
+        expect(calls[0]!.cmd).toBe('claude');
+        expect(calls[1]!.cmd).toBe('codex');
+        expect(calls[2]!.cmd).toBe('claude');
+      });
+
       it('does not forward the selected provider model to fallback providers in chat mode', async () => {
         const { spawnFn, calls } = createQueuedSpawn([
           { stderr: 'rate limit exceeded', exitCode: 1 },

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -21,6 +21,7 @@ interface MockSpawnResult {
   exitCode?: number;
   delayMs?: number;
   neverExit?: boolean;
+  error?: Error & { code?: string };
 }
 
 function createMockSpawn(opts: {
@@ -98,7 +99,11 @@ function createQueuedSpawn(results: MockSpawnResult[]): {
     });
     Object.defineProperty(proc, 'kill', { value: killFn, writable: false });
 
-    if (!current.neverExit) {
+    if (current.error) {
+      setTimeout(() => {
+        proc.emit('error', current.error);
+      }, current.delayMs ?? 5);
+    } else if (!current.neverExit) {
       setTimeout(() => {
         if (current.stdout) stdoutStream.write(current.stdout);
         stdoutStream.end();
@@ -566,6 +571,47 @@ describe('CliLlmAdapter', () => {
         expect(calls).toHaveLength(2);
         expect(calls[0]!.cmd).toBe('claude');
         expect(calls[1]!.cmd).toBe('codex');
+      });
+
+      it('switches to the next provider when the selected provider is missing from PATH', async () => {
+        const enoent = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
+        const { spawnFn, calls } = createQueuedSpawn([
+          { error: enoent },
+          { stdout: 'codex success', exitCode: 0 },
+        ]);
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providers: ['codex', 'claude'],
+          } as never,
+          spawnFn,
+        );
+
+        const result = await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+        expect(result).toBe('codex success');
+        expect(calls).toHaveLength(2);
+        expect(calls[0]!.cmd).toBe('claude');
+        expect(calls[1]!.cmd).toBe('codex');
+      });
+
+      it('throws an actionable install/configuration error when no configured provider CLI exists', async () => {
+        const { spawnFn } = createQueuedSpawn([
+          { error: Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }) },
+          { error: Object.assign(new Error('spawn codex ENOENT'), { code: 'ENOENT' }) },
+        ]);
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providers: ['codex', 'claude'],
+          } as never,
+          spawnFn,
+        );
+
+        await expect(adapter.execute({ prompt: 'test', maxTurns: 1 }))
+          .rejects.toThrow('Install one of: claude, codex, gemini, aider');
       });
 
       it('sleeps after all configured providers are exhausted, then retries from the selected provider', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -992,7 +992,7 @@ describe('main() execution', () => {
       budget: 10,
       provider: 'claude',
       providerSpecified: true,
-      providers: undefined,
+      providers: ['gemini'],
       designDoc: undefined,
       planDir: undefined,
       planName: undefined,

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -208,7 +208,7 @@ vi.mock('../../../src/cli/config-loader.js', () => ({
     enableHeartbeat: false,
     minCritiqueScore: 0.7,
     maxTotalTokens: 100_000,
-    providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+    providers: { default: 'gemini', fallbackChain: [], overrides: { gemini: { command: 'sh' } } },
     network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
     beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
     chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -295,6 +295,27 @@ describe('resolvePhases', () => {
       designDoc: '/some/doc.md',
     });
     expect(result).toEqual({ entryPhase: 'execute' });
+  });
+});
+
+describe('provider CLI availability preflight', () => {
+  it('reports provider commands and honors command overrides', () => {
+    const report = checkProviderCliAvailability('claude', ['codex'], {
+      claude: { command: 'sh' },
+      codex: { command: 'definitely-missing-frankenbeast-provider-cli' },
+    });
+
+    expect(report).toEqual([
+      { provider: 'claude', command: 'sh', available: true },
+      { provider: 'codex', command: 'definitely-missing-frankenbeast-provider-cli', available: false },
+    ]);
+  });
+
+  it('throws an actionable error when no configured provider CLI is available', () => {
+    expect(() => assertAnyProviderCliAvailable('claude', ['codex'], {
+      claude: { command: 'definitely-missing-frankenbeast-claude' },
+      codex: { command: 'definitely-missing-frankenbeast-codex' },
+    })).toThrow('Install one of: claude, codex, gemini, aider');
   });
 });
 
@@ -1008,7 +1029,7 @@ describe('main() execution', () => {
       enableHeartbeat: false,
       minCritiqueScore: 0.7,
       maxTotalTokens: 100_000,
-      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      providers: { default: 'gemini', fallbackChain: [], overrides: { gemini: { command: 'sh' } } },
       security: {
         profile: 'permissive',
         webhookSignaturePolicy: 'local-dev-unsigned',
@@ -1109,7 +1130,7 @@ describe('main() execution', () => {
       enableHeartbeat: false,
       minCritiqueScore: 0.7,
       maxTotalTokens: 100_000,
-      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      providers: { default: 'gemini', fallbackChain: [], overrides: { gemini: { command: 'sh' } } },
       network: { mode: 'insecure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
       beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
       chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
@@ -1299,7 +1320,7 @@ describe('main() execution', () => {
       enableHeartbeat: false,
       minCritiqueScore: 0.7,
       maxTotalTokens: 100_000,
-      providers: { default: 'gemini', fallbackChain: [], overrides: {} },
+      providers: { default: 'gemini', fallbackChain: [], overrides: { gemini: { command: 'sh' } } },
       network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
       beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
       chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -760,6 +760,7 @@ describe('main() execution', () => {
     delete process.env.VITE_BEAST_OPERATOR_TOKEN;
     delete process.env.FRANKENBEAST_BEAST_OPERATOR_TOKEN;
     delete process.env.FRANKENBEAST_BEAST_DAEMON_URL;
+    delete process.env.FRANKENBEAST_RUN_CONFIG;
     delete process.env.DISCORD_BOT_TOKEN;
     delete process.env.DISCORD_PUBLIC_KEY;
     for (const dir of tempDirs.splice(0)) {
@@ -816,6 +817,45 @@ describe('main() execution', () => {
     expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
       entryPhase: 'execute',
       resume: true,
+    }));
+  });
+
+  it('uses FRANKENBEAST_RUN_CONFIG provider for availability preflight before creating the Session', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-config-provider-${Date.now()}`);
+    const runConfigPath = join(root, 'run-config.json');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(runConfigPath, JSON.stringify({ provider: 'codex' }));
+    tempDirs.push(root);
+    process.env.FRANKENBEAST_RUN_CONFIG = runConfigPath;
+
+    vi.mocked(loadConfig).mockResolvedValueOnce({
+      maxCritiqueIterations: 3,
+      maxDurationMs: 600_000,
+      enableTracing: false,
+      enableHeartbeat: false,
+      minCritiqueScore: 0.7,
+      maxTotalTokens: 100_000,
+      providers: {
+        default: 'claude',
+        fallbackChain: [],
+        overrides: {
+          claude: { command: 'definitely-missing-frankenbeast-claude' },
+          codex: { command: 'sh' },
+        },
+      },
+      network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+    } as any);
+
+    await main();
+
+    expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
+      provider: 'claude',
+      orchestratorConfig: expect.objectContaining({
+        providers: expect.objectContaining({ default: 'claude' }),
+      }),
     }));
   });
 

--- a/packages/franken-orchestrator/tests/unit/errors/command-failure.test.ts
+++ b/packages/franken-orchestrator/tests/unit/errors/command-failure.test.ts
@@ -98,4 +98,26 @@ describe('commandFailureFromExecError', () => {
     expect(failure.details).toEqual(expect.objectContaining({ code: 'EPERM' }));
     expect(failure.summary).toContain('spawn');
   });
+
+  it('preserves timeout classification for ETIMEDOUT exec-style errors', () => {
+    const error = Object.assign(new Error('CLI timeout after 1000ms'), {
+      code: 'ETIMEDOUT',
+      stderr: 'model output mentioned rate limit handling',
+    });
+
+    const failure = commandFailureFromExecError({
+      tool: 'llm',
+      provider: 'claude',
+      command: 'claude',
+      error,
+      detectRateLimit: (text) => /rate limit/i.test(text),
+      parseRetryAfterMs: () => 5_000,
+    });
+
+    expect(failure.kind).toBe('timeout');
+    expect(failure.timedOut).toBe(true);
+    expect(failure.rateLimited).toBe(false);
+    expect(failure.retryAfterMs).toBeUndefined();
+    expect(failure.details).toEqual(expect.objectContaining({ code: 'ETIMEDOUT' }));
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -323,6 +323,20 @@ describe('ProviderRegistry', () => {
       }).rejects.toThrow('connection timeout');
     });
 
+    it('throws an actionable error when every provider reports unavailable', async () => {
+      const p1 = mockProvider('claude', { available: false });
+      const p2 = mockProvider('codex', { available: false });
+      const brain = mockBrain();
+
+      const registry = new ProviderRegistry([p1, p2], brain);
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow('No providers available. Checked: claude, codex');
+      expect(p1.execute).not.toHaveBeenCalled();
+      expect(p2.execute).not.toHaveBeenCalled();
+    });
+
     it('applies exponential backoff between retries', async () => {
       const timestamps: number[] = [];
       const p1: ILlmProvider = {

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -386,7 +386,7 @@ describe('MartinLoop', () => {
     const loop = new MartinLoop();
     const result = await loop.run(baseConfig({
       providers: ['claude', 'codex'],
-      maxIterations: 2,
+      maxIterations: 1,
       onProviderSwitch,
     }));
 
@@ -409,7 +409,7 @@ describe('MartinLoop', () => {
     const loop = new MartinLoop();
     const result = await loop.run(baseConfig({
       providers: ['claude', 'codex'],
-      maxIterations: 3,
+      maxIterations: 1,
       _sleepFn: sleepFn,
       onSleep,
       onProviderSwitch,

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -26,6 +26,7 @@ interface MockChildOpts {
   stderr?: string;
   exitCode?: number;
   hang?: boolean;
+  error?: Error & { code?: string };
 }
 
 /** Create a mock ChildProcess that emits stdout/stderr then closes. */
@@ -38,7 +39,11 @@ function mockChild(opts: MockChildOpts): ChildProcess {
     pid: 12345,
   }) as unknown as ChildProcess;
 
-  if (!opts.hang) {
+  if (opts.error) {
+    process.nextTick(() => {
+      child.emit('error', opts.error);
+    });
+  } else if (!opts.hang) {
     process.nextTick(() => {
       if (opts.stdout) (child.stdout as EventEmitter).emit('data', Buffer.from(opts.stdout));
       if (opts.stderr) (child.stderr as EventEmitter).emit('data', Buffer.from(opts.stderr));
@@ -370,6 +375,55 @@ describe('MartinLoop', () => {
     // Second call should use codex provider's command
     const secondCallArgs = mockSpawn.mock.calls[1] as unknown[];
     expect(secondCallArgs[0]).toBe('codex');
+  });
+
+  it('switches to the next configured provider when the active provider binary is missing', async () => {
+    const onProviderSwitch = vi.fn();
+
+    queueMock({ error: Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }) });
+    queueMock({ stdout: 'Codex did it!\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    const result = await loop.run(baseConfig({
+      providers: ['claude', 'codex'],
+      maxIterations: 2,
+      onProviderSwitch,
+    }));
+
+    expect(result.completed).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect((mockSpawn.mock.calls[0] as unknown[])[0]).toBe('claude');
+    expect((mockSpawn.mock.calls[1] as unknown[])[0]).toBe('codex');
+    expect(onProviderSwitch).toHaveBeenCalledWith('claude', 'codex', 'spawn-error');
+  });
+
+  it('sleeps and retries the original provider when a rate-limited primary is followed by a missing fallback CLI', async () => {
+    const sleepFn = vi.fn(async () => undefined);
+    const onSleep = vi.fn();
+    const onProviderSwitch = vi.fn();
+
+    queueMock({ stderr: 'rate limit exceeded retry-after: 1', exitCode: 1 });
+    queueMock({ error: Object.assign(new Error('spawn codex ENOENT'), { code: 'ENOENT' }) });
+    queueMock({ stdout: 'Claude recovered!\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    const result = await loop.run(baseConfig({
+      providers: ['claude', 'codex'],
+      maxIterations: 3,
+      _sleepFn: sleepFn,
+      onSleep,
+      onProviderSwitch,
+    }));
+
+    expect(result.completed).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+    expect((mockSpawn.mock.calls[0] as unknown[])[0]).toBe('claude');
+    expect((mockSpawn.mock.calls[1] as unknown[])[0]).toBe('codex');
+    expect((mockSpawn.mock.calls[2] as unknown[])[0]).toBe('claude');
+    expect(onSleep).toHaveBeenCalledWith(1_000, 'claude parseRetryAfter');
+    expect(sleepFn).toHaveBeenCalledWith(1_000);
+    expect(onProviderSwitch).toHaveBeenCalledWith('claude', 'codex', 'rate-limit');
+    expect(onProviderSwitch).toHaveBeenCalledWith('codex', 'claude', 'post-sleep-reset');
   });
 
   // ── 10. Strips CLAUDE* env vars for claude provider ──

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -397,6 +397,42 @@ describe('MartinLoop', () => {
     expect(onProviderSwitch).toHaveBeenCalledWith('claude', 'codex', 'spawn-error');
   });
 
+  it('does not reuse the primary command override when switching after spawn error', async () => {
+    queueMock({ error: Object.assign(new Error('spawn /custom/missing-claude ENOENT'), { code: 'ENOENT' }) });
+    queueMock({ stdout: 'Codex did it!\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    const result = await loop.run(baseConfig({
+      command: '/custom/missing-claude',
+      providers: ['claude', 'codex'],
+      maxIterations: 1,
+    }));
+
+    expect(result.completed).toBe(true);
+    expect((mockSpawn.mock.calls[0] as unknown[])[0]).toBe('/custom/missing-claude');
+    expect((mockSpawn.mock.calls[1] as unknown[])[0]).toBe('codex');
+  });
+
+  it('uses per-provider command overrides when switching after spawn error', async () => {
+    queueMock({ error: Object.assign(new Error('spawn /custom/missing-claude ENOENT'), { code: 'ENOENT' }) });
+    queueMock({ stdout: 'Codex did it!\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    const result = await loop.run(baseConfig({
+      command: '/custom/missing-claude',
+      providerCommands: {
+        claude: '/custom/missing-claude',
+        codex: '/custom/codex',
+      },
+      providers: ['claude', 'codex'],
+      maxIterations: 1,
+    }));
+
+    expect(result.completed).toBe(true);
+    expect((mockSpawn.mock.calls[0] as unknown[])[0]).toBe('/custom/missing-claude');
+    expect((mockSpawn.mock.calls[1] as unknown[])[0]).toBe('/custom/codex');
+  });
+
   it('sleeps and retries the original provider when a rate-limited primary is followed by a missing fallback CLI', async () => {
     const sleepFn = vi.fn(async () => undefined);
     const onSleep = vi.fn();
@@ -515,6 +551,7 @@ describe('MartinLoop', () => {
       parseRetryAfter: () => undefined,
       filterEnv: (env) => ({ ...env }),
       supportsStreamJson: () => false,
+      defaultContextWindowTokens: () => 200_000,
     };
 
     const registry = new ProviderRegistry();


### PR DESCRIPTION
## Summary
- preflight configured provider CLI commands before starting orchestrator sessions so zero-provider setups fail with an actionable message
- convert provider spawn ENOENT errors into normal CLI-provider failover/exhaustion handling
- improve provider-registry exhaustion errors when every provider reports unavailable

## Test Plan
- npm ci
- cd packages/franken-orchestrator && npm test -- tests/unit/adapters/cli-llm-adapter.test.ts tests/unit/providers/provider-registry.test.ts tests/unit/cli/run.test.ts
- npm run typecheck
- npm run build
- cd packages/franken-orchestrator && npm run lint (0 errors, existing warnings remain)

Closes #743