### PR TITLE
test(governor): cover factory and sandbox user policy

### DIFF
--- a/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
@@ -67,6 +67,24 @@ describe('createGovernor', () => {
     });
   });
 
+  it('applies config overrides over defaults', async () => {
+    const readline = makeReadline(['a']);
+    const memoryPort = makeMemoryPort();
+    const governor = createGovernor({
+      readline,
+      memoryPort,
+      config: { requireSignedApprovals: true },
+      evaluators: [new BudgetTrigger()],
+      budgetState: { getBudgetState: () => ({ tripped: true, limitUsd: 10, spendUsd: 11 }) },
+    });
+
+    await expect(governor.verifyRationale(makeRationale())).rejects.toThrow(
+      'Signed approvals are required but no signature verifier is configured',
+    );
+    expect(readline.question).not.toHaveBeenCalled();
+    expect(memoryPort.recordDecision).not.toHaveBeenCalled();
+  });
+
   it('prefers explicit operatorName and forwards optional skill metadata sources', async () => {
     const memoryPort = makeMemoryPort();
     const governor = createGovernor({

--- a/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BudgetTrigger } from '../../../src/triggers/budget-trigger.js';
+import { SkillTrigger } from '../../../src/triggers/skill-trigger.js';
+import { createGovernor } from '../../../src/gateway/governor-factory.js';
+import type { ReadlineAdapter } from '../../../src/channels/cli-channel.js';
+import type { EpisodicTraceRecord, GovernorMemoryPort } from '../../../src/audit/governor-memory-port.js';
+import type { RationaleBlock } from '@franken/types';
+
+function makeRationale(overrides: Partial<RationaleBlock> = {}): RationaleBlock {
+  return {
+    taskId: 'task-645',
+    reasoning: 'Deploy because staging checks passed',
+    selectedTool: 'deploy-prod',
+    expectedOutcome: 'Production deployment succeeds',
+    timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeReadline(inputs: string[]): ReadlineAdapter {
+  let index = 0;
+  return {
+    question: vi.fn(async () => inputs[index++] ?? ''),
+  };
+}
+
+function makeMemoryPort(): GovernorMemoryPort & { records: EpisodicTraceRecord[] } {
+  const records: EpisodicTraceRecord[] = [];
+  return {
+    records,
+    recordDecision: vi.fn(async (trace: EpisodicTraceRecord) => {
+      records.push(trace);
+    }),
+  };
+}
+
+describe('createGovernor', () => {
+  it('wires readline, memory audit recording, config, and project id into a GovernorCritiqueAdapter', async () => {
+    const readline = makeReadline(['a']);
+    const memoryPort = makeMemoryPort();
+    const governor = createGovernor({
+      readline,
+      memoryPort,
+      projectId: 'proj-645',
+      config: { operatorName: 'config-operator' },
+      evaluators: [new BudgetTrigger()],
+      budgetState: { getBudgetState: () => ({ tripped: true, limitUsd: 10, spendUsd: 11 }) },
+    });
+
+    const result = await governor.verifyRationale(makeRationale());
+
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(readline.question).toHaveBeenCalledOnce();
+    expect(memoryPort.recordDecision).toHaveBeenCalledOnce();
+    expect(memoryPort.records[0]).toMatchObject({
+      projectId: 'proj-645',
+      taskId: 'task-645',
+      status: 'success',
+      output: {
+        decision: 'APPROVE',
+        respondedBy: 'config-operator',
+      },
+      input: {
+        triggerId: 'budget',
+        triggerSeverity: 'critical',
+      },
+    });
+  });
+
+  it('prefers explicit operatorName and forwards optional skill metadata sources', async () => {
+    const memoryPort = makeMemoryPort();
+    const governor = createGovernor({
+      readline: makeReadline(['x']),
+      memoryPort,
+      operatorName: 'explicit-operator',
+      config: { operatorName: 'config-operator' },
+      evaluators: [new SkillTrigger()],
+      skillMetadata: {
+        getSkillMetadata: (skillId) => ({
+          requiresHitl: skillId === 'deploy-prod',
+          isDestructive: false,
+        }),
+      },
+    });
+
+    const result = await governor.verifyRationale(makeRationale());
+
+    expect(result.verdict).toBe('rejected');
+    expect(memoryPort.records[0]).toMatchObject({
+      projectId: 'default',
+      status: 'failure',
+      output: {
+        decision: 'ABORT',
+        respondedBy: 'explicit-operator',
+      },
+      input: {
+        triggerId: 'skill',
+        triggerReason: expect.stringContaining('deploy-prod'),
+      },
+    });
+  });
+
+  it('uses an empty evaluator list by default without prompting or auditing', async () => {
+    const readline = makeReadline(['x']);
+    const memoryPort = makeMemoryPort();
+    const governor = createGovernor({ readline, memoryPort });
+
+    const result = await governor.verifyRationale(makeRationale());
+
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(readline.question).not.toHaveBeenCalled();
+    expect(memoryPort.recordDecision).not.toHaveBeenCalled();
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/sandbox-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/sandbox-policy.test.ts
@@ -1,0 +1,55 @@
+import { statSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { nonRootUserForWorkspace } from '../../../../src/beasts/execution/sandbox-policy.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    statSync: vi.fn(),
+  };
+});
+
+const mockedStatSync = vi.mocked(statSync);
+
+describe('nonRootUserForWorkspace', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockedStatSync.mockReset();
+  });
+
+  it('uses the current non-root process uid and gid without inspecting the workspace', () => {
+    vi.spyOn(process, 'getuid').mockReturnValue(1234);
+    vi.spyOn(process, 'getgid').mockReturnValue(1235);
+
+    expect(nonRootUserForWorkspace('/workspace')).toBe('1234:1235');
+    expect(mockedStatSync).not.toHaveBeenCalled();
+  });
+
+  it('uses workspace ownership when the current process is root', () => {
+    vi.spyOn(process, 'getuid').mockReturnValue(0);
+    vi.spyOn(process, 'getgid').mockReturnValue(0);
+    mockedStatSync.mockReturnValue({ uid: 4242, gid: 4243 } as ReturnType<typeof statSync>);
+
+    expect(nonRootUserForWorkspace('/owned-workspace')).toBe('4242:4243');
+    expect(mockedStatSync).toHaveBeenCalledWith('/owned-workspace');
+  });
+
+  it('falls back to the image non-root user when root cannot inspect a non-root workspace owner', () => {
+    vi.spyOn(process, 'getuid').mockReturnValue(0);
+    vi.spyOn(process, 'getgid').mockReturnValue(0);
+    mockedStatSync.mockImplementation(() => {
+      throw new Error('missing workspace');
+    });
+
+    expect(nonRootUserForWorkspace('/missing-workspace')).toBe('10001:10001');
+  });
+
+  it('falls back when the workspace itself is owned by root', () => {
+    vi.spyOn(process, 'getuid').mockReturnValue(0);
+    vi.spyOn(process, 'getgid').mockReturnValue(0);
+    mockedStatSync.mockReturnValue({ uid: 0, gid: 0 } as ReturnType<typeof statSync>);
+
+    expect(nonRootUserForWorkspace('/root-owned-workspace')).toBe('10001:10001');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/sandbox-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/sandbox-policy.test.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'node:fs';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nonRootUserForWorkspace } from '../../../../src/beasts/execution/sandbox-policy.js';
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -13,6 +13,10 @@ vi.mock('node:fs', async (importOriginal) => {
 const mockedStatSync = vi.mocked(statSync);
 
 describe('nonRootUserForWorkspace', () => {
+  beforeEach(() => {
+    mockedStatSync.mockReset();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     mockedStatSync.mockReset();


### PR DESCRIPTION
$## Summary\n- Add unit coverage for createGovernor factory behavior.\n- Add sandbox policy coverage for nonRootUserForWorkspace.\n\n## Test Plan\n- npm test -- tests/unit/gateway/governor-factory.test.ts (packages/franken-governor)\n- npm test -- tests/unit/beasts/execution/sandbox-policy.test.ts (packages/franken-orchestrator)\n- npm run typecheck --workspace @franken/governor\n- npm run typecheck --workspace franken-orchestrator\n- npm run build --workspace @franken/governor\n\nCloses #645