### PR TITLE
fix(orchestrator): make sharp optional so the published CLI runs standalone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -614,7 +614,7 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6549,7 +6549,7 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7713,6 +7713,9 @@
       },
       "engines": {
         "node": ">=22.13.0 <23 || >=24.0.0 <26"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.5"
       }
     },
     "packages/franken-orchestrator/node_modules/@types/node": {

--- a/packages/franken-orchestrator/package.json
+++ b/packages/franken-orchestrator/package.json
@@ -64,5 +64,8 @@
     "@types/ws": "^8.18.1",
     "typescript": "^5.8.3",
     "vitest": "^4.1.9"
+  },
+  "optionalDependencies": {
+    "sharp": "^0.34.5"
   }
 }

--- a/packages/franken-orchestrator/src/logging/beast-logger.ts
+++ b/packages/franken-orchestrator/src/logging/beast-logger.ts
@@ -8,7 +8,6 @@
 
 import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, truncateSync, writeSync } from 'node:fs';
 import { resolve } from 'node:path';
-import sharp from 'sharp';
 import type { ILogger } from '../deps.js';
 import { isCommandFailure } from '../errors/command-failure.js';
 
@@ -111,6 +110,11 @@ export async function renderBanner(root: string): Promise<string> {
   }
 
   try {
+    // sharp is an optional dependency used only to render the graphic banner.
+    // It is a heavy native module and may be absent (unsupported platform, or a
+    // slim install); load it lazily so its absence degrades to the ASCII banner
+    // instead of crashing the CLI at import time.
+    const sharp = (await import('sharp')).default;
     const columns = process.stdout.columns ?? 100;
     const width = Math.max(28, Math.min(Math.floor(columns * 0.55), 44));
     const pipeline = sharp(logoPath)


### PR DESCRIPTION
## Publish-integrity blocker (found during Phase-2 boundary proof)
Installed from a packed tarball (as a real `npm install -g` would), the flagship `frankenbeast` CLI **crashes on every invocation** before it can print anything:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'sharp' imported from .../@franken/orchestrator/dist/logging/beast-logger.js
```

## Root cause
`beast-logger.ts` imported `sharp` at the top level, but **no package declared it** — only the repo *root* does (`sharp ^0.34.5`). In the monorepo it resolves via hoisting; published/installed standalone it is absent, and the top-level import runs at module load, so the whole CLI dies.

`sharp` is used only to render a **cosmetic PNG banner**, and the code already has an ASCII fallback (`buildFallbackBanner`, gated by `shouldRenderGraphicBanner` / `FRANKENBEAST_PLAIN_BANNER`).

## Fix
- Load `sharp` lazily via `await import('sharp')` **inside the existing `try`**, so its absence is caught and degrades to the ASCII banner instead of crashing.
- Declare `sharp` in `optionalDependencies` (`^0.34.5`) so it installs when the platform supports it, but a missing/failed native install never breaks `npm install` or the CLI.

Optional (not top-level) is the right call: sharp is a large native module and forcing it as a hard dependency would bloat the CLI and break installs on unsupported platforms just for a logo.

## Verification (offline packed-artifact install, outside the monorepo)
- **Before:** `frankenbeast --help` → `ERR_MODULE_NOT_FOUND`, exit 1.
- **After (sharp omitted via `--omit=optional`):** `frankenbeast --help` → full help, **exit 0**.
- `beast-logger` + `run` unit tests green (112).

Part of proving the publish pipeline yields a runnable CLI. Pairs with #844 (files allowlist); a CI pack-and-install smoke test to catch this class automatically is planned as a follow-up guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)