### PR TITLE
fix(orchestrator): clean up process beast worktrees

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -15,6 +15,7 @@ export interface GitWorktreeIsolationConfig {
 export interface BeastWorktreeAllocation {
   readonly agentId: string;
   readonly branchName: string;
+  readonly branchCreated: boolean;
   readonly created: boolean;
   readonly executionCwd: string;
   readonly gitTopLevel: string;
@@ -83,10 +84,12 @@ export function createBeastWorktree(
 
   mkdirSync(worktreesRoot, { recursive: true });
   const alreadyExists = existsSync(worktreePath);
+  const branchAlreadyExists = branchExists(runGit, projectRoot, branchName);
 
   const allocation: BeastWorktreeAllocation = {
     agentId: safeAgentId,
     branchName,
+    branchCreated: !alreadyExists && !branchAlreadyExists,
     created: !alreadyExists,
     executionCwd: isolatedExecutionCwd(root, worktreePath, baseCwd),
     gitTopLevel: root,
@@ -98,7 +101,7 @@ export function createBeastWorktree(
     return allocation;
   }
 
-  if (branchExists(runGit, projectRoot, branchName)) {
+  if (branchAlreadyExists) {
     runGit(['worktree', 'add', worktreePath, branchName], projectRoot);
   } else {
     runGit(['worktree', 'add', '-b', branchName, worktreePath], projectRoot);
@@ -111,7 +114,7 @@ export function removeBeastWorktree(allocation: BeastWorktreeAllocation, runGit:
   if (existsSync(allocation.worktreePath)) {
     runGit(['worktree', 'remove', '--force', allocation.worktreePath], allocation.projectRoot);
   }
-  if (branchExists(runGit, allocation.projectRoot, allocation.branchName)) {
+  if (allocation.branchCreated && branchExists(runGit, allocation.projectRoot, allocation.branchName)) {
     runGit(['branch', '-D', allocation.branchName], allocation.projectRoot);
   }
 }

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -178,7 +178,8 @@ export interface ProcessBeastExecutorOptions {
 export class ProcessBeastExecutor implements BeastExecutor {
   private readonly exitPromises = new Map<string, { resolve: () => void }>();
   private readonly stoppingAttempts = new Set<string>();
-  private readonly configFilePaths = new Map<string, string>();
+  private readonly pendingConfigFilePaths = new Map<string, string>();
+  private readonly attemptConfigFilePaths = new Map<string, string>();
   private readonly worktreeAllocations = new Map<string, BeastWorktreeAllocation>();
 
   constructor(
@@ -226,7 +227,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     mkdirSync(configDir, { recursive: true });
     const configFilePath = join(configDir, `${run.id}.json`);
     writeFileSync(configFilePath, JSON.stringify(isolatedConfigSnapshot, null, 2));
-    this.configFilePaths.set(run.id, configFilePath);
+    this.pendingConfigFilePaths.set(run.id, configFilePath);
 
     const mergedSpec = {
       ...isolatedSpec,
@@ -353,6 +354,12 @@ export class ProcessBeastExecutor implements BeastExecutor {
       },
     });
 
+    // Once an attempt owns the worktree, preserve it for PR/merge or debugging per ADR-028.
+    // The pending allocation map is only for pre-attempt spawn failures.
+    this.worktreeAllocations.delete(run.id);
+    this.pendingConfigFilePaths.delete(run.id);
+    this.attemptConfigFilePaths.set(attempt.id, configFilePath);
+
     attemptId = attempt.id;
 
     // Flush early buffered lines to logs and SSE
@@ -478,8 +485,8 @@ export class ProcessBeastExecutor implements BeastExecutor {
         this.exitPromises.delete(attemptId);
         exitEntry.resolve();
       }
-      // Still clean up config file
-      this.cleanupRunResources(runId);
+      // Still clean up this attempt's config file; completed/failed worktrees are preserved for PRs/debugging.
+      this.cleanupAttemptConfig(attemptId);
       return;
     }
 
@@ -491,7 +498,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         this.exitPromises.delete(attemptId);
         exitEntry.resolve();
       }
-      this.cleanupRunResources(runId);
+      this.cleanupAttemptConfig(attemptId);
       return;
     }
 
@@ -541,7 +548,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       exitEntry.resolve();
     }
 
-    this.cleanupRunResources(runId);
+    this.cleanupAttemptConfig(attemptId);
 
     this.options.eventBus?.publish({
       type: 'run.status',
@@ -560,16 +567,32 @@ export class ProcessBeastExecutor implements BeastExecutor {
   }
 
   private cleanupRunResources(runId: string): void {
-    const configPath = this.configFilePaths.get(runId);
-    if (configPath) {
-      try { unlinkSync(configPath); } catch { /* already removed */ }
-      this.configFilePaths.delete(runId);
-    }
+    this.cleanupPendingRunConfig(runId);
 
     const worktree = this.worktreeAllocations.get(runId);
     if (worktree) {
-      try { removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit); } catch { /* best effort */ }
+      try {
+        if (worktree.created) {
+          removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit);
+        }
+      } catch { /* best effort */ }
       finally { this.worktreeAllocations.delete(runId); }
+    }
+  }
+
+  private cleanupPendingRunConfig(runId: string): void {
+    const configPath = this.pendingConfigFilePaths.get(runId);
+    if (configPath) {
+      try { unlinkSync(configPath); } catch { /* already removed */ }
+      this.pendingConfigFilePaths.delete(runId);
+    }
+  }
+
+  private cleanupAttemptConfig(attemptId: string): void {
+    const configPath = this.attemptConfigFilePaths.get(attemptId);
+    if (configPath) {
+      try { unlinkSync(configPath); } catch { /* already removed */ }
+      this.attemptConfigFilePaths.delete(attemptId);
     }
   }
 
@@ -607,7 +630,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       data: { runId, attemptId: attempt.id, stream: 'stderr', line: stopReason, createdAt: finishedAt },
     });
 
-    this.cleanupRunResources(runId);
+    this.cleanupAttemptConfig(attempt.id);
 
     this.options.eventBus?.publish({
       type: 'run.status',

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -4,7 +4,12 @@ import { BeastLogStore } from '../events/beast-log-store.js';
 import type { BeastEventBus } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import type { BeastExecutor, StopOptions } from './beast-executor.js';
-import { createBeastWorktree, removeBeastWorktree, type GitWorktreeIsolationConfig } from './git-worktree-isolation.js';
+import {
+  createBeastWorktree,
+  removeBeastWorktree,
+  type BeastWorktreeAllocation,
+  type GitWorktreeIsolationConfig,
+} from './git-worktree-isolation.js';
 import type { ProcessSupervisorLike } from './process-supervisor.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
@@ -174,6 +179,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
   private readonly exitPromises = new Map<string, { resolve: () => void }>();
   private readonly stoppingAttempts = new Set<string>();
   private readonly configFilePaths = new Map<string, string>();
+  private readonly worktreeAllocations = new Map<string, BeastWorktreeAllocation>();
 
   constructor(
     private readonly repository: SQLiteBeastRepository,
@@ -193,6 +199,9 @@ export class ProcessBeastExecutor implements BeastExecutor {
           processSpec.cwd,
         )
       : undefined;
+    if (worktree) {
+      this.worktreeAllocations.set(run.id, worktree);
+    }
     const isolatedConfigSnapshot = worktree
       ? remapRuntimeConfigSnapshot(run.configSnapshot, processSpec.cwd, worktree.executionCwd)
       : run.configSnapshot;
@@ -310,14 +319,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       });
 
       // Clean up config file and worktree allocation written before spawn
-      const configPath = this.configFilePaths.get(run.id);
-      if (configPath) {
-        try { unlinkSync(configPath); } catch { /* already removed */ }
-        this.configFilePaths.delete(run.id);
-      }
-      if (worktree?.created) {
-        try { removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit); } catch { /* best effort */ }
-      }
+      this.cleanupRunResources(run.id);
 
       this.options.eventBus?.publish({
         type: 'run.status',
@@ -477,11 +479,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         exitEntry.resolve();
       }
       // Still clean up config file
-      const configPath = this.configFilePaths.get(runId);
-      if (configPath) {
-        try { unlinkSync(configPath); } catch { /* already removed */ }
-        this.configFilePaths.delete(runId);
-      }
+      this.cleanupRunResources(runId);
       return;
     }
 
@@ -493,11 +491,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         this.exitPromises.delete(attemptId);
         exitEntry.resolve();
       }
-      const configPath = this.configFilePaths.get(runId);
-      if (configPath) {
-        try { unlinkSync(configPath); } catch { /* already removed */ }
-        this.configFilePaths.delete(runId);
-      }
+      this.cleanupRunResources(runId);
       return;
     }
 
@@ -547,12 +541,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       exitEntry.resolve();
     }
 
-    // Clean up config file
-    const configPath = this.configFilePaths.get(runId);
-    if (configPath) {
-      try { unlinkSync(configPath); } catch { /* already removed */ }
-      this.configFilePaths.delete(runId);
-    }
+    this.cleanupRunResources(runId);
 
     this.options.eventBus?.publish({
       type: 'run.status',
@@ -568,6 +557,20 @@ export class ProcessBeastExecutor implements BeastExecutor {
       throw new Error(`Unknown Beast attempt: ${attemptId}`);
     }
     return attempt;
+  }
+
+  private cleanupRunResources(runId: string): void {
+    const configPath = this.configFilePaths.get(runId);
+    if (configPath) {
+      try { unlinkSync(configPath); } catch { /* already removed */ }
+      this.configFilePaths.delete(runId);
+    }
+
+    const worktree = this.worktreeAllocations.get(runId);
+    if (worktree) {
+      try { removeBeastWorktree(worktree, this.options.worktreeIsolation?.runGit); } catch { /* best effort */ }
+      finally { this.worktreeAllocations.delete(runId); }
+    }
   }
 
   private finishAttempt(
@@ -603,6 +606,8 @@ export class ProcessBeastExecutor implements BeastExecutor {
       type: 'run.log',
       data: { runId, attemptId: attempt.id, stream: 'stderr', line: stopReason, createdAt: finishedAt },
     });
+
+    this.cleanupRunResources(runId);
 
     this.options.eventBus?.publish({
       type: 'run.status',

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -344,11 +344,15 @@ describe('ProcessBeastExecutor', () => {
       stop: vi.fn(async () => {}),
       kill: vi.fn(async () => {}),
     };
+    let branchCreated = false;
     const runGit = vi.fn((args: readonly string[]): string => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
       if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
-      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(String(args.at(-1)), { recursive: true });
-      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        if (args[2] === '-b') branchCreated = true;
+        mkdirSync(String(args.at(-1)), { recursive: true });
+      }
+      if (args[0] === 'branch' && args[1] === '--list') return branchCreated ? String(args[2] ?? '') : '';
       return '';
     });
     const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
@@ -382,7 +386,103 @@ describe('ProcessBeastExecutor', () => {
     expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
   });
 
-  it('removes a worktree allocation after a tracked process exits successfully', async () => {
+  it('does not remove an existing worktree allocation when process spawning fails', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = {
+      spawn: vi.fn(async () => { throw new Error('spawn failed'); }),
+      stop: vi.fn(async () => {}),
+      kill: vi.fn(async () => {}),
+    };
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const existingWorktreePath = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    mkdirSync(existingWorktreePath, { recursive: true });
+
+    await expect(executor.start(run, createDefinitionWithCwd(workDir))).rejects.toThrow('spawn failed');
+
+    expect(runGit).not.toHaveBeenCalledWith(['worktree', 'remove', '--force', existingWorktreePath], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+  });
+
+  it('does not delete a pre-existing branch when spawn cleanup removes a new worktree', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = {
+      spawn: vi.fn(async () => { throw new Error('spawn failed'); }),
+      stop: vi.fn(async () => {}),
+      kill: vi.fn(async () => {}),
+    };
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(String(args[2]), { recursive: true });
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await expect(executor.start(run, createDefinitionWithCwd(workDir))).rejects.toThrow('spawn failed');
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'add', expectedWorktree, `beast/${agent.id}`], workDir);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+  });
+
+  it('preserves a worktree allocation after a tracked process exits successfully', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
@@ -430,11 +530,11 @@ describe('ProcessBeastExecutor', () => {
     capturedCallbacks!.onExit(0, null);
 
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
-    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
-    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
   });
 
-  it('removes a worktree allocation after a tracked process exits with failure', async () => {
+  it('preserves a worktree allocation after a tracked process exits with failure', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
@@ -482,11 +582,11 @@ describe('ProcessBeastExecutor', () => {
     capturedCallbacks!.onExit(1, null);
 
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
-    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
-    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
   });
 
-  it('removes a worktree allocation after a tracked process is killed by the operator', async () => {
+  it('preserves a worktree allocation after a tracked process is killed by the operator', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
@@ -530,8 +630,8 @@ describe('ProcessBeastExecutor', () => {
     await executor.kill(run.id, attempt.id);
 
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
-    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
-    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
   });
 
   it('stops the current attempt without deleting the run row', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -347,6 +347,7 @@ describe('ProcessBeastExecutor', () => {
     const runGit = vi.fn((args: readonly string[]): string => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
       if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(String(args.at(-1)), { recursive: true });
       if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
       return '';
     });
@@ -375,6 +376,158 @@ describe('ProcessBeastExecutor', () => {
     });
 
     await expect(executor.start(run, createDefinitionWithCwd(workDir))).rejects.toThrow('spawn failed');
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+  });
+
+  it('removes a worktree allocation after a tracked process exits successfully', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    let capturedCallbacks: ProcessCallbacks | undefined;
+    const supervisor = {
+      spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+        capturedCallbacks = callbacks as ProcessCallbacks;
+        return { pid: 4242 };
+      }),
+      stop: vi.fn(async () => {}),
+      kill: vi.fn(async () => {}),
+    };
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(String(args.at(-1)), { recursive: true });
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await executor.start(run, createDefinitionWithCwd(workDir));
+    capturedCallbacks!.onExit(0, null);
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+  });
+
+  it('removes a worktree allocation after a tracked process exits with failure', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    let capturedCallbacks: ProcessCallbacks | undefined;
+    const supervisor = {
+      spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+        capturedCallbacks = callbacks as ProcessCallbacks;
+        return { pid: 4242 };
+      }),
+      stop: vi.fn(async () => {}),
+      kill: vi.fn(async () => {}),
+    };
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(String(args.at(-1)), { recursive: true });
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await executor.start(run, createDefinitionWithCwd(workDir));
+    capturedCallbacks!.onExit(1, null);
+
+    const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
+  });
+
+  it('removes a worktree allocation after a tracked process is killed by the operator', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = {
+      spawn: vi.fn(async () => ({ pid: 4242 })),
+      stop: vi.fn(async () => {}),
+      kill: vi.fn(async () => {}),
+    };
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return workDir!;
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(String(args.at(-1)), { recursive: true });
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, {
+      worktreeIsolation: { enabled: true, projectRoot: workDir!, runGit },
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'test-beast',
+      source: 'dashboard',
+      status: 'dispatching',
+      createdByUser: 'pfk',
+      initAction: { kind: 'martin-loop', command: 'test', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const attempt = await executor.start(run, createDefinitionWithCwd(workDir));
+    await executor.kill(run.id, attempt.id);
 
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
     expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);


### PR DESCRIPTION
## Summary
- Track ProcessBeastExecutor git worktree allocations through the run lifecycle
- Clean up worktrees and branches on successful exit, failed exit, spawn failure, stop, and kill terminal paths
- Add regression coverage for tracked process worktree cleanup

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/process-beast-executor.test.ts
- npm run build -- --filter=@franken/types --filter=@franken/observer --filter=@franken/brain --filter=@franken/critique --filter=@franken/governor --filter=@franken/planner
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator run lint
- npm --prefix packages/franken-orchestrator test

Closes #686