### PR TITLE
ci: add publish-smoke + workspace-dep guards to lock the boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
 
       - run: npx turbo run build test lint
 
+      - name: Phantom dependency check (every runtime import is declared)
+        run: node scripts/check-phantom-deps.mjs
+
   publish-smoke:
     name: publish smoke (pack + offline install + run)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,33 @@ jobs:
 
       - run: npm run lint:security
 
+      - name: Workspace dependency hygiene (no wildcard internal deps)
+        run: node scripts/check-workspace-deps.mjs
+
       - run: npx turbo run build test lint
+
+  publish-smoke:
+    name: publish smoke (pack + offline install + run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Enable packageManager-pinned npm
+        run: |
+          corepack enable npm
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
+      - run: npm ci
+
+      # Packs every publishable package, installs the CLI + its workspace deps
+      # into a clean project OUTSIDE the monorepo (optional deps omitted), and
+      # runs `frankenbeast --help`. Catches phantom/undeclared deps, packages
+      # shipping no dist, and broken bins — the class of breakage the in-repo
+      # test suite hides via workspace hoisting.
+      - name: Publish smoke test
+        run: node scripts/publish-smoke.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.3.0",
         "@vitest/coverage-v8": "^4.1.9",
+        "acorn": "^8.17.0",
         "better-sqlite3": "^12.6.2",
         "sharp": "^0.34.5",
         "turbo": "^2.10.3",
@@ -3290,7 +3291,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7555,6 +7558,7 @@
       "license": "MIT",
       "dependencies": {
         "@franken/types": "0.7.6",
+        "acorn": "^8.17.0",
         "acorn-typescript": "^1.4.13",
         "hono": "^4.12.27",
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.3.0",
     "@vitest/coverage-v8": "^4.1.9",
+    "acorn": "^8.17.0",
     "better-sqlite3": "^12.6.2",
     "sharp": "^0.34.5",
     "turbo": "^2.10.3",

--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@franken/types": "0.7.6",
+    "acorn": "^8.17.0",
     "acorn-typescript": "^1.4.13",
     "hono": "^4.12.27",
     "zod": "^3.24.0"

--- a/scripts/check-phantom-deps.mjs
+++ b/scripts/check-phantom-deps.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Phantom-dependency guard.
+ *
+ * For every publishable package, parses its BUILT output (dist/) with acorn and
+ * asserts every bare module specifier it imports at runtime — static
+ * `import`/`export ... from`, dynamic `import('x')`, and `require('x')` — is
+ * declared in that package's own dependencies / optionalDependencies /
+ * peerDependencies.
+ *
+ * This catches the class of bug the in-monorepo test suite hides via workspace
+ * hoisting: a runtime import of a package that isn't declared (e.g. the
+ * undeclared `sharp` that crashed the installed CLI, the undeclared `acorn`
+ * imported by the logic-loop evaluator, or an internal `@franken/*` dep
+ * silently dropped from `dependencies`). Using a real parser (not a regex)
+ * means comments and string literals like `{ name: '@franken/observer' }` are
+ * not mistaken for imports, and scanning dist (not src) ignores type-only
+ * imports that are erased at compile time.
+ *
+ * Run: node scripts/check-phantom-deps.mjs   (requires a prior build)
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { builtinModules } from 'node:module';
+import { parse } from 'acorn';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgsDir = join(repoRoot, 'packages');
+const NODE_BUILTINS = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+/** Resolve a bare specifier to its package name (handles scoped + subpaths). */
+function packageOf(spec) {
+  if (spec.startsWith('@')) {
+    const [scope, name] = spec.split('/');
+    return name ? `${scope}/${name}` : spec;
+  }
+  return spec.split('/')[0];
+}
+
+const isBare = (spec) =>
+  typeof spec === 'string' &&
+  spec.length > 0 &&
+  !spec.startsWith('.') &&
+  !spec.startsWith('/') &&
+  !spec.startsWith('node:') &&
+  !NODE_BUILTINS.has(spec);
+
+function jsFilesUnder(dir) {
+  const out = [];
+  const walk = (d) => {
+    for (const entry of readdirSync(d)) {
+      const full = join(d, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (/\.(js|mjs|cjs)$/.test(entry)) out.push(full);
+    }
+  };
+  if (existsSync(dir)) walk(dir);
+  return out;
+}
+
+/** Collect runtime import specifiers from one JS file via acorn AST walk. */
+function importsIn(file) {
+  const src = readFileSync(file, 'utf8');
+  let ast;
+  for (const sourceType of ['module', 'script']) {
+    try {
+      ast = parse(src, { ecmaVersion: 'latest', sourceType, allowReturnOutsideFunction: true });
+      break;
+    } catch {
+      /* try next sourceType */
+    }
+  }
+  if (!ast) throw new Error(`acorn could not parse ${file}`);
+
+  const specs = new Set();
+  const visit = (node) => {
+    if (!node || typeof node.type !== 'string') return;
+    switch (node.type) {
+      case 'ImportDeclaration':
+      case 'ExportNamedDeclaration':
+      case 'ExportAllDeclaration':
+        if (node.source?.type === 'Literal' && typeof node.source.value === 'string') specs.add(node.source.value);
+        break;
+      case 'ImportExpression': // dynamic import('x')
+        if (node.source?.type === 'Literal' && typeof node.source.value === 'string') specs.add(node.source.value);
+        break;
+      case 'CallExpression':
+        if (
+          node.callee?.type === 'Identifier' &&
+          node.callee.name === 'require' &&
+          node.arguments[0]?.type === 'Literal' &&
+          typeof node.arguments[0].value === 'string'
+        ) {
+          specs.add(node.arguments[0].value);
+        }
+        break;
+      default:
+        break;
+    }
+    for (const key of Object.keys(node)) {
+      const child = node[key];
+      if (Array.isArray(child)) child.forEach((c) => c && typeof c.type === 'string' && visit(c));
+      else if (child && typeof child.type === 'string') visit(child);
+    }
+  };
+  visit(ast);
+
+  return new Set([...specs].filter(isBare).map(packageOf));
+}
+
+let failures = 0;
+for (const name of readdirSync(pkgsDir)) {
+  const pkgDir = join(pkgsDir, name);
+  let pj;
+  try {
+    pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+  } catch {
+    continue;
+  }
+  if (pj.private) continue;
+  const declared = new Set([
+    ...Object.keys(pj.dependencies ?? {}),
+    ...Object.keys(pj.optionalDependencies ?? {}),
+    ...Object.keys(pj.peerDependencies ?? {}),
+  ]);
+  const dist = join(pkgDir, 'dist');
+  if (!existsSync(dist)) {
+    console.error(`FAIL: ${pj.name} has no dist/ — run the build before this check`);
+    failures += 1;
+    continue;
+  }
+  const used = new Set();
+  for (const f of jsFilesUnder(dist)) for (const s of importsIn(f)) used.add(s);
+  // A package importing itself by name is always allowed (barrel re-exports).
+  used.delete(pj.name);
+  const missing = [...used].filter((s) => !declared.has(s)).sort();
+  for (const s of missing) {
+    console.error(`FAIL: ${pj.name} imports "${s}" at runtime but does not declare it as a dependency`);
+    failures += 1;
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} undeclared (phantom) dependency import(s) found.`);
+  process.exit(1);
+}
+console.log('phantom-dependency check OK — every runtime import in dist is declared');

--- a/scripts/check-workspace-deps.mjs
+++ b/scripts/check-workspace-deps.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Workspace dependency hygiene guard.
+ *
+ * Fails if any publishable package declares an internal `@franken/*` dependency
+ * with a `"*"` specifier. `*` only resolves via local workspace linking; once
+ * published it means "latest of whatever exists", giving no version coherence
+ * and breaking off-registry installs. release-please rewrites pinned versions,
+ * so `*` must never reappear.
+ *
+ * Run: node scripts/check-workspace-deps.mjs
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgsDir = join(repoRoot, 'packages');
+
+let failures = 0;
+for (const name of readdirSync(pkgsDir)) {
+  let pj;
+  try {
+    pj = JSON.parse(readFileSync(join(pkgsDir, name, 'package.json'), 'utf8'));
+  } catch {
+    continue;
+  }
+  const groups = ['dependencies', 'optionalDependencies', 'peerDependencies'];
+  for (const g of groups) {
+    for (const [dep, spec] of Object.entries(pj[g] ?? {})) {
+      if (dep.startsWith('@franken/') && spec === '*') {
+        console.error(`FAIL: ${pj.name} → ${g}.${dep} is "*" (must be a pinned version, not a wildcard)`);
+        failures += 1;
+      }
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} wildcard internal-dependency specifier(s) found.`);
+  process.exit(1);
+}
+console.log('workspace dependency hygiene OK — no "*" internal specifiers');

--- a/scripts/publish-smoke.mjs
+++ b/scripts/publish-smoke.mjs
@@ -3,62 +3,35 @@
  * Publish smoke test — proves the packages install and run the way a real
  * `npm install` off the registry would, catching the class of bug that the
  * in-monorepo test suite hides via workspace hoisting:
- *   - phantom/undeclared runtime dependencies (import X without depending on X)
- *   - packages that ship no `dist` because they lack a `files` allowlist
- *   - broken/ missing bin targets
+ *   - packages that ship no `dist` because they lack a `files` allowlist,
+ *   - published `bin` targets missing from the tarball,
+ *   - a CLI that crashes at startup (e.g. a missing optionalDependency).
+ *
+ * Undeclared/phantom *dependencies* are caught separately and more precisely by
+ * scripts/check-phantom-deps.mjs (static AST scan); this script complements it
+ * with a real pack + install + execute.
  *
  * It does NOT publish anything. It:
  *   1. builds the workspace,
- *   2. `npm pack`s every publishable package into a staging dir,
- *   3. installs the CLI + its workspace deps into a clean temp project
- *      OUTSIDE the monorepo, with optional deps omitted (so a missing
- *      optionalDependency like sharp must degrade gracefully, not crash),
- *   4. runs `frankenbeast --help` and asserts a clean exit + expected output.
+ *   2. `npm pack`s every publishable package into a staging dir (asserting each
+ *      ships dist/ files),
+ *   3. installs the packages that carry bins + their workspace deps into a
+ *      clean temp project OUTSIDE the monorepo, with optional deps omitted (so
+ *      a missing optionalDependency must degrade, not crash),
+ *   4. asserts every declared bin file exists, and runs each executable CLI's
+ *      `--help`, asserting a clean exit and non-empty output.
  *
  * Run: node scripts/publish-smoke.mjs
  */
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const run = (cmd, args, opts = {}) =>
-  execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', ...opts });
-
-function log(msg) {
-  console.log(`[publish-smoke] ${msg}`);
-}
-
-// Packages whose install+run we assert. The orchestrator ships the
-// `frankenbeast` CLI; its workspace deps must all resolve from local tarballs.
-const CLI_DEP_DIRS = [
-  'franken-types',
-  'franken-observer',
-  'franken-brain',
-  'franken-planner',
-  'franken-critique',
-  'franken-governor',
-  'franken-orchestrator',
-];
-
-function publishablePackages() {
-  const dir = join(repoRoot, 'packages');
-  const out = [];
-  for (const name of readdirSync(dir)) {
-    const pjPath = join(dir, name, 'package.json');
-    let pj;
-    try {
-      pj = JSON.parse(readFileSync(pjPath, 'utf8'));
-    } catch {
-      continue;
-    }
-    if (pj.private) continue;
-    out.push({ name, dir: join(dir, name), pkg: pj });
-  }
-  return out;
-}
+const run = (cmd, args, opts = {}) => execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', ...opts });
+const log = (msg) => console.log(`[publish-smoke] ${msg}`);
 
 let failures = 0;
 const fail = (msg) => {
@@ -66,30 +39,59 @@ const fail = (msg) => {
   failures += 1;
 };
 
+// Packages we install + run. web is a browser SPA (no runtime bin) so it is
+// packed/dist-checked but not installed for execution here.
+const RUNTIME_DIRS = [
+  'franken-types',
+  'franken-observer',
+  'franken-brain',
+  'franken-planner',
+  'franken-critique',
+  'franken-governor',
+  'franken-orchestrator',
+  'franken-mcp-suite',
+  'live-bench',
+];
+
+// Executable CLIs whose `--help` must run cleanly. Stdio-server bins
+// (e.g. fbeast-mcp) are asserted to exist but not executed.
+const EXECUTABLE_BINS = [
+  { bin: 'frankenbeast', mustMatch: /Usage: frankenbeast/ },
+  { bin: 'fbeast' },
+  { bin: 'fbeast-live-bench' },
+];
+
+function publishablePackages() {
+  const dir = join(repoRoot, 'packages');
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    let pj;
+    try {
+      pj = JSON.parse(readFileSync(join(dir, name, 'package.json'), 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!pj.private) out.push({ name, dir: join(dir, name), pkg: pj });
+  }
+  return out;
+}
+
 // 1. Build
 log('building workspace…');
 run('npx', ['turbo', 'run', 'build'], { cwd: repoRoot, stdio: 'inherit' });
 
-// 2. Pack every publishable package into a staging dir
+// 2. Pack + assert dist ships
 const stage = mkdtempSync(join(tmpdir(), 'fbeast-pack-'));
 const pkgs = publishablePackages();
 log(`packing ${pkgs.length} publishable packages → ${stage}`);
 for (const p of pkgs) {
   run('npm', ['pack', '--pack-destination', stage], { cwd: p.dir });
-  // Assert the tarball actually contains dist/ files (catches missing `files`
-  // allowlist shipping an empty package).
   const dry = run('npm', ['pack', '--dry-run', '--json'], { cwd: p.dir });
-  const files = JSON.parse(dry)[0].files.map((f) => f.path);
-  const distCount = files.filter((f) => f.startsWith('dist/')).length;
-  if (distCount === 0) {
-    fail(`${p.name} packs 0 dist files — did you forget "files": ["dist"]?`);
-  } else {
-    log(`  ${p.name}: ${distCount} dist files`);
-  }
+  const distCount = JSON.parse(dry)[0].files.filter((f) => f.path.startsWith('dist/')).length;
+  if (distCount === 0) fail(`${p.name} packs 0 dist files — did you forget "files": ["dist"]?`);
+  else log(`  ${p.name}: ${distCount} dist files`);
 }
 
-// 3. Install the CLI + workspace deps into a clean temp project (no monorepo),
-//    omitting optional deps so a missing optionalDependency must degrade.
 const tarballFor = (dirName) => {
   const pj = JSON.parse(readFileSync(join(repoRoot, 'packages', dirName, 'package.json'), 'utf8'));
   const base = pj.name.replace('@', '').replace('/', '-');
@@ -98,27 +100,39 @@ const tarballFor = (dirName) => {
   return join(stage, hit);
 };
 
+// 3. Install into a clean project outside the monorepo, optional deps omitted.
 const proj = mkdtempSync(join(tmpdir(), 'fbeast-install-'));
 writeFileSync(join(proj, 'package.json'), JSON.stringify({ name: 'smoke', private: true }, null, 2));
-const tarballs = CLI_DEP_DIRS.map(tarballFor);
-log('installing packed CLI + deps (optional omitted) into a clean project…');
-run('npm', ['install', '--no-audit', '--no-fund', '--omit=optional', ...tarballs], { cwd: proj, stdio: 'inherit' });
+log('installing packed packages (optional omitted) into a clean project…');
+run('npm', ['install', '--no-audit', '--no-fund', '--omit=optional', ...RUNTIME_DIRS.map(tarballFor)], {
+  cwd: proj,
+  stdio: 'inherit',
+});
 
-// 4. Run the installed CLI
-log('running `frankenbeast --help` from the installed artifact…');
-let help = '';
-try {
-  help = run(join(proj, 'node_modules', '.bin', 'frankenbeast'), ['--help'], { cwd: proj });
-} catch (err) {
-  fail(`frankenbeast --help crashed: ${err.stderr || err.message}`);
-}
-if (help && !/Usage: frankenbeast/.test(help)) {
-  fail('frankenbeast --help did not print the expected usage banner');
-} else if (help) {
-  log('  CLI ran and printed usage ✓');
+// 4a. Every declared bin file must exist in the installed package.
+for (const dirName of RUNTIME_DIRS) {
+  const pj = JSON.parse(readFileSync(join(repoRoot, 'packages', dirName, 'package.json'), 'utf8'));
+  for (const [binName, binPath] of Object.entries(pj.bin ?? {})) {
+    const installed = join(proj, 'node_modules', pj.name, binPath);
+    if (!existsSync(installed)) fail(`${pj.name} bin "${binName}" → ${binPath} missing from the installed package`);
+  }
 }
 
-// Cleanup best-effort
+// 4b. Each executable CLI's --help must exit cleanly with non-empty output.
+for (const { bin, mustMatch } of EXECUTABLE_BINS) {
+  const binFile = join(proj, 'node_modules', '.bin', bin);
+  if (!existsSync(binFile)) {
+    fail(`bin "${bin}" was not linked into node_modules/.bin`);
+    continue;
+  }
+  const res = spawnSync(binFile, ['--help'], { cwd: proj, encoding: 'utf8', timeout: 30_000 });
+  if (res.error) fail(`${bin} --help failed to run: ${res.error.message}`);
+  else if (res.status !== 0) fail(`${bin} --help exited ${res.status}\n${(res.stderr || '').slice(0, 500)}`);
+  else if (!(res.stdout || '').trim()) fail(`${bin} --help produced no stdout`);
+  else if (mustMatch && !mustMatch.test(res.stdout)) fail(`${bin} --help output did not match ${mustMatch}`);
+  else log(`  ${bin} --help ran and printed output ✓`);
+}
+
 for (const d of [stage, proj]) {
   try {
     rmSync(d, { recursive: true, force: true });

--- a/scripts/publish-smoke.mjs
+++ b/scripts/publish-smoke.mjs
@@ -119,13 +119,19 @@ for (const dirName of RUNTIME_DIRS) {
 }
 
 // 4b. Each executable CLI's --help must exit cleanly with non-empty output.
+// Put the project's node_modules/.bin on PATH so a bin that shells out to a
+// sibling bin (e.g. `fbeast` forwards non-mcp commands to `frankenbeast`)
+// resolves it — exactly as a real co-install does, where every package bin
+// lands in the same PATH-visible directory.
+const binDir = join(proj, 'node_modules', '.bin');
+const childEnv = { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` };
 for (const { bin, mustMatch } of EXECUTABLE_BINS) {
-  const binFile = join(proj, 'node_modules', '.bin', bin);
+  const binFile = join(binDir, bin);
   if (!existsSync(binFile)) {
     fail(`bin "${bin}" was not linked into node_modules/.bin`);
     continue;
   }
-  const res = spawnSync(binFile, ['--help'], { cwd: proj, encoding: 'utf8', timeout: 30_000 });
+  const res = spawnSync(binFile, ['--help'], { cwd: proj, env: childEnv, encoding: 'utf8', timeout: 30_000 });
   if (res.error) fail(`${bin} --help failed to run: ${res.error.message}`);
   else if (res.status !== 0) fail(`${bin} --help exited ${res.status}\n${(res.stderr || '').slice(0, 500)}`);
   else if (!(res.stdout || '').trim()) fail(`${bin} --help produced no stdout`);

--- a/scripts/publish-smoke.mjs
+++ b/scripts/publish-smoke.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Publish smoke test — proves the packages install and run the way a real
+ * `npm install` off the registry would, catching the class of bug that the
+ * in-monorepo test suite hides via workspace hoisting:
+ *   - phantom/undeclared runtime dependencies (import X without depending on X)
+ *   - packages that ship no `dist` because they lack a `files` allowlist
+ *   - broken/ missing bin targets
+ *
+ * It does NOT publish anything. It:
+ *   1. builds the workspace,
+ *   2. `npm pack`s every publishable package into a staging dir,
+ *   3. installs the CLI + its workspace deps into a clean temp project
+ *      OUTSIDE the monorepo, with optional deps omitted (so a missing
+ *      optionalDependency like sharp must degrade gracefully, not crash),
+ *   4. runs `frankenbeast --help` and asserts a clean exit + expected output.
+ *
+ * Run: node scripts/publish-smoke.mjs
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const run = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', ...opts });
+
+function log(msg) {
+  console.log(`[publish-smoke] ${msg}`);
+}
+
+// Packages whose install+run we assert. The orchestrator ships the
+// `frankenbeast` CLI; its workspace deps must all resolve from local tarballs.
+const CLI_DEP_DIRS = [
+  'franken-types',
+  'franken-observer',
+  'franken-brain',
+  'franken-planner',
+  'franken-critique',
+  'franken-governor',
+  'franken-orchestrator',
+];
+
+function publishablePackages() {
+  const dir = join(repoRoot, 'packages');
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const pjPath = join(dir, name, 'package.json');
+    let pj;
+    try {
+      pj = JSON.parse(readFileSync(pjPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (pj.private) continue;
+    out.push({ name, dir: join(dir, name), pkg: pj });
+  }
+  return out;
+}
+
+let failures = 0;
+const fail = (msg) => {
+  console.error(`[publish-smoke] FAIL: ${msg}`);
+  failures += 1;
+};
+
+// 1. Build
+log('building workspace…');
+run('npx', ['turbo', 'run', 'build'], { cwd: repoRoot, stdio: 'inherit' });
+
+// 2. Pack every publishable package into a staging dir
+const stage = mkdtempSync(join(tmpdir(), 'fbeast-pack-'));
+const pkgs = publishablePackages();
+log(`packing ${pkgs.length} publishable packages → ${stage}`);
+for (const p of pkgs) {
+  run('npm', ['pack', '--pack-destination', stage], { cwd: p.dir });
+  // Assert the tarball actually contains dist/ files (catches missing `files`
+  // allowlist shipping an empty package).
+  const dry = run('npm', ['pack', '--dry-run', '--json'], { cwd: p.dir });
+  const files = JSON.parse(dry)[0].files.map((f) => f.path);
+  const distCount = files.filter((f) => f.startsWith('dist/')).length;
+  if (distCount === 0) {
+    fail(`${p.name} packs 0 dist files — did you forget "files": ["dist"]?`);
+  } else {
+    log(`  ${p.name}: ${distCount} dist files`);
+  }
+}
+
+// 3. Install the CLI + workspace deps into a clean temp project (no monorepo),
+//    omitting optional deps so a missing optionalDependency must degrade.
+const tarballFor = (dirName) => {
+  const pj = JSON.parse(readFileSync(join(repoRoot, 'packages', dirName, 'package.json'), 'utf8'));
+  const base = pj.name.replace('@', '').replace('/', '-');
+  const hit = readdirSync(stage).find((f) => f.startsWith(`${base}-`) && f.endsWith('.tgz'));
+  if (!hit) throw new Error(`no tarball for ${pj.name} (${base})`);
+  return join(stage, hit);
+};
+
+const proj = mkdtempSync(join(tmpdir(), 'fbeast-install-'));
+writeFileSync(join(proj, 'package.json'), JSON.stringify({ name: 'smoke', private: true }, null, 2));
+const tarballs = CLI_DEP_DIRS.map(tarballFor);
+log('installing packed CLI + deps (optional omitted) into a clean project…');
+run('npm', ['install', '--no-audit', '--no-fund', '--omit=optional', ...tarballs], { cwd: proj, stdio: 'inherit' });
+
+// 4. Run the installed CLI
+log('running `frankenbeast --help` from the installed artifact…');
+let help = '';
+try {
+  help = run(join(proj, 'node_modules', '.bin', 'frankenbeast'), ['--help'], { cwd: proj });
+} catch (err) {
+  fail(`frankenbeast --help crashed: ${err.stderr || err.message}`);
+}
+if (help && !/Usage: frankenbeast/.test(help)) {
+  fail('frankenbeast --help did not print the expected usage banner');
+} else if (help) {
+  log('  CLI ran and printed usage ✓');
+}
+
+// Cleanup best-effort
+for (const d of [stage, proj]) {
+  try {
+    rmSync(d, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+if (failures > 0) {
+  console.error(`[publish-smoke] ${failures} failure(s)`);
+  process.exit(1);
+}
+log('all publish smoke checks passed ✓');


### PR DESCRIPTION
## Why
While proving the publish pipeline (the robustness "boundary" work) I found three bugs that a fully green in-monorepo test suite completely hid, because workspace **hoisting** masks phantom/undeclared dependencies:
- `@franken/governor` + `@franken/planner` packed **zero dist files** → would publish broken (#844)
- the `frankenbeast` CLI **crashed on every run** when installed, from an undeclared top-level `sharp` import (#854)
- `main` was **red/unbuildable** from an undeclared `acorn-typescript` (#840)

All three fixed — but nothing stops them recurring. These guards do.

## What
- **`scripts/publish-smoke.mjs`** (new CI job `publish-smoke`): builds → `npm pack`s every publishable package (asserting each ships `dist/`) → installs the CLI + its workspace deps into a clean temp project **outside the monorepo**, with `--omit=optional` (so a missing optionalDependency must degrade, not crash) → runs `frankenbeast --help` and asserts a clean exit + usage banner. This reproduces a real off-registry `npm install` and would have caught **all three** bugs above.
- **`scripts/check-workspace-deps.mjs`** (new step in `build-test-lint`): fails if any internal `@franken/*` dep reverts to a `"*"` wildcard specifier.

## Verification
- Both pass on current `main` (with #844/#854 landed): all 10 packages ship dist; the packed CLI installs offline and runs.
- Both **fail on a deliberate break** (acceptance criterion): a `"*"` internal dep → dep-guard exits 1; a stripped `files` field → smoke reports 0 dist files and exits 1.

The `publish-smoke` job runs on every PR and push to main, so this class of "green tests, broken product" regression is now caught before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)