### PR TITLE
docs(env): reconcile local environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,59 @@
 # Frankenbeast Local Development Environment
-# Copy to .env and fill in values
+# Copy to .env and fill in values. Keep secret values out of git.
 
-# ── LLM Provider ──
+# ── LLM Providers ──
+# Anthropic/OpenAI providers read these directly.
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
-# OLLAMA_BASE_URL=http://localhost:11434
+# Gemini accepts either Google AI Studio env var name.
+# GOOGLE_API_KEY=...
+# GEMINI_API_KEY=...
 
 # ── ChromaDB ──
 # Local docker-compose exposes Chroma over plain HTTP. Use a TLS-terminated endpoint in production.
 CHROMA_URL=http://localhost:8000
 
-# ── Observability ──
-# Local docker-compose exposes Tempo over plain HTTP. Use a TLS-terminated endpoint in production.
-TEMPO_ENDPOINT=http://localhost:4318
+# ── Grafana ──
+# Local docker-compose reads these when starting Grafana.
 GRAFANA_USER=admin
 GRAFANA_PASSWORD=admin
 
-# ── Orchestrator ──
+# ── Orchestrator runtime config ──
+# These map to OrchestratorConfig env overrides in packages/franken-orchestrator/src/cli/config-loader.ts.
 FRANKEN_MAX_TOTAL_TOKENS=100000
 FRANKEN_MAX_DURATION_MS=300000
 FRANKEN_MAX_CRITIQUE_ITERATIONS=3
-# Opt into debug/observability features explicitly for development.
 FRANKEN_ENABLE_HEARTBEAT=false
 FRANKEN_ENABLE_TRACING=false
+FRANKEN_ENABLE_REFLECTION=true
 FRANKEN_MIN_CRITIQUE_SCORE=0.7
+
+# ── Local encrypted secret store / headless runs ──
+# Required for local-encrypted secrets in non-interactive init/run/chat-server paths.
+# FRANKENBEAST_PASSPHRASE=replace-with-strong-passphrase
 
 # Shared local Beast operator token used by chat-server and dashboard Beast routes.
 # Preferred location for local development; package-local franken-web .env.local remains fallback-only.
 # FRANKENBEAST_BEAST_OPERATOR_TOKEN=replace-with-random-token
 
+# Optional: proxy chat-server Beast routes to an already-running Beast daemon.
+# Local plaintext loopback is allowed for development; use HTTPS for remote endpoints.
+# FRANKENBEAST_BEAST_DAEMON_URL=http://127.0.0.1:4050
+
+# Optional: load a run config file for `frankenbeast run`.
+# FRANKENBEAST_RUN_CONFIG=.fbeast/run-config.json
+
+# ── Safety/module escape hatches ──
+# Leave safety modules enabled unless you intentionally disable one for local debugging.
+# FRANKENBEAST_MODULE_MEMORY=true
+# FRANKENBEAST_MODULE_PLANNER=true
+# FRANKENBEAST_MODULE_CRITIQUE=true
+# FRANKENBEAST_MODULE_GOVERNOR=true
+# Unsafe: allow missing safety packages to fall back to stubs.
+# FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=0
+# Trusted CI/headless only: allow required HITL gates without an interactive TTY.
+# FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=0
+
+# ── Advanced local diagnostics ──
+# FRANKENBEAST_PLAIN_BANNER=0
+# FRANKENBEAST_NETWORK_MANAGED=0

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -52,4 +52,41 @@ describe('local setup scripts', () => {
     expect(compose).toContain('http://localhost:8000/api/v2/heartbeat');
     expect(compose).not.toContain('http://localhost:8000/api/v1/heartbeat');
   });
+
+  it('.env.example documents current local env vars without removed service knobs', () => {
+    const envExample = read('.env.example');
+
+    for (const required of [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'GOOGLE_API_KEY',
+      'GEMINI_API_KEY',
+      'CHROMA_URL',
+      'GRAFANA_USER',
+      'GRAFANA_PASSWORD',
+      'FRANKEN_MAX_TOTAL_TOKENS',
+      'FRANKEN_MAX_DURATION_MS',
+      'FRANKEN_MAX_CRITIQUE_ITERATIONS',
+      'FRANKEN_ENABLE_HEARTBEAT',
+      'FRANKEN_ENABLE_TRACING',
+      'FRANKEN_ENABLE_REFLECTION',
+      'FRANKEN_MIN_CRITIQUE_SCORE',
+      'FRANKENBEAST_PASSPHRASE',
+      'FRANKENBEAST_BEAST_OPERATOR_TOKEN',
+      'FRANKENBEAST_BEAST_DAEMON_URL',
+      'FRANKENBEAST_RUN_CONFIG',
+      'FRANKENBEAST_MODULE_MEMORY',
+      'FRANKENBEAST_MODULE_PLANNER',
+      'FRANKENBEAST_MODULE_CRITIQUE',
+      'FRANKENBEAST_MODULE_GOVERNOR',
+      'FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES',
+      'FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL',
+    ]) {
+      expect(envExample).toContain(required);
+    }
+
+    for (const removed of ['OLLAMA_BASE_URL', 'TEMPO_ENDPOINT', 'FIREWALL_PORT']) {
+      expect(envExample).not.toContain(removed);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Document Gemini API key env vars and local-encrypted passphrase/Beast daemon env vars in `.env.example`.
- Remove stale `.env.example` references to unsupported local OLLAMA/TEMPO/FIREWALL knobs.
- Add a root setup test to keep `.env.example` aligned with the current local env surface.

## Test Plan
- `npx vitest run tests/local-setup-scripts.test.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run build`
- `npm run lint:security`
- `npm test`

Closes #755