### PR TITLE
fix(mcp): stream hook audit payloads via stdin

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
@@ -64,7 +64,18 @@ function installFakeHook(root: string): string {
     'fi',
     '',
     'if [ "$PHASE" = "post-tool" ]; then',
-    '  TOOL_NAME="${3:-}"',
+    '  TOOL_NAME="${4:-}"',
+    '  PAYLOAD=$(cat)',
+    '  if [ "${FBEAST_EXPECT_STDIN_PAYLOAD:-}" = "1" ]; then',
+    "    if [ \"$#\" -ne 4 ]; then",
+    "      printf 'post-tool payload should not be passed as argv; saw %s args\\n' \"$#\" >&2",
+    '      exit 98',
+    '    fi',
+    '    if [ ${#PAYLOAD} -lt 300000 ]; then',
+    "      printf 'post-tool payload was not streamed on stdin\\n' >&2",
+    '      exit 97',
+    '    fi',
+    '  fi',
     '  if [ "$TOOL_NAME" = "hang" ]; then',
     '    sleep 10',
     '    exit 0',
@@ -358,6 +369,24 @@ describe('Codex hook scripts', () => {
       tool_response: { ok: true },
       session_id: 'sess-1',
     }, binDir);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('streams large post-tool responses to fbeast-hook stdin instead of argv', () => {
+    const root = makeTempRoot();
+    tempRoots.push(root);
+    const binDir = installFakeHook(root);
+    const { postTool } = writeHookScripts(root, 'codex');
+
+    const result = runScript(postTool, {
+      tool_name: 'read_file',
+      tool_response: { output: 'x'.repeat(300_000) },
+      session_id: 'sess-1',
+    }, binDir, {
+      FBEAST_EXPECT_STDIN_PAYLOAD: '1',
+    });
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toBe('');

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
@@ -64,10 +64,10 @@ function installFakeHook(root: string): string {
     'fi',
     '',
     'if [ "$PHASE" = "post-tool" ]; then',
-    '  TOOL_NAME="${4:-}"',
+    '  TOOL_NAME="${5:-}"',
     '  PAYLOAD=$(cat)',
     '  if [ "${FBEAST_EXPECT_STDIN_PAYLOAD:-}" = "1" ]; then',
-    "    if [ \"$#\" -ne 4 ]; then",
+    "    if [ \"$#\" -ne 5 ]; then",
     "      printf 'post-tool payload should not be passed as argv; saw %s args\\n' \"$#\" >&2",
     '      exit 98',
     '    fi',
@@ -387,6 +387,25 @@ describe('Codex hook scripts', () => {
     }, binDir, {
       FBEAST_EXPECT_STDIN_PAYLOAD: '1',
     });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('fails open when post-tool payload staging cannot create temp files', () => {
+    const root = makeTempRoot();
+    tempRoots.push(root);
+    const binDir = installFakeHook(root);
+    const pythonPath = join(binDir, 'python3');
+    writeFileSync(pythonPath, '#!/bin/sh\nexit 42\n');
+    chmodSync(pythonPath, 0o755);
+    const { postTool } = writeHookScripts(root, 'codex');
+
+    const result = runScript(postTool, {
+      tool_name: 'read_file',
+      tool_response: { output: 'x'.repeat(300_000) },
+      session_id: 'sess-1',
+    }, binDir);
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toBe('');

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -105,17 +105,20 @@ fi
 DB_PATH=${JSON.stringify(dbPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()")
-PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()")
-trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:]]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
-cat > "$INPUT_FILE"
+INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()") || exit 0
+PAYLOAD_FILE=""
+trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:] if p]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()") || exit 0
+cat > "$INPUT_FILE" || exit 0
 TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
-python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null || printf '{}' > "$PAYLOAD_FILE"
+if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+  printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
+fi
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
+  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" --stdin-payload -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 else
-  fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
+  fbeast-hook post-tool --db "$DB_PATH" --stdin-payload -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 fi
 exit 0
 `);
@@ -197,17 +200,20 @@ fi
 DB_PATH=${JSON.stringify(dbPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()")
-PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()")
-trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:]]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
-cat > "$INPUT_FILE"
+INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()") || exit 0
+PAYLOAD_FILE=""
+trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:] if p]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()") || exit 0
+cat > "$INPUT_FILE" || exit 0
 TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
-python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null || printf '{}' > "$PAYLOAD_FILE"
+if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+  printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
+fi
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
+  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" --stdin-payload -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 else
-  fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
+  fbeast-hook post-tool --db "$DB_PATH" --stdin-payload -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 fi
 exit 0
 `);
@@ -290,17 +296,20 @@ fi
 DB_PATH=${JSON.stringify(dbPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()")
-PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()")
-trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:]]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
-cat > "$INPUT_FILE"
+INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()") || exit 0
+PAYLOAD_FILE=""
+trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:] if p]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()") || exit 0
+cat > "$INPUT_FILE" || exit 0
 TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
-python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null || printf '{}' > "$PAYLOAD_FILE"
+if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+  printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
+fi
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
+  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" --stdin-payload -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 else
-  fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
+  fbeast-hook post-tool --db "$DB_PATH" --stdin-payload -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 fi
 exit 0
 `);

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -105,14 +105,17 @@ fi
 DB_PATH=${JSON.stringify(dbPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null || echo "")
-TOOL_RESPONSE=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('tool_response',{})))" 2>/dev/null || echo "{}")
+INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()")
+PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()")
+trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:]]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+cat > "$INPUT_FILE"
+TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
+python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null || printf '{}' > "$PAYLOAD_FILE"
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" "$TOOL_NAME" "$TOOL_RESPONSE" >/dev/null 2>&1 || true
+  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 else
-  fbeast-hook post-tool --db "$DB_PATH" "$TOOL_NAME" "$TOOL_RESPONSE" >/dev/null 2>&1 || true
+  fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 fi
 exit 0
 `);
@@ -194,14 +197,17 @@ fi
 DB_PATH=${JSON.stringify(dbPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null || echo "")
-TOOL_RESPONSE=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('tool_response',{})))" 2>/dev/null || echo "{}")
+INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()")
+PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()")
+trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:]]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+cat > "$INPUT_FILE"
+TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
+python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null || printf '{}' > "$PAYLOAD_FILE"
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" "$TOOL_NAME" "$TOOL_RESPONSE" >/dev/null 2>&1 || true
+  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 else
-  fbeast-hook post-tool --db "$DB_PATH" "$TOOL_NAME" "$TOOL_RESPONSE" >/dev/null 2>&1 || true
+  fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 fi
 exit 0
 `);
@@ -284,14 +290,17 @@ fi
 DB_PATH=${JSON.stringify(dbPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null || echo "")
-TOOL_RESPONSE=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('tool_response',{})))" 2>/dev/null || echo "{}")
+INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()")
+PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()")
+trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:]]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+cat > "$INPUT_FILE"
+TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
+python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null || printf '{}' > "$PAYLOAD_FILE"
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" "$TOOL_NAME" "$TOOL_RESPONSE" >/dev/null 2>&1 || true
+  timeout "$HOOK_TIMEOUT_SECONDS" fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 else
-  fbeast-hook post-tool --db "$DB_PATH" "$TOOL_NAME" "$TOOL_RESPONSE" >/dev/null 2>&1 || true
+  fbeast-hook post-tool --db "$DB_PATH" -- "$TOOL_NAME" < "$PAYLOAD_FILE" >/dev/null 2>&1 || true
 fi
 exit 0
 `);

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -18,6 +18,11 @@ export interface HookDeps {
    * rather than stdin is also non-blocking.
    */
   readContext(): string;
+  /**
+   * Reads a streamed post-tool payload. Generated client hook scripts use stdin
+   * for tool responses so large outputs never become argv/env exec payloads.
+   */
+  readPostToolPayload?(): Promise<string>;
 }
 
 export function defaultHookDeps(dbPath?: string): HookDeps {
@@ -49,6 +54,18 @@ export function redactSecrets(text: string): string {
     .replace(/(\b(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key)\b\s*[=:]\s*)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
+}
+
+async function readStdinPayload(): Promise<string> {
+  if (process.stdin.isTTY) {
+    return '';
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
 }
 
 export async function runHook(
@@ -99,9 +116,15 @@ export async function runHook(
   }
 
   if (phase === 'post-tool') {
+    // Generated hook scripts stream large tool responses on stdin instead of
+    // passing them through argv, avoiding ARG_MAX/E2BIG audit bypasses. Keep the
+    // positional payload fallback for direct/legacy callers.
+    const streamedPayload = payload === ''
+      ? await (resolvedDeps.readPostToolPayload?.() ?? readStdinPayload())
+      : '';
     await resolvedDeps.observer.log({
       event: 'tool_call',
-      metadata: JSON.stringify({ toolName, payload, phase }),
+      metadata: JSON.stringify({ toolName, payload: payload || streamedPayload, phase }),
       sessionId: resolvedDeps.sessionId(),
     });
     process.stdout.write(JSON.stringify({ logged: true }) + '\n');

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -76,6 +76,7 @@ export async function runHook(
   // option parsing so any following token (e.g. an untrusted tool name) is never
   // interpreted as a flag.
   let dbPath: string | undefined;
+  let streamPostToolPayload = false;
   const positionals: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
@@ -87,6 +88,8 @@ export async function runHook(
       dbPath = argv[++i];
     } else if (arg.startsWith('--db=')) {
       dbPath = arg.slice(5);
+    } else if (arg === '--stdin-payload') {
+      streamPostToolPayload = true;
     } else {
       positionals.push(arg);
     }
@@ -116,10 +119,10 @@ export async function runHook(
   }
 
   if (phase === 'post-tool') {
-    // Generated hook scripts stream large tool responses on stdin instead of
-    // passing them through argv, avoiding ARG_MAX/E2BIG audit bypasses. Keep the
-    // positional payload fallback for direct/legacy callers.
-    const streamedPayload = payload === ''
+    // Generated hook scripts pass --stdin-payload and stream large tool responses
+    // on stdin instead of argv, avoiding ARG_MAX/E2BIG audit bypasses. Keep stdin
+    // opt-in so direct/legacy callers that omit payload keep empty-payload behavior.
+    const streamedPayload = payload === '' && streamPostToolPayload
       ? await (resolvedDeps.readPostToolPayload?.() ?? readStdinPayload())
       : '';
     await resolvedDeps.observer.log({

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -69,9 +69,9 @@ describe('fbeast-hook runtime', () => {
     expect(result.stdout).toContain('"logged":true');
   });
 
-  it('reads post-tool payloads from the stream when argv payload is omitted', async () => {
+  it('reads post-tool payloads from the stream when argv payload is omitted and stdin opt-in is set', async () => {
     const streamedPayload = JSON.stringify({ ok: true, output: 'x'.repeat(300_000) });
-    const result = await runHookForTest(['post-tool', '--', 'read_file'], {
+    const result = await runHookForTest(['post-tool', '--stdin-payload', '--', 'read_file'], {
       streamedPayload,
     });
 
@@ -80,6 +80,20 @@ describe('fbeast-hook runtime', () => {
     expect(JSON.parse(result.observerLogs[0]!.metadata)).toEqual({
       toolName: 'read_file',
       payload: streamedPayload,
+      phase: 'post-tool',
+    });
+  });
+
+  it('preserves empty payload behavior for legacy post-tool callers that omit stdin opt-in', async () => {
+    const result = await runHookForTest(['post-tool', '--', 'read_file'], {
+      streamedPayload: JSON.stringify({ shouldNotBeRead: true }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.observerLogs).toHaveLength(1);
+    expect(JSON.parse(result.observerLogs[0]!.metadata)).toEqual({
+      toolName: 'read_file',
+      payload: '',
       phase: 'post-tool',
     });
   });

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -68,6 +68,21 @@ describe('fbeast-hook runtime', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('"logged":true');
   });
+
+  it('reads post-tool payloads from the stream when argv payload is omitted', async () => {
+    const streamedPayload = JSON.stringify({ ok: true, output: 'x'.repeat(300_000) });
+    const result = await runHookForTest(['post-tool', '--', 'read_file'], {
+      streamedPayload,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.observerLogs).toHaveLength(1);
+    expect(JSON.parse(result.observerLogs[0]!.metadata)).toEqual({
+      toolName: 'read_file',
+      payload: streamedPayload,
+      phase: 'post-tool',
+    });
+  });
 });
 
 async function runHookForTest(
@@ -75,16 +90,19 @@ async function runHookForTest(
   options: {
     governorDecision?: { decision: string; reason: string };
     context?: string;
+    streamedPayload?: string;
   } = {},
 ): Promise<{
   exitCode: number;
   stdout: string;
   stderr: string;
   checkCalls: Array<{ action: string; context: string }>;
+  observerLogs: Array<{ event: string; metadata: string; sessionId: string }>;
 }> {
   let stdout = '';
   let stderr = '';
   const checkCalls: Array<{ action: string; context: string }> = [];
+  const observerLogs: Array<{ event: string; metadata: string; sessionId: string }> = [];
 
   vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
     stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
@@ -109,6 +127,7 @@ async function runHookForTest(
       };
       sessionId(): string;
       readContext(): string;
+      readPostToolPayload?(): Promise<string>;
     },
   ) => Promise<void>)(argv, {
     governor: {
@@ -118,11 +137,15 @@ async function runHookForTest(
       }),
     },
     observer: {
-      log: vi.fn().mockResolvedValue({ id: 1, hash: 'abc123' }),
+      log: vi.fn().mockImplementation(async (input: { event: string; metadata: string; sessionId: string }) => {
+        observerLogs.push(input);
+        return { id: 1, hash: 'abc123' };
+      }),
     },
     sessionId: () => 'sess-test',
     readContext: () => options.context ?? '',
+    readPostToolPayload: async () => options.streamedPayload ?? '',
   });
 
-  return { exitCode: process.exitCode ?? 0, stdout, stderr, checkCalls };
+  return { exitCode: process.exitCode ?? 0, stdout, stderr, checkCalls, observerLogs };
 }


### PR DESCRIPTION
## Summary
- stream generated MCP hook post-tool responses into `fbeast-hook` via stdin instead of argv
- teach `fbeast-hook post-tool` to read stdin when the positional payload is omitted while keeping legacy argv payload support
- add regression coverage for large post-tool responses and runtime stdin payload logging

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/cli/hook-scripts.test.ts src/integration/hook.integration.test.ts
- npx turbo run typecheck --filter=@franken/mcp-suite...
- npx turbo run build --filter=@franken/mcp-suite...
- npx turbo run test --filter=@franken/mcp-suite

Closes #848
