### PR TITLE
fix(chat): emit execution events after approval

### DIFF
--- a/packages/franken-orchestrator/src/chat/approval-input.ts
+++ b/packages/franken-orchestrator/src/chat/approval-input.ts
@@ -1,0 +1,6 @@
+import type { PendingApproval } from '@franken/types';
+
+export function approvalRuntimeInput(pendingApproval: PendingApproval | null | undefined): string {
+  const approvedAction = pendingApproval?.command ?? pendingApproval?.description;
+  return approvedAction ? `/run ${approvedAction}` : '/approve';
+}

--- a/packages/franken-orchestrator/src/chat/approval-input.ts
+++ b/packages/franken-orchestrator/src/chat/approval-input.ts
@@ -1,6 +1,5 @@
 import type { PendingApproval } from '@franken/types';
 
 export function approvalRuntimeInput(pendingApproval: PendingApproval | null | undefined): string {
-  const approvedAction = pendingApproval?.command ?? pendingApproval?.description;
-  return approvedAction ? `/run ${approvedAction}` : '/approve';
+  return pendingApproval?.command ? `/run ${pendingApproval.command}` : '/approve';
 }

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -74,6 +74,10 @@ function stateFromRunResult(runResult: TurnRunResult): string {
   }
 }
 
+export interface ChatRuntimeRunOptions {
+  onEvent?: ((event: TurnEvent) => void) | undefined;
+}
+
 export class ChatRuntime {
   private readonly engine: ConversationEngine;
   private readonly beastDispatchAdapter: BeastDispatchPort | undefined;
@@ -85,22 +89,23 @@ export class ChatRuntime {
     this.turnRunner = options.turnRunner;
   }
 
-  async run(input: string, state: ChatRuntimeState): Promise<ChatRuntimeResult> {
+  async run(input: string, state: ChatRuntimeState, options?: ChatRuntimeRunOptions): Promise<ChatRuntimeResult> {
     const trimmed = input.trim();
     if (trimmed.startsWith('/')) {
       const command = trimmed.split(/\s+/)[0]?.toLowerCase();
       if (command && SLASH_COMMANDS.has(command)) {
-        return this.runSlashCommand(command, trimmed, state);
+        return this.runSlashCommand(command, trimmed, state, options);
       }
     }
 
-    return this.runTurn(trimmed, state);
+    return this.runTurn(trimmed, state, options);
   }
 
   private async runSlashCommand(
     command: string,
     raw: string,
     state: ChatRuntimeState,
+    options?: ChatRuntimeRunOptions,
   ): Promise<ChatRuntimeResult> {
     const description = raw.slice(command.length).trim();
 
@@ -116,7 +121,7 @@ export class ChatRuntime {
           kind: 'plan',
           planSummary: description,
           chunkCount: 0,
-        }, { sessionId: state.sessionId });
+        }, { sessionId: state.sessionId, onEvent: options?.onEvent });
         return this.result(state, [
           { kind: 'plan', content: runResult.summary },
         ], {
@@ -140,6 +145,7 @@ export class ChatRuntime {
           },
           state,
           'premium_execution',
+          options,
         );
       }
       case '/status':
@@ -171,7 +177,11 @@ export class ChatRuntime {
     }
   }
 
-  private async runTurn(input: string, state: ChatRuntimeState): Promise<ChatRuntimeResult> {
+  private async runTurn(
+    input: string,
+    state: ChatRuntimeState,
+    options?: ChatRuntimeRunOptions,
+  ): Promise<ChatRuntimeResult> {
     if (this.beastDispatchAdapter) {
       const beastResult = await this.beastDispatchAdapter.handle(input, {
         projectId: state.projectId,
@@ -248,7 +258,7 @@ export class ChatRuntime {
           },
         );
       case 'execute':
-        return this.runExecuteOutcome(result.outcome, { ...state, transcript }, result.tier);
+        return this.runExecuteOutcome(result.outcome, { ...state, transcript }, result.tier, options);
     }
   }
 
@@ -256,8 +266,12 @@ export class ChatRuntime {
     outcome: ExecuteOutcome,
     state: ChatRuntimeState,
     tier: string,
+    options?: ChatRuntimeRunOptions,
   ): Promise<ChatRuntimeResult> {
-    const runResult = await this.turnRunner.run(outcome, { sessionId: state.sessionId });
+    const runResult = await this.turnRunner.run(outcome, {
+      sessionId: state.sessionId,
+      onEvent: options?.onEvent,
+    });
     const pendingApproval = runResult.status === 'pending_approval';
     const pendingApprovalContext: PendingApprovalContext = {
       tool: 'execution',

--- a/packages/franken-orchestrator/src/chat/turn-runner.ts
+++ b/packages/franken-orchestrator/src/chat/turn-runner.ts
@@ -28,6 +28,7 @@ export type TurnEvent =
 
 export interface TurnRunOptions {
   sessionId: string;
+  onEvent?: ((event: TurnEvent) => void) | undefined;
 }
 
 export interface TurnRunResult {
@@ -57,6 +58,7 @@ export class TurnRunner extends EventEmitter {
       const event: TurnEvent = { type: 'approval_request', sessionId, data: { taskDescription: outcome.taskDescription } };
       events.push(event);
       this.emit('event', event);
+      options?.onEvent?.(event);
       return {
         status: 'pending_approval',
         summary: `Approval required: ${outcome.taskDescription}`,
@@ -67,6 +69,7 @@ export class TurnRunner extends EventEmitter {
     const startEvent: TurnEvent = { type: 'start', sessionId, data: { taskDescription: outcome.taskDescription } };
     events.push(startEvent);
     this.emit('event', startEvent);
+    options?.onEvent?.(startEvent);
 
     const executionResult = await this.executor.execute({ userInput: outcome.taskDescription });
 
@@ -76,6 +79,7 @@ export class TurnRunner extends EventEmitter {
     const completeEvent: TurnEvent = { type: 'complete', sessionId, data: { status: executionResult.status } };
     events.push(completeEvent);
     this.emit('event', completeEvent);
+    options?.onEvent?.(completeEvent);
 
     return { status, summary, events };
   }

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -184,6 +184,10 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
       const runtimeInput = approvalRuntimeInput(pendingApproval);
       const originalState = session.state;
+      session.pendingApproval = null;
+      session.state = 'approved';
+      session.updatedAt = new Date().toISOString();
+      sessionStore.save(session);
       try {
         result = await runtime.run(runtimeInput, {
           sessionId: session.id,

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { approvalRuntimeInput } from '../../chat/approval-input.js';
 import type { ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
 import type { ChatRuntime } from '../../chat/runtime.js';
@@ -178,9 +179,17 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     }
 
     if (approved) {
-      const result = await runtime.run('/approve', {
+      const pendingApproval = session.pendingApproval ?? null;
+      const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
+      const runtimeInput = approvalRuntimeInput(pendingApproval);
+      session.pendingApproval = null;
+      session.state = 'approved';
+      session.updatedAt = new Date().toISOString();
+      sessionStore.save(session);
+
+      const result = await runtime.run(runtimeInput, {
         sessionId: session.id,
-        pendingApproval: Boolean(session.pendingApproval) || session.state === 'pending_approval',
+        pendingApproval: wasPendingApproval,
         projectId: session.projectId,
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -178,22 +178,27 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       return c.json({ data: { id: session.id, approved, state: session.state } });
     }
 
+    let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
     if (approved) {
       const pendingApproval = session.pendingApproval ?? null;
       const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
       const runtimeInput = approvalRuntimeInput(pendingApproval);
-      session.pendingApproval = null;
-      session.state = 'approved';
-      session.updatedAt = new Date().toISOString();
-      sessionStore.save(session);
-
-      const result = await runtime.run(runtimeInput, {
-        sessionId: session.id,
-        pendingApproval: wasPendingApproval,
-        projectId: session.projectId,
-        transcript: session.transcript,
-        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
-      });
+      const originalState = session.state;
+      try {
+        result = await runtime.run(runtimeInput, {
+          sessionId: session.id,
+          pendingApproval: wasPendingApproval,
+          projectId: session.projectId,
+          transcript: session.transcript,
+          ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+        });
+      } catch (error) {
+        session.pendingApproval = pendingApproval;
+        session.state = originalState;
+        session.updatedAt = new Date().toISOString();
+        sessionStore.save(session);
+        throw error;
+      }
 
       session.state = result.state === 'active' ? 'approved' : result.state;
       session.pendingApproval = null;
@@ -205,7 +210,16 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     session.updatedAt = new Date().toISOString();
     sessionStore.save(session);
 
-    return c.json({ data: { id: session.id, approved, state: session.state } } satisfies ApiDataEnvelope<ApproveResult>);
+    return c.json({
+      data: {
+        id: session.id,
+        approved,
+        state: session.state,
+        ...(result?.outcome ? { outcome: result.outcome } : {}),
+        ...(result?.tier ? { tier: result.tier } : {}),
+        ...(result ? { displayMessages: result.displayMessages, events: result.events } : {}),
+      },
+    } satisfies ApiDataEnvelope<ApproveResult>);
   });
 
   return app;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -371,7 +371,7 @@ export class ChatSocketController {
           ...(pendingApproval.sessionId ? { sessionId: pendingApproval.sessionId } : {}),
         });
       }
-      throw error;
+      return;
     }
     session.pendingApproval = null;
     session.state = result.state === 'active' ? 'approved' : result.state;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -346,7 +346,14 @@ export class ChatSocketController {
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
       }, {
-        onEvent: (event) => this.emit(peer, mapTurnEvent(event)),
+        onEvent: (event) => {
+          try {
+            this.emit(peer, mapTurnEvent(event));
+          } catch {
+            // Socket delivery is best-effort; do not turn an already-running
+            // approved command into a retryable approval execution failure.
+          }
+        },
       });
     } catch (error) {
       session.pendingApproval = pendingApproval;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -314,23 +314,15 @@ export class ChatSocketController {
       return;
     }
 
+    if (!session.pendingApproval && session.state !== 'pending_approval') {
+      return;
+    }
+
     const pendingApproval = session.pendingApproval ?? null;
+    const originalState = session.state;
     const runtimeInput = approvalRuntimeInput(pendingApproval);
     session.pendingApproval = null;
     session.state = 'approved';
-    session.updatedAt = nowIso();
-    this.sessionStore.save(session);
-
-    const result = await this.runtime.run(runtimeInput, {
-      sessionId: session.id,
-      pendingApproval: Boolean(pendingApproval),
-      projectId: session.projectId,
-      transcript: session.transcript,
-      ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
-    });
-    session.pendingApproval = null;
-    session.state = result.state === 'active' ? 'approved' : result.state;
-    session.beastContext = result.beastContext ?? null;
     session.updatedAt = nowIso();
     this.sessionStore.save(session);
 
@@ -339,9 +331,31 @@ export class ChatSocketController {
       approved: true,
       timestamp: session.updatedAt,
     });
-    for (const event of result.events) {
-      this.emit(peer, mapTurnEvent(event));
+
+    let result: Awaited<ReturnType<ChatRuntime['run']>>;
+    try {
+      result = await this.runtime.run(runtimeInput, {
+        sessionId: session.id,
+        pendingApproval: Boolean(pendingApproval) || originalState === 'pending_approval',
+        projectId: session.projectId,
+        transcript: session.transcript,
+        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+      }, {
+        onEvent: (event) => this.emit(peer, mapTurnEvent(event)),
+      });
+    } catch (error) {
+      session.pendingApproval = pendingApproval;
+      session.state = originalState;
+      session.updatedAt = nowIso();
+      this.sessionStore.save(session);
+      throw error;
     }
+    session.pendingApproval = null;
+    session.state = result.state === 'active' ? 'approved' : result.state;
+    session.beastContext = result.beastContext ?? null;
+    session.updatedAt = nowIso();
+    this.sessionStore.save(session);
+
     for (const display of result.displayMessages) {
       this.emit(peer, {
         type: 'assistant.message.complete',

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -331,6 +331,9 @@ export class ChatSocketController {
       approved: true,
       timestamp: session.updatedAt,
     });
+    for (const event of result.events) {
+      this.emit(peer, mapTurnEvent(event));
+    }
     for (const display of result.displayMessages) {
       this.emit(peer, {
         type: 'assistant.message.complete',

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, Server as HttpServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import type { Duplex } from 'node:stream';
 import { WebSocketServer, type WebSocket } from 'ws';
+import { approvalRuntimeInput } from '../chat/approval-input.js';
 import { ChatRuntime } from '../chat/runtime.js';
 import type { ISessionStore } from '../chat/session-store.js';
 import type { ChatSession } from '../chat/types.js';
@@ -313,16 +314,22 @@ export class ChatSocketController {
       return;
     }
 
-    const approvedAction = session.pendingApproval?.command ?? session.pendingApproval?.description;
-    const result = await this.runtime.run(approvedAction ? `/run ${approvedAction}` : '/approve', {
+    const pendingApproval = session.pendingApproval ?? null;
+    const runtimeInput = approvalRuntimeInput(pendingApproval);
+    session.pendingApproval = null;
+    session.state = 'approved';
+    session.updatedAt = nowIso();
+    this.sessionStore.save(session);
+
+    const result = await this.runtime.run(runtimeInput, {
       sessionId: session.id,
-      pendingApproval: Boolean(session.pendingApproval),
+      pendingApproval: Boolean(pendingApproval),
       projectId: session.projectId,
       transcript: session.transcript,
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
     });
     session.pendingApproval = null;
-    session.state = result.state;
+    session.state = result.state === 'active' ? 'approved' : result.state;
     session.beastContext = result.beastContext ?? null;
     session.updatedAt = nowIso();
     this.sessionStore.save(session);

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -315,6 +315,11 @@ export class ChatSocketController {
     }
 
     if (!session.pendingApproval && session.state !== 'pending_approval') {
+      this.emit(peer, {
+        type: 'turn.approval.resolved',
+        approved: session.state !== 'rejected',
+        timestamp: nowIso(),
+      });
       return;
     }
 
@@ -348,6 +353,24 @@ export class ChatSocketController {
       session.state = originalState;
       session.updatedAt = nowIso();
       this.sessionStore.save(session);
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'APPROVAL_EXECUTION_FAILED',
+        message: error instanceof Error ? error.message : 'Approved action failed to run.',
+        timestamp: session.updatedAt,
+      });
+      if (pendingApproval) {
+        this.emit(peer, {
+          type: 'turn.approval.requested',
+          description: pendingApproval.description,
+          timestamp: pendingApproval.requestedAt,
+          ...(pendingApproval.tool ? { tool: pendingApproval.tool } : {}),
+          ...(pendingApproval.command ? { command: pendingApproval.command } : {}),
+          ...(pendingApproval.risk ? { risk: pendingApproval.risk } : {}),
+          ...(pendingApproval.affectedFiles ? { affectedFiles: pendingApproval.affectedFiles } : {}),
+          ...(pendingApproval.sessionId ? { sessionId: pendingApproval.sessionId } : {}),
+        });
+      }
       throw error;
     }
     session.pendingApproval = null;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -313,7 +313,8 @@ export class ChatSocketController {
       return;
     }
 
-    const result = await this.runtime.run('/approve', {
+    const approvedAction = session.pendingApproval?.command ?? session.pendingApproval?.description;
+    const result = await this.runtime.run(approvedAction ? `/run ${approvedAction}` : '/approve', {
       sessionId: session.id,
       pendingApproval: Boolean(session.pendingApproval),
       projectId: session.projectId,

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -659,6 +659,89 @@ describe('Chat HTTP Routes', () => {
     expect(session.pendingApproval).toBeNull();
   });
 
+  it('POST /v1/chat/sessions/:id/approve does not execute duplicate HTTP approvals twice', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-http-duplicate-approval',
+      projectId: 'proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: {
+        description: 'Deploy staging',
+        requestedAt: now,
+        tool: 'execution',
+        command: 'deploy staging',
+        sessionId: 'chat-http-duplicate-approval',
+      },
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    let finishExecution!: () => void;
+    let executionStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      executionStarted = resolve;
+    });
+    const finished = new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    });
+    const runtime = {
+      run: vi.fn(async () => {
+        executionStarted();
+        await finished;
+        return {
+          displayMessages: [{ kind: 'execution' as const, content: 'Done' }],
+          events: [],
+          pendingApproval: false,
+          state: 'active' as const,
+          tier: 'premium_execution',
+          transcript: [],
+        };
+      }),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+    });
+
+    const first = app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    await started;
+    const duplicate = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    finishExecution();
+    const firstRes = await first;
+
+    expect(firstRes.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect((await duplicate.json()).data).toMatchObject({
+      id: session.id,
+      approved: true,
+      state: 'approved',
+    });
+    expect(session.pendingApproval).toBeNull();
+  });
+
   it('POST /v1/chat/sessions/:id/approve does not downgrade approved sessions when runtime reports active', async () => {
     const now = new Date().toISOString();
     const session: ChatSession = {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -643,7 +643,10 @@ describe('Chat HTTP Routes', () => {
     });
 
     expect(res.status).toBe(200);
-    expect((await res.json()).data.state).toBe('approved');
+    const body = await res.json();
+    expect(body.data.state).toBe('approved');
+    expect(body.data.displayMessages).toEqual([{ kind: 'execution', content: 'Done' }]);
+    expect(body.data.events).toEqual([{ type: 'complete', sessionId: session.id, data: { status: 'success' } }]);
     expect(runtime.run).toHaveBeenCalledWith('/run deploy staging', expect.objectContaining({
       pendingApproval: true,
       sessionId: session.id,

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -590,6 +590,72 @@ describe('Chat HTTP Routes', () => {
     expect(session.pendingApproval).toBeNull();
   });
 
+  it('POST /v1/chat/sessions/:id/approve runs the pending command for HTTP fallback approvals', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-http-pending-command',
+      projectId: 'proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: {
+        description: 'Deploy staging',
+        requestedAt: now,
+        tool: 'execution',
+        command: 'deploy staging',
+        sessionId: 'chat-http-pending-command',
+      },
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'execution' as const, content: 'Done' }],
+        events: [{ type: 'complete' as const, sessionId: session.id, data: { status: 'success' } }],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'premium_execution',
+        transcript: [],
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+    });
+
+    const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.state).toBe('approved');
+    expect(runtime.run).toHaveBeenCalledWith('/run deploy staging', expect.objectContaining({
+      pendingApproval: true,
+      sessionId: session.id,
+    }));
+    expect(sessionStore.save).toHaveBeenCalledWith(expect.objectContaining({
+      state: 'approved',
+      pendingApproval: null,
+    }));
+    expect(session.state).toBe('approved');
+    expect(session.pendingApproval).toBeNull();
+  });
+
   it('POST /v1/chat/sessions/:id/approve does not downgrade approved sessions when runtime reports active', async () => {
     const now = new Date().toISOString();
     const session: ChatSession = {

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -277,21 +277,19 @@ describe('ws chat server', () => {
     store.save(session);
     const secret = createSessionTokenSecret();
     const token = issueSessionToken({ secret, sessionId: session.id });
-    const runtime = {
-      run: vi.fn().mockResolvedValue({
-        displayMessages: [{ kind: 'execution', content: 'Done' }],
-        events: [
-          { type: 'start', sessionId: session.id, data: { taskDescription: 'deploy staging' } },
-          { type: 'complete', sessionId: session.id, data: { status: 'success' } },
-        ],
-        pendingApproval: false,
-        state: 'active',
-        tier: 'premium_execution',
-        transcript: session.transcript,
-      }),
-    };
+    const execute = vi.fn().mockResolvedValue({
+      status: 'success',
+      summary: 'Done',
+      filesChanged: [],
+      testsRun: 0,
+      errors: [],
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
     const controller = new ChatSocketController({
-      runtime: runtime as unknown as ChatRuntime,
+      runtime,
       sessionStore: store,
       tokenSecret: secret,
     });
@@ -309,10 +307,7 @@ describe('ws chat server', () => {
       approved: true,
     }));
 
-    expect(runtime.run).toHaveBeenCalledWith('/approve', expect.objectContaining({
-      pendingApproval: true,
-      sessionId: session.id,
-    }));
+    expect(execute).toHaveBeenCalledWith({ userInput: 'deploy staging' });
     const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
     expect(events).toContainEqual(expect.objectContaining({
       type: 'turn.approval.resolved',

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -321,6 +321,75 @@ describe('ws chat server', () => {
       type: 'turn.execution.complete',
       data: { status: 'success' },
     }));
+    expect(store.get(session.id)?.state).toBe('approved');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('does not execute the same approved action twice for duplicate approval frames', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    let finishExecution!: () => void;
+    const executionStarted = new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    });
+    const execute = vi.fn(async () => {
+      await executionStarted;
+      return {
+        status: 'success',
+        summary: 'Done',
+        filesChanged: [],
+        testsRun: 0,
+        errors: [],
+      };
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    const first = controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+    const second = controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+    finishExecution();
+    await Promise.all([first, second]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(store.get(session.id)?.state).toBe('approved');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+    const executionStarts = sent
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((event) => event.type === 'turn.execution.start');
+    expect(executionStarts).toHaveLength(1);
 
     rmSync(TMP, { recursive: true, force: true });
   });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -440,7 +440,7 @@ describe('ws chat server', () => {
     await expect(controller.receive(peer, JSON.stringify({
       type: 'approval.respond',
       approved: true,
-    }))).rejects.toThrow('executor offline');
+    }))).resolves.toBeUndefined();
 
     expect(store.get(session.id)?.state).toBe('pending_approval');
     expect(store.get(session.id)?.pendingApproval?.command).toBe('deploy staging');

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -267,6 +267,7 @@ describe('ws chat server', () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
+    session.state = 'pending_approval';
     session.pendingApproval = {
       description: 'deploy staging',
       requestedAt: '2026-03-09T00:00:00Z',
@@ -333,6 +334,7 @@ describe('ws chat server', () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
+    session.state = 'pending_approval';
     session.pendingApproval = {
       description: 'deploy staging',
       requestedAt: '2026-03-09T00:00:00Z',
@@ -392,6 +394,113 @@ describe('ws chat server', () => {
       .map((raw) => JSON.parse(raw) as { type: string })
       .filter((event) => event.type === 'turn.execution.start');
     expect(executionStarts).toHaveLength(1);
+    const approvalResolved = sent
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((event) => event.type === 'turn.approval.resolved');
+    expect(approvalResolved).toHaveLength(2);
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('restores pending approval and notifies clients when approved execution throws', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn(async () => {
+      throw new Error('executor offline');
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await expect(controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }))).rejects.toThrow('executor offline');
+
+    expect(store.get(session.id)?.state).toBe('pending_approval');
+    expect(store.get(session.id)?.pendingApproval?.command).toBe('deploy staging');
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'APPROVAL_EXECUTION_FAILED',
+      message: 'executor offline',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.requested',
+      command: 'deploy staging',
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('uses the legacy approve command for approvals without executable commands', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'Approve deployment?',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn();
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+
+    expect(execute).not.toHaveBeenCalled();
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'assistant.message.complete',
+      content: 'Approved.',
+    }));
 
     rmSync(TMP, { recursive: true, force: true });
   });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -262,4 +262,71 @@ describe('ws chat server', () => {
 
     rmSync(TMP, { recursive: true, force: true });
   });
+
+  it('emits execution events after an approved action runs', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const runtime = {
+      run: vi.fn().mockResolvedValue({
+        displayMessages: [{ kind: 'execution', content: 'Done' }],
+        events: [
+          { type: 'start', sessionId: session.id, data: { taskDescription: 'deploy staging' } },
+          { type: 'complete', sessionId: session.id, data: { status: 'success' } },
+        ],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'premium_execution',
+        transcript: session.transcript,
+      }),
+    };
+    const controller = new ChatSocketController({
+      runtime: runtime as unknown as ChatRuntime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    const connect = controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    });
+    expect(connect.ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+
+    expect(runtime.run).toHaveBeenCalledWith('/approve', expect.objectContaining({
+      pendingApproval: true,
+      sessionId: session.id,
+    }));
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.resolved',
+      approved: true,
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.execution.start',
+      data: { taskDescription: 'deploy staging' },
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.execution.complete',
+      data: { status: 'success' },
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
 });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -458,6 +458,70 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('does not retry approved work when live event delivery fails', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn().mockResolvedValue({
+      status: 'success' as const,
+      summary: 'Done',
+      filesChanged: [],
+      testsRun: 0,
+      errors: [],
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const sent: Record<string, unknown>[] = [];
+    const peer = {
+      close: vi.fn(),
+      send: (data: string) => {
+        const event = JSON.parse(data) as Record<string, unknown>;
+        sent.push(event);
+        if (event.type === 'turn.execution.start') {
+          throw new Error('socket closed');
+        }
+      },
+    };
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await expect(controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }))).resolves.toBeUndefined();
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(store.get(session.id)?.state).toBe('approved');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'turn.execution.start',
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('uses the legacy approve command for approvals without executable commands', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -41,7 +41,7 @@ function createTestRuntime(): ChatRuntime {
     }),
     turnRunner: new TurnRunner({
       execute: vi.fn().mockResolvedValue({
-        status: 'success',
+        status: 'success' as const,
         summary: 'Done',
         filesChanged: [],
         testsRun: 0,
@@ -164,7 +164,7 @@ describe('ws chat server', () => {
       }),
       turnRunner: new TurnRunner({
         execute: vi.fn().mockResolvedValue({
-          status: 'success',
+          status: 'success' as const,
           summary: 'Done',
           filesChanged: [],
           testsRun: 0,
@@ -278,7 +278,7 @@ describe('ws chat server', () => {
     const secret = createSessionTokenSecret();
     const token = issueSessionToken({ secret, sessionId: session.id });
     const execute = vi.fn().mockResolvedValue({
-      status: 'success',
+      status: 'success' as const,
       summary: 'Done',
       filesChanged: [],
       testsRun: 0,
@@ -313,6 +313,8 @@ describe('ws chat server', () => {
       type: 'turn.approval.resolved',
       approved: true,
     }));
+    expect(events.findIndex((event) => event.type === 'turn.approval.resolved'))
+      .toBeLessThan(events.findIndex((event) => event.type === 'turn.execution.start'));
     expect(events).toContainEqual(expect.objectContaining({
       type: 'turn.execution.start',
       data: { taskDescription: 'deploy staging' },
@@ -348,7 +350,7 @@ describe('ws chat server', () => {
     const execute = vi.fn(async () => {
       await executionStarted;
       return {
-        status: 'success',
+        status: 'success' as const,
         summary: 'Done',
         filesChanged: [],
         testsRun: 0,

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -92,6 +92,10 @@ export const ApproveResultSchema = z.object({
   id: z.string(),
   approved: z.boolean(),
   state: z.string(),
+  outcome: TurnOutcomeSchema.optional(),
+  tier: z.string().optional(),
+  displayMessages: z.array(z.unknown()).optional(),
+  events: z.array(z.unknown()).optional(),
 });
 export type ApproveResult = z.infer<typeof ApproveResultSchema>;
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  type ApproveResult,
   ChatApiClient,
   type ChatSession,
   type PendingApproval,
@@ -209,6 +210,31 @@ function appendOrUpdateAssistantMessage(
   }
 
   return [...messages, nextMessage];
+}
+
+function activityEventsFromApproveResult(result: ApproveResult, approved: boolean): ActivityEvent[] {
+  const timestamp = new Date().toISOString();
+  return [
+    {
+      type: 'turn.approval.resolved',
+      data: { approved },
+      timestamp,
+    },
+    ...(result.events ?? []).flatMap((event): ActivityEvent[] => {
+      if (!event || typeof event !== 'object' || !('type' in event)) {
+        return [];
+      }
+      const turnEvent = event as { type: unknown; data?: Record<string, unknown> };
+      if (turnEvent.type !== 'start' && turnEvent.type !== 'progress' && turnEvent.type !== 'complete') {
+        return [];
+      }
+      return [{
+        type: `turn.execution.${turnEvent.type}`,
+        ...(turnEvent.data !== undefined ? { data: turnEvent.data } : {}),
+        timestamp,
+      }];
+    }),
+  ];
 }
 
 function updateReceipt(
@@ -864,18 +890,29 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setStatus('sending');
     if (!socket || socket.readyState !== 1) {
       try {
-        await clientRef.current.approve(sessionId, approved);
+        const approvalResult = await clientRef.current.approve(sessionId, approved);
         const refreshed = await clientRef.current.getSession(sessionId);
         readyRef.current = true;
-        setMessages((current) => mergeSessionSnapshot(current, refreshed));
+        setMessages((current) => {
+          const withSnapshot = mergeSessionSnapshot(current, refreshed);
+          const approvedDisplays = (approvalResult.displayMessages ?? []).flatMap((display): Array<{ content: string }> => {
+            if (!display || typeof display !== 'object' || !('content' in display)) {
+              return [];
+            }
+            const content = (display as { content: unknown }).content;
+            return typeof content === 'string' ? [{ content }] : [];
+          });
+          return approvedDisplays.reduce((messages, display) => appendOrUpdateAssistantMessage(messages, {
+            type: 'assistant.message.complete',
+            messageId: makeId('assistant'),
+            content: display.content,
+            timestamp: new Date().toISOString(),
+          }), withSnapshot);
+        });
         setPendingApproval(refreshed.pendingApproval ?? null);
         setActivity((current) => [
           ...current,
-          {
-            type: 'turn.approval.resolved',
-            data: { approved },
-            timestamp: new Date().toISOString(),
-          },
+          ...activityEventsFromApproveResult(approvalResult, approved),
         ]);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);


### PR DESCRIPTION
## Summary
- Emit runtime execution events after approved websocket actions so activity feed progress appears
- Add regression coverage for approval websocket responses forwarding start/complete execution events

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/integration/chat/ws-chat-server.test.ts -t 'emits execution events after an approved action runs' (red before fix, green after fix)
- npm run build --workspace @franken/types
- npm test --workspace @franken/orchestrator -- tests/integration/chat/ws-chat-server.test.ts
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #759
