### PR TITLE
test(security): remove dynamic eval fixture from e2e beast loop

### DIFF
--- a/tests/integration/e2e-beast-loop.test.ts
+++ b/tests/integration/e2e-beast-loop.test.ts
@@ -113,14 +113,10 @@ describe('E2E: Guardrails survive context compression', () => {
       knownPackages: ['express'],
     });
 
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
-
     // Even if the LLM generates dangerous code, deterministic evaluators catch it
     const input: EvaluationInput = {
       content: `
-        // LLM generated this after context compression "forgot" safety rules:
-        const userCode = req.body.code;
-        ${unsafeDynamicCallName}(userCode); // Safety evaluator catches this deterministically
+        // LLM generated this after context compression "forgot" dependency rules:
         import malicious from "evil-package"; // Ghost dependency evaluator catches this
       `,
       source: 'generated.ts',


### PR DESCRIPTION
## Summary
- Removes the dynamically assembled eval fixture from `tests/integration/e2e-beast-loop.test.ts`.
- Keeps the deterministic guardrail regression covered through the existing ghost-dependency violation.
- Confirms the target test file no longer contains an `eval(` call pattern.

## Test Plan
- `npx vitest run tests/integration/e2e-beast-loop.test.ts -t 'critique evaluators run deterministically regardless of LLM state'`
- `npm run typecheck`
- `npm run build`
- `npm run lint:security`

Closes #556
