### PR TITLE
fix(orchestrator): remove unsafe type-safety bypasses

### DIFF
--- a/packages/franken-orchestrator/src/network/secret-backends/cli-runner.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/cli-runner.ts
@@ -3,6 +3,25 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+interface CliProcessError {
+  code?: unknown;
+  stdout?: string;
+  stderr?: string;
+}
+
+function toCliProcessError(error: unknown): CliProcessError | null {
+  if (typeof error !== 'object' || error === null) {
+    return null;
+  }
+
+  const record = error as Record<string, unknown>;
+  return {
+    ...('code' in record ? { code: record.code } : {}),
+    ...(typeof record.stdout === 'string' ? { stdout: record.stdout } : {}),
+    ...(typeof record.stderr === 'string' ? { stderr: record.stderr } : {}),
+  };
+}
+
 export interface CliResult {
   stdout: string;
   stderr: string;
@@ -26,8 +45,8 @@ export async function runCli(
       exitCode: 0,
     };
   } catch (error: unknown) {
-    const execError = error as { stdout?: string; stderr?: string; code?: number | string };
-    if (typeof execError.code === 'number') {
+    const execError = toCliProcessError(error);
+    if (execError && typeof execError.code === 'number') {
       return {
         stdout: execError.stdout ?? '',
         stderr: execError.stderr ?? '',
@@ -60,14 +79,15 @@ export async function runCliWithStdin(
       maxBuffer: 10 * 1024 * 1024,
       env: env ? { ...process.env, ...env } : undefined,
     }, (error, stdout, stderr) => {
-      if (error && typeof (error as any).code !== 'number') {
+      const execError = toCliProcessError(error);
+      if (error && typeof execError?.code !== 'number') {
         reject(error);
         return;
       }
       resolve({
         stdout: stdout ?? '',
         stderr: stderr ?? '',
-        exitCode: (error as any)?.code ?? 0,
+        exitCode: typeof execError?.code === 'number' ? execError.code : 0,
       });
     });
     child.stdin?.write(stdin);

--- a/packages/franken-orchestrator/src/phases/closure.ts
+++ b/packages/franken-orchestrator/src/phases/closure.ts
@@ -94,7 +94,10 @@ export async function runClosure(
     try {
       const pr = await prCreator.create(result, logger);
       if (pr) {
-        (result as any).prUrl = pr.url;
+        result = {
+          ...result,
+          prUrl: pr.url,
+        };
       }
     } catch (error) {
       if (error instanceof PrCreationRequiredActionError) {

--- a/packages/franken-orchestrator/tests/unit/type-safety-bypasses.test.ts
+++ b/packages/franken-orchestrator/tests/unit/type-safety-bypasses.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(testDir, '..', '..');
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(packageRoot, relativePath), 'utf8');
+}
+
+describe('orchestrator type-safety bypass cleanup', () => {
+  it('does not use unsafe any casts in the issue #639 production files', () => {
+    const files = [
+      'src/phases/closure.ts',
+      'src/network/secret-backends/cli-runner.ts',
+      'src/comms/channels/whatsapp/whatsapp-router.ts',
+    ];
+
+    for (const file of files) {
+      expect(readSource(file), file).not.toMatch(/\bas\s+any\b|:\s*any\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Rebuild closure PR URL updates immutably instead of casting `BeastResult` to `any`
- Add a typed CLI exec-error normalizer for stdout/stderr/exit code handling
- Add a regression test covering the issue #639 production files for unsafe `any` bypasses

## Test Plan
- `npm --prefix packages/franken-orchestrator test -- tests/unit/type-safety-bypasses.test.ts`
- `npm --prefix packages/franken-orchestrator test -- tests/unit/type-safety-bypasses.test.ts tests/unit/network/secret-backends/cli-runner.test.ts tests/unit/phases/closure.test.ts`
- `node scripts/audit-explicit-any.mjs --json | jq '.files[] | select(.path=="packages/franken-orchestrator/src/phases/closure.ts" or .path=="packages/franken-orchestrator/src/network/secret-backends/cli-runner.ts" or .path=="packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts")'`
- `npm --prefix packages/franken-orchestrator run lint`
- `npx turbo run typecheck --filter=@franken/orchestrator`
- `npx turbo run build --filter=@franken/orchestrator`
- `npx turbo run test --filter=@franken/orchestrator`

Closes #639
