### PR TITLE
fix(observer): optimize trace summaries

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -210,6 +210,45 @@ describe('SQLiteAdapter', () => {
     })
   })
 
+  describe('listTraceSummaries()', () => {
+    it('returns trace summaries with span counts without parsing span payloads', async () => {
+      const trace = TraceContext.createTrace('summary goal')
+      const first = TraceContext.startSpan(trace, { name: 'first' })
+      SpanLifecycle.setMetadata(first, { expensive: 'payload' })
+      TraceContext.endSpan(first)
+      const second = TraceContext.startSpan(trace, { name: 'second' })
+      SpanLifecycle.addThoughtBlock(second, 'private reasoning')
+      TraceContext.endSpan(second)
+      TraceContext.endTrace(trace)
+      await adapter.flush(trace)
+
+      const raw = new Database(dbPath)
+      raw.prepare('UPDATE spans SET metadata = ?, thoughtBlocks = ? WHERE traceId = ?')
+        .run('not valid json', 'also not valid json', trace.id)
+      raw.close()
+
+      const summaries = await (adapter as SQLiteAdapter & {
+        listTraceSummaries: () => Promise<Array<{ id: string; goal: string; status: string; spanCount: number; startedAt: number }>>
+      }).listTraceSummaries()
+
+      expect(summaries).toEqual([
+        { id: trace.id, goal: 'summary goal', status: 'completed', spanCount: 2, startedAt: trace.startedAt },
+      ])
+    })
+
+    it('creates a composite index for trace detail span ordering', () => {
+      const raw = new Database(dbPath)
+      const indexes = raw.prepare("PRAGMA index_list('spans')").all() as Array<{ name: string }>
+      const columns = indexes.map(index => ({
+        name: index.name,
+        columns: (raw.prepare(`PRAGMA index_info('${index.name}')`).all() as Array<{ name: string }>).map(row => row.name),
+      }))
+      raw.close()
+
+      expect(columns).toContainEqual({ name: 'idx_spans_traceId_startedAt', columns: ['traceId', 'startedAt'] })
+    })
+  })
+
   describe('concurrent sequential writes', () => {
     it('handles 20 traces written in rapid succession without corruption', async () => {
       const traces = Array.from({ length: 20 }, (_, i) => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3'
 import type { Trace, Span } from '../../core/types.js'
-import type { ExportAdapter } from '../../export/ExportAdapter.js'
+import type { ExportAdapter, TraceSummary } from '../../export/ExportAdapter.js'
 import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 import {
   CREATE_TABLES,
@@ -9,6 +9,7 @@ import {
   SELECT_TRACE,
   SELECT_SPANS,
   SELECT_ALL_TRACE_IDS,
+  SELECT_TRACE_SUMMARIES,
 } from './schema.js'
 
 interface TraceRow {
@@ -31,6 +32,14 @@ interface SpanRow {
   errorMessage: string | null
   metadata: string
   thoughtBlocks: string
+}
+
+interface TraceSummaryRow {
+  id: string
+  goal: string
+  status: string
+  startedAt: number
+  spanCount: number
 }
 
 /**
@@ -130,6 +139,17 @@ export class SQLiteAdapter implements ExportAdapter {
   async listTraceIds(): Promise<string[]> {
     const rows = this.db.prepare(SELECT_ALL_TRACE_IDS).all() as { id: string }[]
     return rows.map(r => r.id)
+  }
+
+  async listTraceSummaries(): Promise<TraceSummary[]> {
+    const rows = this.db.prepare(SELECT_TRACE_SUMMARIES).all() as TraceSummaryRow[]
+    return rows.map(row => ({
+      id: row.id,
+      goal: row.goal,
+      status: row.status as Trace['status'],
+      spanCount: row.spanCount,
+      startedAt: row.startedAt,
+    }))
   }
 
   /** Release the DB connection. Call when shutting down. */

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -23,6 +23,7 @@ export const CREATE_TABLES = `
   ) STRICT;
 
   CREATE INDEX IF NOT EXISTS idx_spans_traceId ON spans(traceId);
+  CREATE INDEX IF NOT EXISTS idx_spans_traceId_startedAt ON spans(traceId, startedAt);
 `
 
 export const UPSERT_TRACE = `
@@ -54,3 +55,15 @@ export const UPSERT_SPAN = `
 export const SELECT_TRACE = `SELECT * FROM traces WHERE id = ?`
 export const SELECT_SPANS = `SELECT * FROM spans WHERE traceId = ? ORDER BY startedAt ASC`
 export const SELECT_ALL_TRACE_IDS = `SELECT id FROM traces ORDER BY startedAt ASC`
+export const SELECT_TRACE_SUMMARIES = `
+  SELECT
+    traces.id,
+    traces.goal,
+    traces.status,
+    traces.startedAt,
+    COUNT(spans.id) AS spanCount
+  FROM traces
+  LEFT JOIN spans ON spans.traceId = traces.id
+  GROUP BY traces.id
+  ORDER BY traces.startedAt ASC
+`

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -61,7 +61,7 @@ export const SELECT_TRACE_SUMMARIES = `
     traces.goal,
     traces.status,
     traces.startedAt,
-    COUNT(spans.id) AS spanCount
+    COUNT(spans.traceId) AS spanCount
   FROM traces
   LEFT JOIN spans ON spans.traceId = traces.id
   GROUP BY traces.id

--- a/packages/franken-observer/src/export/ExportAdapter.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.ts
@@ -1,6 +1,14 @@
 import type { Trace } from '../core/types.js'
 import { TraceContext } from '../core/TraceContext.js'
 
+export interface TraceSummary {
+  id: string
+  goal: string
+  status: Trace['status']
+  spanCount: number
+  startedAt: number
+}
+
 export function warnIfTraceHasActiveSpans(trace: Trace, destination = 'export'): void {
   const validation = TraceContext.validateTrace(trace)
   if (validation.ok) return
@@ -23,4 +31,10 @@ export interface ExportAdapter {
   queryByTraceId(traceId: string): Promise<Trace | null>
   /** List all stored trace ids. */
   listTraceIds(): Promise<string[]>
+  /**
+   * List lightweight trace summaries without hydrating child span payloads.
+   * Adapters that do not support this can omit it; callers should fall back to
+   * listTraceIds() + queryByTraceId().
+   */
+  listTraceSummaries?(): Promise<TraceSummary[]>
 }

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -37,7 +37,7 @@ export { WebhookNotifier } from './notify/WebhookNotifier.js'
 export { TraceServer } from './ui/TraceServer.js'
 export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
 
-export type { ExportAdapter } from './export/ExportAdapter.js'
+export type { ExportAdapter, TraceSummary } from './export/ExportAdapter.js'
 export type { MultiAdapterOptions } from './adapters/multi/MultiAdapter.js'
 export type { BatchAdapterOptions } from './adapters/batch/BatchAdapter.js'
 export type { SamplerStrategy, SamplingAdapterOptions, RateLimitedSamplerOptions } from './sampling/TraceSampler.js'

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -4,6 +4,7 @@ import { TraceServer } from './TraceServer.js'
 import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
 import { TraceContext } from '../core/TraceContext.js'
 import { SpanLifecycle } from '../core/SpanLifecycle.js'
+import type { ExportAdapter } from '../export/ExportAdapter.js'
 
 function makeTrace(goal: string) {
   const trace = TraceContext.createTrace(goal)
@@ -162,6 +163,38 @@ describe('TraceServer', () => {
       await adapter.flush(makeTrace('Goal B'))
       const { traces } = await fetch(server.url + '/api/traces').then(r => r.json()) as { traces: unknown[] }
       expect(traces).toHaveLength(2)
+    })
+
+    it('uses adapter-provided summaries without loading full traces when available', async () => {
+      await server.stop()
+      const summaryAdapter = {
+        flush: async () => {},
+        queryByTraceId: async () => { throw new Error('queryByTraceId should not be called for summaries') },
+        listTraceIds: async () => { throw new Error('listTraceIds should not be called when summaries are available') },
+        listTraceSummaries: async () => [{
+          id: 'trace-summary-only',
+          goal: 'summary path',
+          status: 'completed',
+          spanCount: 12,
+          startedAt: 12345,
+        }],
+      } satisfies ExportAdapter & {
+        listTraceSummaries: () => Promise<Array<{
+          id: string
+          goal: string
+          status: string
+          spanCount: number
+          startedAt: number
+        }>>
+      }
+
+      server = new TraceServer({ adapter: summaryAdapter, port: 0 })
+      await server.start()
+
+      const { traces } = await fetch(server.url + '/api/traces').then(r => r.json()) as { traces: unknown[] }
+      expect(traces).toEqual([
+        { id: 'trace-summary-only', goal: 'summary path', status: 'completed', spanCount: 12, startedAt: 12345 },
+      ])
     })
   })
 

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http'
 import type { IncomingMessage, ServerResponse, Server } from 'node:http'
-import type { ExportAdapter } from '../export/ExportAdapter.js'
+import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
 import type { Trace } from '../core/types.js'
 
 export interface TraceServerOptions {
@@ -78,15 +78,7 @@ export class TraceServer {
       }
 
       if (path === '/api/traces') {
-        const ids = await this.adapter.listTraceIds()
-        const all = await Promise.all(ids.map(id => this.adapter.queryByTraceId(id)))
-        const traces = (all.filter(Boolean) as Trace[]).map(t => ({
-          id: t.id,
-          goal: t.goal,
-          status: t.status,
-          spanCount: t.spans.length,
-          startedAt: t.startedAt,
-        }))
+        const traces = await this.listTraceSummaries()
         json(res, 200, { traces })
         return
       }
@@ -114,6 +106,22 @@ export class TraceServer {
     } catch (err) {
       json(res, 500, { error: 'internal server error' })
     }
+  }
+
+  private async listTraceSummaries(): Promise<TraceSummary[]> {
+    if (this.adapter.listTraceSummaries) {
+      return this.adapter.listTraceSummaries()
+    }
+
+    const ids = await this.adapter.listTraceIds()
+    const all = await Promise.all(ids.map(id => this.adapter.queryByTraceId(id)))
+    return (all.filter(Boolean) as Trace[]).map(t => ({
+      id: t.id,
+      goal: t.goal,
+      status: t.status,
+      spanCount: t.spans.length,
+      startedAt: t.startedAt,
+    }))
   }
 }
 


### PR DESCRIPTION
## Summary
- add a lightweight trace summary adapter path for GET /api/traces
- implement SQLite trace summaries with span counts without hydrating span metadata/thought blocks
- add a composite spans(traceId, startedAt) index for detail-view ordering

## Test Plan
- npm run typecheck --workspace @frankenbeast/observer
- npm run build --workspace @frankenbeast/observer
- npm test --workspace @frankenbeast/observer
- npm run test:integration --workspace @frankenbeast/observer

Closes #772