### PR TITLE
fix(orchestrator): reuse beast control services

### DIFF
--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -95,7 +95,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
   let ownsControl = false;
   const getControl = (): BeastControlClient => {
     if (!control) {
-      control = createBeastControlClient(paths);
+      control = createBeastControlClient(paths, services);
       ownsControl = true;
     }
     const activeControl = control;

--- a/packages/franken-orchestrator/src/cli/beast-control-client.ts
+++ b/packages/franken-orchestrator/src/cli/beast-control-client.ts
@@ -1,8 +1,10 @@
 import { createBeastServices } from '../beasts/create-beast-services.js';
+import type { BeastServiceBundle } from '../beasts/create-beast-services.js';
 import type { ProjectPaths } from './project-root.js';
 
-export function createBeastControlClient(paths: ProjectPaths) {
-  const services = createBeastServices(paths);
+export function createBeastControlClient(paths: ProjectPaths, serviceBundle?: BeastServiceBundle) {
+  const services = serviceBundle ?? createBeastServices(paths);
+  const ownsServices = !serviceBundle;
   return {
     listRuns: () => services.runs.listRuns(),
     getRun: (runId: string) => services.runs.getRun(runId),
@@ -34,6 +36,10 @@ export function createBeastControlClient(paths: ProjectPaths) {
     },
     createRun: (input: Parameters<typeof services.dispatch.createRun>[0]) =>
       services.dispatch.createRun(input),
-    dispose: () => services.dispose(),
+    dispose: () => {
+      if (ownsServices) {
+        services.dispose();
+      }
+    },
   };
 }

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -32,8 +32,16 @@ vi.mock('../../../src/beasts/create-beast-services.js', () => ({
   createBeastServices: () => mockServices,
 }));
 
+const mockControlClient = vi.hoisted(() => ({
+  createBeastControlClient: vi.fn(() => ({
+    deleteAgent: vi.fn().mockResolvedValue({ id: 'agent-1' }),
+    dispose: vi.fn(),
+    resumeAgent: vi.fn().mockResolvedValue({ id: 'run-42', status: 'failed' }),
+  })),
+}));
+
 vi.mock('../../../src/cli/beast-control-client.js', () => ({
-  createBeastControlClient: () => ({}),
+  createBeastControlClient: mockControlClient.createBeastControlClient,
 }));
 
 function makeDeps(overrides: Partial<Parameters<typeof handleBeastCommand>[0]> = {}) {
@@ -305,6 +313,18 @@ describe('handleBeastCommand() resume', () => {
     expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses the command service bundle when creating the default control client', async () => {
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'resume', beastTarget: 'agent-1' } as CliArgs,
+      control: undefined,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(mockControlClient.createBeastControlClient).toHaveBeenCalledWith(deps.paths, mockServices);
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it('throws if no beastTarget provided and still disposes services', async () => {
     const deps = makeDeps({
       args: { subcommand: 'beasts', beastAction: 'resume' } as CliArgs,
@@ -325,6 +345,18 @@ describe('handleBeastCommand() delete', () => {
 
     expect(deps.control.deleteAgent).toHaveBeenCalledWith('agent-1');
     expect(deps.print).toHaveBeenCalledWith('Deleted agent-1');
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the command service bundle when creating the default control client', async () => {
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'delete', beastTarget: 'agent-1' } as CliArgs,
+      control: undefined,
+    });
+
+    await handleBeastCommand(deps);
+
+    expect(mockControlClient.createBeastControlClient).toHaveBeenCalledWith(deps.paths, mockServices);
     expect(mockServices.dispose).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- Reuses the existing Beast command service bundle when CLI control routes create their default control client.
- Keeps standalone control-client callers owning and disposing their own services.
- Adds regression coverage for resume/delete control routes so they do not instantiate a second service bundle/SQLite connection.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/cli/beast-cli.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator test
- npm --prefix packages/franken-orchestrator run lint
- npm --prefix packages/franken-orchestrator run build

Closes #700
