### PR TITLE
fix(web): wire beast prompt file picker selection

### DIFF
--- a/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
@@ -4,6 +4,11 @@ import { isAbsolute, relative, resolve, sep } from 'node:path';
 import type { BeastDefinition } from '../types.js';
 import { resolveCliEntrypoint } from './resolve-cli-entrypoint.js';
 
+const promptConfigSchema = z.object({
+  text: z.string().optional(),
+  files: z.array(z.string()).optional(),
+}).strict();
+
 function canonicalPath(path: string): string {
   try {
     return realpathSync(path);
@@ -37,6 +42,7 @@ export const chunkPlanDefinition: BeastDefinition = {
     designDocPath: z.string().min(1),
     outputDir: z.string().min(1),
     projectRoot: z.string().optional(),
+    promptConfig: promptConfigSchema.optional(),
   }).strict(),
   interviewPrompts: [
     {

--- a/packages/franken-orchestrator/src/beasts/definitions/design-interview-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/design-interview-definition.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import type { BeastDefinition } from '../types.js';
 import { resolveCliEntrypoint } from './resolve-cli-entrypoint.js';
 
+const promptConfigSchema = z.object({
+  text: z.string().optional(),
+  files: z.array(z.string()).optional(),
+}).strict();
+
 export const designInterviewDefinition: BeastDefinition = {
   id: 'design-interview',
   version: 1,
@@ -12,6 +17,7 @@ export const designInterviewDefinition: BeastDefinition = {
     goal: z.string().min(1),
     outputPath: z.string().min(1),
     projectRoot: z.string().optional(),
+    promptConfig: promptConfigSchema.optional(),
   }).strict(),
   interviewPrompts: [
     {

--- a/packages/franken-orchestrator/src/beasts/definitions/martin-loop-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/martin-loop-definition.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import type { BeastDefinition } from '../types.js';
 import { resolveCliEntrypoint } from './resolve-cli-entrypoint.js';
 
+const promptConfigSchema = z.object({
+  text: z.string().optional(),
+  files: z.array(z.string()).optional(),
+}).strict();
+
 export const martinLoopDefinition: BeastDefinition = {
   id: 'martin-loop',
   version: 1,
@@ -13,6 +18,7 @@ export const martinLoopDefinition: BeastDefinition = {
     objective: z.string().min(1),
     chunkDirectory: z.string().min(1),
     projectRoot: z.string().optional(),
+    promptConfig: promptConfigSchema.optional(),
   }).strict(),
   interviewPrompts: [
     {

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -47,6 +47,11 @@ function resolveContainedExistingPath(projectRoot: string, requestedPath: string
   return target;
 }
 
+function appendPromptContext(value: string, promptText: string | undefined): string {
+  if (!promptText || promptText.trim().length === 0) return value;
+  return `${value}\n\nAdditional prompt context:\n${promptText.trim()}`;
+}
+
 export interface SessionConfig {
   paths: ProjectPaths;
   baseBranch: string;
@@ -243,8 +248,9 @@ export class Session {
         },
       };
 
+      const runConfig = loadRunConfigFromEnv();
       const capturingInterview = new InterviewLoop(progressLlm, interviewIo, capturingGraphBuilder);
-      await capturingInterview.build({ goal: 'Gather requirements' });
+      await capturingInterview.build({ goal: appendPromptContext('Gather requirements', runConfig?.promptConfig?.text) });
 
       const displayDesignCard = (designDoc: string): string => {
         const designPath = writeDesignDoc(paths, designDoc);
@@ -326,6 +332,9 @@ export class Session {
       }
       designContent = stored;
     }
+
+    const runConfig = loadRunConfigFromEnv();
+    designContent = appendPromptContext(designContent, runConfig?.promptConfig?.text);
 
     const inferredPlanName = paths.plansDir.split('/').filter(Boolean).pop() ?? 'plans';
     const planName = this.config.planDirOverride
@@ -470,10 +479,11 @@ export class Session {
     loopConfig.stateDir = this.config.orchestratorConfig?.stateDir ?? paths.stateDir;
 
     try {
+      const runConfig = loadRunConfigFromEnv();
       const result = await new BeastLoop(fullDeps, loopConfig).run({
         projectId,
         sessionId: runSessionId,
-        userInput: `Process chunks in ${chunkDir}`,
+        userInput: appendPromptContext(`Process chunks in ${chunkDir}`, runConfig?.promptConfig?.text),
       });
 
       this.displaySummary(result);

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -18,7 +18,7 @@ import type { ProjectPaths } from './project-root.js';
 import type { ReviewIO } from '../issues/issue-review.js';
 import type { IssueFetchOptions, IssueOutcome } from '../issues/types.js';
 import { createCliDeps, type CliDepOptions } from './dep-factory.js';
-import { loadRunConfigFromEnv } from './run-config-loader.js';
+import { PromptConfigSchema, RunConfigSchema, type RunConfig } from './run-config-loader.js';
 import { extractDesignSummary, formatDesignCard } from './design-summary.js';
 import { reviewLoop } from './review-loop.js';
 import { isNoOpDesign } from './noop-detector.js';
@@ -50,6 +50,24 @@ function resolveContainedExistingPath(projectRoot: string, requestedPath: string
 function appendPromptContext(value: string, promptText: string | undefined): string {
   if (!promptText || promptText.trim().length === 0) return value;
   return `${value}\n\nAdditional prompt context:\n${promptText.trim()}`;
+}
+
+function loadPromptConfigFromEnv(): RunConfig['promptConfig'] | undefined {
+  const filePath = process.env['FRANKENBEAST_RUN_CONFIG'];
+  if (!filePath) return undefined;
+  const raw = readFileSync(filePath, 'utf-8');
+  const parsed = JSON.parse(raw) as { promptConfig?: unknown };
+  if (!parsed.promptConfig) return undefined;
+  return PromptConfigSchema.parse(parsed.promptConfig);
+}
+
+function loadCompatibleRunConfigFromEnv(): RunConfig | undefined {
+  const filePath = process.env['FRANKENBEAST_RUN_CONFIG'];
+  if (!filePath) return undefined;
+  const raw = readFileSync(filePath, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  const result = RunConfigSchema.safeParse(parsed);
+  return result.success ? result.data : undefined;
 }
 
 export interface SessionConfig {
@@ -248,9 +266,9 @@ export class Session {
         },
       };
 
-      const runConfig = loadRunConfigFromEnv();
+      const promptConfig = loadPromptConfigFromEnv();
       const capturingInterview = new InterviewLoop(progressLlm, interviewIo, capturingGraphBuilder);
-      await capturingInterview.build({ goal: appendPromptContext('Gather requirements', runConfig?.promptConfig?.text) });
+      await capturingInterview.build({ goal: appendPromptContext('Gather requirements', promptConfig?.text) });
 
       const displayDesignCard = (designDoc: string): string => {
         const designPath = writeDesignDoc(paths, designDoc);
@@ -333,8 +351,8 @@ export class Session {
       designContent = stored;
     }
 
-    const runConfig = loadRunConfigFromEnv();
-    designContent = appendPromptContext(designContent, runConfig?.promptConfig?.text);
+    const promptConfig = loadPromptConfigFromEnv();
+    designContent = appendPromptContext(designContent, promptConfig?.text);
 
     const inferredPlanName = paths.plansDir.split('/').filter(Boolean).pop() ?? 'plans';
     const planName = this.config.planDirOverride
@@ -479,11 +497,11 @@ export class Session {
     loopConfig.stateDir = this.config.orchestratorConfig?.stateDir ?? paths.stateDir;
 
     try {
-      const runConfig = loadRunConfigFromEnv();
+      const promptConfig = loadPromptConfigFromEnv();
       const result = await new BeastLoop(fullDeps, loopConfig).run({
         projectId,
         sessionId: runSessionId,
-        userInput: appendPromptContext(`Process chunks in ${chunkDir}`, runConfig?.promptConfig?.text),
+        userInput: appendPromptContext(`Process chunks in ${chunkDir}`, promptConfig?.text),
       });
 
       this.displaySummary(result);
@@ -591,7 +609,7 @@ export class Session {
       reset: this.config.reset,
       resume: this.config.resume ?? false,
       planDirOverride: this.config.planDirOverride,
-      runConfig: loadRunConfigFromEnv(),
+      runConfig: loadCompatibleRunConfigFromEnv(),
       orchestratorConfig: this.config.orchestratorConfig,
     };
   }

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
@@ -112,6 +112,17 @@ describe('chunkPlanDefinition', () => {
       expect(result.success).toBe(true);
     });
 
+    it('keeps promptConfig for dashboard frontloaded prompts', () => {
+      const result = chunkPlanDefinition.configSchema.safeParse({
+        ...validConfig,
+        promptConfig: { text: 'attached context' },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.promptConfig?.text).toBe('attached context');
+      }
+    });
+
     it('rejects missing designDocPath', () => {
       const result = chunkPlanDefinition.configSchema.safeParse({
         outputDir: '/tmp',

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/design-interview-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/design-interview-definition.test.ts
@@ -75,6 +75,17 @@ describe('designInterviewDefinition', () => {
       expect(result.success).toBe(true);
     });
 
+    it('keeps promptConfig for dashboard frontloaded prompts', () => {
+      const result = designInterviewDefinition.configSchema.safeParse({
+        ...validConfig,
+        promptConfig: { text: 'attached context' },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.promptConfig?.text).toBe('attached context');
+      }
+    });
+
     it('rejects missing goal', () => {
       const result = designInterviewDefinition.configSchema.safeParse({
         outputPath: '/tmp/out.md',

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/martin-loop-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/martin-loop-definition.test.ts
@@ -75,6 +75,17 @@ describe('martinLoopDefinition', () => {
       expect(result.success).toBe(true);
     });
 
+    it('keeps promptConfig for dashboard frontloaded prompts', () => {
+      const result = martinLoopDefinition.configSchema.safeParse({
+        ...validConfig,
+        promptConfig: { text: 'attached context' },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.promptConfig?.text).toBe('attached context');
+      }
+    });
+
     it('rejects missing provider', () => {
       const result = martinLoopDefinition.configSchema.safeParse({
         objective: 'test',

--- a/packages/franken-web/src/components/beasts/shared/file-picker.tsx
+++ b/packages/franken-web/src/components/beasts/shared/file-picker.tsx
@@ -1,4 +1,5 @@
-import type { ContextHealth } from '../../../lib/token-estimator';
+import type { ChangeEvent } from 'react';
+import { estimateTokens, getContextHealth, type ContextHealth } from '../../../lib/token-estimator';
 
 export interface PickedFile {
   name: string;
@@ -19,12 +20,48 @@ const HEALTH_STYLES: Record<ContextHealth, { badge: string; label: string }> = {
   critical: { badge: 'bg-red-500/20 text-red-400', label: 'Critical' },
 };
 
-export function FilePicker({ files, onFilesChange: _onFilesChange, onRemoveFile }: FilePickerProps) {
+function readFileText(file: File): Promise<string> {
+  if (typeof file.text === 'function') {
+    return file.text();
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error ?? new Error(`Failed to read ${file.name}`));
+    reader.readAsText(file);
+  });
+}
+
+export function FilePicker({ files, onFilesChange, onRemoveFile }: FilePickerProps) {
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const selectedFiles = Array.from(event.target.files ?? []);
+    if (selectedFiles.length === 0) return;
+
+    const pickedFiles = await Promise.all(
+      selectedFiles.map(async (file) => {
+        const content = await readFileText(file);
+        const tokens = estimateTokens(content);
+        return {
+          name: file.name,
+          content,
+          tokens,
+          health: getContextHealth(tokens),
+        } satisfies PickedFile;
+      }),
+    );
+
+    onFilesChange([...files, ...pickedFiles]);
+    event.target.value = '';
+  }
+
   return (
     <div className="space-y-3">
       <input
         type="file"
         multiple
+        aria-label="Attach files"
+        onChange={handleFileChange}
         className="block w-full text-sm text-beast-text file:mr-4 file:py-2 file:px-4
           file:rounded-lg file:border file:border-beast-border file:text-sm
           file:bg-beast-control file:text-beast-text hover:file:bg-beast-elevated"

--- a/packages/franken-web/src/components/beasts/shared/file-picker.tsx
+++ b/packages/franken-web/src/components/beasts/shared/file-picker.tsx
@@ -61,6 +61,11 @@ export function FilePicker({ files, onFilesChange, onRemoveFile, onLoadingChange
   }
 
   async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    if (isReading) {
+      event.target.value = '';
+      return;
+    }
+
     const selectedFiles = Array.from(event.target.files ?? []);
     if (selectedFiles.length === 0) return;
 
@@ -102,6 +107,7 @@ export function FilePicker({ files, onFilesChange, onRemoveFile, onLoadingChange
       <input
         type="file"
         multiple
+        disabled={isReading}
         aria-label="Attach files"
         onChange={handleFileChange}
         className="block w-full text-sm text-beast-text file:mr-4 file:py-2 file:px-4

--- a/packages/franken-web/src/components/beasts/shared/file-picker.tsx
+++ b/packages/franken-web/src/components/beasts/shared/file-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ChangeEvent } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 import { estimateTokens, getContextHealth, type ContextHealth } from '../../../lib/token-estimator';
 
 export interface PickedFile {
@@ -12,6 +12,7 @@ interface FilePickerProps {
   files: PickedFile[];
   onFilesChange: (files: PickedFile[]) => void;
   onRemoveFile: (index: number) => void;
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 const HEALTH_STYLES: Record<ContextHealth, { badge: string; label: string }> = {
@@ -33,18 +34,39 @@ function readFileText(file: File): Promise<string> {
   });
 }
 
-export function FilePicker({ files, onFilesChange, onRemoveFile }: FilePickerProps) {
+export function FilePicker({ files, onFilesChange, onRemoveFile, onLoadingChange }: FilePickerProps) {
   const filesRef = useRef(files);
+  const isMountedRef = useRef(true);
+  const onLoadingChangeRef = useRef(onLoadingChange);
+  const [isReading, setIsReading] = useState(false);
+  const [readError, setReadError] = useState<string | null>(null);
 
   useEffect(() => {
     filesRef.current = files;
   }, [files]);
 
+  useEffect(() => {
+    onLoadingChangeRef.current = onLoadingChange;
+  }, [onLoadingChange]);
+
+  useEffect(() => () => {
+    isMountedRef.current = false;
+    onLoadingChangeRef.current?.(false);
+  }, []);
+
+  function setReadingState(loading: boolean) {
+    if (!isMountedRef.current) return;
+    setIsReading(loading);
+    onLoadingChangeRef.current?.(loading);
+  }
+
   async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const selectedFiles = Array.from(event.target.files ?? []);
     if (selectedFiles.length === 0) return;
 
-    const pickedFiles = await Promise.all(
+    setReadError(null);
+    setReadingState(true);
+    const results = await Promise.allSettled(
       selectedFiles.map(async (file) => {
         const content = await readFileText(file);
         const tokens = estimateTokens(content);
@@ -57,12 +79,26 @@ export function FilePicker({ files, onFilesChange, onRemoveFile }: FilePickerPro
       }),
     );
 
-    onFilesChange([...filesRef.current, ...pickedFiles]);
+    if (!isMountedRef.current) return;
+    const pickedFiles = results
+      .filter((result): result is PromiseFulfilledResult<PickedFile> => result.status === 'fulfilled')
+      .map((result) => result.value);
+    const failedCount = results.length - pickedFiles.length;
+
+    if (pickedFiles.length > 0) {
+      onFilesChange([...filesRef.current, ...pickedFiles]);
+    }
+    if (failedCount > 0) {
+      setReadError(`${failedCount} file${failedCount === 1 ? '' : 's'} could not be read and were skipped.`);
+    }
     event.target.value = '';
+    setReadingState(false);
   }
 
   return (
     <div className="space-y-3">
+      {readError && <p className="text-xs text-beast-danger" role="alert">{readError}</p>}
+      {isReading && <p className="text-xs text-beast-subtle" role="status">Reading selected files…</p>}
       <input
         type="file"
         multiple

--- a/packages/franken-web/src/components/beasts/shared/file-picker.tsx
+++ b/packages/franken-web/src/components/beasts/shared/file-picker.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from 'react';
+import { useEffect, useRef, type ChangeEvent } from 'react';
 import { estimateTokens, getContextHealth, type ContextHealth } from '../../../lib/token-estimator';
 
 export interface PickedFile {
@@ -34,6 +34,12 @@ function readFileText(file: File): Promise<string> {
 }
 
 export function FilePicker({ files, onFilesChange, onRemoveFile }: FilePickerProps) {
+  const filesRef = useRef(files);
+
+  useEffect(() => {
+    filesRef.current = files;
+  }, [files]);
+
   async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const selectedFiles = Array.from(event.target.files ?? []);
     if (selectedFiles.length === 0) return;
@@ -51,7 +57,7 @@ export function FilePicker({ files, onFilesChange, onRemoveFile }: FilePickerPro
       }),
     );
 
-    onFilesChange([...files, ...pickedFiles]);
+    onFilesChange([...filesRef.current, ...pickedFiles]);
     event.target.value = '';
   }
 

--- a/packages/franken-web/src/components/beasts/steps/step-prompts.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-prompts.tsx
@@ -33,6 +33,7 @@ export function StepPrompts() {
         <FilePicker
           files={values.files ?? []}
           onFilesChange={(files) => updateField('files', files)}
+          onLoadingChange={(loading) => updateField('filesLoading', loading)}
           onRemoveFile={(i) => {
             const currentValues = (useBeastStore.getState().stepValues[5] ?? {}) as { files?: PickedFile[] };
             const files = [...(currentValues.files ?? [])];

--- a/packages/franken-web/src/components/beasts/steps/step-prompts.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-prompts.tsx
@@ -6,7 +6,8 @@ export function StepPrompts() {
   const values = (stepValues[5] ?? {}) as { promptText?: string; files?: PickedFile[] };
 
   function updateField(field: string, value: unknown) {
-    setStepValues(5, { ...values, [field]: value });
+    const currentValues = (useBeastStore.getState().stepValues[5] ?? {}) as Record<string, unknown>;
+    setStepValues(5, { ...currentValues, [field]: value });
   }
 
   return (
@@ -33,7 +34,8 @@ export function StepPrompts() {
           files={values.files ?? []}
           onFilesChange={(files) => updateField('files', files)}
           onRemoveFile={(i) => {
-            const files = [...(values.files ?? [])];
+            const currentValues = (useBeastStore.getState().stepValues[5] ?? {}) as { files?: PickedFile[] };
+            const files = [...(currentValues.files ?? [])];
             files.splice(i, 1);
             updateField('files', files);
           }}

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -50,6 +50,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
   const currentStepIsValid = Object.keys(currentValidationErrors).length === 0;
   const formValidationErrors = validateWizardStep(STEP_LABELS.length - 1, stepValues);
   const formIsValid = Object.keys(formValidationErrors).length === 0;
+  const promptFilesLoading = Boolean(stepValues[5]?.filesLoading);
   const stepStatuses = buildStepStatuses(wizardStep, highestCompleted, stepValues);
 
   function syncValidationErrors(step: number, errors: WizardValidationErrors) {
@@ -61,6 +62,14 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
   }
 
   function buildAndLaunch() {
+    if (promptFilesLoading) {
+      setValidationErrors(5, { files: 'Wait for selected files to finish loading before launching.' });
+      if (wizardMode === 'wizard') {
+        setWizardStep(5);
+      }
+      return;
+    }
+
     const firstInvalidStep = getFirstInvalidWizardStep(stepValues);
     if (firstInvalidStep !== null) {
       for (let i = 0; i < STEP_LABELS.length - 1; i += 1) {
@@ -103,7 +112,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
     }
   }
 
-  const primaryActionDisabled = Boolean(launching) || !currentStepIsValid;
+  const primaryActionDisabled = Boolean(launching) || promptFilesLoading || !currentStepIsValid;
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -176,13 +185,18 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
               aria-atomic="true"
               className="sr-only"
             >
-              {launching ? 'Launching agent. Please wait.' : ''}
+              {launching ? 'Launching agent. Please wait.' : promptFilesLoading ? 'Reading selected files. Please wait.' : ''}
             </div>
             {wizardMode === 'wizard' && !launchError && !currentStepIsValid && (
               <ValidationSummary stepLabel={STEP_LABELS[wizardStep] ?? 'Current step'} errors={currentValidationErrors} />
             )}
             {wizardMode === 'form' && !launchError && !formIsValid && (
               <ValidationSummary stepLabel="Form View" errors={formValidationErrors} />
+            )}
+            {promptFilesLoading && !launchError && (
+              <div role="status" className="px-4 py-3 rounded-lg bg-beast-elevated border border-beast-border text-beast-muted text-sm">
+                Reading selected files… launch will be available when loading finishes.
+              </div>
             )}
             {launchError && (
               <div
@@ -221,7 +235,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
                   <button
                     type="button"
                     onClick={buildAndLaunch}
-                    disabled={launching}
+                    disabled={Boolean(launching) || promptFilesLoading}
                     className="px-6 py-2.5 rounded-lg text-sm font-semibold transition-colors
                       bg-beast-accent text-beast-bg hover:bg-beast-accent-strong disabled:opacity-50"
                   >

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -115,7 +115,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
   const primaryActionDisabled = Boolean(launching) || promptFilesLoading || !currentStepIsValid;
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open && !promptFilesLoading) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/60 z-[70]" />
         <Dialog.Content
@@ -130,6 +130,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
               <button
                 type="button"
                 onClick={toggleWizardMode}
+                disabled={promptFilesLoading}
                 aria-label="Toggle form mode"
                 className="text-xs px-4 py-2 rounded-lg border border-beast-border text-beast-muted
                   hover:text-beast-text hover:bg-beast-elevated transition-colors"
@@ -139,6 +140,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
               <Dialog.Close asChild>
                 <button
                   type="button"
+                  disabled={promptFilesLoading}
                   className="p-2.5 rounded-lg text-beast-subtle hover:text-beast-text hover:bg-beast-elevated transition-colors"
                   aria-label="Close"
                 >
@@ -157,7 +159,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
               currentStep={wizardStep}
               highestCompleted={highestCompleted}
               stepStatuses={stepStatuses}
-              onStepClick={setWizardStep}
+              onStepClick={promptFilesLoading ? () => undefined : setWizardStep}
             />
           )}
 
@@ -212,7 +214,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
                   <button
                     type="button"
                     onClick={prevStep}
-                    disabled={isFirstStep || launching}
+                    disabled={isFirstStep || launching || promptFilesLoading}
                     className="px-5 py-2.5 rounded-lg text-sm font-medium text-beast-muted hover:text-beast-text
                       hover:bg-beast-elevated border border-beast-border disabled:opacity-50 disabled:cursor-not-allowed
                       transition-colors"

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -13,6 +13,18 @@ describe('buildWizardLaunchConfig', () => {
     });
   });
 
+  it('frontloads prompt text and attached files into design interview goals', () => {
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
+      5: {
+        promptText: 'Consider enterprise billing.',
+        files: [{ name: 'notes.md', content: 'Existing constraints.' }],
+      },
+    })).toMatchObject({
+      goal: 'Draft a billing design\n\nAdditional prompt context:\nConsider enterprise billing.\n\n---\n\nAttached file: notes.md\n\nExisting constraints.',
+    });
+  });
+
   it('maps martin loop fields to backend init config keys', () => {
     expect(buildWizardLaunchConfig({
       1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
@@ -22,6 +34,15 @@ describe('buildWizardLaunchConfig', () => {
       provider: 'codex',
       objective: 'Implement chunks',
       chunkDirectory: 'tasks/chunks',
+    });
+  });
+
+  it('frontloads prompt text and attached files into martin loop objectives', () => {
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
+      5: { files: [{ name: 'context.txt', content: 'Use this context.' }] },
+    })).toMatchObject({
+      objective: 'Implement chunks\n\nAdditional prompt context:\nAttached file: context.txt\n\nUse this context.',
     });
   });
 });

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -14,16 +14,19 @@ describe('buildWizardLaunchConfig', () => {
   });
 
   it('frontloads prompt text and attached files into run config promptConfig', () => {
-    expect(buildWizardLaunchConfig({
+    const config = buildWizardLaunchConfig({
       1: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
       5: {
         promptText: 'Consider enterprise billing.',
         files: [{ name: 'notes.md', content: 'Existing constraints.' }],
       },
-    })).toMatchObject({
+    });
+
+    expect(config).toMatchObject({
       goal: 'Draft a billing design',
       promptConfig: { text: 'Consider enterprise billing.\n\n---\n\nAttached file: notes.md\n\nExisting constraints.' },
     });
+    expect(config).not.toHaveProperty('prompts');
   });
 
   it('maps martin loop fields to backend init config keys', () => {

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -13,7 +13,7 @@ describe('buildWizardLaunchConfig', () => {
     });
   });
 
-  it('frontloads prompt text and attached files into design interview goals', () => {
+  it('frontloads prompt text and attached files into run config promptConfig', () => {
     expect(buildWizardLaunchConfig({
       1: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
       5: {
@@ -21,7 +21,8 @@ describe('buildWizardLaunchConfig', () => {
         files: [{ name: 'notes.md', content: 'Existing constraints.' }],
       },
     })).toMatchObject({
-      goal: 'Draft a billing design\n\nAdditional prompt context:\nConsider enterprise billing.\n\n---\n\nAttached file: notes.md\n\nExisting constraints.',
+      goal: 'Draft a billing design',
+      promptConfig: { text: 'Consider enterprise billing.\n\n---\n\nAttached file: notes.md\n\nExisting constraints.' },
     });
   });
 
@@ -37,12 +38,13 @@ describe('buildWizardLaunchConfig', () => {
     });
   });
 
-  it('frontloads prompt text and attached files into martin loop objectives', () => {
+  it('leaves martin objective as a CLI-safe scalar and carries attached files in promptConfig', () => {
     expect(buildWizardLaunchConfig({
       1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
       5: { files: [{ name: 'context.txt', content: 'Use this context.' }] },
     })).toMatchObject({
-      objective: 'Implement chunks\n\nAdditional prompt context:\nAttached file: context.txt\n\nUse this context.',
+      objective: 'Implement chunks',
+      promptConfig: { text: 'Attached file: context.txt\n\nUse this context.' },
     });
   });
 });

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -2,6 +2,35 @@ export const WIZARD_SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 's
 
 type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
 
+interface PromptFile {
+  name?: unknown;
+  content?: unknown;
+}
+
+function buildPromptFrontload(prompts: Record<string, unknown> | undefined): string | undefined {
+  if (!prompts) return undefined;
+
+  const parts: string[] = [];
+  if (typeof prompts.promptText === 'string' && prompts.promptText.trim().length > 0) {
+    parts.push(prompts.promptText.trim());
+  }
+
+  const files = Array.isArray(prompts.files) ? (prompts.files as PromptFile[]) : [];
+  const fileSections = files.flatMap((file) => {
+    if (typeof file.content !== 'string' || file.content.length === 0) return [];
+    const name = typeof file.name === 'string' && file.name.trim().length > 0 ? file.name.trim() : 'attached-file';
+    return [`Attached file: ${name}\n\n${file.content}`];
+  });
+  parts.push(...fileSections);
+
+  return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
+}
+
+function appendPromptFrontload(value: unknown, promptFrontload: string | undefined): unknown {
+  if (typeof value !== 'string' || !promptFrontload) return value;
+  return `${value}\n\nAdditional prompt context:\n${promptFrontload}`;
+}
+
 export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<string, unknown> {
   const config: Record<string, unknown> = {};
 
@@ -12,6 +41,7 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
   }
 
   const workflow = config.workflow as Record<string, unknown> | undefined;
+  const promptFrontload = buildPromptFrontload(config.prompts as Record<string, unknown> | undefined);
   if (workflow?.executionMode === 'process' || workflow?.executionMode === 'container') {
     config.executionMode = workflow.executionMode;
   } else {
@@ -20,7 +50,7 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
 
   if (workflow?.workflowType === 'design-interview') {
     if (typeof workflow.topic === 'string') {
-      config.goal = workflow.topic;
+      config.goal = appendPromptFrontload(workflow.topic, promptFrontload);
     }
     if (typeof workflow.outputPath === 'string') {
       config.outputPath = workflow.outputPath;
@@ -40,7 +70,7 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
       config.provider = workflow.provider;
     }
     if (typeof workflow.objective === 'string') {
-      config.objective = workflow.objective;
+      config.objective = appendPromptFrontload(workflow.objective, promptFrontload);
     }
     if (typeof workflow.chunkDir === 'string') {
       config.chunkDirectory = workflow.chunkDir;

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -26,11 +26,6 @@ function buildPromptFrontload(prompts: Record<string, unknown> | undefined): str
   return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
 }
 
-function appendPromptFrontload(value: unknown, promptFrontload: string | undefined): unknown {
-  if (typeof value !== 'string' || !promptFrontload) return value;
-  return `${value}\n\nAdditional prompt context:\n${promptFrontload}`;
-}
-
 export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<string, unknown> {
   const config: Record<string, unknown> = {};
 
@@ -42,6 +37,9 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
 
   const workflow = config.workflow as Record<string, unknown> | undefined;
   const promptFrontload = buildPromptFrontload(config.prompts as Record<string, unknown> | undefined);
+  if (promptFrontload) {
+    config.promptConfig = { text: promptFrontload };
+  }
   if (workflow?.executionMode === 'process' || workflow?.executionMode === 'container') {
     config.executionMode = workflow.executionMode;
   } else {
@@ -50,7 +48,7 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
 
   if (workflow?.workflowType === 'design-interview') {
     if (typeof workflow.topic === 'string') {
-      config.goal = appendPromptFrontload(workflow.topic, promptFrontload);
+      config.goal = workflow.topic;
     }
     if (typeof workflow.outputPath === 'string') {
       config.outputPath = workflow.outputPath;
@@ -70,7 +68,7 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
       config.provider = workflow.provider;
     }
     if (typeof workflow.objective === 'string') {
-      config.objective = appendPromptFrontload(workflow.objective, promptFrontload);
+      config.objective = workflow.objective;
     }
     if (typeof workflow.chunkDir === 'string') {
       config.chunkDirectory = workflow.chunkDir;

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -39,6 +39,7 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
   const promptFrontload = buildPromptFrontload(config.prompts as Record<string, unknown> | undefined);
   if (promptFrontload) {
     config.promptConfig = { text: promptFrontload };
+    delete config.prompts;
   }
   if (workflow?.executionMode === 'process' || workflow?.executionMode === 'container') {
     config.executionMode = workflow.executionMode;

--- a/packages/franken-web/tests/components/beasts/shared/file-picker.test.tsx
+++ b/packages/franken-web/tests/components/beasts/shared/file-picker.test.tsx
@@ -59,6 +59,49 @@ describe('FilePicker', () => {
     expect(input.value).toBe('');
   });
 
+  it('appends to the latest file list after async reads finish', async () => {
+    let resolveContent!: (value: string) => void;
+    const onFilesChange = vi.fn();
+    const slowFile = new File(['pending'], 'pending.md', { type: 'text/markdown' });
+    Object.defineProperty(slowFile, 'text', {
+      value: () => new Promise<string>((resolve) => {
+        resolveContent = resolve;
+      }),
+    });
+
+    const { rerender } = render(
+      <FilePicker
+        files={[existingFile]}
+        onFilesChange={onFilesChange}
+        onRemoveFile={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Attach files'), { target: { files: [slowFile] } });
+    const interveningFile: PickedFile = { name: 'intervening.md', content: 'typed later', tokens: 3, health: 'good' };
+    rerender(
+      <FilePicker
+        files={[existingFile, interveningFile]}
+        onFilesChange={onFilesChange}
+        onRemoveFile={vi.fn()}
+      />,
+    );
+
+    resolveContent('loaded after rerender');
+
+    await waitFor(() => expect(onFilesChange).toHaveBeenCalledTimes(1));
+    expect(onFilesChange).toHaveBeenCalledWith([
+      existingFile,
+      interveningFile,
+      {
+        name: 'pending.md',
+        content: 'loaded after rerender',
+        tokens: 6,
+        health: 'good',
+      },
+    ]);
+  });
+
   it('shows critical health indicator for large files', () => {
     const files = [
       { name: 'big.md', content: 'x'.repeat(80000), tokens: 20000, health: 'critical' as const },

--- a/packages/franken-web/tests/components/beasts/shared/file-picker.test.tsx
+++ b/packages/franken-web/tests/components/beasts/shared/file-picker.test.tsx
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
-import { FilePicker } from '../../../../src/components/beasts/shared/file-picker';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { FilePicker, type PickedFile } from '../../../../src/components/beasts/shared/file-picker';
 
 afterEach(cleanup);
+
+const existingFile: PickedFile = {
+  name: 'existing.md',
+  content: 'already loaded',
+  tokens: 4,
+  health: 'good',
+};
 
 describe('FilePicker', () => {
   it('renders file input and selected files', () => {
@@ -12,6 +19,44 @@ describe('FilePicker', () => {
     render(<FilePicker files={files} onFilesChange={vi.fn()} onRemoveFile={vi.fn()} />);
     expect(screen.getByText('test.md')).toBeTruthy();
     expect(screen.getByText(/3 tokens/i)).toBeTruthy();
+  });
+
+  it('reads selected files, estimates tokens and health, appends them, and clears the input', async () => {
+    const onFilesChange = vi.fn();
+    render(
+      <FilePicker
+        files={[existingFile]}
+        onFilesChange={onFilesChange}
+        onRemoveFile={vi.fn()}
+      />,
+    );
+
+    const largeContent = 'x'.repeat(16_000);
+    const input = screen.getByLabelText('Attach files') as HTMLInputElement;
+    const files = [
+      new File(['hello beast'], 'notes.md', { type: 'text/markdown' }),
+      new File([largeContent], 'large.txt', { type: 'text/plain' }),
+    ];
+
+    fireEvent.change(input, { target: { files } });
+
+    await waitFor(() => expect(onFilesChange).toHaveBeenCalledTimes(1));
+    expect(onFilesChange).toHaveBeenCalledWith([
+      existingFile,
+      {
+        name: 'notes.md',
+        content: 'hello beast',
+        tokens: 3,
+        health: 'good',
+      },
+      {
+        name: 'large.txt',
+        content: largeContent,
+        tokens: 4000,
+        health: 'warning',
+      },
+    ]);
+    expect(input.value).toBe('');
   });
 
   it('shows critical health indicator for large files', () => {

--- a/packages/franken-web/tests/components/beasts/steps/step-prompts.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-prompts.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 
-afterEach(cleanup);
 import { StepPrompts } from '../../../../src/components/beasts/steps/step-prompts';
 import { useBeastStore } from '../../../../src/stores/beast-store';
+
+afterEach(cleanup);
 
 describe('StepPrompts', () => {
   beforeEach(() => {
@@ -24,5 +25,26 @@ describe('StepPrompts', () => {
   it('renders file picker section', () => {
     render(<StepPrompts />);
     expect(screen.getByText('Files')).toBeTruthy();
+  });
+
+  it('preserves prompt edits made while selected files are being read', async () => {
+    let resolveContent!: (value: string) => void;
+    const slowFile = new File(['pending'], 'context.md', { type: 'text/markdown' });
+    Object.defineProperty(slowFile, 'text', {
+      value: () => new Promise<string>((resolve) => {
+        resolveContent = resolve;
+      }),
+    });
+
+    render(<StepPrompts />);
+
+    fireEvent.change(screen.getByLabelText('Attach files'), { target: { files: [slowFile] } });
+    fireEvent.change(screen.getByLabelText(/prompt text/i), { target: { value: 'Typed while loading' } });
+    resolveContent('file content');
+
+    await waitFor(() => {
+      expect(useBeastStore.getState().stepValues[5]?.files).toHaveLength(1);
+    });
+    expect(useBeastStore.getState().stepValues[5]?.promptText).toBe('Typed while loading');
   });
 });


### PR DESCRIPTION
## Summary
- Wire the beast prompt FilePicker input to read selected files and append them to prompt frontloading state
- Estimate tokens/health for selected files and clear the file input so the same file can be reselected
- Add a regression test covering file selection, token/health mapping, append behavior, and input clearing

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @frankenbeast/web
- npm run test --workspace @frankenbeast/web -- tests/components/beasts/shared/file-picker.test.tsx
- npm run typecheck --workspace @frankenbeast/web
- npm run build --workspace @frankenbeast/web

Closes #355
