### PR TITLE
fix(orchestrator): release supervisor exit on inherited stdio

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -172,6 +172,7 @@ export interface ProcessBeastExecutorOptions {
 
 export class ProcessBeastExecutor implements BeastExecutor {
   private readonly exitPromises = new Map<string, { resolve: () => void }>();
+  private readonly stoppingAttempts = new Set<string>();
   private readonly configFilePaths = new Map<string, string>();
 
   constructor(
@@ -410,15 +411,16 @@ export class ProcessBeastExecutor implements BeastExecutor {
   async stop(runId: string, attemptId: string, options?: StopOptions): Promise<BeastRunAttempt> {
     const attempt = this.requireAttempt(attemptId);
     if (attempt.pid !== undefined) {
+      const timeoutMs = options?.timeoutMs ?? this.options.defaultStopTimeoutMs ?? 10_000;
+      const pid = attempt.pid;
+      const exitPromise = new Promise<boolean>((resolve) => {
+        this.exitPromises.set(attemptId, { resolve: () => resolve(true) });
+      });
+
+      this.stoppingAttempts.add(attemptId);
       await this.supervisor.stop(attempt.pid);
 
       {
-        const timeoutMs = options?.timeoutMs ?? this.options.defaultStopTimeoutMs ?? 10_000;
-        const pid = attempt.pid;
-        const exitPromise = new Promise<boolean>((resolve) => {
-          this.exitPromises.set(attemptId, { resolve: () => resolve(true) });
-        });
-
         let timer: ReturnType<typeof setTimeout>;
         const timeoutPromise = new Promise<boolean>((resolve) => {
           timer = setTimeout(() => resolve(false), timeoutMs);
@@ -429,15 +431,17 @@ export class ProcessBeastExecutor implements BeastExecutor {
 
         if (!exited && this.exitPromises.has(attemptId)) {
           this.exitPromises.delete(attemptId);
+          this.stoppingAttempts.delete(attemptId);
           await this.supervisor.kill(pid);
         }
 
-        // If process exited naturally, handleProcessExit already updated status — don't overwrite
+        // If process exited after an operator stop, handleProcessExit already updated status — don't overwrite
         if (exited) {
           return this.repository.getAttempt(attemptId) ?? attempt;
         }
       }
     }
+    this.stoppingAttempts.delete(attemptId);
     return this.finishAttempt(runId, attempt, 'stopped', 'operator_stop');
   }
 
@@ -476,6 +480,21 @@ export class ProcessBeastExecutor implements BeastExecutor {
     }
 
     const status: BeastRunStatus = code === 0 ? 'completed' : 'failed';
+    if (this.stoppingAttempts.delete(attemptId)) {
+      this.finishAttempt(runId, currentAttempt ?? this.requireAttempt(attemptId), 'stopped', 'operator_stop');
+      const exitEntry = this.exitPromises.get(attemptId);
+      if (exitEntry) {
+        this.exitPromises.delete(attemptId);
+        exitEntry.resolve();
+      }
+      const configPath = this.configFilePaths.get(runId);
+      if (configPath) {
+        try { unlinkSync(configPath); } catch { /* already removed */ }
+        this.configFilePaths.delete(runId);
+      }
+      return;
+    }
+
     const stopReason = code === 0 ? undefined : signal ? `signal_${signal}` : code != null ? `exit_code_${code}` : 'unknown_exit';
     const finishedAt = new Date().toISOString();
 

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -418,7 +418,13 @@ export class ProcessBeastExecutor implements BeastExecutor {
       });
 
       this.stoppingAttempts.add(attemptId);
-      await this.supervisor.stop(attempt.pid);
+      try {
+        await this.supervisor.stop(attempt.pid);
+      } catch (error) {
+        this.exitPromises.delete(attemptId);
+        this.stoppingAttempts.delete(attemptId);
+        throw error;
+      }
 
       {
         let timer: ReturnType<typeof setTimeout>;

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -85,34 +85,60 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
     let stdoutClosed = false;
     let stderrClosed = false;
     let exitInfo: { code: number | null; signal: string | null } | undefined;
+    let exitFired = false;
 
     const maybeFireExit = () => {
-      if (stdoutClosed && stderrClosed && exitInfo) {
+      if (!exitFired && stdoutClosed && stderrClosed && exitInfo) {
+        exitFired = true;
         this.processes.delete(pid);
         callbacks.onExit(exitInfo.code, exitInfo.signal);
       }
     };
 
-    if (child.stdout) {
-      const stdoutRl = createInterface({ input: child.stdout });
+    const markStdoutClosed = () => {
+      stdoutClosed = true;
+      maybeFireExit();
+    };
+    const markStderrClosed = () => {
+      stderrClosed = true;
+      maybeFireExit();
+    };
+
+    const stdoutRl = child.stdout
+      ? createInterface({ input: child.stdout })
+      : undefined;
+    if (stdoutRl) {
       stdoutRl.on('line', (line) => callbacks.onStdout(line));
-      stdoutRl.on('close', () => { stdoutClosed = true; maybeFireExit(); });
+      stdoutRl.on('close', markStdoutClosed);
     } else {
       stdoutClosed = true;
     }
 
-    if (child.stderr) {
-      const stderrRl = createInterface({ input: child.stderr });
+    const stderrRl = child.stderr
+      ? createInterface({ input: child.stderr })
+      : undefined;
+    if (stderrRl) {
       stderrRl.on('line', (line) => callbacks.onStderr(line));
-      stderrRl.on('close', () => { stderrClosed = true; maybeFireExit(); });
+      stderrRl.on('close', markStderrClosed);
     } else {
       stderrClosed = true;
     }
 
-    child.on('close', (code, signal) => {
+    const recordExit = (code: number | null, signal: string | null) => {
       exitInfo = { code, signal };
-      maybeFireExit();
-    });
+      setImmediate(() => {
+        if (!stdoutClosed) {
+          stdoutRl?.close();
+        }
+        if (!stderrClosed) {
+          stderrRl?.close();
+        }
+        maybeFireExit();
+      });
+    };
+
+    child.on('exit', recordExit);
+    child.on('close', recordExit);
 
     return { pid };
   }

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -129,7 +129,7 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       stream.setEncoding('utf8');
       stream.on('data', (chunk: string | Buffer) => {
         buffer += chunk.toString();
-        const lines = buffer.split(/\r?\n/u);
+        const lines = buffer.split(/\r\n|[\n\r]/u);
         buffer = lines.pop() ?? '';
         for (const line of lines) {
           onLine(line);

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -113,9 +113,31 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
 
       const flushBufferedLine = () => {
         if (buffer.length > 0) {
-          onLine(buffer);
+          onLine(buffer.endsWith('\r') ? buffer.slice(0, -1) : buffer);
           buffer = '';
         }
+      };
+      const processBuffer = () => {
+        let start = 0;
+        for (let i = 0; i < buffer.length; i += 1) {
+          const char = buffer[i];
+          if (char === '\n') {
+            onLine(buffer.slice(start, i));
+            start = i + 1;
+            continue;
+          }
+          if (char === '\r') {
+            if (i + 1 >= buffer.length) {
+              break;
+            }
+            onLine(buffer.slice(start, i));
+            if (buffer[i + 1] === '\n') {
+              i += 1;
+            }
+            start = i + 1;
+          }
+        }
+        buffer = buffer.slice(start);
       };
       const finish = () => {
         if (closed) {
@@ -129,11 +151,7 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       stream.setEncoding('utf8');
       stream.on('data', (chunk: string | Buffer) => {
         buffer += chunk.toString();
-        const lines = buffer.split(/\r\n|[\n\r]/u);
-        buffer = lines.pop() ?? '';
-        for (const line of lines) {
-          onLine(line);
-        }
+        processBuffer();
       });
       stream.on('end', flushBufferedLine);
       stream.on('close', finish);

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -111,15 +111,22 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       let buffer = '';
       let closed = false;
 
+      let skipLfAfterCr = false;
       const flushBufferedLine = () => {
         if (buffer.length > 0) {
-          onLine(buffer.endsWith('\r') ? buffer.slice(0, -1) : buffer);
+          onLine(buffer);
           buffer = '';
         }
       };
       const processBuffer = () => {
         let start = 0;
-        for (let i = 0; i < buffer.length; i += 1) {
+        if (skipLfAfterCr) {
+          skipLfAfterCr = false;
+          if (buffer[0] === '\n') {
+            start = 1;
+          }
+        }
+        for (let i = start; i < buffer.length; i += 1) {
           const char = buffer[i];
           if (char === '\n') {
             onLine(buffer.slice(start, i));
@@ -127,12 +134,11 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
             continue;
           }
           if (char === '\r') {
-            if (i + 1 >= buffer.length) {
-              break;
-            }
             onLine(buffer.slice(start, i));
             if (buffer[i + 1] === '\n') {
               i += 1;
+            } else if (i + 1 >= buffer.length) {
+              skipLfAfterCr = true;
             }
             start = i + 1;
           }

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -1,7 +1,6 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
-import { createInterface } from 'node:readline';
 import type { BeastProcessSpec } from '../types.js';
 import { DEFAULT_BEAST_ENV_ALLOWLIST } from './sandbox-policy.js';
 
@@ -104,23 +103,58 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       maybeFireExit();
     };
 
-    const stdoutRl = child.stdout
-      ? createInterface({ input: child.stdout })
+    const wireLineReader = (
+      stream: NonNullable<ChildProcess['stdout']>,
+      onLine: (line: string) => void,
+      markClosed: () => void,
+    ) => {
+      let buffer = '';
+      let closed = false;
+
+      const flushBufferedLine = () => {
+        if (buffer.length > 0) {
+          onLine(buffer);
+          buffer = '';
+        }
+      };
+      const finish = () => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        flushBufferedLine();
+        markClosed();
+      };
+
+      stream.setEncoding('utf8');
+      stream.on('data', (chunk: string | Buffer) => {
+        buffer += chunk.toString();
+        const lines = buffer.split(/\r?\n/u);
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          onLine(line);
+        }
+      });
+      stream.on('end', flushBufferedLine);
+      stream.on('close', finish);
+
+      return () => {
+        finish();
+        stream.destroy();
+      };
+    };
+
+    const forceCloseStdout = child.stdout
+      ? wireLineReader(child.stdout, callbacks.onStdout, markStdoutClosed)
       : undefined;
-    if (stdoutRl) {
-      stdoutRl.on('line', (line) => callbacks.onStdout(line));
-      stdoutRl.on('close', markStdoutClosed);
-    } else {
+    if (!forceCloseStdout) {
       stdoutClosed = true;
     }
 
-    const stderrRl = child.stderr
-      ? createInterface({ input: child.stderr })
+    const forceCloseStderr = child.stderr
+      ? wireLineReader(child.stderr, callbacks.onStderr, markStderrClosed)
       : undefined;
-    if (stderrRl) {
-      stderrRl.on('line', (line) => callbacks.onStderr(line));
-      stderrRl.on('close', markStderrClosed);
-    } else {
+    if (!forceCloseStderr) {
       stderrClosed = true;
     }
 
@@ -128,10 +162,10 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       exitInfo = { code, signal };
       setImmediate(() => {
         if (!stdoutClosed) {
-          stdoutRl?.close();
+          forceCloseStdout?.();
         }
         if (!stderrClosed) {
-          stderrRl?.close();
+          forceCloseStderr?.();
         }
         maybeFireExit();
       });

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -141,6 +141,7 @@ const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
   detached: true,
   stdio: 'inherit',
 });
+process.stdout.write('final partial stdout');
 require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
 child.unref();`,
         ],
@@ -152,6 +153,7 @@ child.unref();`,
         await vi.waitFor(() => {
           expect(callbacks.onExit).toHaveBeenCalledWith(0, null);
         }, { timeout: 500 });
+        expect(callbacks.onStdout).toHaveBeenCalledWith('final partial stdout');
       } finally {
         const grandchildPid = Number(await readFile(pidFile, 'utf8').catch(() => '0'));
         if (grandchildPid > 0) {

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -83,6 +83,24 @@ describe('ProcessSupervisor', () => {
       expect(callbacks.onStdout).toHaveBeenCalledWith('line2');
     });
 
+    it('streams carriage-return terminated stdout updates separately', async () => {
+      const callbacks = makeCallbacks();
+      const spec = makeSpec({
+        command: '/bin/sh',
+        args: ['-c', 'printf "step1\\rstep2\\rdone\\n"'],
+      });
+
+      await supervisor.spawn(spec, callbacks);
+
+      await vi.waitFor(() => {
+        expect(callbacks.onExit).toHaveBeenCalled();
+      }, { timeout: 5000 });
+
+      expect(callbacks.onStdout).toHaveBeenCalledWith('step1');
+      expect(callbacks.onStdout).toHaveBeenCalledWith('step2');
+      expect(callbacks.onStdout).toHaveBeenCalledWith('done');
+    });
+
     it('captures stderr lines via onStderr callback', async () => {
       const callbacks = makeCallbacks();
       const spec = makeSpec({

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -101,6 +101,25 @@ describe('ProcessSupervisor', () => {
       expect(callbacks.onStdout).toHaveBeenCalledWith('done');
     });
 
+    it('flushes CR-only stdout progress before the next chunk arrives', async () => {
+      const callbacks = makeCallbacks();
+      const spec = makeSpec({
+        command: process.execPath,
+        args: ['-e', "process.stdout.write('step1\\r'); setTimeout(() => process.exit(0), 1000);"],
+      });
+
+      await supervisor.spawn(spec, callbacks);
+
+      await vi.waitFor(() => {
+        expect(callbacks.onStdout).toHaveBeenCalledWith('step1');
+      }, { timeout: 500 });
+      expect(callbacks.onExit).not.toHaveBeenCalled();
+
+      await vi.waitFor(() => {
+        expect(callbacks.onExit).toHaveBeenCalledWith(0, null);
+      }, { timeout: 5000 });
+    });
+
     it('does not emit blank lines for CRLF split across stdout chunks', async () => {
       const callbacks = makeCallbacks();
       const spec = makeSpec({

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ProcessSupervisor } from '../../../../src/beasts/execution/process-supervisor.js';
@@ -126,6 +126,44 @@ describe('ProcessSupervisor', () => {
         'stderr:stack trace here',
         'exit:1:null',
       ]);
+    });
+
+    it('fires onExit promptly when a grandchild keeps inherited stdio open', async () => {
+      workDir = await mkdtemp(join(tmpdir(), 'franken-supervisor-grandchild-'));
+      const pidFile = join(workDir, 'grandchild.pid');
+      const callbacks = makeCallbacks();
+      const spec = makeSpec({
+        command: process.execPath,
+        args: [
+          '-e',
+          `const { spawn } = require('node:child_process');
+const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+  detached: true,
+  stdio: 'inherit',
+});
+require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+child.unref();`,
+        ],
+      });
+
+      try {
+        await supervisor.spawn(spec, callbacks);
+
+        await vi.waitFor(() => {
+          expect(callbacks.onExit).toHaveBeenCalledWith(0, null);
+        }, { timeout: 500 });
+      } finally {
+        const grandchildPid = Number(await readFile(pidFile, 'utf8').catch(() => '0'));
+        if (grandchildPid > 0) {
+          try {
+            process.kill(grandchildPid, 'SIGKILL');
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+              throw error;
+            }
+          }
+        }
+      }
     });
 
     it('strips CLAUDE env vars from spawned process environment', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -101,6 +101,27 @@ describe('ProcessSupervisor', () => {
       expect(callbacks.onStdout).toHaveBeenCalledWith('done');
     });
 
+    it('does not emit blank lines for CRLF split across stdout chunks', async () => {
+      const callbacks = makeCallbacks();
+      const spec = makeSpec({
+        command: process.execPath,
+        args: [
+          '-e',
+          "process.stdout.write('one\\r'); setImmediate(() => process.stdout.write('\\ntwo\\r\\n'));",
+        ],
+      });
+
+      await supervisor.spawn(spec, callbacks);
+
+      await vi.waitFor(() => {
+        expect(callbacks.onExit).toHaveBeenCalled();
+      }, { timeout: 5000 });
+
+      expect(callbacks.onStdout).toHaveBeenCalledTimes(2);
+      expect(callbacks.onStdout).toHaveBeenNthCalledWith(1, 'one');
+      expect(callbacks.onStdout).toHaveBeenNthCalledWith(2, 'two');
+    });
+
     it('captures stderr lines via onStderr callback', async () => {
       const callbacks = makeCallbacks();
       const spec = makeSpec({

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -421,6 +421,52 @@ describe('ProcessBeastExecutor', () => {
     });
   });
 
+  it('marks run as stopped when the process exits from an operator stop signal', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    let capturedCallbacks: ProcessCallbacks | undefined;
+    const supervisor = {
+      spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+        capturedCallbacks = callbacks as ProcessCallbacks;
+        return { pid: 777 };
+      }),
+      stop: vi.fn(async () => {
+        capturedCallbacks?.onExit(null, 'SIGTERM');
+      }),
+      kill: vi.fn(async () => {}),
+    };
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, { defaultStopTimeoutMs: 100 });
+    const run = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {
+        provider: 'claude',
+        objective: 'Implement the stop button',
+        chunkDirectory: '/tmp/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const attempt = await executor.start(run, martinLoopDefinition);
+    const stoppedAttempt = await executor.stop(run.id, attempt.id);
+
+    expect(supervisor.stop).toHaveBeenCalledWith(777);
+    expect(supervisor.kill).not.toHaveBeenCalled();
+    expect(stoppedAttempt).toMatchObject({
+      id: attempt.id,
+      status: 'stopped',
+      stopReason: 'operator_stop',
+    });
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'stopped',
+      stopReason: 'operator_stop',
+    });
+  });
+
   describe('onRunStatusChange callback', () => {
     it('accepts optional onRunStatusChange as 4th constructor argument', () => {
       const repo = {} as SQLiteBeastRepository;

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -467,6 +467,49 @@ describe('ProcessBeastExecutor', () => {
     });
   });
 
+  it('clears operator-stop bookkeeping when stop dispatch fails', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    let capturedCallbacks: ProcessCallbacks | undefined;
+    const supervisor = {
+      spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+        capturedCallbacks = callbacks as ProcessCallbacks;
+        return { pid: 777 };
+      }),
+      stop: vi.fn(async () => {
+        throw new Error('stop dispatch failed');
+      }),
+      kill: vi.fn(async () => {}),
+    };
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, { defaultStopTimeoutMs: 100 });
+    const run = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {
+        provider: 'claude',
+        objective: 'Implement the stop button',
+        chunkDirectory: '/tmp/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const attempt = await executor.start(run, martinLoopDefinition);
+    await expect(executor.stop(run.id, attempt.id)).rejects.toThrow('stop dispatch failed');
+
+    capturedCallbacks?.onExit(0, null);
+
+    expect(repo.getAttempt(attempt.id)).toMatchObject({
+      status: 'completed',
+    });
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'completed',
+    });
+  });
+
   describe('onRunStatusChange callback', () => {
     it('accepts optional onRunStatusChange as 4th constructor argument', () => {
       const repo = {} as SQLiteBeastRepository;

--- a/tasks/resolve-issue-873-progress.md
+++ b/tasks/resolve-issue-873-progress.md
@@ -10,7 +10,7 @@
 Checks run:
 - RED: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts -t "grandchild keeps inherited stdio"` failed before implementation.
 - GREEN: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts` passed.
-- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2623 tests after Codex fixes.
+- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2624 tests after Codex fixes.
 - `npm run typecheck` in `packages/franken-orchestrator` passed after root workspace build prepared dependent package declarations.
 - `npm run lint` in `packages/franken-orchestrator` passed with existing warnings.
 - `npm run build` at repo root passed: 10/10 turbo build tasks successful.

--- a/tasks/resolve-issue-873-progress.md
+++ b/tasks/resolve-issue-873-progress.md
@@ -10,7 +10,7 @@
 Checks run:
 - RED: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts -t "grandchild keeps inherited stdio"` failed before implementation.
 - GREEN: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts` passed.
-- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2621 tests after Codex fixes.
+- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2623 tests after Codex fixes.
 - `npm run typecheck` in `packages/franken-orchestrator` passed after root workspace build prepared dependent package declarations.
 - `npm run lint` in `packages/franken-orchestrator` passed with existing warnings.
 - `npm run build` at repo root passed: 10/10 turbo build tasks successful.

--- a/tasks/resolve-issue-873-progress.md
+++ b/tasks/resolve-issue-873-progress.md
@@ -10,7 +10,7 @@
 Checks run:
 - RED: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts -t "grandchild keeps inherited stdio"` failed before implementation.
 - GREEN: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts` passed.
-- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2624 tests after Codex fixes.
+- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2625 tests after Codex fixes.
 - `npm run typecheck` in `packages/franken-orchestrator` passed after root workspace build prepared dependent package declarations.
 - `npm run lint` in `packages/franken-orchestrator` passed with existing warnings.
 - `npm run build` at repo root passed: 10/10 turbo build tasks successful.

--- a/tasks/resolve-issue-873-progress.md
+++ b/tasks/resolve-issue-873-progress.md
@@ -10,7 +10,7 @@
 Checks run:
 - RED: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts -t "grandchild keeps inherited stdio"` failed before implementation.
 - GREEN: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts` passed.
-- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2620 tests.
+- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2621 tests after Codex fixes.
 - `npm run typecheck` in `packages/franken-orchestrator` passed after root workspace build prepared dependent package declarations.
 - `npm run lint` in `packages/franken-orchestrator` passed with existing warnings.
 - `npm run build` at repo root passed: 10/10 turbo build tasks successful.

--- a/tasks/resolve-issue-873-progress.md
+++ b/tasks/resolve-issue-873-progress.md
@@ -1,0 +1,16 @@
+# Resolve issue #873 progress
+
+- [x] Read issue, shared lessons, and affected process supervisor code.
+- [x] Add a targeted regression test for child exit with grandchild-inherited stdio.
+- [x] Implement the minimal supervisor exit handling fix.
+- [x] Run targeted tests and package checks.
+- [ ] Commit, push, open PR, and complete Codex/CI gate.
+- [ ] Merge or block with exact remaining gate; append reusable lessons if discovered.
+
+Checks run:
+- RED: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts -t "grandchild keeps inherited stdio"` failed before implementation.
+- GREEN: `npm test -- tests/unit/beasts/execution/process-supervisor.test.ts` passed.
+- `npm test` in `packages/franken-orchestrator` passed: 239 files / 2620 tests.
+- `npm run typecheck` in `packages/franken-orchestrator` passed after root workspace build prepared dependent package declarations.
+- `npm run lint` in `packages/franken-orchestrator` passed with existing warnings.
+- `npm run build` at repo root passed: 10/10 turbo build tasks successful.


### PR DESCRIPTION
## Summary
- fire ProcessSupervisor exit callbacks after child exit even when inherited grandchild stdio keeps pipes open
- keep stdout/stderr readline draining through the immediate next tick before forcing closure
- add a regression test for a detached grandchild that inherits stdio

## Test Plan
- npm test -- tests/unit/beasts/execution/process-supervisor.test.ts -t "grandchild keeps inherited stdio" (failed before fix)
- npm test -- tests/unit/beasts/execution/process-supervisor.test.ts
- npm test (packages/franken-orchestrator)
- npm run typecheck (packages/franken-orchestrator; after root build prepared dependent declarations)
- npm run lint (packages/franken-orchestrator; existing warnings only)
- npm run build (repo root)

Closes #873