### PR TITLE
feat(orchestrator): execute ready tasks in parallel waves

### DIFF
--- a/docs/beast-loop-explained.md
+++ b/docs/beast-loop-explained.md
@@ -124,22 +124,24 @@ while tasks remain pending:
 
 ### Execution strategies
 
-The live orchestrator execution phase is sequential: it runs ready tasks one at a time in topological order. Planner strategy modules describe additional target execution modes, but parallel waves and recursive expansion are not wired into `BeastLoop`/`runExecution` yet; that implementation gap is tracked in [#497](https://github.com/djm204/frankenbeast/issues/497).
+The live orchestrator execution phase runs topological parallel waves: parallel-safe ready tasks execute together, downstream waves wait for their dependencies to complete, and checkout/HITL-sensitive tasks are serialized. Planner strategy modules still describe additional strategy variants; recursive expansion remains a target planner/orchestrator integration and is not wired into `BeastLoop`/`runExecution` yet.
 
-**Sequential topological execution** (`@franken/orchestrator/src/phases/execution.ts`) — current live behavior
-- Tasks execute one at a time in topological order
+**Parallel wave execution** (`@franken/orchestrator/src/phases/execution.ts`) — current live behavior
+- Each wave contains pending tasks whose dependencies are already completed
+- Parallel-safe tasks in a wave run concurrently via `Promise.all`
+- CLI-backed and HITL-gated tasks are serialized because they share a checkout and operator approval channel
 - A failed task is recorded but not added to the completed set
-- Independent ready tasks can still run; dependents of the failed task are later skipped as unmet dependencies
+- Later waves continue with tasks whose dependencies are satisfied; dependents of failed tasks are later skipped as unmet dependencies
 
 **Linear planner strategy** (`@franken/planner/src/planners/linear.ts`) — planner strategy module, not the live orchestrator execution loop
 - Tasks execute one at a time in topological order
 - First failure stops the strategy sequence
 
-**Parallel** (`@franken/planner/src/planners/parallel.ts`) — target architecture, not wired into orchestrator execution yet
+**Parallel planner strategy** (`@franken/planner/src/planners/parallel.ts`) — planner strategy module, mirrored by the live executor's wave scheduling
 - Tasks execute in concurrent "waves"
 - Each wave contains all tasks whose dependencies are satisfied
 - All tasks in a wave run simultaneously via `Promise.all`
-- A failure in any wave stops subsequent waves
+- A failure in any wave stops subsequent waves in the planner strategy; the live executor preserves its existing recovery and skip semantics
 
 **Recursive** (`@franken/planner/src/planners/recursive.ts`) — target architecture, not wired into orchestrator execution yet
 - Tasks can expand into sub-graphs during execution

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -11,6 +11,7 @@ import type {
   MemoryContext,
   ILogger,
   ICheckpointStore,
+  SkillDescriptor,
 } from '../deps.js';
 import type { TaskOutcome } from '../types.js';
 import type { CliSkillExecutor } from '../skills/cli-skill-executor.js';
@@ -37,6 +38,64 @@ export class HitlRejectedError extends Error {
     super(`Task ${taskId} rejected by governor: ${reason}`);
     this.name = 'HitlRejectedError';
   }
+}
+
+type PendingTaskEntry = [string, PlanTask];
+
+type WaveExecutionResult = {
+  readonly taskId: string;
+  readonly task: PlanTask;
+  readonly outcome: TaskOutcome;
+};
+
+function selectExecutableWave(
+  pendingEntries: readonly PendingTaskEntry[],
+  completed: ReadonlySet<string>,
+  skills: ISkillsModule,
+): PendingTaskEntry[] {
+  const readyEntries = pendingEntries.filter(([, task]) =>
+    task.dependsOn.every(dep => completed.has(dep)),
+  );
+
+  const firstReadyEntry = readyEntries[0];
+  if (!firstReadyEntry) {
+    return [];
+  }
+
+  if (taskRequiresSerializedExecution(firstReadyEntry[1], skills)) {
+    return [firstReadyEntry];
+  }
+
+  return readyEntries.filter(([, task]) =>
+    !taskRequiresSerializedExecution(task, skills),
+  );
+}
+
+function taskRequiresSerializedExecution(task: PlanTask, skills: ISkillsModule): boolean {
+  if (task.requiredSkills.length === 0) {
+    return false;
+  }
+
+  let availableSkills: readonly SkillDescriptor[];
+  try {
+    availableSkills = skills.getAvailableSkills();
+  } catch {
+    return false;
+  }
+
+  return task.requiredSkills.some(skillId => {
+    const descriptor = availableSkills.find(skill => skill.id === skillId);
+    return skillRequiresSerializedExecution(skillId, descriptor);
+  });
+}
+
+function skillRequiresSerializedExecution(
+  skillId: string,
+  descriptor: SkillDescriptor | undefined,
+): boolean {
+  return descriptor?.requiresHitl === true
+    || descriptor?.executionType === 'cli'
+    || (!descriptor && skillId.startsWith('cli:'));
 }
 
 function describeApprovalRejection(reason: string | undefined): string {
@@ -114,11 +173,9 @@ export async function runExecution(
       }
     }
 
-    const readyEntry = [...pending].find(([, task]) =>
-      task.dependsOn.every(dep => completed.has(dep)),
-    );
+    const readyEntries = selectExecutableWave([...pending], completed, skills);
 
-    if (!readyEntry) {
+    if (readyEntries.length === 0) {
       // All remaining tasks have unmet dependencies — deadlock
       ctx.circuitBreakerTripped = true;
       for (const task of pending.values()) {
@@ -132,72 +189,112 @@ export async function runExecution(
       break;
     }
 
-    const [taskId, task] = readyEntry;
-    pending.delete(taskId);
-
-    // Skip tasks already completed in a previous run (checkpoint recovery)
-    if (checkpoint?.has(`${task.id}:done`)) {
-      const checkpointedOutput = checkpoint.readTaskOutput?.(task.id);
-      logger.info('Execution: Skipping checkpointed task', { taskId: task.id });
-      if (checkpointedOutput?.found) {
-        completedOutputs.set(task.id, checkpointedOutput.output);
-      }
-      outcomes.push({ taskId: task.id, status: 'success', output: checkpointedOutput?.output });
-      completed.add(task.id);
-      continue;
+    for (const [taskId] of readyEntries) {
+      pending.delete(taskId);
     }
 
-    const outcome = await executeTask(
-      task,
-      skills,
-      governor,
-      memory,
-      observer,
-      ctx,
-      completedOutputs,
-      mcp,
-      logger,
-      cliExecutor,
-      checkpoint,
-      config,
-    );
+    logger.info('Execution: parallel wave start', {
+      size: readyEntries.length,
+      taskIds: readyEntries.map(([taskId]) => taskId),
+    });
 
-    if (outcome.status === 'success') {
-      outcomes.push(outcome);
-      // Persist the task output before the done marker so a crash after marking
-      // done can still rehydrate dependency outputs for downstream tasks.
-      checkpoint?.writeTaskOutput?.(task.id, outcome.output);
-      // Persist the checkpoint before mutating in-memory state so a crash here
-      // is recovered as "done" on restart instead of silently re-running the task.
-      checkpoint?.write(`${task.id}:done`);
-      completed.add(task.id);
-      completedOutputs.set(task.id, outcome.output);
-    } else if (outcome.status === 'skipped') {
-      outcomes.push(outcome);
-      terminalSkipped.add(task.id);
-    } else if (outcome.status === 'failure') {
-      const recovered = await recoverFailedTask({
-        ctx,
+    const settledWaveResults = await Promise.allSettled(readyEntries.map(async ([taskId, task]) => {
+      // Skip tasks already completed in a previous run (checkpoint recovery)
+      if (checkpoint?.has(`${task.id}:done`)) {
+        const checkpointedOutput = checkpoint.readTaskOutput?.(task.id);
+        logger.info('Execution: Skipping checkpointed task', { taskId: task.id });
+        const outcome = { taskId: task.id, status: 'success' as const, output: checkpointedOutput?.output };
+        if (checkpointedOutput?.found) {
+          completedOutputs.set(task.id, checkpointedOutput.output);
+        }
+        completed.add(task.id);
+        return { taskId, task, outcome };
+      }
+
+      const outcome = await executeTask(
+        task,
+        skills,
         governor,
         memory,
-        task,
-        error: new Error(outcome.error ?? 'Task failed'),
-        pending,
-        completed,
-        knownTaskIds,
-        terminalSkipped,
-        terminalFailures,
-        recoveryAttempts,
-        checkpoint,
+        observer,
+        ctx,
+        completedOutputs,
+        mcp,
         logger,
-      });
+        cliExecutor,
+        checkpoint,
+        config,
+      );
 
-      if (recovered) {
-        maxIterations += 2;
-      } else {
-        await recordFailureTrace(memory, task, outcome.error ?? 'Task failed');
+      if (outcome.status === 'success') {
+        // Persist the task output before the done marker so a crash after marking
+        // done can still rehydrate dependency outputs for downstream tasks.
+        checkpoint?.writeTaskOutput?.(task.id, outcome.output);
+        // Persist the checkpoint before mutating in-memory state so a crash here
+        // is recovered as "done" on restart instead of silently re-running the task.
+        checkpoint?.write(`${task.id}:done`);
+        completed.add(task.id);
+        completedOutputs.set(task.id, outcome.output);
+      } else if (outcome.status === 'skipped') {
+        terminalSkipped.add(task.id);
+      }
+
+      return { taskId, task, outcome };
+    }));
+
+    const rejectedWaveResult = settledWaveResults.find(result => result.status === 'rejected');
+    if (rejectedWaveResult?.status === 'rejected') {
+      throw rejectedWaveResult.reason;
+    }
+
+    const waveResults: WaveExecutionResult[] = settledWaveResults.map(result => {
+      if (result.status === 'rejected') {
+        throw result.reason;
+      }
+      return result.value;
+    });
+
+    logger.info('Execution: parallel wave done', {
+      size: waveResults.length,
+      taskIds: waveResults.map(result => result.taskId),
+    });
+
+    const waveFailureIds = new Set(
+      waveResults
+        .filter(result => result.outcome.status === 'failure')
+        .map(result => result.task.id),
+    );
+
+    for (const { task, outcome } of waveResults) {
+      if (outcome.status === 'success' || outcome.status === 'skipped') {
         outcomes.push(outcome);
-        terminalFailures.add(task.id);
+      } else if (outcome.status === 'failure') {
+        const recovered = await recoverFailedTask({
+          ctx,
+          governor,
+          memory,
+          task,
+          error: new Error(outcome.error ?? 'Task failed'),
+          pending,
+          completed,
+          knownTaskIds,
+          terminalSkipped,
+          terminalFailures,
+          replacePendingTaskIds: waveFailureIds,
+          recoveryAttempts,
+          checkpoint,
+          logger,
+        });
+
+        if (recovered) {
+          maxIterations += 2;
+        } else {
+          await recordFailureTrace(memory, task, outcome.error ?? 'Task failed');
+          outcomes.push(outcome);
+          pending.delete(task.id);
+          terminalFailures.add(task.id);
+          ctx.circuitBreakerTripped = true;
+        }
       }
     }
   }
@@ -229,6 +326,7 @@ interface RecoveryAttemptInput {
   readonly knownTaskIds: Set<string>;
   readonly terminalSkipped: ReadonlySet<string>;
   readonly terminalFailures: ReadonlySet<string>;
+  readonly replacePendingTaskIds?: ReadonlySet<string> | undefined;
   readonly recoveryAttempts: Map<string, number>;
   readonly checkpoint?: ICheckpointStore | undefined;
   readonly logger: ILogger;
@@ -246,6 +344,7 @@ async function recoverFailedTask(input: RecoveryAttemptInput): Promise<boolean> 
     knownTaskIds,
     terminalSkipped,
     terminalFailures,
+    replacePendingTaskIds,
     recoveryAttempts,
     checkpoint,
     logger,
@@ -287,11 +386,12 @@ async function recoverFailedTask(input: RecoveryAttemptInput): Promise<boolean> 
 
     for (const recoveredTask of recoveredTasks) {
       knownTaskIds.add(recoveredTask.id);
+      const shouldReplacePending = replacePendingTaskIds?.has(recoveredTask.id) === true;
       if (
         !completed.has(recoveredTask.id) &&
         !terminalSkipped.has(recoveredTask.id) &&
         !terminalFailures.has(recoveredTask.id) &&
-        !pending.has(recoveredTask.id)
+        (!pending.has(recoveredTask.id) || shouldReplacePending)
       ) {
         pending.set(recoveredTask.id, recoveredTask);
       }

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -34,6 +34,98 @@ describe('runExecution', () => {
     expect(outcomes[1]!.taskId).toBe('t2');
   });
 
+  it('executes independent ready tasks in the same parallel wave', async () => {
+    const active = new Set<string>();
+    let observedOverlap = false;
+    const execute = vi.fn(async (skillId: string) => {
+      active.add(skillId);
+      if (skillId === 'alpha') {
+        await new Promise<void>(resolve => setTimeout(resolve, 25));
+      } else if (skillId === 'beta') {
+        observedOverlap = active.has('alpha');
+      }
+      active.delete(skillId);
+      return { output: `${skillId}-output`, tokensUsed: 1 };
+    });
+
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      execute,
+    });
+    const c = ctx([
+      { id: 't1', objective: 'first independent task', requiredSkills: ['alpha'], dependsOn: [] },
+      { id: 't2', objective: 'second independent task', requiredSkills: ['beta'], dependsOn: [] },
+      { id: 't3', objective: 'dependent task', requiredSkills: ['gamma'], dependsOn: ['t1', 't2'] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver());
+
+    expect(outcomes.map(outcome => outcome.taskId)).toEqual(['t1', 't2', 't3']);
+    expect(observedOverlap).toBe(true);
+  });
+
+  it('serializes ready CLI-backed tasks that share the checkout', async () => {
+    const active = new Set<string>();
+    let observedOverlap = false;
+    const cliExec = makeCliExecutor({
+      execute: vi.fn(async (skillId: string) => {
+        observedOverlap ||= active.size > 0;
+        active.add(skillId);
+        await new Promise<void>(resolve => setTimeout(resolve, 5));
+        active.delete(skillId);
+        return { output: `${skillId}-output`, tokensUsed: 1 };
+      }),
+    });
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      getAvailableSkills: vi.fn(() => [
+        { id: 'cli:alpha', name: 'Alpha CLI', requiresHitl: false, executionType: 'cli' },
+        { id: 'cli:beta', name: 'Beta CLI', requiresHitl: false, executionType: 'cli' },
+      ]),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'first cli task', requiredSkills: ['cli:alpha'], dependsOn: [] },
+      { id: 't2', objective: 'second cli task', requiredSkills: ['cli:beta'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), undefined, undefined, cliExec);
+
+    expect(outcomes.map(outcome => outcome.taskId)).toEqual(['t1', 't2']);
+    expect(cliExec.execute).toHaveBeenCalledTimes(2);
+    expect((cliExec.execute as ReturnType<typeof vi.fn>).mock.calls.map(call => call[0])).toEqual(['cli:alpha', 'cli:beta']);
+    expect(observedOverlap).toBe(false);
+  });
+
+  it('serializes ready HITL-gated tasks so approval prompts do not overlap', async () => {
+    let activeApprovalCount = 0;
+    let observedOverlap = false;
+    const governor = makeGovernor({
+      requestApproval: vi.fn(async () => {
+        observedOverlap ||= activeApprovalCount > 0;
+        activeApprovalCount += 1;
+        await new Promise<void>(resolve => setTimeout(resolve, 5));
+        activeApprovalCount -= 1;
+        return { decision: 'approved' as const };
+      }),
+    });
+    const skills = makeSkills({
+      getAvailableSkills: vi.fn(() => [
+        { id: 'deploy-a', name: 'Deploy A', requiresHitl: true, executionType: 'function' as const },
+        { id: 'deploy-b', name: 'Deploy B', requiresHitl: true, executionType: 'function' as const },
+      ]),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'first deploy', requiredSkills: ['deploy-a'], dependsOn: [] },
+      { id: 't2', objective: 'second deploy', requiredSkills: ['deploy-b'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, governor, makeMemory(), makeObserver());
+
+    expect(outcomes.map(outcome => outcome.taskId)).toEqual(['t1', 't2']);
+    expect(governor.requestApproval).toHaveBeenCalledTimes(2);
+    expect(observedOverlap).toBe(false);
+  });
+
   it('records trace for each completed task', async () => {
     const memory = makeMemory();
     const c = ctx();
@@ -75,10 +167,48 @@ describe('runExecution', () => {
     expect(outcomes[0]!.error).toContain('dependencies');
   });
 
+  it('does not query skill descriptors for no-skill tasks', async () => {
+    const skills = makeSkills({
+      getAvailableSkills: vi.fn(() => {
+        throw new Error('manifest unavailable');
+      }),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'passthrough', requiredSkills: [], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver());
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toEqual(expect.objectContaining({ taskId: 't1', status: 'success' }));
+    expect(skills.getAvailableSkills).not.toHaveBeenCalled();
+  });
+
+  it('records descriptor lookup failures as task failures for required-skill tasks', async () => {
+    const skills = makeSkills({
+      getAvailableSkills: vi.fn(() => {
+        throw new Error('manifest unavailable');
+      }),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'requires alpha', requiredSkills: ['alpha'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver());
+
+    expect(outcomes).toEqual([
+      expect.objectContaining({
+        taskId: 't1',
+        status: 'failure',
+        error: expect.stringContaining('manifest unavailable'),
+      }),
+    ]);
+  });
+
   it('checks HITL requirement and requests governor approval', async () => {
     const skills = makeSkills({
       getAvailableSkills: vi.fn(() => [
-        { id: 'deploy', name: 'Deploy', requiresHitl: true },
+        { id: 'deploy', name: 'Deploy', requiresHitl: true, executionType: 'function' as const },
       ]),
     });
     const governor = makeGovernor();
@@ -96,7 +226,7 @@ describe('runExecution', () => {
   it('skips task when governor rejects', async () => {
     const skills = makeSkills({
       getAvailableSkills: vi.fn(() => [
-        { id: 'deploy', name: 'Deploy', requiresHitl: true },
+        { id: 'deploy', name: 'Deploy', requiresHitl: true, executionType: 'function' as const },
       ]),
     });
     const governor = makeGovernor({
@@ -119,7 +249,7 @@ describe('runExecution', () => {
     const logger = makeLogger();
     const skills = makeSkills({
       getAvailableSkills: vi.fn(() => [
-        { id: 'deploy', name: 'Deploy', requiresHitl: true },
+        { id: 'deploy', name: 'Deploy', requiresHitl: true, executionType: 'function' as const },
       ]),
     });
     const governor = makeGovernor({
@@ -190,6 +320,50 @@ describe('runExecution', () => {
     await expect(
       runExecution(c, makeSkills(), makeGovernor(), makeMemory(), makeObserver(), undefined, undefined, undefined, checkpoint),
     ).rejects.toThrow('disk full');
+  });
+
+  it('drains parallel peers before surfacing wave persistence errors', async () => {
+    let slowPeerFinished = false;
+    const execute = vi.fn(async (_skillId: string, input: SkillInput) => {
+      if (input.objective === 'slow peer') {
+        await new Promise(resolve => setTimeout(resolve, 20));
+        slowPeerFinished = true;
+      }
+      return { output: input.objective, tokensUsed: 1 };
+    });
+    const c = ctx([
+      { id: 't1', objective: 'fast failing checkpoint', requiredSkills: ['alpha'], dependsOn: [] },
+      { id: 't2', objective: 'slow peer', requiredSkills: ['alpha'], dependsOn: [] },
+    ]);
+    const checkpoint = {
+      checkpointPath: '/tmp/franken-checkpoint.txt',
+      has: vi.fn(() => false),
+      write: vi.fn((key: string) => {
+        if (key === 't1:done') {
+          throw new Error('disk full');
+        }
+      }),
+      readAll: vi.fn(() => new Set<string>()),
+      clear: vi.fn(),
+      recordCommit: vi.fn(),
+      lastCommit: vi.fn(),
+    };
+
+    await expect(
+      runExecution(
+        c,
+        makeSkills({ hasSkill: vi.fn(() => true), execute }),
+        makeGovernor(),
+        makeMemory(),
+        makeObserver(),
+        undefined,
+        undefined,
+        undefined,
+        checkpoint,
+      ),
+    ).rejects.toThrow('disk full');
+
+    expect(slowPeerFinished).toBe(true);
   });
 
   it('throws if plan is missing', async () => {
@@ -525,6 +699,74 @@ describe('runExecution', () => {
     expect(c.circuitBreakerTripped).toBe(false);
   });
 
+  it('keeps the circuit breaker clear when peer wave failures are both recovered', async () => {
+    const failedOnce = new Set<string>();
+    const execute = vi.fn(async (_skillId: string, input: SkillInput) => {
+      if (input.objective.startsWith('write artifact') && !failedOnce.has(input.objective)) {
+        failedOnce.add(input.objective);
+        throw new Error('disk full while writing artifact');
+      }
+      return { output: input.objective, tokensUsed: 1 };
+    });
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      execute,
+    });
+    const memory = makeMemory({
+      getContext: vi.fn(async () => ({
+        adrs: [],
+        knownErrors: ['disk full => free temporary files before retrying'],
+        rules: [],
+      })),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'write artifact one', requiredSkills: ['alpha'], dependsOn: [] },
+      { id: 't2', objective: 'write artifact two', requiredSkills: ['alpha'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), memory, makeObserver());
+
+    expect(outcomes).toHaveLength(4);
+    expect(outcomes.every(outcome => outcome.status === 'success')).toBe(true);
+    expect(c.circuitBreakerTripped).toBe(false);
+  });
+
+  it('keeps terminal peer wave failures from being requeued after recovery rebuilds pending', async () => {
+    const seenRecoverable = new Set<string>();
+    const execute = vi.fn(async (_skillId: string, input: SkillInput) => {
+      if (input.objective === 'recoverable artifact' && !seenRecoverable.has(input.objective)) {
+        seenRecoverable.add(input.objective);
+        throw new Error('disk full while writing artifact');
+      }
+      if (input.objective === 'unknown artifact') {
+        throw new Error('unknown transient explosion');
+      }
+      return { output: input.objective, tokensUsed: 1 };
+    });
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      execute,
+    });
+    const memory = makeMemory({
+      getContext: vi.fn(async () => ({
+        adrs: [],
+        knownErrors: ['disk full => free temporary files before retrying'],
+        rules: [],
+      })),
+    });
+    const c = ctx([
+      { id: 't1', objective: 'recoverable artifact', requiredSkills: ['alpha'], dependsOn: [] },
+      { id: 't2', objective: 'unknown artifact', requiredSkills: ['alpha'], dependsOn: [] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), memory, makeObserver());
+
+    expect(outcomes.filter(outcome => outcome.taskId === 't2')).toHaveLength(1);
+    expect(outcomes.find(outcome => outcome.taskId === 't2')).toEqual(expect.objectContaining({ status: 'failure' }));
+    expect(outcomes.some(outcome => outcome.taskId === 't1' && outcome.status === 'success')).toBe(true);
+    expect(c.circuitBreakerTripped).toBe(true);
+  });
+
   it('does not requeue terminal skipped tasks when recovery rebuilds the graph', async () => {
     const execute = vi
       .fn()
@@ -534,7 +776,7 @@ describe('runExecution', () => {
     const skills = makeSkills({
       hasSkill: vi.fn((id: string) => id === 'alpha'),
       execute,
-      getAvailableSkills: vi.fn(() => [{ id: 'hitl', name: 'HITL', requiresHitl: true }]),
+      getAvailableSkills: vi.fn(() => [{ id: 'hitl', name: 'HITL', requiresHitl: true, executionType: 'function' as const }]),
     });
     const governor = makeGovernor({
       requestApproval: vi.fn(async () => ({ decision: 'rejected', reason: 'nope' })),
@@ -1453,7 +1695,7 @@ describe('runExecution', () => {
     const logger = makeLogger();
     const skills = makeSkills({
       getAvailableSkills: vi.fn(() => [
-        { id: 'deploy', name: 'Deploy', requiresHitl: true },
+        { id: 'deploy', name: 'Deploy', requiresHitl: true, executionType: 'function' as const },
       ]),
       hasSkill: vi.fn(() => true),
       execute: vi.fn(async () => ({ output: 'done', tokensUsed: 2 })),


### PR DESCRIPTION
## Summary
- Runs all currently ready execution tasks together as a parallel topological wave via Promise.all.
- Preserves existing checkpoint, recovery, failure, and unmet-dependency semantics while processing completed wave results deterministically.
- Updates beast-loop docs to describe live parallel wave execution and keep recursive expansion marked as target architecture.

## Test Plan
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm test --workspace @franken/orchestrator -- tests/unit/phases/execution.test.ts
- npm test --workspace @franken/orchestrator

Closes #497