### PR TITLE
fix(orchestrator): support init backend flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,10 +558,12 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 Set this in `.fbeast/config.json`, then run `frankenbeast init` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
 
 **1Password / Bitwarden:**
-```json
-{ "network": { "secureBackend": "1password" } }
+```bash
+frankenbeast init --backend 1password
+# or
+frankenbeast init --backend bitwarden
 ```
-Set the backend in `.fbeast/config.json`, then run `frankenbeast init` (there is no `--backend` CLI flag). For 1Password, create or use a vault literally named `frankenbeast`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, run `bw login`/`bw unlock` and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+You can also set the backend in `.fbeast/config.json` with `{ "network": { "secureBackend": "1password" } }` before running `frankenbeast init`. For 1Password, create or use a vault literally named `frankenbeast`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, run `bw login`/`bw unlock` and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -95,6 +95,7 @@ export interface CliArgs {
   initVerify: boolean;
   initRepair: boolean;
   initNonInteractive: boolean;
+  initBackend?: string | undefined;
   beastExecutionMode?: import('../beasts/types.js').BeastExecutionMode | undefined;
   moduleConfig?: import('../beasts/types.js').ModuleConfig | undefined;
 }
@@ -107,7 +108,7 @@ const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
 const STRING_OPTIONS = new Set([
   'base-dir', 'base-branch', 'budget', 'provider', 'providers', 'design-doc', 'plan-dir', 'plan-name', 'output-dir',
   'goal', 'output', 'config', 'host', 'port', 'allow-origin', 'label', 'milestone', 'search', 'assignee', 'limit',
-  'repo', 'mode', 'set',
+  'repo', 'mode', 'set', 'backend',
 ]);
 const BOOLEAN_SHORT_OPTIONS = new Set(['d']);
 const DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
@@ -151,6 +152,7 @@ Options:
   --verify                Verify init config and readiness
   --repair                Re-run only missing or failed init steps
   --non-interactive       Disable interactive prompts for init
+  --backend <name>        Init secret backend: local-encrypted, os-keychain, 1password, bitwarden
   --help                  Show this help message
 
 Non-interactive HITL:
@@ -385,6 +387,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       verify: { type: 'boolean', default: false },
       repair: { type: 'boolean', default: false },
       'non-interactive': { type: 'boolean', default: false },
+      backend: { type: 'string' },
       help: { type: 'boolean', default: false },
       label: { type: 'string' },
       milestone: { type: 'string' },
@@ -494,6 +497,18 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     throw new TypeError('--mode is only supported for beasts create, spawn, status, and logs');
   }
 
+  if (values.backend !== undefined && subcommand !== 'init') {
+    throw new TypeError('--backend is only supported for init');
+  }
+
+  const initBackend = values.backend?.toLowerCase();
+  if (initBackend !== undefined) {
+    const validBackends = new Set(['local-encrypted', 'os-keychain', '1password', 'bitwarden']);
+    if (!validBackends.has(initBackend)) {
+      throw new TypeError(`Invalid init backend '${values.backend}'. Valid: local-encrypted, os-keychain, 1password, bitwarden`);
+    }
+  }
+
   const providersRaw = values.providers;
   const providers = providersRaw
     ? providersRaw.split(',').map((p) => p.trim().toLowerCase())
@@ -583,6 +598,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     initVerify: values.verify ?? false,
     initRepair: values.repair ?? false,
     initNonInteractive: values['non-interactive'] ?? false,
+    initBackend,
     help: values.help ?? false,
     issueLabel,
     issueMilestone: values.milestone,

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -103,6 +103,10 @@ function fromCli(args: CliArgs): Partial<OrchestratorConfig> {
     cli.enableTracing = true;
   }
 
+  if (args.initBackend) {
+    cli.network = { secureBackend: args.initBackend } as Partial<OrchestratorConfig['network']> as OrchestratorConfig['network'];
+  }
+
   return cli;
 }
 

--- a/packages/franken-orchestrator/src/cli/init-command.ts
+++ b/packages/franken-orchestrator/src/cli/init-command.ts
@@ -68,6 +68,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
       configFile: options.paths.configFile,
       stateStore,
       io: options.io,
+      baseConfig: options.config,
       secretStore,
     });
     options.print(
@@ -79,6 +80,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     configFile: options.paths.configFile,
     stateStore,
     io: options.io,
+    baseConfig: options.config,
     secretStore,
   });
 

--- a/packages/franken-orchestrator/src/cli/init-command.ts
+++ b/packages/franken-orchestrator/src/cli/init-command.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
+import type { SecureBackend } from '../network/network-config.js';
 import type { CliArgs } from './args.js';
 import type { ProjectPaths } from './project-root.js';
 import type { InterviewIO } from '../planning/interview-loop.js';
@@ -62,13 +63,14 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     io: options.io,
     passphrase,
   });
+  const initBackend = options.args.initBackend as SecureBackend | undefined;
 
   if (options.args.initRepair) {
     const result = await runRepairInit({
       configFile: options.paths.configFile,
       stateStore,
       io: options.io,
-      baseConfig: options.config,
+      initBackend,
       secretStore,
     });
     options.print(
@@ -80,7 +82,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     configFile: options.paths.configFile,
     stateStore,
     io: options.io,
-    baseConfig: options.config,
+    initBackend,
     secretStore,
   });
 

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -17,6 +17,7 @@ interface RunInteractiveInitOptions {
   configFile: string;
   stateStore: FileInitStateStore;
   io: InterviewIO;
+  baseConfig?: OrchestratorConfig | undefined;
   secretStore?: ISecretStore | undefined;
 }
 
@@ -41,7 +42,7 @@ async function saveConfig(configFile: string, config: OrchestratorConfig): Promi
 
 export async function runInteractiveInit(options: RunInteractiveInitOptions): Promise<InitEngineResult> {
   const initialState = await options.stateStore.load(options.configFile);
-  const baseConfig = await loadExistingConfig(options.configFile);
+  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile);
   const result = await runInitWizard({
     io: options.io,
     initialState,
@@ -79,7 +80,7 @@ export async function runRepairInit(options: RunRepairInitOptions): Promise<Init
   }
 
   const initialState = await options.stateStore.load(options.configFile);
-  const baseConfig = await loadExistingConfig(options.configFile);
+  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile);
   const scope = verification.issues.flatMap((issue) => {
     switch (issue.code) {
       case 'slack-incomplete':

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -18,6 +18,7 @@ interface RunInteractiveInitOptions {
   stateStore: FileInitStateStore;
   io: InterviewIO;
   baseConfig?: OrchestratorConfig | undefined;
+  initBackend?: OrchestratorConfig['network']['secureBackend'] | undefined;
   secretStore?: ISecretStore | undefined;
 }
 
@@ -35,6 +36,20 @@ async function loadExistingConfig(configFile: string): Promise<OrchestratorConfi
   }
 }
 
+async function resolveBaseConfig(options: RunInteractiveInitOptions): Promise<OrchestratorConfig> {
+  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile);
+  if (!options.initBackend) {
+    return baseConfig;
+  }
+  return {
+    ...baseConfig,
+    network: {
+      ...baseConfig.network,
+      secureBackend: options.initBackend,
+    },
+  };
+}
+
 async function saveConfig(configFile: string, config: OrchestratorConfig): Promise<void> {
   await mkdir(dirname(configFile), { recursive: true });
   await writeFile(configFile, JSON.stringify(config, null, 2) + '\n', 'utf-8');
@@ -42,7 +57,7 @@ async function saveConfig(configFile: string, config: OrchestratorConfig): Promi
 
 export async function runInteractiveInit(options: RunInteractiveInitOptions): Promise<InitEngineResult> {
   const initialState = await options.stateStore.load(options.configFile);
-  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile);
+  const baseConfig = await resolveBaseConfig(options);
   const result = await runInitWizard({
     io: options.io,
     initialState,
@@ -80,7 +95,7 @@ export async function runRepairInit(options: RunRepairInitOptions): Promise<Init
   }
 
   const initialState = await options.stateStore.load(options.configFile);
-  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile);
+  const baseConfig = await resolveBaseConfig(options);
   const scope = verification.issues.flatMap((issue) => {
     switch (issue.code) {
       case 'slack-incomplete':

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -47,6 +47,20 @@ describe('parseArgs', () => {
     expect(args.initNonInteractive).toBe(true);
   });
 
+  it('parses init --backend and normalizes the backend id', () => {
+    const args = parseArgs(['init', '--backend', '1PASSWORD']);
+    expect(args.subcommand).toBe('init');
+    expect(args.initBackend).toBe('1password');
+  });
+
+  it('rejects --backend outside the init subcommand', () => {
+    expect(() => parseArgs(['run', '--backend', '1password'])).toThrow('--backend is only supported for init');
+  });
+
+  it('rejects unsupported init backends', () => {
+    expect(() => parseArgs(['init', '--backend', 'vault'])).toThrow('Invalid init backend');
+  });
+
   it('parses chat-server subcommand with local defaults', () => {
     const args = parseArgs(['chat-server']);
     expect(args.subcommand).toBe('chat-server');

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -118,6 +118,16 @@ describe('Config loader', () => {
     expect(config.enableTracing).toBe(true);
   });
 
+  it('CLI init backend overrides the configured secret backend', async () => {
+    const filePath = join(tmpdir(), `beast-backend-config-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({ network: { secureBackend: 'local-encrypted' } }));
+
+    const config = await loadConfig(makeArgs({ subcommand: 'init', initBackend: '1password', config: filePath }));
+
+    expect(config.network.secureBackend).toBe('1password');
+  });
+
   it('reads boolean env vars', async () => {
     process.env['FRANKEN_ENABLE_HEARTBEAT'] = 'false';
     const config = await loadConfig(makeArgs());

--- a/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
@@ -110,6 +110,102 @@ describe('handleInitCommand', () => {
     expect(initState.selectedModules).toEqual(['chat']);
   });
 
+  it('does not persist unrelated resolved CLI/env config when applying init backend', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-command-'));
+    const frankenbeastDir = join(tempDir, '.fbeast');
+    const configFile = join(frankenbeastDir, 'config.json');
+    const resolvedConfig = defaultConfig();
+    resolvedConfig.enableTracing = true;
+    resolvedConfig.network.secureBackend = 'local-encrypted';
+
+    await handleInitCommand({
+      args: {
+        subcommand: 'init',
+        networkAction: undefined,
+        networkTarget: undefined,
+        networkDetached: false,
+        networkSet: undefined,
+        baseDir: tempDir,
+        baseBranch: undefined,
+        budget: 10,
+        provider: 'claude',
+        providers: undefined,
+        designDoc: undefined,
+        planDir: undefined,
+        planName: undefined,
+        noPr: false,
+        verbose: false,
+        reset: false,
+        resume: false,
+        cleanup: false,
+        config: undefined,
+        host: undefined,
+        port: undefined,
+        allowOrigin: undefined,
+        help: false,
+        issueLabel: undefined,
+        issueMilestone: undefined,
+        issueSearch: undefined,
+        issueAssignee: undefined,
+        issueLimit: undefined,
+        issueRepo: undefined,
+        dryRun: undefined,
+        initVerify: false,
+        initRepair: false,
+        initNonInteractive: false,
+        initBackend: 'local-encrypted',
+      },
+      config: resolvedConfig,
+      io: {
+        ask: async (prompt: string) => {
+          switch (prompt) {
+            case 'Enter passphrase for local encrypted store:':
+              return 'test-passphrase';
+            case 'Enable Chat? [Y/n]':
+              return 'n';
+            case 'Enable Dashboard? [Y/n]':
+              return 'n';
+            case 'Enable Comms? [y/N]':
+              return 'n';
+            case 'Default provider [claude]':
+              return '';
+            case 'Security mode [secure/insecure] (default: secure)':
+              return '';
+            case 'Enter operator token (leave blank to auto-generate):':
+              return '';
+            default:
+              return '';
+          }
+        },
+        display: () => undefined,
+      },
+      paths: {
+        root: tempDir,
+        frankenbeastDir,
+        llmCacheDir: join(frankenbeastDir, '.cache', 'llm'),
+        plansDir: join(frankenbeastDir, 'plans'),
+        buildDir: join(frankenbeastDir, '.build'),
+        beastsDir: join(frankenbeastDir, '.build', 'beasts'),
+        beastLogsDir: join(frankenbeastDir, '.build', 'beasts', 'logs'),
+        beastsDb: join(frankenbeastDir, 'beast.db'),
+        chunkSessionsDir: join(frankenbeastDir, '.build', 'chunk-sessions'),
+        chunkSessionSnapshotsDir: join(frankenbeastDir, '.build', 'chunk-session-snapshots'),
+        checkpointFile: join(frankenbeastDir, '.build', '.checkpoint'),
+        tracesDb: join(frankenbeastDir, '.build', 'build-traces.db'),
+        logFile: join(frankenbeastDir, '.build', 'build.log'),
+        designDocFile: join(frankenbeastDir, 'plans', 'design.md'),
+        configFile,
+        llmResponseFile: join(frankenbeastDir, 'plans', 'llm-response.json'),
+      },
+      print: () => undefined,
+    });
+
+    const config = JSON.parse(await readFile(configFile, 'utf-8')) as { enableTracing: boolean; network: { secureBackend: string } };
+
+    expect(config.network.secureBackend).toBe('local-encrypted');
+    expect(config.enableTracing).toBe(false);
+  });
+
   it('fails fast without prompting when init is non-interactive and config is missing', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-init-command-'));
     const frankenbeastDir = join(tempDir, '.fbeast');

--- a/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { runInteractiveInit } from '../../../src/init/init-engine.js';
 import { FileInitStateStore } from '../../../src/init/init-state-store.js';
 import { createEmptyInitState } from '../../../src/init/init-types.js';
+import { defaultConfig } from '../../../src/config/orchestrator-config.js';
 
 function scriptedIo(...answers: string[]) {
   const prompts: string[] = [];
@@ -93,6 +94,35 @@ describe('runInteractiveInit', () => {
     expect(result.config.comms.enabled).toBe(false);
     expect(prompts.some((prompt) => prompt.includes('Slack'))).toBe(false);
     expect(prompts.some((prompt) => prompt.includes('Discord'))).toBe(false);
+  });
+
+  it('preserves a CLI-provided init secret backend in the saved config', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-engine-'));
+    const configFile = join(tempDir, '.fbeast', 'config.json');
+    const stateStore = new FileInitStateStore(join(tempDir, '.fbeast', 'init-state.json'));
+    const { io } = scriptedIo(
+      'n', // chat
+      'y', // dashboard
+      'n', // comms
+      'claude', // provider
+      'secure', // security mode
+    );
+    const baseConfig = defaultConfig();
+
+    const result = await runInteractiveInit({
+      configFile,
+      stateStore,
+      io,
+      baseConfig: {
+        ...baseConfig,
+        network: {
+          ...baseConfig.network,
+          secureBackend: '1password',
+        },
+      },
+    });
+
+    expect(result.config.network.secureBackend).toBe('1password');
   });
 
   it('resumes from saved init state defaults instead of starting from scratch', async () => {


### PR DESCRIPTION
## Summary
- Add `frankenbeast init --backend <name>` parsing/validation for supported secret backends.
- Feed the init backend CLI override through config loading into interactive/repair init flows.
- Update init backend docs and add CLI/config/init-engine tests.

## Test Plan
- `npx vitest run tests/unit/cli/args.test.ts tests/unit/cli/config-loader.test.ts tests/unit/init/init-engine.test.ts` from `packages/franken-orchestrator`
- `npm run typecheck -- --filter=@franken/orchestrator`
- `npm test -- --filter=@franken/orchestrator`
- `npm run lint` from `packages/franken-orchestrator` (passes with existing warnings)
- `npx turbo run typecheck test --filter=@franken/orchestrator`

Closes #674
