### PR TITLE
fix(orchestrator): ticket-authenticate chat SSE streams

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -2,6 +2,7 @@ import { randomUUID, timingSafeEqual } from 'node:crypto';
 
 interface TicketEntry {
   token: string;
+  scope?: string | undefined;
   expiresAt: number;
 }
 
@@ -22,22 +23,24 @@ export class SseConnectionTicketStore {
     this.cleanupInterval.unref?.();
   }
 
-  issue(token: string): string {
+  issue(token: string, scope?: string | undefined): string {
     const ticket = randomUUID();
     this.tickets.set(ticket, {
       token,
+      scope,
       expiresAt: Date.now() + this.ttlMs,
     });
     return ticket;
   }
 
-  validate(ticket: string, operatorToken: string): boolean {
+  validate(ticket: string, operatorToken: string, scope?: string | undefined): boolean {
     const entry = this.tickets.get(ticket);
     if (!entry) return false;
 
     this.tickets.delete(ticket);
 
     if (Date.now() > entry.expiresAt) return false;
+    if (entry.scope !== scope) return false;
 
     // Verify the ticket was issued for this operator token
     const bufA = Buffer.from(entry.token);

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -65,6 +65,8 @@ export interface ChatAppOptions {
   dashboardDeps?: DashboardRouteDeps;
   /** Read-only observer/governor/cost analytics aggregation. */
   analyticsDeps?: AnalyticsRouteDeps;
+  /** Optional owner-managed ticket store for browser EventSource chat streams. */
+  chatStreamTicketStore?: SseConnectionTicketStore;
   /** Optional gateway compatibility proxy for /v1/beasts/* now owned by beasts-daemon. */
   beastDaemon?: { baseUrl: string; operatorToken?: string | undefined };
 }
@@ -125,7 +127,8 @@ export function createChatApp(opts: ChatAppOptions): Hono {
       });
   const sessionTokenSecret = opts.sessionTokenSecret ?? createSessionTokenSecret();
   const transportSecurity = opts.transportSecurity ?? new TransportSecurityService();
-  const chatStreamTicketStore = new SseConnectionTicketStore();
+  const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken ?? opts.beastDaemon?.operatorToken;
+  const chatStreamTicketStore = opts.chatStreamTicketStore ?? (effectiveOperatorToken ? new SseConnectionTicketStore() : undefined);
 
   const app = new Hono();
   app.use('*', requestId);
@@ -143,7 +146,6 @@ export function createChatApp(opts: ChatAppOptions): Hono {
   // (franken-web ChatApiClient, network/chat-attach) plumb the token through.
   // `startChatServer` separately fails closed when chat is exposed without a
   // token (managed mode or non-loopback host).
-  const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken ?? opts.beastDaemon?.operatorToken;
   const operatorSecurity = opts.beastControl?.security ?? transportSecurity;
   // Gate the chat plane and every sensitive control-plane route group behind the
   // same operator token whenever one is configured. Each group mutates process
@@ -185,7 +187,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     });
     app.use('/v1/chat', requireAuth());
     app.use('/v1/chat/*', async (c, next) => {
-      if (isChatSessionStreamPath(new URL(c.req.url).pathname)) {
+      if (isChatSessionStreamPath(new URL(c.req.url).pathname) && c.req.query('ticket')) {
         await next();
         return;
       }

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -91,6 +91,10 @@ function credentialedCorsForAllowedOrigins(allowedOrigins: Set<string>): Middlew
   };
 }
 
+function isChatSessionStreamPath(pathname: string): boolean {
+  return /^\/v1\/chat\/sessions\/[^/]+\/stream$/.test(pathname);
+}
+
 export function createChatApp(opts: ChatAppOptions): Hono {
   const sessionStore = opts.sessionStore
     ?? new FileSessionStore(required(opts.sessionStoreDir, 'sessionStoreDir'));
@@ -121,6 +125,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
       });
   const sessionTokenSecret = opts.sessionTokenSecret ?? createSessionTokenSecret();
   const transportSecurity = opts.transportSecurity ?? new TransportSecurityService();
+  const chatStreamTicketStore = new SseConnectionTicketStore();
 
   const app = new Hono();
   app.use('*', requestId);
@@ -178,8 +183,15 @@ export function createChatApp(opts: ChatAppOptions): Hono {
       }
       return requireAuth()(c, next);
     });
+    app.use('/v1/chat', requireAuth());
+    app.use('/v1/chat/*', async (c, next) => {
+      if (isChatSessionStreamPath(new URL(c.req.url).pathname)) {
+        await next();
+        return;
+      }
+      return requireAuth()(c, next);
+    });
     for (const base of [
-      '/v1/chat',
       '/v1/network',
       '/v1/comms',
       '/api/security',
@@ -197,6 +209,8 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     engine: runtimeBundle.engine,
     runtime: runtimeBundle.runtime,
     turnRunner: runtimeBundle.turnRunner,
+    operatorToken: effectiveOperatorToken,
+    streamTicketStore: chatStreamTicketStore,
     issueSocketToken: (sessionId) => issueSessionToken({
       secret: sessionTokenSecret,
       sessionId,

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -27,6 +27,7 @@ import { isLoopbackHost } from '../network/network-config.js';
 import { localPlaintextOrSecureEndpoint, localPlaintextOrSecureWebSocketUrl } from '../network/network-url.js';
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
 import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
+import { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
 
 export interface StartChatServerOptions {
   host?: string;
@@ -295,6 +296,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ?? (options.commsConfig
       ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName)
       : undefined);
+  const chatStreamTicketStore = effectiveOperatorToken ? new SseConnectionTicketStore() : undefined;
   const app = createChatApp({
     sessionStore,
     engine: runtime.engine,
@@ -312,6 +314,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ...(options.providerRegistry ? { providerRegistry: options.providerRegistry } : {}),
     ...(options.dashboardDeps ? { dashboardDeps: options.dashboardDeps } : {}),
     ...(options.analyticsDeps ? { analyticsDeps: options.analyticsDeps } : {}),
+    ...(chatStreamTicketStore ? { chatStreamTicketStore } : {}),
     ...(options.beastDaemon ? { beastDaemon: options.beastDaemon } : {}),
   });
   const server = createServer((request, response) => {
@@ -353,6 +356,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     close: async () => {
       await stopLiveBeastControlRuns(options.beastControl);
       options.beastControl?.ticketStore.destroy();
+      chatStreamTicketStore?.destroy();
       options.disposeBeastControl?.();
       const closedServer = closeHttpServer(server);
       server.closeAllConnections();

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -14,6 +14,7 @@ import type {
 } from '@franken/types';
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
+import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 
 const CreateSessionBody = z.object({
   projectId: z.string().min(1),
@@ -34,6 +35,8 @@ export interface ChatRoutesDeps {
   runtime: ChatRuntime;
   turnRunner: TurnRunner;
   issueSocketToken: (sessionId: string) => string;
+  operatorToken?: string | undefined;
+  streamTicketStore?: SseConnectionTicketStore | undefined;
 }
 
 function getSessionOrThrow(store: ISessionStore, id: string) {
@@ -52,7 +55,7 @@ function sessionResponse(
 }
 
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
-  const { sessionStore, runtime, turnRunner, issueSocketToken } = deps;
+  const { sessionStore, runtime, turnRunner, issueSocketToken, operatorToken, streamTicketStore } = deps;
   const app = new Hono();
 
   // Health check
@@ -140,8 +143,28 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     return c.json(response);
   });
 
+  // Browser EventSource cannot attach Authorization headers. Authenticated
+  // callers mint a short-lived, one-shot ticket with normal fetch credentials,
+  // then place only that ticket in the stream URL.
+  app.post('/v1/chat/sessions/:id/stream/ticket', (c) => {
+    const id = c.req.param('id');
+    getSessionOrThrow(sessionStore, id);
+    if (!operatorToken) {
+      return c.json({ ticket: null });
+    }
+    if (!streamTicketStore) {
+      return c.json({ error: { code: 'UNAVAILABLE', message: 'Chat stream tickets are not configured' } }, 503);
+    }
+    return c.json({ ticket: streamTicketStore.issue(operatorToken) });
+  });
+
   // SSE stream
-  app.get('/v1/chat/sessions/:id/stream', createSseHandler({ sessionStore, turnRunner }));
+  app.get('/v1/chat/sessions/:id/stream', createSseHandler({
+    sessionStore,
+    turnRunner,
+    operatorToken,
+    ticketStore: streamTicketStore,
+  }));
 
   // Approve action
   app.post('/v1/chat/sessions/:id/approve', async (c) => {

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -155,7 +155,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     if (!streamTicketStore) {
       return c.json({ error: { code: 'UNAVAILABLE', message: 'Chat stream tickets are not configured' } }, 503);
     }
-    return c.json({ ticket: streamTicketStore.issue(operatorToken) });
+    return c.json({ ticket: streamTicketStore.issue(operatorToken, id) });
   });
 
   // SSE stream

--- a/packages/franken-orchestrator/src/http/sse.ts
+++ b/packages/franken-orchestrator/src/http/sse.ts
@@ -2,14 +2,17 @@ import { streamSSE } from 'hono/streaming';
 import type { Context } from 'hono';
 import type { ISessionStore } from '../chat/session-store.js';
 import type { TurnRunner, TurnEvent } from '../chat/turn-runner.js';
+import type { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
 
 export interface SseHandlerDeps {
   sessionStore: ISessionStore;
   turnRunner: TurnRunner;
+  operatorToken?: string | undefined;
+  ticketStore?: SseConnectionTicketStore | undefined;
 }
 
 export function createSseHandler(deps: SseHandlerDeps) {
-  const { sessionStore, turnRunner } = deps;
+  const { sessionStore, turnRunner, operatorToken, ticketStore } = deps;
 
   return async (c: Context) => {
     const id = c.req.param('id');
@@ -25,6 +28,13 @@ export function createSseHandler(deps: SseHandlerDeps) {
         { error: { code: 'NOT_FOUND', message: `Session '${id}' not found` } },
         404,
       );
+    }
+
+    if (operatorToken) {
+      const ticket = c.req.query('ticket');
+      if (!ticketStore || !ticket || !ticketStore.validate(ticket, operatorToken)) {
+        return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+      }
     }
 
     return streamSSE(c, async (stream) => {

--- a/packages/franken-orchestrator/src/http/sse.ts
+++ b/packages/franken-orchestrator/src/http/sse.ts
@@ -1,8 +1,10 @@
+import { timingSafeEqual } from 'node:crypto';
 import { streamSSE } from 'hono/streaming';
 import type { Context } from 'hono';
 import type { ISessionStore } from '../chat/session-store.js';
 import type { TurnRunner, TurnEvent } from '../chat/turn-runner.js';
 import type { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
+import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthAllowed } from './operator-auth.js';
 
 export interface SseHandlerDeps {
   sessionStore: ISessionStore;
@@ -22,19 +24,17 @@ export function createSseHandler(deps: SseHandlerDeps) {
         400,
       );
     }
+
+    if (operatorToken && !hasValidStreamCredential(c, operatorToken, ticketStore)) {
+      return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+    }
+
     const session = sessionStore.get(id);
     if (!session) {
       return c.json(
         { error: { code: 'NOT_FOUND', message: `Session '${id}' not found` } },
         404,
       );
-    }
-
-    if (operatorToken) {
-      const ticket = c.req.query('ticket');
-      if (!ticketStore || !ticket || !ticketStore.validate(ticket, operatorToken)) {
-        return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
-      }
     }
 
     return streamSSE(c, async (stream) => {
@@ -77,4 +77,38 @@ export function createSseHandler(deps: SseHandlerDeps) {
       });
     });
   };
+}
+
+function hasValidStreamCredential(
+  c: Context,
+  operatorToken: string,
+  ticketStore: SseConnectionTicketStore | undefined,
+): boolean {
+  const headerToken = extractOperatorToken(c.req.header('authorization'))
+    ?? c.req.header('x-frankenbeast-operator-token')
+    ?? undefined;
+  const cookieToken = extractOperatorTokenCookie(c.req.header('cookie'));
+  if (!headerToken && cookieToken && !isCookieOperatorAuthAllowed({
+    method: c.req.method,
+    origin: c.req.header('origin'),
+    requestUrl: c.req.url,
+    secFetchSite: c.req.header('sec-fetch-site'),
+  })) {
+    return false;
+  }
+
+  const provided = headerToken ?? cookieToken;
+  if (provided && safeTokenCompare(provided, operatorToken)) {
+    return true;
+  }
+
+  const ticket = c.req.query('ticket');
+  return Boolean(ticketStore && ticket && ticketStore.validate(ticket, operatorToken));
+}
+
+function safeTokenCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
 }

--- a/packages/franken-orchestrator/src/http/sse.ts
+++ b/packages/franken-orchestrator/src/http/sse.ts
@@ -25,7 +25,7 @@ export function createSseHandler(deps: SseHandlerDeps) {
       );
     }
 
-    if (operatorToken && !hasValidStreamCredential(c, operatorToken, ticketStore)) {
+    if (operatorToken && !hasValidStreamCredential(c, operatorToken, id, ticketStore)) {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }
 
@@ -82,8 +82,14 @@ export function createSseHandler(deps: SseHandlerDeps) {
 function hasValidStreamCredential(
   c: Context,
   operatorToken: string,
+  sessionId: string,
   ticketStore: SseConnectionTicketStore | undefined,
 ): boolean {
+  const ticket = c.req.query('ticket');
+  if (ticket) {
+    return Boolean(ticketStore && ticketStore.validate(ticket, operatorToken, sessionId));
+  }
+
   const headerToken = extractOperatorToken(c.req.header('authorization'))
     ?? c.req.header('x-frankenbeast-operator-token')
     ?? undefined;
@@ -102,8 +108,7 @@ function hasValidStreamCredential(
     return true;
   }
 
-  const ticket = c.req.query('ticket');
-  return Boolean(ticketStore && ticket && ticketStore.validate(ticket, operatorToken));
+  return false;
 }
 
 function safeTokenCompare(a: string, b: string): boolean {

--- a/packages/franken-orchestrator/tests/unit/http/chat-sse-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-sse-ticket.test.ts
@@ -58,6 +58,26 @@ describe('chat SSE stream ticket authentication', () => {
     await response.body?.cancel();
   });
 
+  it('returns the same auth failure for missing sessions before session lookup', async () => {
+    const app = createApp(sessionStoreDir);
+
+    const response = await app.request('/v1/chat/sessions/not-a-real-session/stream?ticket=bogus');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('preserves bearer authentication for non-browser stream callers', async () => {
+    const app = createApp(sessionStoreDir);
+    const sessionId = await createSession(app);
+
+    const response = await app.request(`/v1/chat/sessions/${sessionId}/stream`, {
+      headers: AUTH_HEADER,
+    });
+
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+  });
+
   it('accepts a one-shot query ticket for browser EventSource streams without bearer headers', async () => {
     const app = createApp(sessionStoreDir);
     const sessionId = await createSession(app);

--- a/packages/franken-orchestrator/tests/unit/http/chat-sse-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-sse-ticket.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createChatApp } from '../../../src/http/chat-app.js';
+
+const AUTH_HEADER = { authorization: 'Bearer op-secret' };
+
+function createApp(sessionStoreDir: string) {
+  return createChatApp({
+    sessionStoreDir,
+    llm: { complete: vi.fn().mockResolvedValue('hello') },
+    projectName: 'chat-sse-ticket-test',
+    operatorToken: 'op-secret',
+  });
+}
+
+async function createSession(app: ReturnType<typeof createChatApp>): Promise<string> {
+  const response = await app.request('/v1/chat/sessions', {
+    method: 'POST',
+    headers: { ...AUTH_HEADER, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ projectId: 'project-1' }),
+  });
+  expect(response.status).toBe(201);
+  const body = await response.json() as { data: { id: string } };
+  return body.data.id;
+}
+
+describe('chat SSE stream ticket authentication', () => {
+  let sessionStoreDir: string;
+
+  beforeEach(() => {
+    sessionStoreDir = mkdtempSync(join(tmpdir(), 'franken-chat-sse-ticket-'));
+  });
+
+  afterEach(() => {
+    rmSync(sessionStoreDir, { recursive: true, force: true });
+  });
+
+  it('keeps the ticket minting endpoint behind operator auth', async () => {
+    const app = createApp(sessionStoreDir);
+    const sessionId = await createSession(app);
+
+    const response = await app.request(`/v1/chat/sessions/${sessionId}/stream/ticket`, {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects direct stream access without a short-lived ticket', async () => {
+    const app = createApp(sessionStoreDir);
+    const sessionId = await createSession(app);
+
+    const response = await app.request(`/v1/chat/sessions/${sessionId}/stream`);
+
+    expect(response.status).toBe(401);
+    await response.body?.cancel();
+  });
+
+  it('accepts a one-shot query ticket for browser EventSource streams without bearer headers', async () => {
+    const app = createApp(sessionStoreDir);
+    const sessionId = await createSession(app);
+
+    const ticketResponse = await app.request(`/v1/chat/sessions/${sessionId}/stream/ticket`, {
+      method: 'POST',
+      headers: AUTH_HEADER,
+    });
+    expect(ticketResponse.status).toBe(200);
+    const { ticket } = await ticketResponse.json() as { ticket: string };
+    expect(ticket).toEqual(expect.any(String));
+
+    const streamResponse = await app.request(`/v1/chat/sessions/${sessionId}/stream?${new URLSearchParams({ ticket })}`);
+    expect(streamResponse.status).toBe(200);
+    await streamResponse.body?.cancel();
+
+    const reuseResponse = await app.request(`/v1/chat/sessions/${sessionId}/stream?${new URLSearchParams({ ticket })}`);
+    expect(reuseResponse.status).toBe(401);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/http/chat-sse-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-sse-ticket.test.ts
@@ -97,4 +97,27 @@ describe('chat SSE stream ticket authentication', () => {
     const reuseResponse = await app.request(`/v1/chat/sessions/${sessionId}/stream?${new URLSearchParams({ ticket })}`);
     expect(reuseResponse.status).toBe(401);
   });
+
+  it('scopes one-shot stream tickets to the session that minted them', async () => {
+    const app = createApp(sessionStoreDir);
+    const firstSessionId = await createSession(app);
+    const secondSessionId = await createSession(app);
+
+    const ticketResponse = await app.request(`/v1/chat/sessions/${firstSessionId}/stream/ticket`, {
+      method: 'POST',
+      headers: AUTH_HEADER,
+    });
+    expect(ticketResponse.status).toBe(200);
+    const { ticket } = await ticketResponse.json() as { ticket: string };
+
+    const wrongSessionResponse = await app.request(
+      `/v1/chat/sessions/${secondSessionId}/stream?${new URLSearchParams({ ticket })}`,
+    );
+    expect(wrongSessionResponse.status).toBe(401);
+
+    const consumedResponse = await app.request(
+      `/v1/chat/sessions/${firstSessionId}/stream?${new URLSearchParams({ ticket })}`,
+    );
+    expect(consumedResponse.status).toBe(401);
+  });
 });


### PR DESCRIPTION
## Summary
- add one-shot ticket minting for chat session SSE streams
- exempt only the chat session stream route from bearer middleware and validate ticket query tokens in the stream handler
- add regression coverage for protected ticket minting, unauthenticated stream rejection, and one-shot stream access

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner
- npm test --workspace @franken/orchestrator -- --run tests/unit/http/chat-sse-ticket.test.ts tests/integration/chat/sse.test.ts tests/integration/http/control-plane-auth.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)

Closes #684