### PR TITLE
fix(security): share realpath containment checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7656,6 +7656,7 @@
       "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
+        "@franken/types": "0.7.6",
         "better-sqlite3": "^12.6.2"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7537,7 +7537,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "better-sqlite3": "^12.6.2"
       },
       "devDependencies": {
@@ -7557,7 +7557,7 @@
       "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "acorn": "^8.17.0",
         "acorn-typescript": "^1.4.13",
         "hono": "^4.12.27",
@@ -7597,7 +7597,7 @@
       "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "hono": "^4.12.27"
       },
       "devDependencies": {
@@ -7621,7 +7621,7 @@
         "@franken/observer": "0.7.11",
         "@franken/orchestrator": "0.40.0",
         "@franken/planner": "0.4.9",
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2"
       },
@@ -7656,7 +7656,7 @@
       "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "better-sqlite3": "^12.6.2"
       },
       "devDependencies": {
@@ -7695,7 +7695,7 @@
         "@franken/governor": "0.5.9",
         "@franken/observer": "0.7.11",
         "@franken/planner": "0.4.9",
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "@google/genai": "^1.46.0",
         "better-sqlite3": "^12.6.2",
         "dotenv": "^17.3.1",
@@ -7745,7 +7745,7 @@
       "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "0.7.6"
+        "@franken/types": "0.7.7"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.9",
@@ -7775,7 +7775,7 @@
     },
     "packages/franken-types": {
       "name": "@franken/types",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.25.76"
@@ -7809,7 +7809,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@franken/types": "0.7.6",
+        "@franken/types": "0.7.7",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/franken-brain/package.json
+++ b/packages/franken-brain/package.json
@@ -30,7 +30,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "better-sqlite3": "^12.6.2"
   },
   "engines": {

--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -52,7 +52,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "acorn": "^8.17.0",
     "acorn-typescript": "^1.4.13",
     "hono": "^4.12.27",

--- a/packages/franken-governor/package.json
+++ b/packages/franken-governor/package.json
@@ -34,7 +34,7 @@
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
   "dependencies": {
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "hono": "^4.12.27"
   },
   "devDependencies": {

--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "@franken/brain": "0.7.0",
     "@franken/critique": "0.6.11",
     "@franken/governor": "0.5.9",

--- a/packages/franken-observer/package.json
+++ b/packages/franken-observer/package.json
@@ -30,7 +30,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "better-sqlite3": "^12.6.2"
   },
   "engines": {

--- a/packages/franken-observer/package.json
+++ b/packages/franken-observer/package.json
@@ -30,6 +30,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
+    "@franken/types": "0.7.6",
     "better-sqlite3": "^12.6.2"
   },
   "engines": {

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -2,7 +2,7 @@ import { constants as fsConstants } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { join, resolve } from 'node:path'
-import { resolveContainedPath } from '@franken/types'
+import { resolveContainedPath } from '@franken/types/path-containment'
 import type { Trace } from '../core/types.js'
 import type { InterruptSignal } from './InterruptEmitter.js'
 

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -1,7 +1,8 @@
 import { constants as fsConstants } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { createHash } from 'node:crypto'
-import { isAbsolute, join, relative, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
+import { resolveContainedPath } from '@franken/types'
 import type { Trace } from '../core/types.js'
 import type { InterruptSignal } from './InterruptEmitter.js'
 
@@ -16,11 +17,6 @@ function traceIdHashForFilename(value: string): string {
 
 function timestampForFilename(timestamp: number): string {
   return Number.isFinite(timestamp) ? String(Math.trunc(timestamp)) : 'invalid-timestamp'
-}
-
-function isInsideDirectory(baseDir: string, targetPath: string): boolean {
-  const relativePath = relative(baseDir, targetPath)
-  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
 }
 
 async function writeNewReportFile(filePath: string, content: string): Promise<void> {
@@ -119,12 +115,7 @@ without reaching a terminal condition. Possible causes:
 
     try {
       await fs.mkdir(this.outputDir, { recursive: true })
-      const outputDir = await fs.realpath(this.outputDir)
-      writeFilePath = resolve(outputDir, filename)
-
-      if (!isInsideDirectory(outputDir, writeFilePath)) {
-        throw new Error(`Resolved post-mortem path escapes output directory: ${writeFilePath}`)
-      }
+      writeFilePath = resolveContainedPath(this.outputDir, filename, 'postMortemPath')
 
       await writeNewReportFile(writeFilePath, content)
       return configuredFilePath

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReplayContentStore } from './replay-content-store.js';
@@ -50,6 +50,20 @@ describe('ReplayContentStore', () => {
 
     for (const invalidRef of invalidRefs) {
       expect(() => store.get(invalidRef)).toThrow(/exactly 64 lowercase sha256 hex/i);
+    }
+  });
+
+  it('rejects a blobs directory symlink that escapes the replay base directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const outside = mkdtempSync(join(tmpdir(), 'replay-outside-'));
+    symlinkSync(outside, join(root, 'blobs'), 'dir');
+
+    try {
+      expect(() => new ReplayContentStore(root)).toThrow(/replayBlobsDir resolves outside base directory/i);
+      expect(existsSync(join(outside, hashContent('secret')))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
     }
   });
 });

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -66,4 +66,19 @@ describe('ReplayContentStore', () => {
       rmSync(outside, { recursive: true, force: true });
     }
   });
+
+  it('rejects dangling blob symlinks before writing content', () => {
+    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const store = new ReplayContentStore(root);
+    const ref = hashContent('secret');
+    const danglingTarget = join(tmpdir(), `missing-replay-target-${Date.now()}`);
+    symlinkSync(danglingTarget, join(root, 'blobs', ref));
+
+    try {
+      expect(() => store.put('secret')).toThrow(/replayBlobPath must not be a symbolic link/i);
+      expect(existsSync(danglingTarget)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolveContainedExistingPath, resolveContainedPath } from '@franken/types';
+import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolveContainedExistingPath, resolveContainedPath } from '@franken/types/path-containment';
 import { contentHashMatches } from '../utils/crypto.js';
 import { hashContent } from './replay-record.js';
 
@@ -37,6 +37,15 @@ export class ReplayContentStore {
       throw new Error('Replay content ref must be exactly 64 lowercase sha256 hex characters');
     }
     const containedPath = resolveContainedPath(this.dir, ref, 'replayBlobPath');
+    try {
+      if (lstatSync(containedPath).isSymbolicLink()) {
+        throw new Error('replayBlobPath must not be a symbolic link');
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw err;
+      }
+    }
     return existsSync(containedPath)
       ? resolveContainedExistingPath(this.dir, ref, 'replayBlobPath')
       : containedPath;

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { resolveContainedExistingPath, resolveContainedPath } from '@franken/types';
 import { contentHashMatches } from '../utils/crypto.js';
 import { hashContent } from './replay-record.js';
 
@@ -9,10 +9,10 @@ export class ReplayContentStore {
   private readonly dir: string;
 
   constructor(baseDir: string) {
-    this.dir = join(baseDir, 'blobs');
-    if (!existsSync(this.dir)) {
-      mkdirSync(this.dir, { recursive: true });
-    }
+    mkdirSync(baseDir, { recursive: true });
+    const blobDir = resolveContainedPath(baseDir, 'blobs', 'replayBlobsDir');
+    mkdirSync(blobDir, { recursive: true });
+    this.dir = resolveContainedExistingPath(baseDir, 'blobs', 'replayBlobsDir');
   }
 
   put(content: string): string {
@@ -36,6 +36,9 @@ export class ReplayContentStore {
     if (!SHA256_HEX_REF.test(ref)) {
       throw new Error('Replay content ref must be exactly 64 lowercase sha256 hex characters');
     }
-    return join(this.dir, ref);
+    const containedPath = resolveContainedPath(this.dir, ref, 'replayBlobPath');
+    return existsSync(containedPath)
+      ? resolveContainedExistingPath(this.dir, ref, 'replayBlobPath')
+      : containedPath;
   }
 }

--- a/packages/franken-orchestrator/package.json
+++ b/packages/franken-orchestrator/package.json
@@ -46,7 +46,7 @@
     "@anthropic-ai/sdk": "^0.110.0",
     "@franken/critique": "0.6.11",
     "@franken/governor": "0.5.9",
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "@franken/observer": "0.7.11",
     "@google/genai": "^1.46.0",
     "better-sqlite3": "^12.6.2",

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { resolveContainedExistingPath } from '@franken/types';
+import { resolveContainedExistingPath } from '@franken/types/path-containment';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { BeastLoop } from '../beast-loop.js';
@@ -321,13 +321,18 @@ export class Session {
     let designContent: string;
     if (designDocPath) {
       try {
-        const safeDesignDocPath = resolveContainedExistingPath(paths.root, designDocPath, 'designDocPath');
+        const safeDesignDocPath = resolveContainedExistingPath(paths.root, designDocPath, 'designDocPath', {
+          relativeTo: process.cwd(),
+        });
         designContent = readFileSync(safeDesignDocPath, 'utf-8');
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
           throw new Error(
             `No design document found at ${designDocPath}. Check the path, run "frankenbeast interview" first, or provide --design-doc.`,
           );
+        }
+        if ((err as Error).message === 'designDocPath resolves outside base directory') {
+          throw new Error('designDocPath resolves outside project root');
         }
         throw err;
       }

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -1,5 +1,5 @@
-import { readFileSync, mkdirSync, realpathSync } from 'node:fs';
-import { isAbsolute, relative, resolve, join, sep } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { resolveContainedExistingPath } from '@franken/types';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { BeastLoop } from '../beast-loop.js';
@@ -34,18 +34,6 @@ function printLine(...args: unknown[]): void {
   console.info(...args);
 }
 export type SessionPhase = 'interview' | 'plan' | 'execute';
-
-function resolveContainedExistingPath(projectRoot: string, requestedPath: string, fieldName: string): string {
-  const root = realpathSync(resolve(projectRoot));
-  const requested = isAbsolute(requestedPath) ? requestedPath : resolve(process.cwd(), requestedPath);
-  const target = realpathSync(requested);
-  const rel = relative(root, target);
-  if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('../') || rel.startsWith('..\\') || isAbsolute(rel)) {
-    throw new Error(`${fieldName} resolves outside project root: ${requestedPath}`);
-  }
-
-  return target;
-}
 
 function appendPromptContext(value: string, promptText: string | undefined): string {
   if (!promptText || promptText.trim().length === 0) return value;

--- a/packages/franken-planner/package.json
+++ b/packages/franken-planner/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
-    "@franken/types": "0.7.6"
+    "@franken/types": "0.7.7"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.9",

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -8,6 +8,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./path-containment": {
+      "import": "./dist/path-containment.js",
+      "types": "./dist/path-containment.d.ts"
     }
   },
   "files": [

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@franken/types",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -96,6 +96,9 @@ export {
 // Web/API contract DTOs
 export * from './api-contracts.js';
 
+// Path containment helpers
+export { resolveContainedExistingPath, resolveContainedPath } from './path-containment.js';
+
 // Skill schemas
 export type { McpConfig, SkillInfo, SkillToolManifest } from './skill.js';
 export {

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -96,8 +96,6 @@ export {
 // Web/API contract DTOs
 export * from './api-contracts.js';
 
-// Path containment helpers
-export { resolveContainedExistingPath, resolveContainedPath } from './path-containment.js';
 
 // Skill schemas
 export type { McpConfig, SkillInfo, SkillToolManifest } from './skill.js';

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 
 interface ResolveContainedPathOptions {
   relativeTo?: string;
@@ -7,7 +7,7 @@ interface ResolveContainedPathOptions {
 
 function isContainedBy(baseRealPath: string, targetRealPath: string): boolean {
   const relativePath = relative(baseRealPath, targetRealPath);
-  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+  return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
 }
 
 function containmentError(fieldName: string): Error {

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -1,0 +1,49 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
+
+function isContainedBy(baseRealPath: string, targetRealPath: string): boolean {
+  const relativePath = relative(baseRealPath, targetRealPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+function containmentError(fieldName: string): Error {
+  return new Error(`${fieldName} resolves outside base directory`);
+}
+
+function resolveRequestedPath(baseRealPath: string, requestedPath: string): string {
+  return isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(baseRealPath, requestedPath);
+}
+
+export function resolveContainedExistingPath(
+  baseDir: string,
+  requestedPath: string,
+  fieldName = 'path',
+): string {
+  const baseRealPath = realpathSync(resolve(baseDir));
+  const requestedAbsolutePath = resolveRequestedPath(baseRealPath, requestedPath);
+  const targetRealPath = realpathSync(requestedAbsolutePath);
+
+  if (!isContainedBy(baseRealPath, targetRealPath)) {
+    throw containmentError(fieldName);
+  }
+
+  return targetRealPath;
+}
+
+export function resolveContainedPath(baseDir: string, requestedPath: string, fieldName = 'path'): string {
+  const baseRealPath = realpathSync(resolve(baseDir));
+  const requestedAbsolutePath = resolveRequestedPath(baseRealPath, requestedPath);
+
+  if (existsSync(requestedAbsolutePath)) {
+    return resolveContainedExistingPath(baseRealPath, requestedAbsolutePath, fieldName);
+  }
+
+  const parentRealPath = realpathSync(dirname(requestedAbsolutePath));
+  const targetPath = resolve(parentRealPath, basename(requestedAbsolutePath));
+
+  if (!isContainedBy(baseRealPath, targetPath)) {
+    throw containmentError(fieldName);
+  }
+
+  return targetPath;
+}

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -1,6 +1,10 @@
 import { existsSync, realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 
+interface ResolveContainedPathOptions {
+  relativeTo?: string;
+}
+
 function isContainedBy(baseRealPath: string, targetRealPath: string): boolean {
   const relativePath = relative(baseRealPath, targetRealPath);
   return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
@@ -10,17 +14,23 @@ function containmentError(fieldName: string): Error {
   return new Error(`${fieldName} resolves outside base directory`);
 }
 
-function resolveRequestedPath(baseRealPath: string, requestedPath: string): string {
-  return isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(baseRealPath, requestedPath);
+function resolveRequestedPath(
+  baseRealPath: string,
+  requestedPath: string,
+  options: ResolveContainedPathOptions = {},
+): string {
+  const relativeBase = options.relativeTo ?? baseRealPath;
+  return isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(relativeBase, requestedPath);
 }
 
 export function resolveContainedExistingPath(
   baseDir: string,
   requestedPath: string,
   fieldName = 'path',
+  options: ResolveContainedPathOptions = {},
 ): string {
   const baseRealPath = realpathSync(resolve(baseDir));
-  const requestedAbsolutePath = resolveRequestedPath(baseRealPath, requestedPath);
+  const requestedAbsolutePath = resolveRequestedPath(baseRealPath, requestedPath, options);
   const targetRealPath = realpathSync(requestedAbsolutePath);
 
   if (!isContainedBy(baseRealPath, targetRealPath)) {
@@ -30,9 +40,14 @@ export function resolveContainedExistingPath(
   return targetRealPath;
 }
 
-export function resolveContainedPath(baseDir: string, requestedPath: string, fieldName = 'path'): string {
+export function resolveContainedPath(
+  baseDir: string,
+  requestedPath: string,
+  fieldName = 'path',
+  options: ResolveContainedPathOptions = {},
+): string {
   const baseRealPath = realpathSync(resolve(baseDir));
-  const requestedAbsolutePath = resolveRequestedPath(baseRealPath, requestedPath);
+  const requestedAbsolutePath = resolveRequestedPath(baseRealPath, requestedPath, options);
 
   if (existsSync(requestedAbsolutePath)) {
     return resolveContainedExistingPath(baseRealPath, requestedAbsolutePath, fieldName);

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -29,6 +29,19 @@ describe('realpath containment helpers', () => {
     });
   });
 
+  it('can resolve relative paths from an explicit cwd before containment', () => {
+    withTempRoot('contained-explicit-relative-base', root => {
+      const nested = join(root, 'docs');
+      const designDoc = join(nested, 'design.md');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(designDoc, '# Design', 'utf8');
+
+      expect(resolveContainedExistingPath(root, 'design.md', 'designDocPath', { relativeTo: nested })).toBe(
+        realpathSync(designDoc),
+      );
+    });
+  });
+
   it('rejects existing paths that escape the base through a symlink', () => {
     withTempRoot('contained-symlink', root => {
       const outside = join(root, '..', `outside-${randomUUID()}`);

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -42,6 +42,19 @@ describe('realpath containment helpers', () => {
     });
   });
 
+  it('allows contained path names whose first segment starts with dot-dot', () => {
+    withTempRoot('contained-dot-dot-prefix', root => {
+      const nested = join(root, '..design');
+      const designDoc = join(nested, 'design.md');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(designDoc, '# Design', 'utf8');
+
+      expect(resolveContainedExistingPath(root, '..design/design.md', 'designDocPath')).toBe(
+        realpathSync(designDoc),
+      );
+    });
+  });
+
   it('rejects existing paths that escape the base through a symlink', () => {
     withTempRoot('contained-symlink', root => {
       const outside = join(root, '..', `outside-${randomUUID()}`);

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import {
+  resolveContainedExistingPath,
+  resolveContainedPath,
+} from '../src/path-containment.js';
+
+function withTempRoot<T>(prefix: string, fn: (root: string) => T): T {
+  const root = mkdtempSync(join(tmpdir(), `${prefix}-${randomUUID()}-`));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('realpath containment helpers', () => {
+  it('resolves existing relative paths inside the real base directory', () => {
+    withTempRoot('contained-existing', root => {
+      const nested = join(root, 'docs');
+      const designDoc = join(nested, 'design.md');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(designDoc, '# Design', 'utf8');
+
+      expect(resolveContainedExistingPath(root, 'docs/design.md', 'designDocPath')).toBe(realpathSync(designDoc));
+    });
+  });
+
+  it('rejects existing paths that escape the base through a symlink', () => {
+    withTempRoot('contained-symlink', root => {
+      const outside = join(root, '..', `outside-${randomUUID()}`);
+      const outsideFile = join(outside, 'secret.md');
+      const link = join(root, 'linked-outside');
+      mkdirSync(outside, { recursive: true });
+      writeFileSync(outsideFile, 'secret', 'utf8');
+      symlinkSync(outside, link, 'dir');
+
+      try {
+        expect(() => resolveContainedExistingPath(root, 'linked-outside/secret.md', 'designDocPath')).toThrow(
+          /designDocPath resolves outside base directory/i,
+        );
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('resolves new leaf paths via a real parent and rejects parent symlink escapes', () => {
+    withTempRoot('contained-new-leaf', root => {
+      const outside = join(root, '..', `outside-${randomUUID()}`);
+      const link = join(root, 'reports-link');
+      mkdirSync(outside, { recursive: true });
+      symlinkSync(outside, link, 'dir');
+
+      try {
+        expect(() => resolveContainedPath(root, 'reports-link/report.md', 'outputPath')).toThrow(
+          /outputPath resolves outside base directory/i,
+        );
+
+        mkdirSync(join(root, 'reports'), { recursive: true });
+        expect(resolveContainedPath(root, 'reports/report.md', 'outputPath')).toBe(resolve(root, 'reports/report.md'));
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/franken-web/package.json
+++ b/packages/franken-web/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {
-    "@franken/types": "0.7.6",
+    "@franken/types": "0.7.7",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/vitest-source-aliases.ts
+++ b/scripts/vitest-source-aliases.ts
@@ -8,6 +8,7 @@ const FRANKEN_SOURCE_ENTRYPOINTS = {
   '@franken/observer': 'packages/franken-observer/src/index.ts',
   '@franken/critique': 'packages/franken-critique/src/index.ts',
   '@franken/governor': 'packages/franken-governor/src/index.ts',
+  '@franken/types/path-containment': 'packages/franken-types/src/path-containment.ts',
   '@franken/types': 'packages/franken-types/src/index.ts',
   '@franken/orchestrator': 'packages/franken-orchestrator/src/index.ts',
 } as const;

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_ALIASES: Record<string, string> = {
   '@franken/observer': './packages/franken-observer/src/index.ts',
   '@franken/critique': './packages/franken-critique/src/index.ts',
   '@franken/governor': './packages/franken-governor/src/index.ts',
+  '@franken/types/path-containment': './packages/franken-types/src/path-containment.ts',
   '@franken/types': './packages/franken-types/src/index.ts',
   '@franken/orchestrator': './packages/franken-orchestrator/src/index.ts',
 };
@@ -24,8 +25,8 @@ describe('tsconfig.json path aliases', () => {
     expect(paths).toBeDefined();
   });
 
-  it('has exactly 7 aliases', () => {
-    expect(Object.keys(paths)).toHaveLength(7);
+  it('has exactly 8 aliases', () => {
+    expect(Object.keys(paths)).toHaveLength(8);
   });
 
   for (const [alias, expectedPath] of Object.entries(EXPECTED_ALIASES)) {

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -11,6 +11,7 @@ const EXPECTED_ALIASES = {
   '@franken/observer': resolve(ROOT, 'packages/franken-observer/src/index.ts'),
   '@franken/critique': resolve(ROOT, 'packages/franken-critique/src/index.ts'),
   '@franken/governor': resolve(ROOT, 'packages/franken-governor/src/index.ts'),
+  '@franken/types/path-containment': resolve(ROOT, 'packages/franken-types/src/path-containment.ts'),
   '@franken/types': resolve(ROOT, 'packages/franken-types/src/index.ts'),
   '@franken/orchestrator': resolve(ROOT, 'packages/franken-orchestrator/src/index.ts'),
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,9 @@
       "@franken/governor": [
         "./packages/franken-governor/src/index.ts"
       ],
+      "@franken/types/path-containment": [
+        "./packages/franken-types/src/path-containment.ts"
+      ],
       "@franken/types": [
         "./packages/franken-types/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- adds shared realpath-based containment helpers in `@franken/types`
- replaces ad-hoc containment checks in session design-doc loading and post-mortem report writes
- hardens replay blob storage against symlinked blob directories and existing blob symlink escapes

## Test Plan
- [x] `npm --workspace @franken/types test`
- [x] `npm --workspace @franken/observer test`
- [x] `npm --workspace @franken/orchestrator test -- tests/unit/cli/session-plan.test.ts tests/unit/beasts/definitions/chunk-plan-definition.test.ts`
- [x] `npm --workspace @franken/types run build && npm --workspace @franken/types run typecheck && npm --workspace @franken/observer run typecheck && npm --workspace @franken/orchestrator run typecheck && npm --workspace @franken/orchestrator run build`
- [x] `npm --workspace @franken/orchestrator run lint` (0 errors, existing warnings only)

Closes #615
