### PR TITLE
fix(mcp-suite): guide standalone beast handoff installs

### DIFF
--- a/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
@@ -133,4 +133,19 @@ describe('runBeastMode', () => {
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(raw.mode).toBe('beast');
   });
+
+  it('prints standalone install guidance when the frankenbeast handoff binary is missing', async () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const deps = makeDeps(root, { exec: vi.fn().mockRejectedValue(new Error('frankenbeast: binary not found')) });
+    const mockLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await runBeastMode([], deps);
+
+    const message = mockLog.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(message).toContain('npm install -g franken-orchestrator');
+    expect(message).toContain('frankenbeast beasts catalog');
+    expect(message).not.toContain('npm link --workspace=franken-orchestrator');
+    mockLog.mockRestore();
+  });
 });

--- a/packages/franken-mcp-suite/src/cli/beast-mode.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { FbeastConfig } from '../shared/config.js';
 
+const FRANKENBEAST_INSTALL_COMMAND = 'npm install -g franken-orchestrator';
+
 export interface BeastModeDeps {
   root: string;
   confirm(message: string): Promise<boolean>;
@@ -38,7 +40,7 @@ export async function runBeastMode(argv: string[], deps: BeastModeDeps): Promise
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('binary not found') || msg.includes('ENOENT')) {
       console.log('\nTo launch the orchestrator, install the frankenbeast CLI:');
-      console.log('  npm link --workspace=franken-orchestrator');
+      console.log(`  ${FRANKENBEAST_INSTALL_COMMAND}`);
       console.log('  frankenbeast beasts catalog');
     } else {
       throw err;

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
 
 const originalArgv = process.argv;
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = join(tmpdir(), `fbeast-main-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  tmpDirs.push(dir);
+  return dir;
+}
 
 describe('fbeast main CLI', () => {
   afterEach(() => {
@@ -9,6 +21,9 @@ describe('fbeast main CLI', () => {
     vi.resetModules();
     vi.doUnmock('./init.js');
     vi.doUnmock('./uninstall.js');
+    for (const dir of tmpDirs.splice(0)) {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('passes explicit uninstall client into uninstall execution', async () => {
@@ -160,6 +175,31 @@ describe('fbeast main CLI', () => {
     expect(mockExit).toHaveBeenCalledWith(1);
     mockError.mockRestore();
     mockExit.mockRestore();
+  });
+
+  it('maps Windows mcp beast handoff exit status to standalone install help', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir());
+    const mockSpawnSync = vi.fn().mockReturnValue({ status: 1, signal: null, error: undefined });
+    vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
+
+    process.argv = ['node', 'fbeast', 'mcp', 'beast'];
+
+    const mockLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await import('./main.js');
+
+    const message = mockLog.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'frankenbeast',
+      ['beasts', 'catalog'],
+      expect.objectContaining({ stdio: 'inherit', shell: true }),
+    );
+    expect(message).toContain('npm install -g franken-orchestrator');
+    expect(message).not.toContain('npm link --workspace=franken-orchestrator');
+    mockLog.mockRestore();
+    cwdSpy.mockRestore();
+    platformSpy.mockRestore();
   });
 
   it('propagates signal termination from passthrough commands', async () => {

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -177,10 +177,16 @@ describe('fbeast main CLI', () => {
     mockExit.mockRestore();
   });
 
-  it('maps Windows mcp beast handoff exit status to standalone install help', async () => {
+  it('maps Windows missing mcp beast handoff binary output to standalone install help', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir());
-    const mockSpawnSync = vi.fn().mockReturnValue({ status: 1, signal: null, error: undefined });
+    const mockSpawnSync = vi.fn().mockReturnValue({
+      status: 1,
+      signal: null,
+      error: undefined,
+      stdout: '',
+      stderr: "'frankenbeast' is not recognized as an internal or external command",
+    });
     vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
 
     process.argv = ['node', 'fbeast', 'mcp', 'beast'];
@@ -193,11 +199,30 @@ describe('fbeast main CLI', () => {
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'frankenbeast',
       ['beasts', 'catalog'],
-      expect.objectContaining({ stdio: 'inherit', shell: true }),
+      expect.objectContaining({ stdio: 'pipe', shell: true, encoding: 'utf8' }),
     );
     expect(message).toContain('npm install -g franken-orchestrator');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');
     mockLog.mockRestore();
+    cwdSpy.mockRestore();
+    platformSpy.mockRestore();
+  });
+
+  it('preserves real Windows mcp beast handoff failures', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir());
+    const mockSpawnSync = vi.fn().mockReturnValue({
+      status: 1,
+      signal: null,
+      error: undefined,
+      stdout: '',
+      stderr: 'catalog configuration failed',
+    });
+    vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
+
+    process.argv = ['node', 'fbeast', 'mcp', 'beast'];
+
+    await expect(import('./main.js')).rejects.toThrow('frankenbeast exited with 1');
     cwdSpy.mockRestore();
     platformSpy.mockRestore();
   });

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -98,7 +98,14 @@ switch (subcommand) {
         });
       },
       exec: async (cmd, args) => {
-        const result = spawn(cmd, args, { stdio: 'inherit', shell: process.platform === 'win32' });
+        const isWindows = process.platform === 'win32';
+        const result = spawn(
+          cmd,
+          args,
+          isWindows
+            ? { stdio: 'pipe', shell: true, encoding: 'utf8' }
+            : { stdio: 'inherit', shell: false },
+        );
         if (result.error) {
           const isNotFound = (result.error as NodeJS.ErrnoException).code === 'ENOENT';
           throw new Error(
@@ -108,15 +115,27 @@ switch (subcommand) {
           );
         }
         if (result.status !== 0) {
-          if (process.platform === 'win32' && result.status === 1) {
+          const stdout = result.stdout ? String(result.stdout) : '';
+          const stderr = result.stderr ? String(result.stderr) : '';
+          const shellOutput = `${stdout}\n${stderr}`.toLowerCase();
+          const isWindowsCommandNotFound =
+            isWindows &&
+            (shellOutput.includes('is not recognized') ||
+              shellOutput.includes('not recognized as an internal or external command') ||
+              shellOutput.includes('command not found'));
+          if (isWindowsCommandNotFound) {
             throw new Error(`${cmd}: binary not found — ${FRANKENBEAST_INSTALL_HELP}`);
           }
+          if (stdout) process.stdout.write(stdout);
+          if (stderr) process.stderr.write(stderr);
           throw new Error(
             result.signal
               ? `${cmd} killed by signal ${result.signal}`
               : `${cmd} exited with ${result.status}`,
           );
         }
+        if (result.stdout) process.stdout.write(String(result.stdout));
+        if (result.stderr) process.stderr.write(String(result.stderr));
       },
     });
     break;

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -6,6 +6,7 @@ import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient
 import { resolveInitOptions } from './init-options.js';
 
 const command = process.argv[2];
+const FRANKENBEAST_INSTALL_HELP = "install franken-orchestrator with 'npm install -g franken-orchestrator'";
 
 function resolveClient(): McpClient {
   const clientArg = parseMcpClient(process.argv.find((a) => a.startsWith('--client='))?.split('=')[1]);
@@ -27,7 +28,7 @@ function passthrough(): never {
   if (result.error) {
     const isNotFound = (result.error as NodeJS.ErrnoException).code === 'ENOENT';
     if (isNotFound) {
-      console.error("frankenbeast: binary not found — install franken-orchestrator or run 'npm link --workspace=franken-orchestrator'");
+      console.error(`frankenbeast: binary not found — ${FRANKENBEAST_INSTALL_HELP}`);
     } else {
       console.error(`frankenbeast: ${result.error.message}`);
     }
@@ -102,11 +103,14 @@ switch (subcommand) {
           const isNotFound = (result.error as NodeJS.ErrnoException).code === 'ENOENT';
           throw new Error(
             isNotFound
-              ? `${cmd}: binary not found — install franken-orchestrator or run 'npm link --workspace=franken-orchestrator'`
+              ? `${cmd}: binary not found — ${FRANKENBEAST_INSTALL_HELP}`
               : `${cmd} failed: ${result.error.message}`,
           );
         }
         if (result.status !== 0) {
+          if (process.platform === 'win32' && result.status === 1) {
+            throw new Error(`${cmd}: binary not found — ${FRANKENBEAST_INSTALL_HELP}`);
+          }
           throw new Error(
             result.signal
               ? `${cmd} killed by signal ${result.signal}`


### PR DESCRIPTION
## Summary
- Replace monorepo npm-link fallback text with standalone install guidance for the frankenbeast CLI handoff.
- Treat Windows shell exit status 1 during the mcp beast handoff as missing CLI install help instead of an opaque exit error.
- Add regression coverage for the beast handoff guidance and Windows status mapping.

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/cli/beast-mode.test.ts src/cli/main.test.ts
- npm run build
- npm --prefix packages/franken-mcp-suite run typecheck
- npm --prefix packages/franken-mcp-suite test
- git diff --check

Closes #749