### PR TITLE
fix(planner): reject dangling raw DAG edges

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -111,6 +111,7 @@ export class PlanGraph {
   }
 
   hasCycle(): boolean {
+    this._assertEdgesReferenceKnownNodes();
     return this._kahn().sorted.length !== this._nodes.size;
   }
 
@@ -121,6 +122,7 @@ export class PlanGraph {
    * Throws CyclicDependencyError if the graph contains a cycle.
    */
   topoSort(): Task[] {
+    this._assertEdgesReferenceKnownNodes();
     const { sorted } = this._kahn();
     if (sorted.length !== this._nodes.size) {
       throw new CyclicDependencyError(
@@ -202,6 +204,19 @@ export class PlanGraph {
   }
 
   // ─── Private helpers ───────────────────────────────────────────────────────
+
+  private _assertEdgesReferenceKnownNodes(): void {
+    for (const [id, deps] of this._edges) {
+      if (!this._nodes.has(id)) {
+        throw new Error(`Graph edge references unknown task node '${id}'`);
+      }
+      for (const dep of deps) {
+        if (!this._nodes.has(dep)) {
+          throw new Error(`Task '${id}' depends on unknown dependency node '${dep}'`);
+        }
+      }
+    }
+  }
 
   /** Kahn's BFS topological sort. Returns sorted ids (may be shorter than nodes if cyclic). */
   private _kahn(): { sorted: TaskId[] } {

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -156,6 +156,30 @@ describe('PlanGraph — cycle detection', () => {
     const g = PlanGraph.createWithRawEdges(nodes, edges);
     expect(() => g.topoSort()).toThrowError(CyclicDependencyError);
   });
+
+  it('topoSort rejects raw edges whose task id is missing from nodes', () => {
+    const a = makeTask('a');
+    const b = makeTask('b');
+    const dangling = createTaskId('dangling');
+    const nodes = new Map([[a.id, a], [b.id, b]]);
+    const edges = new Map([
+      [dangling, new Set([a.id])],
+      [b.id, new Set([dangling])],
+    ]);
+    const g = PlanGraph.createWithRawEdges(nodes, edges);
+
+    expect(() => g.topoSort()).toThrow(/unknown task node 'dangling'/);
+  });
+
+  it('topoSort rejects raw dependencies that are missing from nodes', () => {
+    const a = makeTask('a');
+    const missing = createTaskId('missing');
+    const nodes = new Map([[a.id, a]]);
+    const edges = new Map([[a.id, new Set([missing])]]);
+    const g = PlanGraph.createWithRawEdges(nodes, edges);
+
+    expect(() => g.topoSort()).toThrow(/unknown dependency node 'missing'/);
+  });
 });
 
 // ─── Mutations ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- validate raw DAG edge maps before cycle checks/topological sorting
- reject dangling edge task IDs and dependency IDs with descriptive errors
- add regression coverage for raw edge task IDs and dependency IDs missing from nodes

## Test Plan
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-planner test -- tests/unit/core/dag.test.ts
- npm --prefix packages/franken-planner test
- npm --prefix packages/franken-planner run typecheck
- npm --prefix packages/franken-planner run build
- npm --prefix packages/franken-planner run lint
- npx turbo run test --filter=@franken/planner

Closes #847