### PR TITLE
fix(critique): parse logic loops with AST

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,8 +3278,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "dev": true,
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7546,6 +7547,7 @@
       "license": "MIT",
       "dependencies": {
         "@franken/types": "0.7.5",
+        "acorn": "^8.17.0",
         "hono": "^4.12.27",
         "zod": "^3.24.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3297,6 +3297,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-typescript": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": ">=8.9.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "license": "MIT",
@@ -7548,6 +7557,7 @@
       "dependencies": {
         "@franken/types": "0.7.5",
         "acorn": "^8.17.0",
+        "acorn-typescript": "^1.4.13",
         "hono": "^4.12.27",
         "zod": "^3.24.0"
       },

--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@franken/types": "0.7.5",
+    "acorn": "^8.17.0",
     "hono": "^4.12.27",
     "zod": "^3.24.0"
   }

--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@franken/types": "0.7.5",
     "acorn": "^8.17.0",
+    "acorn-typescript": "^1.4.13",
     "hono": "^4.12.27",
     "zod": "^3.24.0"
   }

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -217,15 +217,19 @@ function hasKeywordBoundary(code: string, keyword: string, index: number): boole
   return !/[A-Za-z0-9_$]/.test(before) && !/[A-Za-z0-9_$]/.test(after);
 }
 
+function isPlausibleSnippetStart(code: string, keyword: string, index: number): boolean {
+  const rest = code.slice(index + keyword.length).trimStart();
+  if (keyword === 'while' || keyword === 'for') return rest.startsWith('(');
+  if (keyword === 'function' || keyword === 'async function') return /^[*\s]*[A-Za-z_$({]/.test(rest);
+  if (keyword === 'class') return /^[A-Za-z_$]/.test(rest);
+  return true;
+}
+
 function pushCandidate(candidates: string[], seen: Set<string>, candidate: string): void {
   const normalized = candidate.trim();
   if (!normalized || seen.has(normalized)) return;
   seen.add(normalized);
   candidates.push(normalized);
-}
-
-function hasMarkdownFence(code: string): boolean {
-  return /(^|\n)```/.test(code);
 }
 
 function codeCandidates(code: string): string[] {
@@ -239,7 +243,7 @@ function codeCandidates(code: string): string[] {
   pushCandidate(candidates, seen, code);
 
   const ignoredRanges = ignoredSyntaxRanges(code, true);
-  const maxFallbackSnippets = 50;
+  const maxFallbackSnippets = 200;
   let fallbackSnippetCount = 0;
 
   for (const keyword of ['async function', 'function', 'while', 'for', 'class']) {
@@ -248,11 +252,13 @@ function codeCandidates(code: string): string[] {
       if (
         fallbackSnippetCount < maxFallbackSnippets &&
         hasKeywordBoundary(code, keyword, index) &&
+        isPlausibleSnippetStart(code, keyword, index) &&
         !isIndexInRanges(ignoredRanges, index)
       ) {
         const snippet = code.slice(index);
-        pushCandidate(candidates, seen, snippet);
-        pushCandidate(candidates, seen, trimToBalancedSnippet(snippet));
+        const trimmed = trimToBalancedSnippet(snippet);
+        pushCandidate(candidates, seen, trimmed);
+        if (trimmed === snippet) pushCandidate(candidates, seen, snippet);
         fallbackSnippetCount += 1;
       }
       index = code.indexOf(keyword, index + keyword.length);
@@ -288,7 +294,7 @@ function parseJavaScript(code: string): AstNode[] {
     }
   };
 
-  if (!hasMarkdownFence(code)) {
+  if (!code.trimStart().startsWith('```')) {
     for (const sourceType of ['module', 'script'] as const) {
       const ast = parseCandidate(code, sourceType);
       if (ast) return [ast];
@@ -392,7 +398,27 @@ function identifierName(node: AstNode): string | undefined {
   return typeof name === 'string' ? name : undefined;
 }
 
+function localFunctionDeclaration(root: AstNode, name: string): AstNode | null {
+  const visit = (current: AstNode): AstNode | null => {
+    if (current !== root && isFunctionLike(current)) {
+      const id = current.id;
+      if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return current;
+      return null;
+    }
+
+    for (const child of childNodes(current)) {
+      const found = visit(child);
+      if (found) return found;
+    }
+
+    return null;
+  };
+
+  return visit(root);
+}
+
 function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
+  const enteredHelpers = new Set<string>();
   const visit = (current: AstNode, enterFunction = false): number | null => {
     if (current !== node && !enterFunction && isFunctionLike(current)) {
       return null;
@@ -400,8 +426,21 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
 
     if (current.type === 'CallExpression') {
       const callee = current.callee;
-      if (isNode(callee) && callee.type === 'Identifier' && identifierName(callee) === fnName) {
-        return current.start;
+      if (isNode(callee) && callee.type === 'Identifier') {
+        const callName = identifierName(callee);
+        if (callName === fnName) {
+          return current.start;
+        }
+
+        if (callName && !enteredHelpers.has(callName)) {
+          const helper = localFunctionDeclaration(node, callName);
+          if (helper) {
+            enteredHelpers.add(callName);
+            const found = visit(helper, true);
+            enteredHelpers.delete(callName);
+            if (found != null) return found;
+          }
+        }
       }
 
       if (isNode(callee)) {
@@ -438,6 +477,38 @@ function hasReturnBefore(node: AstNode, position: number, enterFunction = false)
   return visit(node, enterFunction);
 }
 
+function syntaxMaskedText(code: string): string {
+  const chars = [...code];
+  for (const range of ignoredSyntaxRanges(code, true)) {
+    for (let index = range.start; index < range.end && index < chars.length; index += 1) {
+      chars[index] = ' ';
+    }
+  }
+  return chars.join('');
+}
+
+function fallbackInfiniteLoopFindings(code: string): EvaluationFinding[] {
+  const masked = syntaxMaskedText(code);
+  const findings: EvaluationFinding[] = [];
+  const loopHeaders = [/while\s*\(\s*true\s*\)/g, /for\s*\(\s*;\s*;\s*\)/g];
+
+  for (const loopHeader of loopHeaders) {
+    for (const match of masked.matchAll(loopHeader)) {
+      const start = match.index ?? 0;
+      const snippet = trimToBalancedSnippet(masked.slice(start));
+      if (/\b(break|return|throw|await|yield)\b/.test(snippet)) continue;
+      findings.push({
+        message: 'Potential infinite loop detected: loop has no break or return statement',
+        severity: 'critical',
+        suggestion: 'Add a break condition or return statement inside the loop',
+      });
+      break;
+    }
+  }
+
+  return findings;
+}
+
 export class LogicLoopEvaluator implements Evaluator {
   readonly name = 'logic-loop';
   readonly category = 'deterministic' as const;
@@ -449,6 +520,10 @@ export class LogicLoopEvaluator implements Evaluator {
     for (const ast of asts) {
       this.checkInfiniteLoops(ast, findings);
       this.checkUnguardedRecursion(ast, findings);
+    }
+
+    if (asts.length === 0) {
+      findings.push(...fallbackInfiniteLoopFindings(input.content));
     }
 
     const score = findings.length === 0 ? 1 : 0;

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -31,7 +31,7 @@ type AstNode = Node & Record<string, unknown>;
 
 type AcornPlugin = (BaseParser: typeof Parser) => typeof Parser;
 
-const TypeScriptParser = Parser.extend(tsPlugin() as unknown as AcornPlugin);
+const TypeScriptParser = Parser.extend(tsPlugin({ jsx: { allowNamespaces: true } }) as unknown as AcornPlugin);
 
 function isNode(value: unknown): value is AstNode {
   return Boolean(value && typeof value === 'object' && typeof (value as AstNode).type === 'string');
@@ -60,6 +60,32 @@ function childNodes(node: AstNode): AstNode[] {
   return children;
 }
 
+function isInsideComment(code: string, index: number): boolean {
+  const lineStart = code.lastIndexOf('\n', index - 1) + 1;
+  if (code.slice(lineStart, index).includes('//')) return true;
+
+  const lastBlockStart = code.lastIndexOf('/*', index);
+  const lastBlockEnd = code.lastIndexOf('*/', index);
+  return lastBlockStart > lastBlockEnd;
+}
+
+function trimToBalancedSnippet(candidate: string): string {
+  const firstOpen = candidate.indexOf('{');
+  if (firstOpen < 0) return candidate;
+
+  let depth = 0;
+  for (let index = firstOpen; index < candidate.length; index += 1) {
+    const char = candidate[index];
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return candidate.slice(0, index + 1);
+    }
+  }
+
+  return candidate;
+}
+
 function codeCandidates(code: string): string[] {
   const fencedBlocks = Array.from(code.matchAll(/```(?:[\w-]+)?\s*\n([\s\S]*?)```/g), (match) => match[1]).filter(
     (block): block is string => typeof block === 'string' && block.trim().length > 0,
@@ -68,8 +94,11 @@ function codeCandidates(code: string): string[] {
 
   for (const keyword of ['while', 'for', 'function', 'async function', 'class']) {
     let index = code.indexOf(keyword);
-    while (index > 0) {
-      candidates.push(code.slice(index));
+    while (index >= 0) {
+      if (!isInsideComment(code, index)) {
+        const snippet = code.slice(index);
+        candidates.push(snippet, trimToBalancedSnippet(snippet));
+      }
       index = code.indexOf(keyword, index + keyword.length);
     }
   }

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -425,19 +425,20 @@ function containsIfStatement(
   node: AstNode,
   enterFunction = false,
   beforePosition = Number.POSITIVE_INFINITY,
+  targetName?: string,
 ): boolean {
   const enteredHelpers = new Set<string>();
-  const visit = (current: AstNode, allowFunctionBody = false): boolean => {
+  const visit = (current: AstNode, allowFunctionBody = false, activePosition = beforePosition): boolean => {
     if (
       current !== node &&
       !allowFunctionBody &&
       typeof current.start === 'number' &&
-      current.start > beforePosition
+      current.start > activePosition
     ) {
       return false;
     }
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
-    if (current.type === 'IfStatement') return true;
+    if (current.type === 'IfStatement' && current.start < activePosition) return true;
     if (current.type === 'CallExpression' && isNode(current.callee)) {
       const callee = current.callee;
       if (callee.type === 'Identifier') {
@@ -445,16 +446,17 @@ function containsIfStatement(
         if (callName && !enteredHelpers.has(callName)) {
           const helper = localFunctionDeclaration(node, callName, current.start);
           if (helper) {
+            const helperPosition = targetName ? findRecursiveCallStart(helper, targetName) ?? activePosition : activePosition;
             enteredHelpers.add(callName);
-            if (visit(helper, true)) return true;
+            if (visit(helper, true, helperPosition)) return true;
             enteredHelpers.delete(callName);
           }
         }
       }
       const invokedFunction = invokedFunctionCallee(callee);
-      if (invokedFunction) return visit(invokedFunction, true);
+      if (invokedFunction) return visit(invokedFunction, true, activePosition);
     }
-    return childNodes(current).some((child) => visit(child));
+    return childNodes(current).some((child) => visit(child, false, activePosition));
   };
 
   return visit(node, enterFunction);
@@ -487,38 +489,32 @@ function functionBodyStatements(root: AstNode): AstNode[] {
   if (isNode(body) && body.type === 'BlockStatement' && Array.isArray(body.body)) {
     return body.body.filter(isNode);
   }
+  if (root.type === 'BlockStatement' && Array.isArray(body)) return body.filter(isNode);
   if (Array.isArray(body)) return body.filter(isNode);
   return [];
 }
 
-function localFunctionDeclaration(root: AstNode, name: string, callStart = Number.POSITIVE_INFINITY): AstNode | null {
-  const candidateBlocks: AstNode[] = [];
-  const collectBlocks = (current: AstNode): void => {
-    if (
-      current !== root &&
-      (isFunctionLike(current) || current.type === 'ClassDeclaration' || current.type === 'ClassExpression')
-    ) {
-      return;
-    }
+function containsPosition(node: AstNode, position: number): boolean {
+  return typeof node.start === 'number' && typeof node.end === 'number' && node.start <= position && position <= node.end;
+}
 
-    if (
-      (current === root || current.type === 'BlockStatement' || current.type === 'Program') &&
-      typeof current.start === 'number' &&
-      typeof current.end === 'number' &&
-      current.start <= callStart &&
-      callStart <= current.end
-    ) {
-      candidateBlocks.push(current);
-    }
-
-    for (const child of childNodes(current)) collectBlocks(child);
+function lexicalScopesAt(root: AstNode, position: number): AstNode[] {
+  const scopes: AstNode[] = [];
+  const visit = (current: AstNode): void => {
+    if (!containsPosition(current, position)) return;
+    if (functionBodyStatements(current).length > 0) scopes.push(current);
+    for (const child of childNodes(current)) visit(child);
   };
 
-  collectBlocks(root);
-  candidateBlocks.sort((a, b) => (b.start - a.start) || (a.end - b.end));
+  visit(root);
+  return scopes;
+}
 
-  for (const block of candidateBlocks) {
-    for (const statement of functionBodyStatements(block)) {
+function localFunctionDeclaration(root: AstNode, name: string, callStart = Number.POSITIVE_INFINITY): AstNode | null {
+  const scopes = lexicalScopesAt(root, callStart).reverse();
+
+  for (const scope of scopes) {
+    for (const statement of functionBodyStatements(scope)) {
       if (statement.type === 'FunctionDeclaration') {
         const id = statement.id;
         if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return statement;
@@ -589,19 +585,19 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
   return visit(node);
 }
 
-function hasReturnBefore(node: AstNode, position: number, enterFunction = false): boolean {
+function hasReturnBefore(node: AstNode, position: number, enterFunction = false, targetName?: string): boolean {
   const enteredHelpers = new Set<string>();
-  const visit = (current: AstNode, allowFunctionBody = false): boolean => {
+  const visit = (current: AstNode, allowFunctionBody = false, activePosition = position): boolean => {
     if (
       current !== node &&
       !allowFunctionBody &&
       typeof current.start === 'number' &&
-      current.start > position
+      current.start > activePosition
     ) {
       return false;
     }
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
-    if (current.type === 'ReturnStatement' && current.start < position) return true;
+    if (current.type === 'ReturnStatement' && current.start < activePosition) return true;
     if (current.type === 'CallExpression' && isNode(current.callee)) {
       const callee = current.callee;
       if (callee.type === 'Identifier') {
@@ -609,16 +605,17 @@ function hasReturnBefore(node: AstNode, position: number, enterFunction = false)
         if (callName && !enteredHelpers.has(callName)) {
           const helper = localFunctionDeclaration(node, callName, current.start);
           if (helper) {
+            const helperPosition = targetName ? findRecursiveCallStart(helper, targetName) ?? activePosition : activePosition;
             enteredHelpers.add(callName);
-            if (visit(helper, true)) return true;
+            if (visit(helper, true, helperPosition)) return true;
             enteredHelpers.delete(callName);
           }
         }
       }
       const invokedFunction = invokedFunctionCallee(callee);
-      if (invokedFunction) return visit(invokedFunction, true);
+      if (invokedFunction) return visit(invokedFunction, true, activePosition);
     }
-    return childNodes(current).some((child) => visit(child));
+    return childNodes(current).some((child) => visit(child, false, activePosition));
   };
 
   return visit(node, enterFunction);
@@ -824,9 +821,9 @@ export class LogicLoopEvaluator implements Evaluator {
           const recursiveCallStart = findRecursiveCallStart(node, fnName);
           if (recursiveCallStart != null) {
             const hasGuard =
-              containsIfStatement(node, false, recursiveCallStart) ||
+              containsIfStatement(node, false, recursiveCallStart, fnName) ||
               containsIfInRecursivePath(node, recursiveCallStart) ||
-              hasReturnBefore(node, recursiveCallStart);
+              hasReturnBefore(node, recursiveCallStart, false, fnName);
             if (!hasGuard) {
               findings.push({
                 message: `Potential unguarded recursion detected: "${fnName}" calls itself without a visible base case`,

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -380,11 +380,24 @@ function invokedFunctionCallee(callee: AstNode): AstNode | null {
 }
 
 function containsIfStatement(node: AstNode, enterFunction = false): boolean {
+  const enteredHelpers = new Set<string>();
   const visit = (current: AstNode, allowFunctionBody = false): boolean => {
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'IfStatement') return true;
     if (current.type === 'CallExpression' && isNode(current.callee)) {
-      const invokedFunction = invokedFunctionCallee(current.callee);
+      const callee = current.callee;
+      if (callee.type === 'Identifier') {
+        const callName = identifierName(callee);
+        if (callName && !enteredHelpers.has(callName)) {
+          const helper = localFunctionDeclaration(node, callName);
+          if (helper) {
+            enteredHelpers.add(callName);
+            if (visit(helper, true)) return true;
+            enteredHelpers.delete(callName);
+          }
+        }
+      }
+      const invokedFunction = invokedFunctionCallee(callee);
       if (invokedFunction) return visit(invokedFunction, true);
     }
     return childNodes(current).some((child) => visit(child));
@@ -404,6 +417,11 @@ function localFunctionDeclaration(root: AstNode, name: string): AstNode | null {
       const id = current.id;
       if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return current;
       return null;
+    }
+
+    if (current.type === 'VariableDeclarator' && isNode(current.id) && identifierName(current.id) === name) {
+      const init = current.init;
+      if (isNode(init) && isFunctionLike(init)) return init;
     }
 
     for (const child of childNodes(current)) {
@@ -464,11 +482,24 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
 }
 
 function hasReturnBefore(node: AstNode, position: number, enterFunction = false): boolean {
+  const enteredHelpers = new Set<string>();
   const visit = (current: AstNode, allowFunctionBody = false): boolean => {
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'ReturnStatement' && current.start < position) return true;
     if (current.type === 'CallExpression' && isNode(current.callee)) {
-      const invokedFunction = invokedFunctionCallee(current.callee);
+      const callee = current.callee;
+      if (callee.type === 'Identifier') {
+        const callName = identifierName(callee);
+        if (callName && !enteredHelpers.has(callName)) {
+          const helper = localFunctionDeclaration(node, callName);
+          if (helper) {
+            enteredHelpers.add(callName);
+            if (visit(helper, true)) return true;
+            enteredHelpers.delete(callName);
+          }
+        }
+      }
+      const invokedFunction = invokedFunctionCallee(callee);
       if (invokedFunction) return visit(invokedFunction, true);
     }
     return childNodes(current).some((child) => visit(child));
@@ -479,7 +510,7 @@ function hasReturnBefore(node: AstNode, position: number, enterFunction = false)
 
 function syntaxMaskedText(code: string): string {
   const chars = [...code];
-  for (const range of ignoredSyntaxRanges(code, true)) {
+  for (const range of ignoredSyntaxRanges(code, false)) {
     for (let index = range.start; index < range.end && index < chars.length; index += 1) {
       chars[index] = ' ';
     }
@@ -487,8 +518,16 @@ function syntaxMaskedText(code: string): string {
   return chars.join('');
 }
 
+function hasFallbackLoopExit(snippet: string): boolean {
+  const withoutNestedFunctions = snippet
+    .replace(/=>\s*\{[\s\S]*?\}/g, '')
+    .replace(/function\b[^{}]*\{[\s\S]*?\}/g, '');
+  return /\b(break|return|throw|await|yield)\b/.test(withoutNestedFunctions);
+}
+
 function fallbackInfiniteLoopFindings(code: string): EvaluationFinding[] {
-  const masked = syntaxMaskedText(code);
+  const withoutFenceDelimiters = code.replace(/^```[^\n]*$/gm, '');
+  const masked = syntaxMaskedText(withoutFenceDelimiters);
   const findings: EvaluationFinding[] = [];
   const loopHeaders = [/while\s*\(\s*true\s*\)/g, /for\s*\(\s*;\s*;\s*\)/g];
 
@@ -496,7 +535,7 @@ function fallbackInfiniteLoopFindings(code: string): EvaluationFinding[] {
     for (const match of masked.matchAll(loopHeader)) {
       const start = match.index ?? 0;
       const snippet = trimToBalancedSnippet(masked.slice(start));
-      if (/\b(break|return|throw|await|yield)\b/.test(snippet)) continue;
+      if (hasFallbackLoopExit(snippet)) continue;
       findings.push({
         message: 'Potential infinite loop detected: loop has no break or return statement',
         severity: 'critical',
@@ -522,7 +561,7 @@ export class LogicLoopEvaluator implements Evaluator {
       this.checkUnguardedRecursion(ast, findings);
     }
 
-    if (asts.length === 0) {
+    if (!findings.some((finding) => finding.message.includes('infinite loop'))) {
       findings.push(...fallbackInfiniteLoopFindings(input.content));
     }
 

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -60,6 +60,15 @@ function childNodes(node: AstNode): AstNode[] {
   return children;
 }
 
+function codeCandidates(code: string): string[] {
+  const fencedBlocks = Array.from(code.matchAll(/```(?:[\w-]+)?\s*\n([\s\S]*?)```/g), (match) => match[1]).filter(
+    (block): block is string => typeof block === 'string' && block.trim().length > 0,
+  );
+  const candidates = fencedBlocks.length > 0 ? [...fencedBlocks, code] : [code];
+
+  return candidates.flatMap((candidate) => [candidate, `${candidate}\n}`, `${candidate}\n}}`, `${candidate}\n}}}`]);
+}
+
 function parseJavaScript(code: string): AstNode | null {
   const baseOptions = {
     ecmaVersion: 'latest' as const,
@@ -68,7 +77,7 @@ function parseJavaScript(code: string): AstNode | null {
     allowHashBang: true,
   };
 
-  for (const candidate of [code, `${code}\n}`, `${code}\n}}`, `${code}\n}}}`]) {
+  for (const candidate of codeCandidates(code)) {
     for (const sourceType of ['module', 'script'] as const) {
       try {
         try {
@@ -142,14 +151,17 @@ function hasLoopExit(body: AstNode): boolean {
   return visit(body, 0);
 }
 
-function containsIfStatement(node: AstNode): boolean {
-  const visit = (current: AstNode): boolean => {
-    if (current !== node && (isFunctionLike(current) || isClassLike(current))) return false;
+function containsIfStatement(node: AstNode, enterFunction = false): boolean {
+  const visit = (current: AstNode, allowFunctionBody = false): boolean => {
+    if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'IfStatement') return true;
-    return childNodes(current).some(visit);
+    if (current.type === 'CallExpression' && isNode(current.callee) && isFunctionLike(current.callee)) {
+      return visit(current.callee, true);
+    }
+    return childNodes(current).some((child) => visit(child));
   };
 
-  return visit(node);
+  return visit(node, enterFunction);
 }
 
 function identifierName(node: AstNode): string | undefined {
@@ -159,7 +171,7 @@ function identifierName(node: AstNode): string | undefined {
 
 function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
   const visit = (current: AstNode, enterFunction = false): number | null => {
-    if (current !== node && !enterFunction && (isFunctionLike(current) || isClassLike(current))) {
+    if (current !== node && !enterFunction && isFunctionLike(current)) {
       return null;
     }
 
@@ -186,14 +198,17 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
   return visit(node);
 }
 
-function hasReturnBefore(node: AstNode, position: number): boolean {
-  const visit = (current: AstNode): boolean => {
-    if (current !== node && (isFunctionLike(current) || isClassLike(current))) return false;
+function hasReturnBefore(node: AstNode, position: number, enterFunction = false): boolean {
+  const visit = (current: AstNode, allowFunctionBody = false): boolean => {
+    if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'ReturnStatement' && current.start < position) return true;
-    return childNodes(current).some(visit);
+    if (current.type === 'CallExpression' && isNode(current.callee) && isFunctionLike(current.callee)) {
+      return visit(current.callee, true);
+    }
+    return childNodes(current).some((child) => visit(child));
   };
 
-  return visit(node);
+  return visit(node, enterFunction);
 }
 
 export class LogicLoopEvaluator implements Evaluator {
@@ -237,10 +252,13 @@ export class LogicLoopEvaluator implements Evaluator {
 
   private checkUnguardedRecursion(ast: AstNode, findings: EvaluationFinding[]): void {
     const visit = (node: AstNode): void => {
-      if (node.type === 'FunctionDeclaration') {
-        const id = node.id;
-        const fnName = isNode(id) && id.type === 'Identifier' ? identifierName(id) : undefined;
+      const namedFunction =
+        (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') && isNode(node.id)
+          ? node.id
+          : null;
 
+      if (namedFunction?.type === 'Identifier') {
+        const fnName = identifierName(namedFunction);
         if (fnName) {
           const recursiveCallStart = findRecursiveCallStart(node, fnName);
           if (recursiveCallStart != null) {

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -28,6 +28,7 @@ const LOOP_OR_SWITCH_NODE_TYPES = new Set([
 ]);
 
 type AstNode = Node & Record<string, unknown>;
+type Range = { start: number; end: number };
 
 type AcornPlugin = (BaseParser: typeof Parser) => typeof Parser;
 
@@ -60,21 +61,145 @@ function childNodes(node: AstNode): AstNode[] {
   return children;
 }
 
-function isInsideComment(code: string, index: number): boolean {
-  const lineStart = code.lastIndexOf('\n', index - 1) + 1;
-  if (code.slice(lineStart, index).includes('//')) return true;
+function mergeRanges(ranges: Range[]): Range[] {
+  const sorted = ranges.slice().sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: Range[] = [];
 
-  const lastBlockStart = code.lastIndexOf('/*', index);
-  const lastBlockEnd = code.lastIndexOf('*/', index);
-  return lastBlockStart > lastBlockEnd;
+  for (const range of sorted) {
+    const previous = merged.at(-1);
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+
+  return merged;
+}
+
+function isIndexInRanges(ranges: Range[], index: number): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function fenceRanges(code: string): Range[] {
+  return Array.from(code.matchAll(/```(?:[\w-]+)?\s*\n([\s\S]*?)```/g), (match) => ({
+    start: match.index ?? 0,
+    end: (match.index ?? 0) + match[0].length,
+  }));
+}
+
+function isRegexLiteralStart(code: string, index: number): boolean {
+  let cursor = index - 1;
+  while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
+  if (cursor < 0) return true;
+
+  return '([{=,:;!&|?+-*%^~<>'.includes(code[cursor]!);
+}
+
+function ignoredSyntaxRanges(code: string, includeFences = false): Range[] {
+  const ranges: Range[] = includeFences ? fenceRanges(code) : [];
+  let index = 0;
+
+  while (index < code.length) {
+    const fenced = includeFences ? ranges.find((range) => range.start === index) : undefined;
+    if (fenced) {
+      index = fenced.end;
+      continue;
+    }
+
+    const char = code[index];
+    const next = code[index + 1];
+
+    if ((char === '\'' || char === '"') && !isIndexInRanges(ranges, index)) {
+      const quote = char;
+      const start = index;
+      index += 1;
+      while (index < code.length) {
+        if (code[index] === '\\') {
+          index += 2;
+          continue;
+        }
+        if (code[index] === quote) {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      ranges.push({ start, end: index });
+      continue;
+    }
+
+    if (char === '`' && !isIndexInRanges(ranges, index)) {
+      const start = index;
+      index += 1;
+      while (index < code.length) {
+        if (code[index] === '\\') {
+          index += 2;
+          continue;
+        }
+        if (code[index] === '`') {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      ranges.push({ start, end: index });
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      const start = index;
+      index = code.indexOf('\n', index + 2);
+      if (index < 0) index = code.length;
+      ranges.push({ start, end: index });
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      const start = index;
+      const end = code.indexOf('*/', index + 2);
+      index = end < 0 ? code.length : end + 2;
+      ranges.push({ start, end: index });
+      continue;
+    }
+
+    if (char === '/' && isRegexLiteralStart(code, index)) {
+      const start = index;
+      index += 1;
+      let inCharacterClass = false;
+      while (index < code.length) {
+        if (code[index] === '\\') {
+          index += 2;
+          continue;
+        }
+        if (code[index] === '[') inCharacterClass = true;
+        if (code[index] === ']') inCharacterClass = false;
+        if (code[index] === '/' && !inCharacterClass) {
+          index += 1;
+          while (/[a-z]/i.test(code[index] ?? '')) index += 1;
+          break;
+        }
+        index += 1;
+      }
+      ranges.push({ start, end: index });
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return mergeRanges(ranges);
 }
 
 function trimToBalancedSnippet(candidate: string): string {
+  const ignoredRanges = ignoredSyntaxRanges(candidate);
   const firstOpen = candidate.indexOf('{');
   if (firstOpen < 0) return candidate;
 
   let depth = 0;
   for (let index = firstOpen; index < candidate.length; index += 1) {
+    if (isIndexInRanges(ignoredRanges, index)) continue;
+
     const char = candidate[index];
     if (char === '{') depth += 1;
     if (char === '}') {
@@ -86,18 +211,49 @@ function trimToBalancedSnippet(candidate: string): string {
   return candidate;
 }
 
-function codeCandidates(code: string): string[] {
-  const fencedBlocks = Array.from(code.matchAll(/```(?:[\w-]+)?\s*\n([\s\S]*?)```/g), (match) => match[1]).filter(
-    (block): block is string => typeof block === 'string' && block.trim().length > 0,
-  );
-  const candidates = fencedBlocks.length > 0 ? [...fencedBlocks, code] : [code];
+function hasKeywordBoundary(code: string, keyword: string, index: number): boolean {
+  const before = code[index - 1] ?? '';
+  const after = code[index + keyword.length] ?? '';
+  return !/[A-Za-z0-9_$]/.test(before) && !/[A-Za-z0-9_$]/.test(after);
+}
 
-  for (const keyword of ['while', 'for', 'function', 'async function', 'class']) {
+function pushCandidate(candidates: string[], seen: Set<string>, candidate: string): void {
+  const normalized = candidate.trim();
+  if (!normalized || seen.has(normalized)) return;
+  seen.add(normalized);
+  candidates.push(normalized);
+}
+
+function hasMarkdownFence(code: string): boolean {
+  return /(^|\n)```/.test(code);
+}
+
+function codeCandidates(code: string): string[] {
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  const fences = Array.from(code.matchAll(/```(?:[\w-]+)?\s*\n([\s\S]*?)```/g));
+  for (const match of fences) {
+    const block = match[1];
+    if (typeof block === 'string' && block.trim().length > 0) pushCandidate(candidates, seen, block);
+  }
+  pushCandidate(candidates, seen, code);
+
+  const ignoredRanges = ignoredSyntaxRanges(code, true);
+  const maxFallbackSnippets = 50;
+  let fallbackSnippetCount = 0;
+
+  for (const keyword of ['async function', 'function', 'while', 'for', 'class']) {
     let index = code.indexOf(keyword);
     while (index >= 0) {
-      if (!isInsideComment(code, index)) {
+      if (
+        fallbackSnippetCount < maxFallbackSnippets &&
+        hasKeywordBoundary(code, keyword, index) &&
+        !isIndexInRanges(ignoredRanges, index)
+      ) {
         const snippet = code.slice(index);
-        candidates.push(snippet, trimToBalancedSnippet(snippet));
+        pushCandidate(candidates, seen, snippet);
+        pushCandidate(candidates, seen, trimToBalancedSnippet(snippet));
+        fallbackSnippetCount += 1;
       }
       index = code.indexOf(keyword, index + keyword.length);
     }
@@ -132,7 +288,7 @@ function parseJavaScript(code: string): AstNode[] {
     }
   };
 
-  if (!code.includes('```')) {
+  if (!hasMarkdownFence(code)) {
     for (const sourceType of ['module', 'script'] as const) {
       const ast = parseCandidate(code, sourceType);
       if (ast) return [ast];

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -1,4 +1,5 @@
-import { parse } from 'acorn';
+import { Parser, parse } from 'acorn';
+import { tsPlugin } from 'acorn-typescript';
 import type { Node } from 'acorn';
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
 
@@ -27,6 +28,10 @@ const LOOP_OR_SWITCH_NODE_TYPES = new Set([
 ]);
 
 type AstNode = Node & Record<string, unknown>;
+
+type AcornPlugin = (BaseParser: typeof Parser) => typeof Parser;
+
+const TypeScriptParser = Parser.extend(tsPlugin() as unknown as AcornPlugin);
 
 function isNode(value: unknown): value is AstNode {
   return Boolean(value && typeof value === 'object' && typeof (value as AstNode).type === 'string');
@@ -66,7 +71,15 @@ function parseJavaScript(code: string): AstNode | null {
   for (const candidate of [code, `${code}\n}`, `${code}\n}}`, `${code}\n}}}`]) {
     for (const sourceType of ['module', 'script'] as const) {
       try {
-        return parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode;
+        try {
+          return TypeScriptParser.parse(candidate, {
+            ...baseOptions,
+            sourceType,
+            locations: true,
+          }) as unknown as AstNode;
+        } catch {
+          return parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode;
+        }
       } catch {
         // Try the next source type or the next simple truncation repair.
       }
@@ -102,6 +115,8 @@ function isInfiniteFor(node: AstNode): boolean {
 function hasLoopExit(body: AstNode): boolean {
   const visit = (node: AstNode, nestedLoopOrSwitchDepth: number): boolean => {
     if (isFunctionLike(node) || isClassLike(node)) return false;
+
+    if (node.type === 'ForOfStatement' && node.await === true) return true;
 
     if (LOOP_EXIT_NODE_TYPES.has(node.type)) return true;
 
@@ -143,13 +158,20 @@ function identifierName(node: AstNode): string | undefined {
 }
 
 function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
-  const visit = (current: AstNode): number | null => {
-    if (current !== node && (isFunctionLike(current) || isClassLike(current))) return null;
+  const visit = (current: AstNode, enterFunction = false): number | null => {
+    if (current !== node && !enterFunction && (isFunctionLike(current) || isClassLike(current))) {
+      return null;
+    }
 
     if (current.type === 'CallExpression') {
       const callee = current.callee;
       if (isNode(callee) && callee.type === 'Identifier' && identifierName(callee) === fnName) {
         return current.start;
+      }
+
+      if (isNode(callee) && isFunctionLike(callee)) {
+        const found = visit(callee, true);
+        if (found != null) return found;
       }
     }
 

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -130,11 +130,27 @@ function ignoredSyntaxRanges(code: string, includeFences = false): Range[] {
     }
 
     if (char === '`' && !isIndexInRanges(ranges, index)) {
-      const start = index;
+      let segmentStart = index;
       index += 1;
       while (index < code.length) {
         if (code[index] === '\\') {
           index += 2;
+          continue;
+        }
+        if (code[index] === '$' && code[index + 1] === '{') {
+          ranges.push({ start: segmentStart, end: index + 2 });
+          index += 2;
+          let expressionDepth = 1;
+          while (index < code.length && expressionDepth > 0) {
+            if (code[index] === '\\') {
+              index += 2;
+              continue;
+            }
+            if (code[index] === '{') expressionDepth += 1;
+            if (code[index] === '}') expressionDepth -= 1;
+            index += 1;
+          }
+          segmentStart = index - 1;
           continue;
         }
         if (code[index] === '`') {
@@ -143,7 +159,7 @@ function ignoredSyntaxRanges(code: string, includeFences = false): Range[] {
         }
         index += 1;
       }
-      ranges.push({ start, end: index });
+      ranges.push({ start: segmentStart, end: index });
       continue;
     }
 
@@ -444,6 +460,23 @@ function containsIfStatement(
   return visit(node, enterFunction);
 }
 
+function containsIfInRecursivePath(node: AstNode, position: number): boolean {
+  const visit = (current: AstNode): boolean => {
+    if (current.type === 'IfStatement' && current.start < position) return true;
+    if (
+      current !== node &&
+      typeof current.start === 'number' &&
+      typeof current.end === 'number' &&
+      (current.start > position || current.end < position)
+    ) {
+      return false;
+    }
+    return childNodes(current).some((child) => visit(child));
+  };
+
+  return visit(node);
+}
+
 function identifierName(node: AstNode): string | undefined {
   const name = node.name;
   return typeof name === 'string' ? name : undefined;
@@ -459,23 +492,50 @@ function functionBodyStatements(root: AstNode): AstNode[] {
 }
 
 function localFunctionDeclaration(root: AstNode, name: string, callStart = Number.POSITIVE_INFINITY): AstNode | null {
-  for (const statement of functionBodyStatements(root)) {
-    if (statement.type === 'FunctionDeclaration') {
-      const id = statement.id;
-      if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return statement;
-      continue;
+  const candidateBlocks: AstNode[] = [];
+  const collectBlocks = (current: AstNode): void => {
+    if (
+      current !== root &&
+      (isFunctionLike(current) || current.type === 'ClassDeclaration' || current.type === 'ClassExpression')
+    ) {
+      return;
     }
 
-    if (statement.start > callStart) continue;
+    if (
+      (current === root || current.type === 'BlockStatement' || current.type === 'Program') &&
+      typeof current.start === 'number' &&
+      typeof current.end === 'number' &&
+      current.start <= callStart &&
+      callStart <= current.end
+    ) {
+      candidateBlocks.push(current);
+    }
 
-    const declarations = statement.type === 'VariableDeclaration' && Array.isArray(statement.declarations)
-      ? statement.declarations
-      : [];
-    for (const declaration of declarations) {
-      if (!isNode(declaration)) continue;
-      if (isNode(declaration.id) && identifierName(declaration.id) === name) {
-        const init = declaration.init;
-        if (isNode(init) && isFunctionLike(init)) return init;
+    for (const child of childNodes(current)) collectBlocks(child);
+  };
+
+  collectBlocks(root);
+  candidateBlocks.sort((a, b) => (b.start - a.start) || (a.end - b.end));
+
+  for (const block of candidateBlocks) {
+    for (const statement of functionBodyStatements(block)) {
+      if (statement.type === 'FunctionDeclaration') {
+        const id = statement.id;
+        if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return statement;
+        continue;
+      }
+
+      if (statement.start > callStart) continue;
+
+      const declarations = statement.type === 'VariableDeclaration' && Array.isArray(statement.declarations)
+        ? statement.declarations
+        : [];
+      for (const declaration of declarations) {
+        if (!isNode(declaration)) continue;
+        if (isNode(declaration.id) && identifierName(declaration.id) === name) {
+          const init = declaration.init;
+          if (isNode(init) && isFunctionLike(init)) return init;
+        }
       }
     }
   }
@@ -504,7 +564,7 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
             enteredHelpers.add(callName);
             const found = visit(helper, true);
             enteredHelpers.delete(callName);
-            if (found != null) return current.start;
+            if (found != null) return found;
           }
         }
       }
@@ -765,6 +825,7 @@ export class LogicLoopEvaluator implements Evaluator {
           if (recursiveCallStart != null) {
             const hasGuard =
               containsIfStatement(node, false, recursiveCallStart) ||
+              containsIfInRecursivePath(node, recursiveCallStart) ||
               hasReturnBefore(node, recursiveCallStart);
             if (!hasGuard) {
               findings.push({

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -66,10 +66,17 @@ function codeCandidates(code: string): string[] {
   );
   const candidates = fencedBlocks.length > 0 ? [...fencedBlocks, code] : [code];
 
+  for (const keyword of ['while', 'for', 'function', 'async function', 'class']) {
+    const index = code.indexOf(keyword);
+    if (index > 0) candidates.push(code.slice(index));
+  }
+
   return candidates.flatMap((candidate) => [candidate, `${candidate}\n}`, `${candidate}\n}}`, `${candidate}\n}}}`]);
 }
 
-function parseJavaScript(code: string): AstNode | null {
+function parseJavaScript(code: string): AstNode[] {
+  const asts: AstNode[] = [];
+  const seen = new Set<string>();
   const baseOptions = {
     ecmaVersion: 'latest' as const,
     allowAwaitOutsideFunction: true,
@@ -78,16 +85,20 @@ function parseJavaScript(code: string): AstNode | null {
   };
 
   for (const candidate of codeCandidates(code)) {
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
     for (const sourceType of ['module', 'script'] as const) {
       try {
         try {
-          return TypeScriptParser.parse(candidate, {
+          asts.push(TypeScriptParser.parse(candidate, {
             ...baseOptions,
             sourceType,
             locations: true,
-          }) as unknown as AstNode;
+          }) as unknown as AstNode);
+          break;
         } catch {
-          return parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode;
+          asts.push(parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode);
+          break;
         }
       } catch {
         // Try the next source type or the next simple truncation repair.
@@ -95,15 +106,11 @@ function parseJavaScript(code: string): AstNode | null {
     }
   }
 
-  return null;
+  return asts;
 }
 
 function isFunctionLike(node: AstNode): boolean {
   return FUNCTION_NODE_TYPES.has(node.type);
-}
-
-function isClassLike(node: AstNode): boolean {
-  return node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
 }
 
 function isInfiniteWhile(node: AstNode): boolean {
@@ -123,7 +130,7 @@ function isInfiniteFor(node: AstNode): boolean {
 
 function hasLoopExit(body: AstNode): boolean {
   const visit = (node: AstNode, nestedLoopOrSwitchDepth: number): boolean => {
-    if (isFunctionLike(node) || isClassLike(node)) return false;
+    if (isFunctionLike(node)) return false;
 
     if (node.type === 'ForOfStatement' && node.await === true) return true;
 
@@ -217,9 +224,9 @@ export class LogicLoopEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     const findings: EvaluationFinding[] = [];
-    const ast = parseJavaScript(input.content);
+    const asts = parseJavaScript(input.content);
 
-    if (ast) {
+    for (const ast of asts) {
       this.checkInfiniteLoops(ast, findings);
       this.checkUnguardedRecursion(ast, findings);
     }

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -1,313 +1,177 @@
+import { parse } from 'acorn';
+import type { Node } from 'acorn';
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
-
-// Loop headers we treat as unconditional: while(true){ and for(;;){.
-// We only match up to the opening brace; the body is extracted with a
-// brace-balanced scan so nested `{ ... }` blocks (if/try/switch) are preserved.
-const INFINITE_LOOP_HEADERS = [
-  /while\s*\(\s*true\s*\)\s*\{/g,
-  /for\s*\(\s*;;\s*\)\s*\{/g,
-];
-
-// Matches function name() { ... } — body captured lazily; recursion detection
-// works on the sanitized body (comments/strings removed, interpolations kept).
-const SELF_RECURSION_PATTERN =
-  /function\s+(\w+)\s*\([^)]*\)\s*\{([\s\S]*?)\}/g;
 
 // Keywords that legitimately exit (or suspend) a loop. `await`/`yield` cover
 // intentional async event loops such as `while (true) { await queue.next(); }`.
-const LOOP_EXIT_KEYWORDS = new Set(['break', 'return', 'throw', 'await', 'yield']);
+const LOOP_EXIT_NODE_TYPES = new Set([
+  'ReturnStatement',
+  'ThrowStatement',
+  'AwaitExpression',
+  'YieldExpression',
+]);
 
-// Keywords that open a nested loop or switch. A `break` inside one of these is
-// captured by it, not by the outer loop, so it does not count as an outer exit.
-const LOOP_OR_SWITCH_KEYWORDS = new Set(['for', 'while', 'do', 'switch']);
+const FUNCTION_NODE_TYPES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+]);
 
-/**
- * Returns true if a `/` at this position can legally start a regex literal,
- * based on the previous significant character. A `/` after a value (identifier,
- * number, closing bracket, or string) is division; anywhere an expression is
- * expected it begins a regex. This is the standard JS lexer heuristic.
- */
-function regexCanStart(prevSignificant: string): boolean {
-  if (prevSignificant === '') return true;
-  return !/[A-Za-z0-9_$)\]}'"`]/.test(prevSignificant);
+const LOOP_OR_SWITCH_NODE_TYPES = new Set([
+  'ForInStatement',
+  'ForOfStatement',
+  'ForStatement',
+  'DoWhileStatement',
+  'WhileStatement',
+  'SwitchStatement',
+]);
+
+type AstNode = Node & Record<string, unknown>;
+
+function isNode(value: unknown): value is AstNode {
+  return Boolean(value && typeof value === 'object' && typeof (value as AstNode).type === 'string');
 }
 
-/**
- * Removes comments, string literals, and regex literals from a code snippet so
- * that keyword detection operates on real code, not on prose or data. Template
- * literals are special-cased: the literal text is dropped but the code inside
- * `${ ... }` interpolations is preserved (and recursively sanitized) so that
- * real expressions like `` `${loop()}` `` remain visible to recursion detection.
- *
- * Implemented as a single left-to-right scan so whichever construct opens first
- * wins. A naive replace-comments-then-strings ordering would treat the `//`
- * inside `log("http://x"); break;` or `/\/\//.test(x); break;` as a line comment
- * and delete the real `break`, producing a false infinite-loop finding.
- */
-function sanitize(code: string): string {
-  let out = '';
-  let i = 0;
-  const n = code.length;
-  let prevSignificant = '';
+function childNodes(node: AstNode): AstNode[] {
+  const children: AstNode[] = [];
 
-  while (i < n) {
-    const c = code[i]!;
-    const next = code[i + 1];
-
-    // Line comment: skip to end of line.
-    if (c === '/' && next === '/') {
-      i += 2;
-      while (i < n && code[i] !== '\n') i++;
-      out += ' ';
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'type' || key === 'start' || key === 'end' || key === 'loc' || key === 'range') {
       continue;
     }
 
-    // Block comment: skip to closing */.
-    if (c === '/' && next === '*') {
-      i += 2;
-      while (i < n && !(code[i] === '*' && code[i + 1] === '/')) i++;
-      i += 2;
-      out += ' ';
+    if (isNode(value)) {
+      children.push(value);
       continue;
     }
 
-    // String literal: skip to matching unescaped quote.
-    if (c === '"' || c === "'") {
-      const quote = c;
-      i++;
-      while (i < n) {
-        if (code[i] === '\\') {
-          i += 2;
-          continue;
-        }
-        if (code[i] === quote) {
-          i++;
-          break;
-        }
-        i++;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isNode(item)) children.push(item);
       }
-      out += ' ';
-      prevSignificant = ')';
-      continue;
-    }
-
-    // Template literal: drop literal text, keep & sanitize ${...} code.
-    if (c === '`') {
-      i++;
-      out += ' ';
-      while (i < n) {
-        if (code[i] === '\\') {
-          i += 2;
-          continue;
-        }
-        if (code[i] === '`') {
-          i++;
-          break;
-        }
-        if (code[i] === '$' && code[i + 1] === '{') {
-          i += 2;
-          let depth = 1;
-          let inner = '';
-          while (i < n && depth > 0) {
-            const cc = code[i];
-            if (cc === '{') depth++;
-            else if (cc === '}') {
-              depth--;
-              if (depth === 0) {
-                i++;
-                break;
-              }
-            }
-            inner += cc;
-            i++;
-          }
-          out += ` ${sanitize(inner)} `;
-          continue;
-        }
-        i++;
-      }
-      prevSignificant = ')';
-      continue;
-    }
-
-    // Regex literal: skip to closing unescaped `/` (respecting char classes).
-    if (c === '/' && regexCanStart(prevSignificant)) {
-      i++;
-      let inClass = false;
-      let terminated = false;
-      while (i < n) {
-        const ch = code[i];
-        if (ch === '\\') {
-          i += 2;
-          continue;
-        }
-        if (ch === '\n') break; // unterminated — not a regex, bail
-        if (ch === '[') inClass = true;
-        else if (ch === ']') inClass = false;
-        else if (ch === '/' && !inClass) {
-          i++;
-          terminated = true;
-          break;
-        }
-        i++;
-      }
-      if (terminated) {
-        out += ' ';
-        prevSignificant = ')';
-        continue;
-      }
-      // Not a regex after all: fall through and treat `/` as a normal char.
-      out += c;
-      prevSignificant = c;
-      i++;
-      continue;
-    }
-
-    out += c;
-    if (!/\s/.test(c)) prevSignificant = c;
-    i++;
-  }
-
-  return out;
-}
-
-/**
- * Extracts the brace-balanced block starting at `openBraceIdx` (which must point
- * at a `{`). Returns the content between the outer braces. If the block is never
- * closed (truncated input), returns everything after the opening brace.
- * Assumes the code has already been sanitized so all braces are real.
- */
-function extractBlock(code: string, openBraceIdx: number): string {
-  let depth = 0;
-  for (let i = openBraceIdx; i < code.length; i++) {
-    const ch = code[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return code.slice(openBraceIdx + 1, i);
-    }
-  }
-  return code.slice(openBraceIdx + 1);
-}
-
-/**
- * Word-boundary keyword check. Matches `break` but not `breakPoint`, and
- * `return` but not `returnValue`, eliminating identifier-based false matches.
- */
-function hasKeyword(code: string, keyword: string): boolean {
-  return new RegExp(`\\b${keyword}\\b`).test(code);
-}
-
-/**
- * Detects whether a (sanitized, brace-balanced) loop body contains a real
- * loop-level exit/suspend keyword.
- *
- * A bare keyword match anywhere in the body is not enough. An exit counts only
- * when it executes as part of the loop's own control flow, so this scan rejects:
- *   - member accesses (`timer.await()` — `await` is a method name),
- *   - keywords inside a nested function (braced `() => { return; }` or concise
- *     `() => await work(...)` arrow bodies, and `function` declarations), and
- *   - a `break` captured by a nested loop or `switch` rather than the outer loop.
- *
- * `return`/`throw`/`await`/`yield` inside plain blocks (`if`/`try`) still count,
- * which is why brace-balanced extraction matters: an exit inside `if (x) { ... }`
- * is a legitimate loop exit.
- */
-function hasLoopExit(body: string): boolean {
-  const tokenPattern = /=>|function\b|[{}()[\];,]|\.\s*[A-Za-z_$][\w$]*|[A-Za-z_$][\w$]*/g;
-
-  // Semantic stack of `{ ... }` frames; brackets ()[]{} all bump `bracketDepth`,
-  // which positions concise-arrow markers.
-  const braceStack: Array<{ isFunc: boolean; loopOrSwitch: boolean }> = [];
-  const conciseMarkers: number[] = []; // bracketDepth at each open concise arrow
-  let bracketDepth = 0;
-  let pendingFunc = false; // next `{` opens a function body
-  let pendingLoopOrSwitch = false; // next `{` opens a loop/switch body
-  let arrowPending = false; // we just saw `=>`, awaiting its body
-
-  const isInsideNestedCallable = (): boolean =>
-    conciseMarkers.length > 0 || braceStack.some((f) => f.isFunc);
-  const insideNestedLoopOrSwitch = (): boolean =>
-    braceStack.some((f) => f.loopOrSwitch);
-
-  for (const match of body.matchAll(tokenPattern)) {
-    const token = match[0];
-
-    // Resolve a concise-vs-braced arrow body the moment we see the next token.
-    if (arrowPending) {
-      arrowPending = false;
-      if (token === '{') {
-        pendingFunc = true; // braced arrow body; fall through to `{` handling
-      } else {
-        conciseMarkers.push(bracketDepth); // concise body; keep scanning token
-      }
-    }
-
-    if (token === '{') {
-      braceStack.push({
-        isFunc: pendingFunc,
-        loopOrSwitch: !pendingFunc && pendingLoopOrSwitch,
-      });
-      bracketDepth++;
-      pendingFunc = false;
-      pendingLoopOrSwitch = false;
-      continue;
-    }
-    if (token === '(' || token === '[') {
-      bracketDepth++;
-      continue;
-    }
-    if (token === '}') {
-      braceStack.pop();
-      bracketDepth = Math.max(0, bracketDepth - 1);
-      while (conciseMarkers.length && conciseMarkers[conciseMarkers.length - 1]! > bracketDepth) {
-        conciseMarkers.pop();
-      }
-      pendingLoopOrSwitch = false;
-      pendingFunc = false;
-      continue;
-    }
-    if (token === ')' || token === ']') {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-      while (conciseMarkers.length && conciseMarkers[conciseMarkers.length - 1]! > bracketDepth) {
-        conciseMarkers.pop();
-      }
-      continue;
-    }
-    if (token === ';' || token === ',') {
-      // A statement/argument boundary at the arrow's own depth ends a concise body.
-      while (conciseMarkers.length && conciseMarkers[conciseMarkers.length - 1]! >= bracketDepth) {
-        conciseMarkers.pop();
-      }
-      pendingLoopOrSwitch = false;
-      pendingFunc = false;
-      continue;
-    }
-    if (token === '=>') {
-      arrowPending = true;
-      continue;
-    }
-    if (token === 'function') {
-      pendingFunc = true;
-      continue;
-    }
-    if (token.startsWith('.')) {
-      continue; // member access — never a loop keyword
-    }
-
-    if (LOOP_OR_SWITCH_KEYWORDS.has(token)) {
-      pendingLoopOrSwitch = true;
-      continue;
-    }
-
-    if (LOOP_EXIT_KEYWORDS.has(token)) {
-      if (isInsideNestedCallable()) continue;
-      if (token === 'break' && insideNestedLoopOrSwitch()) continue;
-      return true;
     }
   }
 
-  return false;
+  return children;
+}
+
+function parseJavaScript(code: string): AstNode | null {
+  const baseOptions = {
+    ecmaVersion: 'latest' as const,
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+    allowHashBang: true,
+  };
+
+  for (const candidate of [code, `${code}\n}`, `${code}\n}}`, `${code}\n}}}`]) {
+    for (const sourceType of ['module', 'script'] as const) {
+      try {
+        return parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode;
+      } catch {
+        // Try the next source type or the next simple truncation repair.
+      }
+    }
+  }
+
+  return null;
+}
+
+function isFunctionLike(node: AstNode): boolean {
+  return FUNCTION_NODE_TYPES.has(node.type);
+}
+
+function isClassLike(node: AstNode): boolean {
+  return node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
+}
+
+function isInfiniteWhile(node: AstNode): boolean {
+  if (node.type !== 'WhileStatement') return false;
+  const test = node.test;
+  return isNode(test) && test.type === 'Literal' && test.value === true;
+}
+
+function isInfiniteFor(node: AstNode): boolean {
+  return (
+    node.type === 'ForStatement' &&
+    node.init == null &&
+    node.test == null &&
+    node.update == null
+  );
+}
+
+function hasLoopExit(body: AstNode): boolean {
+  const visit = (node: AstNode, nestedLoopOrSwitchDepth: number): boolean => {
+    if (isFunctionLike(node) || isClassLike(node)) return false;
+
+    if (LOOP_EXIT_NODE_TYPES.has(node.type)) return true;
+
+    if (node.type === 'BreakStatement') {
+      return nestedLoopOrSwitchDepth === 0;
+    }
+
+    const nextDepth = LOOP_OR_SWITCH_NODE_TYPES.has(node.type)
+      ? nestedLoopOrSwitchDepth + 1
+      : nestedLoopOrSwitchDepth;
+
+    for (const child of childNodes(node)) {
+      if (visit(child, nextDepth)) return true;
+    }
+
+    return false;
+  };
+
+  if (body.type === 'BlockStatement' && Array.isArray(body.body)) {
+    return body.body.some((statement) => isNode(statement) && visit(statement, 0));
+  }
+
+  return visit(body, 0);
+}
+
+function containsIfStatement(node: AstNode): boolean {
+  const visit = (current: AstNode): boolean => {
+    if (current !== node && (isFunctionLike(current) || isClassLike(current))) return false;
+    if (current.type === 'IfStatement') return true;
+    return childNodes(current).some(visit);
+  };
+
+  return visit(node);
+}
+
+function identifierName(node: AstNode): string | undefined {
+  const name = node.name;
+  return typeof name === 'string' ? name : undefined;
+}
+
+function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
+  const visit = (current: AstNode): number | null => {
+    if (current !== node && (isFunctionLike(current) || isClassLike(current))) return null;
+
+    if (current.type === 'CallExpression') {
+      const callee = current.callee;
+      if (isNode(callee) && callee.type === 'Identifier' && identifierName(callee) === fnName) {
+        return current.start;
+      }
+    }
+
+    for (const child of childNodes(current)) {
+      const found = visit(child);
+      if (found != null) return found;
+    }
+
+    return null;
+  };
+
+  return visit(node);
+}
+
+function hasReturnBefore(node: AstNode, position: number): boolean {
+  const visit = (current: AstNode): boolean => {
+    if (current !== node && (isFunctionLike(current) || isClassLike(current))) return false;
+    if (current.type === 'ReturnStatement' && current.start < position) return true;
+    return childNodes(current).some(visit);
+  };
+
+  return visit(node);
 }
 
 export class LogicLoopEvaluator implements Evaluator {
@@ -316,10 +180,12 @@ export class LogicLoopEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     const findings: EvaluationFinding[] = [];
-    const sanitized = sanitize(input.content);
+    const ast = parseJavaScript(input.content);
 
-    this.checkInfiniteLoops(sanitized, findings);
-    this.checkUnguardedRecursion(sanitized, findings);
+    if (ast) {
+      this.checkInfiniteLoops(ast, findings);
+      this.checkUnguardedRecursion(ast, findings);
+    }
 
     const score = findings.length === 0 ? 1 : 0;
 
@@ -331,49 +197,46 @@ export class LogicLoopEvaluator implements Evaluator {
     };
   }
 
-  private checkInfiniteLoops(sanitized: string, findings: EvaluationFinding[]): void {
-    for (const header of INFINITE_LOOP_HEADERS) {
-      for (const match of sanitized.matchAll(header)) {
-        const braceIdx = match.index! + match[0].length - 1; // position of `{`
-        const body = extractBlock(sanitized, braceIdx);
-        if (!hasLoopExit(body)) {
-          findings.push({
-            message: 'Potential infinite loop detected: loop has no break or return statement',
-            severity: 'critical',
-            suggestion: 'Add a break condition or return statement inside the loop',
-          });
-        }
-      }
-    }
-  }
-
-  private checkUnguardedRecursion(sanitized: string, findings: EvaluationFinding[]): void {
-    for (const match of sanitized.matchAll(SELF_RECURSION_PATTERN)) {
-      const fnName = match[1];
-      const body = match[2] ?? '';
-
-      if (!fnName) continue;
-
-      // Check if the function calls itself.
-      const callPattern = new RegExp(`\\b${fnName}\\s*\\(`, 'g');
-      if (!callPattern.test(body)) continue;
-
-      // Check for a guard: a conditional, or a return before the recursive call.
-      // Word-boundary matching avoids treating identifiers like `notify` or
-      // `returnValue` as guards.
-      const returnIdx = body.search(/\breturn\b/);
-      const recursiveCallIdx = body.search(new RegExp(`\\b${fnName}\\s*\\(`));
-      const hasGuard =
-        hasKeyword(body, 'if') ||
-        (returnIdx !== -1 && recursiveCallIdx !== -1 && returnIdx < recursiveCallIdx);
-
-      if (!hasGuard) {
+  private checkInfiniteLoops(ast: AstNode, findings: EvaluationFinding[]): void {
+    const visit = (node: AstNode): void => {
+      if ((isInfiniteWhile(node) || isInfiniteFor(node)) && isNode(node.body) && !hasLoopExit(node.body)) {
         findings.push({
-          message: `Potential unguarded recursion detected: "${fnName}" calls itself without a visible base case`,
+          message: 'Potential infinite loop detected: loop has no break or return statement',
           severity: 'critical',
-          suggestion: `Add a base case (if/return) before the recursive call to "${fnName}"`,
+          suggestion: 'Add a break condition or return statement inside the loop',
         });
       }
-    }
+
+      for (const child of childNodes(node)) visit(child);
+    };
+
+    visit(ast);
+  }
+
+  private checkUnguardedRecursion(ast: AstNode, findings: EvaluationFinding[]): void {
+    const visit = (node: AstNode): void => {
+      if (node.type === 'FunctionDeclaration') {
+        const id = node.id;
+        const fnName = isNode(id) && id.type === 'Identifier' ? identifierName(id) : undefined;
+
+        if (fnName) {
+          const recursiveCallStart = findRecursiveCallStart(node, fnName);
+          if (recursiveCallStart != null) {
+            const hasGuard = containsIfStatement(node) || hasReturnBefore(node, recursiveCallStart);
+            if (!hasGuard) {
+              findings.push({
+                message: `Potential unguarded recursion detected: "${fnName}" calls itself without a visible base case`,
+                severity: 'critical',
+                suggestion: `Add a base case (if/return) before the recursive call to "${fnName}"`,
+              });
+            }
+          }
+        }
+      }
+
+      for (const child of childNodes(node)) visit(child);
+    };
+
+    visit(ast);
   }
 }

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -316,6 +316,32 @@ function parseJavaScript(code: string): AstNode[] {
   return asts;
 }
 
+function parsesAsJavaScript(code: string): boolean {
+  if (code.trimStart().startsWith('```')) return false;
+  const baseOptions = {
+    ecmaVersion: 'latest' as const,
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+    allowHashBang: true,
+  };
+
+  for (const sourceType of ['module', 'script'] as const) {
+    try {
+      TypeScriptParser.parse(code, { ...baseOptions, sourceType, locations: true });
+      return true;
+    } catch {
+      try {
+        parse(code, { ...baseOptions, sourceType });
+        return true;
+      } catch {
+        // Try the next source type.
+      }
+    }
+  }
+
+  return false;
+}
+
 function isFunctionLike(node: AstNode): boolean {
   return FUNCTION_NODE_TYPES.has(node.type);
 }
@@ -379,9 +405,21 @@ function invokedFunctionCallee(callee: AstNode): AstNode | null {
   return null;
 }
 
-function containsIfStatement(node: AstNode, enterFunction = false): boolean {
+function containsIfStatement(
+  node: AstNode,
+  enterFunction = false,
+  beforePosition = Number.POSITIVE_INFINITY,
+): boolean {
   const enteredHelpers = new Set<string>();
   const visit = (current: AstNode, allowFunctionBody = false): boolean => {
+    if (
+      current !== node &&
+      !allowFunctionBody &&
+      typeof current.start === 'number' &&
+      current.start > beforePosition
+    ) {
+      return false;
+    }
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'IfStatement') return true;
     if (current.type === 'CallExpression' && isNode(current.callee)) {
@@ -389,7 +427,7 @@ function containsIfStatement(node: AstNode, enterFunction = false): boolean {
       if (callee.type === 'Identifier') {
         const callName = identifierName(callee);
         if (callName && !enteredHelpers.has(callName)) {
-          const helper = localFunctionDeclaration(node, callName);
+          const helper = localFunctionDeclaration(node, callName, current.start);
           if (helper) {
             enteredHelpers.add(callName);
             if (visit(helper, true)) return true;
@@ -411,28 +449,38 @@ function identifierName(node: AstNode): string | undefined {
   return typeof name === 'string' ? name : undefined;
 }
 
-function localFunctionDeclaration(root: AstNode, name: string): AstNode | null {
-  const visit = (current: AstNode): AstNode | null => {
-    if (current !== root && isFunctionLike(current)) {
-      const id = current.id;
-      if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return current;
-      return null;
+function functionBodyStatements(root: AstNode): AstNode[] {
+  const body = root.body;
+  if (isNode(body) && body.type === 'BlockStatement' && Array.isArray(body.body)) {
+    return body.body.filter(isNode);
+  }
+  if (Array.isArray(body)) return body.filter(isNode);
+  return [];
+}
+
+function localFunctionDeclaration(root: AstNode, name: string, callStart = Number.POSITIVE_INFINITY): AstNode | null {
+  for (const statement of functionBodyStatements(root)) {
+    if (statement.type === 'FunctionDeclaration') {
+      const id = statement.id;
+      if (isNode(id) && id.type === 'Identifier' && identifierName(id) === name) return statement;
+      continue;
     }
 
-    if (current.type === 'VariableDeclarator' && isNode(current.id) && identifierName(current.id) === name) {
-      const init = current.init;
-      if (isNode(init) && isFunctionLike(init)) return init;
+    if (statement.start > callStart) continue;
+
+    const declarations = statement.type === 'VariableDeclaration' && Array.isArray(statement.declarations)
+      ? statement.declarations
+      : [];
+    for (const declaration of declarations) {
+      if (!isNode(declaration)) continue;
+      if (isNode(declaration.id) && identifierName(declaration.id) === name) {
+        const init = declaration.init;
+        if (isNode(init) && isFunctionLike(init)) return init;
+      }
     }
+  }
 
-    for (const child of childNodes(current)) {
-      const found = visit(child);
-      if (found) return found;
-    }
-
-    return null;
-  };
-
-  return visit(root);
+  return null;
 }
 
 function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
@@ -451,12 +499,12 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
         }
 
         if (callName && !enteredHelpers.has(callName)) {
-          const helper = localFunctionDeclaration(node, callName);
+          const helper = localFunctionDeclaration(node, callName, current.start);
           if (helper) {
             enteredHelpers.add(callName);
             const found = visit(helper, true);
             enteredHelpers.delete(callName);
-            if (found != null) return found;
+            if (found != null) return current.start;
           }
         }
       }
@@ -484,6 +532,14 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
 function hasReturnBefore(node: AstNode, position: number, enterFunction = false): boolean {
   const enteredHelpers = new Set<string>();
   const visit = (current: AstNode, allowFunctionBody = false): boolean => {
+    if (
+      current !== node &&
+      !allowFunctionBody &&
+      typeof current.start === 'number' &&
+      current.start > position
+    ) {
+      return false;
+    }
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'ReturnStatement' && current.start < position) return true;
     if (current.type === 'CallExpression' && isNode(current.callee)) {
@@ -491,7 +547,7 @@ function hasReturnBefore(node: AstNode, position: number, enterFunction = false)
       if (callee.type === 'Identifier') {
         const callName = identifierName(callee);
         if (callName && !enteredHelpers.has(callName)) {
-          const helper = localFunctionDeclaration(node, callName);
+          const helper = localFunctionDeclaration(node, callName, current.start);
           if (helper) {
             enteredHelpers.add(callName);
             if (visit(helper, true)) return true;
@@ -509,7 +565,7 @@ function hasReturnBefore(node: AstNode, position: number, enterFunction = false)
 }
 
 function syntaxMaskedText(code: string): string {
-  const chars = [...code];
+  const chars = code.split('');
   for (const range of ignoredSyntaxRanges(code, false)) {
     for (let index = range.start; index < range.end && index < chars.length; index += 1) {
       chars[index] = ' ';
@@ -519,10 +575,109 @@ function syntaxMaskedText(code: string): string {
 }
 
 function hasFallbackLoopExit(snippet: string): boolean {
-  const withoutNestedFunctions = snippet
-    .replace(/=>\s*\{[\s\S]*?\}/g, '')
-    .replace(/function\b[^{}]*\{[\s\S]*?\}/g, '');
-  return /\b(break|return|throw|await|yield)\b/.test(withoutNestedFunctions);
+  const firstOpen = snippet.indexOf('{');
+  if (firstOpen < 0) return /\b(await|yield)\b/.test(snippet);
+
+  const nestedScopeDepths: number[] = [];
+  let pendingNestedScope = false;
+  let conciseArrowDepth: number | null = null;
+  let depth = 0;
+
+  const startsKeyword = (keyword: string, index: number): boolean =>
+    snippet.startsWith(keyword, index) && hasKeywordBoundary(snippet, keyword, index);
+
+  for (let index = firstOpen; index < snippet.length; index += 1) {
+    const char = snippet[index];
+
+    if (char === '}') {
+      if (nestedScopeDepths.at(-1) === depth) nestedScopeDepths.pop();
+      if (conciseArrowDepth === depth) conciseArrowDepth = null;
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+
+    if (char === '{') {
+      depth += 1;
+      if (pendingNestedScope && depth > 1) nestedScopeDepths.push(depth);
+      pendingNestedScope = false;
+      continue;
+    }
+
+    if (depth <= 0) continue;
+
+    if (char === ';' && conciseArrowDepth === depth) {
+      conciseArrowDepth = null;
+      continue;
+    }
+
+    if (snippet.startsWith('=>', index)) {
+      const next = snippet.slice(index + 2).trimStart()[0];
+      if (next === '{') {
+        pendingNestedScope = true;
+      } else {
+        conciseArrowDepth = depth;
+      }
+      index += 1;
+      continue;
+    }
+
+    let consumedNestedKeyword = false;
+    for (const keyword of ['function', 'class', 'while', 'for', 'switch']) {
+      if (startsKeyword(keyword, index)) {
+        pendingNestedScope = true;
+        index += keyword.length - 1;
+        consumedNestedKeyword = true;
+        break;
+      }
+    }
+    if (consumedNestedKeyword) continue;
+
+    if (nestedScopeDepths.length > 0 || conciseArrowDepth != null) continue;
+
+    for (const keyword of ['break', 'return', 'throw', 'await', 'yield']) {
+      if (startsKeyword(keyword, index)) return true;
+    }
+  }
+
+  return false;
+}
+
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function fallbackRecursionFindings(code: string): EvaluationFinding[] {
+  const masked = syntaxMaskedText(code.replace(/^```[^\n]*$/gm, ''));
+  const findings: EvaluationFinding[] = [];
+
+  for (const match of masked.matchAll(/\bfunction\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/g)) {
+    const fnName = match[1];
+    const start = match.index ?? 0;
+    if (!fnName) continue;
+    const snippet = trimToBalancedSnippet(masked.slice(start));
+    const selfCall = new RegExp(`\\b${escapeRegExpLiteral(fnName)}\\s*\\(`).exec(snippet.slice(match[0].length));
+    if (!selfCall) continue;
+    const beforeCall = snippet.slice(0, match[0].length + selfCall.index);
+    if (/\b(if|return|throw)\b/.test(beforeCall)) continue;
+    findings.push({
+      message: `Potential unguarded recursion detected: "${fnName}" calls itself without a visible base case`,
+      severity: 'critical',
+      suggestion: `Add a base case (if/return) before the recursive call to "${fnName}"`,
+    });
+    break;
+  }
+
+  return findings;
+}
+
+function dedupeFindings(findings: EvaluationFinding[]): EvaluationFinding[] {
+  const seen = new Set<string>();
+  return findings.filter((finding) => {
+    const key = `${finding.severity}\0${finding.message}\0${finding.suggestion ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 function fallbackInfiniteLoopFindings(code: string): EvaluationFinding[] {
@@ -554,6 +709,7 @@ export class LogicLoopEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     const findings: EvaluationFinding[] = [];
+    const fullSourceParses = parsesAsJavaScript(input.content);
     const asts = parseJavaScript(input.content);
 
     for (const ast of asts) {
@@ -561,17 +717,21 @@ export class LogicLoopEvaluator implements Evaluator {
       this.checkUnguardedRecursion(ast, findings);
     }
 
-    if (!findings.some((finding) => finding.message.includes('infinite loop'))) {
+    if (!fullSourceParses && !findings.some((finding) => finding.message.includes('infinite loop'))) {
       findings.push(...fallbackInfiniteLoopFindings(input.content));
     }
+    if (!fullSourceParses && !findings.some((finding) => finding.message.includes('recursion'))) {
+      findings.push(...fallbackRecursionFindings(input.content));
+    }
 
-    const score = findings.length === 0 ? 1 : 0;
+    const uniqueFindings = dedupeFindings(findings);
+    const score = uniqueFindings.length === 0 ? 1 : 0;
 
     return {
       evaluatorName: this.name,
-      verdict: findings.length === 0 ? 'pass' : 'fail',
+      verdict: uniqueFindings.length === 0 ? 'pass' : 'fail',
       score,
-      findings,
+      findings: uniqueFindings,
     };
   }
 
@@ -603,7 +763,9 @@ export class LogicLoopEvaluator implements Evaluator {
         if (fnName) {
           const recursiveCallStart = findRecursiveCallStart(node, fnName);
           if (recursiveCallStart != null) {
-            const hasGuard = containsIfStatement(node) || hasReturnBefore(node, recursiveCallStart);
+            const hasGuard =
+              containsIfStatement(node, false, recursiveCallStart) ||
+              hasReturnBefore(node, recursiveCallStart);
             if (!hasGuard) {
               findings.push({
                 message: `Potential unguarded recursion detected: "${fnName}" calls itself without a visible base case`,

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -116,24 +116,37 @@ function parseJavaScript(code: string): AstNode[] {
     allowHashBang: true,
   };
 
+  const parseCandidate = (candidate: string, sourceType: 'module' | 'script'): AstNode | null => {
+    try {
+      try {
+        return TypeScriptParser.parse(candidate, {
+          ...baseOptions,
+          sourceType,
+          locations: true,
+        }) as unknown as AstNode;
+      } catch {
+        return parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode;
+      }
+    } catch {
+      return null;
+    }
+  };
+
+  if (!code.includes('```')) {
+    for (const sourceType of ['module', 'script'] as const) {
+      const ast = parseCandidate(code, sourceType);
+      if (ast) return [ast];
+    }
+  }
+
   for (const candidate of codeCandidates(code)) {
     if (seen.has(candidate)) continue;
     seen.add(candidate);
     for (const sourceType of ['module', 'script'] as const) {
-      try {
-        try {
-          asts.push(TypeScriptParser.parse(candidate, {
-            ...baseOptions,
-            sourceType,
-            locations: true,
-          }) as unknown as AstNode);
-          break;
-        } catch {
-          asts.push(parse(candidate, { ...baseOptions, sourceType }) as unknown as AstNode);
-          break;
-        }
-      } catch {
-        // Try the next source type or the next simple truncation repair.
+      const ast = parseCandidate(candidate, sourceType);
+      if (ast) {
+        asts.push(ast);
+        break;
       }
     }
   }
@@ -190,12 +203,27 @@ function hasLoopExit(body: AstNode): boolean {
   return visit(body, 0);
 }
 
+function invokedFunctionCallee(callee: AstNode): AstNode | null {
+  if (isFunctionLike(callee)) return callee;
+  if (callee.type !== 'MemberExpression') return null;
+
+  const property = callee.property;
+  const object = callee.object;
+  const propertyName = isNode(property) ? identifierName(property) : undefined;
+  if ((propertyName === 'call' || propertyName === 'apply') && isNode(object) && isFunctionLike(object)) {
+    return object;
+  }
+
+  return null;
+}
+
 function containsIfStatement(node: AstNode, enterFunction = false): boolean {
   const visit = (current: AstNode, allowFunctionBody = false): boolean => {
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'IfStatement') return true;
-    if (current.type === 'CallExpression' && isNode(current.callee) && isFunctionLike(current.callee)) {
-      return visit(current.callee, true);
+    if (current.type === 'CallExpression' && isNode(current.callee)) {
+      const invokedFunction = invokedFunctionCallee(current.callee);
+      if (invokedFunction) return visit(invokedFunction, true);
     }
     return childNodes(current).some((child) => visit(child));
   };
@@ -220,9 +248,12 @@ function findRecursiveCallStart(node: AstNode, fnName: string): number | null {
         return current.start;
       }
 
-      if (isNode(callee) && isFunctionLike(callee)) {
-        const found = visit(callee, true);
-        if (found != null) return found;
+      if (isNode(callee)) {
+        const invokedFunction = invokedFunctionCallee(callee);
+        if (invokedFunction) {
+          const found = visit(invokedFunction, true);
+          if (found != null) return found;
+        }
       }
     }
 
@@ -241,8 +272,9 @@ function hasReturnBefore(node: AstNode, position: number, enterFunction = false)
   const visit = (current: AstNode, allowFunctionBody = false): boolean => {
     if (current !== node && !allowFunctionBody && isFunctionLike(current)) return false;
     if (current.type === 'ReturnStatement' && current.start < position) return true;
-    if (current.type === 'CallExpression' && isNode(current.callee) && isFunctionLike(current.callee)) {
-      return visit(current.callee, true);
+    if (current.type === 'CallExpression' && isNode(current.callee)) {
+      const invokedFunction = invokedFunctionCallee(current.callee);
+      if (invokedFunction) return visit(invokedFunction, true);
     }
     return childNodes(current).some((child) => visit(child));
   };

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -67,8 +67,11 @@ function codeCandidates(code: string): string[] {
   const candidates = fencedBlocks.length > 0 ? [...fencedBlocks, code] : [code];
 
   for (const keyword of ['while', 'for', 'function', 'async function', 'class']) {
-    const index = code.indexOf(keyword);
-    if (index > 0) candidates.push(code.slice(index));
+    let index = code.indexOf(keyword);
+    while (index > 0) {
+      candidates.push(code.slice(index));
+      index = code.indexOf(keyword, index + keyword.length);
+    }
   }
 
   return candidates.flatMap((candidate) => [candidate, `${candidate}\n}`, `${candidate}\n}}`, `${candidate}\n}}}`]);

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -429,6 +429,50 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('infinite loop');
   });
 
+  it('keeps malformed loops inside fences visible to fallback detection', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = '```js\nwhile (true) { doWork(; }\n```';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('detects recursion through invoked arrow helper functions', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(){ const again = () => loop(); again(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('falls back for malformed loops even when another snippet parses', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { doWork(; } function ok() {}';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('honors guards inside invoked helper functions', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(n){ function again(){ if (n <= 0) return; loop(n - 1); } again(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('does not treat nested fallback returns as loop exits', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { const f = () => { return; }; doWork(; }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('does not duplicate findings when the full source already parses', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `function run() { while (true) { doWork(); } }`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -342,6 +342,32 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('infinite loop');
   });
 
+  it('does not extract fallback snippets from string literals', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `const msg = "while (true) { work(); }";`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('does not duplicate findings when the full source already parses', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function run() { while (true) { doWork(); } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('detects unguarded recursion through immediately invoked function call helpers', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop(){ (function(){ loop(); }).call(null); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('detects unguarded recursion in named function expressions', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `const f = function loop() { loop(); };`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -384,6 +384,51 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('infinite loop');
   });
 
+  it('parses valid sources before extracting fenced comments', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = '/* ```js\nwhile (true) { work(); }\n``` */\nconst ok = true;';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('detects recursion through invoked local helper functions', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(){ function again(){ loop(); } again(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('falls back for obvious malformed infinite loops', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { doWork(; }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('does not duplicate overlapping fallback snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'Note: while (true) { work(); } function ok() {}';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('continues past many non-code keyword hits when extracting fallback snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const prefix = Array.from({ length: 60 }, () => 'while ordinary prose').join(' ');
+    const content = `${prefix} while (true) { work(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('does not duplicate findings when the full source already parses', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `function run() { while (true) { doWork(); } }`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -350,6 +350,40 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  it('parses valid sources before treating fence markers inside strings as markdown', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'const msg = "```js\\nwhile (true) { work(); }\\n```";';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('ignores string literal keywords during fallback extraction', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'const msg = "while (true) { work(); }"; ???';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('does not duplicate findings from a single fenced block', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = '```js\nwhile (true) { doWork(); }\n```';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('balances fallback snippets without counting string braces', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { log("}"); work(); } and then hangs';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('does not duplicate findings when the full source already parses', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `function run() { while (true) { doWork(); } }`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -316,6 +316,32 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('infinite loop');
   });
 
+  it('trims prose after embedded code snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { doWork(); }\nThis hangs.';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('does not treat commented snippets as executable fallback code', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'const ok = true; // while (true) { doWork(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('detects infinite loops in TSX snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function C() { while (true) { doWork(); } return <div />; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('detects unguarded recursion in named function expressions', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `const f = function loop() { loop(); };`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -579,10 +579,29 @@ describe('LogicLoopEvaluator', () => {
 
   it('resolves helper calls only from the call-site lexical scope', async () => {
     const evaluator = new LogicLoopEvaluator();
-    const content = 'function loop(){ { function again(){ loop(); } } function again(){ return; } again(); }';
+    const hiddenHelper = 'function loop(){ { function again(){ loop(); } } function again(){ return; } again(); }';
+    const blockScopedHelper = 'function loop(){ { function again(){ loop(); } again(); } }';
+
+    await expect(evaluator.evaluate(createInput(hiddenHelper))).resolves.toMatchObject({ verdict: 'pass' });
+    await expect(evaluator.evaluate(createInput(blockScopedHelper))).resolves.toMatchObject({ verdict: 'fail' });
+  });
+
+  it('does not treat returns after helper recursion as guards', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(){ function again(){ loop(); return; } again(); }';
     const result = await evaluator.evaluate(createInput(content));
 
-    expect(result.verdict).toBe('pass');
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('preserves template interpolation code during malformed fallback scans', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(){ const s = `${loop()}`; bad(; }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
   });
 
   it('handles empty content', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -254,6 +254,32 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  it('detects unguarded recursion through an immediately invoked arrow function', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { (() => loop())(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('detects TypeScript functions that contain infinite loops', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function run(): void { while (true) { work(); } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('treats for-await loops as intentional async suspension points', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `async function run() { while (true) { for await (const job of queue) { handle(job); } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
   // Regression for PR #385 round 2 (Codex F6): real code inside a template
   // interpolation must remain visible to recursion detection.
   it('detects recursion that occurs inside a template interpolation', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -289,6 +289,24 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('infinite loop');
   });
 
+  it('detects infinite loops in later markdown code fences', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = '```js\nconst ok = true;\n```\n```js\nwhile (true) { doWork(); }\n```';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('detects infinite loop snippets embedded in prose', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'Here is the issue: while (true) { doWork(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('detects unguarded recursion in named function expressions', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `const f = function loop() { loop(); };`;
@@ -313,6 +331,14 @@ describe('LogicLoopEvaluator', () => {
 
     expect(result.verdict).toBe('fail');
     expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('treats throws in class static blocks as loop exits', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { class C { static { throw new Error('stop'); } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
   });
 
   // Regression for PR #385 round 2 (Codex F6): real code inside a template

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -237,6 +237,23 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  it('does not treat exits inside class methods as exits from the containing loop', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `while (true) { class Worker { run() { return work(); } } doWork(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('does not treat a nested function call as outer unguarded recursion', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { function inner() { loop(); } return inner; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
   // Regression for PR #385 round 2 (Codex F6): real code inside a template
   // interpolation must remain visible to recursion detection.
   it('detects recursion that occurs inside a template interpolation', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -280,6 +280,41 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  it('detects infinite loops inside markdown code fences', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = '```js\nwhile (true) { doWork(); }\n```';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('detects unguarded recursion in named function expressions', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `const f = function loop() { loop(); };`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('honors guards inside recursive immediately invoked functions', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop(n) { (() => { if (n <= 0) return; loop(n - 1); })(); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('detects unguarded recursion inside class static blocks', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { class C { static { loop(); } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   // Regression for PR #385 round 2 (Codex F6): real code inside a template
   // interpolation must remain visible to recursion detection.
   it('detects recursion that occurs inside a template interpolation', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -307,6 +307,15 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('infinite loop');
   });
 
+  it('tries later keyword occurrences when extracting prose snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'This may run while the snippet is while (true) { doWork(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('detects unguarded recursion in named function expressions', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `const f = function loop() { loop(); };`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -536,6 +536,55 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('recursion');
   });
 
+  it('keeps fallback exits scoped out of nested loops and functions', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const nestedBreak = 'while (true) { for (;;) { break; } doWork(; }';
+    const nestedAwait = 'while (true) { const f = async () => await job; doWork(; }';
+
+    await expect(evaluator.evaluate(createInput(nestedBreak))).resolves.toMatchObject({ verdict: 'fail' });
+    await expect(evaluator.evaluate(createInput(nestedAwait))).resolves.toMatchObject({ verdict: 'fail' });
+  });
+
+  it('falls back to recursion checks for malformed function snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const result = await evaluator.evaluate(createInput('function loop() { loop(; }'));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('does not duplicate overlapping prose function and loop snippets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const result = await evaluator.evaluate(createInput('Note: function run() { while (true) { work(); } }'));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('masks fallback text using code-unit offsets', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const result = await evaluator.evaluate(createInput('😀😀😀😀😀😀 const msg = "while (true) { work(); }"; ???'));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('does not count helper guards that run after helper-mediated recursion', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(){ function guard(){ return; } function again(){ loop(); } again(); guard(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('resolves helper calls only from the call-site lexical scope', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'function loop(){ { function again(){ loop(); } } function again(){ return; } again(); }';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
   it('handles empty content', async () => {
     const evaluator = new LogicLoopEvaluator();
     const result = await evaluator.evaluate(createInput(''));


### PR DESCRIPTION
## Summary
- Replaces LogicLoopEvaluator's hand-rolled sanitizing lexer with Acorn parsing and AST traversal.
- Detects unconditional `while (true)` / `for (;;)` loops and function-declaration self-recursion from syntax nodes instead of keyword text.
- Adds regressions for class-method loop exits and nested-function recursion false positives.

## Test Plan
- `corepack npm run build --workspace @franken/types`
- `corepack npm run build --workspace @franken/critique`
- `corepack npm test --workspace @franken/critique -- --reporter=dot`
- `corepack npm run lint --workspace @franken/critique`
- `corepack npm run lint:security`

Closes #390
