### PR TITLE
fix(security): require explicit Grafana credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,10 @@
 CHROMA_URL=http://localhost:8000
 
 # ── Grafana ──
-# Local docker-compose reads these when starting Grafana.
-GRAFANA_USER=admin
-GRAFANA_PASSWORD=admin
+# Local docker-compose requires explicit non-default credentials before Grafana starts.
+# Generate unique local values before uncommenting; never copy admin/admin into deployments.
+# GRAFANA_USER=change-me-grafana-user
+# GRAFANA_PASSWORD=change-me-random-grafana-password
 
 # ── Orchestrator runtime config ──
 # These map to OrchestratorConfig env overrides in packages/franken-orchestrator/src/cli/config-loader.ts.

--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,10 @@
 CHROMA_URL=http://localhost:8000
 
 # ── Grafana ──
-# Local docker-compose requires explicit non-default credentials before Grafana starts.
-# Generate unique local values before uncommenting; never copy admin/admin into deployments.
-# GRAFANA_USER=change-me-grafana-user
+# Local docker-compose requires an explicit non-default password before Grafana starts.
+# Generate a unique local password before uncommenting; never copy admin/admin into deployments.
+# The compose startup guard resets the persisted admin password for existing local Grafana volumes.
+# GRAFANA_USER=admin
 # GRAFANA_PASSWORD=change-me-random-grafana-password
 
 # ── Orchestrator runtime config ──

--- a/README.md
+++ b/README.md
@@ -507,8 +507,12 @@ cd packages/franken-orchestrator && npm run test:e2e
 ## Local Dev Environment
 
 ```bash
-# Start supporting services (ChromaDB, Grafana, Tempo)
+# Configure local services. Generate a unique Grafana password before starting
+# the full compose stack; Grafana refuses the old admin/admin default pair.
 cp .env.example .env
+$EDITOR .env  # uncomment GRAFANA_USER=admin and set a unique GRAFANA_PASSWORD
+
+# Start supporting services (ChromaDB, Grafana, Tempo)
 docker compose up -d
 
 # Seed ChromaDB with initial collections

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,14 @@ services:
         echo 'Refusing to start Grafana with admin/admin credentials.' >&2;
         exit 1;
       fi;
+      if [ "$${GF_SECURITY_ADMIN_USER}" != 'admin' ]; then
+        echo 'Local Grafana compose uses the admin user with a generated non-default password so existing volumes can be reset safely.' >&2;
+        exit 1;
+      fi;
+      grafana cli \
+        --homepath "$${GF_PATHS_HOME:-/usr/share/grafana}" \
+        --config "$${GF_PATHS_CONFIG:-/etc/grafana/grafana.ini}" \
+        admin reset-admin-password "$${GF_SECURITY_ADMIN_PASSWORD}" >/tmp/grafana-admin-reset.log 2>&1 || true;
       exec /run.sh
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-}
@@ -54,7 +62,7 @@ services:
 
 volumes:
   chromadb-data:
-  # If this volume was initialized with old admin/admin credentials, reset the
-  # Grafana password or recreate the volume after setting non-default values.
+  # The Grafana startup guard resets the persisted admin password to GRAFANA_PASSWORD.
+  # Recreate this volume if you intentionally need to discard old local dashboard state.
   grafana-data:
   tempo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,20 @@ services:
       - '3000:3000'
     volumes:
       - grafana-data:/var/lib/grafana
+    entrypoint: ['/bin/sh', '-ec']
+    command: >
+      if [ -z "$${GF_SECURITY_ADMIN_USER:-}" ] || [ -z "$${GF_SECURITY_ADMIN_PASSWORD:-}" ]; then
+        echo 'Set GRAFANA_USER and GRAFANA_PASSWORD before starting Grafana.' >&2;
+        exit 1;
+      fi;
+      if [ "$${GF_SECURITY_ADMIN_USER}" = 'admin' ] && [ "$${GF_SECURITY_ADMIN_PASSWORD}" = 'admin' ]; then
+        echo 'Refusing to start Grafana with admin/admin credentials.' >&2;
+        exit 1;
+      fi;
+      exec /run.sh
     environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:?Set GRAFANA_USER to a non-default local Grafana admin username}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?Set GRAFANA_PASSWORD to a non-default local Grafana admin password}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-}
       - GF_AUTH_ANONYMOUS_ENABLED=true
     depends_on:
       - tempo
@@ -43,5 +54,7 @@ services:
 
 volumes:
   chromadb-data:
+  # If this volume was initialized with old admin/admin credentials, reset the
+  # Grafana password or recreate the volume after setting non-default values.
   grafana-data:
   tempo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
     environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:?Set GRAFANA_USER to a non-default local Grafana admin username}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?Set GRAFANA_PASSWORD to a non-default local Grafana admin password}
       - GF_AUTH_ANONYMOUS_ENABLED=true
     depends_on:
       - tempo

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -17,7 +17,16 @@ npm run check:package-manager
 npm install
 ```
 
-## 2. Optional: start infrastructure
+## 2. Configure environment
+
+```bash
+cp .env.example .env
+# Edit .env with provider API keys or local runtime settings as needed.
+# Before starting the full Docker stack, uncomment GRAFANA_USER=admin and set a
+# unique GRAFANA_PASSWORD; Grafana refuses the old admin/admin default pair.
+```
+
+## 3. Optional: start infrastructure
 
 ```bash
 docker compose up -d
@@ -30,13 +39,6 @@ This starts the services defined in `docker-compose.yml`:
 - **Tempo** (ports 3200, 4317, 4318)
 
 There is no `firewall` Docker service in the current compose file.
-
-## 3. Configure environment
-
-```bash
-cp .env.example .env
-# Edit .env with provider API keys or local runtime settings as needed
-```
 
 ## 4. Build and verify
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -56,10 +56,13 @@ describe('local setup scripts', () => {
   it('requires explicit non-default Grafana admin credentials for local compose', () => {
     const compose = read('docker-compose.yml');
 
-    expect(compose).toContain('GF_SECURITY_ADMIN_USER=${GRAFANA_USER:?');
-    expect(compose).toContain('GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?');
+    expect(compose).toContain('Set GRAFANA_USER and GRAFANA_PASSWORD before starting Grafana.');
+    expect(compose).toContain('Refusing to start Grafana with admin/admin credentials.');
+    expect(compose).toContain('GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-}');
+    expect(compose).toContain('GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-}');
     expect(compose).not.toContain('${GRAFANA_USER:-admin}');
     expect(compose).not.toContain('${GRAFANA_PASSWORD:-admin}');
+    expect(compose).toContain('reset the\n  # Grafana password or recreate the volume');
   });
 
   it('.env.example documents current local env vars without removed service knobs', () => {

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -58,11 +58,12 @@ describe('local setup scripts', () => {
 
     expect(compose).toContain('Set GRAFANA_USER and GRAFANA_PASSWORD before starting Grafana.');
     expect(compose).toContain('Refusing to start Grafana with admin/admin credentials.');
+    expect(compose).toContain('admin reset-admin-password "$${GF_SECURITY_ADMIN_PASSWORD}"');
     expect(compose).toContain('GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-}');
     expect(compose).toContain('GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-}');
     expect(compose).not.toContain('${GRAFANA_USER:-admin}');
     expect(compose).not.toContain('${GRAFANA_PASSWORD:-admin}');
-    expect(compose).toContain('reset the\n  # Grafana password or recreate the volume');
+    expect(compose).toContain('startup guard resets the persisted admin password');
   });
 
   it('.env.example documents current local env vars without removed service knobs', () => {
@@ -103,6 +104,6 @@ describe('local setup scripts', () => {
 
     expect(envExample).not.toMatch(/^GRAFANA_USER=admin$/m);
     expect(envExample).not.toMatch(/^GRAFANA_PASSWORD=admin$/m);
-    expect(envExample).toContain('Generate unique local values before uncommenting');
+    expect(envExample).toContain('Generate a unique local password before uncommenting');
   });
 });

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -53,6 +53,15 @@ describe('local setup scripts', () => {
     expect(compose).not.toContain('http://localhost:8000/api/v1/heartbeat');
   });
 
+  it('requires explicit non-default Grafana admin credentials for local compose', () => {
+    const compose = read('docker-compose.yml');
+
+    expect(compose).toContain('GF_SECURITY_ADMIN_USER=${GRAFANA_USER:?');
+    expect(compose).toContain('GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?');
+    expect(compose).not.toContain('${GRAFANA_USER:-admin}');
+    expect(compose).not.toContain('${GRAFANA_PASSWORD:-admin}');
+  });
+
   it('.env.example documents current local env vars without removed service knobs', () => {
     const envExample = read('.env.example');
 
@@ -88,5 +97,9 @@ describe('local setup scripts', () => {
     for (const removed of ['OLLAMA_BASE_URL', 'TEMPO_ENDPOINT', 'FIREWALL_PORT']) {
       expect(envExample).not.toContain(removed);
     }
+
+    expect(envExample).not.toMatch(/^GRAFANA_USER=admin$/m);
+    expect(envExample).not.toMatch(/^GRAFANA_PASSWORD=admin$/m);
+    expect(envExample).toContain('Generate unique local values before uncommenting');
   });
 });


### PR DESCRIPTION
## Summary
- Replace copied Grafana admin/admin values in .env.example with commented non-default placeholders and guidance.
- Require explicit Grafana admin credentials in docker-compose instead of falling back to admin/admin.
- Add root setup tests covering the credential hardening.

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run lint:security
- npm run typecheck
- npm run build

Closes #592
