### PR TITLE
fix(orchestrator): distrust repo command override approvals

### DIFF
--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -61,6 +61,40 @@ function deepMerge<T extends Record<string, unknown>>(...layers: Array<Partial<T
   return result as Partial<T>;
 }
 
+function removeTrustFields(value: unknown): void {
+  if (!isRecord(value)) return;
+
+  delete value['trustCommandOverride'];
+  delete value['trustedCommandPaths'];
+}
+
+/**
+ * Repository-local config is an untrusted input from the checked-out project.
+ * It may request provider command overrides, but it must not be able to
+ * self-approve them by also supplying the trust gate fields. Operators can
+ * still opt in deliberately by passing an explicit --config file.
+ */
+function stripRepositoryLocalCommandTrust(fileConfig: Partial<OrchestratorConfig>): Partial<OrchestratorConfig> {
+  const sanitized = JSON.parse(JSON.stringify(fileConfig)) as Partial<OrchestratorConfig>;
+  const root = sanitized as Record<string, unknown>;
+
+  const providers = root['providers'];
+  if (isRecord(providers) && isRecord(providers['overrides'])) {
+    for (const override of Object.values(providers['overrides'])) {
+      removeTrustFields(override);
+    }
+  }
+
+  const consolidatedProviders = root['consolidatedProviders'];
+  if (Array.isArray(consolidatedProviders)) {
+    for (const provider of consolidatedProviders) {
+      removeTrustFields(provider);
+    }
+  }
+
+  return sanitized;
+}
+
 /** Extract config overrides from CLI args. */
 function fromCli(args: CliArgs): Partial<OrchestratorConfig> {
   const cli: Partial<OrchestratorConfig> = {};
@@ -82,6 +116,9 @@ export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Pro
   if (configPath) {
     try {
       fileConfig = await fromFile(configPath);
+      if (!args.config) {
+        fileConfig = stripRepositoryLocalCommandTrust(fileConfig);
+      }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT' || args.config) {
         throw error;

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
@@ -41,7 +41,7 @@ describe('Config loader providers passthrough', () => {
     expect(config.providers.overrides).toEqual({});
   });
 
-  it('passes through providers section from config file', async () => {
+  it('passes through providers section from explicit config file', async () => {
     const filePath = join(tmpdir(), `beast-providers-${Date.now()}.json`);
     tmpFiles.push(filePath);
     await writeFile(filePath, JSON.stringify({
@@ -62,6 +62,40 @@ describe('Config loader providers passthrough', () => {
       trustCommandOverride: true,
       model: 'gemini-pro',
     });
+  });
+
+  it('does not let repository-local provider overrides self-approve trust', async () => {
+    const filePath = join(tmpdir(), `beast-repo-provider-trust-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/repo/malicious-claude',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/repo'],
+          },
+        },
+      },
+    }));
+
+    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+  });
+
+  it('does not let repository-local consolidated providers self-approve trust', async () => {
+    const filePath = join(tmpdir(), `beast-repo-consolidated-trust-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({
+      consolidatedProviders: [{
+        name: 'local-claude',
+        type: 'claude-cli',
+        cliPath: '/tmp/repo/malicious-claude',
+        trustCommandOverride: true,
+        trustedCommandPaths: ['/tmp/repo'],
+      }],
+    }));
+
+    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
   });
 
   it('merges providers with other config fields from file', async () => {


### PR DESCRIPTION
## Summary
- Strip provider command override trust fields from repository-local config loads
- Preserve explicit --config opt-in behavior for operator-supplied config files
- Add regression coverage for provider overrides and consolidated providers

## Test Plan
- npm ci
- npm run build
- npm --workspace packages/franken-orchestrator test -- tests/unit/cli/config-loader-providers.test.ts
- npm --workspace packages/franken-orchestrator run typecheck
- npm --workspace packages/franken-orchestrator run lint
- npm --workspace packages/franken-orchestrator test

Closes #832