### PR TITLE
test(orchestrator): guard chat attach console output

### DIFF
--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
@@ -111,5 +111,12 @@ describe('resolveManagedChatAttachment', () => {
         throw new Error('healthcheck should not run for rejected persisted URL');
       },
     })).rejects.toThrow(/https:\/\//);
+  });
+
+  it('keeps chat attachment output routed through the package print helper', async () => {
+    const source = await readFile(join(process.cwd(), 'src/network/chat-attach.ts'), 'utf-8');
+    const directConsoleCall = ['console', 'log'].join('.');
+
+    expect(source).not.toContain(directConsoleCall);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a targeted franken-orchestrator regression test for the managed chat attachment source.
- Verifies the chat attachment path remains free of direct console log calls while preserving the existing print helper behavior.

Closes #558

## Test Plan
- git grep -n 'console\\.log' -- packages/franken-orchestrator/src/network/chat-attach.ts packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts (no matches)
- npm run build --workspace @franken/types
- npm run build --workspace franken-planner
- npm run build --workspace franken-brain
- npm run build --workspace @frankenbeast/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm test -- tests/unit/cli/chat-attach.test.ts (from packages/franken-orchestrator)
- npm run typecheck (from packages/franken-orchestrator)
- npm run lint (from packages/franken-orchestrator; warnings only, pre-existing)
- npm run build (from packages/franken-orchestrator)
- npm run lint:security
