### PR TITLE
test(security): cover npm audit dependency floors

### DIFF
--- a/tasks/issue-498-security-audit-progress.md
+++ b/tasks/issue-498-security-audit-progress.md
@@ -1,0 +1,18 @@
+# Issue 498 Security Audit Progress
+
+- [x] Read issue #498 and repo lessons.
+- [x] Created issue branch `resolve/issue-498-security-audit-npm-audit-reports-multiple-vulner` in isolated workspace.
+- [x] Installed dependencies with pinned npm.
+- [x] Verified current lockfile reports 0 npm audit vulnerabilities.
+- [x] Added targeted regression coverage for the issue #498 vulnerable dependency floors.
+- [x] Ran relevant test/audit/typecheck/build/lint gates.
+- [ ] Commit, push, open PR closing #498, run Codex/CI gate, merge or block with exact status.
+- [ ] Record any reusable lesson and complete/block Kanban card.
+
+Verification so far:
+- `npm run test:root -- tests/workspaces.test.ts` passed (32 tests).
+- `npm run audit:security` passed with 0 vulnerabilities.
+- `npm run typecheck` passed (16/16 turbo tasks).
+- `npm run build` passed (10/10 turbo tasks).
+- `npm run lint:any && npm run lint:security && git diff --check` passed; explicit-any audit reports existing counts but exits 0.
+- Initial `npm test` had one orchestrator redaction test failure that passed when rerun directly; full `npm test` then passed (20/20 turbo tasks).

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -118,6 +118,61 @@ describe('npm workspaces configuration', () => {
         }
       }
     });
+
+    it('keeps the issue #498 npm audit packages on non-vulnerable locked versions', () => {
+      const lockfile = readJson('package-lock.json');
+      const packageFloors = {
+        '@anthropic-ai/sdk': '0.110.0',
+        '@babel/core': '7.29.1',
+        '@protobufjs/utf8': '1.1.1',
+        esbuild: '0.28.1',
+        'fast-uri': '3.1.3',
+        'form-data': '4.0.6',
+        hono: '4.12.27',
+        'ip-address': '10.2.0',
+        'js-yaml': '4.3.0',
+        postcss: '8.5.10',
+        protobufjs: '7.6.5',
+        qs: '6.15.3',
+        vite: '8.1.3',
+        'vite-node': '4.1.9',
+        vitest: minimumVitest,
+        '@vitest/coverage-v8': minimumVitest,
+        '@vitest/mocker': minimumVitest,
+        ws: '8.21.0',
+      };
+
+      for (const [packageName, minimumVersion] of Object.entries(packageFloors)) {
+        const lockedEntries = Object.entries(lockfile.packages ?? {})
+          .filter(([path]) => path === `node_modules/${packageName}` || path.endsWith(`/node_modules/${packageName}`));
+
+        for (const [path, packageDetails] of lockedEntries) {
+          const lockedVersion = (packageDetails as { version?: string }).version;
+
+          expect(lockedVersion, `${packageName} at ${path} is missing a locked version`).toBeDefined();
+          expect(
+            isAtLeast(lockedVersion ?? '0.0.0', minimumVersion),
+            `${packageName} at ${path} must stay >= ${minimumVersion}`,
+          ).toBe(true);
+        }
+      }
+
+      const braceExpansionEntries = Object.entries(lockfile.packages ?? {})
+        .filter(([path]) => path === 'node_modules/brace-expansion' || path.endsWith('/node_modules/brace-expansion'));
+
+      expect(braceExpansionEntries.length, 'brace-expansion missing from package-lock.json').toBeGreaterThan(0);
+      for (const [path, packageDetails] of braceExpansionEntries) {
+        const lockedVersion = (packageDetails as { version?: string }).version;
+
+        expect(lockedVersion, `brace-expansion at ${path} is missing a locked version`).toBeDefined();
+        if ((lockedVersion ?? '').startsWith('5.')) {
+          expect(
+            isAtLeast(lockedVersion ?? '0.0.0', '5.0.7'),
+            `brace-expansion at ${path} must stay outside the vulnerable 5.0.2 - 5.0.5 range`,
+          ).toBe(true);
+        }
+      }
+    });
   });
 
   describe('cross-module dependencies use coherent internal versions', () => {

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -159,18 +159,30 @@ describe('npm workspaces configuration', () => {
 
       const braceExpansionEntries = Object.entries(lockfile.packages ?? {})
         .filter(([path]) => path === 'node_modules/brace-expansion' || path.endsWith('/node_modules/brace-expansion'));
+      const braceExpansionFloorsByMajor: Record<number, string> = {
+        1: '1.1.15',
+        2: '2.1.1',
+        3: '3.0.2',
+        4: '4.0.1',
+        5: '5.0.7',
+      };
 
       expect(braceExpansionEntries.length, 'brace-expansion missing from package-lock.json').toBeGreaterThan(0);
       for (const [path, packageDetails] of braceExpansionEntries) {
         const lockedVersion = (packageDetails as { version?: string }).version;
 
         expect(lockedVersion, `brace-expansion at ${path} is missing a locked version`).toBeDefined();
-        if ((lockedVersion ?? '').startsWith('5.')) {
-          expect(
-            isAtLeast(lockedVersion ?? '0.0.0', '5.0.7'),
-            `brace-expansion at ${path} must stay outside the vulnerable 5.0.2 - 5.0.5 range`,
-          ).toBe(true);
-        }
+        const [major] = majorMinorPatch(lockedVersion ?? '0.0.0');
+        const minimumVersion = braceExpansionFloorsByMajor[major];
+
+        expect(
+          minimumVersion,
+          `brace-expansion at ${path} uses unsupported major ${major}; add its fixed floor before allowing it`,
+        ).toBeDefined();
+        expect(
+          isAtLeast(lockedVersion ?? '0.0.0', minimumVersion ?? '999.999.999'),
+          `brace-expansion at ${path} must stay on the fixed floor for major ${major}`,
+        ).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Summary
- Add regression coverage for the dependency floors implicated by issue #498.
- Verify package-lock entries stay on non-vulnerable versions when those packages are present.
- Preserve the current zero-vulnerability npm audit state behind the guarded audit script.

## Test Plan
- npm run test:root -- tests/workspaces.test.ts
- npm run audit:security
- npm run typecheck
- npm run build
- npm run lint:any && npm run lint:security && git diff --check
- npm test (first full run hit one unrelated orchestrator test flake; targeted rerun passed, then full rerun passed)

Closes #498