### PR TITLE
fix(cli): surface non-interactive HITL remedy

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,8 @@ frankenbeast run
 
 With `local-encrypted` backend and `FRANKENBEAST_PASSPHRASE` set, the orchestrator decrypts the vault from `.fbeast/config.json` without prompting. If you run with `--config <path>`, keep that file in sync with the backend and token refs written by `frankenbeast init`.
 
+Required HITL approvals fail closed when a run has no interactive TTY. In trusted CI/headless automation that intentionally allows required HITL-gated skills, set `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`; otherwise rerun in an interactive TTY and approve the prompt.
+
 ### References
 
 - [ADR-018](docs/adr/018-secret-store-architecture.md) — secret store design and backend selection rationale

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -149,6 +149,11 @@ Options:
   --non-interactive       Disable interactive prompts for init
   --help                  Show this help message
 
+Non-interactive HITL:
+  Required HITL gates fail closed in non-TTY runs. In trusted CI/headless
+  automation, set FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1 to explicitly
+  allow those required approvals; otherwise rerun in an interactive TTY.
+
 Issue Flags (for 'issues' subcommand):
   --label <labels>        Comma-separated labels (e.g. critical,high)
   --milestone <name>      Filter by milestone

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -27,6 +27,8 @@ import {
   type Task as RecoveryTask,
 } from 'franken-planner';
 
+export const NON_INTERACTIVE_HITL_REMEDY = 'HITL approval was rejected by the non-interactive fail-closed default. To explicitly allow required HITL gates in trusted CI/headless runs, set FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1; otherwise rerun in an interactive TTY and approve the prompt.';
+
 export class HitlRejectedError extends Error {
   constructor(
     public readonly taskId: string,
@@ -35,6 +37,14 @@ export class HitlRejectedError extends Error {
     super(`Task ${taskId} rejected by governor: ${reason}`);
     this.name = 'HitlRejectedError';
   }
+}
+
+function describeApprovalRejection(reason: string | undefined): string {
+  if (reason === 'defaultDecision') {
+    return NON_INTERACTIVE_HITL_REMEDY;
+  }
+
+  return reason ?? 'Rejected';
 }
 
 /**
@@ -743,13 +753,14 @@ async function executeTask(
       ctx.governorApproval = approval.decision === 'approved';
 
       if (approval.decision === 'rejected' || approval.decision === 'abort') {
+        const reason = describeApprovalRejection(approval.reason);
         ctx.circuitBreakerTripped = true;
-        ctx.addAudit('governor', 'task:rejected', { taskId: task.id, reason: approval.reason });
+        ctx.addAudit('governor', 'task:rejected', { taskId: task.id, reason });
         logger.warn('Execution: task rejected', {
           taskId: task.id,
-          reason: approval.reason,
+          reason,
         });
-        return { taskId: task.id, status: 'skipped', error: approval.reason ?? 'Rejected' };
+        return { taskId: task.id, status: 'skipped', error: reason };
       }
     }
 

--- a/packages/franken-orchestrator/tests/unit/cli/args-usage.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args-usage.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { printUsage } from '../../../src/cli/args.js';
+
+describe('CLI usage text', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('documents the non-interactive approval escape hatch', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printUsage();
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1'));
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -115,6 +115,38 @@ describe('runExecution', () => {
     expect(c.circuitBreakerTripped).toBe(true);
   });
 
+  it('surfaces the non-interactive approval escape hatch when a HITL task is rejected', async () => {
+    const logger = makeLogger();
+    const skills = makeSkills({
+      getAvailableSkills: vi.fn(() => [
+        { id: 'deploy', name: 'Deploy', requiresHitl: true },
+      ]),
+    });
+    const governor = makeGovernor({
+      requestApproval: vi.fn(async () => ({
+        decision: 'rejected' as const,
+        reason: 'defaultDecision',
+      })),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'deploy', requiredSkills: ['deploy'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, governor, makeMemory(), makeObserver(), undefined, logger);
+
+    expect(outcomes[0]).toEqual(expect.objectContaining({
+      status: 'skipped',
+      error: expect.stringContaining('FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1'),
+    }));
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Execution: task rejected',
+      expect.objectContaining({
+        taskId: 't1',
+        reason: expect.stringContaining('FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1'),
+      }),
+    );
+  });
+
   it('tracks retry count and checkpoint path for execution recovery', async () => {
     const c = ctx([
       { id: 't1', objective: 'first', requiredSkills: [], dependsOn: [] },


### PR DESCRIPTION
## Summary
- Add an inline remedy when a required HITL task is skipped by the non-interactive fail-closed default
- Document FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1 in CLI help and README CI guidance
- Add regression coverage for skipped HITL task output and help text

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace franken-planner
- npm run build --workspace franken-brain
- npm run build --workspace @frankenbeast/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace franken-orchestrator -- --run tests/unit/phases/execution.test.ts tests/unit/cli/args-usage.test.ts
- npm run typecheck --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator
- npm run build --workspace franken-orchestrator
- npm run test --workspace franken-orchestrator

Closes #748