### PR TITLE
fix(web): show analytics JSON copy feedback

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -332,6 +332,41 @@ describe('AnalyticsPage', () => {
     expect(client.fetchEventDetail).toHaveBeenCalledWith('governor:1');
   });
 
+  it('announces when full event JSON is copied to the clipboard', async () => {
+    const client = mockClient();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<AnalyticsPage client={client} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'View details for Denied destructive command' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Copy JSON' }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('{\n  "decision": "denied"\n}');
+    });
+    expect(await screen.findByText('Copied JSON to clipboard.')).toBeTruthy();
+  });
+
+  it('shows a manual fallback when copying full event JSON fails', async () => {
+    const client = mockClient();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<AnalyticsPage client={client} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'View details for Denied destructive command' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Copy JSON' }));
+
+    expect(await screen.findByText('Clipboard is unavailable. Select the JSON below and copy it manually.')).toBeTruthy();
+    expect(screen.getByRole('textbox', { name: 'Raw JSON manual copy fallback' })).toHaveProperty('value', '{\n  "decision": "denied"\n}');
+  });
+
   it('labels row data as partial and disables JSON copy until full detail loads', async () => {
     const client = mockClient();
     let resolveDetail!: (event: Awaited<ReturnType<AnalyticsApiClient['fetchEventDetail']>>) => void;

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -33,6 +33,9 @@ const TIME_WINDOWS = [
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 const DEFAULT_PAGE_SIZE = 50;
+const COPY_JSON_SUCCESS_MESSAGE = 'Copied JSON to clipboard.';
+const COPY_JSON_UNAVAILABLE_MESSAGE = 'Clipboard is unavailable. Select the JSON below and copy it manually.';
+const COPY_JSON_FAILURE_MESSAGE = 'Copy failed. Select the JSON below and copy it manually.';
 
 export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [filters, setFilters] = useState<AnalyticsFilters>({ timeWindow: '24h' });
@@ -491,8 +494,49 @@ function DetailDrawer({
 }) {
   const rawJson = JSON.stringify(detail.raw, null, 2);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [copyFeedback, setCopyFeedback] = useState<{
+    message: string;
+    showManualFallback: boolean;
+    tone: 'success' | 'error';
+  } | null>(null);
   const detailStateLabel = hasFullDetail ? 'Full event detail' : 'Partial row data';
   const copyDisabled = !hasFullDetail;
+
+  useEffect(() => {
+    setCopyFeedback(null);
+  }, [rawJson]);
+
+  useEffect(() => {
+    if (copyFeedback?.tone !== 'success') return;
+    const timeoutId = window.setTimeout(() => setCopyFeedback(null), 3000);
+    return () => window.clearTimeout(timeoutId);
+  }, [copyFeedback]);
+
+  async function copyRawJson() {
+    if (!navigator.clipboard?.writeText) {
+      setCopyFeedback({
+        message: COPY_JSON_UNAVAILABLE_MESSAGE,
+        showManualFallback: true,
+        tone: 'error',
+      });
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(rawJson);
+      setCopyFeedback({
+        message: COPY_JSON_SUCCESS_MESSAGE,
+        showManualFallback: false,
+        tone: 'success',
+      });
+    } catch {
+      setCopyFeedback({
+        message: COPY_JSON_FAILURE_MESSAGE,
+        showManualFallback: true,
+        tone: 'error',
+      });
+    }
+  }
 
   return (
     <Dialog.Root open={true} onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -555,7 +599,7 @@ function DetailDrawer({
                 className="button button--secondary button--small"
                 type="button"
                 disabled={copyDisabled}
-                onClick={() => void navigator.clipboard?.writeText(rawJson)}
+                onClick={() => void copyRawJson()}
               >
                 Copy JSON
               </button>
@@ -574,6 +618,25 @@ function DetailDrawer({
               <p className="analytics-drawer__caption">
                 Copy JSON is available after full event detail loads.
               </p>
+            )}
+
+            {copyFeedback && (
+              <div
+                className={copyFeedback.tone === 'error' ? 'analytics-alert' : 'analytics-detail-status'}
+                role={copyFeedback.tone === 'error' ? 'alert' : 'status'}
+              >
+                {copyFeedback.message}
+              </div>
+            )}
+
+            {copyFeedback?.showManualFallback && (
+              <textarea
+                aria-label="Raw JSON manual copy fallback"
+                className="field-control"
+                readOnly
+                rows={Math.min(rawJson.split('\n').length, 12)}
+                value={rawJson}
+              />
             )}
 
             <pre className="analytics-raw">


### PR DESCRIPTION
## Summary
- add accessible success/error feedback after analytics detail Copy JSON attempts
- surface a read-only manual-copy fallback when Clipboard API support or permission fails
- cover success and unsupported clipboard cases in analytics page tests

## Test Plan
- npm run build --workspace @franken/types
- npm --workspace @franken/web test -- analytics-page.test.tsx
- npm --workspace @franken/web run typecheck
- npm --workspace @franken/web run build
- npm --workspace @franken/web test

Closes #633