### PR TITLE
fix(mcp): validate beast provider values

### DIFF
--- a/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
@@ -72,6 +72,22 @@ describe('runBeastMode', () => {
     expect(raw.beast.acknowledged_cli_risk).toBe(true);
   });
 
+  it('rejects unsupported provider values before saving config or launching beast catalog', async () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const deps = makeDeps(root);
+    const configPath = join(root, '.fbeast', 'config.json');
+
+    await expect(runBeastMode(['--provider=local-llm'], deps)).rejects.toThrow(TypeError);
+    await expect(runBeastMode(['--provider=local-llm'], deps)).rejects.toThrow(
+      'Unsupported beast provider: local-llm',
+    );
+
+    expect(existsSync(configPath)).toBe(false);
+    expect(deps.confirm).not.toHaveBeenCalled();
+    expect(deps.exec).not.toHaveBeenCalled();
+  });
+
   it('aborts if claude-cli confirmation denied', async () => {
     const root = tmpDir();
     dirs.push(root);

--- a/packages/franken-mcp-suite/src/cli/beast-mode.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.ts
@@ -7,6 +7,17 @@ function printLine(...args: unknown[]): void {
   console.info(...args);
 }
 const FRANKENBEAST_INSTALL_COMMAND = 'npm install -g @franken/orchestrator';
+const SUPPORTED_BEAST_PROVIDERS = new Set(['anthropic-api', 'codex-cli', 'claude-cli']);
+
+function parseProvider(argv: string[]): string {
+  const provider = argv.find((arg) => arg.startsWith('--provider='))?.split('=')[1] ?? 'anthropic-api';
+  if (!SUPPORTED_BEAST_PROVIDERS.has(provider)) {
+    throw new TypeError(
+      `Unsupported beast provider: ${provider}. Supported providers: anthropic-api, codex-cli, claude-cli`,
+    );
+  }
+  return provider;
+}
 
 export interface BeastModeDeps {
   root: string;
@@ -15,7 +26,7 @@ export interface BeastModeDeps {
 }
 
 export async function runBeastMode(argv: string[], deps: BeastModeDeps): Promise<void> {
-  const provider = argv.find((arg) => arg.startsWith('--provider='))?.split('=')[1] ?? 'anthropic-api';
+  const provider = parseProvider(argv);
 
   const config = existsSync(join(deps.root, '.fbeast', 'config.json'))
     ? FbeastConfig.load(deps.root)


### PR DESCRIPTION
## Summary
- validate `fbeast beast --provider` before loading or saving config
- reject unsupported provider values with a `TypeError`
- add regression coverage that invalid providers do not write config or launch the beast catalog handoff

## Test Plan
- `npm --prefix packages/franken-mcp-suite test -- src/cli/beast-mode.test.ts` (red before fix, green after fix)
- `npx turbo run build --filter=@franken/mcp-suite...`
- `npm --prefix packages/franken-mcp-suite run typecheck`
- `npx turbo run test --filter=@franken/mcp-suite`
- `npm run lint:any`
- `npm run lint:security`

Closes #420
