### PR TITLE
fix(orchestrator): validate Slack interactive payloads

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/slack/slack-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/slack/slack-router.ts
@@ -75,8 +75,18 @@ export function slackRouter(options: SlackRouterOptions) {
       return c.json({ error: 'Missing payload' }, 400);
     }
 
-    const body = JSON.parse(payloadRaw);
-    const parsed = SlackInteractionSchema.parse(body);
+    let body: unknown;
+    try {
+      body = JSON.parse(payloadRaw);
+    } catch {
+      return c.json({ error: 'Malformed payload' }, 400);
+    }
+
+    const interaction = SlackInteractionSchema.safeParse(body);
+    if (!interaction.success) {
+      return c.json({ error: 'Invalid payload' }, 400);
+    }
+    const parsed = interaction.data;
 
     const sessionId = sessionMapper.mapToSessionId({
       channelType: 'slack',

--- a/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { Hono } from 'hono';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { slackRouter } from '../../../src/comms/channels/slack/slack-router.js';
-import { SlackInteractionSchema } from '../../../src/comms/channels/slack/slack-schemas.js';
 import { createHmac } from 'node:crypto';
 import type { ChatGateway } from '../../../src/comms/gateway/chat-gateway.js';
 import type { SessionMapper } from '../../../src/comms/core/session-mapper.js';
@@ -20,6 +18,10 @@ describe('slackRouter', () => {
     gateway,
     sessionMapper,
     signingSecret: secret,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   function getSignature(body: string, timestamp: string) {
@@ -80,26 +82,11 @@ describe('slackRouter', () => {
   });
 
   it('handles interactive button clicks', async () => {
-    // Create a version of the router WITHOUT signature verification just for this test
-    // to bypass the undici/Hono body parsing issues in the test environment.
-    // Signature verification is already verified in slack-signature.test.ts.
-    const appWithoutSig = new Hono();
-    appWithoutSig.post('/interactive', async (c) => {
-      const formData = await c.req.formData();
-      const payloadRaw = formData.get('payload');
-      if (typeof payloadRaw !== 'string') return c.json({ error: 'Missing payload' }, 400);
-      const body = JSON.parse(payloadRaw);
-      const parsed = SlackInteractionSchema.parse(body);
-      const sessionId = sessionMapper.mapToSessionId({
-        channelType: 'slack',
-        externalUserId: parsed.user.id,
-        externalChannelId: parsed.channel.id,
-        externalThreadId: parsed.container.thread_ts || parsed.container.message_ts,
-      });
-      for (const action of parsed.actions) {
-        await gateway.handleAction('slack', sessionId, action.action_id);
-      }
-      return c.json({ ok: true });
+    const appWithoutSig = slackRouter({
+      gateway,
+      sessionMapper,
+      signingSecret: secret,
+      verifySignature: false,
     });
 
     const payload = JSON.stringify({
@@ -121,6 +108,50 @@ describe('slackRouter', () => {
 
     expect(res.status).toBe(200);
     expect(gateway.handleAction).toHaveBeenCalledWith('slack', 'session-123', 'approve');
+  });
+
+  it('returns 400 for malformed interactive JSON without invoking handlers', async () => {
+    const appWithoutSig = slackRouter({
+      gateway,
+      sessionMapper,
+      signingSecret: secret,
+      verifySignature: false,
+    });
+
+    const formData = new FormData();
+    formData.append('payload', '{not-json');
+
+    const res = await appWithoutSig.request('/interactive', {
+      method: 'POST',
+      body: formData,
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Malformed payload' });
+    expect(sessionMapper.mapToSessionId).not.toHaveBeenCalled();
+    expect(gateway.handleAction).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for unexpected interactive payload shapes without invoking handlers', async () => {
+    const appWithoutSig = slackRouter({
+      gateway,
+      sessionMapper,
+      signingSecret: secret,
+      verifySignature: false,
+    });
+
+    const formData = new FormData();
+    formData.append('payload', JSON.stringify({ type: 'block_actions', actions: 'approve' }));
+
+    const res = await appWithoutSig.request('/interactive', {
+      method: 'POST',
+      body: formData,
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid payload' });
+    expect(sessionMapper.mapToSessionId).not.toHaveBeenCalled();
+    expect(gateway.handleAction).not.toHaveBeenCalled();
   });
 
   it('verifySignature: false allows request without valid signature', async () => {


### PR DESCRIPTION
## Summary
- Return 400 for malformed Slack interactive JSON payloads.
- Validate parsed interactive payloads with the Slack interaction schema before reading user/channel/container/action fields.
- Exercise the real router path for valid, malformed, and invalid interactive payloads.

## Test Plan
- npm run test --workspace franken-orchestrator -- tests/unit/comms/slack-router.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace franken-planner
- npm run build --workspace franken-brain
- npm run build --workspace @frankenbeast/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace franken-orchestrator
- npm run lint --workspace franken-orchestrator (passes with pre-existing warnings)
- npm run build --workspace franken-orchestrator
- npm run test --workspace franken-orchestrator

Closes #624