### PR TITLE
fix: validate pinned npm install executable

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -5,12 +5,13 @@ Get Frankenbeast running locally.
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26` (see `.nvmrc` for the pinned local default; npm enforces this with `engine-strict=true`)
-- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)
+- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`; install Corepack first on Node.js 25)
 - Docker only if you want the optional ChromaDB/Grafana/Tempo stack
 
 ## 1. Install dependencies
 
 ```bash
+if ! command -v corepack >/dev/null 2>&1; then npm install -g corepack; fi
 corepack enable npm
 corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 npm run check:package-manager

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 
 const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const packageManager = manifest.packageManager;
@@ -17,26 +17,21 @@ if (!match) {
 }
 
 const expected = match[1];
-
-function readVersion(command, args) {
-  try {
-    return execFileSync(command, args, { encoding: 'utf8' }).trim();
-  } catch {
-    return null;
-  }
-}
-
-const corepackVersion = readVersion('corepack', ['npm', '--version']);
-const actual = corepackVersion || readVersion('npm', ['--version']);
-if (!actual) {
-  console.error('Unable to determine npm version via `corepack npm --version` or `npm --version`.');
+let actual;
+try {
+  actual = execSync('npm --version', {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  }).trim();
+} catch (error) {
+  console.error('Unable to determine npm version via `npm --version`.');
+  console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }
 
 if (actual !== expected) {
-  const source = corepackVersion ? 'corepack npm' : 'npm';
-  console.error(`npm version mismatch: packageManager pins npm@${expected}, but ${source} --version returned ${actual}.`);
-  console.error(`Run \`corepack enable && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
+  console.error(`npm version mismatch: packageManager pins npm@${expected}, but npm --version returned ${actual}.`);
+  console.error(`Run \`corepack enable npm && corepack prepare npm@${expected} --activate\` before installing dependencies.`);
   process.exit(1);
 }
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -17,6 +17,9 @@ describe('local setup scripts', () => {
 
     expect(read('.nvmrc').trim()).toBe('22.13.0');
     expect(read('.npmrc')).toContain('engine-strict=true');
+    expect(read('docs/guides/quickstart.md')).toContain('npm install -g corepack');
+    expect(read('docs/guides/quickstart.md')).toContain('corepack enable npm');
+    expect(read('docs/guides/quickstart.md')).toContain('npm run check:package-manager');
 
     for (const packagePath of packagePaths) {
       const manifest = JSON.parse(read(packagePath)) as { engines?: { node?: string } };


### PR DESCRIPTION
## Summary
- address late Codex findings from PR #811 by checking the same plain npm executable used for installs
- keep the npm version check Windows-compatible for .cmd shims
- document installing Corepack first for supported Node.js 25 local setups

## Test Plan
- npm run check:package-manager
- npm run test:root -- tests/unit/ci-workflow.test.ts tests/local-setup-scripts.test.ts
- npm run lint:security

Follow-up to #811 for #625.