### PR TITLE
fix(critique): remove literal fixme markers

### DIFF
--- a/docs/superpowers/plans/2026-04-08-fbeast-mcp-suite.md
+++ b/docs/superpowers/plans/2026-04-08-fbeast-mcp-suite.md
@@ -1657,8 +1657,10 @@ function evaluateContent(content: string, criteria: string[]): EvalResult {
         if (/console\.log\(/g.test(content)) {
           findings.push({ criterion, severity: 'warning', message: 'Contains console.log — remove before production' });
         }
-        if (/TODO|FIXME|HACK/g.test(content)) {
-          findings.push({ criterion, severity: 'warning', message: 'Contains TODO/FIXME/HACK markers' });
+        const unresolvedMarkers = ['TODO', ['FIX', 'ME'].join(''), 'HACK'];
+        const unresolvedMarkerPattern = new RegExp(unresolvedMarkers.join('|'), 'g');
+        if (unresolvedMarkerPattern.test(content)) {
+          findings.push({ criterion, severity: 'warning', message: 'Contains unresolved-work markers' });
         }
         break;
       case 'readability':

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -1,8 +1,22 @@
-import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
+import type {
+  Evaluator,
+  EvaluationInput,
+  EvaluationResult,
+  EvaluationFinding,
+} from './evaluator.js';
 
 const COMMENT_LINE_PATTERN = /^\s*\/\//;
 const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
-const TODO_PATTERN = /\/\/\s*(TODO|FIXME|HACK|XXX)\b/gi;
+const UNRESOLVED_COMMENT_MARKERS = [
+  'TODO',
+  ['FIX', 'ME'].join(''),
+  'HACK',
+  'XXX',
+] as const;
+const TODO_PATTERN = new RegExp(
+  `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
+  'gi',
+);
 const MAX_COMMENT_RATIO = 0.5;
 
 export class ConcisenessEvaluator implements Evaluator {
@@ -11,7 +25,12 @@ export class ConcisenessEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     if (!input.content.trim()) {
-      return { evaluatorName: this.name, verdict: 'pass', score: 1, findings: [] };
+      return {
+        evaluatorName: this.name,
+        verdict: 'pass',
+        score: 1,
+        findings: [],
+      };
     }
 
     const findings: EvaluationFinding[] = [];
@@ -29,7 +48,10 @@ export class ConcisenessEvaluator implements Evaluator {
     };
   }
 
-  private checkCommentRatio(content: string, findings: EvaluationFinding[]): void {
+  private checkCommentRatio(
+    content: string,
+    findings: EvaluationFinding[],
+  ): void {
     const lines = content.split('\n');
     const totalLines = lines.filter((l) => l.trim().length > 0).length;
     if (totalLines === 0) return;
@@ -47,17 +69,21 @@ export class ConcisenessEvaluator implements Evaluator {
       findings.push({
         message: `Excessive comment ratio: ${Math.round(ratio * 100)}% of lines are comments. Code should be self-documenting.`,
         severity: 'info',
-        suggestion: 'Remove obvious comments and let clear naming convey intent',
+        suggestion:
+          'Remove obvious comments and let clear naming convey intent',
       });
     }
   }
 
-  private checkTodoComments(content: string, findings: EvaluationFinding[]): void {
+  private checkTodoComments(
+    content: string,
+    findings: EvaluationFinding[],
+  ): void {
     const matches = [...content.matchAll(TODO_PATTERN)];
     if (matches.length > 0) {
       const labels = matches.map((m) => m[1]).join(', ');
       findings.push({
-        message: `Found ${matches.length} TODO/FIXME/HACK comment(s): ${labels}. Address or track these as issues.`,
+        message: `Found ${matches.length} unresolved marker comment(s): ${labels}. Address or track these as issues.`,
         severity: 'info',
         suggestion: 'Resolve TODO items or convert them to tracked issues',
       });

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -37,15 +37,25 @@ describe('ConcisenessEvaluator', () => {
     ];
     const result = await evaluator.evaluate(createInput(lines.join('\n')));
 
-    expect(result.findings.some((f) => f.message.includes('comment'))).toBe(true);
+    expect(result.findings.some((f) => f.message.includes('comment'))).toBe(
+      true,
+    );
   });
 
-  it('flags TODO/FIXME/HACK comments', async () => {
+  it('flags unresolved marker comments', async () => {
     const evaluator = new ConcisenessEvaluator();
-    const content = `// TODO: fix this later\n// HACK: temporary workaround\nconst x = 1;`;
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = `// TODO: fix this later\n// ${trackedMarker}: tracked follow-up\n// HACK: temporary workaround\nconst x = 1;`;
     const result = await evaluator.evaluate(createInput(content));
 
-    expect(result.findings.some((f) => f.message.includes('TODO') || f.message.includes('HACK'))).toBe(true);
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('TODO') &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes('HACK'),
+      ),
+    ).toBe(true);
   });
 
   it('passes empty content', async () => {


### PR DESCRIPTION
## Summary
- removes literal fixme marker occurrences while preserving unresolved-marker detection
- keeps the conciseness evaluator test coverage for the constructed marker
- updates the historical MCP suite plan snippet to avoid raw marker matches

## Test Plan
- npm test --workspace @franken/critique
- npm run build --workspace @franken/types
- npm run build --workspace @franken/critique
- npm run lint --workspace @franken/critique
- repository search for literal FIXME returns 0 matches

Closes #595