### PR TITLE
fix(orchestrator): validate telegram webhook secret token

### DIFF
--- a/frankenbeast.example.json
+++ b/frankenbeast.example.json
@@ -63,6 +63,11 @@
       "applicationId": "123456789012345678",
       "botTokenRef": "frankenbeast/discord-bot-token",
       "publicKeyRef": "frankenbeast/discord-public-key"
+    },
+    "telegram": {
+      "enabled": false,
+      "botTokenRef": "frankenbeast/telegram-bot-token",
+      "webhookSecretTokenRef": "frankenbeast/telegram-webhook-secret-token"
     }
   }
 }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -578,6 +578,11 @@ async function buildChatServerCommsConfig(
     isDiscordPublicKeyLiteral,
   );
   const telegramBotToken = await resolveCommsSecret(root, config.comms.telegram.botTokenRef, secretStore);
+  const telegramWebhookSecretToken = await resolveCommsSecret(
+    root,
+    config.comms.telegram.webhookSecretTokenRef,
+    secretStore,
+  );
   const whatsappAccessToken = await resolveCommsSecret(root, config.comms.whatsapp.accessTokenRef, secretStore);
   const whatsappPhoneNumberId = await resolveCommsPublicRef(
     root,
@@ -598,6 +603,7 @@ async function buildChatServerCommsConfig(
   });
   requireCommsChannelFields('telegram', config.comms.telegram.enabled, {
     botToken: telegramBotToken,
+    webhookSecretToken: telegramWebhookSecretToken,
   });
   requireCommsChannelFields('whatsapp', config.comms.whatsapp.enabled, {
     accessToken: whatsappAccessToken,
@@ -625,6 +631,7 @@ async function buildChatServerCommsConfig(
       telegram: {
         enabled: config.comms.telegram.enabled,
         botToken: telegramBotToken,
+        webhookSecretToken: telegramWebhookSecretToken,
       },
       whatsapp: {
         enabled: config.comms.whatsapp.enabled,

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { Hono } from 'hono';
 import { TelegramUpdateSchema } from './telegram-schemas.js';
 import { decodeTelegramCallbackData } from './telegram-adapter.js';
@@ -9,22 +10,21 @@ export interface TelegramRouterOptions {
   gateway: ChatGateway;
   sessionMapper: SessionMapper;
   botToken: string;
+  webhookSecretToken: string;
 }
+
+const TELEGRAM_SECRET_TOKEN_HEADER = 'x-telegram-bot-api-secret-token';
 
 /**
  * Router for Telegram webhook updates.
- * Security is handled by having the botToken as part of the path (standard Telegram practice).
+ * Security is handled by Telegram's secret_token webhook header.
  */
 export function telegramRouter(options: TelegramRouterOptions) {
-  const { gateway, sessionMapper, botToken } = options;
+  const { gateway, sessionMapper, botToken, webhookSecretToken } = options;
   const app = new Hono();
 
-  // Telegram recommends using the bot token in the webhook URL for security.
-  // Compare the token as route data instead of interpolating it into the route
-  // template because Telegram tokens contain ':' and Hono treats ':' as a
-  // parameter marker in literal route strings.
-  app.post('/:token', async (c) => {
-    if (c.req.param('token') !== botToken) {
+  app.post('/', async (c) => {
+    if (!isTelegramSecretTokenValid(c.req.header(TELEGRAM_SECRET_TOKEN_HEADER), webhookSecretToken)) {
       return c.json({ error: 'Not found' }, 404);
     }
     const body = await c.req.json();
@@ -102,4 +102,16 @@ export function telegramRouter(options: TelegramRouterOptions) {
   });
 
   return app;
+}
+
+function isTelegramSecretTokenValid(received: string | undefined, expected: string): boolean {
+  if (!received) {
+    return false;
+  }
+  const receivedBuffer = Buffer.from(received);
+  const expectedBuffer = Buffer.from(expected);
+  if (receivedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(receivedBuffer, expectedBuffer);
 }

--- a/packages/franken-orchestrator/src/comms/config/comms-config.ts
+++ b/packages/franken-orchestrator/src/comms/config/comms-config.ts
@@ -20,6 +20,7 @@ export const CommsConfigSchema = z.object({
     telegram: z.object({
       enabled: z.boolean().default(false),
       botToken: z.string().optional(),
+      webhookSecretToken: z.string().optional(),
     }).optional(),
     whatsapp: z.object({
       enabled: z.boolean().default(false),

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -75,13 +75,14 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   }
 
   const telegram = config.channels.telegram;
-  if (telegram?.enabled && telegram.botToken) {
+  if (telegram?.enabled && telegram.botToken && telegram.webhookSecretToken) {
     const adapter = new TelegramAdapter({ token: telegram.botToken });
     gateway.registerAdapter(adapter);
     app.route('/webhooks/telegram', telegramRouter({
       gateway,
       sessionMapper,
       botToken: telegram.botToken,
+      webhookSecretToken: telegram.webhookSecretToken,
     }));
   }
 

--- a/packages/franken-orchestrator/src/init/init-verify.ts
+++ b/packages/franken-orchestrator/src/init/init-verify.ts
@@ -98,6 +98,7 @@ export async function verifyInit(options: {
   if (config.comms.telegram.enabled) {
     const missing: string[] = [];
     if (!config.comms.telegram.botTokenRef) missing.push('botTokenRef');
+    if (!config.comms.telegram.webhookSecretTokenRef) missing.push('webhookSecretTokenRef');
     if (missing.length > 0) {
       issues.push({
         code: 'telegram-incomplete',

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -115,6 +115,7 @@ function buildConfig(baseConfig: OrchestratorConfig, state: InitState): Orchestr
         ...baseConfig.comms.telegram,
         enabled: state.selectedCommsTransports.includes('telegram'),
         botTokenRef: stateValue<string>(state, 'comms.telegram.botTokenRef') ?? baseConfig.comms.telegram.botTokenRef,
+        webhookSecretTokenRef: stateValue<string>(state, 'comms.telegram.webhookSecretTokenRef') ?? baseConfig.comms.telegram.webhookSecretTokenRef,
       },
       whatsapp: {
         ...baseConfig.comms.whatsapp,
@@ -323,6 +324,11 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
             await options.secretStore.store('comms.telegram.botTokenRef', rawBotToken);
             answers['comms.telegram.botTokenRef'] = 'comms.telegram.botTokenRef';
           }
+          const rawWebhookSecretToken = await askText(options.io, 'Enter your Telegram webhook secret token:', '');
+          if (rawWebhookSecretToken.length > 0) {
+            await options.secretStore.store('comms.telegram.webhookSecretTokenRef', rawWebhookSecretToken);
+            answers['comms.telegram.webhookSecretTokenRef'] = 'comms.telegram.webhookSecretTokenRef';
+          }
         } else {
           const currentBotTokenRef = String(
             stateValue(options.initialState, 'comms.telegram.botTokenRef')
@@ -333,6 +339,16 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
             answers['comms.telegram.botTokenRef'] = await askText(options.io, 'Telegram bot token ref', currentBotTokenRef);
           } else {
             answers['comms.telegram.botTokenRef'] = currentBotTokenRef;
+          }
+          const currentWebhookSecretTokenRef = String(
+            stateValue(options.initialState, 'comms.telegram.webhookSecretTokenRef')
+              ?? config.comms.telegram.webhookSecretTokenRef
+              ?? '',
+          );
+          if (!scope.has('telegram') || currentWebhookSecretTokenRef.length === 0) {
+            answers['comms.telegram.webhookSecretTokenRef'] = await askText(options.io, 'Telegram webhook secret token ref', currentWebhookSecretTokenRef);
+          } else {
+            answers['comms.telegram.webhookSecretTokenRef'] = currentWebhookSecretTokenRef;
           }
         }
       }

--- a/packages/franken-orchestrator/src/network/network-config-paths.ts
+++ b/packages/franken-orchestrator/src/network/network-config-paths.ts
@@ -31,6 +31,7 @@ const NETWORK_CONFIG_PATH_DEFINITIONS = {
   'comms.discord.publicKeyRef': { type: 'string' },
   'comms.telegram.enabled': { type: 'boolean' },
   'comms.telegram.botTokenRef': { type: 'string', sensitive: true },
+  'comms.telegram.webhookSecretTokenRef': { type: 'string', sensitive: true },
   'comms.whatsapp.enabled': { type: 'boolean' },
   'comms.whatsapp.accessTokenRef': { type: 'string', sensitive: true },
   'comms.whatsapp.phoneNumberIdRef': { type: 'string' },

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -124,6 +124,7 @@ export const DiscordChannelConfigSchema = z.object({
 export const TelegramChannelConfigSchema = z.object({
   enabled: z.boolean().default(false),
   botTokenRef: z.string().min(1).optional(),
+  webhookSecretTokenRef: z.string().min(1).optional(),
 });
 
 export const WhatsAppChannelConfigSchema = z.object({

--- a/packages/franken-orchestrator/src/network/network-secrets.ts
+++ b/packages/franken-orchestrator/src/network/network-secrets.ts
@@ -44,6 +44,7 @@ const SENSITIVE_CONFIG_PATHS = [
   'comms.slack.signingSecretRef',
   'comms.discord.botTokenRef',
   'comms.telegram.botTokenRef',
+  'comms.telegram.webhookSecretTokenRef',
   'comms.whatsapp.accessTokenRef',
   'comms.whatsapp.appSecretRef',
   'comms.whatsapp.verifyTokenRef',

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
@@ -13,13 +13,16 @@ describe('telegramRouter', () => {
     mapToSessionId: vi.fn().mockReturnValue('session-123'),
   } as unknown as SessionMapper;
 
+  const webhookSecretToken = 'telegram-webhook-secret';
   const app = telegramRouter({
     gateway,
     sessionMapper,
     botToken,
+    webhookSecretToken,
   });
 
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
@@ -36,8 +39,11 @@ describe('telegramRouter', () => {
       },
     });
 
-    const res = await app.request(`/${botToken}`, {
+    const res = await app.request('/', {
       method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
       body,
     });
 
@@ -62,8 +68,11 @@ describe('telegramRouter', () => {
       },
     });
 
-    const res = await app.request(`/${botToken}`, {
+    const res = await app.request('/', {
       method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
       body,
     });
 
@@ -92,8 +101,11 @@ describe('telegramRouter', () => {
       },
     });
 
-    const res = await app.request(`/${botToken}`, {
+    const res = await app.request('/', {
       method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
       body,
     });
 
@@ -110,6 +122,7 @@ describe('telegramRouter', () => {
       gateway,
       sessionMapper,
       botToken: token,
+      webhookSecretToken,
     });
     const mockFetch = vi.mocked(fetch);
     mockFetch.mockResolvedValue({
@@ -130,8 +143,11 @@ describe('telegramRouter', () => {
       },
     });
 
-    const res = await appWithRealisticToken.request(`/${token}`, {
+    const res = await appWithRealisticToken.request('/', {
       method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
       body,
     });
 
@@ -144,5 +160,42 @@ describe('telegramRouter', () => {
       expect.stringContaining('https://api.telegram.org/bot[REDACTED]/answerCallbackQuery'),
     );
     expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining(token));
+  });
+
+  it('rejects Telegram webhooks without the configured secret_token header', async () => {
+    const body = JSON.stringify({
+      update_id: 5,
+      message: {
+        message_id: 100,
+        from: { id: 123, first_name: 'User' },
+        chat: { id: 456, type: 'private' },
+        date: Math.floor(Date.now() / 1000),
+        text: 'hello franken',
+      },
+    });
+
+    const missingHeader = await app.request('/', {
+      method: 'POST',
+      body,
+    });
+    const wrongHeader = await app.request('/', {
+      method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': 'wrong-secret',
+      },
+      body,
+    });
+    const tokenPath = await app.request(`/${botToken}`, {
+      method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
+      body,
+    });
+
+    expect(missingHeader.status).toBe(404);
+    expect(wrongHeader.status).toBe(404);
+    expect(tokenPath.status).toBe(404);
+    expect(gateway.handleInbound).not.toHaveBeenCalled();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -206,11 +206,16 @@ describe('commsRoutes', () => {
     expect(() => commsRoutes({ config: minimalConfig() })).toThrow('CommsRuntimePort');
   });
 
-  it('requires the full Telegram token segment before accepting updates', async () => {
+  it('requires the Telegram secret_token header before accepting updates', async () => {
+    const webhookSecretToken = 'telegram-webhook-secret';
     const app = commsRoutes({
       config: minimalConfig({
         channels: {
-          telegram: { enabled: true, botToken: '123456:secret-token' },
+          telegram: {
+            enabled: true,
+            botToken: '123456:secret-token',
+            webhookSecretToken,
+          },
         },
       }),
       runtime: mockRuntime(),
@@ -226,18 +231,30 @@ describe('commsRoutes', () => {
         from: { id: 42, is_bot: false, first_name: 'Ada' },
       },
     };
-    const headers = { 'Content-Type': 'application/json' };
 
-    const partial = await app.request('/webhooks/telegram/123456anything', {
+    const missingHeader = await app.request('/webhooks/telegram', {
       method: 'POST',
-      headers,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    expect(partial.status).toBe(404);
+    expect(missingHeader.status).toBe(404);
 
-    const exact = await app.request('/webhooks/telegram/123456:secret-token', {
+    const tokenPath = await app.request('/webhooks/telegram/123456:secret-token', {
       method: 'POST',
-      headers,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
+      body: JSON.stringify(body),
+    });
+    expect(tokenPath.status).toBe(404);
+
+    const exact = await app.request('/webhooks/telegram', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+      },
       body: JSON.stringify(body),
     });
     expect(exact.status).toBe(200);

--- a/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
@@ -167,7 +167,7 @@ describe('verifyInit', () => {
         'comms.slack.signingSecretRef': 'op://slack/signing-secret',
       },
     });
-    const { io, prompts } = scriptedIo('op://telegram/bot-token');
+    const { io, prompts } = scriptedIo('op://telegram/bot-token', 'op://telegram/webhook-secret');
 
     const result = await runRepairInit({
       configFile,
@@ -178,8 +178,9 @@ describe('verifyInit', () => {
     expect(result.config.comms.slack.enabled).toBe(true);
     expect(result.config.comms.telegram.enabled).toBe(true);
     expect(result.config.comms.telegram.botTokenRef).toBe('op://telegram/bot-token');
+    expect(result.config.comms.telegram.webhookSecretTokenRef).toBe('op://telegram/webhook-secret');
     expect(result.state.selectedCommsTransports).toEqual(['slack', 'telegram']);
-    expect(prompts).toEqual(['Telegram bot token ref']);
+    expect(prompts).toEqual(['Telegram bot token ref', 'Telegram webhook secret token ref']);
   });
 
   it('repair treats directly enabled channel flags as comms-enabled', async () => {
@@ -198,7 +199,7 @@ describe('verifyInit', () => {
       completedSteps: ['module-selection', 'provider-config', 'security-selection', 'comms-transport-selection'],
       answers: {},
     });
-    const { io, prompts } = scriptedIo('op://telegram/bot-token');
+    const { io, prompts } = scriptedIo('op://telegram/bot-token', 'op://telegram/webhook-secret');
 
     const result = await runRepairInit({
       configFile,
@@ -209,7 +210,8 @@ describe('verifyInit', () => {
     expect(result.config.comms.enabled).toBe(true);
     expect(result.config.comms.telegram.enabled).toBe(true);
     expect(result.config.comms.telegram.botTokenRef).toBe('op://telegram/bot-token');
+    expect(result.config.comms.telegram.webhookSecretTokenRef).toBe('op://telegram/webhook-secret');
     expect(result.state.selectedCommsTransports).toEqual(['telegram']);
-    expect(prompts).toEqual(['Telegram bot token ref']);
+    expect(prompts).toEqual(['Telegram bot token ref', 'Telegram webhook secret token ref']);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -199,6 +199,7 @@ describe('runInitWizard – with Telegram and WhatsApp enabled', () => {
       'n',                    // Enable Discord?
       'y',                    // Enable Telegram?
       'telegram-bot-token',   // Telegram bot token (raw value)
+      'telegram-secret-token', // Telegram webhook secret token (raw value)
       'y',                    // Enable WhatsApp?
       'wa-access-token',      // WhatsApp access token (raw value)
       'wa-phone-number-id',   // WhatsApp phone number ID
@@ -213,7 +214,9 @@ describe('runInitWizard – with Telegram and WhatsApp enabled', () => {
 
     expect(result.config.comms.telegram.enabled).toBe(true);
     expect(result.config.comms.telegram.botTokenRef).toBe('comms.telegram.botTokenRef');
+    expect(result.config.comms.telegram.webhookSecretTokenRef).toBe('comms.telegram.webhookSecretTokenRef');
     expect(secretStore.stored.get('comms.telegram.botTokenRef')).toBe('telegram-bot-token');
+    expect(secretStore.stored.get('comms.telegram.webhookSecretTokenRef')).toBe('telegram-secret-token');
     expect(result.config.comms.whatsapp.enabled).toBe(true);
     expect(result.config.comms.whatsapp.accessTokenRef).toBe('comms.whatsapp.accessTokenRef');
     expect(result.config.comms.whatsapp.phoneNumberIdRef).toBe('wa-phone-number-id');
@@ -234,6 +237,7 @@ describe('runInitWizard – with Telegram and WhatsApp enabled', () => {
     baseConfig.comms.telegram = {
       enabled: true,
       botTokenRef: 'secret://existing/telegram-token',
+      webhookSecretTokenRef: 'secret://existing/telegram-webhook-secret',
     };
     baseConfig.comms.whatsapp = {
       enabled: true,
@@ -252,6 +256,7 @@ describe('runInitWizard – with Telegram and WhatsApp enabled', () => {
 
     expect(io.ask).not.toHaveBeenCalled();
     expect(result.config.comms.telegram.botTokenRef).toBe('secret://existing/telegram-token');
+    expect(result.config.comms.telegram.webhookSecretTokenRef).toBe('secret://existing/telegram-webhook-secret');
     expect(result.config.comms.whatsapp.accessTokenRef).toBe('secret://existing/whatsapp-access');
     expect(result.config.comms.whatsapp.phoneNumberIdRef).toBe('existing-phone-number-id');
     expect(result.config.comms.whatsapp.appSecretRef).toBe('secret://existing/whatsapp-app-secret');


### PR DESCRIPTION
## Summary
- Replace Telegram webhook URL token matching with validation of Telegram's X-Telegram-Bot-Api-Secret-Token header.
- Add config/init/runtime plumbing for a separate Telegram webhook secret token ref.
- Update Telegram webhook tests, comms route coverage, and example config.

## Test Plan
- npm test -- --run tests/unit/comms/telegram-router.test.ts
- npm test -- --run tests/unit/init/init-verify.test.ts tests/unit/init/init-wizard.test.ts
- npm test -- --run tests/unit/cli/run.test.ts tests/unit/http/chat-server-comms.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace franken-planner --workspace franken-brain --workspace @frankenbeast/observer --workspace @franken/critique --workspace @franken/governor && npm run typecheck --workspace franken-orchestrator
- npm test --workspace franken-orchestrator
- npm run build --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator

Closes #620