### PR TITLE
fix(governor): authenticate approval requests

### DIFF
--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -44,6 +44,8 @@ type GovernorSignatureVerificationResult =
   | { ok: true }
   | { ok: false; reason: 'missing' | 'malformed' | 'invalid' };
 
+type ParsedJsonBody = Record<string, unknown>;
+
 function normalizeGovernorSignature(signature: string): Buffer | null {
   const trimmed = signature.trim();
   if (!trimmed.toLowerCase().startsWith(GOVERNOR_SIGNATURE_PREFIX)) {
@@ -78,6 +80,19 @@ function verifyGovernorSignature(
   }
 
   return { ok: true };
+}
+
+function parseJsonBody(rawBody: Buffer): ParsedJsonBody | null {
+  if (rawBody.length === 0) return {};
+
+  try {
+    const parsed: unknown = JSON.parse(rawBody.toString('utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as ParsedJsonBody)
+      : {};
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -143,9 +158,42 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
   // POST /v1/approval/request — submit an approval request
   app.post('/v1/approval/request', async (c) => {
-    const body = await c.req.json();
+    const rawBody = Buffer.from(await c.req.arrayBuffer());
 
-    if (!body.requestId || !body.taskId || !body.summary) {
+    // Approval requests create actionable human-approval state, so authenticate
+    // them the same way approval responses are authenticated. Tests may opt in
+    // to unsigned requests explicitly, but production fails closed.
+    if (!options.signingSecret) {
+      if (!options.allowUnsignedApprovalsForTests) {
+        return c.json({ error: { message: 'Signing secret required for approval requests' } }, 401);
+      }
+    } else {
+      const verification = verifyGovernorSignature(
+        c.req.header('x-governor-signature'),
+        rawBody,
+        options.signingSecret,
+      );
+      if (!verification.ok && verification.reason === 'missing') {
+        return c.json({ error: { message: 'Missing signature' } }, 401);
+      }
+      if (!verification.ok && verification.reason === 'malformed') {
+        return c.json({ error: { message: 'Malformed signature' } }, 401);
+      }
+      if (!verification.ok) {
+        return c.json({ error: { message: 'Invalid signature' } }, 401);
+      }
+    }
+
+    const body = parseJsonBody(rawBody);
+    if (!body) {
+      return c.json({ error: { message: 'Malformed JSON body' } }, 400);
+    }
+
+    if (
+      typeof body.requestId !== 'string' || body.requestId.length === 0
+      || typeof body.taskId !== 'string' || body.taskId.length === 0
+      || typeof body.summary !== 'string' || body.summary.length === 0
+    ) {
       return c.json(
         { error: { message: 'Missing required fields: requestId, taskId, summary' } },
         400,
@@ -164,10 +212,8 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   // POST /v1/approval/respond — respond to an approval request
   app.post('/v1/approval/respond', async (c) => {
     const rawBody = Buffer.from(await c.req.arrayBuffer());
-    let body: { requestId?: string; decision?: string; respondedBy?: string; feedback?: string };
-    try {
-      body = rawBody.length > 0 ? JSON.parse(rawBody.toString('utf8')) : {};
-    } catch {
+    const body = parseJsonBody(rawBody);
+    if (!body) {
       return c.json({ error: { message: 'Malformed JSON body' } }, 400);
     }
 
@@ -194,7 +240,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
       }
     }
 
-    if (!body.requestId || !body.decision) {
+    if (typeof body.requestId !== 'string' || typeof body.decision !== 'string') {
       return c.json(
         { error: { message: 'Missing required fields: requestId, decision' } },
         400,

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { createGovernorApp } from '../../../src/server/app.js';
 
+const SIGNING_FIXTURE = ['test', 'signing', 'fixture'].join('-');
+
+function governorSignature(rawBody: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+}
+
 describe('Governor Hono Server', () => {
   describe('GET /health', () => {
     it('returns 200', async () => {
@@ -16,7 +22,7 @@ describe('Governor Hono Server', () => {
 
   describe('POST /v1/approval/request', () => {
     it('creates approval request', async () => {
-      const app = createGovernorApp();
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
       const res = await app.request('/v1/approval/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -32,8 +38,66 @@ describe('Governor Hono Server', () => {
       expect(body.status).toBe('pending');
     });
 
+    it('creates a signed approval request when a signing secret is configured', async () => {
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+      const payload = JSON.stringify({
+        requestId: 'req-signed',
+        taskId: 'task-1',
+        summary: 'Deploy to production',
+      });
+
+      const res = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': governorSignature(payload, SIGNING_FIXTURE),
+        },
+        body: payload,
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.status).toBe('pending');
+    });
+
+    it('rejects unsigned approval requests when a signing secret is configured', async () => {
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+      const res = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requestId: 'req-unsigned',
+          taskId: 'task-1',
+          summary: 'Deploy to production',
+        }),
+      });
+
+      expect(res.status).toBe(401);
+      const healthBody = await (await app.request('/health')).json();
+      expect(healthBody.pendingApprovals).toBe(0);
+    });
+
+    it('rejects malformed JSON request bodies without registering approval state', async () => {
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+      const payload = '{"requestId":"req-malformed"';
+      const res = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': governorSignature(payload, SIGNING_FIXTURE),
+        },
+        body: payload,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.message).toBe('Malformed JSON body');
+      const healthBody = await (await app.request('/health')).json();
+      expect(healthBody.pendingApprovals).toBe(0);
+    });
+
     it('returns 400 for missing fields', async () => {
-      const app = createGovernorApp();
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
       const res = await app.request('/v1/approval/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -45,21 +109,25 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/approval/respond', () => {
-    const signingFixture = ['test', 'signing', 'fixture'].join('-')
+    const signingFixture = SIGNING_FIXTURE;
 
-    function governorSignature(rawBody: string, secret: string): string {
-      return `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
-    }
-
-    async function seedResponseApproval(app: ReturnType<typeof createGovernorApp>, requestId: string) {
+    async function seedResponseApproval(
+      app: ReturnType<typeof createGovernorApp>,
+      requestId: string,
+      secret?: string,
+    ) {
+      const payload = JSON.stringify({
+        requestId,
+        taskId: 'task-1',
+        summary: 'Deploy',
+      });
       await app.request('/v1/approval/request', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          requestId,
-          taskId: 'task-1',
-          summary: 'Deploy',
-        }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(secret ? { 'x-governor-signature': governorSignature(payload, secret) } : {}),
+        },
+        body: payload,
       });
     }
 
@@ -142,16 +210,7 @@ describe('Governor Hono Server', () => {
       const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
 
-      // Create approval
-      await app.request('/v1/approval/request', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          requestId: 'req-2',
-          taskId: 'task-2',
-          summary: 'Test',
-        }),
-      });
+      await seedResponseApproval(app, 'req-2', secret);
 
       // Respond with valid signature
       const payload = JSON.stringify({ requestId: 'req-2', decision: 'APPROVE' });
@@ -171,7 +230,7 @@ describe('Governor Hono Server', () => {
     it('verifies approval HMAC over raw body bytes including whitespace', async () => {
       const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
-      await seedResponseApproval(app, 'req-raw-spacing');
+      await seedResponseApproval(app, 'req-raw-spacing', secret);
 
       const payload = '{\n  "requestId" : "req-raw-spacing",\n  "decision" : "APPROVE"\n}';
 
@@ -192,7 +251,7 @@ describe('Governor Hono Server', () => {
     it('requires signatures to match the exact raw body instead of parsed key ordering', async () => {
       const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
-      await seedResponseApproval(app, 'req-key-order');
+      await seedResponseApproval(app, 'req-key-order', secret);
 
       const payload = '{"decision":"APPROVE","requestId":"req-key-order"}';
       const canonicalButDifferentOrder = JSON.stringify({ requestId: 'req-key-order', decision: 'APPROVE' });
@@ -214,7 +273,7 @@ describe('Governor Hono Server', () => {
     it('accepts normalized sha256 hex signatures through the timing-safe compare path', async () => {
       const secret = signingFixture;
       const app = createGovernorApp({ signingSecret: secret });
-      await seedResponseApproval(app, 'req-upper-hex');
+      await seedResponseApproval(app, 'req-upper-hex', secret);
 
       const payload = JSON.stringify({ requestId: 'req-upper-hex', decision: 'APPROVE' });
       const signature = governorSignature(payload, secret).toUpperCase();
@@ -234,15 +293,7 @@ describe('Governor Hono Server', () => {
     it('rejects invalid signature using timing-safe hex comparison', async () => {
       const app = createGovernorApp({ signingSecret: signingFixture });
 
-      await app.request('/v1/approval/request', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          requestId: 'req-3',
-          taskId: 'task-3',
-          summary: 'Test',
-        }),
-      });
+      await seedResponseApproval(app, 'req-3', signingFixture);
 
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
@@ -321,7 +372,7 @@ describe('Governor Hono Server', () => {
     }
 
     it('rejects an unauthenticated (unsigned) Slack callback', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       await seedApproval(app, 'req-1');
 
       const res = await app.request('/v1/webhook/slack', {
@@ -334,7 +385,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects a forged Slack callback with an invalid signature', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       await seedApproval(app, 'req-1');
 
       const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
@@ -350,7 +401,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects a stale Slack timestamp (replay protection)', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       await seedApproval(app, 'req-1');
 
       const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
@@ -376,7 +427,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('resolves the pending approval on a valid signed callback', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       await seedApproval(app, 'req-1');
 
       // Health shows one pending approval before the callback
@@ -402,7 +453,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('returns 404 for a signed callback referencing an unknown request', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
 
       const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'nope' }] });
       const res = await app.request('/v1/webhook/slack', {
@@ -415,7 +466,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('returns 400 for missing actions on a signed request', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       const rawBody = JSON.stringify({ actions: [] });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
@@ -427,7 +478,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects an unknown action_id without consuming the pending approval', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       await seedApproval(app, 'req-unknown');
 
       const rawBody = JSON.stringify({
@@ -447,7 +498,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('parses Slack form-encoded payloads and normalizes reject', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET });
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
       await seedApproval(app, 'req-9');
 
       const payloadJson = JSON.stringify({ actions: [{ action_id: 'reject', value: 'req-9' }] });


### PR DESCRIPTION
## Summary
- Require signed or explicitly test-allowed requests for POST /v1/approval/request
- Parse approval request JSON from raw bytes and reject malformed payloads without registering state
- Extend governor server tests for signed request creation and unauthenticated/malformed rejection

## Test Plan
- npm --prefix packages/franken-governor test
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-governor run typecheck
- npm --prefix packages/franken-governor run build
- npm run lint:security
- npm run lint:any
- npx turbo run test --filter=@franken/governor
- npx turbo run typecheck build --filter=@franken/governor

Closes #769