### PR TITLE
fix(observer): validate replay content refs

### DIFF
--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -11,10 +11,10 @@ describe('ReplayContentStore', () => {
     const store = new ReplayContentStore(root);
     const ref = store.put('hello world');
 
-    expect(ref).toBe(hashContent('hello world'));
-    expect(ref).toMatch(/^sha256:[a-f0-9]{64}$/);
-    expect(existsSync(join(root, 'blobs', ref.replace(/^sha256:/, '')))).toBe(true);
-    expect(existsSync(join(root, 'blobs', ref))).toBe(false);
+    expect(ref).toBe(hashContent('hello world').replace(/^sha256:/, ''));
+    expect(ref).toMatch(/^[a-f0-9]{64}$/);
+    expect(existsSync(join(root, 'blobs', ref))).toBe(true);
+    expect(existsSync(join(root, 'blobs', `sha256:${ref}`))).toBe(false);
     expect(store.get(ref)).toBe('hello world');
   });
 
@@ -28,14 +28,23 @@ describe('ReplayContentStore', () => {
     expect(() => store.get(ref)).toThrow(/hash mismatch/i);
   });
 
-  it('can read pre-prefix replay refs for existing durable artifacts', () => {
+  it('rejects refs that are not exact lowercase sha256 hex before reading', () => {
     const root = mkdtempSync(join(tmpdir(), 'replay-'));
     const store = new ReplayContentStore(root);
     const ref = store.put('legacy content');
-    const legacyRef = ref.replace(/^sha256:/, '');
 
-    store.__corruptForTest(legacyRef, 'legacy content');
+    const invalidRefs = [
+      `sha256:${ref}`,
+      ref.toUpperCase(),
+      ref.slice(0, 63),
+      `../${ref}`,
+      `/tmp/${ref}`,
+      `${ref.slice(0, 32)}/${ref.slice(32)}`,
+      `${ref}00`,
+    ];
 
-    expect(store.get(legacyRef)).toBe('legacy content');
+    for (const invalidRef of invalidRefs) {
+      expect(() => store.get(invalidRef)).toThrow(/exactly 64 lowercase sha256 hex/i);
+    }
   });
 });

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -11,7 +11,7 @@ describe('ReplayContentStore', () => {
     const store = new ReplayContentStore(root);
     const ref = store.put('hello world');
 
-    expect(ref).toBe(hashContent('hello world').replace(/^sha256:/, ''));
+    expect(ref).toBe(hashContent('hello world'));
     expect(ref).toMatch(/^[a-f0-9]{64}$/);
     expect(existsSync(join(root, 'blobs', ref))).toBe(true);
     expect(existsSync(join(root, 'blobs', `sha256:${ref}`))).toBe(false);

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { contentHashMatches } from '../utils/crypto.js';
 import { hashContent } from './replay-record.js';
 
+const SHA256_HEX_REF = /^[a-f0-9]{64}$/;
+
 export class ReplayContentStore {
   private readonly dir: string;
 
@@ -14,7 +16,7 @@ export class ReplayContentStore {
   }
 
   put(content: string): string {
-    const ref = hashContent(content);
+    const ref = hashContent(content).replace(/^sha256:/, '');
     const path = this.blobPath(ref);
     if (!existsSync(path)) {
       writeFileSync(path, content, 'utf8');
@@ -35,6 +37,9 @@ export class ReplayContentStore {
   }
 
   private blobPath(ref: string): string {
-    return join(this.dir, ref.replace(/^sha256:/, ''));
+    if (!SHA256_HEX_REF.test(ref)) {
+      throw new Error('Replay content ref must be exactly 64 lowercase sha256 hex characters');
+    }
+    return join(this.dir, ref);
   }
 }

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -16,7 +16,7 @@ export class ReplayContentStore {
   }
 
   put(content: string): string {
-    const ref = hashContent(content).replace(/^sha256:/, '');
+    const ref = hashContent(content);
     const path = this.blobPath(ref);
     if (!existsSync(path)) {
       writeFileSync(path, content, 'utf8');

--- a/packages/franken-observer/src/replay/replay-record.ts
+++ b/packages/franken-observer/src/replay/replay-record.ts
@@ -1,4 +1,4 @@
-import { hashContent } from '../utils/crypto.js';
+import { hashContent as hashContentWithAlgorithm } from '../utils/crypto.js';
 
 export type ReplayRecordKind =
   | 'llm.request'
@@ -18,4 +18,6 @@ export interface ReplayRecord {
   readonly contentRef: string;
 }
 
-export { hashContent };
+export function hashContent(content: string | Buffer): string {
+  return hashContentWithAlgorithm(content).replace(/^sha256:/, '');
+}


### PR DESCRIPTION
## Summary
- Require replay content refs to be exact 64-character lowercase sha256 hex strings before filesystem path construction
- Store replay blobs under the exact hex ref returned by ReplayContentStore.put
- Add regression coverage for sha256: prefixes, mixed case, short refs, absolute/relative traversal, path separators, and overlong refs

## Test Plan
- npm --prefix packages/franken-observer test -- replay-content-store.test.ts
- npm --prefix packages/franken-observer test -- deterministic-replayer.test.ts execution-replayer.test.ts
- npm --prefix packages/franken-observer test
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run build
- npm run lint:security
- npm run typecheck
- npm run build

Closes #618
