### PR TITLE
fix(orchestrator): validate skill MCP config writes

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -3,6 +3,11 @@ import { ZodError } from 'zod';
 import type { SkillManager } from '../../skills/skill-manager.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
 
+function isSkillInstallValidationError(err: unknown): boolean {
+  return err instanceof ZodError
+    || (err instanceof Error && err.message.startsWith('Invalid skill name '));
+}
+
 function skillInstallErrorMessage(err: unknown): string {
   if (err instanceof ZodError) {
     return err.issues
@@ -60,6 +65,9 @@ export function createSkillRoutes(deps: {
         return c.json({ installed: custom.name }, 201);
       }
     } catch (err) {
+      if (!isSkillInstallValidationError(err)) {
+        throw err;
+      }
       return c.json({ error: skillInstallErrorMessage(err) }, 400);
     }
 

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -1,6 +1,16 @@
 import { Hono } from 'hono';
+import { ZodError } from 'zod';
 import type { SkillManager } from '../../skills/skill-manager.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
+
+function skillInstallErrorMessage(err: unknown): string {
+  if (err instanceof ZodError) {
+    return err.issues
+      .map((issue) => `${issue.path.join('.') || 'config'}: ${issue.message}`)
+      .join('; ');
+  }
+  return err instanceof Error ? err.message : 'Failed to install skill';
+}
 
 export function createSkillRoutes(deps: {
   skillManager: SkillManager;
@@ -35,18 +45,22 @@ export function createSkillRoutes(deps: {
   app.post('/', async (c) => {
     const body = (await c.req.json()) as Record<string, unknown>;
 
-    if (body['catalogEntry']) {
-      const entry = body['catalogEntry'] as Parameters<
-        SkillManager['install']
-      >[0];
-      await deps.skillManager.install(entry);
-      return c.json({ installed: entry.name }, 201);
-    }
+    try {
+      if (body['catalogEntry']) {
+        const entry = body['catalogEntry'] as Parameters<
+          SkillManager['install']
+        >[0];
+        await deps.skillManager.install(entry);
+        return c.json({ installed: entry.name }, 201);
+      }
 
-    if (body['custom']) {
-      const custom = body['custom'] as { name: string; config: Parameters<SkillManager['installCustom']>[1] };
-      await deps.skillManager.installCustom(custom.name, custom.config);
-      return c.json({ installed: custom.name }, 201);
+      if (body['custom']) {
+        const custom = body['custom'] as { name: string; config: Parameters<SkillManager['installCustom']>[1] };
+        await deps.skillManager.installCustom(custom.name, custom.config);
+        return c.json({ installed: custom.name }, 201);
+      }
+    } catch (err) {
+      return c.json({ error: skillInstallErrorMessage(err) }, 400);
     }
 
     return c.json({ error: 'Must provide catalogEntry or custom' }, 400);

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -67,14 +67,14 @@ export class SkillManager {
 
   async install(catalogEntry: SkillCatalogEntry): Promise<void> {
     this.validateName(catalogEntry.name);
-    const skillDir = join(this.skillsDir, catalogEntry.name);
-    mkdirSync(skillDir, { recursive: true });
-
-    const mcpConfig: McpConfig = {
+    const mcpConfig = McpConfigSchema.parse({
       mcpServers: {
         [catalogEntry.name]: catalogEntry.installConfig,
       },
-    };
+    });
+    const skillDir = join(this.skillsDir, catalogEntry.name);
+    mkdirSync(skillDir, { recursive: true });
+
     writeFileSync(
       join(skillDir, 'mcp.json'),
       JSON.stringify(mcpConfig, null, 2),
@@ -90,12 +90,12 @@ export class SkillManager {
 
   async installCustom(name: string, serverConfig: McpServerConfig): Promise<void> {
     this.validateName(name);
+    const mcpConfig = McpConfigSchema.parse({
+      mcpServers: { [name]: serverConfig },
+    });
     const skillDir = join(this.skillsDir, name);
     mkdirSync(skillDir, { recursive: true });
 
-    const mcpConfig: McpConfig = {
-      mcpServers: { [name]: serverConfig },
-    };
     writeFileSync(
       join(skillDir, 'mcp.json'),
       JSON.stringify(mcpConfig, null, 2),

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { Hono } from 'hono';
 import { SkillManager } from '../../../src/skills/skill-manager.js';
 import { createSkillRoutes } from '../../../src/http/routes/skill-routes.js';
+import { errorHandler } from '../../../src/http/middleware.js';
 import type { ProviderRegistry } from '../../../src/providers/provider-registry.js';
 
 function mockProviderRegistry(): ProviderRegistry {
@@ -142,6 +143,31 @@ describe('Skill API routes', () => {
       expect(listRes.status).toBe(200);
       const listBody = await listRes.json();
       expect(listBody.skills).toEqual([]);
+    });
+
+    it('propagates operational install failures to the error handler', async () => {
+      const failingManager = {
+        installCustom: vi.fn().mockRejectedValue(new Error('EACCES: permission denied')),
+      } as unknown as SkillManager;
+      const failingApp = new Hono();
+      failingApp.onError(errorHandler);
+      failingApp.route('/api/skills', createSkillRoutes({
+        skillManager: failingManager,
+        providerRegistry: mockProviderRegistry(),
+      }));
+
+      const res = await failingApp.request('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          custom: { name: 'valid-tool', config: { command: 'node' } },
+        }),
+      });
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.code).toBe('INTERNAL_ERROR');
+      expect(JSON.stringify(body)).not.toContain('EACCES');
     });
 
     it('returns 400 when neither provided', async () => {

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Hono } from 'hono';
@@ -123,6 +123,25 @@ describe('Skill API routes', () => {
       });
       expect(res.status).toBe(201);
       expect(manager.exists('my-tool')).toBe(true);
+    });
+
+    it('rejects invalid custom MCP configs without poisoning the skills list', async () => {
+      const res = await app.request('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          custom: { name: 'broken-tool', config: { command: 'node', args: [123] } },
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('mcpServers.broken-tool.args.0');
+      expect(existsSync(join(skillsDir, 'broken-tool', 'mcp.json'))).toBe(false);
+
+      const listRes = await app.request('/api/skills');
+      expect(listRes.status).toBe(200);
+      const listBody = await listRes.json();
+      expect(listBody.skills).toEqual([]);
     });
 
     it('returns 400 when neither provided', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -87,6 +87,19 @@ describe('SkillManager', () => {
       expect(() => McpConfigSchema.parse(raw)).not.toThrow();
     });
 
+    it('rejects invalid catalog MCP configs before writing mcp.json', async () => {
+      await expect(manager.install({
+        name: 'broken-catalog',
+        description: 'Broken catalog entry',
+        provider: 'cli',
+        installConfig: { command: '' },
+        authFields: [],
+      })).rejects.toThrow();
+
+      expect(existsSync(join(skillsDir, 'broken-catalog', 'mcp.json'))).toBe(false);
+      expect(manager.listInstalled()).toEqual([]);
+    });
+
     it('writes tools.json when catalog entry includes toolDefinitions', async () => {
       await manager.install({
         name: 'github',
@@ -112,6 +125,16 @@ describe('SkillManager', () => {
       expect(manager.exists('my-tool')).toBe(true);
       const config = manager.readMcpConfig('my-tool');
       expect(config?.mcpServers['my-tool']?.command).toBe('node');
+    });
+
+    it('rejects invalid custom MCP configs before writing mcp.json', async () => {
+      await expect(manager.installCustom('broken-custom', {
+        command: 'node',
+        args: [123],
+      } as unknown as Parameters<SkillManager['installCustom']>[1])).rejects.toThrow();
+
+      expect(existsSync(join(skillsDir, 'broken-custom', 'mcp.json'))).toBe(false);
+      expect(manager.listInstalled()).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary
- validate catalog and custom skill MCP configs with McpConfigSchema before writing mcp.json
- return HTTP 400 for invalid skill install payloads instead of persisting poisoned configs
- add unit/integration regression coverage for malformed catalog/custom configs

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- tests/unit/skills/skill-manager.test.ts tests/integration/skills/skill-routes.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #682