### PR TITLE
fix(observer): set SQLite busy timeout

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+
+const { pragmaMock, execMock, prepareMock, transactionMock, closeMock } = vi.hoisted(() => ({
+  pragmaMock: vi.fn(),
+  execMock: vi.fn(),
+  prepareMock: vi.fn(),
+  transactionMock: vi.fn(),
+  closeMock: vi.fn(),
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(function MockDatabase() {
+    return {
+      pragma: pragmaMock,
+      exec: execMock,
+      prepare: prepareMock,
+      transaction: transactionMock,
+      close: closeMock,
+    }
+  }),
+}))
+
+import { SQLiteAdapter } from './SQLiteAdapter.js'
+
+describe('SQLiteAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('configures a busy timeout so concurrent writers wait for locks', () => {
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+
+    expect(Database).toHaveBeenCalledWith('/tmp/traces.db')
+    expect(pragmaMock).toHaveBeenCalledWith('busy_timeout = 5000')
+
+    adapter.close()
+  })
+})

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -82,6 +82,7 @@ export class SQLiteAdapter implements ExportAdapter {
 
   constructor(filePath: string) {
     this.db = new Database(filePath)
+    this.db.pragma('busy_timeout = 5000')
     this.db.pragma('journal_mode = WAL')
     this.db.pragma('foreign_keys = ON')
     this.db.exec(CREATE_TABLES)


### PR DESCRIPTION
## Summary
- Configure SQLiteAdapter connections with PRAGMA busy_timeout = 5000.
- Add a unit regression test that verifies the pragma is applied during adapter initialization.

## Test Plan
- npm --workspace @franken/observer exec -- vitest run src/adapters/sqlite/SQLiteAdapter.test.ts --reporter=verbose
- npm --workspace @franken/observer run test:integration -- src/adapters/sqlite/SQLiteAdapter.integration.test.ts
- npm --workspace @franken/observer run typecheck
- npm --workspace @franken/observer run build
- npm --workspace @franken/observer test -- --run

Closes #702