### PR TITLE
fix(orchestrator): return bad request for invalid webhook payloads

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/discord/discord-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/discord/discord-router.ts
@@ -24,8 +24,17 @@ export function discordRouter(options: DiscordRouterOptions) {
   });
 
   app.post('/interactions', async (c) => {
-    const body = await c.req.json();
-    const interaction = DiscordInteractionSchema.parse(body);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Malformed Discord payload' }, 400);
+    }
+    const interactionPayload = DiscordInteractionSchema.safeParse(body);
+    if (!interactionPayload.success) {
+      return c.json({ error: 'Invalid payload' }, 400);
+    }
+    const interaction = interactionPayload.data;
 
     // 1. Handle PING for interaction endpoint verification
     if (interaction.type === DiscordInteractionType.PING) {

--- a/packages/franken-orchestrator/src/comms/channels/slack/slack-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/slack/slack-router.ts
@@ -25,8 +25,17 @@ export function slackRouter(options: SlackRouterOptions) {
 
   // Events API: https://api.slack.com/events-api
   app.post('/events', async (c) => {
-    const body = await c.req.json();
-    const parsed = SlackEventBaseSchema.parse(body);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Malformed Slack payload' }, 400);
+    }
+    const eventPayload = SlackEventBaseSchema.safeParse(body);
+    if (!eventPayload.success) {
+      return c.json({ error: 'Invalid payload' }, 400);
+    }
+    const parsed = eventPayload.data;
 
     // Handle Slack challenge (url_verification)
     if (parsed.type === 'url_verification') {

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-router.ts
@@ -27,8 +27,17 @@ export function telegramRouter(options: TelegramRouterOptions) {
     if (!isTelegramSecretTokenValid(c.req.header(TELEGRAM_SECRET_TOKEN_HEADER), webhookSecretToken)) {
       return c.json({ error: 'Not found' }, 404);
     }
-    const body = await c.req.json();
-    const update = TelegramUpdateSchema.parse(body);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Malformed Telegram payload' }, 400);
+    }
+    const updatePayload = TelegramUpdateSchema.safeParse(body);
+    if (!updatePayload.success) {
+      return c.json({ error: 'Invalid payload' }, 400);
+    }
+    const update = updatePayload.data;
 
     // 1. Handle incoming message
     if (update.message?.text) {

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
@@ -37,8 +37,17 @@ export function whatsappRouter(options: WhatsAppRouterOptions) {
     return verify(c, next);
   };
   app.post('/webhook', whatsappMiddleware, async (c) => {
-    const body = await c.req.json();
-    const parsed = WhatsAppWebhookSchema.parse(body);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Malformed WhatsApp payload' }, 400);
+    }
+    const webhookPayload = WhatsAppWebhookSchema.safeParse(body);
+    if (!webhookPayload.success) {
+      return c.json({ error: 'Invalid payload' }, 400);
+    }
+    const parsed = webhookPayload.data;
 
     for (const entry of parsed.entry) {
       for (const change of entry.changes) {

--- a/packages/franken-orchestrator/tests/unit/comms/discord-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-router.test.ts
@@ -17,6 +17,7 @@ describe('discordRouter', () => {
   } as unknown as SessionMapper;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     keys = generateKeyPairSync('ed25519');
     rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');
   });
@@ -127,5 +128,25 @@ describe('discordRouter', () => {
 
     expect(res.status).toBe(200);
     expect(gateway.handleAction).toHaveBeenCalledWith('discord', 'session-123', 'approve');
+  });
+
+  it('returns 400 for invalid interaction payloads without invoking handlers', async () => {
+    const app = discordRouter({
+      gateway,
+      sessionMapper,
+      publicKey: rawPublicKey,
+      verifySignature: false,
+    });
+
+    const res = await app.request('/interactions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: DiscordInteractionType.APPLICATION_COMMAND, data: 'not-an-object' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid payload' });
+    expect(gateway.handleInbound).not.toHaveBeenCalled();
+    expect(gateway.handleAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
@@ -81,6 +81,25 @@ describe('slackRouter', () => {
     }));
   });
 
+  it('returns 400 for invalid event payloads without invoking handlers', async () => {
+    const appWithoutSig = slackRouter({
+      gateway,
+      sessionMapper,
+      signingSecret: secret,
+      verifySignature: false,
+    });
+
+    const res = await appWithoutSig.request('/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'event_callback', event: 'not-an-object' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid payload' });
+    expect(gateway.handleInbound).not.toHaveBeenCalled();
+  });
+
   it('handles interactive button clicks', async () => {
     const appWithoutSig = slackRouter({
       gateway,

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
@@ -87,6 +87,22 @@ describe('telegramRouter', () => {
     );
   });
 
+  it('returns 400 for invalid webhook payloads without invoking handlers', async () => {
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: {
+        'X-Telegram-Bot-Api-Secret-Token': webhookSecretToken,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ update_id: 'not-a-number' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid payload' });
+    expect(gateway.handleInbound).not.toHaveBeenCalled();
+    expect(gateway.handleAction).not.toHaveBeenCalled();
+  });
+
   it('uses embedded session ids from callback data when another group operator clicks', async () => {
     const body = JSON.stringify({
       update_id: 3,

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { whatsappRouter } from '../../../src/comms/channels/whatsapp/whatsapp-router.js';
 import { createHmac } from 'node:crypto';
 import type { ChatGateway } from '../../../src/comms/gateway/chat-gateway.js';
@@ -20,6 +20,10 @@ describe('whatsappRouter', () => {
     sessionMapper,
     appSecret,
     verifyToken,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   function getSignature(body: string) {
@@ -68,6 +72,27 @@ describe('whatsappRouter', () => {
       text: 'hello',
       externalUserId: '123456',
     }));
+  });
+
+  it('returns 400 for invalid webhook payloads without invoking handlers', async () => {
+    const appWithoutSig = whatsappRouter({
+      gateway,
+      sessionMapper,
+      appSecret,
+      verifyToken,
+      verifySignature: false,
+    });
+
+    const res = await appWithoutSig.request('/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ object: 'whatsapp_business_account', entry: 'not-an-array' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid payload' });
+    expect(gateway.handleInbound).not.toHaveBeenCalled();
+    expect(gateway.handleAction).not.toHaveBeenCalled();
   });
 
   it('routes button reply to gateway', async () => {


### PR DESCRIPTION
## Summary
- return HTTP 400 for malformed or schema-invalid Slack, Discord, Telegram, and WhatsApp webhook payloads
- add regression coverage that invalid payloads do not invoke gateway handlers

## Test Plan
- npm --workspace @franken/orchestrator test -- tests/unit/comms/slack-router.test.ts tests/unit/comms/discord-router.test.ts tests/unit/comms/telegram-router.test.ts tests/unit/comms/whatsapp-router.test.ts
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator run lint (passes with existing warnings)
- npm --workspace @franken/orchestrator run build
- npx turbo run test --filter=@franken/orchestrator

Closes #680