### PR TITLE
fix(observer): remove replay test mutator from production class

### DIFF
--- a/packages/franken-observer/src/replay/deterministic-replayer.test.ts
+++ b/packages/franken-observer/src/replay/deterministic-replayer.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReplayContentStore } from './replay-content-store.js';
 import { DeterministicReplayer } from './deterministic-replayer.js';
 import type { ReplayRecord } from './replay-record.js';
+
+function corruptReplayBlob(baseDir: string, ref: string, replacement: string): void {
+  writeFileSync(join(baseDir, 'blobs', ref), replacement, 'utf8');
+}
 
 describe('DeterministicReplayer', () => {
   it('replays a saved llm.response without calling a live provider', () => {
@@ -23,7 +27,7 @@ describe('DeterministicReplayer', () => {
     const root = mkdtempSync(join(tmpdir(), 'replay-'));
     const store = new ReplayContentStore(root);
     const ref = store.put('x');
-    store.__corruptForTest(ref, 'y');
+    corruptReplayBlob(root, ref, 'y');
     const replayer = new DeterministicReplayer(store);
 
     expect(() => replayer.replayLlmResponse(

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReplayContentStore } from './replay-content-store.js';
 import { hashContent } from './replay-record.js';
 
+function corruptReplayBlob(baseDir: string, ref: string, replacement: string): void {
+  writeFileSync(join(baseDir, 'blobs', ref), replacement, 'utf8');
+}
+
 describe('ReplayContentStore', () => {
-  it('stores content by sha256 and reads it back', () => {
+  it('stores content by sha256 and reads it back without exposing test-only mutators', () => {
     const root = mkdtempSync(join(tmpdir(), 'replay-'));
     const store = new ReplayContentStore(root);
     const ref = store.put('hello world');
@@ -16,6 +20,7 @@ describe('ReplayContentStore', () => {
     expect(existsSync(join(root, 'blobs', ref))).toBe(true);
     expect(existsSync(join(root, 'blobs', `sha256:${ref}`))).toBe(false);
     expect(store.get(ref)).toBe('hello world');
+    expect('__corruptForTest' in store).toBe(false);
   });
 
   it('detects tampering on read by checking the content hash', () => {
@@ -23,7 +28,7 @@ describe('ReplayContentStore', () => {
     const store = new ReplayContentStore(root);
     const ref = store.put('original');
 
-    store.__corruptForTest(ref, 'tampered');
+    corruptReplayBlob(root, ref, 'tampered');
 
     expect(() => store.get(ref)).toThrow(/hash mismatch/i);
   });

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -32,10 +32,6 @@ export class ReplayContentStore {
     return content;
   }
 
-  __corruptForTest(ref: string, replacement: string): void {
-    writeFileSync(this.blobPath(ref), replacement, 'utf8');
-  }
-
   private blobPath(ref: string): string {
     if (!SHA256_HEX_REF.test(ref)) {
       throw new Error('Replay content ref must be exactly 64 lowercase sha256 hex characters');


### PR DESCRIPTION
## Summary
- remove the test-only `__corruptForTest` mutator from the production `ReplayContentStore` class
- keep tamper-path coverage by moving direct blob corruption into replay tests
- assert production store instances no longer expose the test-only mutator

## Test Plan
- [x] `corepack npm test -- --run src/replay/replay-content-store.test.ts src/replay/deterministic-replayer.test.ts` (from `packages/franken-observer`)
- [x] `corepack npm test --workspace @frankenbeast/observer`
- [x] `corepack npm run typecheck --workspace @frankenbeast/observer`
- [x] `corepack npm run build --workspace @frankenbeast/observer`
- [x] `corepack npm run lint:security`

Closes #619
