### PR TITLE
docs: refresh agent ramp-up guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ frankenbeast --design-doc docs/my-feature-design.md
 frankenbeast --plan-dir ./my-chunks/
 ```
 
-Rerunning against an existing `.fbeast/.build/.checkpoint` file can skip completed tasks. The `--resume` flag is parsed by the CLI, but it is not yet wired as a distinct resume mode.
+Cold `frankenbeast run` clears checkpoint/chunk-session state before execution. Use `--resume` to preserve existing checkpoint data and continue an interrupted run; when no checkpoint exists, `--resume` fails fast instead of silently behaving like a cold run.
 
 ### Subcommands
 

--- a/docs/AGENT_RAMP_UP.md
+++ b/docs/AGENT_RAMP_UP.md
@@ -1,0 +1,22 @@
+# Frankenbeast Agent Ramp-Up
+
+> Agent-oriented companion to `docs/RAMP_UP.md`. Keep this current when structural changes affect how agents should read, modify, or verify the repository.
+
+## Start Here
+
+- Read `docs/RAMP_UP.md` first for the package map, Beast Loop overview, CLI surfaces, build/test commands, and known limitations.
+- Treat live source and focused tests as the source of truth when older docs disagree.
+- Prefer the narrowest package-level test command that covers your change, then run broader root checks when the change crosses package boundaries.
+
+## Active Decisions
+
+- **Workspace shape:** the repo currently has 10 first-party packages under `packages/`, including `franken-mcp-suite` (`@fbeast/mcp-suite`) and `live-bench` (`@fbeast/live-bench`). Do not use the old “8 packages / MCP deleted” summary as current architecture.
+- **Fail-closed deps:** required Beast dependency assembly is fail-closed. `createBeastDeps()` failures are surfaced by `createCliDeps()` instead of being converted into permissive runtime success stubs. Unsafe safety-module stubs require the explicit `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opt-out.
+- **Resume semantics:** cold `frankenbeast run` starts from cleared checkpoint/chunk-session state. Use `--resume` only to continue an interrupted run with existing checkpoint data; without that data it fails fast.
+- **ADR anchors:** ADR-033 covers explicit resume/fail-closed dependency assembly, ADR-036 covers sandboxed Beast execution, and ADR-038 covers fail-closed safety-module loading.
+
+## Agent Workflow Notes
+
+- Before changing runtime behavior, inspect the corresponding tests under the affected package and add or update focused coverage first when practical.
+- Before changing documentation, check for stale duplicate claims in the same document and add a lightweight doc regression test when the claim previously regressed.
+- Keep PRs issue-scoped: one issue, one branch, one PR, with `Closes #<issue>` in the PR body when the PR should close the issue.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -403,7 +403,7 @@ Append-only `AuditTrail` with hash-verified integrity, `AuditTrailStore` persist
 - **Chunk F** (#267): Added `SkillConfigStore` for persistent skill toggle state.
 - **One-Shots**: Deleted standalone comms server files, added HITL integration test, fixed checkpoint flush.
 
-**Test counts**: ~2,100 orchestrator tests passing. Typecheck clean across all 8 packages.
+**Test counts**: ~2,100 orchestrator tests passing. Typecheck clean across the current 10-package workspace.
 
 ---
 

--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -4,7 +4,7 @@
 
 ## What Is This?
 
-A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. All **8 packages** live under `packages/`. Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-monorepo-migration.md). Architecture consolidation (ADR-031) reduced from 13 to 8 packages — firewall, skills, heartbeat, MCP deleted; comms absorbed into orchestrator.
+A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`: the consolidated core packages, `franken-mcp-suite` (`@fbeast/mcp-suite`), and `live-bench` (`@fbeast/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-monorepo-migration.md) and ADR-031 for the earlier consolidation history; do not treat the deleted pre-consolidation MCP package as the current MCP suite.
 
 ## Modules
 
@@ -18,6 +18,8 @@ A deterministic guardrails framework for AI agents organized as an **npm workspa
 | `packages/franken-governor/` | HITL approval gates, triggers (budget/skill/confidence/ambiguity), CLI/Slack channels |
 | `packages/franken-web/` | React web dashboard — chat UI, beast catalog/dispatch controls, network config, metrics |
 | `packages/franken-orchestrator/` | Beast Loop, CLI, chat server, comms gateway (Slack/Discord/Telegram/WhatsApp), beast control APIs, phases, circuit breakers, skill execution, crash recovery |
+| `packages/franken-mcp-suite/` | MCP suite (`@fbeast/mcp-suite`) for tool registry/server/proxy integrations |
+| `packages/live-bench/` | Live benchmark harness (`@fbeast/live-bench`) and fixture workspace tooling |
 
 ## The Beast Loop (4 Phases)
 
@@ -112,7 +114,7 @@ packages/franken-orchestrator/src/
   - `--target-upstream` derive the canonical target repository from the checkout's GitHub `upstream` remote; mutually exclusive with `--repo`
   - `--dry-run` preview triage without executing
 - Build artifacts are plan-scoped under `.fbeast/.build/`: `<plan-name>.checkpoint` for execution state, `<plan-name>-<datetime>-build.log` for session logs (written incrementally, crash-safe), `chunk-sessions/<plan>/<chunk>.json` for canonical chunk execution state, and `chunk-session-snapshots/<plan>/<chunk>/...json` for pre-compaction rollback points. Different plans have independent checkpoints and log histories.
-- `dep-factory.ts` calls `createBeastDeps()` which wires real consolidated adapters for all module ports: `MiddlewareChainFirewallAdapter` (firewall), `SqliteBrainMemoryAdapter` (memory), `SkillManagerAdapter` (skills), `ReflectionHeartbeatAdapter` (heartbeat), `AuditTrailObserverAdapter` (observer). Falls back to passthrough stubs only when `createBeastDeps()` throws (e.g., no providers configured).
+- `dep-factory.ts` calls `createBeastDeps()` which wires real consolidated adapters for the required module ports. If consolidated dependency construction fails, `createCliDeps()` logs the cause and re-throws a `createBeastDeps failed: ...` error; it does **not** synthesize permissive passthrough success deps on the required Beast path. Missing safety packages only fall back to all-pass stubs when `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` explicitly opts into that unsafe degraded mode (ADR-033/ADR-038).
 - `ProviderRegistryIAdapter` bridges `ProviderRegistry.execute()` (async generator) to `IAdapter` (Promise), with `MiddlewareChain` applied on request/response. Active in the heartbeat/reflection LLM path.
 - `SkillConfigStore` persists enabled-skill state to `.fbeast/config.json`.
 - `OrchestratorConfigSchema` accepts `security`, `brain`, and `consolidatedProviders` fields from config files, threaded through `dep-bridge.ts` → `createBeastDeps()`.
@@ -153,7 +155,7 @@ Most packages build with `tsc`; `franken-web` uses `tsc && vite build`.
 2. **SkillManagerAdapter.execute() and McpSdkAdapter.callTool() are stubs**: Return hardcoded strings. Real MCP tool dispatch is a future effort.
 3. **No `--non-interactive` flag**: Headless usage relies on starting at `plan` or `run` with existing inputs.
 4. **No top-level `provider` or `dashboard` CLI subcommands**: Current subcommands are `init`, `interview`, `plan`, `run`, `beasts`, `issues`, `chat`, `chat-server`, `beasts-daemon`, `network`, `skill`, and `security` (see `packages/franken-orchestrator/src/cli/args.ts`). Provider/dashboard capabilities are exposed through provider config, `chat-server`, the HTTP dashboard routes, and `franken-web`.
-5. **`--resume` parsed but not a distinct control path**: Checkpoint-based task skipping works from existing checkpoint files.
+5. **Explicit `--resume` semantics**: Cold `frankenbeast run` clears existing execution checkpoint/chunk-session state before starting. `frankenbeast run --resume` preserves that state and fails fast when no checkpoint exists, so resumed runs are an intentional control path rather than implicit checkpoint reuse (ADR-033).
 
 ## Key Documentation
 

--- a/docs/audits/test-suite-audit.md
+++ b/docs/audits/test-suite-audit.md
@@ -208,7 +208,7 @@ The root-level suite has the highest uselessness rate (31.3%).
 **Brittle hard-coded values** (2 tests):
 | File | Tests | Action |
 |------|-------|--------|
-| `verify-everything.test.ts` | `turbo run build succeeds for all 8 packages` | Fix: don't hard-code count |
+| `verify-everything.test.ts` | `turbo run build succeeds for all workspace packages` | Fixed: derives the package count from the workspace instead of hard-coding it |
 | `verify-everything.test.ts` | `total test count is at least 1572` | Delete (CI already runs all tests) |
 
 **Redundant with package-level tests** (6 tests):

--- a/tests/docs-issue-511.test.ts
+++ b/tests/docs-issue-511.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+describe('issue #511 ramp-up documentation', () => {
+  it('keeps RAMP_UP aligned with the current package set', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+    const packages = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')))
+      .map((entry) => entry.name)
+      .sort();
+
+    expect(packages).toHaveLength(10);
+    expect(packages).toContain('franken-mcp-suite');
+    expect(packages).toContain('live-bench');
+    expect(rampUp).toContain('10 first-party packages');
+    expect(rampUp).toContain('packages/franken-mcp-suite/');
+    expect(rampUp).toContain('packages/live-bench/');
+    expect(rampUp).not.toContain('All **8 packages**');
+  });
+
+  it('documents fail-closed dependency assembly instead of passthrough fallback', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+
+    expect(rampUp).toContain('does **not** synthesize permissive passthrough success deps');
+    expect(rampUp).toContain('createBeastDeps failed:');
+    expect(rampUp).toContain('FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1');
+    expect(rampUp).not.toContain('Falls back to passthrough stubs only when `createBeastDeps()` throws');
+  });
+
+  it('documents explicit resume behavior and provides the agent ramp-up file', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+    const agentRampUp = readDoc('docs/AGENT_RAMP_UP.md');
+
+    expect(rampUp).toContain('Cold `frankenbeast run` clears existing execution checkpoint/chunk-session state');
+    expect(rampUp).toContain('`frankenbeast run --resume` preserves that state and fails fast when no checkpoint exists');
+    expect(rampUp).not.toContain('`--resume` parsed but not a distinct control path');
+    expect(agentRampUp).toContain('## Active Decisions');
+    expect(agentRampUp).toContain('ADR-033');
+    expect(agentRampUp).toContain('Fail-closed deps');
+    expect(agentRampUp).toContain('Resume semantics');
+  });
+});

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -1,28 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const exec = (cmd: string) =>
   execSync(cmd, { cwd: ROOT, encoding: 'utf8' }).trim();
 
-const ALL_PACKAGES = [
-  'franken-brain',
-  'franken-critique',
-  'franken-governor',
-  'franken-observer',
-  'franken-orchestrator',
-  'franken-planner',
-  'franken-types',
-  'franken-web',
-] as const;
+const ALL_PACKAGES = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')))
+  .map((entry) => entry.name)
+  .sort();
 
 describe('Chunk 10: full verification pass', () => {
   describe('build', () => {
-    it('turbo run build succeeds for all 8 packages', () => {
+    it('turbo run build succeeds for all workspace packages', () => {
       const output = exec('npx turbo run build 2>&1');
-      expect(output).toContain('8 successful, 8 total');
+      expect(output).toContain(`${ALL_PACKAGES.length} successful, ${ALL_PACKAGES.length} total`);
     });
   });
 


### PR DESCRIPTION
## Summary
- update RAMP_UP package, fail-closed dependency, and explicit resume guidance
- add docs/AGENT_RAMP_UP.md with Active Decisions for agents
- add issue #511 doc regression coverage and remove stale 8-package verification assumptions

## Test Plan
- npm run test:root -- --run tests/docs-issue-511.test.ts tests/verify-everything.test.ts -t 'issue #511|turbo run build succeeds|no root-level module directories|no .git dirs inside packages'
- npm run typecheck -- --filter=franken-orchestrator
- npm run build
- npm run lint:security

Closes #511