### PR TITLE
refactor(tests): remove recursive Turbo verification

### DIFF
--- a/tests/verify-everything-meta.test.ts
+++ b/tests/verify-everything-meta.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const VERIFY_EVERYTHING_TEST = resolve(ROOT, 'tests/verify-everything.test.ts');
+
+describe('verify-everything test boundaries', () => {
+  it('does not recursively invoke Turbo workspace pipelines', () => {
+    const source = readFileSync(VERIFY_EVERYTHING_TEST, 'utf8');
+
+    for (const pipeline of ['build', 'test']) {
+      expect(source).not.toContain(['npx', 'turbo', 'run', pipeline].join(' '));
+    }
+  });
+});

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -13,35 +13,6 @@ const ALL_PACKAGES = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: tru
   .sort();
 
 describe('Chunk 10: full verification pass', () => {
-  describe('build', () => {
-    it('turbo run build succeeds for all workspace packages', () => {
-      const output = exec('npx turbo run build 2>&1');
-      expect(output).toContain(`${ALL_PACKAGES.length} successful, ${ALL_PACKAGES.length} total`);
-    });
-  });
-
-  describe('tests', () => {
-    it('turbo run test succeeds for all packages', () => {
-      const output = exec('npx turbo run test 2>&1');
-      expect(output).toContain('successful');
-      // Check the turbo Tasks summary line, not the entire output
-      // (test names may contain the word "failed" in passing tests)
-      const tasksLine = output.split('\n').find((l) => l.includes('Tasks:'));
-      expect(tasksLine).toBeDefined();
-      expect(tasksLine).not.toContain('failed');
-    });
-
-    it('total test count is at least 1572', () => {
-      const output = exec('npx turbo run test 2>&1');
-      const testLines = output.match(/(\d+) passed/g) ?? [];
-      const total = testLines.reduce((sum, line) => {
-        const match = line.match(/(\d+) passed/);
-        return sum + (match ? parseInt(match[1], 10) : 0);
-      }, 0);
-      expect(total).toBeGreaterThanOrEqual(1572);
-    });
-  });
-
   describe('workspace resolution', () => {
     it('npm ls @franken/types resolves without errors', () => {
       // npm ls exits non-zero on errors, so a successful exec means no errors


### PR DESCRIPTION
## Summary
- Remove recursive `npx turbo run build` / `npx turbo run test` executions from `tests/verify-everything.test.ts`.
- Add a root-level regression test that keeps `verify-everything.test.ts` from invoking Turbo workspace pipelines.

## Test Plan
- [x] `npx vitest run tests/verify-everything-meta.test.ts` (failed before fix)
- [x] `npx vitest run tests/verify-everything-meta.test.ts tests/verify-everything.test.ts`
- [x] `npm run test:root -- tests/verify-everything-meta.test.ts tests/verify-everything.test.ts`
- [x] `npm run lint:any`
- [x] `npm run lint:security`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`

Closes #673
