### PR TITLE
fix(critique): ignore inert source text in evaluators

### DIFF
--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -1,11 +1,18 @@
-import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
+import type {
+  Evaluator,
+  EvaluationInput,
+  EvaluationResult,
+  EvaluationFinding,
+} from './evaluator.js';
+import { stripCommentsAndStringLiterals } from './source-sanitizer.js';
 
 const MAX_PARAMS = 5;
 const MAX_NESTING = 4;
 const MAX_FUNCTION_LINES = 50;
 
 const FUNCTION_PATTERN = /function\s+\w+\s*\(([^)]*)\)\s*\{([\s\S]*?)\}/g;
-const ARROW_FUNCTION_PATTERN = /(?:const|let|var)\s+\w+\s*=\s*\(([^)]*)\)\s*(?::\s*\w+\s*)?=>\s*\{([\s\S]*?)\}/g;
+const ARROW_FUNCTION_PATTERN =
+  /(?:const|let|var)\s+\w+\s*=\s*\(([^)]*)\)\s*(?::\s*\w+\s*)?=>\s*\{([\s\S]*?)\}/g;
 
 export class ComplexityEvaluator implements Evaluator {
   readonly name = 'complexity';
@@ -13,14 +20,20 @@ export class ComplexityEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     if (!input.content.trim()) {
-      return { evaluatorName: this.name, verdict: 'pass', score: 1, findings: [] };
+      return {
+        evaluatorName: this.name,
+        verdict: 'pass',
+        score: 1,
+        findings: [],
+      };
     }
 
+    const sanitizedContent = stripCommentsAndStringLiterals(input.content);
     const findings: EvaluationFinding[] = [];
 
-    this.checkParameterCount(input.content, findings);
-    this.checkNestingDepth(input.content, findings);
-    this.checkFunctionLength(input.content, findings);
+    this.checkParameterCount(sanitizedContent, findings);
+    this.checkNestingDepth(sanitizedContent, findings);
+    this.checkFunctionLength(sanitizedContent, findings);
 
     const score = Math.max(0, 1 - findings.length * 0.25);
 
@@ -32,7 +45,10 @@ export class ComplexityEvaluator implements Evaluator {
     };
   }
 
-  private checkParameterCount(content: string, findings: EvaluationFinding[]): void {
+  private checkParameterCount(
+    content: string,
+    findings: EvaluationFinding[],
+  ): void {
     for (const pattern of [FUNCTION_PATTERN, ARROW_FUNCTION_PATTERN]) {
       for (const match of content.matchAll(pattern)) {
         const params = match[1]?.trim();
@@ -42,14 +58,18 @@ export class ComplexityEvaluator implements Evaluator {
           findings.push({
             message: `Function has ${count} parameters (max ${MAX_PARAMS}). Consider using an options object.`,
             severity: 'warning',
-            suggestion: 'Group related parameters into an options/config object',
+            suggestion:
+              'Group related parameters into an options/config object',
           });
         }
       }
     }
   }
 
-  private checkNestingDepth(content: string, findings: EvaluationFinding[]): void {
+  private checkNestingDepth(
+    content: string,
+    findings: EvaluationFinding[],
+  ): void {
     let maxDepth = 0;
     let currentDepth = 0;
 
@@ -66,12 +86,16 @@ export class ComplexityEvaluator implements Evaluator {
       findings.push({
         message: `Code nesting depth is ${maxDepth} levels (max ${MAX_NESTING}). Extract nested logic into separate functions.`,
         severity: 'warning',
-        suggestion: 'Use early returns, guard clauses, or extract helper functions to reduce nesting',
+        suggestion:
+          'Use early returns, guard clauses, or extract helper functions to reduce nesting',
       });
     }
   }
 
-  private checkFunctionLength(content: string, findings: EvaluationFinding[]): void {
+  private checkFunctionLength(
+    content: string,
+    findings: EvaluationFinding[],
+  ): void {
     for (const pattern of [FUNCTION_PATTERN, ARROW_FUNCTION_PATTERN]) {
       for (const match of content.matchAll(pattern)) {
         const body = match[2] ?? '';
@@ -80,7 +104,8 @@ export class ComplexityEvaluator implements Evaluator {
           findings.push({
             message: `Function is ${lineCount} lines long (max ${MAX_FUNCTION_LINES}). Break it into smaller functions.`,
             severity: 'warning',
-            suggestion: 'Extract logical sections into well-named helper functions',
+            suggestion:
+              'Extract logical sections into well-named helper functions',
           });
         }
       }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -144,8 +144,11 @@ function readStaticImportSpecifier(
 ): StringLiteralRead | null {
   let i = skipWhitespace(content, index);
 
-  // Ignore import.meta and dynamic import(...), neither of which is a static dependency declaration.
-  if (content[i] === '.' || content[i] === '(') return null;
+  // Ignore import.meta, dynamic import(...), and non-declaration object keys like
+  // `{ import: { from: 'pkg' } }`.
+  if (content[i] === '.' || content[i] === '(' || content[i] === ':') {
+    return null;
+  }
 
   if (content[i] === "'" || content[i] === '"') {
     return readQuotedString(content, i);
@@ -340,11 +343,58 @@ function isRegexLiteralStart(content: string, index: number): boolean {
     const ch = content[i]!;
     if (/\s/.test(ch)) continue;
 
+    if (
+      (ch === '+' || ch === '-') &&
+      previousNonWhitespace(content, i - 1) === ch
+    ) {
+      return false;
+    }
+
+    if (isIdentifierCharacter(ch)) {
+      const wordStart = readIdentifierStart(content, i);
+      const word = content.slice(wordStart, i + 1);
+      return REGEX_PREFIX_KEYWORDS.has(word);
+    }
+
     return '([{:;,=!?&|+-*~^%<>'.includes(ch);
   }
 
   return true;
 }
+
+function previousNonWhitespace(content: string, index: number): string | null {
+  for (let i = index; i >= 0; i--) {
+    const ch = content[i]!;
+    if (!/\s/.test(ch)) return ch;
+  }
+
+  return null;
+}
+
+function readIdentifierStart(content: string, index: number): number {
+  let i = index;
+  while (i > 0 && isIdentifierCharacter(content[i - 1]!)) i -= 1;
+  return i;
+}
+
+function isIdentifierCharacter(ch: string): boolean {
+  return /[$_A-Za-z0-9]/.test(ch);
+}
+
+const REGEX_PREFIX_KEYWORDS = new Set([
+  'case',
+  'delete',
+  'do',
+  'else',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'throw',
+  'typeof',
+  'void',
+  'yield',
+]);
 
 function skipRegexLiteral(content: string, startIndex: number): number {
   let inCharacterClass = false;

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -174,7 +174,7 @@ function readStaticImportSpecifier(
     }
 
     if (startsWithKeyword(content, i, 'from')) {
-      const specifierStart = skipWhitespace(content, i + 'from'.length);
+      const specifierStart = skipImportTrivia(content, i + 'from'.length);
       if (content[specifierStart] === "'" || content[specifierStart] === '"') {
         return readQuotedString(content, specifierStart);
       }
@@ -328,6 +328,26 @@ function skipWhitespace(content: string, index: number): number {
   return i;
 }
 
+function skipImportTrivia(content: string, index: number): number {
+  let i = skipWhitespace(content, index);
+
+  while (i < content.length) {
+    if (content[i] === '/' && content[i + 1] === '/') {
+      i = skipWhitespace(content, skipSingleLineComment(content, i + 2));
+      continue;
+    }
+
+    if (content[i] === '/' && content[i + 1] === '*') {
+      i = skipWhitespace(content, skipMultiLineComment(content, i + 2) + 1);
+      continue;
+    }
+
+    return i;
+  }
+
+  return i;
+}
+
 function skipSingleLineComment(content: string, index: number): number {
   const newlineIndex = content.indexOf('\n', index);
   return newlineIndex === -1 ? content.length : newlineIndex;
@@ -356,6 +376,10 @@ function isRegexLiteralStart(content: string, index: number): boolean {
       return REGEX_PREFIX_KEYWORDS.has(word);
     }
 
+    if (ch === '<' && /[A-Za-z>]/.test(content[index + 1] ?? '')) {
+      return false;
+    }
+
     return '([{:;,=!?&|+-*~^%<>'.includes(ch);
   }
 
@@ -382,6 +406,7 @@ function isIdentifierCharacter(ch: string): boolean {
 }
 
 const REGEX_PREFIX_KEYWORDS = new Set([
+  'await',
   'case',
   'delete',
   'do',

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -84,6 +84,11 @@ function extractDependencySpecifiers(content: string): string[] {
       continue;
     }
 
+    if (ch === '/' && isRegexLiteralStart(content, i)) {
+      i = skipRegexLiteral(content, i);
+      continue;
+    }
+
     if (ch === '`') {
       const template = readTemplateString(content, i);
       specifiers.push(...template.specifiers);
@@ -166,11 +171,12 @@ function readStaticImportSpecifier(
     }
 
     if (startsWithKeyword(content, i, 'from')) {
-      i = skipWhitespace(content, i + 'from'.length);
-      if (content[i] === "'" || content[i] === '"') {
-        return readQuotedString(content, i);
+      const specifierStart = skipWhitespace(content, i + 'from'.length);
+      if (content[specifierStart] === "'" || content[specifierStart] === '"') {
+        return readQuotedString(content, specifierStart);
       }
-      return null;
+      i += 'from'.length;
+      continue;
     }
 
     if (ch === ';') return null;
@@ -320,6 +326,47 @@ function skipSingleLineComment(content: string, index: number): number {
 function skipMultiLineComment(content: string, index: number): number {
   const endIndex = content.indexOf('*/', index);
   return endIndex === -1 ? content.length : endIndex + 1;
+}
+
+function isRegexLiteralStart(content: string, index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const ch = content[i]!;
+    if (/\s/.test(ch)) continue;
+
+    return '([{:;,=!?&|+-*~^%<>'.includes(ch);
+  }
+
+  return true;
+}
+
+function skipRegexLiteral(content: string, startIndex: number): number {
+  let inCharacterClass = false;
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+
+    if (ch === '[') {
+      inCharacterClass = true;
+      continue;
+    }
+
+    if (ch === ']') {
+      inCharacterClass = false;
+      continue;
+    }
+
+    if (ch === '/' && !inCharacterClass) {
+      while (/[A-Za-z]/.test(content[i + 1] ?? '')) i += 1;
+      return i;
+    }
+  }
+
+  return content.length;
 }
 
 function skipStringLiteral(content: string, startIndex: number): number {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -1,6 +1,17 @@
-import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
+import type {
+  Evaluator,
+  EvaluationInput,
+  EvaluationResult,
+  EvaluationFinding,
+} from './evaluator.js';
 
-const IMPORT_PATTERN = /(?:import\s+(?:[\s\S]*?\s+from\s+)?['"]([^'"]+)['"]|require\s*\(\s*['"]([^'"]+)['"]\s*\))/g;
+const IDENTIFIER_PATTERN = /[A-Za-z0-9_$]/;
+const QUOTE_CHARS = new Set(["'", '"', '`']);
+
+interface StringLiteralRead {
+  value: string;
+  endIndex: number;
+}
 
 export class GhostDependencyEvaluator implements Evaluator {
   readonly name = 'ghost-dependency';
@@ -16,10 +27,7 @@ export class GhostDependencyEvaluator implements Evaluator {
     const findings: EvaluationFinding[] = [];
     const seen = new Set<string>();
 
-    for (const match of input.content.matchAll(IMPORT_PATTERN)) {
-      const specifier = match[1] ?? match[2];
-      if (!specifier) continue;
-
+    for (const specifier of extractDependencySpecifiers(input.content)) {
       // Skip relative imports
       if (specifier.startsWith('.')) continue;
 
@@ -52,4 +60,173 @@ export class GhostDependencyEvaluator implements Evaluator {
       findings,
     };
   }
+}
+
+function extractDependencySpecifiers(content: string): string[] {
+  const specifiers: string[] = [];
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i = skipSingleLineComment(content, i + 2);
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      i = skipMultiLineComment(content, i + 2);
+      continue;
+    }
+
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i);
+      continue;
+    }
+
+    if (startsWithKeyword(content, i, 'import')) {
+      const imported = readStaticImportSpecifier(content, i + 'import'.length);
+      if (imported) {
+        specifiers.push(imported.value);
+        i = imported.endIndex;
+      }
+      continue;
+    }
+
+    if (startsWithKeyword(content, i, 'require')) {
+      const required = readRequireSpecifier(content, i + 'require'.length);
+      if (required) {
+        specifiers.push(required.value);
+        i = required.endIndex;
+      }
+    }
+  }
+
+  return specifiers;
+}
+
+function startsWithKeyword(
+  content: string,
+  index: number,
+  keyword: string,
+): boolean {
+  if (!content.startsWith(keyword, index)) return false;
+
+  const before = content[index - 1];
+  const after = content[index + keyword.length];
+
+  return (
+    (!before || !IDENTIFIER_PATTERN.test(before)) &&
+    (!after || !IDENTIFIER_PATTERN.test(after))
+  );
+}
+
+function readStaticImportSpecifier(
+  content: string,
+  index: number,
+): StringLiteralRead | null {
+  let i = skipWhitespace(content, index);
+
+  // Ignore dynamic import(...) expressions; they were not covered by the original evaluator.
+  if (content[i] === '(') return null;
+
+  while (i < content.length) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i = skipSingleLineComment(content, i + 2) + 1;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      i = skipMultiLineComment(content, i + 2) + 1;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      return readQuotedString(content, i);
+    }
+
+    if (ch === ';') return null;
+
+    i += 1;
+  }
+
+  return null;
+}
+
+function readRequireSpecifier(
+  content: string,
+  index: number,
+): StringLiteralRead | null {
+  let i = skipWhitespace(content, index);
+  if (content[i] !== '(') return null;
+
+  i = skipWhitespace(content, i + 1);
+  if (content[i] !== "'" && content[i] !== '"') return null;
+
+  return readQuotedString(content, i);
+}
+
+function readQuotedString(
+  content: string,
+  startIndex: number,
+): StringLiteralRead | null {
+  const quote = content[startIndex]!;
+  let value = '';
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+
+    if (ch === '\\') {
+      const escaped = content[i + 1];
+      if (escaped) {
+        value += escaped;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === quote) {
+      return { value, endIndex: i };
+    }
+
+    value += ch;
+  }
+
+  return null;
+}
+
+function skipWhitespace(content: string, index: number): number {
+  let i = index;
+  while (i < content.length && /\s/.test(content[i]!)) i += 1;
+  return i;
+}
+
+function skipSingleLineComment(content: string, index: number): number {
+  const newlineIndex = content.indexOf('\n', index);
+  return newlineIndex === -1 ? content.length : newlineIndex;
+}
+
+function skipMultiLineComment(content: string, index: number): number {
+  const endIndex = content.indexOf('*/', index);
+  return endIndex === -1 ? content.length : endIndex + 1;
+}
+
+function skipStringLiteral(content: string, startIndex: number): number {
+  const quote = content[startIndex]!;
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+
+    if (ch === quote) return i;
+  }
+
+  return content.length;
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -286,6 +286,13 @@ function readTemplateExpression(
       continue;
     }
 
+    if (ch === '/' && isRegexLiteralStart(content, i)) {
+      const endIndex = skipRegexLiteral(content, i);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
     if (QUOTE_CHARS.has(ch)) {
       const endIndex = skipStringLiteral(content, i);
       value += content.slice(i, Math.min(endIndex + 1, content.length));

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -13,6 +13,11 @@ interface StringLiteralRead {
   endIndex: number;
 }
 
+interface TemplateRead {
+  specifiers: string[];
+  endIndex: number;
+}
+
 export class GhostDependencyEvaluator implements Evaluator {
   readonly name = 'ghost-dependency';
   readonly category = 'deterministic' as const;
@@ -79,7 +84,14 @@ function extractDependencySpecifiers(content: string): string[] {
       continue;
     }
 
-    if (QUOTE_CHARS.has(ch)) {
+    if (ch === '`') {
+      const template = readTemplateString(content, i);
+      specifiers.push(...template.specifiers);
+      i = template.endIndex;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
       i = skipStringLiteral(content, i);
       continue;
     }
@@ -127,8 +139,12 @@ function readStaticImportSpecifier(
 ): StringLiteralRead | null {
   let i = skipWhitespace(content, index);
 
-  // Ignore dynamic import(...) expressions; they were not covered by the original evaluator.
-  if (content[i] === '(') return null;
+  // Ignore import.meta and dynamic import(...), neither of which is a static dependency declaration.
+  if (content[i] === '.' || content[i] === '(') return null;
+
+  if (content[i] === "'" || content[i] === '"') {
+    return readQuotedString(content, i);
+  }
 
   while (i < content.length) {
     const ch = content[i]!;
@@ -144,8 +160,17 @@ function readStaticImportSpecifier(
       continue;
     }
 
-    if (ch === "'" || ch === '"') {
-      return readQuotedString(content, i);
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i) + 1;
+      continue;
+    }
+
+    if (startsWithKeyword(content, i, 'from')) {
+      i = skipWhitespace(content, i + 'from'.length);
+      if (content[i] === "'" || content[i] === '"') {
+        return readQuotedString(content, i);
+      }
+      return null;
     }
 
     if (ch === ';') return null;
@@ -166,7 +191,13 @@ function readRequireSpecifier(
   i = skipWhitespace(content, i + 1);
   if (content[i] !== "'" && content[i] !== '"') return null;
 
-  return readQuotedString(content, i);
+  const specifier = readQuotedString(content, i);
+  if (!specifier) return null;
+
+  const closeParenIndex = skipWhitespace(content, specifier.endIndex + 1);
+  if (content[closeParenIndex] !== ')') return null;
+
+  return specifier;
 }
 
 function readQuotedString(
@@ -196,6 +227,83 @@ function readQuotedString(
   }
 
   return null;
+}
+
+function readTemplateString(content: string, startIndex: number): TemplateRead {
+  const specifiers: string[] = [];
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+
+    if (ch === '`') {
+      return { specifiers, endIndex: i };
+    }
+
+    if (ch === '$' && next === '{') {
+      const expression = readTemplateExpression(content, i + 1);
+      specifiers.push(...extractDependencySpecifiers(expression.value));
+      i = expression.endIndex;
+    }
+  }
+
+  return { specifiers, endIndex: content.length };
+}
+
+function readTemplateExpression(
+  content: string,
+  openBraceIndex: number,
+): StringLiteralRead {
+  let depth = 1;
+  let value = '';
+
+  for (let i = openBraceIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      const endIndex = skipSingleLineComment(content, i + 2);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      const endIndex = skipMultiLineComment(content, i + 2);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
+    if (QUOTE_CHARS.has(ch)) {
+      const endIndex = skipStringLiteral(content, i);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth += 1;
+      value += ch;
+      continue;
+    }
+
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return { value, endIndex: i };
+      value += ch;
+      continue;
+    }
+
+    value += ch;
+  }
+
+  return { value, endIndex: content.length };
 }
 
 function skipWhitespace(content: string, index: number): number {

--- a/packages/franken-critique/src/evaluators/source-sanitizer.ts
+++ b/packages/franken-critique/src/evaluators/source-sanitizer.ts
@@ -35,6 +35,13 @@ export function stripCommentsAndStringLiterals(content: string): string {
         continue;
       }
 
+      if (ch === '/' && isRegexLiteralStart(content, i)) {
+        const endIndex = skipRegexLiteral(content, i);
+        result += blankPreservingNewlines(content.slice(i, endIndex + 1));
+        i = endIndex;
+        continue;
+      }
+
       if (ch === "'") {
         state = ScannerState.SingleQuote;
         result += ' ';
@@ -174,6 +181,13 @@ function readTemplateExpression(
       continue;
     }
 
+    if (ch === '/' && isRegexLiteralStart(content, i)) {
+      const endIndex = skipRegexLiteral(content, i);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
     if (ch === "'" || ch === '"' || ch === '`') {
       const endIndex = skipStringLiteral(content, i);
       value += content.slice(i, Math.min(endIndex + 1, content.length));
@@ -208,6 +222,51 @@ function skipSingleLineComment(content: string, index: number): number {
 function skipMultiLineComment(content: string, index: number): number {
   const endIndex = content.indexOf('*/', index);
   return endIndex === -1 ? content.length : endIndex + 1;
+}
+
+function isRegexLiteralStart(content: string, index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const ch = content[i]!;
+    if (/\s/.test(ch)) continue;
+
+    return '([{:;,=!?&|+-*~^%<>'.includes(ch);
+  }
+
+  return true;
+}
+
+function skipRegexLiteral(content: string, startIndex: number): number {
+  let inCharacterClass = false;
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+
+    if (ch === '[') {
+      inCharacterClass = true;
+      continue;
+    }
+
+    if (ch === ']') {
+      inCharacterClass = false;
+      continue;
+    }
+
+    if (ch === '/' && !inCharacterClass) {
+      while (/[A-Za-z]/.test(content[i + 1] ?? '')) i += 1;
+      return i;
+    }
+  }
+
+  return content.length;
+}
+
+function blankPreservingNewlines(content: string): string {
+  return content.replace(/[^\n]/g, ' ');
 }
 
 function skipStringLiteral(content: string, startIndex: number): number {

--- a/packages/franken-critique/src/evaluators/source-sanitizer.ts
+++ b/packages/franken-critique/src/evaluators/source-sanitizer.ts
@@ -229,11 +229,58 @@ function isRegexLiteralStart(content: string, index: number): boolean {
     const ch = content[i]!;
     if (/\s/.test(ch)) continue;
 
+    if (
+      (ch === '+' || ch === '-') &&
+      previousNonWhitespace(content, i - 1) === ch
+    ) {
+      return false;
+    }
+
+    if (isIdentifierCharacter(ch)) {
+      const wordStart = readIdentifierStart(content, i);
+      const word = content.slice(wordStart, i + 1);
+      return REGEX_PREFIX_KEYWORDS.has(word);
+    }
+
     return '([{:;,=!?&|+-*~^%<>'.includes(ch);
   }
 
   return true;
 }
+
+function previousNonWhitespace(content: string, index: number): string | null {
+  for (let i = index; i >= 0; i--) {
+    const ch = content[i]!;
+    if (!/\s/.test(ch)) return ch;
+  }
+
+  return null;
+}
+
+function readIdentifierStart(content: string, index: number): number {
+  let i = index;
+  while (i > 0 && isIdentifierCharacter(content[i - 1]!)) i -= 1;
+  return i;
+}
+
+function isIdentifierCharacter(ch: string): boolean {
+  return /[$_A-Za-z0-9]/.test(ch);
+}
+
+const REGEX_PREFIX_KEYWORDS = new Set([
+  'case',
+  'delete',
+  'do',
+  'else',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'throw',
+  'typeof',
+  'void',
+  'yield',
+]);
 
 function skipRegexLiteral(content: string, startIndex: number): number {
   let inCharacterClass = false;

--- a/packages/franken-critique/src/evaluators/source-sanitizer.ts
+++ b/packages/franken-critique/src/evaluators/source-sanitizer.ts
@@ -1,0 +1,138 @@
+enum ScannerState {
+  Code = 'code',
+  SingleLineComment = 'singleLineComment',
+  MultiLineComment = 'multiLineComment',
+  SingleQuote = 'singleQuote',
+  DoubleQuote = 'doubleQuote',
+  TemplateString = 'templateString',
+}
+
+export function stripCommentsAndStringLiterals(content: string): string {
+  let result = '';
+  let state: ScannerState = ScannerState.Code;
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (state === ScannerState.Code) {
+      if (ch === '/' && next === '/') {
+        state = ScannerState.SingleLineComment;
+        result += '  ';
+        i += 1;
+        continue;
+      }
+
+      if (ch === '/' && next === '*') {
+        state = ScannerState.MultiLineComment;
+        result += '  ';
+        i += 1;
+        continue;
+      }
+
+      if (ch === "'") {
+        state = ScannerState.SingleQuote;
+        result += ' ';
+        continue;
+      }
+
+      if (ch === '"') {
+        state = ScannerState.DoubleQuote;
+        result += ' ';
+        continue;
+      }
+
+      if (ch === '`') {
+        state = ScannerState.TemplateString;
+        result += ' ';
+        continue;
+      }
+
+      result += ch;
+      continue;
+    }
+
+    if (state === ScannerState.SingleLineComment) {
+      if (ch === '\n') {
+        state = ScannerState.Code;
+        result += '\n';
+      } else {
+        result += ' ';
+      }
+      continue;
+    }
+
+    if (state === ScannerState.MultiLineComment) {
+      if (ch === '*' && next === '/') {
+        state = ScannerState.Code;
+        result += '  ';
+        i += 1;
+        continue;
+      }
+
+      result += ch === '\n' ? '\n' : ' ';
+      continue;
+    }
+
+    if (state === ScannerState.SingleQuote) {
+      if (ch === '\\') {
+        result += ' ';
+        if (i + 1 < content.length) {
+          result += ' ';
+          i += 1;
+        }
+        continue;
+      }
+
+      if (ch === "'") {
+        state = ScannerState.Code;
+        result += ' ';
+        continue;
+      }
+
+      result += ch === '\n' ? '\n' : ' ';
+      continue;
+    }
+
+    if (state === ScannerState.DoubleQuote) {
+      if (ch === '\\') {
+        result += ' ';
+        if (i + 1 < content.length) {
+          result += ' ';
+          i += 1;
+        }
+        continue;
+      }
+
+      if (ch === '"') {
+        state = ScannerState.Code;
+        result += ' ';
+        continue;
+      }
+
+      result += ch === '\n' ? '\n' : ' ';
+      continue;
+    }
+
+    if (state === ScannerState.TemplateString) {
+      if (ch === '\\') {
+        result += ' ';
+        if (i + 1 < content.length) {
+          result += content[i + 1] === '\n' ? '\n' : ' ';
+          i += 1;
+        }
+        continue;
+      }
+
+      if (ch === '`') {
+        state = ScannerState.Code;
+        result += ' ';
+        continue;
+      }
+
+      result += ch === '\n' ? '\n' : ' ';
+    }
+  }
+
+  return result;
+}

--- a/packages/franken-critique/src/evaluators/source-sanitizer.ts
+++ b/packages/franken-critique/src/evaluators/source-sanitizer.ts
@@ -7,6 +7,11 @@ enum ScannerState {
   TemplateString = 'templateString',
 }
 
+interface TemplateExpressionRead {
+  value: string;
+  endIndex: number;
+}
+
 export function stripCommentsAndStringLiterals(content: string): string {
   let result = '';
   let state: ScannerState = ScannerState.Code;
@@ -124,6 +129,13 @@ export function stripCommentsAndStringLiterals(content: string): string {
         continue;
       }
 
+      if (ch === '$' && next === '{') {
+        const expression = readTemplateExpression(content, i + 1);
+        result += `  ${stripCommentsAndStringLiterals(expression.value)} `;
+        i = expression.endIndex;
+        continue;
+      }
+
       if (ch === '`') {
         state = ScannerState.Code;
         result += ' ';
@@ -135,4 +147,82 @@ export function stripCommentsAndStringLiterals(content: string): string {
   }
 
   return result;
+}
+
+function readTemplateExpression(
+  content: string,
+  openBraceIndex: number,
+): TemplateExpressionRead {
+  let depth = 1;
+  let value = '';
+
+  for (let i = openBraceIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      const endIndex = skipSingleLineComment(content, i + 2);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      const endIndex = skipMultiLineComment(content, i + 2);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const endIndex = skipStringLiteral(content, i);
+      value += content.slice(i, Math.min(endIndex + 1, content.length));
+      i = endIndex;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth += 1;
+      value += ch;
+      continue;
+    }
+
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return { value, endIndex: i };
+      value += ch;
+      continue;
+    }
+
+    value += ch;
+  }
+
+  return { value, endIndex: content.length };
+}
+
+function skipSingleLineComment(content: string, index: number): number {
+  const newlineIndex = content.indexOf('\n', index);
+  return newlineIndex === -1 ? content.length : newlineIndex;
+}
+
+function skipMultiLineComment(content: string, index: number): number {
+  const endIndex = content.indexOf('*/', index);
+  return endIndex === -1 ? content.length : endIndex + 1;
+}
+
+function skipStringLiteral(content: string, startIndex: number): number {
+  const quote = content[startIndex]!;
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+
+    if (ch === quote) return i;
+  }
+
+  return content.length;
 }

--- a/packages/franken-critique/src/evaluators/source-sanitizer.ts
+++ b/packages/franken-critique/src/evaluators/source-sanitizer.ts
@@ -242,6 +242,10 @@ function isRegexLiteralStart(content: string, index: number): boolean {
       return REGEX_PREFIX_KEYWORDS.has(word);
     }
 
+    if (ch === '<' && /[A-Za-z>]/.test(content[index + 1] ?? '')) {
+      return false;
+    }
+
     return '([{:;,=!?&|+-*~^%<>'.includes(ch);
   }
 
@@ -268,6 +272,7 @@ function isIdentifierCharacter(ch: string): boolean {
 }
 
 const REGEX_PREFIX_KEYWORDS = new Set([
+  'await',
   'case',
   'delete',
   'do',

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -22,13 +22,33 @@ describe('ComplexityEvaluator', () => {
     expect(result.score).toBeGreaterThan(0.5);
   });
 
+  it('ignores braces and nested patterns inside comments', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function sample(value: boolean) {\n  // if (value) {\n  //   doThing();\n  // }\n  return value ? 'ok' : 'skip';\n}`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('ignores braces in string literals', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function sample(value: boolean) {\n  const marker = '{ { { { {';\n  const other = "{ }";\n  return value ? marker : other;\n}`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('flags functions with too many parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(true);
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
   });
 
   it('flags deeply nested code', async () => {
@@ -37,7 +57,9 @@ describe('ComplexityEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(true);
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
   });
 
   it('flags very long functions', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -52,6 +52,29 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('does not let regex literals hide later active code', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const pattern = /[/*]/;\nif (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
+  it('keeps template interpolation code after regex braces', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content =
+      'function sample() {\n  return `${/}/.test(source) && (() => { if (a) { if (b) { if (c) { if (d) { work(); } } } } })()}`;\n}';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
   it('flags functions with too many parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -74,9 +74,31 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('recognizes awaited regex literals', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `async function check(source) { await /[//]/.test(source); if (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
   it('does not treat division after postfix operators as regex literals', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `const ratio = count++ / total;\nif (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
+  it('does not treat JSX closing tags as regex literals', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const el = <div></div>; if (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } }`;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -63,6 +63,28 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('recognizes regex literals after keywords', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function check(source) { return /[/*]/.test(source); }\nif (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
+  it('does not treat division after postfix operators as regex literals', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const ratio = count++ / total;\nif (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
   it('keeps template interpolation code after regex braces', async () => {
     const evaluator = new ComplexityEvaluator();
     const content =

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -40,6 +40,18 @@ describe('ComplexityEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
+  it('preserves active code inside template literal interpolations', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content =
+      'function sample() {\n  return `${(() => { if (a) { if (b) { if (c) { if (d) { work(); } } } } })()}`;\n}';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
   it('flags functions with too many parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -26,6 +26,24 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
+  it('ignores imports and require calls inside comments', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `// import ghost from 'ghost-package';\n/* const hidden = require('unknown-lib'); */\nimport express from 'express';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('ignores import-like text inside string literals', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const message = "import ghost from 'ghost-package'";\nconst dynamic = 'require(\"unknown-lib\")';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('fails when an unknown package is imported', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `import ghost from 'ghost-package';`;

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -73,6 +73,26 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('reads static import specifiers after bindings named from', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `import { from } from "ghost-package";`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('does not treat regex literal contents as comments', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const pattern = /[/*]/;\nimport ghost from 'ghost-package';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
   it('ignores dynamic require expressions', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const adapter = require('adapter-' + target);`;

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -83,6 +83,16 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('allows comments between from and the module specifier', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `import { x } from /* generated */ "ghost-package";`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
   it('ignores object-literal import keys', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const cfg = { import: { from: 'ghost-package' } };`;
@@ -112,9 +122,29 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('recognizes awaited regex literals', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `async function check(source) { await /[//]/.test(source); require('ghost-package'); }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
   it('does not treat division after postfix operators as regex literals', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const ratio = count++ / total;\nrequire('ghost-package');`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('does not treat JSX closing tags as regex literals', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const el = <div></div>; require('ghost-package');`;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -83,9 +83,38 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('ignores object-literal import keys', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const cfg = { import: { from: 'ghost-package' } };`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('does not treat regex literal contents as comments', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const pattern = /[/*]/;\nimport ghost from 'ghost-package';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('recognizes regex literals after keywords', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `function check(source) { return /[/*]/.test(source); }\nrequire('ghost-package');`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('does not treat division after postfix operators as regex literals', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const ratio = count++ / total;\nrequire('ghost-package');`;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -44,6 +44,44 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
+  it('does not treat import.meta string comparisons as imports', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `if (import.meta.env.MODE === 'production') {\n  console.log('ready');\n}`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('detects require calls inside template literal interpolations', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = "const value = `${require('ghost-package')}`;";
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('reads static import specifiers after string-named bindings', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `import { "foo" as foo } from "ghost-package";`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('ignores dynamic require expressions', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const adapter = require('adapter-' + target);`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('fails when an unknown package is imported', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `import ghost from 'ghost-package';`;

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -93,6 +93,17 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('keeps scanning template interpolations after regex braces', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content =
+      "const value = `${/}/.test(source) && require('ghost-package')}`;";
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
   it('ignores dynamic require expressions', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const adapter = require('adapter-' + target);`;

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,0 +1,3 @@
+
+## 2026-07-06 — Critique scanner edge cases
+- Dependency/comment/string scanners that manually skip regex literals must cover keyword-prefixed regexes (including await), postfix-operator division, JSX closing tags, template interpolations, and import trivia comments. Add regression tests for each Codex-reported lexical edge case before re-triggering review.


### PR DESCRIPTION
## Summary
- add source sanitization so complexity checks ignore braces/nesting in comments and string literals
- replace raw regex dependency scanning with a lexer-style extractor that skips comments and string literals while preserving real import/require specifiers
- add regression coverage for commented-out dependencies and import-like strings

## Test Plan
- npm test -- --run tests/unit/evaluators/complexity.test.ts tests/unit/evaluators/ghost-dependency.test.ts
- npm test
- npm run lint
- npm run build --workspace @franken/types && npm run build
- npx prettier --check packages/franken-critique/src/evaluators/complexity.ts packages/franken-critique/src/evaluators/ghost-dependency.ts packages/franken-critique/src/evaluators/source-sanitizer.ts packages/franken-critique/tests/unit/evaluators/complexity.test.ts packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts

Closes #774