### PR TITLE
fix(test): validate Vitest environment flags

### DIFF
--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import { readVitestFlags } from '../../scripts/vitest-env.js'
 
-const vitestFlags = readVitestFlags()
+const vitestFlags = readVitestFlags(['INTEGRATION', 'EVAL'])
 const isIntegration = vitestFlags.INTEGRATION
 const isEval = vitestFlags.EVAL
 

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import { readVitestFlags } from '../../scripts/vitest-env.js'
 
-const isIntegration = Boolean(process.env['INTEGRATION'])
-const isEval = Boolean(process.env['EVAL'])
+const vitestFlags = readVitestFlags()
+const isIntegration = vitestFlags.INTEGRATION
+const isEval = vitestFlags.EVAL
 
 export default defineConfig({
   test: {

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitest/config';
 import { readVitestFlags } from '../../scripts/vitest-env.js';
 
 const packageRoot = dirname(fileURLToPath(import.meta.url));
-const vitestFlags = readVitestFlags();
+const vitestFlags = readVitestFlags(['INTEGRATION', 'E2E']);
 const isIntegration = vitestFlags.INTEGRATION;
 const isE2e = vitestFlags.E2E;
 const requestedPaths = process.argv

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -1,10 +1,12 @@
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import { defineConfig } from 'vitest/config';
+import { readVitestFlags } from '../../scripts/vitest-env.js';
 
 const packageRoot = dirname(fileURLToPath(import.meta.url));
-const isIntegration = Boolean(process.env['INTEGRATION']);
-const isE2e = Boolean(process.env['E2E']);
+const vitestFlags = readVitestFlags();
+const isIntegration = vitestFlags.INTEGRATION;
+const isE2e = vitestFlags.E2E;
 const requestedPaths = process.argv
   .slice(2)
   .filter((arg) => !arg.startsWith('-') && arg !== 'run');

--- a/scripts/vitest-env.ts
+++ b/scripts/vitest-env.ts
@@ -1,0 +1,29 @@
+export type VitestFlagName = 'INTEGRATION' | 'EVAL' | 'E2E';
+
+export type VitestEnv = Readonly<Record<string, string | undefined>>;
+
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const DISABLED_VALUES = new Set(['', '0', 'false', 'no', 'off']);
+const ALLOWED_VALUES = 'true, false, 1, 0, yes, no, on, or off';
+
+export function readVitestFlag(env: VitestEnv, name: VitestFlagName): boolean {
+  const normalized = (env[name] ?? '').trim().toLowerCase();
+
+  if (ENABLED_VALUES.has(normalized)) {
+    return true;
+  }
+
+  if (DISABLED_VALUES.has(normalized)) {
+    return false;
+  }
+
+  throw new Error(`${name} must be one of ${ALLOWED_VALUES}.`);
+}
+
+export function readVitestFlags(env: VitestEnv = process.env): Record<VitestFlagName, boolean> {
+  return {
+    INTEGRATION: readVitestFlag(env, 'INTEGRATION'),
+    EVAL: readVitestFlag(env, 'EVAL'),
+    E2E: readVitestFlag(env, 'E2E'),
+  };
+}

--- a/scripts/vitest-env.ts
+++ b/scripts/vitest-env.ts
@@ -20,10 +20,11 @@ export function readVitestFlag(env: VitestEnv, name: VitestFlagName): boolean {
   throw new Error(`${name} must be one of ${ALLOWED_VALUES}.`);
 }
 
-export function readVitestFlags(env: VitestEnv = process.env): Record<VitestFlagName, boolean> {
-  return {
-    INTEGRATION: readVitestFlag(env, 'INTEGRATION'),
-    EVAL: readVitestFlag(env, 'EVAL'),
-    E2E: readVitestFlag(env, 'E2E'),
-  };
+export function readVitestFlags<const Names extends readonly VitestFlagName[]>(
+  names: Names,
+  env: VitestEnv = process.env,
+): Record<Names[number], boolean> {
+  return Object.fromEntries(
+    names.map((name) => [name, readVitestFlag(env, name)]),
+  ) as Record<Names[number], boolean>;
 }

--- a/tests/vitest-env.test.ts
+++ b/tests/vitest-env.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { readVitestFlag } from '../scripts/vitest-env.js';
+
+describe('Vitest environment flag helper', () => {
+  it('treats missing and explicit false-like values as disabled', () => {
+    expect(readVitestFlag({}, 'INTEGRATION')).toBe(false);
+    expect(readVitestFlag({ INTEGRATION: '' }, 'INTEGRATION')).toBe(false);
+    expect(readVitestFlag({ INTEGRATION: 'false' }, 'INTEGRATION')).toBe(false);
+    expect(readVitestFlag({ INTEGRATION: '0' }, 'INTEGRATION')).toBe(false);
+    expect(readVitestFlag({ INTEGRATION: 'off' }, 'INTEGRATION')).toBe(false);
+  });
+
+  it('accepts only sanitized true-like values as enabled', () => {
+    expect(readVitestFlag({ EVAL: 'true' }, 'EVAL')).toBe(true);
+    expect(readVitestFlag({ EVAL: '1' }, 'EVAL')).toBe(true);
+    expect(readVitestFlag({ EVAL: ' yes ' }, 'EVAL')).toBe(true);
+    expect(readVitestFlag({ EVAL: 'ON' }, 'EVAL')).toBe(true);
+  });
+
+  it('rejects unexpected values without echoing the raw input', () => {
+    expect(() => readVitestFlag({ E2E: 'secret-token-value' }, 'E2E')).toThrow(
+      /E2E must be one of true, false, 1, 0, yes, no, on, or off/u,
+    );
+    expect(() => readVitestFlag({ E2E: 'secret-token-value' }, 'E2E')).not.toThrow(
+      /secret-token-value/u,
+    );
+  });
+});

--- a/tests/vitest-env.test.ts
+++ b/tests/vitest-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { readVitestFlag } from '../scripts/vitest-env.js';
+import { readVitestFlag, readVitestFlags } from '../scripts/vitest-env.js';
 
 describe('Vitest environment flag helper', () => {
   it('treats missing and explicit false-like values as disabled', () => {
@@ -25,5 +25,11 @@ describe('Vitest environment flag helper', () => {
     expect(() => readVitestFlag({ E2E: 'secret-token-value' }, 'E2E')).not.toThrow(
       /secret-token-value/u,
     );
+  });
+
+  it('validates only the flags requested by a config', () => {
+    expect(readVitestFlags(['INTEGRATION'], { INTEGRATION: 'true', E2E: 'secret-token-value' })).toEqual({
+      INTEGRATION: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a shared Vitest environment flag helper that validates boolean-like values without echoing raw input
- route observer and orchestrator Vitest config environment checks through the helper
- cover sanitized flag parsing and invalid-value rejection with root Vitest tests

## Test Plan
- npm run typecheck
- npm run build
- npm run test:root -- tests/vitest-env.test.ts
- npm --prefix packages/franken-observer test
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run build
- npm --prefix packages/franken-orchestrator test -- tests/unit
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build

Closes #557