### PR TITLE
test: replace secret-looking fixture literals

### DIFF
--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -49,10 +49,12 @@ function makeFakeAuditRecorder() {
 }
 
 describe('ApprovalGateway — security integration', () => {
+  const signingFixture = ['test', 'signing', 'fixture'].join('-')
+
   it('throws SignatureVerificationError when requireSignedApprovals is true and signature is invalid', async () => {
-    const verifier = new SignatureVerifier('secret');
+    const verifier = new SignatureVerifier(signingFixture);
     const channel = makeFakeChannel({ signature: 'invalid-sig' });
-    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
     const gateway = new ApprovalGateway({
       channel,
       auditRecorder: makeFakeAuditRecorder(),
@@ -64,14 +66,14 @@ describe('ApprovalGateway — security integration', () => {
   });
 
   it('passes when requireSignedApprovals is true and signature is valid', async () => {
-    const verifier = new SignatureVerifier('secret');
+    const verifier = new SignatureVerifier(signingFixture);
     const responsePayload = formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
     });
     const validSig = verifier.sign(responsePayload);
     const channel = makeFakeChannel({ signature: validSig });
-    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
     const gateway = new ApprovalGateway({
       channel,
       auditRecorder: makeFakeAuditRecorder(),
@@ -84,14 +86,14 @@ describe('ApprovalGateway — security integration', () => {
   });
 
   it('uses a deterministic signature payload that is independent of JSON key order', async () => {
-    const verifier = new SignatureVerifier('secret');
+    const verifier = new SignatureVerifier(signingFixture);
     const jsonPayloadWithDifferentOrder = JSON.stringify({ decision: 'APPROVE', requestId: 'req-001' });
     const deterministicPayload = formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
     });
     const channel = makeFakeChannel({ signature: verifier.sign(deterministicPayload) });
-    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
     const gateway = new ApprovalGateway({
       channel,
       auditRecorder: makeFakeAuditRecorder(),
@@ -187,12 +189,12 @@ describe('ApprovalGateway — security integration', () => {
 
   it('rejects a validly-signed response whose requestId does not match the active request', async () => {
     // Attacker replays a genuinely-signed approval for request A against active request B.
-    const verifier = new SignatureVerifier('secret');
+    const verifier = new SignatureVerifier(signingFixture);
     const signedForOther = verifier.sign(
       formatApprovalResponseSignaturePayload({ requestId: 'req-OTHER', decision: 'APPROVE' }),
     );
     const channel = makeFakeChannel({ requestId: 'req-OTHER', signature: signedForOther });
-    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'secret' };
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
     const gateway = new ApprovalGateway({
       channel,
       auditRecorder: makeFakeAuditRecorder(),

--- a/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
+++ b/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../src/security/signature-verifier.js';
 
 describe('SignatureVerifier', () => {
-  const secret = 'test-secret-key';
+  const secret = ['test', 'signing', 'fixture'].join('-');
   const verifier = new SignatureVerifier(secret);
 
   it('sign() produces a hex-encoded string', () => {

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -45,6 +45,8 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/approval/respond', () => {
+    const signingFixture = ['test', 'signing', 'fixture'].join('-')
+
     function governorSignature(rawBody: string, secret: string): string {
       return `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
     }
@@ -137,7 +139,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('verifies HMAC signature when signing secret configured', async () => {
-      const secret = 'test-secret';
+      const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
 
       // Create approval
@@ -167,7 +169,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('verifies approval HMAC over raw body bytes including whitespace', async () => {
-      const secret = 'test-secret';
+      const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
       await seedResponseApproval(app, 'req-raw-spacing');
 
@@ -188,7 +190,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('requires signatures to match the exact raw body instead of parsed key ordering', async () => {
-      const secret = 'test-secret';
+      const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
       await seedResponseApproval(app, 'req-key-order');
 
@@ -210,7 +212,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('accepts normalized sha256 hex signatures through the timing-safe compare path', async () => {
-      const secret = 'test-secret';
+      const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
       await seedResponseApproval(app, 'req-upper-hex');
 
@@ -230,7 +232,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects invalid signature using timing-safe hex comparison', async () => {
-      const app = createGovernorApp({ signingSecret: 'secret' });
+      const app = createGovernorApp({ signingSecret: signingFixture });
 
       await app.request('/v1/approval/request', {
         method: 'POST',
@@ -257,7 +259,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('returns a clear 401 for a malformed signature', async () => {
-      const app = createGovernorApp({ signingSecret: 'secret' });
+      const app = createGovernorApp({ signingSecret: signingFixture });
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
         headers: {
@@ -282,7 +284,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects missing signature when secret configured', async () => {
-      const app = createGovernorApp({ signingSecret: 'secret' });
+      const app = createGovernorApp({ signingSecret: signingFixture });
 
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
@@ -297,7 +299,7 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/webhook/slack', () => {
-    const SLACK_SECRET = 'slack-signing-secret';
+    const SLACK_SECRET = ['slack', 'signing', 'fixture'].join('-');
 
     function slackHeaders(rawBody: string, secret = SLACK_SECRET, timestamp?: string) {
       const ts = timestamp ?? Math.floor(Date.now() / 1000).toString();

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -50,12 +50,12 @@ describe('fbeast-hook runtime', () => {
 
   it('redacts inline credentials from the governor context before it is checked/logged', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
-      context: "curl -H 'Authorization: Bearer sk-secret-abc123' https://api.example.com --password credential-fixture",
+      context: "curl -H 'Authorization: Bearer bearer-fixture-token' https://api.example.com --password credential-fixture",
     });
 
     expect(result.exitCode).toBe(0);
     const seen = result.checkCalls[0]!.context;
-    expect(seen).not.toContain('«redacted:key-prefix…»');
+    expect(seen).not.toContain('bearer-fixture-token');
     expect(seen).not.toContain('credential-fixture');
     expect(seen).toContain('[REDACTED]');
   });

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -50,13 +50,13 @@ describe('fbeast-hook runtime', () => {
 
   it('redacts inline credentials from the governor context before it is checked/logged', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
-      context: "curl -H 'Authorization: Bearer sk-secret-abc123' https://api.example.com --password hunter2",
+      context: "curl -H 'Authorization: Bearer sk-secret-abc123' https://api.example.com --password credential-fixture",
     });
 
     expect(result.exitCode).toBe(0);
     const seen = result.checkCalls[0]!.context;
-    expect(seen).not.toContain('sk-secret-abc123');
-    expect(seen).not.toContain('hunter2');
+    expect(seen).not.toContain('«redacted:key-prefix…»');
+    expect(seen).not.toContain('credential-fixture');
     expect(seen).toContain('[REDACTED]');
   });
 

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -209,8 +209,8 @@ describe('proxy server', () => {
       vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);
       gateCheck.mockResolvedValue({ decision: 'denied', reason: 'destructive' });
 
-      await executeToolDef.handler({ tool: 'test_tool', args: { key: 'secret' } });
-      expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'denied', args: { key: 'secret' } });
+      await executeToolDef.handler({ tool: 'test_tool', args: { key: 'credential' } });
+      expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'denied', args: { key: 'credential' } });
     });
 
     it('audits a fail-closed gate error of the target (decision="error")', async () => {

--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
@@ -21,7 +21,7 @@ describe('LangfuseAdapter', () => {
 
   describe('flush()', () => {
     it('POSTs to the Langfuse OTEL endpoint', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       await adapter.flush(makeTrace())
       expect(mockFetch).toHaveBeenCalledOnce()
       const [url] = mockFetch.mock.calls[0]
@@ -29,7 +29,7 @@ describe('LangfuseAdapter', () => {
     })
 
     it('defaults baseUrl to https://cloud.langfuse.com', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [url] = mockFetch.mock.calls[0]
       expect(url).toMatch(/^https:\/\/cloud\.langfuse\.com/)
@@ -38,8 +38,8 @@ describe('LangfuseAdapter', () => {
     it('uses a custom baseUrl when provided', async () => {
       const adapter = new LangfuseAdapter({
         baseUrl: 'https://eu.cloud.langfuse.com',
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
+        publicKey: 'public-key-test',
+        secretKey: 'private-key-test',
         fetch: mockFetch,
       })
       await adapter.flush(makeTrace())
@@ -48,22 +48,22 @@ describe('LangfuseAdapter', () => {
     })
 
     it('sends a Basic Authorization header using publicKey:secretKey', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-abc', secretKey: 'sk-xyz', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-abc', secretKey: 'private-key-xyz', fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
-      const expected = `Basic ${Buffer.from('pk-abc:sk-xyz').toString('base64')}`
+      const expected = `Basic ${Buffer.from('public-key-abc:private-key-xyz').toString('base64')}`
       expect(init.headers['Authorization']).toBe(expected)
     })
 
     it('sends Content-Type: application/json', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
       expect(init.headers['Content-Type']).toBe('application/json')
     })
 
     it('sends a JSON body with a resourceSpans array', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
       const body = JSON.parse(init.body as string)
@@ -72,7 +72,7 @@ describe('LangfuseAdapter', () => {
     })
 
     it('body contains the trace id in resource attributes', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       const trace = makeTrace()
       await adapter.flush(trace)
       const [, init] = mockFetch.mock.calls[0]
@@ -89,7 +89,7 @@ describe('LangfuseAdapter', () => {
     })
 
     it('uses HTTP POST method', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
       expect(init.method).toBe('POST')
@@ -104,7 +104,7 @@ describe('LangfuseAdapter', () => {
         .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
         .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
       const adapter = new LangfuseAdapter({
-        publicKey: 'pk', secretKey: 'sk', fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
+        publicKey: 'public-key', secretKey: 'private-key', fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
       })
       await expect(adapter.flush(makeTrace())).resolves.toBeUndefined()
       expect(mockFetch).toHaveBeenCalledTimes(2)
@@ -113,7 +113,7 @@ describe('LangfuseAdapter', () => {
     it('throws after exhausting retries on persistent 5xx', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const adapter = new LangfuseAdapter({
-        publicKey: 'pk', secretKey: 'sk', fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
+        publicKey: 'public-key', secretKey: 'private-key', fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
       })
       await expect(adapter.flush(makeTrace())).rejects.toThrow('503')
       expect(mockFetch).toHaveBeenCalledTimes(3)
@@ -122,7 +122,7 @@ describe('LangfuseAdapter', () => {
     it('does not retry a 4xx', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' })
       const adapter = new LangfuseAdapter({
-        publicKey: 'pk', secretKey: 'sk', fetch: mockFetch, retry: { maxRetries: 3, sleep: sleep() },
+        publicKey: 'public-key', secretKey: 'private-key', fetch: mockFetch, retry: { maxRetries: 3, sleep: sleep() },
       })
       await expect(adapter.flush(makeTrace())).rejects.toThrow('401')
       expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -131,12 +131,12 @@ describe('LangfuseAdapter', () => {
 
   describe('ExportAdapter contract — write-only', () => {
     it('queryByTraceId() returns null', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       expect(await adapter.queryByTraceId('any-id')).toBeNull()
     })
 
     it('listTraceIds() returns []', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'pk-test', secretKey: 'sk-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
       expect(await adapter.listTraceIds()).toEqual([])
     })
   })

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
@@ -64,12 +64,12 @@ describe('TempoAdapter', () => {
     it('sends Basic Authorization header when basicAuth is provided', async () => {
       const adapter = new TempoAdapter({
         endpoint: 'https://tempo-us-central1.grafana.net/tempo',
-        basicAuth: { user: '123456', password: 'glc_mytoken' },
+        basicAuth: { user: '123456', password: 'grafana-cloud-token' },
         fetch: mockFetch,
       })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
-      const expected = `Basic ${Buffer.from('123456:glc_mytoken').toString('base64')}`
+      const expected = `Basic ${Buffer.from('123456:grafana-cloud-token').toString('base64')}`
       expect(init.headers['Authorization']).toBe(expected)
     })
 
@@ -184,13 +184,13 @@ describe('TempoAdapter', () => {
       const adapter = new TempoAdapter({
         endpoint: 'https://tempo-us-central1.grafana.net/tempo',
         otlpPath: '/otlp/v1/traces',
-        basicAuth: { user: '987654', password: 'glc_secret_token' },
+        basicAuth: { user: '987654', password: 'grafana-cloud-token' },
         fetch: mockFetch,
       })
       await adapter.flush(makeTrace())
       const [url, init] = mockFetch.mock.calls[0]
       expect(url).toBe('https://tempo-us-central1.grafana.net/tempo/otlp/v1/traces')
-      const expected = `Basic ${Buffer.from('987654:glc_secret_token').toString('base64')}`
+      const expected = `Basic ${Buffer.from('987654:grafana-cloud-token').toString('base64')}`
       expect(init.headers['Authorization']).toBe(expected)
     })
   })

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -43,14 +43,14 @@ describe('WebhookNotifier', () => {
     it('merges custom headers with Content-Type', async () => {
       const notifier = new WebhookNotifier({
         url: 'https://hooks.example.com/signal',
-        headers: { 'X-Api-Key': 'secret', Authorization: 'Bearer token' },
+        headers: { 'X-Api-Key': 'test-api-key', Authorization: 'Bearer test-token' },
         fetch: mockFetch,
       })
       await notifier.send({ type: 'test' })
       const [, init] = mockFetch.mock.calls[0]
       expect(init.headers['Content-Type']).toBe('application/json')
-      expect(init.headers['X-Api-Key']).toBe('secret')
-      expect(init.headers['Authorization']).toBe('Bearer token')
+      expect(init.headers['X-Api-Key']).toBe('test-api-key')
+      expect(init.headers['Authorization']).toBe('Bearer test-token')
     })
 
     it('custom headers can override Content-Type', async () => {

--- a/packages/franken-observer/src/redaction/SpanRedactor.test.ts
+++ b/packages/franken-observer/src/redaction/SpanRedactor.test.ts
@@ -29,7 +29,7 @@ describe('SpanRedactor — metadata rules', () => {
       adapter: inner,
       rules: [{ key: 'api_key', action: 'remove' }],
     })
-    const span = makeSpan({ metadata: { api_key: 'sk-secret', model: 'gpt-4' } })
+    const span = makeSpan({ metadata: { api_key: 'test-api-key-value', model: 'gpt-4' } })
     await redactor.flush(makeTrace([span]))
     const stored = await inner.queryByTraceId('trace-1')
     expect(stored!.spans[0].metadata).not.toHaveProperty('api_key')
@@ -42,7 +42,7 @@ describe('SpanRedactor — metadata rules', () => {
       adapter: inner,
       rules: [{ key: 'password', action: 'mask' }],
     })
-    await redactor.flush(makeTrace([makeSpan({ metadata: { password: 'hunter2' } })]))
+    await redactor.flush(makeTrace([makeSpan({ metadata: { password: 'credential-fixture-value' } })]))
     const stored = await inner.queryByTraceId('trace-1')
     expect(stored!.spans[0].metadata['password']).toBe('[REDACTED]')
   })
@@ -62,9 +62,9 @@ describe('SpanRedactor — metadata rules', () => {
     const inner = new InMemoryAdapter()
     const redactor = new SpanRedactor({
       adapter: inner,
-      rules: [{ key: 'secret', action: 'remove' }],
+      rules: [{ key: 'credential', action: 'remove' }],
     })
-    await redactor.flush(makeTrace([makeSpan({ metadata: { secret: 'x', safe: 'visible' } })]))
+    await redactor.flush(makeTrace([makeSpan({ metadata: { credential: 'x', safe: 'visible' } })]))
     const stored = await inner.queryByTraceId('trace-1')
     expect(stored!.spans[0].metadata['safe']).toBe('visible')
   })
@@ -88,16 +88,16 @@ describe('SpanRedactor — metadata rules', () => {
     const inner = new InMemoryAdapter()
     const redactor = new SpanRedactor({
       adapter: inner,
-      rules: [{ key: 'secret', action: 'remove' }],
+      rules: [{ key: 'credential', action: 'remove' }],
     })
     const spans = [
-      makeSpan({ id: 's1', metadata: { secret: 'a', keep: 1 } }),
-      makeSpan({ id: 's2', metadata: { secret: 'b', keep: 2 } }),
+      makeSpan({ id: 's1', metadata: { credential: 'a', keep: 1 } }),
+      makeSpan({ id: 's2', metadata: { credential: 'b', keep: 2 } }),
     ]
     await redactor.flush(makeTrace(spans))
     const stored = await inner.queryByTraceId('trace-1')
     for (const span of stored!.spans) {
-      expect(span.metadata).not.toHaveProperty('secret')
+      expect(span.metadata).not.toHaveProperty('credential')
     }
   })
 
@@ -180,12 +180,12 @@ describe('SpanRedactor — immutability', () => {
     const inner = new InMemoryAdapter()
     const redactor = new SpanRedactor({
       adapter: inner,
-      rules: [{ key: 'secret', action: 'remove' }],
+      rules: [{ key: 'credential', action: 'remove' }],
     })
-    const span = makeSpan({ metadata: { secret: 'keep-me', other: 'ok' } })
+    const span = makeSpan({ metadata: { credential: 'keep-me', other: 'ok' } })
     const trace = makeTrace([span])
     await redactor.flush(trace)
-    expect(trace.spans[0].metadata['secret']).toBe('keep-me')
+    expect(trace.spans[0].metadata['credential']).toBe('keep-me')
   })
 
   it('does not mutate original thoughtBlocks', async () => {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -208,7 +208,7 @@ describe('Chat HTTP Routes', () => {
     });
     const { data: created } = await createRes.json();
 
-    const secret = 'test-secret-for-http-routes';
+    const secret = ['test', 'http', 'fixture'].join('-');
     app = createChatApp({
       sessionStoreDir: TMP,
       llm: { complete: vi.fn().mockResolvedValue('Mock reply') },
@@ -572,7 +572,7 @@ describe('Chat HTTP Routes', () => {
       engine: {} as never,
       runtime: runtime as never,
       turnRunner: {} as never,
-      sessionTokenSecret: 'test-secret-for-http-routes',
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
     });
 
     const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
@@ -627,7 +627,7 @@ describe('Chat HTTP Routes', () => {
       engine: {} as never,
       runtime: runtime as never,
       turnRunner: {} as never,
-      sessionTokenSecret: 'test-secret-for-http-routes',
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
     });
 
     const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {

--- a/packages/franken-orchestrator/tests/integration/e2e-consolidated-deps.test.ts
+++ b/packages/franken-orchestrator/tests/integration/e2e-consolidated-deps.test.ts
@@ -141,7 +141,7 @@ describe('E2E: Consolidated deps through BeastLoop', () => {
       {
         providers: [
           { name: 'primary', type: 'claude-cli' },
-          { name: 'fallback', type: 'anthropic-api', apiKey: 'sk-test' },
+          { name: 'fallback', type: 'anthropic-api', apiKey: 'test-api-key-fixture' },
         ],
       },
       mockExistingDeps(),

--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -224,7 +224,7 @@ describe('control-plane operator auth', () => {
         commsConfig: {
           orchestrator: {},
           channels: {
-            slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+            slack: { enabled: true, token: 'xoxb-test', signingSecret: ['test', 'signing', 'fixture'].join('-') },
           },
         } as CommsConfig,
         commsRuntime: mockCommsRuntime(),
@@ -262,7 +262,7 @@ describe('control-plane operator auth', () => {
         commsConfig: {
           orchestrator: {},
           channels: {
-            slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+            slack: { enabled: true, token: 'xoxb-test', signingSecret: ['test', 'signing', 'fixture'].join('-') },
           },
         } as CommsConfig,
         commsRuntime: mockCommsRuntime(),

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -814,19 +814,19 @@ describe('ProcessBeastExecutor', () => {
       const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
       const geminiToken = `AIza${'abcdefghijklmnopqrstuvwxyz123456789'}`;
 
-      cb.onStderr('api_key=sk-live-secret-value password=hunter2');
-      cb.onStderr('OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz CLIENT_SECRET=client-secret-value');
+      cb.onStderr('api_key=sk-live-secret-value password=credential-fixture');
+      cb.onStderr('OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz CLIENT_SECRET=client-fixture-value');
       cb.onStderr('Authorization: Bot discord-bot-token-value');
       cb.onStderr(`Invalid API key: ${standaloneOpenAiKey} and ${githubToken}`);
       cb.onStderr(`Slack token ${slackToken}`);
       cb.onStderr(`Google token ${geminiToken}`);
-      cb.onStderr('{"password":"json-password","client_secret":"json-secret","botToken":"camel-token"}');
+      cb.onStderr('{"password":"json-password","client_secret":"json-fixture","botToken":"camel-token"}');
       cb.onStderr('{"password":"abc\\"def","accessToken":"camel-access-token"}');
       cb.onStderr('redis://:cachepass@localhost:6379/0');
       cb.onStderr('{"Authorization":"Basic basic-token-value"}');
       cb.onStderr("headers: {'Authorization': 'Bot object-token-value'}");
       cb.onStderr('jwt eyJhbG...cret');
-      cb.onStderr('posting to https://hooks.slack.com/services/T000/B000/secret-webhook-token');
+      cb.onStderr('posting to https://hooks.slack.com/services/T000/B000/fixture-webhook-token');
       cb.onExit(1, null);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -865,23 +865,23 @@ describe('ProcessBeastExecutor', () => {
       expect(publishedLogLines).toContain('{"password":[REDACTED],"client_secret":[REDACTED],"botToken":[REDACTED]}');
       const serializedPersistedEvent = JSON.stringify(failEvent);
       expect(serializedPersistedEvent).not.toContain('sk-live-secret-value');
-      expect(serializedPersistedEvent).not.toContain('hunter2');
-      expect(serializedPersistedEvent).not.toContain('client-secret-value');
+      expect(serializedPersistedEvent).not.toContain('credential-fixture');
+      expect(serializedPersistedEvent).not.toContain('client-fixture-value');
       expect(serializedPersistedEvent).not.toContain('discord-bot-token-value');
       expect(serializedPersistedEvent).not.toContain(standaloneOpenAiKey);
       expect(serializedPersistedEvent).not.toContain(githubToken);
       expect(serializedPersistedEvent).not.toContain(slackToken);
       expect(serializedPersistedEvent).not.toContain(geminiToken);
       expect(serializedPersistedEvent).not.toContain('json-password');
-      expect(serializedPersistedEvent).not.toContain('json-secret');
+      expect(serializedPersistedEvent).not.toContain('json-fixture');
       expect(serializedPersistedEvent).not.toContain('camel-token');
       expect(serializedPersistedEvent).not.toContain('abc\\"def');
       expect(serializedPersistedEvent).not.toContain('camel-access-token');
       expect(serializedPersistedEvent).not.toContain('cachepass');
       expect(serializedPersistedEvent).not.toContain('basic-token-value');
       expect(serializedPersistedEvent).not.toContain('object-token-value');
-      expect(serializedPersistedEvent).not.toContain('abc1234567890secret');
-      expect(serializedPersistedEvent).not.toContain('secret-webhook-token');
+      expect(serializedPersistedEvent).not.toContain('abc1234567890fixture');
+      expect(serializedPersistedEvent).not.toContain('fixture-webhook-token');
 
       const publishedFailure = publishSpy.mock.calls
         .map(([event]) => event)
@@ -893,23 +893,23 @@ describe('ProcessBeastExecutor', () => {
       expect(publishedFailure!.data.event.payload).toMatchObject(failEvent!.payload);
       const serializedPublishedEvent = JSON.stringify(publishedFailure);
       expect(serializedPublishedEvent).not.toContain('sk-live-secret-value');
-      expect(serializedPublishedEvent).not.toContain('hunter2');
-      expect(serializedPublishedEvent).not.toContain('client-secret-value');
+      expect(serializedPublishedEvent).not.toContain('credential-fixture');
+      expect(serializedPublishedEvent).not.toContain('client-fixture-value');
       expect(serializedPublishedEvent).not.toContain('discord-bot-token-value');
       expect(serializedPublishedEvent).not.toContain(standaloneOpenAiKey);
       expect(serializedPublishedEvent).not.toContain(githubToken);
       expect(serializedPublishedEvent).not.toContain(slackToken);
       expect(serializedPublishedEvent).not.toContain(geminiToken);
       expect(serializedPublishedEvent).not.toContain('json-password');
-      expect(serializedPublishedEvent).not.toContain('json-secret');
+      expect(serializedPublishedEvent).not.toContain('json-fixture');
       expect(serializedPublishedEvent).not.toContain('camel-token');
       expect(serializedPublishedEvent).not.toContain('abc\\"def');
       expect(serializedPublishedEvent).not.toContain('camel-access-token');
       expect(serializedPublishedEvent).not.toContain('cachepass');
       expect(serializedPublishedEvent).not.toContain('basic-token-value');
       expect(serializedPublishedEvent).not.toContain('object-token-value');
-      expect(serializedPublishedEvent).not.toContain('abc1234567890secret');
-      expect(serializedPublishedEvent).not.toContain('secret-webhook-token');
+      expect(serializedPublishedEvent).not.toContain('abc1234567890fixture');
+      expect(serializedPublishedEvent).not.toContain('fixture-webhook-token');
     });
 
     it('marks attempt as failed on signal kill', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -809,14 +809,16 @@ describe('ProcessBeastExecutor', () => {
       const [, callbacks] = supervisor.spawn.mock.calls[0];
       const cb = callbacks as ProcessCallbacks;
 
-      const standaloneOpenAiKey = `sk-${'standaloneproviderkey1234567890'}`;
-      const githubToken = `ghp_${'abcdefghijklmnopqrstuvwxyz123456'}`;
+      const providerKeyFixture = ['sk', 'proj', 'fixturevalue1234567890'].join('-');
+      const standaloneOpenAiKey = ['sk', 'standaloneproviderkey1234567890'].join('-');
+      const githubToken = ['ghp', 'abcdefghijklmnopqrstuvwxyz123456'].join('_');
       const slackToken = ['xoxb', '123456789012', '123456789012', 'abcdefghijklmnopqrstuvwxyz'].join('-');
-      const geminiToken = `AIza${'abcdefghijklmnopqrstuvwxyz123456789'}`;
+      const geminiToken = ['AI', 'za', 'abcdefghijklmnopqrstuvwxyz123456789'].join('');
+      const discordBotToken = ['discord', 'bot', 'token', 'value'].join('-');
 
-      cb.onStderr('api_key=sk-live-secret-value password=credential-fixture');
-      cb.onStderr('OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz CLIENT_SECRET=client-fixture-value');
-      cb.onStderr('Authorization: Bot discord-bot-token-value');
+      cb.onStderr(`api_key=${providerKeyFixture} password=credential-fixture`);
+      cb.onStderr(`OPENAI_API_KEY=${providerKeyFixture} CLIENT_SECRET=client-fixture-value`);
+      cb.onStderr(`Authorization: Bot ${discordBotToken}`);
       cb.onStderr(`Invalid API key: ${standaloneOpenAiKey} and ${githubToken}`);
       cb.onStderr(`Slack token ${slackToken}`);
       cb.onStderr(`Google token ${geminiToken}`);
@@ -864,10 +866,10 @@ describe('ProcessBeastExecutor', () => {
       expect(publishedLogLines).toContain('api_key=[REDACTED] password=[REDACTED]');
       expect(publishedLogLines).toContain('{"password":[REDACTED],"client_secret":[REDACTED],"botToken":[REDACTED]}');
       const serializedPersistedEvent = JSON.stringify(failEvent);
-      expect(serializedPersistedEvent).not.toContain('sk-live-secret-value');
+      expect(serializedPersistedEvent).not.toContain(providerKeyFixture);
       expect(serializedPersistedEvent).not.toContain('credential-fixture');
       expect(serializedPersistedEvent).not.toContain('client-fixture-value');
-      expect(serializedPersistedEvent).not.toContain('discord-bot-token-value');
+      expect(serializedPersistedEvent).not.toContain(discordBotToken);
       expect(serializedPersistedEvent).not.toContain(standaloneOpenAiKey);
       expect(serializedPersistedEvent).not.toContain(githubToken);
       expect(serializedPersistedEvent).not.toContain(slackToken);
@@ -892,10 +894,10 @@ describe('ProcessBeastExecutor', () => {
       expect(publishedFailure).toBeDefined();
       expect(publishedFailure!.data.event.payload).toMatchObject(failEvent!.payload);
       const serializedPublishedEvent = JSON.stringify(publishedFailure);
-      expect(serializedPublishedEvent).not.toContain('sk-live-secret-value');
+      expect(serializedPublishedEvent).not.toContain(providerKeyFixture);
       expect(serializedPublishedEvent).not.toContain('credential-fixture');
       expect(serializedPublishedEvent).not.toContain('client-fixture-value');
-      expect(serializedPublishedEvent).not.toContain('discord-bot-token-value');
+      expect(serializedPublishedEvent).not.toContain(discordBotToken);
       expect(serializedPublishedEvent).not.toContain(standaloneOpenAiKey);
       expect(serializedPublishedEvent).not.toContain(githubToken);
       expect(serializedPublishedEvent).not.toContain(slackToken);

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -307,7 +307,7 @@ describe('bridgeToBeastConfig()', () => {
 
     it('passes webhook policy and custom rules through config.security', () => {
       const customRules = [
-        { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+        { name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' },
       ];
       const orchestratorConfig = {
         security: {
@@ -335,12 +335,12 @@ describe('bridgeToBeastConfig()', () => {
     it('uses config.consolidatedProviders when provided', () => {
       const orchestratorConfig = {
         consolidatedProviders: [
-          { name: 'my-claude', type: 'anthropic-api', apiKey: 'sk-123' },
+          { name: 'my-claude', type: 'anthropic-api', apiKey: 'test-api-key-fixture' },
         ],
       } as any;
       const config = bridgeToBeastConfig(makeOptions({}), orchestratorConfig);
       expect(config.providers).toEqual([
-        { name: 'my-claude', type: 'anthropic-api', apiKey: 'sk-123' },
+        { name: 'my-claude', type: 'anthropic-api', apiKey: 'test-api-key-fixture' },
       ]);
     });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1176,7 +1176,7 @@ describe('main() execution', () => {
       security: {
         profile: 'permissive',
         webhookSignaturePolicy: 'local-dev-unsigned',
-        customRules: [{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }],
+        customRules: [{ name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' }],
       },
       network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
       beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
@@ -1256,7 +1256,7 @@ describe('main() execution', () => {
     expect(startOptions.dashboardDeps?.getSecurityConfig()).toEqual(expect.objectContaining({
       profile: 'permissive',
       webhookSignaturePolicy: 'local-dev-unsigned',
-      customRules: [{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }],
+      customRules: [{ name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' }],
     }));
     expect(MockSession).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3737'));

--- a/packages/franken-orchestrator/tests/unit/comms/security/slack-signature.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/security/slack-signature.test.ts
@@ -4,7 +4,7 @@ import { slackSignatureMiddleware } from '../../../../src/comms/security/slack-s
 import { createHmac } from 'node:crypto';
 
 describe('slackSignatureMiddleware', () => {
-  const secret = 'test-secret';
+  const secret = ['test', 'signing', 'fixture'].join('-');
   const app = new Hono();
 
   app.use('/slack/*', slackSignatureMiddleware({ signingSecret: secret }));

--- a/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
@@ -7,7 +7,7 @@ import type { ChatGateway } from '../../../src/comms/gateway/chat-gateway.js';
 import type { SessionMapper } from '../../../src/comms/core/session-mapper.js';
 
 describe('slackRouter', () => {
-  const secret = 'test-secret';
+  const secret = ['test', 'signing', 'fixture'].join('-');
   const gateway = {
     handleInbound: vi.fn().mockResolvedValue(undefined),
     handleAction: vi.fn().mockResolvedValue(undefined),

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
@@ -5,7 +5,7 @@ import type { ChatGateway } from '../../../src/comms/gateway/chat-gateway.js';
 import type { SessionMapper } from '../../../src/comms/core/session-mapper.js';
 
 describe('whatsappRouter', () => {
-  const appSecret = 'test-secret';
+  const appSecret = ['test', 'app', 'fixture'].join('-');
   const verifyToken = 'test-token';
   const gateway = {
     handleInbound: vi.fn().mockResolvedValue(undefined),

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -51,13 +51,13 @@ describe('OrchestratorConfig', () => {
       const result = OrchestratorConfigSchema.parse({
         security: {
           customRules: [
-            { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+            { name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' },
           ],
         },
       });
 
       expect(result.security?.customRules).toEqual([
-        { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+        { name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' },
       ]);
     });
 

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -104,12 +104,12 @@ describe('startChatServer comms pass-through', () => {
 
     opts.securityConfig?.setSecurityConfig({
       webhookSignaturePolicy: 'required',
-      customRules: [{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }],
+      customRules: [{ name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' }],
     });
     expect(config.security.webhookSignaturePolicy).toBe('required');
-    expect(config.security.customRules).toEqual([{ name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' }]);
+    expect(config.security.customRules).toEqual([{ name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' }]);
     expect(opts.securityConfig?.getSecurityConfig().customRules).toEqual([
-      { name: 'no-secrets', pattern: 'secret', action: 'block', target: 'request' },
+      { name: 'no-credentials', pattern: 'credential', action: 'block', target: 'request' },
     ]);
     const writtenConfig = await readFile(configFile, 'utf-8');
     expect(writtenConfig).toContain('"webhookSignaturePolicy": "required"');
@@ -135,7 +135,7 @@ describe('startChatServer comms pass-through', () => {
             slack: {
               enabled: true,
               token: 'slack-token',
-              signingSecret: 'slack-signing-secret',
+              signingSecret: ['slack', 'signing', 'fixture'].join('-'),
             },
           },
         },
@@ -181,7 +181,7 @@ describe('startChatServer comms pass-through', () => {
             slack: {
               enabled: true,
               token: 'slack-token',
-              signingSecret: 'slack-signing-secret',
+              signingSecret: ['slack', 'signing', 'fixture'].join('-'),
             },
             discord: {
               enabled: true,
@@ -237,7 +237,7 @@ describe('startChatServer comms pass-through', () => {
           slack: {
             enabled: true,
             token: 'slack-token',
-            signingSecret: 'slack-signing-secret',
+            signingSecret: ['slack', 'signing', 'fixture'].join('-'),
           },
         },
       },

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -86,7 +86,7 @@ describe('commsRoutes', () => {
     const app = commsRoutes({
       config: minimalConfig({
         channels: {
-          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: ['test', 'signing', 'fixture'].join('-') },
         },
       }),
       runtime: mockRuntime(),
@@ -106,7 +106,7 @@ describe('commsRoutes', () => {
     const app = commsRoutes({
       config: minimalConfig({
         channels: {
-          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: ['test', 'signing', 'fixture'].join('-') },
         },
       }),
       runtime: mockRuntime(),
@@ -142,7 +142,7 @@ describe('commsRoutes', () => {
     const app = commsRoutes({
       config: minimalConfig({
         channels: {
-          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: ['test', 'signing', 'fixture'].join('-') },
         },
       }),
       runtime: mockRuntime(),
@@ -178,7 +178,7 @@ describe('commsRoutes', () => {
     const app = commsRoutes({
       config: minimalConfig({
         channels: {
-          slack: { enabled: true, token: 'xoxb-test', signingSecret: 'secret' },
+          slack: { enabled: true, token: 'xoxb-test', signingSecret: ['test', 'signing', 'fixture'].join('-') },
         },
       }),
       runtime: mockRuntime(),

--- a/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
@@ -11,14 +11,14 @@ async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<L
 describe('AnthropicApiAdapter', () => {
   describe('properties', () => {
     it('has correct name and type', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       expect(adapter.name).toBe('anthropic-api');
       expect(adapter.type).toBe('anthropic-api');
       expect(adapter.authMethod).toBe('api-key');
     });
 
     it('has correct capabilities', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       expect(adapter.capabilities).toEqual({
         streaming: true,
         toolUse: true,
@@ -32,12 +32,12 @@ describe('AnthropicApiAdapter', () => {
 
   describe('isAvailable()', () => {
     it('returns true when API key is set via options', async () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       expect(await adapter.isAvailable()).toBe(true);
     });
 
     it('returns true when ANTHROPIC_API_KEY env var is set', async () => {
-      process.env['ANTHROPIC_API_KEY'] = 'sk-env';
+      process.env['ANTHROPIC_API_KEY'] = 'test-env-value';
       const adapter = new AnthropicApiAdapter();
       expect(await adapter.isAvailable()).toBe(true);
       delete process.env['ANTHROPIC_API_KEY'];
@@ -54,7 +54,7 @@ describe('AnthropicApiAdapter', () => {
 
   describe('translateMessages()', () => {
     it('translates string content messages', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const messages: LlmMessage[] = [
         { role: 'user', content: 'Hello' },
         { role: 'assistant', content: 'Hi' },
@@ -67,7 +67,7 @@ describe('AnthropicApiAdapter', () => {
     });
 
     it('translates content block messages', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const messages: LlmMessage[] = [
         {
           role: 'user',
@@ -83,7 +83,7 @@ describe('AnthropicApiAdapter', () => {
 
   describe('translateTools()', () => {
     it('translates ToolDefinition to Anthropic Tool format', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const tools: ToolDefinition[] = [
         { name: 'read', description: 'Read file', inputSchema: { type: 'object' } },
       ];
@@ -100,7 +100,7 @@ describe('AnthropicApiAdapter', () => {
 
   describe('createEventTranslator()', () => {
     it('translates text_delta events', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const translate = adapter.createEventTranslator();
       const result = translate({
         type: 'content_block_delta',
@@ -111,7 +111,7 @@ describe('AnthropicApiAdapter', () => {
     });
 
     it('accumulates tool_use input and emits on content_block_stop', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const translate = adapter.createEventTranslator();
 
       // Start tool_use block
@@ -148,7 +148,7 @@ describe('AnthropicApiAdapter', () => {
     });
 
     it('does not emit tool_use on content_block_start', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const translate = adapter.createEventTranslator();
       const result = translate({
         type: 'content_block_start',
@@ -161,7 +161,7 @@ describe('AnthropicApiAdapter', () => {
 
   describe('formatHandoff()', () => {
     it('returns handoff text', () => {
-      const adapter = new AnthropicApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });
       const snapshot: BrainSnapshot = {
         version: 1,
         timestamp: '2026-03-22T00:00:00.000Z',

--- a/packages/franken-orchestrator/tests/unit/providers/openai-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/openai-api-adapter.test.ts
@@ -11,14 +11,14 @@ async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<L
 describe('OpenAiApiAdapter', () => {
   describe('properties', () => {
     it('has correct name and type', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       expect(adapter.name).toBe('openai-api');
       expect(adapter.type).toBe('openai-api');
       expect(adapter.authMethod).toBe('api-key');
     });
 
     it('has correct capabilities', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       expect(adapter.capabilities.maxContextTokens).toBe(128_000);
       expect(adapter.capabilities.mcpSupport).toBe(false);
     });
@@ -26,12 +26,12 @@ describe('OpenAiApiAdapter', () => {
 
   describe('isAvailable()', () => {
     it('returns true when API key is set', async () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       expect(await adapter.isAvailable()).toBe(true);
     });
 
     it('returns true when OPENAI_API_KEY env var is set', async () => {
-      process.env['OPENAI_API_KEY'] = 'sk-env';
+      process.env['OPENAI_API_KEY'] = 'test-env-value';
       const adapter = new OpenAiApiAdapter();
       expect(await adapter.isAvailable()).toBe(true);
       delete process.env['OPENAI_API_KEY'];
@@ -48,7 +48,7 @@ describe('OpenAiApiAdapter', () => {
 
   describe('translateMessages()', () => {
     it('prepends system message', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const request: LlmRequest = {
         systemPrompt: 'Be helpful',
         messages: [{ role: 'user', content: 'Hi' }],
@@ -59,7 +59,7 @@ describe('OpenAiApiAdapter', () => {
     });
 
     it('maps user and assistant messages', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const request: LlmRequest = {
         systemPrompt: 'sys',
         messages: [
@@ -72,7 +72,7 @@ describe('OpenAiApiAdapter', () => {
     });
 
     it('translates image blocks to image_url format', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const request: LlmRequest = {
         systemPrompt: 'sys',
         messages: [
@@ -98,7 +98,7 @@ describe('OpenAiApiAdapter', () => {
     });
 
     it('translates tool_result blocks as labeled text', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const request: LlmRequest = {
         systemPrompt: 'sys',
         messages: [
@@ -120,7 +120,7 @@ describe('OpenAiApiAdapter', () => {
 
   describe('execute()', () => {
     it('translates text stream chunks and emits done with usage', async () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       // Mock the internal client
       const mockChunks = [
         { choices: [{ delta: { content: 'Hello' }, finish_reason: null }], usage: null },
@@ -148,7 +148,7 @@ describe('OpenAiApiAdapter', () => {
     });
 
     it('emits retryable error on rate limit', async () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const OpenAI = (await import('openai')).default;
       const headers = new Headers({ 'x-request-id': 'test' });
       (adapter as any).client = {
@@ -171,7 +171,7 @@ describe('OpenAiApiAdapter', () => {
 
   describe('translateTools()', () => {
     it('wraps in function type', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const tools: ToolDefinition[] = [
         { name: 'read', description: 'Read file', inputSchema: { type: 'object' } },
       ];
@@ -191,7 +191,7 @@ describe('OpenAiApiAdapter', () => {
 
   describe('formatHandoff()', () => {
     it('returns handoff text', () => {
-      const adapter = new OpenAiApiAdapter({ apiKey: 'sk-test' });
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
       const snapshot: BrainSnapshot = {
         version: 1,
         timestamp: '2026-03-22T00:00:00.000Z',

--- a/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
@@ -61,9 +61,9 @@ describe('AiderProvider', () => {
   });
 
   it('filterEnv returns a copy, does not mutate input', () => {
-    const env = { PATH: '/usr/bin', AIDER_KEY: 'secret' };
+    const env = { PATH: '/usr/bin', AIDER_KEY: 'test-env-value' };
     const filtered = provider.filterEnv(env);
-    expect(env).toHaveProperty('AIDER_KEY', 'secret');
+    expect(env).toHaveProperty('AIDER_KEY', 'test-env-value');
     expect(filtered).not.toBe(env);
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/providers/claude-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/claude-provider.test.ts
@@ -69,7 +69,7 @@ describe('ClaudeProvider', () => {
       PATH: '/usr/bin',
       HOME: '/home/user',
       CLAUDE_CODE_ENTRYPOINT: 'claude-vscode',
-      CLAUDE_API_KEY: 'sk-123',
+      CLAUDE_API_KEY: 'test-env-value',
       CLAUDECODE: 'true',
     };
     const filtered = provider.filterEnv(env);
@@ -81,9 +81,9 @@ describe('ClaudeProvider', () => {
   });
 
   it('filterEnv returns a copy, does not mutate input', () => {
-    const env = { PATH: '/usr/bin', CLAUDE_KEY: 'secret' };
+    const env = { PATH: '/usr/bin', CLAUDE_KEY: 'test-env-value' };
     const filtered = provider.filterEnv(env);
-    expect(env).toHaveProperty('CLAUDE_KEY', 'secret');
+    expect(env).toHaveProperty('CLAUDE_KEY', 'test-env-value');
     expect(filtered).not.toBe(env);
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -51,7 +51,7 @@ describe('CodexProvider', () => {
   // -- filterEnv -----------------------------------------------------------
 
   it('filterEnv marks spawned child processes without filtering credentials', () => {
-    const env = { PATH: '/usr/bin', OPENAI_API_KEY: 'sk-123', HOME: '/home/user' };
+    const env = { PATH: '/usr/bin', OPENAI_API_KEY: 'test-env-value', HOME: '/home/user' };
     const filtered = provider.filterEnv(env);
     expect(filtered).toEqual({
       ...env,

--- a/packages/franken-orchestrator/tests/unit/skills/providers/gemini-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/gemini-provider.test.ts
@@ -76,9 +76,9 @@ describe('GeminiProvider', () => {
   });
 
   it('filterEnv returns a copy, does not mutate input', () => {
-    const env = { PATH: '/usr/bin', GEMINI_KEY: 'secret' };
+    const env = { PATH: '/usr/bin', GEMINI_KEY: 'test-env-value' };
     const filtered = provider.filterEnv(env);
-    expect(env).toHaveProperty('GEMINI_KEY', 'secret');
+    expect(env).toHaveProperty('GEMINI_KEY', 'test-env-value');
     expect(env).not.toHaveProperty('FRANKENBEAST_SPAWNED');
     expect(filtered).not.toBe(env);
     expect(filtered).toHaveProperty('FRANKENBEAST_SPAWNED', '1');

--- a/tests/integration/phase3-execution.test.ts
+++ b/tests/integration/phase3-execution.test.ts
@@ -163,7 +163,7 @@ describe('Phase 3: Execution — TriggerRegistry', () => {
 
 describe('Phase 3: Execution — Security', () => {
   it('generates and verifies HMAC signatures', () => {
-    const verifier = new SignatureVerifier('test-secret-key');
+    const verifier = new SignatureVerifier(['test', 'signing', 'fixture'].join('-'));
 
     const payload = JSON.stringify({ taskId: 'task-001', decision: 'APPROVE' });
     const signature = verifier.sign(payload);


### PR DESCRIPTION
## Summary
- Replace secret-looking test fixture literals with explicit non-secret fixture values or constructed fixtures.
- Keep redaction/signature/auth behavior unchanged while avoiding provider-token-shaped strings in tests.
- Limit scope to test/fixture data for issue #609.

## Test Plan
- npm --prefix packages/franken-observer test
- npm --prefix packages/franken-governor test
- npm --prefix packages/franken-orchestrator test -- tests/unit/http/comms-routes.test.ts tests/integration/http/control-plane-auth.test.ts tests/unit/skills/providers/gemini-provider.test.ts tests/unit/skills/providers/claude-provider.test.ts tests/unit/skills/providers/aider-provider.test.ts tests/unit/skills/providers/codex-provider.test.ts tests/unit/config/orchestrator-config.test.ts tests/unit/http/chat-server-comms.test.ts tests/unit/cli/run.test.ts tests/unit/cli/dep-bridge.test.ts tests/unit/providers/anthropic-api-adapter.test.ts tests/unit/providers/openai-api-adapter.test.ts tests/unit/comms/whatsapp-router.test.ts tests/unit/comms/slack-router.test.ts tests/unit/comms/security/slack-signature.test.ts tests/integration/chat/chat-routes.test.ts tests/unit/beasts/process-beast-executor.test.ts tests/integration/e2e-consolidated-deps.test.ts (one live-provider heartbeat case failed due local claude process exit; targeted provider-registry case passed separately)
- npm --prefix packages/franken-mcp-suite test -- src/servers/proxy.test.ts src/integration/hook.integration.test.ts
- npm --prefix packages/franken-orchestrator test -- tests/integration/e2e-consolidated-deps.test.ts -t "provider registry has configured providers"
- npm run build
- npm run typecheck
- npm run lint:security
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings)

Closes #609
