### PR TITLE
fix(governor): guard signature buffer lengths

### DIFF
--- a/packages/franken-governor/src/security/signature-verifier.ts
+++ b/packages/franken-governor/src/security/signature-verifier.ts
@@ -26,11 +26,12 @@ export class SignatureVerifier {
 
   verify(payload: string, signature: string): boolean {
     const expected = this.sign(payload);
-    if (expected.length !== signature.length) return false;
+    if (!/^[0-9a-f]{64}$/i.test(signature)) return false;
 
-    return timingSafeEqual(
-      Buffer.from(expected, 'hex'),
-      Buffer.from(signature, 'hex'),
-    );
+    const expectedBuffer = Buffer.from(expected, 'hex');
+    const signatureBuffer = Buffer.from(signature, 'hex');
+    if (expectedBuffer.length !== signatureBuffer.length) return false;
+
+    return timingSafeEqual(expectedBuffer, signatureBuffer);
   }
 }

--- a/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
+++ b/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
@@ -30,6 +30,11 @@ describe('SignatureVerifier', () => {
     expect(otherVerifier.verify('payload', sig)).toBe(false);
   });
 
+  it('verify() returns false instead of throwing for a 64-character non-hex signature', () => {
+    expect(() => verifier.verify('payload', 'z'.repeat(64))).not.toThrow();
+    expect(verifier.verify('payload', 'z'.repeat(64))).toBe(false);
+  });
+
   it('sign + verify round-trip succeeds for approval response payloads', () => {
     const payload = formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' });
     const sig = verifier.sign(payload);


### PR DESCRIPTION
## Summary
- Reject non-hex approval signatures before decoding buffers
- Compare decoded HMAC buffer lengths before timingSafeEqual
- Add a regression test for 64-character non-hex signatures returning false instead of throwing

## Test Plan
- npm --prefix packages/franken-governor test -- tests/unit/security/signature-verifier.test.ts
- npx turbo run test --filter=@franken/governor
- npx turbo run typecheck --filter=@franken/governor
- npx turbo run build --filter=@franken/governor

Closes #849