### PR TITLE
fix(packaging): pin internal package deps

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,5 +6,7 @@
   "packages/franken-observer": "0.7.9",
   "packages/franken-orchestrator": "0.39.0",
   "packages/franken-planner": "0.4.7",
-  "packages/franken-types": "0.7.4"
+  "packages/franken-types": "0.7.4",
+  "packages/franken-mcp-suite": "0.1.0",
+  "packages/live-bench": "0.1.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,5 +8,6 @@
   "packages/franken-planner": "0.4.7",
   "packages/franken-types": "0.7.4",
   "packages/franken-mcp-suite": "0.1.0",
-  "packages/live-bench": "0.1.0"
+  "packages/live-bench": "0.1.0",
+  "packages/franken-web": "0.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7522,10 +7522,10 @@
       }
     },
     "packages/franken-brain": {
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "ISC",
       "dependencies": {
-        "@franken/types": "*",
+        "@franken/types": "0.7.4",
         "better-sqlite3": "^12.6.2"
       },
       "devDependencies": {
@@ -7539,10 +7539,10 @@
     },
     "packages/franken-critique": {
       "name": "@franken/critique",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "*",
+        "@franken/types": "0.7.4",
         "hono": "^4.12.27",
         "zod": "^3.24.0"
       },
@@ -7577,10 +7577,10 @@
     },
     "packages/franken-governor": {
       "name": "@franken/governor",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "UNLICENSED",
       "dependencies": {
-        "@franken/types": "*",
+        "@franken/types": "0.7.4",
         "hono": "^4.12.27"
       },
       "devDependencies": {
@@ -7597,15 +7597,15 @@
       "name": "@fbeast/mcp-suite",
       "version": "0.1.0",
       "dependencies": {
-        "@franken/critique": "*",
-        "@franken/governor": "*",
-        "@franken/types": "*",
-        "@frankenbeast/observer": "*",
+        "@franken/critique": "0.6.9",
+        "@franken/governor": "0.5.7",
+        "@franken/types": "0.7.4",
+        "@frankenbeast/observer": "0.7.9",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2",
-        "franken-brain": "*",
-        "franken-orchestrator": "*",
-        "franken-planner": "*"
+        "franken-brain": "0.6.5",
+        "franken-orchestrator": "0.39.0",
+        "franken-planner": "0.4.7"
       },
       "bin": {
         "fbeast": "dist/cli/main.js",
@@ -7632,7 +7632,7 @@
     },
     "packages/franken-observer": {
       "name": "@frankenbeast/observer",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "better-sqlite3": "^12.6.2"
       },
@@ -7659,19 +7659,19 @@
       "license": "MIT"
     },
     "packages/franken-orchestrator": {
-      "version": "0.38.1",
+      "version": "0.39.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
-        "@franken/critique": "*",
-        "@franken/governor": "*",
-        "@franken/types": "*",
-        "@frankenbeast/observer": "*",
+        "@franken/critique": "0.6.9",
+        "@franken/governor": "0.5.7",
+        "@franken/types": "0.7.4",
+        "@frankenbeast/observer": "0.7.9",
         "@google/genai": "^1.46.0",
         "better-sqlite3": "^12.6.2",
         "dotenv": "^17.3.1",
-        "franken-brain": "*",
-        "franken-planner": "*",
+        "franken-brain": "0.6.5",
+        "franken-planner": "0.4.7",
         "hono": "^4.12.27",
         "openai": "^6.32.0",
         "ws": "^8.21.0",
@@ -7709,9 +7709,9 @@
       "license": "MIT"
     },
     "packages/franken-planner": {
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
-        "@franken/types": "*"
+        "@franken/types": "0.7.4"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.9",
@@ -7736,7 +7736,7 @@
     },
     "packages/franken-types": {
       "name": "@franken/types",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "zod": "^3.25.76"
       },
@@ -7765,7 +7765,7 @@
       "name": "@frankenbeast/web",
       "version": "0.1.0",
       "dependencies": {
-        "@franken/types": "*",
+        "@franken/types": "0.7.4",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -7834,7 +7834,7 @@
       "name": "@fbeast/live-bench",
       "version": "0.1.0",
       "dependencies": {
-        "@frankenbeast/observer": "*",
+        "@frankenbeast/observer": "0.7.9",
         "better-sqlite3": "^12.6.2",
         "zod": "^3.24.0"
       },

--- a/packages/franken-brain/package.json
+++ b/packages/franken-brain/package.json
@@ -15,7 +15,8 @@
     "test:watch": "vitest --reporter=verbose",
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --reporter=verbose --config vitest.integration.config.ts",
-    "lint": "eslint src/ tests/"
+    "lint": "eslint src/ tests/",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [],
   "author": "",
@@ -29,7 +30,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@franken/types": "*",
+    "@franken/types": "0.7.4",
     "better-sqlite3": "^12.6.2"
   }
 }

--- a/packages/franken-brain/package.json
+++ b/packages/franken-brain/package.json
@@ -16,7 +16,7 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --reporter=verbose --config vitest.integration.config.ts",
     "lint": "eslint src/ tests/",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [],
   "author": "",

--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [
     "frankenbeast",

--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
-    "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'"
+    "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "frankenbeast",
@@ -51,7 +52,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@franken/types": "*",
+    "@franken/types": "0.7.4",
     "hono": "^4.12.27",
     "zod": "^3.24.0"
   }

--- a/packages/franken-governor/package.json
+++ b/packages/franken-governor/package.json
@@ -17,7 +17,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "INTEGRATION=true vitest run"
+    "test:integration": "INTEGRATION=true vitest run",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "frankenbeast",
@@ -30,7 +31,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@franken/types": "*",
+    "@franken/types": "0.7.4",
     "hono": "^4.12.27"
   },
   "devDependencies": {

--- a/packages/franken-governor/package.json
+++ b/packages/franken-governor/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:integration": "INTEGRATION=true vitest run",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [
     "frankenbeast",

--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run --reporter=verbose",
     "test:watch": "vitest --reporter=verbose",
     "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
     "@franken/types": "0.7.4",

--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -20,22 +20,26 @@
     "fbeast-init": "./dist/cli/init.js",
     "fbeast-uninstall": "./dist/cli/uninstall.js"
   },
-  "files": ["dist", "instructions"],
+  "files": [
+    "dist",
+    "instructions"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --reporter=verbose",
     "test:watch": "vitest --reporter=verbose",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@franken/types": "*",
-    "franken-brain": "*",
-    "@franken/critique": "*",
-    "@franken/governor": "*",
-    "@frankenbeast/observer": "*",
-    "franken-orchestrator": "*",
-    "franken-planner": "*",
+    "@franken/types": "0.7.4",
+    "franken-brain": "0.6.5",
+    "@franken/critique": "0.6.9",
+    "@franken/governor": "0.5.7",
+    "@frankenbeast/observer": "0.7.9",
+    "franken-orchestrator": "0.39.0",
+    "franken-planner": "0.4.7",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "better-sqlite3": "^12.6.2"
   },

--- a/packages/franken-observer/package.json
+++ b/packages/franken-observer/package.json
@@ -21,7 +21,7 @@
     "test:watch": "vitest",
     "test:integration": "INTEGRATION=true vitest run --reporter=verbose",
     "test:eval": "EVAL=true vitest run --reporter=verbose",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/franken-observer/package.json
+++ b/packages/franken-observer/package.json
@@ -20,7 +20,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "INTEGRATION=true vitest run --reporter=verbose",
-    "test:eval": "EVAL=true vitest run --reporter=verbose"
+    "test:eval": "EVAL=true vitest run --reporter=verbose",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/franken-orchestrator/package.json
+++ b/packages/franken-orchestrator/package.json
@@ -29,7 +29,8 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "INTEGRATION=true vitest run",
     "test:e2e": "E2E=true vitest run",
-    "lint": "eslint src/ tests/"
+    "lint": "eslint src/ tests/",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "frankenbeast",
@@ -43,15 +44,15 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
-    "@franken/critique": "*",
-    "@franken/governor": "*",
-    "@franken/types": "*",
-    "@frankenbeast/observer": "*",
+    "@franken/critique": "0.6.9",
+    "@franken/governor": "0.5.7",
+    "@franken/types": "0.7.4",
+    "@frankenbeast/observer": "0.7.9",
     "@google/genai": "^1.46.0",
     "better-sqlite3": "^12.6.2",
     "dotenv": "^17.3.1",
-    "franken-planner": "*",
-    "franken-brain": "*",
+    "franken-planner": "0.4.7",
+    "franken-brain": "0.6.5",
     "hono": "^4.12.27",
     "openai": "^6.32.0",
     "ws": "^8.21.0",

--- a/packages/franken-orchestrator/package.json
+++ b/packages/franken-orchestrator/package.json
@@ -30,7 +30,7 @@
     "test:integration": "INTEGRATION=true vitest run",
     "test:e2e": "E2E=true vitest run",
     "lint": "eslint src/ tests/",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [
     "frankenbeast",

--- a/packages/franken-planner/package.json
+++ b/packages/franken-planner/package.json
@@ -20,7 +20,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:ci": "vitest run --coverage",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
     "@franken/types": "0.7.4"

--- a/packages/franken-planner/package.json
+++ b/packages/franken-planner/package.json
@@ -19,10 +19,11 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:ci": "vitest run --coverage"
+    "test:ci": "vitest run --coverage",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@franken/types": "*"
+    "@franken/types": "0.7.4"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.9",

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -14,7 +14,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "zod": "^3.25.76"

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
     "zod": "^3.25.76"

--- a/packages/franken-web/package.json
+++ b/packages/franken-web/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@franken/types": "*",
+    "@franken/types": "0.7.4",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/live-bench/package.json
+++ b/packages/live-bench/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:live": "FBEAST_LIVE_BENCH_E2E=1 vitest run tests/live",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
     "@frankenbeast/observer": "0.7.9",

--- a/packages/live-bench/package.json
+++ b/packages/live-bench/package.json
@@ -8,15 +8,19 @@
   "bin": {
     "fbeast-live-bench": "./dist/cli/main.js"
   },
-  "files": ["dist", "corpus"],
+  "files": [
+    "dist",
+    "corpus"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:live": "FBEAST_LIVE_BENCH_E2E=1 vitest run tests/live"
+    "test:live": "FBEAST_LIVE_BENCH_E2E=1 vitest run tests/live",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@frankenbeast/observer": "*",
+    "@frankenbeast/observer": "0.7.9",
     "better-sqlite3": "^12.6.2",
     "zod": "^3.24.0"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": false,
-  "plugins": ["node-workspace"],
+  "plugins": [
+    "node-workspace"
+  ],
   "changelog-sections": [
     {
       "type": "feat",
@@ -61,7 +63,8 @@
         "packages/franken-planner",
         "packages/franken-types",
         "packages/franken-mcp-suite",
-        "packages/live-bench"
+        "packages/live-bench",
+        "packages/franken-web"
       ]
     },
     "packages/franken-brain": {
@@ -99,6 +102,10 @@
     "packages/live-bench": {
       "release-type": "node",
       "component": "live-bench"
+    },
+    "packages/franken-web": {
+      "release-type": "node",
+      "component": "franken-web"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,16 +2,46 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": false,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "feature", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Refactoring" },
-    { "type": "chore", "section": "Miscellaneous" },
-    { "type": "docs", "section": "Documentation" },
-    { "type": "ci", "section": "CI/CD" },
-    { "type": "test", "section": "Tests" },
-    { "type": "adr", "section": "Architecture" }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "feature",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring"
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "ci",
+      "section": "CI/CD"
+    },
+    {
+      "type": "test",
+      "section": "Tests"
+    },
+    {
+      "type": "adr",
+      "section": "Architecture"
+    }
   ],
   "packages": {
     ".": {
@@ -28,7 +58,9 @@
         "packages/franken-observer",
         "packages/franken-orchestrator",
         "packages/franken-planner",
-        "packages/franken-types"
+        "packages/franken-types",
+        "packages/franken-mcp-suite",
+        "packages/live-bench"
       ]
     },
     "packages/franken-brain": {
@@ -58,6 +90,14 @@
     "packages/franken-types": {
       "release-type": "node",
       "component": "franken-types"
+    },
+    "packages/franken-mcp-suite": {
+      "release-type": "node",
+      "component": "franken-mcp-suite"
+    },
+    "packages/live-bench": {
+      "release-type": "node",
+      "component": "live-bench"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": false,
+  "plugins": ["node-workspace"],
   "changelog-sections": [
     {
       "type": "feat",

--- a/tests/unit/release-please-config.test.ts
+++ b/tests/unit/release-please-config.test.ts
@@ -8,30 +8,23 @@ function readJson(relPath: string): unknown {
   return JSON.parse(readFileSync(resolve(ROOT, relPath), 'utf-8'));
 }
 
-const PACKAGE_DIRS = [
-  'franken-brain',
-  'franken-critique',
-  'franken-governor',
-  'franken-observer',
-  'franken-orchestrator',
-  'franken-planner',
-  'franken-types',
-] as const;
-
 describe('release-please monorepo config', () => {
   const config = readJson('release-please-config.json') as {
     packages: Record<string, { 'release-type'?: string; component?: string }>;
   };
   const manifest = readJson('.release-please-manifest.json') as Record<string, string>;
   const rootPackage = readJson('package.json') as { version: string };
+  const packageDirs = Object.keys(config.packages)
+    .filter((key) => key.startsWith('packages/'))
+    .map((key) => key.replace(/^packages\//, ''));
 
   it('config has root "." entry preserved', () => {
     expect(config.packages['.']).toBeDefined();
     expect(config.packages['.']['release-type']).toBe('node');
   });
 
-  it('config has entries for all 7 packages', () => {
-    for (const dir of PACKAGE_DIRS) {
+  it('config has entries for every package release-managed in this repo', () => {
+    for (const dir of packageDirs) {
       const key = `packages/${dir}`;
       expect(config.packages[key], `missing config entry for ${key}`).toBeDefined();
     }
@@ -42,14 +35,14 @@ describe('release-please monorepo config', () => {
   });
 
   it('each package entry has release-type "node"', () => {
-    for (const dir of PACKAGE_DIRS) {
+    for (const dir of packageDirs) {
       const key = `packages/${dir}`;
       expect(config.packages[key]?.['release-type'], `${key} missing release-type`).toBe('node');
     }
   });
 
   it('each package entry has a component name', () => {
-    for (const dir of PACKAGE_DIRS) {
+    for (const dir of packageDirs) {
       const key = `packages/${dir}`;
       expect(config.packages[key]?.component, `${key} missing component`).toBeTruthy();
     }
@@ -59,8 +52,8 @@ describe('release-please monorepo config', () => {
     expect(manifest['.']).toBe(rootPackage.version);
   });
 
-  it('manifest has entries for all 7 packages', () => {
-    for (const dir of PACKAGE_DIRS) {
+  it('manifest has entries for every package release-managed in this repo', () => {
+    for (const dir of packageDirs) {
       const key = `packages/${dir}`;
       expect(manifest[key], `missing manifest entry for ${key}`).toBeDefined();
     }
@@ -71,7 +64,7 @@ describe('release-please monorepo config', () => {
   });
 
   it('manifest versions match actual package.json versions', () => {
-    for (const dir of PACKAGE_DIRS) {
+    for (const dir of packageDirs) {
       const key = `packages/${dir}`;
       const pkg = readJson(`packages/${dir}/package.json`) as { version: string };
       expect(manifest[key], `${key} version mismatch`).toBe(pkg.version);
@@ -79,14 +72,14 @@ describe('release-please monorepo config', () => {
   });
 
   it('no per-module release-please-config.json files exist', () => {
-    for (const dir of PACKAGE_DIRS) {
+    for (const dir of packageDirs) {
       const configPath = resolve(ROOT, `packages/${dir}/release-please-config.json`);
       expect(existsSync(configPath), `${configPath} should not exist`).toBe(false);
     }
   });
 
   it('no per-module .release-please-manifest.json files exist', () => {
-    for (const dir of PACKAGE_DIRS) {
+    for (const dir of packageDirs) {
       const manifestPath = resolve(ROOT, `packages/${dir}/.release-please-manifest.json`);
       expect(existsSync(manifestPath), `${manifestPath} should not exist`).toBe(false);
     }

--- a/tests/unit/release-please-config.test.ts
+++ b/tests/unit/release-please-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -14,9 +14,10 @@ describe('release-please monorepo config', () => {
   };
   const manifest = readJson('.release-please-manifest.json') as Record<string, string>;
   const rootPackage = readJson('package.json') as { version: string };
-  const packageDirs = Object.keys(config.packages)
-    .filter((key) => key.startsWith('packages/'))
-    .map((key) => key.replace(/^packages\//, ''));
+  const packageDirs = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
 
   it('config has root "." entry preserved', () => {
     expect(config.packages['.']).toBeDefined();

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -157,8 +157,8 @@ describe('npm workspaces configuration', () => {
         expect(pkg.scripts?.build, `${path} must define a build script`).toBeDefined();
         expect(
           pkg.scripts?.prepublishOnly,
-          `${path} must build before npm publish so dist/bin entries are fresh`,
-        ).toBe('npm run build');
+          `${path} must build the workspace before npm publish so dist/bin entries and internal dependency types are fresh`,
+        ).toBe('npm --prefix ../.. run build');
       }
     });
   });

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -108,41 +108,65 @@ describe('npm workspaces configuration', () => {
     });
   });
 
-  describe('cross-module dependencies use workspace protocol', () => {
-    const modulesWithFileDeps = [
-      { module: 'franken-critique', dep: '@franken/types' },
-      { module: 'franken-governor', dep: '@franken/types' },
-      { module: 'franken-orchestrator', dep: '@franken/types' },
-      { module: 'franken-planner', dep: '@franken/types' },
-    ];
+  describe('cross-module dependencies use coherent internal versions', () => {
+    const packageJsonPaths = readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `packages/${entry.name}/package.json`);
+    const packageManifests = packageJsonPaths.map((path) => ({
+      path,
+      pkg: readPkg(path),
+    }));
+    const internalPackageVersions = new Map(
+      packageManifests.map(({ pkg }) => [pkg.name, pkg.version]),
+    );
 
-    for (const { module, dep } of modulesWithFileDeps) {
-      it(`${module} depends on ${dep} via "*" (not file:)`, () => {
-        const pkg = readPkg(`packages/${module}/package.json`);
-        const version = pkg.dependencies?.[dep];
-        expect(version).toBe('*');
-        expect(version).not.toMatch(/^file:/);
-      });
-    }
+    it('pins every internal dependency to the matching package version instead of registry wildcards', () => {
+      for (const { path, pkg } of packageManifests) {
+        for (const dependencySection of [
+          'dependencies',
+          'devDependencies',
+          'optionalDependencies',
+          'peerDependencies',
+        ]) {
+          const dependencies = pkg[dependencySection] ?? {};
 
-    it('franken-orchestrator depends on @frankenbeast/observer via "*" (not file:)', () => {
-      const pkg = readPkg('packages/franken-orchestrator/package.json');
-      const version = pkg.dependencies?.['@frankenbeast/observer'];
-      expect(version).toBe('*');
-      expect(version).not.toMatch(/^file:/);
+          for (const [name, version] of Object.entries(dependencies)) {
+            const internalVersion = internalPackageVersions.get(name);
+            if (internalVersion === undefined) continue;
+
+            expect(
+              version,
+              `${name} in ${path} ${dependencySection} must match the internal package version`,
+            ).toBe(internalVersion);
+          }
+        }
+      }
+    });
+  });
+
+  describe('publishable package manifests', () => {
+    const packageJsonPaths = readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `packages/${entry.name}/package.json`);
+
+    it('builds dist artifacts before publishing publishable packages', () => {
+      for (const path of packageJsonPaths) {
+        const pkg = readPkg(path);
+        if (pkg.private === true) continue;
+
+        expect(pkg.scripts?.build, `${path} must define a build script`).toBeDefined();
+        expect(
+          pkg.scripts?.prepublishOnly,
+          `${path} must build before npm publish so dist/bin entries are fresh`,
+        ).toBe('npm run build');
+      }
     });
   });
 
   describe('no file: dependencies remain anywhere', () => {
-    const allPackages = [
-      'franken-brain',
-      'franken-critique',
-      'franken-governor',
-      'franken-observer',
-      'franken-orchestrator',
-      'franken-planner',
-      'franken-types',
-    ];
+    const allPackages = readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
 
     for (const module of allPackages) {
       it(`packages/${module}/package.json has no file: dependencies`, () => {


### PR DESCRIPTION
## Summary
- Replace internal workspace wildcard dependencies with exact current package versions so registry installs resolve coherently.
- Add prepublishOnly build hooks to publishable packages with dist/bin outputs.
- Extend workspace manifest tests to guard internal dependency pins and publish-time builds.

## Test Plan
- corepack npm install --package-lock-only --ignore-scripts
- corepack npm run test:root -- tests/workspaces.test.ts
- corepack npm run typecheck
- corepack npm run build
- corepack npm run lint:security
- corepack npx turbo run lint --continue
- corepack npm test (after corepack npm rebuild better-sqlite3 because initial --ignore-scripts install skipped native bindings)
- corepack npm publish --dry-run --workspace @fbeast/mcp-suite --workspace franken-orchestrator --workspace @fbeast/live-bench

Closes #742