### PR TITLE
ci: enforce pinned npm package manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
-          corepack enable
+          corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 
       - name: Verify npm matches packageManager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
           node-version: '22'
           cache: npm
 
+      - name: Enable packageManager-pinned npm
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
+      - name: Verify npm matches packageManager
+        run: node scripts/check-package-manager.mjs
+
       - run: npm ci
 
       - run: npm run test:root -- tests/workspaces.test.ts

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,14 @@ jobs:
           node-version: '22'
           cache: npm
 
+      - name: Enable packageManager-pinned npm
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
+      - name: Verify npm matches packageManager
+        run: node scripts/check-package-manager.mjs
+
       - run: npm ci
 
       - name: Validate release before creating tags
@@ -91,6 +99,14 @@ jobs:
           node-version: '22'
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      - name: Enable packageManager-pinned npm
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
+      - name: Verify npm matches packageManager
+        run: node scripts/check-package-manager.mjs
 
       - run: npm ci
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
-          corepack enable
+          corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 
       - name: Verify npm matches packageManager
@@ -102,7 +102,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
-          corepack enable
+          corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 
       - name: Verify npm matches packageManager

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -11,7 +11,7 @@ Get Frankenbeast running locally.
 ## 1. Install dependencies
 
 ```bash
-corepack enable
+corepack enable npm
 corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 npm run check:package-manager
 npm install

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -5,12 +5,15 @@ Get Frankenbeast running locally.
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26` (see `.nvmrc` for the pinned local default; npm enforces this with `engine-strict=true`)
-- npm >= 10 (the repo is an npm workspaces monorepo; root `packageManager` is npm)
+- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)
 - Docker only if you want the optional ChromaDB/Grafana/Tempo stack
 
 ## 1. Install dependencies
 
 ```bash
+corepack enable
+corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+npm run check:package-manager
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
+    "check:package-manager": "node scripts/check-package-manager.mjs",
     "lint:security": "node scripts/check-plain-http.mjs",
     "test": "turbo run test",
     "test:root": "vitest run",

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -17,11 +17,26 @@ if (!match) {
 }
 
 const expected = match[1];
-const actual = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim();
+
+function readVersion(command, args) {
+  try {
+    return execFileSync(command, args, { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const corepackVersion = readVersion('corepack', ['npm', '--version']);
+const actual = corepackVersion || readVersion('npm', ['--version']);
+if (!actual) {
+  console.error('Unable to determine npm version via `corepack npm --version` or `npm --version`.');
+  process.exit(1);
+}
 
 if (actual !== expected) {
-  console.error(`npm version mismatch: packageManager pins npm@${expected}, but npm --version returned ${actual}.`);
-  console.error(`Run \`corepack enable npm && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
+  const source = corepackVersion ? 'corepack npm' : 'npm';
+  console.error(`npm version mismatch: packageManager pins npm@${expected}, but ${source} --version returned ${actual}.`);
+  console.error(`Run \`corepack enable && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
   process.exit(1);
 }
 

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const packageManager = manifest.packageManager;
+
+if (typeof packageManager !== 'string') {
+  console.error('package.json must declare packageManager, for example "npm@11.5.1".');
+  process.exit(1);
+}
+
+const match = packageManager.match(/^npm@(\d+\.\d+\.\d+)$/);
+if (!match) {
+  console.error(`Unsupported packageManager ${JSON.stringify(packageManager)}; expected an exact npm version like "npm@11.5.1".`);
+  process.exit(1);
+}
+
+const expected = match[1];
+const actual = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim();
+
+if (actual !== expected) {
+  console.error(`npm version mismatch: packageManager pins npm@${expected}, but npm --version returned ${actual}.`);
+  console.error(`Run \`corepack enable && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
+  process.exit(1);
+}
+
+console.log(`npm ${actual} matches packageManager ${packageManager}.`);

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -21,7 +21,7 @@ const actual = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim();
 
 if (actual !== expected) {
   console.error(`npm version mismatch: packageManager pins npm@${expected}, but npm --version returned ${actual}.`);
-  console.error(`Run \`corepack enable && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
+  console.error(`Run \`corepack enable npm && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
   process.exit(1);
 }
 

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -50,7 +50,7 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
     });
 
     it('enables Corepack and verifies the packageManager-pinned npm before installing', () => {
-      expect(content).toContain('corepack enable');
+      expect(content).toContain('corepack enable npm');
       expect(content).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
       expect(content).toContain('node scripts/check-package-manager.mjs');
       expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
@@ -119,7 +119,7 @@ describe('release-please.yml publishes released npm packages', () => {
 
   it('enforces the packageManager-pinned npm before release installs and publishes', () => {
     const content = readFileSync(RELEASE_PATH, 'utf-8');
-    expect(content.match(/corepack enable/g)?.length).toBe(2);
+    expect(content.match(/corepack enable npm/g)?.length).toBe(2);
     expect(content.match(/node scripts\/check-package-manager\.mjs/g)?.length).toBe(2);
     expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     expect(content.lastIndexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.lastIndexOf('npm ci'));

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -49,6 +49,13 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
       expect(content).toContain('npm ci');
     });
 
+    it('enables Corepack and verifies the packageManager-pinned npm before installing', () => {
+      expect(content).toContain('corepack enable');
+      expect(content).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
+      expect(content).toContain('node scripts/check-package-manager.mjs');
+      expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
+    });
+
     it('runs turbo run build test lint', () => {
       expect(content).toContain('turbo run');
       expect(content).toMatch(/turbo run.*build.*test.*lint/);
@@ -108,6 +115,14 @@ describe('release-please.yml publishes released npm packages', () => {
     expect(content).toContain('validate-release:');
     expect(content).toContain('release-please:\n    needs: validate-release');
     expect(content).toMatch(/Validate release before creating tags[\s\S]*turbo run.*build.*typecheck.*test.*lint/);
+  });
+
+  it('enforces the packageManager-pinned npm before release installs and publishes', () => {
+    const content = readFileSync(RELEASE_PATH, 'utf-8');
+    expect(content.match(/corepack enable/g)?.length).toBe(2);
+    expect(content.match(/node scripts\/check-package-manager\.mjs/g)?.length).toBe(2);
+    expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
+    expect(content.lastIndexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.lastIndexOf('npm ci'));
   });
 
   it('defers npm token enforcement until a public package needs publishing', () => {


### PR DESCRIPTION
## Summary
- enable Corepack and activate the root packageManager npm pin before CI installs
- add a package-manager verification script and CI/release workflow checks before npm ci
- update quickstart docs and workflow tests for the pinned npm setup

## Test Plan
- npm run check:package-manager
- npm run test:root -- tests/unit/ci-workflow.test.ts
- npm run lint:security
- npx turbo run build typecheck test lint

Closes #625