### PR TITLE
ci: route security audits through pinned npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run audit:security
+
       - run: npm run test:root -- tests/workspaces.test.ts
 
       - run: npm run lint:security

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -18,6 +18,13 @@ npm run check:package-manager
 npm install
 ```
 
+Run reproducible dependency audits through the guarded script so the live npm
+binary still matches the root `packageManager` pin before `npm audit` runs:
+
+```bash
+npm run audit:security
+```
+
 ## 2. Configure environment
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
+    "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "lint:any": "node scripts/audit-explicit-any.mjs",
     "lint:security": "node scripts/check-plain-http.mjs",

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -49,6 +49,11 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
       expect(content).toContain('npm ci');
     });
 
+    it('runs the guarded security audit after deterministic installs', () => {
+      expect(content).toContain('npm run audit:security');
+      expect(content.indexOf('npm ci')).toBeLessThan(content.indexOf('npm run audit:security'));
+    });
+
     it('enables Corepack and verifies the packageManager-pinned npm before installing', () => {
       expect(content).toContain('corepack enable npm');
       expect(content).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
@@ -123,6 +128,16 @@ describe('release-please.yml publishes released npm packages', () => {
     expect(content.match(/node scripts\/check-package-manager\.mjs/g)?.length).toBe(2);
     expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     expect(content.lastIndexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.lastIndexOf('npm ci'));
+  });
+
+  it('routes security audits through the packageManager-pinned npm guard', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['audit:security']).toBe(
+      'node scripts/check-package-manager.mjs && npm audit --audit-level=moderate',
+    );
   });
 
   it('defers npm token enforcement until a public package needs publishing', () => {


### PR DESCRIPTION
## Summary
- adds a guarded `npm run audit:security` script that checks the live npm binary against the root `packageManager` pin before running `npm audit`
- runs that guarded audit in CI immediately after `npm ci`
- documents the guarded audit command in the quickstart

## Test Plan
- [x] npm run test:root -- tests/unit/ci-workflow.test.ts -t 'routes security audits through the packageManager-pinned npm guard' (failed before implementation)
- [x] npm run test:root -- tests/unit/ci-workflow.test.ts tests/local-setup-scripts.test.ts
- [x] npm run check:package-manager
- [x] npm run audit:security
- [x] npm run lint:security
- [x] npm run build
- [x] npm run typecheck
- [x] npm test

Closes #579
