### PR TITLE
refactor(orchestrator): unify CLI availability checks

### DIFF
--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -11,7 +11,7 @@ import type {
   SkillCatalogEntry,
 } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
-import { collectCliOutput, extractAuthFields } from './discover-skills-helpers.js';
+import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 
 export interface ClaudeCliOptions {
   binaryPath?: string;
@@ -38,18 +38,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
   constructor(private options: ClaudeCliOptions = {}) {}
 
   async isAvailable(): Promise<boolean> {
-    try {
-      const proc = spawn(this.binaryPath, ['--version'], {
-        env: this.sanitizedEnv(),
-        timeout: 5000,
-      });
-      return new Promise((resolve) => {
-        proc.on('close', (code) => resolve(code === 0));
-        proc.on('error', () => resolve(false));
-      });
-    } catch {
-      return false;
-    }
+    return isCliAvailable(this.binaryPath, this.sanitizedEnv());
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -11,7 +11,7 @@ import type {
   SkillCatalogEntry,
 } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
-import { collectCliOutput, extractAuthFields } from './discover-skills-helpers.js';
+import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 
 export interface CodexCliOptions {
   binaryPath?: string;
@@ -37,15 +37,7 @@ export class CodexCliAdapter implements ILlmProvider {
   constructor(private options: CodexCliOptions = {}) {}
 
   async isAvailable(): Promise<boolean> {
-    try {
-      const proc = spawn(this.binaryPath, ['--version'], { timeout: 5000 });
-      return new Promise((resolve) => {
-        proc.on('close', (code) => resolve(code === 0));
-        proc.on('error', () => resolve(false));
-      });
-    } catch {
-      return false;
-    }
+    return isCliAvailable(this.binaryPath);
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {

--- a/packages/franken-orchestrator/src/providers/discover-skills-helpers.ts
+++ b/packages/franken-orchestrator/src/providers/discover-skills-helpers.ts
@@ -7,6 +7,33 @@ export interface CollectResult {
 }
 
 /**
+ * Check whether a CLI binary can be executed successfully.
+ */
+export async function isCliAvailable(
+  command: string,
+  env?: NodeJS.ProcessEnv,
+  timeoutMs = 5_000,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const options: { env?: NodeJS.ProcessEnv; stdio: 'ignore'; timeout: number } = {
+        stdio: 'ignore',
+        timeout: timeoutMs,
+      };
+      if (env) {
+        options.env = env;
+      }
+
+      const proc = spawn(command, ['--version'], options);
+      proc.on('close', (code) => resolve(code === 0));
+      proc.on('error', () => resolve(false));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
  * Spawn a CLI command, collect stdout, enforce timeout.
  * Returns empty stdout on any failure.
  */

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -14,7 +14,7 @@ import type {
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { formatHandoff } from './format-handoff.js';
-import { collectCliOutput, extractAuthFields } from './discover-skills-helpers.js';
+import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 
 const MANAGED_START = '<!-- FRANKENBEAST MANAGED SECTION - DO NOT EDIT -->';
 const MANAGED_END = '<!-- END FRANKENBEAST SECTION -->';
@@ -42,15 +42,7 @@ export class GeminiCliAdapter implements ILlmProvider {
   constructor(private options: GeminiCliOptions = {}) {}
 
   async isAvailable(): Promise<boolean> {
-    try {
-      const proc = spawn(this.binaryPath, ['--version'], { timeout: 5000 });
-      return new Promise((resolve) => {
-        proc.on('close', (code) => resolve(code === 0));
-        proc.on('error', () => resolve(false));
-      });
-    } catch {
-      return false;
-    }
+    return isCliAvailable(this.binaryPath);
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {

--- a/packages/franken-orchestrator/tests/unit/skills/discover-skills-helpers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/discover-skills-helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { extractAuthFields } from '../../../src/providers/discover-skills-helpers.js';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractAuthFields, isCliAvailable } from '../../../src/providers/discover-skills-helpers.js';
 
 describe('extractAuthFields', () => {
   it('extracts env vars matching auth patterns', () => {
@@ -35,5 +38,31 @@ describe('extractAuthFields', () => {
 
   it('returns empty array when no keys match', () => {
     expect(extractAuthFields({ PORT: '80', HOST: 'localhost' })).toEqual([]);
+  });
+});
+
+describe('isCliAvailable', () => {
+  it('returns true when the CLI exits successfully for --version', async () => {
+    await expect(isCliAvailable(process.execPath)).resolves.toBe(true);
+  });
+
+  it('returns false when the CLI cannot be spawned', async () => {
+    await expect(isCliAvailable('definitely-missing-frankenbeast-cli')).resolves.toBe(false);
+  });
+
+  it('passes the provided environment to the availability probe', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'franken-cli-availability-'));
+    const script = join(dir, 'env-check-cli');
+    writeFileSync(
+      script,
+      '#!/usr/bin/env node\nprocess.exit(process.argv[2] === "--version" && process.env.FRANKEN_CLI_AVAILABLE === "1" ? 0 : 1);\n',
+      'utf8',
+    );
+    chmodSync(script, 0o755);
+
+    await expect(
+      isCliAvailable(script, { ...process.env, FRANKEN_CLI_AVAILABLE: '1' }),
+    ).resolves.toBe(true);
+    await expect(isCliAvailable(script, { ...process.env })).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add a shared isCliAvailable helper for CLI provider availability probes
- Reuse the helper in Claude, Codex, and Gemini CLI adapters
- Cover success, missing binary, and custom environment behavior in discover-skills helper tests

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace franken-planner
- npm run build --workspace franken-brain
- npm run build --workspace @frankenbeast/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm test --workspace franken-orchestrator -- --run tests/unit/skills/discover-skills-helpers.test.ts
- npm run typecheck --workspace franken-orchestrator
- npm run build --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator (passes with existing warnings)
- npm test --workspace franken-orchestrator

Closes #641