### PR TITLE
fix(observer): contain post-mortem report paths

### DIFF
--- a/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
@@ -192,7 +192,7 @@ describe('PostMortemGenerator', () => {
         const filePath = await gen.generate(trace, makeSignal(trace.id))
 
         expect(filePath).not.toBeNull()
-        expect(isInsideDirectory(realOutputDir, filePath!)).toBe(true)
+        expect(isInsideDirectory(symlinkedOutputDir, filePath!)).toBe(true)
         expect(existsSync(filePath!)).toBe(true)
 
         const escapedPath = resolve(realOutputDir, `post-mortem-${trace.id}-1700000000000.md`)
@@ -201,6 +201,36 @@ describe('PostMortemGenerator', () => {
       } finally {
         rmSync(parentDir, { recursive: true, force: true })
       }
+    })
+
+    it('preserves configured relative outputDir in the returned path', async () => {
+      const relativeOutputDir = `.pm-relative-${randomUUID()}`
+
+      try {
+        const gen = new PostMortemGenerator({ outputDir: relativeOutputDir })
+        const trace = makeTrace()
+        const filePath = await gen.generate(trace, makeSignal(trace.id))
+
+        expect(filePath).not.toBeNull()
+        expect(isAbsolute(filePath!)).toBe(false)
+        expect(filePath!.startsWith(relativeOutputDir)).toBe(true)
+        expect(existsSync(filePath!)).toBe(true)
+      } finally {
+        rmSync(relativeOutputDir, { recursive: true, force: true })
+      }
+    })
+
+    it('uses reversible trace id encoding so separator-like ids do not overwrite distinct reports', async () => {
+      const gen = new PostMortemGenerator({ outputDir })
+      const signalTimestamp = 1_700_000_000_000
+      const firstPath = await gen.generate(makeTraceWithId('run\\1'), makeSignal('run\\1', { timestamp: signalTimestamp }))
+      const secondPath = await gen.generate(makeTraceWithId('run_1'), makeSignal('run_1', { timestamp: signalTimestamp }))
+
+      expect(firstPath).not.toBeNull()
+      expect(secondPath).not.toBeNull()
+      expect(firstPath).not.toBe(secondPath)
+      expect(existsSync(firstPath!)).toBe(true)
+      expect(existsSync(secondPath!)).toBe(true)
     })
   })
 

--- a/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
@@ -232,6 +232,16 @@ describe('PostMortemGenerator', () => {
       expect(existsSync(firstPath!)).toBe(true)
       expect(existsSync(secondPath!)).toBe(true)
     })
+
+    it('does not throw when encoding malformed UTF-16 trace ids', async () => {
+      const gen = new PostMortemGenerator({ outputDir })
+      const malformedTraceId = 'run-\uD800'
+      const filePath = await gen.generate(makeTraceWithId(malformedTraceId), makeSignal(malformedTraceId))
+
+      expect(filePath).not.toBeNull()
+      expect(isInsideDirectory(outputDir, filePath!)).toBe(true)
+      expect(existsSync(filePath!)).toBe(true)
+    })
   })
 
   describe('generate() error handling (disk full / read-only)', () => {

--- a/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
@@ -203,6 +203,29 @@ describe('PostMortemGenerator', () => {
       }
     })
 
+    it('does not follow a symlink at the report file path', async () => {
+      const parentDir = join(tmpdir(), `pm-leaf-symlink-parent-${randomUUID()}`)
+      const reportsDir = join(parentDir, 'reports')
+      const outsidePath = join(parentDir, 'outside.md')
+      const trace = makeTraceWithId('symlink-target')
+      const signal = makeSignal(trace.id)
+      const expectedReportPath = join(reportsDir, `post-mortem-symlink-target-${signal.timestamp}.md`)
+
+      mkdirSync(reportsDir, { recursive: true })
+      writeFileSync(outsidePath, 'do not overwrite')
+      symlinkSync(outsidePath, expectedReportPath)
+
+      try {
+        const gen = new PostMortemGenerator({ outputDir: reportsDir })
+        const filePath = await gen.generate(trace, signal)
+
+        expect(filePath).toBeNull()
+        expect(readFileSync(outsidePath, 'utf-8')).toBe('do not overwrite')
+      } finally {
+        rmSync(parentDir, { recursive: true, force: true })
+      }
+    })
+
     it('preserves configured relative outputDir in the returned path', async () => {
       const relativeOutputDir = `.pm-relative-${randomUUID()}`
 

--- a/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { join } from 'node:path'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { tmpdir } from 'node:os'
-import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { TraceContext } from '../core/TraceContext.js'
 import { SpanLifecycle } from '../core/SpanLifecycle.js'
@@ -27,6 +27,20 @@ function makeTrace() {
     TraceContext.endSpan(span)
   }
   TraceContext.endTrace(trace)
+  return trace
+}
+
+function isInsideDirectory(baseDir: string, targetPath: string): boolean {
+  const relativePath = relative(resolve(baseDir), resolve(targetPath))
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+function makeTraceWithId(id: string) {
+  const trace = makeTrace()
+  trace.id = id
+  for (const span of trace.spans) {
+    span.traceId = id
+  }
   return trace
 }
 
@@ -105,15 +119,17 @@ describe('PostMortemGenerator', () => {
       const gen = new PostMortemGenerator({ outputDir })
       const trace = makeTrace()
       const filePath = await gen.generate(trace, makeSignal(trace.id))
-      expect(existsSync(filePath)).toBe(true)
-      expect(filePath.endsWith('.md')).toBe(true)
+      expect(filePath).not.toBeNull()
+      expect(existsSync(filePath!)).toBe(true)
+      expect(filePath!.endsWith('.md')).toBe(true)
     })
 
     it('filename contains the trace id', async () => {
       const gen = new PostMortemGenerator({ outputDir })
       const trace = makeTrace()
       const filePath = await gen.generate(trace, makeSignal(trace.id))
-      expect(filePath).toContain(trace.id)
+      expect(filePath).not.toBeNull()
+      expect(filePath!).toContain(trace.id)
     })
 
     it('written file content matches generateContent()', async () => {
@@ -132,6 +148,59 @@ describe('PostMortemGenerator', () => {
       const trace = makeTrace()
       const filePath = await gen.generate(trace, makeSignal(trace.id))
       expect(existsSync(filePath!)).toBe(true)
+    })
+
+    it('keeps reports under outputDir when trace ids contain traversal, absolute paths, or separators', async () => {
+      const parentDir = join(tmpdir(), `pm-parent-${randomUUID()}`)
+      const containedOutputDir = join(parentDir, 'reports')
+      const maliciousIds = [
+        `trace${sep}..${sep}..${sep}escaped`,
+        join(tmpdir(), 'absolute-trace-id'),
+        'slash/and\\backslash',
+      ]
+
+      try {
+        for (const traceId of maliciousIds) {
+          const gen = new PostMortemGenerator({ outputDir: containedOutputDir })
+          const trace = makeTraceWithId(traceId)
+          const filePath = await gen.generate(trace, makeSignal(trace.id))
+
+          expect(filePath).not.toBeNull()
+          expect(isInsideDirectory(containedOutputDir, filePath!)).toBe(true)
+          expect(existsSync(filePath!)).toBe(true)
+        }
+
+        const escapedReports = maliciousIds.map(
+          traceId => resolve(containedOutputDir, `post-mortem-${traceId}-1700000000000.md`),
+        )
+        expect(escapedReports.some(path => !isInsideDirectory(containedOutputDir, path) && existsSync(path))).toBe(false)
+      } finally {
+        rmSync(parentDir, { recursive: true, force: true })
+      }
+    })
+
+    it('enforces containment when outputDir is a symlink', async () => {
+      const parentDir = join(tmpdir(), `pm-symlink-parent-${randomUUID()}`)
+      const realOutputDir = join(parentDir, 'real-reports')
+      const symlinkedOutputDir = join(parentDir, 'reports-link')
+      mkdirSync(realOutputDir, { recursive: true })
+      symlinkSync(realOutputDir, symlinkedOutputDir, 'dir')
+
+      try {
+        const gen = new PostMortemGenerator({ outputDir: symlinkedOutputDir })
+        const trace = makeTraceWithId(`trace${sep}..${sep}..${sep}escaped-from-symlink`)
+        const filePath = await gen.generate(trace, makeSignal(trace.id))
+
+        expect(filePath).not.toBeNull()
+        expect(isInsideDirectory(realOutputDir, filePath!)).toBe(true)
+        expect(existsSync(filePath!)).toBe(true)
+
+        const escapedPath = resolve(realOutputDir, `post-mortem-${trace.id}-1700000000000.md`)
+        expect(isInsideDirectory(realOutputDir, escapedPath)).toBe(false)
+        expect(existsSync(escapedPath)).toBe(false)
+      } finally {
+        rmSync(parentDir, { recursive: true, force: true })
+      }
     })
   })
 
@@ -193,8 +262,8 @@ describe('PostMortemGenerator', () => {
 
       const postMortemDone = new Promise<string>(resolve => {
         emitter.on('interrupt', async signal => {
-          const path = await gen.generate(trace, signal)
-          resolve(path)
+          const generatedPath = await gen.generate(trace, signal)
+          if (typeof generatedPath === 'string') resolve(generatedPath)
         })
       })
 

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -9,7 +9,31 @@ export interface PostMortemOptions {
 }
 
 function safeFilenameComponent(value: string): string {
-  return encodeURIComponent(value)
+  let wellFormedValue = ''
+
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const nextCode = value.charCodeAt(index + 1)
+      if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+        wellFormedValue += value[index] + value[index + 1]
+        index += 1
+      } else {
+        wellFormedValue += '\uFFFD'
+      }
+      continue
+    }
+
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      wellFormedValue += '\uFFFD'
+      continue
+    }
+
+    wellFormedValue += value[index]
+  }
+
+  return encodeURIComponent(wellFormedValue)
 }
 
 function isInsideDirectory(baseDir: string, targetPath: string): boolean {

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve } from 'node:path'
 import type { Trace } from '../core/types.js'
@@ -39,6 +40,20 @@ function safeFilenameComponent(value: string): string {
 function isInsideDirectory(baseDir: string, targetPath: string): boolean {
   const relativePath = relative(baseDir, targetPath)
   return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+async function writeNewReportFile(filePath: string, content: string): Promise<void> {
+  const fileHandle = await fs.open(
+    filePath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+    0o600,
+  )
+
+  try {
+    await fileHandle.writeFile(content, 'utf-8')
+  } finally {
+    await fileHandle.close()
+  }
 }
 
 /**
@@ -128,7 +143,7 @@ without reaching a terminal condition. Possible causes:
         throw new Error(`Resolved post-mortem path escapes output directory: ${writeFilePath}`)
       }
 
-      await fs.writeFile(writeFilePath, content, 'utf-8')
+      await writeNewReportFile(writeFilePath, content)
       return configuredFilePath
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -1,11 +1,20 @@
 import * as fs from 'node:fs/promises'
-import { join } from 'node:path'
+import { isAbsolute, relative, resolve } from 'node:path'
 import type { Trace } from '../core/types.js'
 import type { InterruptSignal } from './InterruptEmitter.js'
 
 export interface PostMortemOptions {
   /** Directory where post-mortem files are written. Default: './post-mortems' */
   outputDir?: string
+}
+
+function safeFilenameComponent(value: string): string {
+  return value.replace(/[\\/]+/g, '_')
+}
+
+function isInsideDirectory(baseDir: string, targetPath: string): boolean {
+  const relativePath = relative(baseDir, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
 }
 
 /**
@@ -80,12 +89,20 @@ without reaching a terminal condition. Possible causes:
    */
   async generate(trace: Trace, signal: InterruptSignal): Promise<string | null> {
     const timestamp = signal.timestamp
-    const filename = `post-mortem-${trace.id}-${timestamp}.md`
-    const filePath = join(this.outputDir, filename)
+    const filename = `post-mortem-${safeFilenameComponent(trace.id)}-${timestamp}.md`
     const content = this.generateContent(trace, signal)
+
+    let filePath = resolve(this.outputDir, filename)
 
     try {
       await fs.mkdir(this.outputDir, { recursive: true })
+      const outputDir = await fs.realpath(this.outputDir)
+      filePath = resolve(outputDir, filename)
+
+      if (!isInsideDirectory(outputDir, filePath)) {
+        throw new Error(`Resolved post-mortem path escapes output directory: ${filePath}`)
+      }
+
       await fs.writeFile(filePath, content, 'utf-8')
       return filePath
     } catch (err) {

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs/promises'
-import { isAbsolute, relative, resolve } from 'node:path'
+import { isAbsolute, join, relative, resolve } from 'node:path'
 import type { Trace } from '../core/types.js'
 import type { InterruptSignal } from './InterruptEmitter.js'
 
@@ -9,7 +9,7 @@ export interface PostMortemOptions {
 }
 
 function safeFilenameComponent(value: string): string {
-  return value.replace(/[\\/]+/g, '_')
+  return encodeURIComponent(value)
 }
 
 function isInsideDirectory(baseDir: string, targetPath: string): boolean {
@@ -90,25 +90,26 @@ without reaching a terminal condition. Possible causes:
   async generate(trace: Trace, signal: InterruptSignal): Promise<string | null> {
     const timestamp = signal.timestamp
     const filename = `post-mortem-${safeFilenameComponent(trace.id)}-${timestamp}.md`
+    const configuredFilePath = join(this.outputDir, filename)
     const content = this.generateContent(trace, signal)
 
-    let filePath = resolve(this.outputDir, filename)
+    let writeFilePath = resolve(this.outputDir, filename)
 
     try {
       await fs.mkdir(this.outputDir, { recursive: true })
       const outputDir = await fs.realpath(this.outputDir)
-      filePath = resolve(outputDir, filename)
+      writeFilePath = resolve(outputDir, filename)
 
-      if (!isInsideDirectory(outputDir, filePath)) {
-        throw new Error(`Resolved post-mortem path escapes output directory: ${filePath}`)
+      if (!isInsideDirectory(outputDir, writeFilePath)) {
+        throw new Error(`Resolved post-mortem path escapes output directory: ${writeFilePath}`)
       }
 
-      await fs.writeFile(filePath, content, 'utf-8')
-      return filePath
+      await fs.writeFile(writeFilePath, content, 'utf-8')
+      return configuredFilePath
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)
       console.warn(
-        `[PostMortemGenerator] Failed to write post-mortem for trace ${trace.id} to ${filePath}: ${reason}. Continuing without persisting the report.`,
+        `[PostMortemGenerator] Failed to write post-mortem for trace ${trace.id} to ${writeFilePath}: ${reason}. Continuing without persisting the report.`,
       )
       return null
     }


### PR DESCRIPTION
## Summary
- sanitize trace IDs before composing post-mortem filenames so path separators cannot create nested or escaping paths
- resolve the output directory through realpath and verify the final report path remains contained before writeFile
- add regression coverage for traversal, absolute-path-like IDs, slash/backslash IDs, and symlinked output directories

## Test Plan
- npm test --workspace @franken/observer -- src/incident/PostMortemGenerator.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm test --workspace @franken/observer
- npm run lint:any
- npm run lint:security

Closes #617