### PR TITLE
fix(publish): add files allowlist so governor/planner/types ship dist

### DIFF
--- a/packages/franken-governor/package.json
+++ b/packages/franken-governor/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/franken-planner/package.json
+++ b/packages/franken-planner/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -10,6 +10,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Publish-integrity bug (found during Phase-2 boundary proof)
`@franken/governor` and `@franken/planner` would publish **completely broken** — with **zero `dist` files** — and `@franken/types` worked only by luck.

## Root cause
`dist/` is gitignored at the repo root. When a package has **no `files` field** and no `.npmignore`, `npm pack` falls back to gitignore resolution and excludes `dist/`. Governor and planner declared no `files` field, so:
- `npm pack --dry-run` produced **0 dist files** for both (their `main`/`exports` point at `./dist/index.js`, which wouldn't exist in the tarball → an unusable package on install), and
- they instead shipped junk: `.github/`, `IMPLEMENTATION_PLAN.md`, `.editorconfig`, `.prettierrc`, `docs/adr/*`.

`@franken/types` also lacked the field and happened to include dist via gitignore-walk behaviour — fragile and version-dependent.

## Fix
Add an explicit `"files": ["dist"]` allowlist to the three packages, matching `franken-brain` and every other publishable package. Packing becomes deterministic and independent of gitignore resolution.

## Verification (`npm pack --dry-run`)
| package | dist files before | after | junk files after |
|---|---|---|---|
| @franken/governor | 0 | 148 | 0 |
| @franken/planner | 0 | 96 | 0 |
| @franken/types | (luck) | 60 | 0 |

This is part of proving the publish pipeline actually yields installable packages. A CI `npm pack` + install smoke test (to catch this class automatically) is planned as a follow-up guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)