### PR TITLE
fix(cli): guide run users when no plan exists

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -112,9 +112,16 @@ export function defaultRunPlanNeedsGuidance(planDir: string): boolean {
   try {
     const stats = statSync(planDir);
     if (!stats.isDirectory()) return false;
-    return readdirSync(planDir).length === 0;
-  } catch {
-    return true;
+    return !readdirSync(planDir).some((entry) => (
+      entry.endsWith('.md') &&
+      !entry.startsWith('00_') &&
+      /^\d{2}/.test(entry)
+    ));
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return true;
+    }
+    throw err;
   }
 }
 
@@ -122,7 +129,7 @@ export function formatMissingRunPlanGuidance(
   planDir: string,
 ): string {
   const planName = basename(planDir);
-  return 'No default run plan directory found under ' + planDir + '. '
+  return 'No runnable default run plan chunks found under ' + planDir + '. '
     + `Create it with \`frankenbeast plan --design-doc <file> --plan-name ${planName}\`, `
     + 'or run `frankenbeast interview` first and then plan the generated design before running.';
 }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -108,18 +108,38 @@ export function resolvePhases(args: Partial<Pick<CliArgs, 'subcommand' | 'design
   return { entryPhase: 'interview' };
 }
 
-export function formatMissingRunPlanGuidance(planDir: string): string {
-  return 'No plan found under ' + planDir + '. '
-    + 'Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.';
+export function hasRunnablePlanChunks(planDir: string): boolean {
+  try {
+    return readdirSync(planDir).some((entry) => (
+      entry.endsWith('.md')
+        && !entry.startsWith('00_')
+        && /^\d{2}/.test(entry)
+    ));
+  } catch {
+    return false;
+  }
+}
+
+export function formatMissingRunPlanGuidance(
+  planDir: string,
+  options: { planName?: string | undefined; planDirOverride?: string | undefined } = {},
+): string {
+  const planCommand = options.planName
+    ? `frankenbeast plan --design-doc <file> --plan-name ${options.planName}`
+    : 'frankenbeast plan --design-doc <file>';
+  const customPlanDirHint = options.planDirOverride
+    ? ' If you intended to use this custom chunk directory, generate or copy numbered chunk files into it before rerunning.'
+    : '';
+  return 'No runnable plan chunks found under ' + planDir + '. '
+    + `Run \`frankenbeast interview\` or \`${planCommand}\` first.`
+    + customPlanDirHint;
 }
 
 export function shouldShowMissingRunPlanGuidance(
-  args: Partial<Pick<CliArgs, 'subcommand'>>,
-  result: { status?: string; taskResults?: readonly unknown[] | undefined } | undefined,
+  args: Partial<Pick<CliArgs, 'subcommand' | 'resume'>>,
+  hasChunks: boolean,
 ): boolean {
-  return args.subcommand === 'run'
-    && result?.status === 'no-op'
-    && (result.taskResults?.length ?? 0) === 0;
+  return args.subcommand === 'run' && !args.resume && !hasChunks;
 }
 
 export interface ResumeTarget {
@@ -959,6 +979,14 @@ export async function main(): Promise<void> {
   const provider = resolveSelectedProvider(args, config);
   const runConfig = loadRunConfigFromEnv();
   const preflightProvider = resolveEffectivePreflightProvider(provider, runConfig);
+  const runPlanDir = planDirOverride ?? paths.plansDir;
+  if (shouldShowMissingRunPlanGuidance(args, hasRunnablePlanChunks(runPlanDir))) {
+    console.log(formatMissingRunPlanGuidance(runPlanDir, {
+      planName: args.planName,
+      planDirOverride,
+    }));
+    return;
+  }
   assertAnyProviderCliAvailable(
     preflightProvider,
     args.providers ?? config.providers.fallbackChain,
@@ -1011,10 +1039,6 @@ export async function main(): Promise<void> {
   }
 
   const result = await session.start();
-
-  if (shouldShowMissingRunPlanGuidance(args, result)) {
-    console.log(formatMissingRunPlanGuidance(planDirOverride ?? paths.plansDir));
-  }
 
   // `no-op` is a benign terminal status (empty or intentionally-skipped plan),
   // so it must exit successfully alongside `completed` — otherwise CI/scripts

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -108,13 +108,9 @@ export function resolvePhases(args: Partial<Pick<CliArgs, 'subcommand' | 'design
   return { entryPhase: 'interview' };
 }
 
-export function hasRunnablePlanChunks(planDir: string): boolean {
+export function planDirectoryExists(planDir: string): boolean {
   try {
-    return readdirSync(planDir).some((entry) => (
-      entry.endsWith('.md')
-        && !entry.startsWith('00_')
-        && /^\d{2}/.test(entry)
-    ));
+    return statSync(planDir).isDirectory();
   } catch {
     return false;
   }
@@ -122,24 +118,22 @@ export function hasRunnablePlanChunks(planDir: string): boolean {
 
 export function formatMissingRunPlanGuidance(
   planDir: string,
-  options: { planName?: string | undefined; planDirOverride?: string | undefined } = {},
 ): string {
-  const planCommand = options.planName
-    ? `frankenbeast plan --design-doc <file> --plan-name ${options.planName}`
-    : 'frankenbeast plan --design-doc <file>';
-  const customPlanDirHint = options.planDirOverride
-    ? ' If you intended to use this custom chunk directory, generate or copy numbered chunk files into it before rerunning.'
-    : '';
-  return 'No runnable plan chunks found under ' + planDir + '. '
-    + `Run \`frankenbeast interview\` or \`${planCommand}\` first.`
-    + customPlanDirHint;
+  const planName = basename(planDir);
+  return 'No default run plan directory found under ' + planDir + '. '
+    + `Create it with \`frankenbeast plan --design-doc <file> --plan-name ${planName}\`, `
+    + 'or run `frankenbeast interview` first and then plan the generated design before running.';
 }
 
 export function shouldShowMissingRunPlanGuidance(
-  args: Partial<Pick<CliArgs, 'subcommand' | 'resume'>>,
-  hasChunks: boolean,
+  args: Partial<Pick<CliArgs, 'subcommand' | 'resume' | 'planDir' | 'planName'>>,
+  planDirExists: boolean,
 ): boolean {
-  return args.subcommand === 'run' && !args.resume && !hasChunks;
+  return args.subcommand === 'run'
+    && !args.resume
+    && !args.planDir
+    && !args.planName
+    && !planDirExists;
 }
 
 export interface ResumeTarget {
@@ -980,11 +974,8 @@ export async function main(): Promise<void> {
   const runConfig = loadRunConfigFromEnv();
   const preflightProvider = resolveEffectivePreflightProvider(provider, runConfig);
   const runPlanDir = planDirOverride ?? paths.plansDir;
-  if (shouldShowMissingRunPlanGuidance(args, hasRunnablePlanChunks(runPlanDir))) {
-    console.log(formatMissingRunPlanGuidance(runPlanDir, {
-      planName: args.planName,
-      planDirOverride,
-    }));
+  if (shouldShowMissingRunPlanGuidance(args, planDirectoryExists(runPlanDir))) {
+    console.log(formatMissingRunPlanGuidance(runPlanDir));
     return;
   }
   assertAnyProviderCliAvailable(

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -108,11 +108,13 @@ export function resolvePhases(args: Partial<Pick<CliArgs, 'subcommand' | 'design
   return { entryPhase: 'interview' };
 }
 
-export function planDirectoryExists(planDir: string): boolean {
+export function defaultRunPlanNeedsGuidance(planDir: string): boolean {
   try {
-    return statSync(planDir).isDirectory();
+    const stats = statSync(planDir);
+    if (!stats.isDirectory()) return false;
+    return readdirSync(planDir).length === 0;
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -127,13 +129,13 @@ export function formatMissingRunPlanGuidance(
 
 export function shouldShowMissingRunPlanGuidance(
   args: Partial<Pick<CliArgs, 'subcommand' | 'resume' | 'planDir' | 'planName'>>,
-  planDirExists: boolean,
+  planNeedsGuidance: boolean,
 ): boolean {
   return args.subcommand === 'run'
     && !args.resume
     && !args.planDir
     && !args.planName
-    && !planDirExists;
+    && planNeedsGuidance;
 }
 
 export interface ResumeTarget {
@@ -706,6 +708,8 @@ export async function main(): Promise<void> {
       : (resumeTarget?.planName ?? generatePlanName(args.designDoc))));
   const paths = getProjectPaths(root, planName);
   const config = await resolveConfig(args, paths.configFile);
+  const runPlanDir = planDirOverride ?? paths.plansDir;
+  const runPlanNeedsGuidance = defaultRunPlanNeedsGuidance(runPlanDir);
 
   const logger = new BeastLogger({ verbose: args.verbose });
   if (args.config) {
@@ -720,6 +724,11 @@ export async function main(): Promise<void> {
 
   if (resumeTarget) {
     logger.info(`Resuming ${resumeTarget.planName} from ${resumeTarget.checkpointFile}`, 'session');
+  }
+
+  if (shouldShowMissingRunPlanGuidance(args, runPlanNeedsGuidance)) {
+    console.log(formatMissingRunPlanGuidance(runPlanDir));
+    return;
   }
 
   scaffoldFrankenbeast(paths);
@@ -973,11 +982,6 @@ export async function main(): Promise<void> {
   const provider = resolveSelectedProvider(args, config);
   const runConfig = loadRunConfigFromEnv();
   const preflightProvider = resolveEffectivePreflightProvider(provider, runConfig);
-  const runPlanDir = planDirOverride ?? paths.plansDir;
-  if (shouldShowMissingRunPlanGuidance(args, planDirectoryExists(runPlanDir))) {
-    console.log(formatMissingRunPlanGuidance(runPlanDir));
-    return;
-  }
   assertAnyProviderCliAvailable(
     preflightProvider,
     args.providers ?? config.providers.fallbackChain,

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -108,6 +108,20 @@ export function resolvePhases(args: Partial<Pick<CliArgs, 'subcommand' | 'design
   return { entryPhase: 'interview' };
 }
 
+export function formatMissingRunPlanGuidance(planDir: string): string {
+  return 'No plan found under ' + planDir + '. '
+    + 'Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.';
+}
+
+export function shouldShowMissingRunPlanGuidance(
+  args: Partial<Pick<CliArgs, 'subcommand'>>,
+  result: { status?: string; taskResults?: readonly unknown[] | undefined } | undefined,
+): boolean {
+  return args.subcommand === 'run'
+    && result?.status === 'no-op'
+    && (result.taskResults?.length ?? 0) === 0;
+}
+
 export interface ResumeTarget {
   planName: string;
   checkpointFile: string;
@@ -997,6 +1011,10 @@ export async function main(): Promise<void> {
   }
 
   const result = await session.start();
+
+  if (shouldShowMissingRunPlanGuidance(args, result)) {
+    console.log(formatMissingRunPlanGuidance(planDirOverride ?? paths.plansDir));
+  }
 
   // `no-op` is a benign terminal status (empty or intentionally-skipped plan),
   // so it must exit successfully alongside `completed` — otherwise CI/scripts

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -301,7 +301,7 @@ describe('resolvePhases', () => {
 describe('missing run plan guidance', () => {
   it('formats an actionable first-run message for an empty plan directory', () => {
     expect(formatMissingRunPlanGuidance('/project/.fbeast/plans/plan-2026-03-08')).toBe(
-      'No default run plan directory found under /project/.fbeast/plans/plan-2026-03-08. Create it with `frankenbeast plan --design-doc <file> --plan-name plan-2026-03-08`, or run `frankenbeast interview` first and then plan the generated design before running.',
+      'No runnable default run plan chunks found under /project/.fbeast/plans/plan-2026-03-08. Create it with `frankenbeast plan --design-doc <file> --plan-name plan-2026-03-08`, or run `frankenbeast interview` first and then plan the generated design before running.',
     );
   });
 
@@ -313,6 +313,12 @@ describe('missing run plan guidance', () => {
     expect(defaultRunPlanNeedsGuidance(root)).toBe(true);
 
     writeFileSync(join(root, '00_PLAN.md'), '# plan metadata');
+    expect(defaultRunPlanNeedsGuidance(root)).toBe(true);
+
+    writeFileSync(join(root, 'design.md'), '# design');
+    expect(defaultRunPlanNeedsGuidance(root)).toBe(true);
+
+    writeFileSync(join(root, '01_IMPLEMENT.md'), '# implementation chunk');
     expect(defaultRunPlanNeedsGuidance(root)).toBe(false);
 
     rmSync(root, { recursive: true, force: true });
@@ -870,7 +876,7 @@ describe('main() execution', () => {
     await main();
 
     expect(logSpy).toHaveBeenCalledWith(
-      'No default run plan directory found under /mock/project/.fbeast/plans/plan-2026-03-08. Create it with `frankenbeast plan --design-doc <file> --plan-name plan-2026-03-08`, or run `frankenbeast interview` first and then plan the generated design before running.',
+      'No runnable default run plan chunks found under /mock/project/.fbeast/plans/plan-2026-03-08. Create it with `frankenbeast plan --design-doc <file> --plan-name plan-2026-03-08`, or run `frankenbeast interview` first and then plan the generated design before running.',
     );
     expect(MockSession).not.toHaveBeenCalled();
     expect(mockSessionStart).not.toHaveBeenCalled();

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, hasRunnablePlanChunks } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, planDirectoryExists } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -301,32 +301,22 @@ describe('resolvePhases', () => {
 describe('missing run plan guidance', () => {
   it('formats an actionable first-run message for an empty plan directory', () => {
     expect(formatMissingRunPlanGuidance('/project/.fbeast/plans/plan-2026-03-08')).toBe(
-      'No runnable plan chunks found under /project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
+      'No default run plan directory found under /project/.fbeast/plans/plan-2026-03-08. Create it with `frankenbeast plan --design-doc <file> --plan-name plan-2026-03-08`, or run `frankenbeast interview` first and then plan the generated design before running.',
     );
   });
 
-  it('preserves selected plan context in the remedy', () => {
-    expect(formatMissingRunPlanGuidance('/project/custom-chunks', {
-      planName: 'release-fix',
-      planDirOverride: '/project/custom-chunks',
-    })).toBe(
-      'No runnable plan chunks found under /project/custom-chunks. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file> --plan-name release-fix` first. If you intended to use this custom chunk directory, generate or copy numbered chunk files into it before rerunning.',
-    );
-  });
-
-  it('detects runnable chunks while ignoring plan metadata files', () => {
+  it('checks whether the selected plan directory exists', () => {
     const root = join(tmpdir(), `frankenbeast-empty-plan-${Date.now()}`);
+    expect(planDirectoryExists(root)).toBe(false);
+
     mkdirSync(root, { recursive: true });
     writeFileSync(join(root, '00_PLAN.md'), '# plan metadata');
-    expect(hasRunnablePlanChunks(root)).toBe(false);
-
-    writeFileSync(join(root, '01_IMPLEMENT.md'), '# implementation chunk');
-    expect(hasRunnablePlanChunks(root)).toBe(true);
+    expect(planDirectoryExists(root)).toBe(true);
 
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('shows guidance only for run when no runnable chunks exist', () => {
+  it('shows guidance only for default run when the plan directory is absent', () => {
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'run' },
       false,
@@ -344,6 +334,16 @@ describe('missing run plan guidance', () => {
 
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'run', resume: true },
+      false,
+    )).toBe(false);
+
+    expect(shouldShowMissingRunPlanGuidance(
+      { subcommand: 'run', planDir: '/typo/custom-dir' },
+      false,
+    )).toBe(false);
+
+    expect(shouldShowMissingRunPlanGuidance(
+      { subcommand: 'run', planName: 'existing-empty-plan' },
       false,
     )).toBe(false);
   });
@@ -868,7 +868,7 @@ describe('main() execution', () => {
     await main();
 
     expect(logSpy).toHaveBeenCalledWith(
-      'No runnable plan chunks found under /mock/project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
+      'No default run plan directory found under /mock/project/.fbeast/plans/plan-2026-03-08. Create it with `frankenbeast plan --design-doc <file> --plan-name plan-2026-03-08`, or run `frankenbeast interview` first and then plan the generated design before running.',
     );
     expect(MockSession).not.toHaveBeenCalled();
     expect(mockSessionStart).not.toHaveBeenCalled();

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -295,6 +295,36 @@ describe('resolvePhases', () => {
       designDoc: '/some/doc.md',
     });
     expect(result).toEqual({ entryPhase: 'execute' });
+  });
+});
+
+describe('missing run plan guidance', () => {
+  it('formats an actionable first-run message for an empty plan directory', () => {
+    expect(formatMissingRunPlanGuidance('/project/.fbeast/plans/plan-2026-03-08')).toBe(
+      'No plan found under /project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
+    );
+  });
+
+  it('shows guidance only for run no-ops with no task results', () => {
+    expect(shouldShowMissingRunPlanGuidance(
+      { subcommand: 'run' },
+      { status: 'no-op', taskResults: [] },
+    )).toBe(true);
+
+    expect(shouldShowMissingRunPlanGuidance(
+      { subcommand: 'run' },
+      { status: 'no-op', taskResults: [{ taskId: 'impl:01' }] },
+    )).toBe(false);
+
+    expect(shouldShowMissingRunPlanGuidance(
+      { subcommand: 'plan' },
+      { status: 'no-op', taskResults: [] },
+    )).toBe(false);
+
+    expect(shouldShowMissingRunPlanGuidance(
+      { subcommand: 'run' },
+      { status: 'completed', taskResults: [] },
+    )).toBe(false);
   });
 });
 
@@ -778,6 +808,49 @@ describe('main() execution', () => {
     await main();
     expect(MockSession).toHaveBeenCalled();
     expect(mockSessionStart).toHaveBeenCalled();
+  });
+
+  it('prints actionable guidance when run exits no-op before any plan chunks exist', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockParseArgs.mockReturnValue({
+      subcommand: 'run',
+      networkAction: undefined,
+      networkTarget: undefined,
+      networkDetached: false,
+      networkSet: undefined,
+      baseDir: '/mock/project',
+      baseBranch: undefined,
+      budget: 10,
+      provider: 'claude',
+      providerSpecified: false,
+      providers: undefined,
+      designDoc: undefined,
+      planDir: undefined,
+      planName: undefined,
+      config: undefined,
+      host: undefined,
+      port: undefined,
+      allowOrigin: undefined,
+      noPr: false,
+      verbose: false,
+      reset: false,
+      resume: false,
+      cleanup: false,
+      help: false,
+      initVerify: false,
+      initRepair: false,
+      initNonInteractive: false,
+      beastAction: undefined,
+      beastTarget: undefined,
+    });
+    mockSessionStart.mockResolvedValueOnce({ status: 'no-op', taskResults: [] });
+
+    await main();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'No plan found under /mock/project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
+    );
+    logSpy.mockRestore();
   });
 
   it('passes the run --resume flag into Session config', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, hasRunnablePlanChunks } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -301,29 +301,50 @@ describe('resolvePhases', () => {
 describe('missing run plan guidance', () => {
   it('formats an actionable first-run message for an empty plan directory', () => {
     expect(formatMissingRunPlanGuidance('/project/.fbeast/plans/plan-2026-03-08')).toBe(
-      'No plan found under /project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
+      'No runnable plan chunks found under /project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
     );
   });
 
-  it('shows guidance only for run no-ops with no task results', () => {
+  it('preserves selected plan context in the remedy', () => {
+    expect(formatMissingRunPlanGuidance('/project/custom-chunks', {
+      planName: 'release-fix',
+      planDirOverride: '/project/custom-chunks',
+    })).toBe(
+      'No runnable plan chunks found under /project/custom-chunks. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file> --plan-name release-fix` first. If you intended to use this custom chunk directory, generate or copy numbered chunk files into it before rerunning.',
+    );
+  });
+
+  it('detects runnable chunks while ignoring plan metadata files', () => {
+    const root = join(tmpdir(), `frankenbeast-empty-plan-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, '00_PLAN.md'), '# plan metadata');
+    expect(hasRunnablePlanChunks(root)).toBe(false);
+
+    writeFileSync(join(root, '01_IMPLEMENT.md'), '# implementation chunk');
+    expect(hasRunnablePlanChunks(root)).toBe(true);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('shows guidance only for run when no runnable chunks exist', () => {
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'run' },
-      { status: 'no-op', taskResults: [] },
+      false,
     )).toBe(true);
 
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'run' },
-      { status: 'no-op', taskResults: [{ taskId: 'impl:01' }] },
+      true,
     )).toBe(false);
 
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'plan' },
-      { status: 'no-op', taskResults: [] },
+      false,
     )).toBe(false);
 
     expect(shouldShowMissingRunPlanGuidance(
-      { subcommand: 'run' },
-      { status: 'completed', taskResults: [] },
+      { subcommand: 'run', resume: true },
+      false,
     )).toBe(false);
   });
 });
@@ -810,7 +831,7 @@ describe('main() execution', () => {
     expect(mockSessionStart).toHaveBeenCalled();
   });
 
-  it('prints actionable guidance when run exits no-op before any plan chunks exist', async () => {
+  it('prints actionable guidance before provider preflight when no plan chunks exist', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockParseArgs.mockReturnValue({
       subcommand: 'run',
@@ -843,13 +864,14 @@ describe('main() execution', () => {
       beastAction: undefined,
       beastTarget: undefined,
     });
-    mockSessionStart.mockResolvedValueOnce({ status: 'no-op', taskResults: [] });
 
     await main();
 
     expect(logSpy).toHaveBeenCalledWith(
-      'No plan found under /mock/project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
+      'No runnable plan chunks found under /mock/project/.fbeast/plans/plan-2026-03-08. Run `frankenbeast interview` or `frankenbeast plan --design-doc <file>` first.',
     );
+    expect(MockSession).not.toHaveBeenCalled();
+    expect(mockSessionStart).not.toHaveBeenCalled();
     logSpy.mockRestore();
   });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, planDirectoryExists } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -305,13 +305,15 @@ describe('missing run plan guidance', () => {
     );
   });
 
-  it('checks whether the selected plan directory exists', () => {
+  it('detects an absent or empty default run plan directory', () => {
     const root = join(tmpdir(), `frankenbeast-empty-plan-${Date.now()}`);
-    expect(planDirectoryExists(root)).toBe(false);
+    expect(defaultRunPlanNeedsGuidance(root)).toBe(true);
 
     mkdirSync(root, { recursive: true });
+    expect(defaultRunPlanNeedsGuidance(root)).toBe(true);
+
     writeFileSync(join(root, '00_PLAN.md'), '# plan metadata');
-    expect(planDirectoryExists(root)).toBe(true);
+    expect(defaultRunPlanNeedsGuidance(root)).toBe(false);
 
     rmSync(root, { recursive: true, force: true });
   });
@@ -319,12 +321,12 @@ describe('missing run plan guidance', () => {
   it('shows guidance only for default run when the plan directory is absent', () => {
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'run' },
-      false,
+      true,
     )).toBe(true);
 
     expect(shouldShowMissingRunPlanGuidance(
       { subcommand: 'run' },
-      true,
+      false,
     )).toBe(false);
 
     expect(shouldShowMissingRunPlanGuidance(


### PR DESCRIPTION
## Summary
- add actionable guidance when `frankenbeast run` returns a no-op before any plan chunks exist
- keep intentional/skipped no-op runs unchanged by only guiding empty task-result `run` invocations
- cover the formatter, gating helper, and `main()` wiring in CLI unit tests

## Test Plan
- npm test --workspace franken-orchestrator -- tests/unit/cli/run.test.ts
- npm run typecheck --workspace franken-orchestrator
- npm run build --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator (passes with existing warnings)
- git diff --check

Closes #747
