### PR TITLE
fix(governor): tighten dangerous pattern matching

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -56,6 +56,15 @@ describe('GovernorAdapter', () => {
       .resolves.toMatchObject({ decision: 'denied' });
   });
 
+  it('denies destructive verbs in action names without relying on payload text', async () => {
+    const governor = createGovernorAdapter(tracked(tmpDbPath()));
+
+    await expect(governor.check({ action: 'delete_file', context: '{"path":"src/app.ts"}' }))
+      .resolves.toMatchObject({ decision: 'denied' });
+    await expect(governor.check({ action: 'dropTable', context: '{"name":"events"}' }))
+      .resolves.toMatchObject({ decision: 'denied' });
+  });
+
   it('approves benign substrings that are not destructive verbs', async () => {
     const governor = createGovernorAdapter(tracked(tmpDbPath()));
 

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -47,10 +47,26 @@ describe('GovernorAdapter', () => {
     expect(result.decision).toBe('denied');
   });
 
+  it('denies split recursive and force rm flags in any order', async () => {
+    const governor = createGovernorAdapter(tracked(tmpDbPath()));
+
+    await expect(governor.check({ action: 'run_shell', context: 'rm -r -f /var/data' }))
+      .resolves.toMatchObject({ decision: 'denied' });
+    await expect(governor.check({ action: 'run_shell', context: 'rm --force --recursive /var/data' }))
+      .resolves.toMatchObject({ decision: 'denied' });
+  });
+
+  it('approves benign substrings that are not destructive verbs', async () => {
+    const governor = createGovernorAdapter(tracked(tmpDbPath()));
+
+    await expect(governor.check({ action: 'edit_file', context: '{"path":"src/dropdown.tsx"}' }))
+      .resolves.toMatchObject({ decision: 'approved' });
+    await expect(governor.check({ action: 'run_node', context: 'formatMessage("hello")' }))
+      .resolves.toMatchObject({ decision: 'approved' });
+  });
+
   it('denies when the dangerous pattern is only in the context payload', async () => {
     const governor = createGovernorAdapter(tracked(tmpDbPath()));
-    // 'rm -rf' is in DANGEROUS_PATTERNS; the tool name alone is benign.
-    // (Word-order variants like 'push --force' are #475's split-flag scope.)
     const result = await governor.check({ action: 'run_shell', context: 'rm -rf /var/data' });
     expect(result.decision).toBe('denied');
   });

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -51,25 +51,23 @@ export const NON_EXECUTING_TOOLS: ReadonlySet<string> = new Set([
 
 /**
  * Fallback patterns for CLI-level dangers the SkillTrigger doesn't cover.
- * Substring (not word-boundary) matching is deliberate: it fails closed, so
- * snake_case/camelCase destructive verbs (`drop_table`, `dropTable`) are still
- * caught. The tradeoff is benign paths containing these substrings
- * (`src/dropdown.tsx`) also trip — a safe false-positive. Tightening this
- * heuristic (tokenizer/verb-aware matching, split-flag detection like
- * `rm -r -f`) is tracked as a follow-up and intentionally out of scope here.
+ * Match destructive verbs as verbs instead of arbitrary substrings so benign
+ * paths or identifiers such as `src/dropdown.tsx` and `formatMessage()` do not
+ * get denied. Command-style flag patterns still fail closed for destructive
+ * split flags such as `rm -r -f`, `rm --recursive --force`, and `reset --hard`.
  */
 const DANGEROUS_PATTERNS = [
-  /delete/i,
-  /drop/i,
-  /truncate/i,
-  /destroy/i,
-  /remove.*all/i,
-  /force.*push/i,
-  /reset.*hard/i,
-  /rm\s+-rf/i,
-  /format/i,
-  /wipe/i,
-  /purge/i,
+  /\bdelete\b/i,
+  /\bdrop\b/i,
+  /\btruncate\b/i,
+  /\bdestroy\b/i,
+  /\bremove\b[^\n;|&]*\ball\b/i,
+  /\b(?:force\b[\s_-]+\bpush|push\b[^\n;|&]*\s--force\b)/i,
+  /\breset\b[^\n;|&]*\b(?:hard|--hard)\b/i,
+  /\brm\b(?=[^\n;|&]*\s(?:-[A-Za-z]*r[A-Za-z]*|--recursive)\b)(?=[^\n;|&]*\s(?:-[A-Za-z]*f[A-Za-z]*|--force)\b)/i,
+  /\bformat\b/i,
+  /\bwipe\b/i,
+  /\bpurge\b/i,
 ];
 
 export interface GovernorCheckResult {

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -51,12 +51,22 @@ export const NON_EXECUTING_TOOLS: ReadonlySet<string> = new Set([
 
 /**
  * Fallback patterns for CLI-level dangers the SkillTrigger doesn't cover.
- * Match destructive verbs as verbs instead of arbitrary substrings so benign
- * paths or identifiers such as `src/dropdown.tsx` and `formatMessage()` do not
- * get denied. Command-style flag patterns still fail closed for destructive
- * split flags such as `rm -r -f`, `rm --recursive --force`, and `reset --hard`.
+ * Action/tool names are tokenized separately so destructive verbs in snake_case
+ * or camelCase names (`delete_file`, `dropTable`) still fail closed, while
+ * payload text uses word/command boundaries so benign paths or identifiers such
+ * as `src/dropdown.tsx` and `formatMessage()` do not get denied.
  */
-const DANGEROUS_PATTERNS = [
+const DANGEROUS_ACTION_VERBS = new Set([
+  'delete',
+  'drop',
+  'truncate',
+  'destroy',
+  'format',
+  'wipe',
+  'purge',
+]);
+
+const DANGEROUS_CONTEXT_PATTERNS = [
   /\bdelete\b/i,
   /\bdrop\b/i,
   /\btruncate\b/i,
@@ -98,8 +108,27 @@ function mapSeverityToDecision(
   return 'review_recommended';
 }
 
-function matchesDangerousPattern(text: string): boolean {
-  return DANGEROUS_PATTERNS.some((p) => p.test(text));
+function tokenizeActionName(action: string): string[] {
+  return action
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((token) => token.toLowerCase());
+}
+
+function matchesDangerousActionName(action: string): boolean {
+  const tokens = tokenizeActionName(action);
+  return (
+    tokens.some((token) => DANGEROUS_ACTION_VERBS.has(token))
+    || (tokens.includes('remove') && tokens.includes('all'))
+    || (tokens.includes('force') && tokens.includes('push'))
+    || (tokens.includes('reset') && tokens.includes('hard'))
+  );
+}
+
+function matchesDangerousPattern(action: string, context: string): boolean {
+  const combined = `${action} ${context}`;
+  return matchesDangerousActionName(action) || DANGEROUS_CONTEXT_PATTERNS.some((p) => p.test(combined));
 }
 
 function assessAction(action: string, context: string): GovernorCheckResult {
@@ -113,8 +142,7 @@ function assessAction(action: string, context: string): GovernorCheckResult {
     };
   }
 
-  const combined = `${action} ${context}`;
-  const isDestructive = DESTRUCTIVE_ACTIONS.has(action) || matchesDangerousPattern(combined);
+  const isDestructive = DESTRUCTIVE_ACTIONS.has(action) || matchesDangerousPattern(action, context);
 
   // Evaluate via governor SkillTrigger with pattern-derived destructiveness
   const triggerResult: TriggerResult = triggerRegistry.evaluateAll({


### PR DESCRIPTION
## Summary
- match dangerous governor verbs with word boundaries to avoid benign substring false positives
- detect recursive+force rm flags when split or long-form
- add targeted regression coverage for issue #475

## Test Plan
- npm exec --workspace @franken/mcp-suite -- vitest run src/adapters/governor-adapter.test.ts --reporter=verbose
- npm run test --workspace @franken/mcp-suite
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite
- npm run typecheck
- npm run build

Closes #475