### PR TITLE
fix(governor): preserve error causes

### DIFF
--- a/packages/franken-governor/src/channels/slack-channel.ts
+++ b/packages/franken-governor/src/channels/slack-channel.ts
@@ -64,8 +64,8 @@ export class SlackChannel implements ApprovalChannel {
 
     try {
       await this.httpClient.post(this.webhookUrl, payload);
-    } catch {
-      throw new ChannelUnavailableError('slack', `Failed to send webhook to ${this.webhookUrl}`);
+    } catch (cause) {
+      throw new ChannelUnavailableError('slack', `Failed to send webhook to ${this.webhookUrl}`, { cause });
     }
   }
 

--- a/packages/franken-governor/src/errors/channel-unavailable-error.ts
+++ b/packages/franken-governor/src/errors/channel-unavailable-error.ts
@@ -4,8 +4,9 @@ export class ChannelUnavailableError extends GovernorError {
   constructor(
     public readonly channelId: string,
     reason: string,
+    options?: ErrorOptions,
   ) {
-    super(`Channel '${channelId}' unavailable: ${reason}`);
+    super(`Channel '${channelId}' unavailable: ${reason}`, options);
     this.name = 'ChannelUnavailableError';
     Object.setPrototypeOf(this, ChannelUnavailableError.prototype);
   }

--- a/packages/franken-governor/src/errors/governor-error.ts
+++ b/packages/franken-governor/src/errors/governor-error.ts
@@ -1,6 +1,6 @@
 export class GovernorError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'GovernorError';
     Object.setPrototypeOf(this, GovernorError.prototype);
   }

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -71,12 +71,13 @@ export class ApprovalGateway {
   }
 
   private verifySignature(response: ApprovalResponse): void {
+    const signatureVerifier = this.signatureVerifier;
     const payload = formatApprovalResponseSignaturePayload({
       requestId: response.requestId,
       decision: response.decision,
     });
 
-    if (!response.signature || !this.signatureVerifier!.verify(payload, response.signature)) {
+    if (!signatureVerifier || !response.signature || !signatureVerifier.verify(payload, response.signature)) {
       throw new SignatureVerificationError(response.requestId);
     }
   }
@@ -110,7 +111,7 @@ export class ApprovalGateway {
     switch (response.decision) {
       case 'APPROVE': {
         const token = this.sessionTokenStore
-          ? this.createAndStoreToken(request, response)
+          ? this.createAndStoreToken(request, response, this.sessionTokenStore)
           : undefined;
         return token !== undefined
           ? { decision: 'APPROVE', token }
@@ -129,14 +130,18 @@ export class ApprovalGateway {
     }
   }
 
-  private createAndStoreToken(request: ApprovalRequest, response: ApprovalResponse) {
+  private createAndStoreToken(
+    request: ApprovalRequest,
+    response: ApprovalResponse,
+    sessionTokenStore: SessionTokenStore,
+  ) {
     const token = createSessionToken({
       approvalId: request.requestId,
       scope: request.skillId ?? request.taskId,
       grantedBy: response.respondedBy,
       ttlMs: this.config.sessionTokenTtlMs,
     });
-    this.sessionTokenStore!.store(token);
+    sessionTokenStore.store(token);
     return token;
   }
 }

--- a/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
@@ -59,9 +59,10 @@ describe('SlackChannel', () => {
     expect((body as { text: string }).text).toContain('Deploy v2.0');
   });
 
-  it('throws ChannelUnavailableError when webhook POST fails', async () => {
+  it('throws ChannelUnavailableError with the original network error as cause when webhook POST fails', async () => {
+    const networkError = new Error('Network error');
     const httpClient: HttpClient = {
-      post: vi.fn().mockRejectedValue(new Error('Network error')),
+      post: vi.fn().mockRejectedValue(networkError),
     };
     const channel = new SlackChannel({
       webhookUrl: 'https://hooks.slack.com/test',
@@ -69,7 +70,17 @@ describe('SlackChannel', () => {
       callbackServer: makeFakeCallbackServer(),
     });
 
-    await expect(channel.requestApproval(makeRequest())).rejects.toThrow(ChannelUnavailableError);
+    let thrown: unknown;
+    try {
+      await channel.requestApproval(makeRequest());
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ChannelUnavailableError);
+    expect(thrown).toMatchObject({
+      cause: networkError,
+    });
   });
 
   it('maps callback response to ApprovalResponse', async () => {

--- a/packages/franken-governor/tests/unit/errors/governor-error.test.ts
+++ b/packages/franken-governor/tests/unit/errors/governor-error.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { GovernorError } from '../../../src/errors/governor-error.js';
+
+describe('GovernorError', () => {
+  it('preserves the original cause when provided', () => {
+    const cause = new Error('database unavailable');
+    const error = new GovernorError('approval failed', { cause });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(GovernorError);
+    expect(error.cause).toBe(cause);
+  });
+});

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi } from 'vitest';
 import { ApprovalGateway } from '../../../src/gateway/approval-gateway.js';
 import type { ApprovalChannel } from '../../../src/gateway/approval-channel.js';
@@ -50,6 +52,16 @@ function makeFakeAuditRecorder() {
 
 describe('ApprovalGateway — security integration', () => {
   const signingFixture = ['test', 'signing', 'fixture'].join('-')
+
+  it('avoids non-null assertions when using optional security dependencies', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('../../../src/gateway/approval-gateway.ts', import.meta.url)),
+      'utf8',
+    );
+
+    expect(source).not.toContain('signatureVerifier!.');
+    expect(source).not.toContain('sessionTokenStore!.');
+  });
 
   it('throws SignatureVerificationError when requireSignedApprovals is true and signature is invalid', async () => {
     const verifier = new SignatureVerifier(signingFixture);


### PR DESCRIPTION
## Summary
- Pass standard `ErrorOptions` through `GovernorError` and `ChannelUnavailableError`.
- Preserve Slack webhook post failures as `ChannelUnavailableError.cause`.
- Remove non-null assertions around optional approval gateway security dependencies.

## Test Plan
- `npm test --workspace @franken/governor`
- `npm run typecheck --workspace @franken/governor`
- `npm run build --workspace @franken/governor`
- `npx turbo run test --filter=@franken/governor`

Closes #643
