### PR TITLE
fix(planner): detect cycles in parallel planner

### DIFF
--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -13,7 +13,9 @@ export class ParallelPlanner implements PlanningStrategy {
   readonly name = 'parallel' as const;
 
   async execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
-    const tasks = graph.getTasks();
+    // Validate the DAG up front so cyclic plans fail loudly instead of
+    // deadlocking the wave scheduler and returning partial success.
+    const tasks = graph.topoSort();
     const completedIds = new Set<TaskId>();
     const allResults: TaskResult[] = [];
 

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ParallelPlanner } from '../../../src/planners/parallel';
 import { PlanGraph } from '../../../src/core/dag';
+import { CyclicDependencyError } from '../../../src/core/errors';
 import { createTaskId } from '../../../src/core/types';
-import type { Task, TaskResult } from '../../../src/core/types';
+import type { Task, TaskId, TaskResult } from '../../../src/core/types';
 
 function makeTask(id: string): Task {
   return {
@@ -20,6 +21,21 @@ function success(id: string): TaskResult {
 
 function failure(id: string, message = 'task failed'): TaskResult {
   return { status: 'failure', taskId: createTaskId(id), error: new Error(message) };
+}
+
+function cyclicGraph(): PlanGraph {
+  const a = makeTask('a');
+  const b = makeTask('b');
+  const nodes = new Map<TaskId, Task>([
+    [a.id, a],
+    [b.id, b],
+  ]);
+  const edges = new Map<TaskId, Set<TaskId>>([
+    [a.id, new Set<TaskId>([b.id])],
+    [b.id, new Set<TaskId>([a.id])],
+  ]);
+
+  return PlanGraph.createWithRawEdges(nodes, edges);
 }
 
 // ─── Happy path ───────────────────────────────────────────────────────────────
@@ -118,6 +134,19 @@ describe('ParallelPlanner — happy path', () => {
 
     if (result.status !== 'completed') throw new Error('unexpected status');
     expect(result.taskResults).toHaveLength(2);
+  });
+});
+
+// ─── Cycle handling ───────────────────────────────────────────────────────────
+
+describe('ParallelPlanner — cycle handling', () => {
+  it('throws CyclicDependencyError before executing tasks when graph contains a cycle', async () => {
+    const executor = vi.fn().mockResolvedValue(success('a'));
+
+    await expect(new ParallelPlanner().execute(cyclicGraph(), { executor })).rejects.toBeInstanceOf(
+      CyclicDependencyError
+    );
+    expect(executor).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Validate ParallelPlanner graphs with topoSort before wave execution.
- Add a regression test proving cyclic graphs throw CyclicDependencyError before any task runs.

## Test Plan
- npm test -- tests/unit/planners/parallel.test.ts -t "throws CyclicDependencyError" (red before fix, green after)
- npm test -- tests/unit/planners/parallel.test.ts
- npx turbo run test --filter=@franken/planner
- npx turbo run typecheck --filter=@franken/planner
- npx turbo run build --filter=@franken/planner
- npx turbo run lint --filter=@franken/planner
- git diff --check

Closes #687