### PR TITLE
fix(scripts): update local setup checks for Chroma v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - IS_PERSISTENT=TRUE
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/v1/heartbeat']
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/v2/heartbeat']
       interval: 10s
       timeout: 5s
       retries: 3

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -7,6 +7,10 @@
  */
 
 const CHROMA_URL = process.env['CHROMA_URL'] ?? 'http://localhost:8000';
+const CHROMA_TENANT = process.env['CHROMA_TENANT'] ?? 'default_tenant';
+const CHROMA_DATABASE = process.env['CHROMA_DATABASE'] ?? 'default_database';
+
+export {};
 
 interface ChromaCollection {
   name: string;
@@ -14,7 +18,9 @@ interface ChromaCollection {
 }
 
 async function createCollection(name: string, metadata?: Record<string, string>): Promise<void> {
-  const res = await fetch(`${CHROMA_URL}/api/v1/collections`, {
+  const tenant = encodeURIComponent(CHROMA_TENANT);
+  const database = encodeURIComponent(CHROMA_DATABASE);
+  const res = await fetch(`${CHROMA_URL}/api/v2/tenants/${tenant}/databases/${database}/collections`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, metadata, get_or_create: true }),
@@ -32,7 +38,7 @@ async function main(): Promise<void> {
 
   // Check connectivity
   try {
-    const heartbeat = await fetch(`${CHROMA_URL}/api/v1/heartbeat`);
+    const heartbeat = await fetch(`${CHROMA_URL}/api/v2/heartbeat`);
     if (!heartbeat.ok) throw new Error(`Status ${heartbeat.status}`);
   } catch (error) {
     console.error(`Cannot reach ChromaDB at ${CHROMA_URL}. Is it running?`);

--- a/scripts/verify-setup.ts
+++ b/scripts/verify-setup.ts
@@ -12,6 +12,8 @@ interface CheckResult {
   detail: string;
 }
 
+export {};
+
 const results: CheckResult[] = [];
 
 function check(name: string, ok: boolean, detail: string): void {
@@ -43,16 +45,13 @@ async function main(): Promise<void> {
 
   // ChromaDB
   const chromaUrl = process.env['CHROMA_URL'] ?? 'http://localhost:8000';
-  await checkHttp('ChromaDB', `${chromaUrl}/api/v1/heartbeat`);
+  await checkHttp('ChromaDB', `${chromaUrl}/api/v2/heartbeat`);
 
   // Grafana
   await checkHttp('Grafana', 'http://localhost:3000/api/health');
 
   // Tempo
   await checkHttp('Tempo', 'http://localhost:3200/ready');
-
-  // Firewall
-  await checkHttp('Firewall server', 'http://localhost:9090/health');
 
   // Print results
   console.log('Results:\n');

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(import.meta.dirname, '..');
+const read = (rel: string) => readFileSync(join(ROOT, rel), 'utf8');
+
+describe('local setup scripts', () => {
+  it('verify-setup checks the live Chroma v2 heartbeat and no removed firewall service', () => {
+    const source = read('scripts/verify-setup.ts');
+
+    expect(source).toContain('/api/v2/heartbeat');
+    expect(source).not.toContain('/api/v1/heartbeat');
+    expect(source).not.toContain('localhost:9090');
+    expect(source).not.toContain('Firewall server');
+  });
+
+  it('seed script uses the Chroma v2 tenant/database collection API', () => {
+    const source = read('scripts/seed.ts');
+
+    expect(source).toContain('/api/v2/heartbeat');
+    expect(source).toContain('/api/v2/tenants/${tenant}/databases/${database}/collections');
+    expect(source).toContain("default_tenant");
+    expect(source).toContain("default_database");
+    expect(source).not.toContain('/api/v1/collections');
+    expect(source).not.toContain('/api/v1/heartbeat');
+  });
+
+  it('docker compose healthcheck targets the Chroma v2 heartbeat', () => {
+    const compose = read('docker-compose.yml');
+
+    expect(compose).toContain('http://localhost:8000/api/v2/heartbeat');
+    expect(compose).not.toContain('http://localhost:8000/api/v1/heartbeat');
+  });
+});


### PR DESCRIPTION
## Summary
- remove the stale verify-setup firewall:9090 health check
- switch Chroma health checks to the v2 heartbeat endpoint
- update seed collection creation to Chroma v2 tenant/database routes
- add root regression coverage for local setup script endpoints

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --lib ES2022 --types node scripts/verify-setup.ts scripts/seed.ts
- npm run lint:security
- npm run typecheck
- npm run build
- npm test

Closes #753