### PR TITLE
fix(governor): use deterministic signature payloads

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -432,18 +432,21 @@ interface EpisodicTraceRecord {
 Enable cryptographic verification of approval responses to prevent tampering:
 
 ```typescript
-import { SignatureVerifier } from '@franken/governor';
+import { formatApprovalResponseSignaturePayload, SignatureVerifier } from '@franken/governor';
 
 const secret = process.env.GOVERNOR_SIGNING_SECRET!;
 const verifier = new SignatureVerifier(secret);
 
-// Sign a payload
-const payload = JSON.stringify({ requestId: 'abc', decision: 'APPROVE' });
+// Sign the deterministic approval-response payload. Do not use JSON.stringify:
+// object key order can differ across runtimes and break verification.
+const payload = formatApprovalResponseSignaturePayload({ requestId: 'abc', decision: 'APPROVE' });
 const signature = verifier.sign(payload);
 
 // Verify (timing-safe comparison)
 const isValid = verifier.verify(payload, signature);
 ```
+
+The canonical signed approval-response payload is `requestId:<url-encoded-id>|decision:<url-encoded-decision>` (for example `requestId:abc|decision:APPROVE`). Custom approval UIs and non-TypeScript clients must sign those exact bytes rather than serialized JSON.
 
 To enable in the gateway:
 

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -1,7 +1,10 @@
 import type { ApprovalRequest, ApprovalResponse, ApprovalOutcome } from '../core/types.js';
 import type { GovernorConfig } from '../core/config.js';
 import type { ApprovalChannel } from './approval-channel.js';
-import { SignatureVerifier } from '../security/signature-verifier.js';
+import {
+  formatApprovalResponseSignaturePayload,
+  SignatureVerifier,
+} from '../security/signature-verifier.js';
 import type { SessionTokenStore } from '../security/session-token-store.js';
 import { createSessionToken } from '../security/session-token.js';
 import {
@@ -68,7 +71,7 @@ export class ApprovalGateway {
   }
 
   private verifySignature(response: ApprovalResponse): void {
-    const payload = JSON.stringify({
+    const payload = formatApprovalResponseSignaturePayload({
       requestId: response.requestId,
       decision: response.decision,
     });

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -58,7 +58,8 @@ export type { GovernorAppOptions } from './server/index.js';
 export type { GovernorMemoryPort, EpisodicTraceRecord } from './audit/index.js';
 export { GovernorAuditRecorder } from './audit/index.js';
 
-export { SignatureVerifier } from './security/index.js';
+export { formatApprovalResponseSignaturePayload, SignatureVerifier } from './security/index.js';
+export type { ApprovalResponseSignaturePayloadFields } from './security/index.js';
 export { createSessionToken, SessionTokenStore } from './security/index.js';
 export type { CreateSessionTokenParams } from './security/index.js';
 

--- a/packages/franken-governor/src/security/index.ts
+++ b/packages/franken-governor/src/security/index.ts
@@ -1,4 +1,8 @@
-export { SignatureVerifier } from './signature-verifier.js';
+export {
+  formatApprovalResponseSignaturePayload,
+  SignatureVerifier,
+} from './signature-verifier.js';
+export type { ApprovalResponseSignaturePayloadFields } from './signature-verifier.js';
 export { createSessionToken } from './session-token.js';
 export type { CreateSessionTokenParams } from './session-token.js';
 export { SessionTokenStore } from './session-token-store.js';

--- a/packages/franken-governor/src/security/signature-verifier.ts
+++ b/packages/franken-governor/src/security/signature-verifier.ts
@@ -1,5 +1,22 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+export interface ApprovalResponseSignaturePayloadFields {
+  readonly requestId: string;
+  readonly decision: string;
+}
+
+/**
+ * Canonical payload signed for governor approval responses.
+ *
+ * Keep this independent from object/JSON key ordering so clients implemented in
+ * other runtimes can produce the same bytes deterministically.
+ */
+export function formatApprovalResponseSignaturePayload(
+  fields: ApprovalResponseSignaturePayloadFields,
+): string {
+  return `requestId:${encodeURIComponent(fields.requestId)}|decision:${encodeURIComponent(fields.decision)}`;
+}
+
 export class SignatureVerifier {
   constructor(private readonly secret: string) {}
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -2,7 +2,10 @@ import { Hono } from 'hono';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { RESPONSE_CODES, type ResponseCode } from '../core/types.js';
 import { ApprovalWaiterRegistry } from '../gateway/approval-waiter-registry.js';
-import { SignatureVerifier } from '../security/signature-verifier.js';
+import {
+  formatApprovalResponseSignaturePayload,
+  SignatureVerifier,
+} from '../security/signature-verifier.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
 
@@ -80,7 +83,7 @@ function verifyGovernorSignature(
 /**
  * Produce a signature for a resolved `ApprovalResponse` matching the format
  * `ApprovalGateway.verifySignature` expects (HMAC-SHA256 hex digest of
- * `JSON.stringify({ requestId, decision })`, via `SignatureVerifier`).
+ * `requestId:<id>|decision:<decision>`, via `SignatureVerifier`).
  *
  * Without this, a caller awaiting the approval through `ApprovalGateway`
  * with `config.requireSignedApprovals: true` would always unblock only to
@@ -98,7 +101,7 @@ function signApprovalResponse(
   signingSecret: string,
 ): string {
   return new SignatureVerifier(signingSecret).sign(
-    JSON.stringify({ requestId, decision }),
+    formatApprovalResponseSignaturePayload({ requestId, decision }),
   );
 }
 

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -3,7 +3,10 @@ import { ApprovalGateway } from '../../../src/gateway/approval-gateway.js';
 import type { ApprovalChannel } from '../../../src/gateway/approval-channel.js';
 import type { ApprovalRequest, ApprovalResponse } from '../../../src/core/types.js';
 import { defaultConfig } from '../../../src/core/config.js';
-import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
+import {
+  formatApprovalResponseSignaturePayload,
+  SignatureVerifier,
+} from '../../../src/security/signature-verifier.js';
 import { SessionTokenStore } from '../../../src/security/session-token-store.js';
 import {
   SignatureVerificationError,
@@ -62,7 +65,10 @@ describe('ApprovalGateway — security integration', () => {
 
   it('passes when requireSignedApprovals is true and signature is valid', async () => {
     const verifier = new SignatureVerifier('secret');
-    const responsePayload = JSON.stringify({ requestId: 'req-001', decision: 'APPROVE' });
+    const responsePayload = formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+    });
     const validSig = verifier.sign(responsePayload);
     const channel = makeFakeChannel({ signature: validSig });
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
@@ -73,6 +79,27 @@ describe('ApprovalGateway — security integration', () => {
       signatureVerifier: verifier,
     });
 
+    const outcome = await gateway.requestApproval(makeRequest());
+    expect(outcome.decision).toBe('APPROVE');
+  });
+
+  it('uses a deterministic signature payload that is independent of JSON key order', async () => {
+    const verifier = new SignatureVerifier('secret');
+    const jsonPayloadWithDifferentOrder = JSON.stringify({ decision: 'APPROVE', requestId: 'req-001' });
+    const deterministicPayload = formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+    });
+    const channel = makeFakeChannel({ signature: verifier.sign(deterministicPayload) });
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+      signatureVerifier: verifier,
+    });
+
+    expect(jsonPayloadWithDifferentOrder).not.toBe(deterministicPayload);
     const outcome = await gateway.requestApproval(makeRequest());
     expect(outcome.decision).toBe('APPROVE');
   });
@@ -126,7 +153,10 @@ describe('ApprovalGateway — security integration', () => {
   it('constructs a verifier from config.signingSecret and accepts a valid signature', async () => {
     const signingSecret = 'secret-from-config';
     const verifier = new SignatureVerifier(signingSecret);
-    const validSig = verifier.sign(JSON.stringify({ requestId: 'req-001', decision: 'APPROVE' }));
+    const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+    }));
     const channel = makeFakeChannel({ signature: validSig });
     const wiredGateway = new ApprovalGateway({
       channel,
@@ -159,7 +189,7 @@ describe('ApprovalGateway — security integration', () => {
     // Attacker replays a genuinely-signed approval for request A against active request B.
     const verifier = new SignatureVerifier('secret');
     const signedForOther = verifier.sign(
-      JSON.stringify({ requestId: 'req-OTHER', decision: 'APPROVE' }),
+      formatApprovalResponseSignaturePayload({ requestId: 'req-OTHER', decision: 'APPROVE' }),
     );
     const channel = makeFakeChannel({ requestId: 'req-OTHER', signature: signedForOther });
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };

--- a/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
+++ b/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
+import {
+  formatApprovalResponseSignaturePayload,
+  SignatureVerifier,
+} from '../../../src/security/signature-verifier.js';
 
 describe('SignatureVerifier', () => {
   const secret = 'test-secret-key';
@@ -27,10 +30,15 @@ describe('SignatureVerifier', () => {
     expect(otherVerifier.verify('payload', sig)).toBe(false);
   });
 
-  it('sign + verify round-trip succeeds', () => {
-    const payload = JSON.stringify({ requestId: 'req-001', decision: 'APPROVE' });
+  it('sign + verify round-trip succeeds for approval response payloads', () => {
+    const payload = formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' });
     const sig = verifier.sign(payload);
     expect(verifier.verify(payload, sig)).toBe(true);
+  });
+
+  it('formats approval response payloads without relying on JSON key order', () => {
+    expect(formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' }))
+      .toBe('requestId:req-001|decision:APPROVE');
   });
 
   it('produces deterministic signatures for same input', () => {


### PR DESCRIPTION
## Summary
- Replace signed approval-response JSON payloads with deterministic delimited payloads: `requestId:<id>|decision:<decision>`
- Reuse the same formatter for gateway verification and server-side response signing
- Add regression coverage for JSON key-order-independent signature verification

## Test Plan
- `npm test -- --run tests/unit/gateway/approval-gateway-security.test.ts tests/unit/security/signature-verifier.test.ts`
- `npm test` in `packages/franken-governor`
- `npm run build --workspace @franken/types`
- `npm run typecheck` in `packages/franken-governor`
- `npm run build` in `packages/franken-governor`
- `npx turbo run test --filter=@franken/governor`
- `npm run lint:security`

Closes #689