### PR TITLE
fix(orchestrator): validate chunk plan design docs

### DIFF
--- a/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
@@ -9,6 +9,26 @@ const promptConfigSchema = z.object({
   files: z.array(z.string()).optional(),
 }).strict();
 
+function hasMarkdownDesignDocExtension(path: string): boolean {
+  return /\.(?:md|mdx|markdown)$/i.test(path);
+}
+
+const markdownDesignDocPathSchema = z.string().min(1)
+  .refine((value) => !value.includes('\0'), 'designDocPath must not contain NUL bytes')
+  .refine((value) => !isAbsolute(value) && !value.startsWith('\\') && !/^[a-zA-Z]:/.test(value), {
+    message: 'designDocPath must be a repo-relative path',
+  })
+  .refine((value) => !value.split(/[\\/]+/).includes('..'), {
+    message: 'designDocPath must not contain parent-directory traversal',
+  })
+  .refine(hasMarkdownDesignDocExtension, {
+    message: 'designDocPath must point to a Markdown design document',
+  });
+
+function validateDesignDocPath(requested: string): string {
+  return markdownDesignDocPathSchema.parse(requested);
+}
+
 function canonicalPath(path: string): string {
   try {
     return realpathSync(path);
@@ -32,6 +52,14 @@ function resolveContainedConfigPath(fieldName: string, projectRoot: string | und
   return target;
 }
 
+function resolveMarkdownDesignDocPath(fieldName: string, projectRoot: string | undefined, requested: string): string {
+  const target = resolveContainedConfigPath(fieldName, projectRoot, requested);
+  if (!hasMarkdownDesignDocExtension(target)) {
+    throw new Error(`${fieldName} must resolve to a Markdown design document: ${requested}`);
+  }
+  return target;
+}
+
 export const chunkPlanDefinition: BeastDefinition = {
   id: 'chunk-plan',
   version: 1,
@@ -39,7 +67,7 @@ export const chunkPlanDefinition: BeastDefinition = {
   description: 'Turn a design document into chunked implementation artifacts through the tracked init workflow.',
   executionModeDefault: 'process',
   configSchema: z.object({
-    designDocPath: z.string().min(1),
+    designDocPath: markdownDesignDocPathSchema,
     outputDir: z.string().min(1),
     projectRoot: z.string().optional(),
     promptConfig: promptConfigSchema.optional(),
@@ -60,10 +88,11 @@ export const chunkPlanDefinition: BeastDefinition = {
   ],
   buildProcessSpec: (config) => {
     const projectRoot = String(config.projectRoot ?? process.env.FBEAST_ROOT ?? process.cwd());
-    const designDocPath = resolveContainedConfigPath(
+    const requestedDesignDocPath = validateDesignDocPath(String(config.designDocPath));
+    const designDocPath = resolveMarkdownDesignDocPath(
       'designDocPath',
       projectRoot,
-      String(config.designDocPath),
+      requestedDesignDocPath,
     );
 
     return {

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/chunk-plan-definition.test.ts
@@ -52,7 +52,7 @@ describe('chunkPlanDefinition', () => {
       expect(spec.cwd).toBe('/home/user/project');
     });
 
-    it('rejects designDocPath values that escape projectRoot', () => {
+    it('rejects designDocPath values with parent-directory traversal before resolving projectRoot', () => {
       const config = {
         ...validConfig,
         projectRoot: '/home/user/project',
@@ -60,8 +60,49 @@ describe('chunkPlanDefinition', () => {
       };
 
       expect(() => chunkPlanDefinition.buildProcessSpec(config)).toThrow(
-        /designDocPath.*outside project root/,
+        /designDocPath.*parent-directory traversal/,
       );
+    });
+
+    it('rejects absolute designDocPath values before CLI argument construction', () => {
+      expect(() => chunkPlanDefinition.buildProcessSpec({
+        ...validConfig,
+        designDocPath: '/tmp/design.md',
+      })).toThrow(/designDocPath.*repo-relative/);
+    });
+
+    it('rejects drive-letter designDocPath values before CLI argument construction', () => {
+      expect(() => chunkPlanDefinition.buildProcessSpec({
+        ...validConfig,
+        designDocPath: 'C:\\tmp\\design.md',
+      })).toThrow(/designDocPath.*repo-relative/);
+    });
+
+    it('rejects non-markdown designDocPath values before CLI argument construction', () => {
+      expect(() => chunkPlanDefinition.buildProcessSpec({
+        ...validConfig,
+        designDocPath: 'docs/design.txt',
+      })).toThrow(/designDocPath.*Markdown design document/);
+    });
+
+    it('rejects symlinked designDocPath values that resolve to non-markdown files', () => {
+      const testDir = mkdtempSync(resolve(tmpdir(), 'fb-chunk-plan-'));
+      const projectRoot = resolve(testDir, 'project');
+      const docsDir = resolve(projectRoot, 'docs');
+
+      try {
+        mkdirSync(docsDir, { recursive: true });
+        writeFileSync(resolve(docsDir, 'design.txt'), '# Not actually Markdown');
+        symlinkSync('design.txt', resolve(docsDir, 'design.md'));
+
+        expect(() => chunkPlanDefinition.buildProcessSpec({
+          ...validConfig,
+          projectRoot,
+          designDocPath: 'docs/design.md',
+        })).toThrow(/designDocPath.*resolve to a Markdown design document/);
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
     });
 
     it('allows designDocPath values inside a symlinked projectRoot', () => {
@@ -78,7 +119,7 @@ describe('chunkPlanDefinition', () => {
         const spec = chunkPlanDefinition.buildProcessSpec({
           ...validConfig,
           projectRoot: linkRoot,
-          designDocPath: designPath,
+          designDocPath: 'docs/design.md',
         });
 
         expect(spec.args[spec.args.indexOf('--design-doc') + 1]).toBe(designPath);
@@ -127,6 +168,22 @@ describe('chunkPlanDefinition', () => {
       const result = chunkPlanDefinition.configSchema.safeParse({
         outputDir: '/tmp',
       });
+      expect(result.success).toBe(false);
+    });
+
+    it.each([
+      ['/tmp/design.md'],
+      ['C:\\tmp\\design.md'],
+      ['..\\secret.md'],
+      ['docs/../secret.md'],
+      ['docs/design.txt'],
+      ['docs/design.md\0'],
+    ])('rejects unsafe designDocPath %s', (designDocPath) => {
+      const result = chunkPlanDefinition.configSchema.safeParse({
+        ...validConfig,
+        designDocPath,
+      });
+
       expect(result.success).toBe(false);
     });
   });

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -129,9 +129,10 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
               type="text"
               value={(values.docPath as string) ?? ''}
               onChange={(e) => updateField('docPath', e.target.value)}
-              placeholder="/path/to/design-doc.md"
+              placeholder="docs/design-doc.md"
               className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
             />
+            <p className="mt-1 text-xs text-beast-muted">Use a repo-relative Markdown path; absolute paths and ../ traversal are rejected.</p>
           </div>
           <div>
             <label htmlFor="wf-output-dir" className="block text-sm font-medium text-beast-text mb-1.5">Output Directory</label>

--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -53,8 +53,8 @@ describe('WizardDialog validation', () => {
     expect(screen.getByRole('alert').textContent).toContain('Design doc path is required');
     expect(screen.getByRole('alert').textContent).toContain('Output directory is required');
 
-    fireEvent.change(screen.getByLabelText('Design Doc Path'), { target: { value: '/tmp/design.md' } });
-    fireEvent.change(screen.getByLabelText('Output Directory'), { target: { value: '/tmp/chunks' } });
+    fireEvent.change(screen.getByLabelText('Design Doc Path'), { target: { value: 'docs/design.md' } });
+    fireEvent.change(screen.getByLabelText('Output Directory'), { target: { value: 'tasks/chunks' } });
 
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', false);
   });

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -18,6 +18,13 @@ function isBlank(value: unknown): boolean {
   return typeof value !== 'string' || value.trim().length === 0;
 }
 
+function isRepoRelativeMarkdownDesignDocPath(value: string): boolean {
+  if (value.includes('\0')) return false;
+  if (value.startsWith('/') || value.startsWith('\\') || /^[a-zA-Z]:/.test(value)) return false;
+  if (value.split(/[\\/]+/).includes('..')) return false;
+  return /\.(?:md|mdx|markdown)$/i.test(value);
+}
+
 export function validateWizardStep(step: number, stepValues: WizardStepValues): WizardValidationErrors {
   const errors: WizardValidationErrors = {};
 
@@ -44,8 +51,11 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
     }
 
     if (values.workflowType === 'chunk-plan') {
-      if (isBlank(values.docPath)) {
+      const docPath = values.docPath;
+      if (isBlank(docPath)) {
         errors.docPath = 'Design doc path is required.';
+      } else if (typeof docPath !== 'string' || !isRepoRelativeMarkdownDesignDocPath(docPath)) {
+        errors.docPath = 'Design doc path must be a repo-relative Markdown file without traversal.';
       }
       if (isBlank(values.outputDir)) {
         errors.outputDir = 'Output directory is required.';

--- a/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { validateWizardStep } from '../../../src/components/beasts/wizard-validation';
+
+describe('wizard validation', () => {
+  it('accepts repo-relative Markdown chunk-plan design docs', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
+    });
+
+    expect(errors).toEqual({});
+  });
+
+  it.each([
+    '/tmp/design.md',
+    'C:\\tmp\\design.md',
+    '../secret.md',
+    'docs/../secret.md',
+    'docs/design.txt',
+    'docs/design.md\0',
+  ])('rejects unsafe chunk-plan design doc path %s', (docPath) => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'chunk-plan', docPath, outputDir: 'tasks/chunks' },
+    });
+
+    expect(errors.docPath).toBe('Design doc path must be a repo-relative Markdown file without traversal.');
+  });
+});


### PR DESCRIPTION
## Summary
- Tighten chunk-plan designDocPath schema to repo-relative Markdown design documents
- Reject absolute paths, Windows drive-letter paths, NUL bytes, parent-directory traversal, and non-Markdown extensions before CLI args are built
- Cover schema and buildProcessSpec rejection paths with targeted tests

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/definitions/chunk-plan-definition.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint
- npm --prefix packages/franken-orchestrator run build

Closes #614