### PR TITLE
fix(runtime): proxy chat-server when beast daemon is live

### DIFF
--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -38,11 +38,17 @@ From the repo root:
 ```bash
 npm --workspace franken-orchestrator run beasts-daemon
 # in another terminal, for chat/WebSocket/dashboard gateway compatibility:
-FRANKENBEAST_BEAST_DAEMON_URL=http://127.0.0.1:4050 \
+npm --workspace franken-orchestrator run chat-server
+```
+
+When a live `beasts-daemon` pidfile exists, `chat-server` automatically proxies Beast control routes to the configured local daemon URL (default `http://127.0.0.1:4050`) instead of starting a second in-process Beast supervisor over the same SQLite database. If the daemon runs on a non-default local port, set `FRANKENBEAST_BEAST_DAEMON_URL` explicitly:
+
+```bash
+FRANKENBEAST_BEAST_DAEMON_URL=http://127.0.0.1:4051 \
   npm --workspace franken-orchestrator run chat-server
 ```
 
-If you omit `FRANKENBEAST_BEAST_DAEMON_URL`, `chat-server` starts an in-process local Beast control plane for standalone development instead of proxying to the daemon.
+If no daemon is running and `FRANKENBEAST_BEAST_DAEMON_URL` is unset, `chat-server` starts an in-process local Beast control plane for standalone development.
 
 Default bind:
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -4,6 +4,7 @@ import { mkdir, open, readFile, writeFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 import { existsSync, lstatSync, readdirSync, statSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
 import { handleBeastCommand } from './beast-cli.js';
@@ -379,22 +380,25 @@ function isPidAlive(pid: number): boolean {
   }
 }
 
-async function hasLiveBeastsDaemon(root: string): Promise<boolean> {
+async function readLiveBeastsDaemonPid(root: string): Promise<number | undefined> {
   try {
     const raw = await readFile(defaultBeastsDaemonPidFile(root), 'utf8');
     const pid = Number.parseInt(raw.trim(), 10);
-    return Number.isFinite(pid) && pid > 0 && isPidAlive(pid);
+    if (!Number.isFinite(pid) || pid <= 0 || !isPidAlive(pid)) {
+      return undefined;
+    }
+    return pid;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return false;
+      return undefined;
     }
     throw error;
   }
 }
 
-async function isHealthyBeastsDaemonEndpoint(baseUrl: string): Promise<boolean> {
+async function isHealthyBeastsDaemonEndpoint(baseUrl: string, expected: { root: string; pid: number }): Promise<boolean> {
   try {
-    const response = await fetch(`${baseUrl}/health`);
+    const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(1000) });
     if (!response.ok) {
       return false;
     }
@@ -403,10 +407,25 @@ async function isHealthyBeastsDaemonEndpoint(baseUrl: string): Promise<boolean> 
       return false;
     }
     const record = body as Record<string, unknown>;
-    return record.ok === true && record.service === 'beasts-daemon';
+    return record.ok === true
+      && record.service === 'beasts-daemon'
+      && record.root === expected.root
+      && record.pid === expected.pid;
   } catch {
     return false;
   }
+}
+
+async function waitForHealthyBeastsDaemonEndpoint(baseUrl: string, expected: { root: string; pid: number }): Promise<boolean> {
+  for (let attempt = 1; attempt <= 8; attempt += 1) {
+    if (await isHealthyBeastsDaemonEndpoint(baseUrl, expected)) {
+      return true;
+    }
+    if (attempt < 8) {
+      await sleep(250);
+    }
+  }
+  return false;
 }
 
 async function resolveDetectedBeastsDaemonUrl(
@@ -414,11 +433,12 @@ async function resolveDetectedBeastsDaemonUrl(
   config: OrchestratorConfig,
   logger: BeastLogger,
 ): Promise<string | undefined> {
-  if (!await hasLiveBeastsDaemon(root)) {
+  const pid = await readLiveBeastsDaemonPid(root);
+  if (pid === undefined) {
     return undefined;
   }
   const candidateUrl = localPlaintextOrSecureEndpoint(config.beastsDaemon.host, config.beastsDaemon.port);
-  if (await isHealthyBeastsDaemonEndpoint(candidateUrl)) {
+  if (await waitForHealthyBeastsDaemonEndpoint(candidateUrl, { root, pid })) {
     logger.info(
       `Detected a live beasts-daemon pid file at ${defaultBeastsDaemonPidFile(root)}; `
       + `chat-server will proxy Beast control routes to ${candidateUrl}.`,
@@ -428,7 +448,7 @@ async function resolveDetectedBeastsDaemonUrl(
   }
   logger.warn(
     `Ignoring live-looking beasts-daemon pid file at ${defaultBeastsDaemonPidFile(root)} because `
-    + `${candidateUrl}/health did not identify a reachable beasts-daemon; `
+    + `${candidateUrl}/health did not identify a reachable beasts-daemon for this checkout and pid; `
     + 'chat-server will keep standalone in-process Beast services.',
     'beasts-daemon',
   );

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -366,6 +366,75 @@ async function readEnvValueFromFile(filePath: string, key: string): Promise<stri
   }
 }
 
+function defaultBeastsDaemonPidFile(root: string): string {
+  return join(root, '.frankenbeast', 'beasts-daemon.pid');
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+async function hasLiveBeastsDaemon(root: string): Promise<boolean> {
+  try {
+    const raw = await readFile(defaultBeastsDaemonPidFile(root), 'utf8');
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(pid) && pid > 0 && isPidAlive(pid);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function isHealthyBeastsDaemonEndpoint(baseUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${baseUrl}/health`);
+    if (!response.ok) {
+      return false;
+    }
+    const body: unknown = await response.json();
+    if (!body || typeof body !== 'object') {
+      return false;
+    }
+    const record = body as Record<string, unknown>;
+    return record.ok === true && record.service === 'beasts-daemon';
+  } catch {
+    return false;
+  }
+}
+
+async function resolveDetectedBeastsDaemonUrl(
+  root: string,
+  config: OrchestratorConfig,
+  logger: BeastLogger,
+): Promise<string | undefined> {
+  if (!await hasLiveBeastsDaemon(root)) {
+    return undefined;
+  }
+  const candidateUrl = localPlaintextOrSecureEndpoint(config.beastsDaemon.host, config.beastsDaemon.port);
+  if (await isHealthyBeastsDaemonEndpoint(candidateUrl)) {
+    logger.info(
+      `Detected a live beasts-daemon pid file at ${defaultBeastsDaemonPidFile(root)}; `
+      + `chat-server will proxy Beast control routes to ${candidateUrl}.`,
+      'beasts-daemon',
+    );
+    return candidateUrl;
+  }
+  logger.warn(
+    `Ignoring live-looking beasts-daemon pid file at ${defaultBeastsDaemonPidFile(root)} because `
+    + `${candidateUrl}/health did not identify a reachable beasts-daemon; `
+    + 'chat-server will keep standalone in-process Beast services.',
+    'beasts-daemon',
+  );
+  return undefined;
+}
+
 async function resolveCommsSecret(root: string, ref: string | undefined, secretStore: ISecretStore | undefined): Promise<string | undefined> {
   if (!ref?.trim()) {
     return undefined;
@@ -759,7 +828,11 @@ export async function main(): Promise<void> {
             'FRANKENBEAST_BEAST_DAEMON_URL',
           )
         : undefined;
-      const localBeastServices = beastOperatorToken && !explicitBeastDaemonUrl
+      const detectedBeastDaemonUrl = !explicitBeastDaemonUrl && beastOperatorToken
+        ? await resolveDetectedBeastsDaemonUrl(root, config, logger)
+        : undefined;
+      const beastDaemonUrl = explicitBeastDaemonUrl ?? detectedBeastDaemonUrl;
+      const localBeastServices = beastOperatorToken && !beastDaemonUrl
         ? createBeastServices({
             beastsDb: join(paths.frankenbeastDir, 'beast.db'),
             beastLogsDir: paths.beastLogsDir,
@@ -787,10 +860,10 @@ export async function main(): Promise<void> {
               disposeBeastControl: localBeastServices.dispose,
             }
           : {}),
-        ...(beastOperatorToken && explicitBeastDaemonUrl
+        ...(beastOperatorToken && beastDaemonUrl
           ? {
               beastDaemon: {
-                baseUrl: explicitBeastDaemonUrl,
+                baseUrl: beastDaemonUrl,
                 operatorToken: beastOperatorToken,
               },
             }

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -10,6 +10,8 @@ export interface BeastDaemonAppOptions {
   services: BeastServiceBundle;
   operatorToken: string;
   startedAt?: string;
+  root?: string;
+  pid?: number;
   rateLimit?: {
     windowMs: number;
     max: number;
@@ -31,6 +33,8 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
       ok: true,
       service: 'beasts-daemon',
       startedAt,
+      root: options.root,
+      pid: options.pid,
       agents: services.agents.listAgents().length,
       runs: services.runs.listRuns().length,
     });

--- a/packages/franken-orchestrator/src/http/beast-daemon-server.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-server.ts
@@ -54,7 +54,12 @@ export async function startBeastDaemon(options: StartBeastDaemonOptions): Promis
     throw error;
   }
 
-  const app = createBeastDaemonApp({ services, operatorToken: options.operatorToken });
+  const app = createBeastDaemonApp({
+    services,
+    operatorToken: options.operatorToken,
+    root: options.root,
+    pid: process.pid,
+  });
   const server = createServer((request, response) => {
     void handleHonoHttpRequest(app, request, response);
   });

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -736,6 +736,7 @@ describe('main() execution', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     delete process.env.VITE_BEAST_OPERATOR_TOKEN;
     delete process.env.FRANKENBEAST_BEAST_OPERATOR_TOKEN;
     delete process.env.FRANKENBEAST_BEAST_DAEMON_URL;
@@ -1351,7 +1352,7 @@ describe('main() execution', () => {
     expect(mockStartChatServer).not.toHaveBeenCalled();
   });
 
-  it('proxies chat-server beast routes only when a daemon URL is explicit', async () => {
+  it('proxies chat-server beast routes when a daemon URL is explicit', async () => {
     process.env.FRANKENBEAST_BEAST_DAEMON_URL = 'http://127.0.0.1:4999';
     mockParseArgs.mockReturnValue({
       subcommand: 'chat-server',
@@ -1395,6 +1396,119 @@ describe('main() execution', () => {
     }));
     expect(mockStartChatServer).toHaveBeenCalledWith(expect.not.objectContaining({
       beastControl: expect.anything(),
+    }));
+  });
+
+  it('auto-proxies chat-server beast routes when a live local daemon pidfile exists', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-daemon-pid`);
+    tempDirs.push(root);
+    mkdirSync(join(root, '.frankenbeast'), { recursive: true });
+    writeFileSync(join(root, '.frankenbeast', 'beasts-daemon.pid'), `${process.pid}\n`);
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({
+      ok: true,
+      service: 'beasts-daemon',
+      startedAt: '2026-07-05T00:00:00.000Z',
+    })));
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    } as never);
+
+    await main();
+
+    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:4050/health');
+    expect(mockCreateBeastServices).not.toHaveBeenCalled();
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      beastDaemon: expect.objectContaining({
+        baseUrl: 'http://127.0.0.1:4050',
+        operatorToken: 'dashboard-operator-token',
+      }),
+    }));
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.not.objectContaining({
+      beastControl: expect.anything(),
+    }));
+  });
+
+  it('keeps local beast services when the daemon pidfile is live but health is not reachable', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-daemon-stale`);
+    tempDirs.push(root);
+    mkdirSync(join(root, '.frankenbeast'), { recursive: true });
+    writeFileSync(join(root, '.frankenbeast', 'beasts-daemon.pid'), `${process.pid}\n`);
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('connection refused'); }));
+    mockParseArgs.mockReturnValue({
+      subcommand: 'chat-server',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: root,
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    } as never);
+
+    await main();
+
+    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:4050/health');
+    expect(mockCreateBeastServices).toHaveBeenCalledWith(expect.objectContaining({
+      beastsDb: join(root, '.fbeast', 'beast.db'),
+      beastLogsDir: join(root, '.fbeast', '.build', 'beasts', 'logs'),
+      root,
+    }));
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      beastControl: expect.objectContaining({
+        operatorToken: 'dashboard-operator-token',
+      }),
+    }));
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.not.objectContaining({
+      beastDaemon: expect.anything(),
     }));
   });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1408,6 +1408,8 @@ describe('main() execution', () => {
       ok: true,
       service: 'beasts-daemon',
       startedAt: '2026-07-05T00:00:00.000Z',
+      root,
+      pid: process.pid,
     })));
     mockParseArgs.mockReturnValue({
       subcommand: 'chat-server',
@@ -1443,7 +1445,10 @@ describe('main() execution', () => {
 
     await main();
 
-    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:4050/health');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:4050/health',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mockCreateBeastServices).not.toHaveBeenCalled();
     expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
       beastDaemon: expect.objectContaining({
@@ -1496,7 +1501,10 @@ describe('main() execution', () => {
 
     await main();
 
-    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:4050/health');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:4050/health',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mockCreateBeastServices).toHaveBeenCalledWith(expect.objectContaining({
       beastsDb: join(root, '.fbeast', 'beast.db'),
       beastLogsDir: join(root, '.fbeast', '.build', 'beasts', 'logs'),
@@ -1506,6 +1514,63 @@ describe('main() execution', () => {
       beastControl: expect.objectContaining({
         operatorToken: 'dashboard-operator-token',
       }),
+    }));
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.not.objectContaining({
+      beastDaemon: expect.anything(),
+    }));
+  });
+
+  it('waits for the live daemon pidfile owner to become healthy before falling back', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-daemon-booting`);
+    tempDirs.push(root);
+    mkdirSync(join(root, '.frankenbeast'), { recursive: true });
+    writeFileSync(join(root, '.frankenbeast', 'beasts-daemon.pid'), `${process.pid}\n`);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json({ ok: false, service: 'beasts-daemon' }, { status: 503 }))
+      .mockResolvedValueOnce(Response.json({
+        ok: true,
+        service: 'beasts-daemon',
+        root,
+        pid: process.pid,
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+    mockParseArgs.mockReturnValue({
+      ...mockParseArgs(),
+      subcommand: 'chat-server',
+      baseDir: root,
+    });
+
+    await main();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mockCreateBeastServices).not.toHaveBeenCalled();
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      beastDaemon: expect.objectContaining({ baseUrl: 'http://127.0.0.1:4050' }),
+    }));
+  });
+
+  it('keeps local beast services when health belongs to a different checkout or pid', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-daemon-other-root`);
+    tempDirs.push(root);
+    mkdirSync(join(root, '.frankenbeast'), { recursive: true });
+    writeFileSync(join(root, '.frankenbeast', 'beasts-daemon.pid'), `${process.pid}\n`);
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({
+      ok: true,
+      service: 'beasts-daemon',
+      root: join(tmpdir(), 'other-checkout'),
+      pid: process.pid,
+    })));
+    mockParseArgs.mockReturnValue({
+      ...mockParseArgs(),
+      subcommand: 'chat-server',
+      baseDir: root,
+    });
+
+    await main();
+
+    expect(mockCreateBeastServices).toHaveBeenCalledWith(expect.objectContaining({ root }));
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      beastControl: expect.objectContaining({ operatorToken: 'dashboard-operator-token' }),
     }));
     expect(mockStartChatServer).toHaveBeenCalledWith(expect.not.objectContaining({
       beastDaemon: expect.anything(),


### PR DESCRIPTION
## Summary
- detect a live local beasts-daemon pidfile during manual chat-server startup and proxy Beast control routes instead of creating a second in-process supervisor
- keep explicit FRANKENBEAST_BEAST_DAEMON_URL precedence for non-default daemon ports
- document the manual two-process startup behavior

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace franken-orchestrator -- tests/unit/cli/run.test.ts
- npm run build
- npm run typecheck --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator
- git diff --check

Closes #752