### PR TITLE
fix(observer): retain batch queue on drain failure

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -187,10 +187,31 @@ describe('BatchAdapter — drain()', () => {
     const oldFlush = batch.flush(makeTrace('old'))
     const newFlush = batch.flush(makeTrace('new'))
 
-    await expect(newFlush).resolves.toBeUndefined()
     oldFailure.reject(new Error('old batch failed'))
     await expect(oldFlush).rejects.toThrow('old batch failed')
+    await expect(newFlush).resolves.toBeUndefined()
     expect((await batch.listTraceIds()).sort()).toEqual(['new', 'old'])
+  })
+
+  it('surfaces failures from follow-up size-triggered drains after the older drain succeeds', async () => {
+    const oldSuccess = deferred()
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        if (trace.id === 'old') return oldSuccess.promise
+        throw new Error('new batch failed')
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 1 })
+
+    const oldFlush = batch.flush(makeTrace('old'))
+    const newFlush = batch.flush(makeTrace('new'))
+    oldSuccess.resolve()
+
+    await expect(oldFlush).resolves.toBeUndefined()
+    await expect(newFlush).rejects.toThrow('new batch failed')
+    expect(await batch.listTraceIds()).toEqual(['new'])
   })
 
   it('drains a snapshot instead of chasing traces appended during the drain', async () => {
@@ -211,6 +232,26 @@ describe('BatchAdapter — drain()', () => {
 
     expect(received).toEqual(['initial'])
     expect(await batch.listTraceIds()).toEqual(['appended'])
+  })
+
+  it('sets the drain guard before invoking inner flush callbacks', async () => {
+    const received: string[] = []
+    let batch!: BatchAdapter
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        received.push(trace.id)
+        if (trace.id === 'initial') void batch.flush(makeTrace('appended'))
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    batch = new BatchAdapter({ adapter: inner, maxBatchSize: 1 })
+
+    await batch.flush(makeTrace('initial'))
+    await batch.drain()
+
+    expect(received).toEqual(['initial', 'appended'])
+    expect(await batch.listTraceIds()).toEqual([])
   })
 })
 
@@ -243,6 +284,31 @@ describe('BatchAdapter — stop()', () => {
     })
     await batch.stop()
     expect(clearFn).toHaveBeenCalledWith(42)
+  })
+
+  it('waits for traces appended during an in-flight drain before stopping', async () => {
+    const firstFlush = deferred()
+    const received: string[] = []
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        received.push(trace.id)
+        if (trace.id === 'initial') return firstFlush.promise
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    await batch.flush(makeTrace('initial'))
+    const inFlightDrain = batch.drain()
+    await batch.flush(makeTrace('appended'))
+    const stopPromise = batch.stop()
+    firstFlush.resolve()
+
+    await expect(inFlightDrain).resolves.toBeUndefined()
+    await expect(stopPromise).resolves.toBeUndefined()
+    expect(received).toEqual(['initial', 'appended'])
+    expect(await batch.listTraceIds()).toEqual([])
   })
 
   it('does not call clearInterval when no timer was started', async () => {

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -190,7 +190,7 @@ describe('BatchAdapter — drain()', () => {
     oldFailure.reject(new Error('old batch failed'))
     await expect(oldFlush).rejects.toThrow('old batch failed')
     await expect(newFlush).resolves.toBeUndefined()
-    expect((await batch.listTraceIds()).sort()).toEqual(['new', 'old'])
+    expect(await batch.listTraceIds()).toEqual(['old'])
   })
 
   it('surfaces failures from follow-up size-triggered drains after the older drain succeeds', async () => {
@@ -252,6 +252,27 @@ describe('BatchAdapter — drain()', () => {
 
     expect(received).toEqual(['initial', 'appended'])
     expect(await batch.listTraceIds()).toEqual([])
+  })
+
+  it('drops an older failed duplicate when a newer trace with the same id succeeds', async () => {
+    const older = { ...makeTrace('same-id'), goal: 'older' }
+    const newer = { ...makeTrace('same-id'), goal: 'newer' }
+    const inner = new InMemoryAdapter()
+    const calls: string[] = []
+    vi.spyOn(inner, 'flush').mockImplementation(async trace => {
+      calls.push(trace.goal)
+      if (trace.goal === 'older') throw new Error('stale write failed')
+      await InMemoryAdapter.prototype.flush.call(inner, trace)
+    })
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    await batch.flush(older)
+    await batch.flush(newer)
+    await batch.drain()
+
+    expect(await batch.listTraceIds()).toEqual(['same-id'])
+    expect(await batch.queryByTraceId('same-id')).toEqual(newer)
+    expect(calls).toEqual(['older', 'newer'])
   })
 })
 

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -22,6 +22,20 @@ class FailingFlushAdapter implements ExportAdapter {
   }
 }
 
+function deferred<T = void>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 // ── buffering ─────────────────────────────────────────────────────────────────
 
 describe('BatchAdapter — buffering', () => {
@@ -126,6 +140,77 @@ describe('BatchAdapter — drain()', () => {
     await batch.flush(makeTrace('q'))
     await batch.drain()
     expect(received.sort()).toEqual(['p', 'q'])
+  })
+
+  it('waits for every flush in a failed batch before retrying only failed traces', async () => {
+    const slowSuccess = deferred()
+    const calls: string[] = []
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        calls.push(trace.id)
+        if (trace.id === 'slow-success') return slowSuccess.promise
+        throw new Error('fast failure')
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    await batch.flush(makeTrace('fast-fail'))
+    await batch.flush(makeTrace('slow-success'))
+    const drainPromise = batch.drain()
+    let rejectedBeforeSlowFlushSettled = false
+    drainPromise.catch(() => { rejectedBeforeSlowFlushSettled = true })
+    await Promise.resolve()
+
+    expect(rejectedBeforeSlowFlushSettled).toBe(false)
+
+    slowSuccess.resolve()
+    await expect(drainPromise).rejects.toThrow('fast failure')
+    expect(await batch.listTraceIds()).toEqual(['fast-fail'])
+
+    await expect(batch.drain()).rejects.toThrow('fast failure')
+    expect(calls).toEqual(['fast-fail', 'slow-success', 'fast-fail'])
+  })
+
+  it('does not fail a newly queued trace because an older drain rejects', async () => {
+    const oldFailure = deferred()
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        if (trace.id === 'old') return oldFailure.promise
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 1 })
+
+    const oldFlush = batch.flush(makeTrace('old'))
+    const newFlush = batch.flush(makeTrace('new'))
+
+    await expect(newFlush).resolves.toBeUndefined()
+    oldFailure.reject(new Error('old batch failed'))
+    await expect(oldFlush).rejects.toThrow('old batch failed')
+    expect((await batch.listTraceIds()).sort()).toEqual(['new', 'old'])
+  })
+
+  it('drains a snapshot instead of chasing traces appended during the drain', async () => {
+    const received: string[] = []
+    let batch!: BatchAdapter
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        received.push(trace.id)
+        if (trace.id === 'initial') await batch.flush(makeTrace('appended'))
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    await batch.flush(makeTrace('initial'))
+    await batch.drain()
+
+    expect(received).toEqual(['initial'])
+    expect(await batch.listTraceIds()).toEqual(['appended'])
   })
 })
 

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -2,9 +2,24 @@ import { describe, it, expect, vi } from 'vitest'
 import { BatchAdapter } from './BatchAdapter.js'
 import { InMemoryAdapter } from '../../export/InMemoryAdapter.js'
 import type { Trace } from '../../core/types.js'
+import type { ExportAdapter } from '../../export/ExportAdapter.js'
 
 function makeTrace(id: string): Trace {
   return { id, goal: 'test', status: 'completed', startedAt: Date.now(), spans: [] }
+}
+
+class FailingFlushAdapter implements ExportAdapter {
+  async flush(_trace: Trace): Promise<void> {
+    throw new Error('database temporarily locked')
+  }
+
+  async queryByTraceId(_traceId: string): Promise<Trace | null> {
+    return null
+  }
+
+  async listTraceIds(): Promise<string[]> {
+    return []
+  }
 }
 
 // ── buffering ─────────────────────────────────────────────────────────────────
@@ -85,6 +100,17 @@ describe('BatchAdapter — drain()', () => {
     const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 5 })
     await batch.drain()
     expect(flushSpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps buffered traces when the inner adapter rejects during drain', async () => {
+    const batch = new BatchAdapter({ adapter: new FailingFlushAdapter(), maxBatchSize: 100 })
+    const trace = makeTrace('retry-me')
+
+    await batch.flush(trace)
+    await expect(batch.drain()).rejects.toThrow('database temporarily locked')
+
+    expect(await batch.queryByTraceId('retry-me')).toEqual(trace)
+    expect(await batch.listTraceIds()).toEqual(['retry-me'])
   })
 
   it('sends all batched traces in parallel (order-independent)', async () => {

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -311,6 +311,31 @@ describe('BatchAdapter — stop()', () => {
     expect(await batch.listTraceIds()).toEqual([])
   })
 
+  it('attempts appended traces before stop rejects an older in-flight drain failure', async () => {
+    const oldFailure = deferred()
+    const received: string[] = []
+    const inner: ExportAdapter = {
+      async flush(trace) {
+        received.push(trace.id)
+        if (trace.id === 'old') return oldFailure.promise
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    await batch.flush(makeTrace('old'))
+    const inFlightDrain = batch.drain()
+    await batch.flush(makeTrace('appended'))
+    const stopPromise = batch.stop()
+    oldFailure.reject(new Error('old drain failed'))
+
+    await expect(inFlightDrain).rejects.toThrow('old drain failed')
+    await expect(stopPromise).rejects.toThrow('old drain failed')
+    expect(received).toEqual(['old', 'old', 'appended'])
+    expect(await batch.listTraceIds()).toEqual(['old'])
+  })
+
   it('does not call clearInterval when no timer was started', async () => {
     const clearFn = vi.fn()
     const batch = new BatchAdapter({

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -61,7 +61,7 @@ export class BatchAdapter implements ExportAdapter {
 
     if (options.flushIntervalMs && options.flushIntervalMs > 0) {
       const si = options.setInterval ?? setInterval
-      this.timer = si(() => { void this.drain() }, options.flushIntervalMs)
+      this.timer = si(() => { void this.drain().catch(() => undefined) }, options.flushIntervalMs)
     }
   }
 
@@ -70,7 +70,7 @@ export class BatchAdapter implements ExportAdapter {
     warnIfTraceHasActiveSpans(trace, 'BatchAdapter')
     this.buffer.push(trace)
     if (this.buffer.length >= this.maxBatchSize) {
-      await this.drainForSizeTriggeredFlush()
+      await this.drainForSizeTriggeredFlush(trace)
     }
   }
 
@@ -88,7 +88,10 @@ export class BatchAdapter implements ExportAdapter {
       } catch (error) {
         currentFailure = error
       }
-      if (this.buffer.length > 0) await this.drain()
+      if (this.buffer.length > 0) {
+        await this.drain()
+        return
+      }
       if (currentFailure !== null) {
         throw currentFailure instanceof Error ? currentFailure : new Error(String(currentFailure))
       }
@@ -105,7 +108,7 @@ export class BatchAdapter implements ExportAdapter {
     }
   }
 
-  private async drainForSizeTriggeredFlush(): Promise<void> {
+  private async drainForSizeTriggeredFlush(triggerTrace: Trace): Promise<void> {
     if (this.drainPromise === null) {
       await this.drain()
       return
@@ -115,6 +118,15 @@ export class BatchAdapter implements ExportAdapter {
     try {
       await currentDrain
     } catch {
+      if (this.buffer.length > 0) {
+        try {
+          await this.drain()
+        } catch (error) {
+          if (this.buffer.includes(triggerTrace)) {
+            throw error instanceof Error ? error : new Error(String(error))
+          }
+        }
+      }
       return
     }
 
@@ -127,12 +139,24 @@ export class BatchAdapter implements ExportAdapter {
     const results = await Promise.allSettled(batch.map(t => this.inner.flush(t)))
     const failures: unknown[] = []
 
+    const latestSucceededIndexByTraceId = new Map<string, number>()
+    for (let i = 0; i < results.length; i++) {
+      if (results[i]?.status === 'fulfilled') latestSucceededIndexByTraceId.set(batch[i]!.id, i)
+    }
+
     for (let i = 0; i < results.length; i++) {
       const result = results[i]
+      const trace = batch[i]!
       if (result.status === 'fulfilled') {
-        const index = this.buffer.indexOf(batch[i]!)
+        const index = this.buffer.indexOf(trace)
         if (index !== -1) this.buffer.splice(index, 1)
       } else {
+        const latestSucceededIndex = latestSucceededIndexByTraceId.get(trace.id)
+        if (latestSucceededIndex !== undefined && latestSucceededIndex > i) {
+          const index = this.buffer.indexOf(trace)
+          if (index !== -1) this.buffer.splice(index, 1)
+          continue
+        }
         failures.push(result.reason)
       }
     }

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -52,6 +52,7 @@ export class BatchAdapter implements ExportAdapter {
   private readonly buffer: Trace[] = []
   private timer: ReturnType<typeof setInterval> | null = null
   private readonly clearIntervalFn: (id: ReturnType<typeof setInterval>) => void
+  private drainPromise: Promise<void> | null = null
 
   constructor(options: BatchAdapterOptions) {
     this.inner = options.adapter
@@ -75,12 +76,26 @@ export class BatchAdapter implements ExportAdapter {
 
   /**
    * Forwards all buffered traces to the inner adapter in parallel and clears
-   * the buffer. Safe to call on an empty buffer (no-op).
+   * only successfully persisted traces from the buffer. Safe to call on an
+   * empty buffer (no-op).
    */
   async drain(): Promise<void> {
-    if (this.buffer.length === 0) return
-    const batch = this.buffer.splice(0, this.buffer.length)
-    await Promise.all(batch.map(t => this.inner.flush(t)))
+    if (this.drainPromise !== null) return this.drainPromise
+
+    this.drainPromise = this.drainBufferedTraces()
+    try {
+      await this.drainPromise
+    } finally {
+      this.drainPromise = null
+    }
+  }
+
+  private async drainBufferedTraces(): Promise<void> {
+    while (this.buffer.length > 0) {
+      const batch = [...this.buffer]
+      await Promise.all(batch.map(t => this.inner.flush(t)))
+      this.buffer.splice(0, batch.length)
+    }
   }
 
   /**

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -53,6 +53,7 @@ export class BatchAdapter implements ExportAdapter {
   private timer: ReturnType<typeof setInterval> | null = null
   private readonly clearIntervalFn: (id: ReturnType<typeof setInterval>) => void
   private drainPromise: Promise<void> | null = null
+  private drainRequestedDuringDrain = false
 
   constructor(options: BatchAdapterOptions) {
     this.inner = options.adapter
@@ -70,6 +71,10 @@ export class BatchAdapter implements ExportAdapter {
     warnIfTraceHasActiveSpans(trace, 'BatchAdapter')
     this.buffer.push(trace)
     if (this.buffer.length >= this.maxBatchSize) {
+      if (this.drainPromise !== null) {
+        this.drainRequestedDuringDrain = true
+        return
+      }
       await this.drain()
     }
   }
@@ -82,19 +87,41 @@ export class BatchAdapter implements ExportAdapter {
   async drain(): Promise<void> {
     if (this.drainPromise !== null) return this.drainPromise
 
+    this.drainRequestedDuringDrain = false
     this.drainPromise = this.drainBufferedTraces()
+    let drainSucceeded = false
     try {
       await this.drainPromise
+      drainSucceeded = true
     } finally {
       this.drainPromise = null
+      if (drainSucceeded && this.drainRequestedDuringDrain && this.buffer.length >= this.maxBatchSize) {
+        this.drainRequestedDuringDrain = false
+        void this.drain().catch(() => undefined)
+      }
     }
   }
 
   private async drainBufferedTraces(): Promise<void> {
-    while (this.buffer.length > 0) {
-      const batch = [...this.buffer]
-      await Promise.all(batch.map(t => this.inner.flush(t)))
-      this.buffer.splice(0, batch.length)
+    const batch = [...this.buffer]
+    if (batch.length === 0) return
+
+    const results = await Promise.allSettled(batch.map(t => this.inner.flush(t)))
+    const failures: unknown[] = []
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i]
+      if (result.status === 'fulfilled') {
+        const index = this.buffer.indexOf(batch[i]!)
+        if (index !== -1) this.buffer.splice(index, 1)
+      } else {
+        failures.push(result.reason)
+      }
+    }
+
+    if (failures.length > 0) {
+      const firstFailure = failures[0]
+      throw firstFailure instanceof Error ? firstFailure : new Error(String(firstFailure))
     }
   }
 

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -53,7 +53,6 @@ export class BatchAdapter implements ExportAdapter {
   private timer: ReturnType<typeof setInterval> | null = null
   private readonly clearIntervalFn: (id: ReturnType<typeof setInterval>) => void
   private drainPromise: Promise<void> | null = null
-  private drainRequestedDuringDrain = false
 
   constructor(options: BatchAdapterOptions) {
     this.inner = options.adapter
@@ -71,11 +70,7 @@ export class BatchAdapter implements ExportAdapter {
     warnIfTraceHasActiveSpans(trace, 'BatchAdapter')
     this.buffer.push(trace)
     if (this.buffer.length >= this.maxBatchSize) {
-      if (this.drainPromise !== null) {
-        this.drainRequestedDuringDrain = true
-        return
-      }
-      await this.drain()
+      await this.drainForSizeTriggeredFlush()
     }
   }
 
@@ -85,25 +80,40 @@ export class BatchAdapter implements ExportAdapter {
    * empty buffer (no-op).
    */
   async drain(): Promise<void> {
-    if (this.drainPromise !== null) return this.drainPromise
+    if (this.drainPromise !== null) {
+      const currentDrain = this.drainPromise
+      await currentDrain
+      if (this.buffer.length > 0) await this.drain()
+      return
+    }
 
-    this.drainRequestedDuringDrain = false
-    this.drainPromise = this.drainBufferedTraces()
-    let drainSucceeded = false
+    const batch = [...this.buffer]
+    const currentDrain = Promise.resolve().then(() => this.drainBufferedTraces(batch))
+    this.drainPromise = currentDrain
     try {
-      await this.drainPromise
-      drainSucceeded = true
+      await currentDrain
     } finally {
-      this.drainPromise = null
-      if (drainSucceeded && this.drainRequestedDuringDrain && this.buffer.length >= this.maxBatchSize) {
-        this.drainRequestedDuringDrain = false
-        void this.drain().catch(() => undefined)
-      }
+      if (this.drainPromise === currentDrain) this.drainPromise = null
     }
   }
 
-  private async drainBufferedTraces(): Promise<void> {
-    const batch = [...this.buffer]
+  private async drainForSizeTriggeredFlush(): Promise<void> {
+    if (this.drainPromise === null) {
+      await this.drain()
+      return
+    }
+
+    const currentDrain = this.drainPromise
+    try {
+      await currentDrain
+    } catch {
+      return
+    }
+
+    if (this.buffer.length >= this.maxBatchSize) await this.drain()
+  }
+
+  private async drainBufferedTraces(batch: Trace[]): Promise<void> {
     if (batch.length === 0) return
 
     const results = await Promise.allSettled(batch.map(t => this.inner.flush(t)))

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -82,8 +82,16 @@ export class BatchAdapter implements ExportAdapter {
   async drain(): Promise<void> {
     if (this.drainPromise !== null) {
       const currentDrain = this.drainPromise
-      await currentDrain
+      let currentFailure: unknown = null
+      try {
+        await currentDrain
+      } catch (error) {
+        currentFailure = error
+      }
       if (this.buffer.length > 0) await this.drain()
+      if (currentFailure !== null) {
+        throw currentFailure instanceof Error ? currentFailure : new Error(String(currentFailure))
+      }
       return
     }
 


### PR DESCRIPTION
## Summary
- keep BatchAdapter buffered traces queued until inner adapter flushes complete successfully
- serialize concurrent drain calls through a shared in-flight promise
- add a regression test that proves failed drains leave traces queryable and retryable

## Test Plan
- npm --prefix packages/franken-observer test -- --run src/adapters/batch/BatchAdapter.test.ts -t "keeps buffered traces"
- npm --prefix packages/franken-observer test -- --run src/adapters/batch/BatchAdapter.test.ts
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run build
- npm --prefix packages/franken-observer test

Closes #773