### PR TITLE
fix(mcp-suite): tolerate commented settings writes

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -65,14 +65,19 @@ describe('fbeast init', () => {
     expect(settings.mcpServers['fbeast-skills']).toBeDefined();
   });
 
-  it('merges with existing settings.json without overwriting', () => {
+  it('merges with existing settings.json comments and trailing commas without overwriting', () => {
     const root = tmpDir();
     dirs.push(root);
     const claudeDir = join(root, '.claude');
     mkdirSync(claudeDir, { recursive: true });
     const settingsPath = join(claudeDir, 'settings.json');
-    const existing = { mcpServers: { 'my-other-server': { command: 'other' } }, customKey: true };
-    writeFileSync(settingsPath, JSON.stringify(existing));
+    writeFileSync(settingsPath, `{
+      // Existing user-managed MCP server.
+      "mcpServers": {
+        "my-other-server": { "command": "other" },
+      },
+      "customKey": true,
+    }`);
 
     runInit({ root, claudeDir, hooks: false });
 

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -14,6 +14,7 @@ import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { writeHookScripts } from './hook-scripts.js';
 import { codexServerName, ensureCodexProjectId } from './codex-server-names.js';
+import { parseJsonObjectWithComments, writeJsonFileAtomic } from './settings-json.js';
 
 const ALL_SERVERS: FbeastServer[] = [
   'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
@@ -91,7 +92,7 @@ function initJsonClient(options: {
   const settingsPath = join(claudeDir, 'settings.json');
   let settings: Record<string, unknown> = {};
   if (existsSync(settingsPath)) {
-    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
   }
 
   // Add MCP server entries
@@ -122,7 +123,7 @@ function initJsonClient(options: {
     }
   }
 
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  writeJsonFileAtomic(settingsPath, settings);
 
   printLine(`fbeast initialized in ${root}`);
   printLine(`  Config:     ${config.configPath}`);

--- a/packages/franken-mcp-suite/src/cli/settings-json.test.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, lstatSync, mkdtempSync, readdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -44,6 +44,31 @@ describe('settings.json helpers', () => {
       mcpServers: { 'fbeast-memory': { command: 'fbeast-memory' } },
     });
     expect(readdirSync(dir).filter((entry) => entry.includes('.tmp-'))).toEqual([]);
+  });
+
+  it('preserves permissions when replacing an existing settings file', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const settingsPath = join(dir, 'settings.json');
+    writeFileSync(settingsPath, '{"existing":true}\n', 'utf-8');
+    chmodSync(settingsPath, 0o600);
+
+    writeJsonFileAtomic(settingsPath, { existing: true, updated: true });
+
+    expect(statSync(settingsPath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toEqual({ existing: true, updated: true });
+  });
+
+  it('updates the target of a symlinked settings file without replacing the symlink', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const targetPath = join(dir, 'settings-target.json');
+    const settingsPath = join(dir, 'settings.json');
+    writeFileSync(targetPath, '{"existing":true}\n', 'utf-8');
+    symlinkSync(targetPath, settingsPath);
+
+    writeJsonFileAtomic(settingsPath, { existing: true, updated: true });
+
+    expect(lstatSync(settingsPath).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(readFileSync(targetPath, 'utf-8'))).toEqual({ existing: true, updated: true });
   });
 
   it('does not modify an existing file when serialization fails before the atomic rename', () => {

--- a/packages/franken-mcp-suite/src/cli/settings-json.test.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.test.ts
@@ -71,6 +71,18 @@ describe('settings.json helpers', () => {
     expect(JSON.parse(readFileSync(targetPath, 'utf-8'))).toEqual({ existing: true, updated: true });
   });
 
+  it('creates the target of a dangling symlinked settings file without replacing the symlink', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const targetPath = join(dir, 'settings-target.json');
+    const settingsPath = join(dir, 'settings.json');
+    symlinkSync(targetPath, settingsPath);
+
+    writeJsonFileAtomic(settingsPath, { created: true });
+
+    expect(lstatSync(settingsPath).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(readFileSync(targetPath, 'utf-8'))).toEqual({ created: true });
+  });
+
   it('does not modify an existing file when serialization fails before the atomic rename', () => {
     const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
     const settingsPath = join(dir, 'settings.json');

--- a/packages/franken-mcp-suite/src/cli/settings-json.test.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { parseJsonObjectWithComments, writeJsonFileAtomic } from './settings-json.js';
+
+describe('settings.json helpers', () => {
+  it('parses comments and trailing commas without treating comment markers inside strings as comments', () => {
+    const parsed = parseJsonObjectWithComments(`{
+      // VS Code-style comment
+      "mcpServers": {
+        "existing": {
+          "command": "node",
+          "args": ["https://example.test//not-a-comment"],
+        },
+      },
+      /* block comment */
+      "note": "literal /* not a comment */ and // also literal",
+    }`);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        existing: {
+          command: 'node',
+          args: ['https://example.test//not-a-comment'],
+        },
+      },
+      note: 'literal /* not a comment */ and // also literal',
+    });
+  });
+
+  it('rejects settings JSON that does not parse to an object', () => {
+    expect(() => parseJsonObjectWithComments('[1, 2, 3]')).toThrow(/settings\.json must contain a JSON object/);
+  });
+
+  it('writes JSON via a sibling temp file and leaves no temp file after success', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const settingsPath = join(dir, 'settings.json');
+
+    writeJsonFileAtomic(settingsPath, { mcpServers: { 'fbeast-memory': { command: 'fbeast-memory' } } });
+
+    expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toEqual({
+      mcpServers: { 'fbeast-memory': { command: 'fbeast-memory' } },
+    });
+    expect(readdirSync(dir).filter((entry) => entry.includes('.tmp-'))).toEqual([]);
+  });
+
+  it('does not modify an existing file when serialization fails before the atomic rename', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const settingsPath = join(dir, 'settings.json');
+    writeFileSync(settingsPath, '{"existing":true}\n', 'utf-8');
+    const value = {
+      toJSON() {
+        throw new Error('boom');
+      },
+    };
+
+    expect(() => writeJsonFileAtomic(settingsPath, value)).toThrow('boom');
+
+    expect(readFileSync(settingsPath, 'utf-8')).toBe('{"existing":true}\n');
+    expect(existsSync(settingsPath)).toBe(true);
+  });
+});

--- a/packages/franken-mcp-suite/src/cli/settings-json.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.ts
@@ -1,4 +1,4 @@
-import { closeSync, fsyncSync, openSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, closeSync, fsyncSync, lstatSync, openSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
@@ -16,13 +16,16 @@ export function readSettingsJson(content: string): Record<string, unknown> {
 
 export function writeJsonFileAtomic(path: string, value: unknown): void {
   const content = JSON.stringify(value, null, 2) + '\n';
-  const dir = dirname(path);
-  const tempPath = join(dir, `.${basename(path)}.tmp-${process.pid}-${randomUUID()}`);
+  const targetPath = resolveAtomicWriteTarget(path);
+  const existingMode = getExistingFileMode(targetPath);
+  const dir = dirname(targetPath);
+  const tempPath = join(dir, `.${basename(targetPath)}.tmp-${process.pid}-${randomUUID()}`);
 
   try {
-    writeFileSync(tempPath, content, { encoding: 'utf-8', flag: 'wx' });
+    writeFileSync(tempPath, content, { encoding: 'utf-8', flag: 'wx', mode: existingMode });
+    if (existingMode !== undefined) chmodSync(tempPath, existingMode);
     fsyncFile(tempPath);
-    renameSync(tempPath, path);
+    renameSync(tempPath, targetPath);
     fsyncDirectory(dir);
   } catch (error) {
     rmSync(tempPath, { force: true });
@@ -32,6 +35,31 @@ export function writeJsonFileAtomic(path: string, value: unknown): void {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function resolveAtomicWriteTarget(path: string): string {
+  try {
+    return lstatSync(path).isSymbolicLink() ? realpathSync(path) : path;
+  } catch (error) {
+    if (isNotFound(error)) return path;
+    throw error;
+  }
+}
+
+function getExistingFileMode(path: string): number | undefined {
+  try {
+    return statSync(path).mode & 0o777;
+  } catch (error) {
+    if (isNotFound(error)) return undefined;
+    throw error;
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: string }).code === 'ENOENT';
 }
 
 function stripJsonCommentsAndTrailingCommas(content: string): string {

--- a/packages/franken-mcp-suite/src/cli/settings-json.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.ts
@@ -1,5 +1,5 @@
-import { chmodSync, closeSync, fsyncSync, lstatSync, openSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { chmodSync, closeSync, fsyncSync, lstatSync, openSync, readlinkSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 export function parseJsonObjectWithComments(content: string): Record<string, unknown> {
@@ -39,7 +39,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function resolveAtomicWriteTarget(path: string): string {
   try {
-    return lstatSync(path).isSymbolicLink() ? realpathSync(path) : path;
+    if (!lstatSync(path).isSymbolicLink()) return path;
+    try {
+      return realpathSync(path);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      return resolve(dirname(path), readlinkSync(path));
+    }
   } catch (error) {
     if (isNotFound(error)) return path;
     throw error;

--- a/packages/franken-mcp-suite/src/cli/settings-json.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.ts
@@ -1,0 +1,179 @@
+import { closeSync, fsyncSync, openSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export function parseJsonObjectWithComments(content: string): Record<string, unknown> {
+  const parsed = JSON.parse(stripJsonCommentsAndTrailingCommas(content));
+  if (!isRecord(parsed)) {
+    throw new Error('settings.json must contain a JSON object');
+  }
+  return parsed;
+}
+
+export function readSettingsJson(content: string): Record<string, unknown> {
+  return parseJsonObjectWithComments(content);
+}
+
+export function writeJsonFileAtomic(path: string, value: unknown): void {
+  const content = JSON.stringify(value, null, 2) + '\n';
+  const dir = dirname(path);
+  const tempPath = join(dir, `.${basename(path)}.tmp-${process.pid}-${randomUUID()}`);
+
+  try {
+    writeFileSync(tempPath, content, { encoding: 'utf-8', flag: 'wx' });
+    fsyncFile(tempPath);
+    renameSync(tempPath, path);
+    fsyncDirectory(dir);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stripJsonCommentsAndTrailingCommas(content: string): string {
+  let output = '';
+  let inString = false;
+  let escaping = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i]!;
+    const next = content[i + 1];
+
+    if (inLineComment) {
+      if (char === '\n' || char === '\r') {
+        inLineComment = false;
+        output += char;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1;
+      } else if (char === '\n' || char === '\r') {
+        output += char;
+      } else {
+        output += ' ';
+      }
+      continue;
+    }
+
+    if (inString) {
+      output += char;
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      inBlockComment = true;
+      output += ' ';
+      i += 1;
+      continue;
+    }
+
+    output += char;
+  }
+
+  return removeTrailingCommas(output);
+}
+
+function removeTrailingCommas(content: string): string {
+  let output = '';
+  let inString = false;
+  let escaping = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i]!;
+
+    if (inString) {
+      output += char;
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === ',') {
+      const nextSignificant = findNextSignificantChar(content, i + 1);
+      if (nextSignificant === '}' || nextSignificant === ']') {
+        continue;
+      }
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+function findNextSignificantChar(content: string, start: number): string | undefined {
+  for (let i = start; i < content.length; i += 1) {
+    const char = content[i]!;
+    if (!/\s/.test(char)) return char;
+  }
+  return undefined;
+}
+
+function fsyncFile(path: string): void {
+  const fd = openSync(path, 'r');
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fsyncDirectory(path: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    fsyncSync(fd);
+  } catch (error) {
+    if (!isUnsupportedDirectoryFsync(error)) throw error;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function isUnsupportedDirectoryFsync(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: string }).code !== undefined
+    && ['EINVAL', 'EISDIR', 'EPERM', 'ENOTSUP'].includes((error as { code: string }).code);
+}

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -39,17 +39,20 @@ describe('fbeast uninstall', () => {
     expect(settings.mcpServers['fbeast-planner']).toBeUndefined();
   });
 
-  it('preserves non-fbeast MCP entries', async () => {
+  it('preserves non-fbeast MCP entries in settings.json with comments and trailing commas', async () => {
     const root = tmpDir();
     dirs.push(root);
     const claudeDir = join(root, '.claude');
-
-    runInit({ root, claudeDir, hooks: false });
+    mkdirSync(claudeDir, { recursive: true });
 
     const settingsPath = join(claudeDir, 'settings.json');
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    settings.mcpServers['my-server'] = { command: 'my-cmd' };
-    writeFileSync(settingsPath, JSON.stringify(settings));
+    writeFileSync(settingsPath, `{
+      "mcpServers": {
+        "fbeast-memory": { "command": "fbeast-memory" },
+        // User-managed server must survive uninstall.
+        "my-server": { "command": "my-cmd" },
+      },
+    }`);
 
     await runUninstall({ root, claudeDir, purge: false });
 

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -11,6 +11,7 @@ import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { confirmYesNo } from './prompt.js';
 import { codexProjectIds, codexServerNamesForProjectIds } from './codex-server-names.js';
+import { parseJsonObjectWithComments, writeJsonFileAtomic } from './settings-json.js';
 import type { FbeastServer } from '../shared/config.js';
 
 export interface UninstallOptions {
@@ -57,7 +58,7 @@ function uninstallJsonClient(options: { root: string; claudeDir: string; client:
   const settingsPath = join(claudeDir, 'settings.json');
 
   if (existsSync(settingsPath)) {
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
 
     // Remove fbeast MCP servers
     const mcpServers = (settings['mcpServers'] as Record<string, unknown>) ?? {};
@@ -95,7 +96,7 @@ function uninstallJsonClient(options: { root: string; claudeDir: string; client:
       }
     }
 
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+    writeJsonFileAtomic(settingsPath, settings);
   }
 
   const instrPath = join(claudeDir, 'fbeast-instructions.md');


### PR DESCRIPTION
## Summary
- add comment/trailing-comma tolerant JSON parsing for Claude/Gemini MCP settings
- write settings.json through a temp file + atomic rename to avoid partial writes
- cover init/uninstall merging and atomic settings helpers with regression tests

## Test Plan
- npm test --workspace @franken/mcp-suite -- settings-json.test.ts init.test.ts uninstall.test.ts
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite
- npx turbo run test --filter=@franken/mcp-suite
- npx turbo run typecheck build --filter=@franken/mcp-suite
- npm run lint:any
- npm run lint:security

Closes #701