### PR TITLE
refactor(tests): alias Vitest configs to package sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,6 @@ jobs:
 
       - run: npm run lint:security
 
-      - run: npx turbo run build test lint
+      - run: |
+          npx turbo run build lint
+          npx turbo run test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           npm run test:root -- tests/workspaces.test.ts tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts
           npm run lint:security
-          npx turbo run build typecheck test lint
+          npx turbo run build typecheck lint
+          npx turbo run test
 
   release-please:
     needs: validate-release

--- a/packages/franken-brain/vitest.config.ts
+++ b/packages/franken-brain/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     globals: false,
     environment: 'node',

--- a/packages/franken-critique/vitest.config.ts
+++ b/packages/franken-critique/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     globals: false,
     environment: 'node',

--- a/packages/franken-governor/vitest.config.ts
+++ b/packages/franken-governor/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     globals: false,
     include: ['tests/**/*.test.ts'],

--- a/packages/franken-mcp-suite/src/integration/server-startup.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/server-startup.integration.test.ts
@@ -9,6 +9,7 @@ import Database from 'better-sqlite3';
 import { DEFAULT_AUDIT_SESSION_ID } from '../shared/central-enforcement.js';
 
 const PACKAGE_ROOT = process.cwd();
+const WORKSPACE_ROOT = join(PACKAGE_ROOT, '..', '..');
 const DIST_ROOT = join(PACKAGE_ROOT, 'dist');
 
 const SERVER_BINS = [
@@ -25,8 +26,8 @@ beforeAll(() => {
   if (process.env['CI'] === 'true' && existsSync(join(DIST_ROOT, 'beast.js'))) {
     return;
   }
-  execFileSync('npm', ['run', 'build'], {
-    cwd: PACKAGE_ROOT,
+  execFileSync('npx', ['turbo', 'run', 'build', '--filter=@franken/mcp-suite...'], {
+    cwd: WORKSPACE_ROOT,
     stdio: 'pipe',
   });
 }, 60_000);

--- a/packages/franken-mcp-suite/vitest.config.ts
+++ b/packages/franken-mcp-suite/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',
+    testTimeout: 15_000,
   },
 });

--- a/packages/franken-mcp-suite/vitest.config.ts
+++ b/packages/franken-mcp-suite/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from 'vitest/config'
 import { readVitestFlags } from '../../scripts/vitest-env.js'
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js'
 
 const vitestFlags = readVitestFlags(['INTEGRATION', 'EVAL'])
 const isIntegration = vitestFlags.INTEGRATION
 const isEval = vitestFlags.EVAL
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     // Default: unit tests only.
     // INTEGRATION=true → integration tests only.

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { readVitestFlags } from '../../scripts/vitest-env.js';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 const packageRoot = dirname(fileURLToPath(import.meta.url));
 const vitestFlags = readVitestFlags(['INTEGRATION', 'E2E']);
@@ -21,6 +22,9 @@ const runMixed = [runE2e, runIntegration, requestedUnit].filter(Boolean).length 
 
 export default defineConfig({
   root: packageRoot,
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     globals: false,
     environment: 'node',

--- a/packages/franken-planner/vitest.config.ts
+++ b/packages/franken-planner/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],

--- a/packages/franken-types/vitest.config.ts
+++ b/packages/franken-types/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     globals: false,
     environment: 'node',

--- a/packages/franken-web/vitest.config.ts
+++ b/packages/franken-web/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { readFileSync } from 'node:fs';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 
 const rootPackageJson = JSON.parse(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
@@ -8,6 +9,9 @@ const rootPackageJson = JSON.parse(
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   define: {
     __FRANKENBEAST_VERSION__: JSON.stringify(rootPackageJson.version),
   },

--- a/scripts/vitest-source-aliases.ts
+++ b/scripts/vitest-source-aliases.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'node:path';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRANKEN_SOURCE_ENTRYPOINTS = {
+  '@franken/brain': 'packages/franken-brain/src/index.ts',
+  '@franken/planner': 'packages/franken-planner/src/index.ts',
+  '@franken/observer': 'packages/franken-observer/src/index.ts',
+  '@franken/critique': 'packages/franken-critique/src/index.ts',
+  '@franken/governor': 'packages/franken-governor/src/index.ts',
+  '@franken/types': 'packages/franken-types/src/index.ts',
+  '@franken/orchestrator': 'packages/franken-orchestrator/src/index.ts',
+} as const;
+
+export type FrankenSourceAlias = keyof typeof FRANKEN_SOURCE_ENTRYPOINTS;
+
+export const createFrankenSourceAliases = (configUrl: string | URL) => {
+  const packageRoot = dirname(fileURLToPath(configUrl));
+  const workspaceRoot = resolve(packageRoot, '../..');
+
+  return Object.fromEntries(
+    Object.entries(FRANKEN_SOURCE_ENTRYPOINTS).map(([alias, sourcePath]) => [
+      alias,
+      resolve(workspaceRoot, sourcePath),
+    ]),
+  ) as Record<FrankenSourceAlias, string>;
+};

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -20,16 +20,18 @@ describe('Turborepo configuration', () => {
       expect(buildTask.outputs).toContain('dist/**');
     });
 
-    it('defines test task with build dependency', () => {
+    it('defines test task without a build dependency for source-alias watch mode', () => {
       const turbo = readJson('turbo.json');
       const testTask = turbo.tasks?.test;
       expect(testTask).toBeDefined();
-      expect(testTask.dependsOn).toContain('build');
+      expect(testTask.dependsOn).toBeUndefined();
     });
 
-    it('defines test:ci task', () => {
+    it('defines test:ci task with package build dependency for CI ordering', () => {
       const turbo = readJson('turbo.json');
-      expect(turbo.tasks?.['test:ci']).toBeDefined();
+      const testCiTask = turbo.tasks?.['test:ci'];
+      expect(testCiTask).toBeDefined();
+      expect(testCiTask.dependsOn).toContain('build');
     });
 
     it('defines typecheck task', () => {

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -61,9 +61,11 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
       expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     });
 
-    it('runs turbo run build test lint', () => {
+    it('builds before running package tests in CI', () => {
       expect(content).toContain('turbo run');
-      expect(content).toMatch(/turbo run.*build.*test.*lint/);
+      expect(content).toMatch(/turbo run build lint[\s\S]*turbo run test/);
+      expect(content.indexOf('turbo run build lint')).toBeLessThan(content.indexOf('turbo run test'));
+      expect(content).not.toMatch(/turbo run.*build\s+test\s+lint/);
     });
 
     it('uses actions/setup-node with npm cache', () => {
@@ -119,7 +121,9 @@ describe('release-please.yml publishes released npm packages', () => {
     const content = readFileSync(RELEASE_PATH, 'utf-8');
     expect(content).toContain('validate-release:');
     expect(content).toContain('release-please:\n    needs: validate-release');
-    expect(content).toMatch(/Validate release before creating tags[\s\S]*turbo run.*build.*typecheck.*test.*lint/);
+    expect(content).toMatch(/Validate release before creating tags[\s\S]*turbo run build typecheck lint[\s\S]*turbo run test/);
+    expect(content.indexOf('turbo run build typecheck lint')).toBeLessThan(content.indexOf('turbo run test'));
+    expect(content).not.toMatch(/turbo run.*build\s+typecheck\s+test\s+lint/);
   });
 
   it('enforces the packageManager-pinned npm before release installs and publishes', () => {

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createFrankenSourceAliases } from '../scripts/vitest-source-aliases.js';
+
+const ROOT = join(import.meta.dirname, '..');
+
+const EXPECTED_ALIASES = {
+  '@franken/brain': resolve(ROOT, 'packages/franken-brain/src/index.ts'),
+  '@franken/planner': resolve(ROOT, 'packages/franken-planner/src/index.ts'),
+  '@franken/observer': resolve(ROOT, 'packages/franken-observer/src/index.ts'),
+  '@franken/critique': resolve(ROOT, 'packages/franken-critique/src/index.ts'),
+  '@franken/governor': resolve(ROOT, 'packages/franken-governor/src/index.ts'),
+  '@franken/types': resolve(ROOT, 'packages/franken-types/src/index.ts'),
+  '@franken/orchestrator': resolve(ROOT, 'packages/franken-orchestrator/src/index.ts'),
+};
+
+const PACKAGE_CONFIGS = [
+  'packages/franken-brain/vitest.config.ts',
+  'packages/franken-critique/vitest.config.ts',
+  'packages/franken-governor/vitest.config.ts',
+  'packages/franken-mcp-suite/vitest.config.ts',
+  'packages/franken-observer/vitest.config.ts',
+  'packages/franken-orchestrator/vitest.config.ts',
+  'packages/franken-planner/vitest.config.ts',
+  'packages/franken-types/vitest.config.ts',
+  'packages/franken-web/vitest.config.ts',
+];
+
+describe('package Vitest source aliases', () => {
+  it('maps every first-party package scope to its TypeScript source entrypoint', () => {
+    expect(createFrankenSourceAliases(new URL('../packages/franken-orchestrator/vitest.config.ts', import.meta.url))).toEqual(
+      EXPECTED_ALIASES,
+    );
+  });
+
+  it('wires source aliases into each package-level Vitest config', () => {
+    for (const configPath of PACKAGE_CONFIGS) {
+      const config = readFileSync(join(ROOT, configPath), 'utf8');
+      expect(config, `${configPath} should import the shared source alias helper`).toContain(
+        'createFrankenSourceAliases',
+      );
+      expect(config, `${configPath} should pass its own import.meta.url to resolve aliases from the package root`).toContain(
+        'createFrankenSourceAliases(import.meta.url)',
+      );
+    }
+  });
+});
+
+describe('turbo test task', () => {
+  it('does not force package builds before local test runs', () => {
+    const turbo = JSON.parse(readFileSync(join(ROOT, 'turbo.json'), 'utf8')) as {
+      tasks: Record<string, { dependsOn?: string[] }>;
+    };
+
+    expect(turbo.tasks.test?.dependsOn ?? []).not.toContain('build');
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -5,9 +5,7 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
-    "test": {
-      "dependsOn": ["build"]
-    },
+    "test": {},
     "test:ci": {
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
## Summary
- Add a shared Vitest source-alias helper mapping first-party `@franken/*` package scopes to `packages/*/src/index.ts`.
- Wire the helper into each package-level `vitest.config.ts` so package tests/watch mode resolve sibling packages from TypeScript sources instead of `dist/`.
- Remove the root `turbo` `test` task dependency on `build` while keeping `test:ci` build-gated.

## Test Plan
- [x] `npm run test:root -- tests/vitest-package-source-aliases.test.ts`
- [x] Package Vitest config smoke loop: `npx vitest run --config <package>/vitest.config.ts --passWithNoTests __vitest_alias_smoke__.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint:any && npm run lint:security && git diff --check`
- [x] `npm --workspace @franken/mcp-suite run test -- src/integration/server-startup.integration.test.ts -t 'starts the proxy server and exposes only proxy meta-tools'`
- [ ] `npm test` full run: 8/10 package tasks passed; `@franken/mcp-suite` hit a 5s timeout in `starts the proxy server and exposes only proxy meta-tools`. The same test passed when rerun targeted.

Closes #675
