### PR TITLE
refactor(orchestrator): share analytics sqlite handle

### DIFF
--- a/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
+++ b/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
@@ -101,6 +101,13 @@ class SqliteAnalyticsService implements AnalyticsService {
     this.db = null;
   }
 
+  private getDb(): Database.Database | null {
+    if (!this.db && existsSync(this.options.dbPath)) {
+      this.db = new Database(this.options.dbPath, { readonly: true, fileMustExist: true });
+    }
+    return this.db;
+  }
+
   async getSummary(filters: AnalyticsFilters): Promise<AnalyticsSummary> {
     const events = this.filteredEvents(filters);
     const costRows = this.readCostRows().filter((row) => matchesFilters(costRowToEvent(row), filters));
@@ -223,22 +230,24 @@ class SqliteAnalyticsService implements AnalyticsService {
   }
 
   private readRows<T>(table: string, sql: string): T[] {
-    if (!this.db) {
+    const db = this.getDb();
+    if (!db) {
       return [];
     }
 
-    if (!hasTable(this.db, table)) {
+    if (!hasTable(db, table)) {
       return [];
     }
-    return this.db.prepare(sql).all() as T[];
+    return db.prepare(sql).all() as T[];
   }
 
   private hasColumn(table: string, column: string): boolean {
-    if (!this.db) {
+    const db = this.getDb();
+    if (!db) {
       return false;
     }
 
-    return hasColumn(this.db, table, column);
+    return hasColumn(db, table, column);
   }
 
   private readBeastEvents(): AnalyticsEvent[] {

--- a/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
+++ b/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
@@ -89,6 +89,7 @@ export function createSqliteAnalyticsService(options: SqliteAnalyticsServiceOpti
 
 class SqliteAnalyticsService implements AnalyticsService {
   private db: Database.Database | null;
+  private closed = false;
 
   constructor(private readonly options: SqliteAnalyticsServiceOptions) {
     this.db = existsSync(options.dbPath)
@@ -99,9 +100,13 @@ class SqliteAnalyticsService implements AnalyticsService {
   close(): void {
     this.db?.close();
     this.db = null;
+    this.closed = true;
   }
 
   private getDb(): Database.Database | null {
+    if (this.closed) {
+      return null;
+    }
     if (!this.db && existsSync(this.options.dbPath)) {
       this.db = new Database(this.options.dbPath, { readonly: true, fileMustExist: true });
     }

--- a/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
+++ b/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
@@ -88,7 +88,18 @@ export function createSqliteAnalyticsService(options: SqliteAnalyticsServiceOpti
 }
 
 class SqliteAnalyticsService implements AnalyticsService {
-  constructor(private readonly options: SqliteAnalyticsServiceOptions) {}
+  private db: Database.Database | null;
+
+  constructor(private readonly options: SqliteAnalyticsServiceOptions) {
+    this.db = existsSync(options.dbPath)
+      ? new Database(options.dbPath, { readonly: true, fileMustExist: true })
+      : null;
+  }
+
+  close(): void {
+    this.db?.close();
+    this.db = null;
+  }
 
   async getSummary(filters: AnalyticsFilters): Promise<AnalyticsSummary> {
     const events = this.filteredEvents(filters);
@@ -212,32 +223,22 @@ class SqliteAnalyticsService implements AnalyticsService {
   }
 
   private readRows<T>(table: string, sql: string): T[] {
-    if (!existsSync(this.options.dbPath)) {
+    if (!this.db) {
       return [];
     }
 
-    const db = new Database(this.options.dbPath, { readonly: true, fileMustExist: true });
-    try {
-      if (!hasTable(db, table)) {
-        return [];
-      }
-      return db.prepare(sql).all() as T[];
-    } finally {
-      db.close();
+    if (!hasTable(this.db, table)) {
+      return [];
     }
+    return this.db.prepare(sql).all() as T[];
   }
 
   private hasColumn(table: string, column: string): boolean {
-    if (!existsSync(this.options.dbPath)) {
+    if (!this.db) {
       return false;
     }
 
-    const db = new Database(this.options.dbPath, { readonly: true, fileMustExist: true });
-    try {
-      return hasColumn(db, table, column);
-    } finally {
-      db.close();
-    }
+    return hasColumn(this.db, table, column);
   }
 
   private readBeastEvents(): AnalyticsEvent[] {

--- a/packages/franken-orchestrator/src/analytics/types.ts
+++ b/packages/franken-orchestrator/src/analytics/types.ts
@@ -73,4 +73,5 @@ export interface AnalyticsService {
   listSessions(filters: AnalyticsFilters): Promise<AnalyticsSessionOption[]>;
   listEvents(request: AnalyticsPageRequest): Promise<AnalyticsEventPage>;
   getEvent(id: string): Promise<AnalyticsEvent | null>;
+  close?(): void;
 }

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -354,10 +354,10 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       await stopLiveBeastControlRuns(options.beastControl);
       options.beastControl?.ticketStore.destroy();
       options.disposeBeastControl?.();
-      options.analyticsDeps?.analytics.close?.();
       const closedServer = closeHttpServer(server);
       server.closeAllConnections();
       await closedServer;
+      options.analyticsDeps?.analytics.close?.();
     },
   };
 }

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -354,6 +354,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       await stopLiveBeastControlRuns(options.beastControl);
       options.beastControl?.ticketStore.destroy();
       options.disposeBeastControl?.();
+      options.analyticsDeps?.analytics.close?.();
       const closedServer = closeHttpServer(server);
       server.closeAllConnections();
       await closedServer;

--- a/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
@@ -193,6 +193,20 @@ describe('createSqliteAnalyticsService', () => {
     closeSpy.mockRestore();
   });
 
+  it('opens the shared SQLite handle when the database appears after service construction', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-analytics-'));
+    const dbPath = join(workDir, 'beast.db');
+    const service = createSqliteAnalyticsService({ dbPath });
+
+    await expect(service.listEvents({ timeWindow: 'all' })).resolves.toMatchObject({ total: 0 });
+
+    seedFbeastDb(dbPath);
+    const result = await service.listEvents({ timeWindow: 'all' });
+
+    expect(result.total).toBe(5);
+    service.close?.();
+  });
+
   it('sorts mixed SQLite and ISO event timestamps by chronological time', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-analytics-'));
     const dbPath = join(workDir, 'beast.db');

--- a/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
@@ -190,6 +190,8 @@ describe('createSqliteAnalyticsService', () => {
     service.close?.();
 
     expect(closeSpy).toHaveBeenCalledTimes(1);
+    await expect(service.listEvents({ timeWindow: 'all' })).resolves.toMatchObject({ total: 0 });
+    expect(closeSpy).toHaveBeenCalledTimes(1);
     closeSpy.mockRestore();
   });
 

--- a/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
@@ -175,6 +175,24 @@ describe('createSqliteAnalyticsService', () => {
     expect(detail?.raw).toMatchObject({ verdict: 'flagged' });
   });
 
+  it('reuses one SQLite handle across a dashboard event read and closes it on service shutdown', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-analytics-'));
+    const dbPath = join(workDir, 'beast.db');
+    seedFbeastDb(dbPath);
+    const closeSpy = vi.spyOn(Database.prototype, 'close');
+
+    const service = createSqliteAnalyticsService({ dbPath });
+    const result = await service.listEvents({ timeWindow: 'all' });
+
+    expect(result.total).toBe(5);
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    service.close?.();
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    closeSpy.mockRestore();
+  });
+
   it('sorts mixed SQLite and ISO event timestamps by chronological time', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-analytics-'));
     const dbPath = join(workDir, 'beast.db');

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -64,6 +64,31 @@ describe('startChatServer comms pass-through', () => {
     expect(opts).toHaveProperty('commsRuntime', commsRuntime);
   });
 
+  it('closes analytics dependencies when the chat server shuts down', async () => {
+    const analyticsClose = vi.fn();
+    handle = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir: '/tmp/chat-server-analytics-test',
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      analyticsDeps: {
+        analytics: {
+          getSummary: vi.fn(),
+          listSessions: vi.fn(),
+          listEvents: vi.fn(),
+          getEvent: vi.fn(),
+          close: analyticsClose,
+        },
+      },
+    });
+
+    await handle.close();
+    handle = undefined;
+
+    expect(analyticsClose).toHaveBeenCalledOnce();
+  });
+
   it('passes network security config to createChatApp so comms can read webhook policy', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chat-server-security-config-'));
     tempDirs.push(dir);


### PR DESCRIPTION
## Summary
- Open the SQLite analytics database once for the analytics service lifecycle instead of per table query.
- Add an optional analytics service close hook and invoke it during chat-server shutdown.
- Cover handle reuse and shutdown disposal with targeted unit tests.

## Test Plan
- npm exec -- vitest run tests/unit/analytics/analytics-service.test.ts tests/unit/http/chat-server-comms.test.ts (from packages/franken-orchestrator)
- npm run typecheck --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator
- npm run build --workspace franken-orchestrator

Closes #681
