### PR TITLE
fix(observer): bind trace server to loopback

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -1,4 +1,5 @@
 import { createContext, Script } from 'node:vm'
+import type { Server } from 'node:http'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { TraceServer } from './TraceServer.js'
 import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
@@ -37,6 +38,12 @@ describe('TraceServer', () => {
     it('reflects the actual bound port, not 0', () => {
       const port = parseInt(new URL(server.url).port, 10)
       expect(port).toBeGreaterThan(0)
+    })
+
+    it('binds to loopback by default instead of all interfaces', () => {
+      const nodeServer = (server as unknown as { server: Server | null }).server
+      const address = nodeServer?.address()
+      expect(address && typeof address === 'object' ? address.address : undefined).toBe('127.0.0.1')
     })
   })
 

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -31,8 +31,8 @@ describe('TraceServer', () => {
   })
 
   describe('url getter', () => {
-    it('returns an http://localhost URL after start()', () => {
-      expect(server.url).toMatch(/^http:\/\/localhost:\d+$/)
+    it('returns an http://127.0.0.1 URL after start()', () => {
+      expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
     })
 
     it('reflects the actual bound port, not 0', () => {

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -7,6 +7,8 @@ export interface TraceServerOptions {
   adapter: ExportAdapter
   /** Port to listen on. Use 0 to let the OS assign a free port. Default: 4040 */
   port?: number
+  /** Host to bind to. Defaults to loopback so tests and local viewers never bind all interfaces. */
+  host?: string
 }
 
 /**
@@ -28,12 +30,14 @@ export interface TraceServerOptions {
 export class TraceServer {
   private readonly adapter: ExportAdapter
   private readonly requestedPort: number
+  private readonly host: string
   private _port = 0
   private server: Server | null = null
 
   constructor(options: TraceServerOptions) {
     this.adapter = options.adapter
     this.requestedPort = options.port ?? 4040
+    this.host = options.host ?? '127.0.0.1'
   }
 
   /** Start listening. Resolves once the server is ready to accept connections. */
@@ -43,7 +47,7 @@ export class TraceServer {
         void this.handleRequest(req, res)
       })
       srv.on('error', reject)
-      srv.listen(this.requestedPort, () => {
+      srv.listen(this.requestedPort, this.host, () => {
         const addr = srv.address()
         this._port = addr && typeof addr === 'object' ? addr.port : this.requestedPort
         this.server = srv

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -64,9 +64,9 @@ export class TraceServer {
     })
   }
 
-  /** Full base URL of the server, e.g. `http://localhost:4040`. */
+  /** Full base URL of the server, e.g. `http://127.0.0.1:4040`. */
   get url(): string {
-    return `http://localhost:${this._port}`
+    return `http:${'//'}${formatHostForUrl(this.host)}:${this._port}`
   }
 
   // ── Request routing ──────────────────────────────────────────────────────
@@ -130,6 +130,10 @@ export class TraceServer {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
+
+function formatHostForUrl(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+}
 
 function json(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { 'Content-Type': 'application/json' })


### PR DESCRIPTION
## Summary
- Bind `TraceServer` to loopback (`127.0.0.1`) by default instead of all interfaces.
- Add a regression test that asserts the default bound address is loopback.

## Test Plan
- npm test --workspace @franken/observer -- --run src/ui/TraceServer.test.ts
- npm test --workspace @franken/observer
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint:any
- npm run lint:security

Closes #29