### PR TITLE
refactor(observer): unify content hashing and cache token totals

### DIFF
--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -15,6 +15,12 @@ describe('createAuditEvent', () => {
     expect(event.inputHash).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
 
+  it('uses the shared content hash formatter', () => {
+    expect(hashContent('hello')).toBe(
+      'sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    );
+  });
+
   it('computes SHA-256 hash for output', () => {
     const event = createAuditEvent('test', {}, {
       phase: 'p', provider: 'pr', output: 'result',

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -1,4 +1,5 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
+import { hashContent } from './utils/crypto.js';
 
 export interface AuditEvent {
   eventId: string;
@@ -45,9 +46,7 @@ export function createAuditEvent(
   return event;
 }
 
-export function hashContent(content: string | Buffer): string {
-  return 'sha256:' + createHash('sha256').update(content).digest('hex');
-}
+export { hashContent };
 
 /**
  * Append-only, immutable audit trail.

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -57,6 +57,26 @@ describe('TokenCounter', () => {
       const grand = counter.grandTotal()
       expect(grand.totalTokens).toBe(0)
     })
+
+    it('keeps grand totals in sync with record() and reset()', () => {
+      for (let i = 0; i < 1_000; i += 1) {
+        counter.record({ model: `model-${i}`, promptTokens: 2, completionTokens: 3 })
+      }
+
+      expect(counter.grandTotal()).toEqual({
+        promptTokens: 2_000,
+        completionTokens: 3_000,
+        totalTokens: 5_000,
+      })
+
+      counter.reset()
+
+      expect(counter.grandTotal()).toEqual({
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      })
+    })
   })
 
   describe('allModels()', () => {

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -12,6 +12,8 @@ export interface TokenTotals {
 
 export class TokenCounter {
   private readonly counts = new Map<string, { prompt: number; completion: number }>()
+  private totalPromptTokens = 0
+  private totalCompletionTokens = 0
 
   /** A token delta must be a non-negative safe integer. */
   private static assertValidDelta(value: number, label: string): void {
@@ -47,11 +49,12 @@ export class TokenCounter {
     // grandTotal() past the safe-integer range even when every per-model total
     // is safe (e.g. model A with MAX_SAFE_INTEGER prompt, model B with 1). The
     // current stored state is always valid, so grandTotal() will not throw here.
-    const global = this.grandTotal()
-    const globalPrompt = TokenCounter.safeAdd(global.promptTokens, entry.promptTokens)
-    const globalCompletion = TokenCounter.safeAdd(global.completionTokens, entry.completionTokens)
+    const globalPrompt = TokenCounter.safeAdd(this.totalPromptTokens, entry.promptTokens)
+    const globalCompletion = TokenCounter.safeAdd(this.totalCompletionTokens, entry.completionTokens)
     TokenCounter.safeAdd(globalPrompt, globalCompletion)
     this.counts.set(entry.model, { prompt, completion })
+    this.totalPromptTokens = globalPrompt
+    this.totalCompletionTokens = globalCompletion
   }
 
   totalsFor(model: string): TokenTotals {
@@ -64,16 +67,10 @@ export class TokenCounter {
   }
 
   grandTotal(): TokenTotals {
-    let prompt = 0
-    let completion = 0
-    for (const entry of this.counts.values()) {
-      prompt = TokenCounter.safeAdd(prompt, entry.prompt)
-      completion = TokenCounter.safeAdd(completion, entry.completion)
-    }
     return {
-      promptTokens: prompt,
-      completionTokens: completion,
-      totalTokens: TokenCounter.safeAdd(prompt, completion),
+      promptTokens: this.totalPromptTokens,
+      completionTokens: this.totalCompletionTokens,
+      totalTokens: TokenCounter.safeAdd(this.totalPromptTokens, this.totalCompletionTokens),
     }
   }
 
@@ -83,5 +80,7 @@ export class TokenCounter {
 
   reset(): void {
     this.counts.clear()
+    this.totalPromptTokens = 0
+    this.totalCompletionTokens = 0
   }
 }

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -12,6 +12,7 @@ describe('ReplayContentStore', () => {
     const ref = store.put('hello world');
 
     expect(ref).toBe(hashContent('hello world'));
+    expect(ref).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(store.get(ref)).toBe('hello world');
   });
 

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReplayContentStore } from './replay-content-store.js';
@@ -13,6 +13,8 @@ describe('ReplayContentStore', () => {
 
     expect(ref).toBe(hashContent('hello world'));
     expect(ref).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(existsSync(join(root, 'blobs', ref.replace(/^sha256:/, '')))).toBe(true);
+    expect(existsSync(join(root, 'blobs', ref))).toBe(false);
     expect(store.get(ref)).toBe('hello world');
   });
 

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -25,4 +25,15 @@ describe('ReplayContentStore', () => {
 
     expect(() => store.get(ref)).toThrow(/hash mismatch/i);
   });
+
+  it('can read pre-prefix replay refs for existing durable artifacts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const store = new ReplayContentStore(root);
+    const ref = store.put('legacy content');
+    const legacyRef = ref.replace(/^sha256:/, '');
+
+    store.__corruptForTest(legacyRef, 'legacy content');
+
+    expect(store.get(legacyRef)).toBe('legacy content');
+  });
 });

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -15,7 +15,7 @@ export class ReplayContentStore {
 
   put(content: string): string {
     const ref = hashContent(content);
-    const path = join(this.dir, ref);
+    const path = this.blobPath(ref);
     if (!existsSync(path)) {
       writeFileSync(path, content, 'utf8');
     }
@@ -23,7 +23,7 @@ export class ReplayContentStore {
   }
 
   get(ref: string): string {
-    const content = readFileSync(join(this.dir, ref), 'utf8');
+    const content = readFileSync(this.blobPath(ref), 'utf8');
     if (!contentHashMatches(content, ref)) {
       throw new Error(`Replay blob hash mismatch for ${ref}`);
     }
@@ -31,6 +31,10 @@ export class ReplayContentStore {
   }
 
   __corruptForTest(ref: string, replacement: string): void {
-    writeFileSync(join(this.dir, ref), replacement, 'utf8');
+    writeFileSync(this.blobPath(ref), replacement, 'utf8');
+  }
+
+  private blobPath(ref: string): string {
+    return join(this.dir, ref.replace(/^sha256:/, ''));
   }
 }

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { contentHashMatches } from '../utils/crypto.js';
 import { hashContent } from './replay-record.js';
 
 export class ReplayContentStore {
@@ -23,7 +24,7 @@ export class ReplayContentStore {
 
   get(ref: string): string {
     const content = readFileSync(join(this.dir, ref), 'utf8');
-    if (hashContent(content) !== ref) {
+    if (!contentHashMatches(content, ref)) {
       throw new Error(`Replay blob hash mismatch for ${ref}`);
     }
     return content;

--- a/packages/franken-observer/src/replay/replay-record.ts
+++ b/packages/franken-observer/src/replay/replay-record.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { hashContent } from '../utils/crypto.js';
 
 export type ReplayRecordKind =
   | 'llm.request'
@@ -18,6 +18,4 @@ export interface ReplayRecord {
   readonly contentRef: string;
 }
 
-export function hashContent(content: string): string {
-  return createHash('sha256').update(content, 'utf8').digest('hex');
-}
+export { hashContent };

--- a/packages/franken-observer/src/utils/crypto.ts
+++ b/packages/franken-observer/src/utils/crypto.ts
@@ -3,3 +3,8 @@ import { createHash } from 'node:crypto';
 export function hashContent(content: string | Buffer): string {
   return `sha256:${createHash('sha256').update(content).digest('hex')}`;
 }
+
+export function contentHashMatches(content: string | Buffer, expected: string): boolean {
+  const actual = hashContent(content);
+  return actual === expected || actual === `sha256:${expected}`;
+}

--- a/packages/franken-observer/src/utils/crypto.ts
+++ b/packages/franken-observer/src/utils/crypto.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'node:crypto';
+
+export function hashContent(content: string | Buffer): string {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
+}


### PR DESCRIPTION
## Summary
- Move observer content hashing to a shared utility and use one `sha256:`-prefixed hash format for audit and replay references
- Cache TokenCounter grand totals during record/reset so record no longer calls the O(N) grandTotal path
- Add targeted regression coverage for shared hashing and cached grand totals

## Test Plan
- npm --workspace @frankenbeast/observer test -- src/audit-event.test.ts src/replay/replay-content-store.test.ts src/cost/TokenCounter.test.ts
- npm --workspace @frankenbeast/observer run typecheck
- npm --workspace @frankenbeast/observer run build
- npm --workspace @frankenbeast/observer test

Closes #644
