### PR TITLE
fix(orchestrator): make beast run updates atomic

### DIFF
--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -258,11 +258,11 @@ export class SQLiteBeastRepository {
   }
 
   createAttempt(runId: string, input: CreateAttemptInput): BeastRunAttempt {
-    return this.insertAttempt(runId, input);
+    return this.transaction(() => this.insertAttempt(runId, input));
   }
 
   restartAttempt(runId: string, input: CreateAttemptInput): BeastRunAttempt {
-    return this.insertAttempt(runId, input);
+    return this.transaction(() => this.insertAttempt(runId, input));
   }
 
   listAttempts(runId: string): BeastRunAttempt[] {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -1,6 +1,6 @@
 import type { BeastDefinition, BeastRun } from '../types.js';
 import { BeastLogStore } from '../events/beast-log-store.js';
-import type { BeastEventBus } from '../events/beast-event-bus.js';
+import type { BeastEventBus, BeastSseEvent } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import type { BeastMetrics } from '../telemetry/beast-metrics.js';
 import type { BeastExecutors } from './beast-dispatch-service.js';
@@ -145,7 +145,8 @@ export class BeastRunService {
     if (!run.trackedAgentId) {
       return;
     }
-    const trackedAgent = this.repository.getTrackedAgent(run.trackedAgentId);
+    const trackedAgentId: string = run.trackedAgentId;
+    const trackedAgent = this.repository.getTrackedAgent(trackedAgentId);
     if (!trackedAgent || trackedAgent.status === 'deleted') {
       return;
     }
@@ -164,41 +165,49 @@ export class BeastRunService {
     }
 
     const updatedAt = new Date().toISOString();
-    this.repository.updateTrackedAgent(run.trackedAgentId, {
-      status,
-      ...(run.id ? { dispatchRunId: run.id } : {}),
-      updatedAt,
-    });
-
-    this.serviceOptions.eventBus?.publish({
-      type: 'agent.status',
-      data: { agentId: run.trackedAgentId, status, updatedAt },
-    });
-
-    if ((run.status === 'failed' || run.status === 'completed' || run.status === 'stopped')) {
-      const level: 'error' | 'info' = run.status === 'failed' ? 'error' : 'info';
-      const type = `agent.run.${run.status}`;
-      const message = run.status === 'failed'
-        ? `Run ${run.id} failed with exit code ${run.latestExitCode ?? 'unknown'}`
-        : run.status === 'completed'
-          ? `Run ${run.id} completed successfully`
-          : `Run ${run.id} stopped`;
-      const agentEvent = {
-        level,
-        type,
-        message,
-        payload: {
-          runId: run.id,
-          ...(run.latestExitCode !== undefined ? { exitCode: run.latestExitCode } : {}),
-          ...(run.stopReason ? { stopReason: run.stopReason } : {}),
-        },
-        createdAt: new Date().toISOString(),
-      };
-      this.repository.appendTrackedAgentEvent(run.trackedAgentId, agentEvent);
-      this.serviceOptions.eventBus?.publish({
-        type: 'agent.event',
-        data: { agentId: run.trackedAgentId, event: agentEvent },
+    const publications = this.repository.transaction(() => {
+      this.repository.updateTrackedAgent(trackedAgentId, {
+        status,
+        dispatchRunId: run.id,
+        updatedAt,
       });
+
+      const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [{
+        type: 'agent.status',
+        data: { agentId: trackedAgentId, status, updatedAt },
+      }];
+
+      if ((run.status === 'failed' || run.status === 'completed' || run.status === 'stopped')) {
+        const level: 'error' | 'info' = run.status === 'failed' ? 'error' : 'info';
+        const type = `agent.run.${run.status}`;
+        const message = run.status === 'failed'
+          ? `Run ${run.id} failed with exit code ${run.latestExitCode ?? 'unknown'}`
+          : run.status === 'completed'
+            ? `Run ${run.id} completed successfully`
+            : `Run ${run.id} stopped`;
+        const agentEvent = {
+          level,
+          type,
+          message,
+          payload: {
+            runId: run.id,
+            ...(run.latestExitCode !== undefined ? { exitCode: run.latestExitCode } : {}),
+            ...(run.stopReason ? { stopReason: run.stopReason } : {}),
+          },
+          createdAt: new Date().toISOString(),
+        };
+        this.repository.appendTrackedAgentEvent(trackedAgentId, agentEvent);
+        pendingPublications.push({
+          type: 'agent.event',
+          data: { agentId: trackedAgentId, event: agentEvent },
+        });
+      }
+
+      return pendingPublications;
+    });
+
+    for (const publication of publications) {
+      this.serviceOptions.eventBus?.publish(publication);
     }
   }
 }

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -6,6 +6,7 @@ import { BeastCatalogService } from '../../../src/beasts/services/beast-catalog-
 import { BeastDispatchService } from '../../../src/beasts/services/beast-dispatch-service.js';
 import { BeastRunService } from '../../../src/beasts/services/beast-run-service.js';
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
+import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
@@ -323,5 +324,81 @@ describe('BeastRunService', () => {
       status: 'running',
       dispatchRunId: run.id,
     });
+  });
+
+  it('rolls back tracked-agent status sync when persisting its terminal event fails', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const eventBus = new BeastEventBus();
+    const publish = vi.spyOn(eventBus, 'publish');
+    const runs = new BeastRunService(
+      repo,
+      new BeastCatalogService(),
+      {
+        process: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+        container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+      },
+      metrics,
+      logs,
+      { eventBus },
+    );
+    const agent = repo.createTrackedAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      status: 'initializing',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Finish atomically',
+          chunkDirectory: 'docs/chunks',
+        },
+      },
+      initConfig: {
+        provider: 'claude',
+        objective: 'Finish atomically',
+        chunkDirectory: 'docs/chunks',
+      },
+      createdAt: '2026-03-11T00:00:00.000Z',
+      updatedAt: '2026-03-11T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {
+        provider: 'claude',
+        objective: 'Finish atomically',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-11T00:00:01.000Z',
+    });
+    repo.updateRun(run.id, {
+      status: 'completed',
+      finishedAt: '2026-03-11T00:00:02.000Z',
+      latestExitCode: 0,
+    });
+    const originalAppendTrackedAgentEvent = repo.appendTrackedAgentEvent.bind(repo);
+    repo.appendTrackedAgentEvent = (() => {
+      throw new Error('simulated tracked-agent event failure');
+    }) as SQLiteBeastRepository['appendTrackedAgentEvent'];
+
+    expect(() => runs.notifyRunStatusChange(run.id)).toThrow('simulated tracked-agent event failure');
+
+    repo.appendTrackedAgentEvent = originalAppendTrackedAgentEvent;
+    const storedAgent = repo.getTrackedAgent(agent.id);
+    expect(storedAgent).toMatchObject({
+      status: 'initializing',
+    });
+    expect(storedAgent).not.toHaveProperty('dispatchRunId');
+    expect(repo.listTrackedAgentEvents(agent.id)).toEqual([]);
+    expect(publish).not.toHaveBeenCalled();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -69,6 +69,40 @@ describe('SQLiteBeastRepository', () => {
     });
   });
 
+  it('rolls back attempt insertion when the paired run update fails', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const run = repo.createRun({
+      definitionId: 'chunk-plan',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { chunkSize: 3 },
+      dispatchedBy: 'cli',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const originalUpdateRun = repo.updateRun.bind(repo);
+    repo.updateRun = (() => {
+      throw new Error('simulated run update failure');
+    }) as SQLiteBeastRepository['updateRun'];
+
+    expect(() => repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 101,
+      startedAt: '2026-03-10T00:01:00.000Z',
+      executorMetadata: { backend: 'process' },
+    })).toThrow('simulated run update failure');
+
+    repo.updateRun = originalUpdateRun;
+    expect(repo.listAttempts(run.id)).toEqual([]);
+    const storedRun = repo.getRun(run.id);
+    expect(storedRun).toMatchObject({
+      attemptCount: 0,
+      status: 'queued',
+    });
+    expect(storedRun).not.toHaveProperty('currentAttemptId');
+  });
+
   it('appends ordered run events and updates terminal status', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));


### PR DESCRIPTION
## Summary
- Wrap beast attempt creation/restart run-state updates in SQLite transactions.
- Make tracked-agent status/event persistence atomic before publishing SSE notifications.
- Add rollback regression tests for failed attempt/run and tracked-agent status/event write paths.

## Test Plan
- npm test -- --run tests/unit/beasts/sqlite-beast-repository.test.ts tests/unit/beasts/beast-run-service.test.ts --reporter=dot
- npx turbo run build --filter=@franken/orchestrator...
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)
- npx turbo run test --filter=@franken/orchestrator

Closes #683