### PR TITLE
fix(web): handle dashboard stream retry races

### DIFF
--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -816,6 +816,27 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('keeps mutation failure alerts when retrying the dashboard stream', async () => {
+    const client = mockClient({
+      subscribeToDashboard: vi.fn()
+        .mockRejectedValueOnce(new Error('SSE unavailable'))
+        .mockResolvedValueOnce(() => undefined),
+      toggleSkill: vi.fn().mockRejectedValue(new Error('HTTP 500')),
+    });
+
+    render(<DashboardPage client={client} />);
+    await screen.findByRole('alert');
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable shell' }));
+    expect(await screen.findByRole('button', { name: 'Retry enabling shell' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading dashboard' }));
+
+    await waitFor(() => {
+      expect(client.subscribeToDashboard).toHaveBeenCalledTimes(2);
+      expect(screen.getByRole('button', { name: 'Retry enabling shell' })).toBeTruthy();
+    });
+  });
+
   it('closes a stream subscription that resolves after it has been superseded', async () => {
     const staleSubscription = deferred<() => void>();
     const unsubscribeStale = vi.fn();

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -796,4 +796,63 @@ describe('DashboardPage', () => {
       expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('standard');
     });
   });
+
+  it('reopens the dashboard stream when retrying a stream failure', async () => {
+    const client = mockClient({
+      subscribeToDashboard: vi.fn()
+        .mockRejectedValueOnce(new Error('SSE unavailable'))
+        .mockResolvedValueOnce(() => undefined),
+    });
+
+    render(<DashboardPage client={client} />);
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to stream dashboard updates. SSE unavailable');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading dashboard' }));
+
+    await waitFor(() => {
+      expect(client.fetchSnapshot).toHaveBeenCalledTimes(2);
+      expect(client.subscribeToDashboard).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText(/Unable to stream dashboard updates/)).toBeNull();
+    });
+  });
+
+  it('closes a stream subscription that resolves after it has been superseded', async () => {
+    const staleSubscription = deferred<() => void>();
+    const unsubscribeStale = vi.fn();
+    const firstClient = mockClient({
+      subscribeToDashboard: vi.fn().mockReturnValue(staleSubscription.promise),
+    });
+    const nextClient = mockClient();
+    const { rerender } = render(<DashboardPage client={firstClient} />);
+
+    await screen.findByRole('switch', { name: 'Enable shell' });
+    rerender(<DashboardPage client={nextClient} />);
+    await screen.findByRole('switch', { name: 'Enable shell' });
+
+    staleSubscription.resolve(unsubscribeStale);
+
+    await waitFor(() => {
+      expect(unsubscribeStale).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('ignores stream setup failures from a superseded dashboard client', async () => {
+    const staleSubscription = deferred<() => void>();
+    const firstClient = mockClient({
+      subscribeToDashboard: vi.fn().mockReturnValue(staleSubscription.promise),
+    });
+    const nextClient = mockClient();
+    const { rerender } = render(<DashboardPage client={firstClient} />);
+
+    await screen.findByRole('switch', { name: 'Enable shell' });
+    rerender(<DashboardPage client={nextClient} />);
+    await screen.findByRole('switch', { name: 'Enable shell' });
+
+    staleSubscription.reject(new Error('old SSE failed'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/old SSE failed/)).toBeNull();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+  });
 });

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -51,6 +51,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [skillErrors, setSkillErrors] = useState<Record<string, SkillMutationError>>({});
   const [securityError, setSecurityError] = useState<SecurityMutationError | null>(null);
+  const [dashboardConnectionRetry, setDashboardConnectionRetry] = useState(0);
 
   const setConfirmedSnapshot = useCallback((snapshot: DashboardSnapshot) => {
     confirmedSnapshotRef.current = snapshot;
@@ -162,25 +163,31 @@ export function DashboardPage({ client }: DashboardPageProps) {
     }
     loadSnapshot();
     let unsub: (() => void) | undefined;
+    let streamActive = true;
     client.subscribeToDashboard((snap) => {
       if (!mountedRef.current) return;
+      if (!streamActive) return;
       if (clientGenerationRef.current !== subscriptionGeneration) return;
       setLoadError(null);
       applyServerSnapshot(snap);
     })
       .then((nextUnsub) => {
-        if (!mountedRef.current) {
+        if (!mountedRef.current || !streamActive || clientGenerationRef.current !== subscriptionGeneration) {
           nextUnsub();
           return;
         }
         unsub = nextUnsub;
       })
       .catch((error) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !streamActive || clientGenerationRef.current !== subscriptionGeneration) return;
         setLoadError(`Unable to stream dashboard updates. ${describeError(error)}`);
       });
-    return () => { mountedRef.current = false; unsub?.(); };
-  }, [applyServerSnapshot, client, loadSnapshot, setConfirmedSnapshot]);
+    return () => { streamActive = false; mountedRef.current = false; unsub?.(); };
+  }, [applyServerSnapshot, client, dashboardConnectionRetry, loadSnapshot, setConfirmedSnapshot]);
+
+  const retryDashboardConnection = useCallback(() => {
+    setDashboardConnectionRetry((retry) => retry + 1);
+  }, []);
 
   const handleToggleSkill = useCallback((name: string, enabled: boolean) => {
     const sequence = (issuedSkillMutationSequenceRef.current.get(name) ?? 0) + 1;
@@ -295,7 +302,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
           {loadError && (
             <div className="analytics-alert dashboard-alert" role="alert">
               <span>{loadError}</span>
-              <button type="button" onClick={loadSnapshot}>Retry loading dashboard</button>
+              <button type="button" onClick={retryDashboardConnection}>Retry loading dashboard</button>
             </div>
           )}
           {Object.values(skillErrors).map((skillError) => (

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -36,6 +36,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     setLoading,
   } = useDashboardStore();
   const mountedRef = useRef(false);
+  const previousClientRef = useRef<DashboardApiClient | null>(null);
   const clientGenerationRef = useRef(0);
   const loadSequenceRef = useRef(0);
   const issuedSkillMutationSequenceRef = useRef(new Map<string, number>());
@@ -146,17 +147,25 @@ export function DashboardPage({ client }: DashboardPageProps) {
   }, [applyServerSnapshot, client, setLoading]);
 
   useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
     // Note: SSE snapshot events replace full store state. If the server pushes
     // a snapshot while an optimistic update is in-flight, the server state wins.
     // Currently only the initial snapshot is pushed (heartbeats carry no data).
-    mountedRef.current = true;
-    clientGenerationRef.current += 1;
-    skillMutationSequenceRef.current.clear();
-    securityMutationSequenceRef.current = 0;
-    failedSkillMutationSequenceRef.current.clear();
-    failedSecurityMutationSequenceRef.current = null;
-    setSkillErrors({});
-    setSecurityError(null);
+    const clientChanged = previousClientRef.current !== client;
+    previousClientRef.current = client;
+    if (clientChanged) {
+      clientGenerationRef.current += 1;
+      skillMutationSequenceRef.current.clear();
+      securityMutationSequenceRef.current = 0;
+      failedSkillMutationSequenceRef.current.clear();
+      failedSecurityMutationSequenceRef.current = null;
+      setSkillErrors({});
+      setSecurityError(null);
+    }
     const subscriptionGeneration = clientGenerationRef.current;
     if (!confirmedSnapshotRef.current && security) {
       setConfirmedSnapshot({ skills, security, providers });
@@ -182,7 +191,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
         if (!mountedRef.current || !streamActive || clientGenerationRef.current !== subscriptionGeneration) return;
         setLoadError(`Unable to stream dashboard updates. ${describeError(error)}`);
       });
-    return () => { streamActive = false; mountedRef.current = false; unsub?.(); };
+    return () => { streamActive = false; unsub?.(); };
   }, [applyServerSnapshot, client, dashboardConnectionRetry, loadSnapshot, setConfirmedSnapshot]);
 
   const retryDashboardConnection = useCallback(() => {


### PR DESCRIPTION
## Summary
- Follow-up for late Codex findings on merged PR #711.
- Reopens dashboard stream subscription when retrying a stream setup failure.
- Ignores and cleans up superseded stream setup promises to avoid stale errors and leaked subscriptions.

## Test Plan
- git diff --check
- cd packages/franken-web && npx vitest run src/pages/dashboard-page.test.tsx src/lib/dashboard-api.test.ts
- cd packages/franken-web && npm run typecheck
- cd packages/franken-web && npm run build

Follow-up to #711.