### PR TITLE
fix(compose): pin local observability images

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,8 @@ cd packages/franken-orchestrator && npm run test:e2e
 cp .env.example .env
 $EDITOR .env  # uncomment GRAFANA_USER=admin and set a unique GRAFANA_PASSWORD
 
-# Start supporting services (ChromaDB, Grafana, Tempo)
+# Start supporting services (ChromaDB, Grafana, Tempo). The compose file pins
+# image versions and mounts ./tempo.yaml so local tracing starts deterministically.
 docker compose up -d
 
 # Seed ChromaDB with initial collections

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: '3.8'
 services:
   # ChromaDB — vector store for @franken/brain episodic memory
   chromadb:
-    image: chromadb/chroma:1.3.5
+    image: chromadb/chroma:1.3.7
     ports:
       - '8000:8000'
     volumes:
-      - chromadb-data:/chroma/chroma
+      - chromadb-data:/data
     environment:
       - IS_PERSISTENT=TRUE
     healthcheck:
@@ -18,7 +18,7 @@ services:
 
   # Grafana — dashboards for observability
   grafana:
-    image: grafana/grafana:12.3.0
+    image: grafana/grafana:12.3.8
     ports:
       - '3000:3000'
     volumes:
@@ -51,7 +51,7 @@ services:
 
   # Tempo — distributed tracing backend for franken-observer
   tempo:
-    image: grafana/tempo:2.9.0
+    image: grafana/tempo:2.9.3
     ports:
       - '3200:3200'   # Tempo query API
       - '4317:4317'   # OTLP gRPC

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # ChromaDB — vector store for @franken/brain episodic memory
   chromadb:
-    image: chromadb/chroma:latest
+    image: chromadb/chroma:1.3.5
     ports:
       - '8000:8000'
     volumes:
@@ -18,7 +18,7 @@ services:
 
   # Grafana — dashboards for observability
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.3.0
     ports:
       - '3000:3000'
     volumes:
@@ -51,13 +51,14 @@ services:
 
   # Tempo — distributed tracing backend for franken-observer
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.9.0
     ports:
       - '3200:3200'   # Tempo query API
       - '4317:4317'   # OTLP gRPC
       - '4318:4318'   # OTLP HTTP
     command: ['-config.file=/etc/tempo.yaml']
     volumes:
+      - ./tempo.yaml:/etc/tempo.yaml:ro
       - tempo-data:/tmp/tempo
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,13 @@ services:
     environment:
       - IS_PERSISTENT=TRUE
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/v2/heartbeat']
+      test:
+        [
+          'CMD',
+          'bash',
+          '-ec',
+          'exec 3<>/dev/tcp/127.0.0.1/8000 && printf "GET /api/v2/heartbeat HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3 && grep -q "200 OK" <&3',
+        ]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -46,6 +46,9 @@ This starts the services defined in `docker-compose.yml`:
 - **Grafana** (port 3000)
 - **Tempo** (ports 3200, 4317, 4318)
 
+The compose stack pins image versions and mounts `tempo.yaml` into Tempo so the
+optional tracing backend does not depend on floating tags or an implicit config.
+
 There is no `firewall` Docker service in the current compose file.
 
 ## 4. Build and verify

--- a/tempo.yaml
+++ b/tempo.yaml
@@ -1,0 +1,30 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tmp/tempo/wal
+    local:
+      path: /tmp/tempo/blocks

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -60,9 +60,10 @@ describe('local setup scripts', () => {
     const compose = read('docker-compose.yml');
     const tempoConfig = read('tempo.yaml');
 
-    expect(compose).toContain('image: chromadb/chroma:1.3.5');
-    expect(compose).toContain('image: grafana/grafana:12.3.0');
-    expect(compose).toContain('image: grafana/tempo:2.9.0');
+    expect(compose).toContain('image: chromadb/chroma:1.3.7');
+    expect(compose).toContain('- chromadb-data:/data');
+    expect(compose).toContain('image: grafana/grafana:12.3.8');
+    expect(compose).toContain('image: grafana/tempo:2.9.3');
     expect(compose).not.toContain(':latest');
     expect(compose).toContain('- ./tempo.yaml:/etc/tempo.yaml:ro');
     expect(compose).toContain("command: ['-config.file=/etc/tempo.yaml']");

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -52,7 +52,10 @@ describe('local setup scripts', () => {
   it('docker compose healthcheck targets the Chroma v2 heartbeat', () => {
     const compose = read('docker-compose.yml');
 
-    expect(compose).toContain('http://localhost:8000/api/v2/heartbeat');
+    expect(compose).toContain('/api/v2/heartbeat');
+    expect(compose).toContain("'bash',");
+    expect(compose).toContain('/dev/tcp/127.0.0.1/8000');
+    expect(compose).not.toContain("'curl'");
     expect(compose).not.toContain('http://localhost:8000/api/v1/heartbeat');
   });
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -56,6 +56,24 @@ describe('local setup scripts', () => {
     expect(compose).not.toContain('http://localhost:8000/api/v1/heartbeat');
   });
 
+  it('pins local compose images and mounts an explicit Tempo config', () => {
+    const compose = read('docker-compose.yml');
+    const tempoConfig = read('tempo.yaml');
+
+    expect(compose).toContain('image: chromadb/chroma:1.3.5');
+    expect(compose).toContain('image: grafana/grafana:12.3.0');
+    expect(compose).toContain('image: grafana/tempo:2.9.0');
+    expect(compose).not.toContain(':latest');
+    expect(compose).toContain('- ./tempo.yaml:/etc/tempo.yaml:ro');
+    expect(compose).toContain("command: ['-config.file=/etc/tempo.yaml']");
+
+    expect(tempoConfig).toContain('http_listen_port: 3200');
+    expect(tempoConfig).toContain('endpoint: 0.0.0.0:4317');
+    expect(tempoConfig).toContain('endpoint: 0.0.0.0:4318');
+    expect(tempoConfig).toContain('path: /tmp/tempo/wal');
+    expect(tempoConfig).toContain('path: /tmp/tempo/blocks');
+  });
+
   it('requires explicit non-default Grafana admin credentials for local compose', () => {
     const compose = read('docker-compose.yml');
 


### PR DESCRIPTION
## Summary
- pin ChromaDB, Grafana, and Tempo compose images instead of using floating latest tags
- add an explicit Tempo config mounted at /etc/tempo.yaml
- document the deterministic compose setup and cover it in local setup tests

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- python3 YAML parse/assertions for docker-compose.yml and tempo.yaml
- npm run check:package-manager
- docker compose config skipped locally because docker is not installed in this worker environment

Closes #754