### PR TITLE
fix(orchestrator): handle child process spawn errors

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -63,6 +63,11 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
   ): Promise<SpawnedProcessHandle> {
     this.validateCwd(spec.cwd);
 
+    let stdoutClosed = false;
+    let stderrClosed = false;
+    let exitInfo: { code: number | null; signal: string | null } | undefined;
+    let exitFired = false;
+
     const child = spawn(spec.command, [...spec.args], {
       cwd: spec.cwd,
       env: {
@@ -70,6 +75,18 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
         ...spec.env,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.once('error', (error) => {
+      const failedPid = child.pid;
+      if (failedPid) {
+        this.processes.delete(failedPid);
+      }
+      callbacks.onStderr(`Process spawn failed for ${spec.command}: ${error.message}`);
+      if (!exitFired) {
+        exitFired = true;
+        callbacks.onExit(1, null);
+      }
     });
 
     if (!child.pid) {
@@ -80,11 +97,6 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
 
     const pid = child.pid;
     this.processes.set(pid, child);
-
-    let stdoutClosed = false;
-    let stderrClosed = false;
-    let exitInfo: { code: number | null; signal: string | null } | undefined;
-    let exitFired = false;
 
     const maybeFireExit = () => {
       if (!exitFired && stdoutClosed && stderrClosed && exitInfo) {

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -28,6 +28,9 @@ export async function startNetworkService(
       detached: true,
       stdio: ['ignore', handle.fd, handle.fd],
     });
+    child.once('error', (error) => {
+      console.error(`[${service.id}] Process spawn failed for ${processSpec.command}: ${error.message}`);
+    });
     child.unref();
     await handle.close();
     if (!child.pid) {
@@ -45,6 +48,10 @@ export async function startNetworkService(
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
+  child.once('error', (error) => {
+    console.error(`[${service.id}] Process spawn failed for ${processSpec.command}: ${error.message}`);
+  });
+
   child.stdout?.on('data', (chunk) => process.stdout.write(`[${service.id}] ${chunk}`));
   child.stderr?.on('data', (chunk) => process.stderr.write(`[${service.id}] ${chunk}`));
 
@@ -55,7 +62,7 @@ export async function startNetworkService(
   return { pid: child.pid };
 }
 
-export async function stopNetworkService(service: { pid: number }): Promise<void> {
+export async function stopNetworkService(service: { pid: number; detached?: boolean | undefined }): Promise<void> {
   if (service.pid <= 0) {
     return;
   }

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -66,6 +66,17 @@ describe('ProcessSupervisor', () => {
       }, { timeout: 5000 });
     });
 
+    it('handles child process error events for missing commands without crashing', async () => {
+      const callbacks = makeCallbacks();
+      const spec = makeSpec({ command: '/definitely/not-a-real-command-franken-698', args: [] });
+
+      await expect(supervisor.spawn(spec, callbacks)).rejects.toThrow(/Failed to spawn Beast process/);
+
+      await vi.waitFor(() => {
+        expect(callbacks.onStderr).toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+      }, { timeout: 5000 });
+    });
+
     it('captures stdout lines via onStdout callback', async () => {
       const callbacks = makeCallbacks();
       const spec = makeSpec({

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -1,5 +1,49 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { stopNetworkService } from '../../../src/network/network-supervisor-runtime.js';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { startNetworkService, stopNetworkService } from '../../../src/network/network-supervisor-runtime.js';
+import type { ResolvedNetworkService } from '../../../src/network/network-registry.js';
+
+function makeService(command: string): ResolvedNetworkService {
+  return {
+    id: 'chat-server',
+    displayName: 'Chat Server',
+    kind: 'app',
+    dependsOn: [],
+    configPaths: [],
+    enabled: () => true,
+    describe: () => 'test service',
+    buildRuntimeConfig: () => ({}),
+    explanation: 'test service',
+    runtimeConfig: {
+      process: {
+        command,
+        args: [],
+        cwd: process.cwd(),
+      },
+    },
+  };
+}
+
+describe('startNetworkService', () => {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterEach(() => {
+    errorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('handles child process error events for missing foreground services without crashing', async () => {
+    await expect(startNetworkService(makeService('/definitely/not-a-real-command-franken-698'), {
+      detached: false,
+    })).rejects.toThrow(/Failed to start service chat-server/);
+
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+    }, { timeout: 5000 });
+  });
+});
 
 describe('stopNetworkService', () => {
   const killSpy = vi.spyOn(process, 'kill');


### PR DESCRIPTION
## Summary
- Add child process `error` listeners in `ProcessSupervisor` and `network-supervisor-runtime` so missing executables/async spawn failures are handled instead of crashing the orchestrator process.
- Surface spawn failures through stderr/onExit for Beast processes and a service-scoped error log for network services.
- Add regression coverage for missing-command spawn failures in both supervisors.

## Test Plan
- `npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/execution/process-supervisor.test.ts tests/unit/network/network-supervisor-runtime.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm --prefix packages/franken-orchestrator run lint` (passes with existing warnings)

Closes #698
