### PR TITLE
fix(web): use active route as page heading

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatShell } from './chat-shell';
+
+vi.mock('../hooks/use-chat-session', () => ({
+  useChatSession: () => ({
+    activity: [],
+    approve: vi.fn(),
+    approvalError: null,
+    approvalResolving: false,
+    clearedFailedDraft: undefined,
+    connectionStatus: 'connected',
+    costUsd: 0,
+    dismissError: vi.fn(),
+    errorBanners: [],
+    messages: [],
+    pendingApproval: null,
+    projectId: 'default',
+    reconnect: vi.fn(),
+    retryError: vi.fn(),
+    retryMessage: vi.fn(),
+    send: vi.fn(),
+    sessionId: 'session-1',
+    showTypingIndicator: false,
+    status: 'idle',
+    tier: 'standard',
+    tokenTotals: { input: 0, output: 0, total: 0 },
+  }),
+}));
+
+vi.mock('../lib/api', () => ({
+  ChatApiClient: class {
+    listSessions = vi.fn().mockResolvedValue([]);
+  },
+}));
+
+vi.mock('../lib/network-api', () => ({
+  NetworkApiClient: class {
+    getStatus = vi.fn().mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    getConfig = vi.fn().mockResolvedValue({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
+    getLogs = vi.fn().mockResolvedValue({ logs: [] });
+    restart = vi.fn().mockResolvedValue(undefined);
+    updateConfig = vi.fn().mockResolvedValue({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
+  },
+}));
+
+vi.mock('../lib/beast-api', () => ({
+  BeastApiClient: class {
+    listCatalog = vi.fn().mockResolvedValue([]);
+    listAgents = vi.fn().mockResolvedValue([]);
+    listRuns = vi.fn().mockResolvedValue([]);
+    getContainerRuntime = vi.fn().mockResolvedValue(undefined);
+    subscribe = vi.fn().mockResolvedValue(() => undefined);
+  },
+}));
+
+vi.mock('../lib/analytics-api', () => ({
+  AnalyticsApiClient: class {},
+}));
+
+vi.mock('../lib/dashboard-api', () => ({
+  DashboardApiClient: class {},
+}));
+
+vi.mock('../pages/dashboard-page', () => ({
+  DashboardPage: () => <div>Dashboard module</div>,
+}));
+
+vi.mock('../pages/beasts-page', () => ({
+  BeastsPage: () => <div>Beasts module</div>,
+}));
+
+vi.mock('../pages/analytics-page', () => ({
+  AnalyticsPage: () => <div>Analytics module</div>,
+}));
+
+vi.mock('./transcript-pane', () => ({
+  TranscriptPane: () => <div>Transcript</div>,
+}));
+
+vi.mock('./composer', () => ({
+  Composer: () => <form aria-label="Composer" />,
+}));
+
+vi.mock('./activity-pane', () => ({
+  ActivityPane: () => <div>Activity</div>,
+}));
+
+vi.mock('./approval-card', () => ({
+  ApprovalCard: () => <div>Approvals</div>,
+}));
+
+vi.mock('./cost-badge', () => ({
+  CostBadge: () => <div>Cost Summary</div>,
+}));
+
+describe('ChatShell route heading', () => {
+  beforeEach(() => {
+    window.location.hash = '#/network';
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  it('uses the active route label as the primary heading and demotes project context to metadata', () => {
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Network' })).toBeTruthy();
+    expect(screen.queryByRole('heading', { level: 1, name: 'default' })).toBeNull();
+    expect(screen.getByText('Project: default')).toBeTruthy();
+    expect(screen.getByText('Service controls')).toBeTruthy();
+  });
+});

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -117,7 +117,7 @@ function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {
   return (
     <section className="placeholder-page">
       <p className="eyebrow">Dashboard Module</p>
-      <h1>{route.label}</h1>
+      <h2>{route.label}</h2>
       <p>{route.summary}</p>
       <span>Chat is the only live section in this first Frankenbeast dashboard cut.</span>
     </section>
@@ -779,10 +779,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             </button>
 
             <div className="topbar__title">
-              <p className="eyebrow">Project</p>
-              <h1>{activeProjectId}</h1>
+              <p className="eyebrow">Project: {activeProjectId}</p>
+              <h1>{activeRoute.label}</h1>
               <p className="topbar__summary">
-                <span>{activeRoute.label}</span>
                 <span>{activeRoute.summary}</span>
               </p>
             </div>

--- a/packages/franken-web/src/components/transcript-pane.tsx
+++ b/packages/franken-web/src/components/transcript-pane.tsx
@@ -21,7 +21,7 @@ export function TranscriptPane({ messages, onRetryMessage, resetKey, retryDisabl
       <div className="transcript-pane__header">
         <div>
           <p className="eyebrow">Command Console</p>
-          <h1>Chat</h1>
+          <h2>Chat</h2>
         </div>
         <p className="transcript-pane__meta">CLI-parity conversation stream with live execution telemetry.</p>
       </div>

--- a/packages/franken-web/src/pages/beasts-page.tsx
+++ b/packages/franken-web/src/pages/beasts-page.tsx
@@ -86,7 +86,7 @@ export function BeastsPage({
       )}
 
       <div className="flex items-center justify-between px-6 py-4 border-b border-beast-border shrink-0">
-        <h2 className="text-beast-text font-semibold text-lg">Beasts</h2>
+        <h2 className="text-beast-text font-semibold text-lg">Agent fleet</h2>
         <button
           type="button"
           onClick={handleOpenWizard}

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -40,7 +40,7 @@ export function NetworkPage({
       <section className="network-page__header rail-card">
         <div>
           <p className="eyebrow">Operator Control</p>
-          <h2>Network</h2>
+          <h2>Service controls</h2>
         </div>
         <button className="button button--secondary" type="button" onClick={onRefresh}>Refresh</button>
       </section>

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -771,7 +771,7 @@ describe('ChatShell', () => {
       expect(screen.getByText('agent-1')).toBeDefined();
     });
 
-    expect(screen.getByRole('heading', { name: 'Beasts' })).toBeDefined();
+    expect(screen.getByRole('heading', { level: 1, name: 'Beasts' })).toBeDefined();
     expect(mockListAgents).toHaveBeenCalled();
   });
 

--- a/packages/franken-web/tests/components/transcript-pane.test.tsx
+++ b/packages/franken-web/tests/components/transcript-pane.test.tsx
@@ -14,6 +14,13 @@ function setScrollMetrics(element: Element, metrics: { scrollHeight: number; scr
 }
 
 describe('TranscriptPane', () => {
+  it('renders Chat as a subordinate heading under the shell page title', () => {
+    render(<TranscriptPane messages={[]} showTypingIndicator={false} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Chat' })).toBeDefined();
+    expect(screen.queryByRole('heading', { level: 1, name: 'Chat' })).toBeNull();
+  });
+
   it('renders messages with role labels', () => {
     const messages = [
       { id: 'u1', role: 'user' as const, content: 'Hello', timestamp: new Date().toISOString() },


### PR DESCRIPTION
## Summary
- Use the active dashboard route label as the shell H1 instead of the project id
- Move project id into eyebrow metadata and keep route summaries below the primary heading
- Demote duplicate/subordinate page headings for placeholder and network content

## Test Plan
- [x] npm run build --workspace @franken/types
- [x] npm run test --workspace @franken/web -- src/components/chat-shell.test.tsx
- [x] npm run typecheck --workspace @franken/web
- [x] npm run build --workspace @franken/web

Closes #648
