### PR TITLE
fix(web): label skill catalog search field

### DIFF
--- a/packages/franken-web/src/components/skills/skill-catalog-browser.tsx
+++ b/packages/franken-web/src/components/skills/skill-catalog-browser.tsx
@@ -16,13 +16,16 @@ export function SkillCatalogBrowser({ skills, onToggle }: SkillCatalogBrowserPro
   return (
     <div className="skill-catalog">
       <div className="skill-catalog__search">
-        <input
-          type="text"
-          placeholder="Filter skills..."
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          className="field-control"
-        />
+        <label className="field-stack">
+          <span>Filter skills</span>
+          <input
+            type="text"
+            placeholder="Filter skills..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="field-control"
+          />
+        </label>
       </div>
       <div className="skill-catalog__list">
         {filtered.length === 0 && (

--- a/packages/franken-web/tests/components/skills/skill-catalog-browser.test.tsx
+++ b/packages/franken-web/tests/components/skills/skill-catalog-browser.test.tsx
@@ -18,9 +18,9 @@ describe('SkillCatalogBrowser', () => {
     expect(screen.getByText('sentry')).toBeDefined();
   });
 
-  it('filters skills by name', () => {
+  it('labels and filters skills by name', () => {
     render(<SkillCatalogBrowser skills={skills} onToggle={vi.fn()} />);
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole('textbox', { name: 'Filter skills' });
     fireEvent.change(input, { target: { value: 'git' } });
     expect(screen.getByText('github')).toBeDefined();
     expect(screen.queryByText('linear')).toBeNull();


### PR DESCRIPTION
## Summary
- Add a visible label for the skill catalog search field
- Update the component test to assert the textbox has the accessible name

## Test Plan
- npm ci
- npm --prefix packages/franken-web test -- --run tests/components/skills/skill-catalog-browser.test.tsx
- npm run build
- npm --prefix packages/franken-web run typecheck

Closes #661