### PR TITLE
fix(orchestrator): clean up chat websocket listeners

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -318,7 +318,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     void handleHonoHttpRequest(app, request, response);
   });
 
-  attachChatWebSocketServer({
+  const webSocketServer = attachChatWebSocketServer({
     server,
     path,
     runtime: runtime.runtime,
@@ -351,6 +351,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     url,
     wsUrl,
     close: async () => {
+      webSocketServer.close();
       await stopLiveBeastControlRuns(options.beastControl);
       options.beastControl?.ticketStore.destroy();
       options.disposeBeastControl?.();

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -450,6 +450,9 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
     server,
     close: () => {
       options.server.off('upgrade', onUpgrade);
+      for (const client of server.clients) {
+        client.terminate();
+      }
       server.close();
     },
   };

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -389,7 +389,7 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
   const controller = new ChatSocketController(options);
   const server = new WebSocketServer({ noServer: true });
 
-  options.server.on('upgrade', (request, socket, head) => {
+  const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer): void => {
     const url = new URL(request.url ?? '', 'http://localhost');
     if (url.pathname !== path) {
       return;
@@ -441,7 +441,16 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
       });
       ws.on('close', () => controller.disconnect(peer));
     });
-  });
+  };
 
-  return { controller, server };
+  options.server.on('upgrade', onUpgrade);
+
+  return {
+    controller,
+    server,
+    close: () => {
+      options.server.off('upgrade', onUpgrade);
+      server.close();
+    },
+  };
 }

--- a/packages/franken-orchestrator/src/ws.d.ts
+++ b/packages/franken-orchestrator/src/ws.d.ts
@@ -9,10 +9,12 @@ declare module 'ws' {
     on(event: 'message', listener: (data: RawData) => void): this;
     on(event: 'close', listener: () => void): this;
     send(data: string): void;
+    terminate(): void;
   }
 
   export class WebSocketServer {
     constructor(options: { noServer?: boolean });
+    clients: Set<WebSocket>;
     close(callback?: (err?: Error) => void): void;
     handleUpgrade(
       request: IncomingMessage,

--- a/packages/franken-orchestrator/src/ws.d.ts
+++ b/packages/franken-orchestrator/src/ws.d.ts
@@ -13,6 +13,7 @@ declare module 'ws' {
 
   export class WebSocketServer {
     constructor(options: { noServer?: boolean });
+    close(callback?: (err?: Error) => void): void;
     handleUpgrade(
       request: IncomingMessage,
       socket: Duplex,

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -91,6 +91,23 @@ describe('chat server bootstrap', () => {
     }
   });
 
+  it('removes websocket upgrade listeners on shutdown', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const server = await startChatServer({
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir: TMP,
+      llm: { complete: vi.fn().mockResolvedValue('') },
+      projectName: 'test-project',
+    });
+
+    expect(server.server.listenerCount('upgrade')).toBe(1);
+
+    await server.close();
+
+    expect(server.server.listenerCount('upgrade')).toBe(0);
+  });
+
   it('mounts beast routes on the live server when beast control is configured', async () => {
     mkdirSync(TMP, { recursive: true });
     const llm = { complete: vi.fn().mockResolvedValue('Server reply') };

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -33,6 +33,22 @@ function waitForSocketEvent(socket: WebSocket, type: string): Promise<Record<str
   });
 }
 
+function waitForSocketClose(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (socket.readyState === WebSocket.CLOSED) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for websocket close'));
+    }, 2_000);
+    socket.addEventListener('close', () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+}
+
 describe('chat server bootstrap', () => {
   afterEach(() => {
     rmSync(TMP, { recursive: true, force: true });
@@ -91,7 +107,7 @@ describe('chat server bootstrap', () => {
     }
   });
 
-  it('removes websocket upgrade listeners on shutdown', async () => {
+  it('removes websocket upgrade listeners and closes active sockets on shutdown', async () => {
     mkdirSync(TMP, { recursive: true });
     const server = await startChatServer({
       host: '127.0.0.1',
@@ -101,9 +117,31 @@ describe('chat server bootstrap', () => {
       projectName: 'test-project',
     });
 
+    const createRes = await fetch(`${server.url}/v1/chat/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    expect(createRes.status).toBe(201);
+    const body = await createRes.json() as {
+      data: {
+        id: string;
+        socketToken: string;
+      };
+    };
+    const socket = new WebSocket(
+      `${server.wsUrl}?sessionId=${encodeURIComponent(body.data.id)}`,
+      [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${body.data.socketToken}`],
+    );
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener('open', () => resolve(), { once: true });
+      socket.addEventListener('error', (event) => reject(event.error ?? new Error('websocket error')), { once: true });
+    });
+
     expect(server.server.listenerCount('upgrade')).toBe(1);
 
     await server.close();
+    await waitForSocketClose(socket);
 
     expect(server.server.listenerCount('upgrade')).toBe(0);
   });

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../../src/http/chat-app.js', () => {
   };
 });
 vi.mock('../../../src/http/ws-chat-server.js', () => ({
-  attachChatWebSocketServer: vi.fn(),
+  attachChatWebSocketServer: vi.fn(() => ({ close: vi.fn() })),
 }));
 
 import { startChatServer } from '../../../src/http/chat-server.js';


### PR DESCRIPTION
## Summary
- detaches the chat WebSocket `upgrade` listener when the chat server handle closes
- closes the `WebSocketServer` no-server instance during shutdown
- adds regression coverage for listener cleanup and updates the websocket type shim

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-server.test.ts -t 'removes websocket upgrade listeners on shutdown' (RED before source fix: failed with listenerCount 1 after close)
- npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-server.test.ts tests/unit/http/chat-server-comms.test.ts tests/unit/cli/session-issues.test.ts tests/unit/cli/session-plan.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings)
- npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator test (full suite: two timeout failures in session-plan/session-issues under full concurrency; both passed when rerun directly)

Closes #690