### PR TITLE
fix(live-bench): add tool-call evidence contract

### DIFF
--- a/packages/live-bench/src/evidence/tool-call-evidence.ts
+++ b/packages/live-bench/src/evidence/tool-call-evidence.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import type { ToolCallEvidence } from '../types.js';
+
+export const ToolCallEvidenceSchema: z.ZodType<ToolCallEvidence> = z.object({
+  id: z.string().min(1),
+  tool: z.string().min(1),
+  params: z.record(z.unknown()),
+  source: z.enum(['client', 'mcp-proxy', 'fbeast-proxy', 'adapter']),
+  startedAt: z.string().datetime({ offset: true }).optional(),
+  completedAt: z.string().datetime({ offset: true }).optional(),
+  ok: z.boolean().optional(),
+  result: z.unknown().optional(),
+  error: z.string().optional(),
+}).strict();
+
+export const ToolCallEvidenceManifestSchema = z.array(ToolCallEvidenceSchema);
+
+export function serializeToolCallEvidence(evidence: readonly ToolCallEvidence[]): string {
+  return `${JSON.stringify(ToolCallEvidenceManifestSchema.parse(evidence), null, 2)}\n`;
+}

--- a/packages/live-bench/src/index.ts
+++ b/packages/live-bench/src/index.ts
@@ -6,9 +6,17 @@ export type {
   TaskClass,
   BenchmarkTask,
   BenchmarkCheck,
+  ToolCallEvidence,
+  ToolCallEvidenceSource,
   BenchmarkMatrixRow,
   ClientRunResult,
 } from './types.js';
+export { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT, UNSUPPORTED_BENCHMARK_CHECK_TYPES } from './types.js';
+export {
+  ToolCallEvidenceManifestSchema,
+  ToolCallEvidenceSchema,
+  serializeToolCallEvidence,
+} from './evidence/tool-call-evidence.js';
 export { BenchmarkTaskSchema } from './corpus/schema.js';
 export { loadCorpus, loadTaskFile } from './corpus/loader.js';
 export { FixtureStore } from './workspace/fixture-store.js';

--- a/packages/live-bench/src/types.ts
+++ b/packages/live-bench/src/types.ts
@@ -24,6 +24,26 @@ export type BenchmarkCheck =
   | { readonly type: 'exit-code'; readonly code: number }
   | { readonly type: 'tool-call'; readonly tool: string; readonly requiredParams: readonly string[] };
 
+export const LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT = 'tool-calls.json';
+
+// Tool-call checks are declarative until the scorer consumes normalized evidence.
+// Keep this explicit so benchmark authors do not assume stdout/stderr scraping is supported.
+export const UNSUPPORTED_BENCHMARK_CHECK_TYPES = ['tool-call'] as const satisfies readonly BenchmarkCheck['type'][];
+
+export type ToolCallEvidenceSource = 'client' | 'mcp-proxy' | 'fbeast-proxy' | 'adapter';
+
+export interface ToolCallEvidence {
+  readonly id: string;
+  readonly tool: string;
+  readonly params: Readonly<Record<string, unknown>>;
+  readonly source: ToolCallEvidenceSource;
+  readonly startedAt?: string;
+  readonly completedAt?: string;
+  readonly ok?: boolean;
+  readonly result?: unknown;
+  readonly error?: string;
+}
+
 export interface BenchmarkMatrixRow {
   readonly runId: string;
   readonly taskId: string;
@@ -47,4 +67,6 @@ export interface ClientRunResult {
   readonly timedOut: boolean;
   readonly wallClockMs: number;
   readonly artifacts: readonly string[];
+  readonly toolCallEvidenceArtifact: typeof LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT;
+  readonly toolCallEvidence: readonly ToolCallEvidence[];
 }

--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -1,6 +1,8 @@
 import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { join, parse, relative, resolve, sep } from 'node:path';
+import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../types.js';
+import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT } from '../types.js';
 import type { FixtureStore } from './fixture-store.js';
 
 export interface WorkspaceProvisionerConfig {
@@ -13,6 +15,7 @@ export interface ProvisionedWorkspace {
   readonly workspaceDir: string;
   readonly evidenceDir: string;
   readonly environmentPath: string;
+  readonly toolCallEvidencePath: string;
 }
 
 export interface BenchmarkEnvironmentSnapshot {
@@ -68,6 +71,7 @@ export class WorkspaceProvisioner {
     const workspaceDir = join(runDir, 'workspace');
     const evidenceDir = join(runDir, 'evidence');
     const environmentPath = join(runDir, 'environment.json');
+    const toolCallEvidencePath = join(evidenceDir, LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT);
 
     ensureContained(runDir, dateDir, 'run directory');
     ensureContained(runDir, this.runsRoot, 'run directory');
@@ -99,8 +103,9 @@ export class WorkspaceProvisioner {
       provisionedAt: new Date().toISOString(),
     };
     writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`, 'utf8');
+    writeFileSync(toolCallEvidencePath, serializeToolCallEvidence([]), 'utf8');
 
-    return { runDir, workspaceDir, evidenceDir, environmentPath };
+    return { runDir, workspaceDir, evidenceDir, environmentPath, toolCallEvidencePath };
   }
 }
 

--- a/packages/live-bench/tests/tool-call-evidence.test.ts
+++ b/packages/live-bench/tests/tool-call-evidence.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ToolCallEvidenceManifestSchema, serializeToolCallEvidence } from '../src/evidence/tool-call-evidence.js';
+
+describe('tool-call evidence contract', () => {
+  it('validates the normalized evidence artifact shape', () => {
+    const evidence = ToolCallEvidenceManifestSchema.parse([
+      {
+        id: 'call-1',
+        tool: 'write_file',
+        params: { path: 'README.md' },
+        source: 'mcp-proxy',
+        startedAt: '2026-01-02T03:04:05.000Z',
+        completedAt: '2026-01-02T03:04:06.000Z',
+        ok: true,
+      },
+    ]);
+
+    expect(evidence[0]?.tool).toBe('write_file');
+  });
+
+  it('rejects non-normalized evidence with missing params or unknown fields', () => {
+    expect(() => ToolCallEvidenceManifestSchema.parse([{ id: 'call-1', tool: 'write_file', source: 'adapter' }])).toThrow();
+    expect(() => ToolCallEvidenceManifestSchema.parse([{ id: 'call-1', tool: 'write_file', params: {}, source: 'adapter', rawArgs: {} }])).toThrow();
+  });
+
+  it('serializes manifests as newline-terminated JSON arrays', () => {
+    expect(serializeToolCallEvidence([])).toBe('[]\n');
+  });
+});

--- a/packages/live-bench/tests/types.test.ts
+++ b/packages/live-bench/tests/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { BenchmarkTask } from '../src/types.js';
+import type { BenchmarkMatrixRow, BenchmarkTask, ClientRunResult, ToolCallEvidence } from '../src/types.js';
+import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT, UNSUPPORTED_BENCHMARK_CHECK_TYPES } from '../src/types.js';
 
 describe('live-bench types', () => {
   it('represents a core artifact-critical task', () => {
@@ -17,5 +18,49 @@ describe('live-bench types', () => {
     };
 
     expect(task.taskId).toBe('write-readme');
+  });
+
+  it('requires normalized tool-call evidence on client run results', () => {
+    const row: BenchmarkMatrixRow = {
+      runId: 'run-123',
+      taskId: 'write-readme',
+      client: 'codex-cli',
+      mode: 'fbeast',
+      fbeastTopology: 'proxy',
+      model: 'gpt-test',
+      clientVersion: '1.2.3',
+      commitSha: 'abc123',
+      hostClass: 'ci-linux',
+      runTimestamp: '2026-01-02T03:04:05.000Z',
+    };
+    const toolCall: ToolCallEvidence = {
+      id: 'call-1',
+      tool: 'write_file',
+      params: { path: 'README.md', content: 'hello' },
+      source: 'mcp-proxy',
+      startedAt: '2026-01-02T03:04:06.000Z',
+      completedAt: '2026-01-02T03:04:07.000Z',
+      ok: true,
+    };
+    const result: ClientRunResult = {
+      row,
+      workspaceDir: '/tmp/workspace',
+      evidenceDir: '/tmp/evidence',
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+      wallClockMs: 1000,
+      artifacts: [LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT],
+      toolCallEvidenceArtifact: LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT,
+      toolCallEvidence: [toolCall],
+    };
+
+    expect(result.toolCallEvidence[0]?.params).toMatchObject({ path: 'README.md' });
+    expect(result.artifacts).toContain(result.toolCallEvidenceArtifact);
+  });
+
+  it('marks tool-call checks unsupported until an evaluator consumes evidence', () => {
+    expect(UNSUPPORTED_BENCHMARK_CHECK_TYPES).toContain('tool-call');
   });
 });

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -85,6 +85,8 @@ describe('workspace provisioning', () => {
     expect(existsSync(join(result.workspaceDir, 'package.json'))).toBe(true);
     expect(readFileSync(join(result.workspaceDir, 'src', 'index.js'), 'utf8')).toContain('answer = 42');
     expect(existsSync(result.evidenceDir)).toBe(true);
+    expect(result.toolCallEvidencePath).toBe(join(result.evidenceDir, 'tool-calls.json'));
+    expect(JSON.parse(readFileSync(result.toolCallEvidencePath, 'utf8'))).toEqual([]);
 
     const environment = JSON.parse(readFileSync(result.environmentPath, 'utf8')) as Record<string, unknown>;
     expect(environment).toMatchObject({


### PR DESCRIPTION
## Summary
- Adds a normalized `ToolCallEvidence` manifest contract to live-bench run results.
- Initializes each provisioned evidence directory with `tool-calls.json` so adapters/proxies have a canonical artifact to populate.
- Exposes runtime validation/serialization for the tool-call evidence manifest and marks tool-call checks unsupported until scoring consumes that evidence.

## Test Plan
- `npm test -- --run tests/tool-call-evidence.test.ts tests/workspace-provisioner.test.ts tests/types.test.ts` from `packages/live-bench`
- `npm run typecheck` from `packages/live-bench`
- `npm test` from `packages/live-bench`
- `npm run build` from `packages/live-bench`
- `npm run lint:any` from repo root
- `npx turbo run typecheck build test --filter @franken/live-bench` from repo root

Closes #377
