### PR TITLE
fix(web): prevent duplicate chat input echo

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -257,6 +257,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const wasSidebarOpenRef = useRef(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>(sessionId);
   const [sessionSeed, setSessionSeed] = useState(0);
+  const [preserveComposerDraft, setPreserveComposerDraft] = useState(!sessionId);
   const [clearedFailedDraft, setClearedFailedDraft] = useState<{ content: string; nonce: number } | undefined>(undefined);
   const [chatSessions, setChatSessions] = useState<ChatSessionSummary[]>([]);
   const [chatSessionsLoading, setChatSessionsLoading] = useState(true);
@@ -355,12 +356,16 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     });
   }, [baseUrl]);
 
+  const composerSessionKey = preserveComposerDraft
+    ? `anonymous:${sessionSeed}`
+    : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
+
   useEffect(() => {
-    if (!activeSessionId) {
+    if (!activeSessionId || preserveComposerDraft) {
       return;
     }
     setSelectedSessionId(activeSessionId);
-  }, [activeSessionId]);
+  }, [activeSessionId, preserveComposerDraft]);
 
   useEffect(() => {
     let cancelled = false;
@@ -829,6 +834,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                       disabled={chatSessionsLoading}
                       onChange={(event) => {
                         const nextId = event.target.value.trim();
+                        setPreserveComposerDraft(false);
                         setSelectedSessionId(nextId || undefined);
                       }}
                       value={selectedSessionId ?? ''}
@@ -870,6 +876,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                   <button
                     className="button button--secondary"
                     onClick={() => {
+                      setPreserveComposerDraft(true);
                       setSelectedSessionId(undefined);
                       setSessionSeed((current) => current + 1);
                     }}
@@ -912,7 +919,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 showTypingIndicator={showTypingIndicator}
               />
               <Composer
-                key={activeSessionId ?? selectedSessionId ?? 'anonymous'}
+                key={composerSessionKey}
                 connectionStatus={connectionStatus}
                 clearedFailedDraft={clearedFailedDraft}
                 disabled={status === 'connecting' || status === 'sending' || status === 'streaming'}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -361,11 +361,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
 
   useEffect(() => {
-    if (!activeSessionId || preserveComposerDraft) {
+    if (!activeSessionId || preserveComposerDraft || selectedSessionId) {
       return;
     }
     setSelectedSessionId(activeSessionId);
-  }, [activeSessionId, preserveComposerDraft]);
+  }, [activeSessionId, preserveComposerDraft, selectedSessionId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -361,11 +361,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
 
   useEffect(() => {
-    if (!activeSessionId || preserveComposerDraft || selectedSessionId) {
+    if (!activeSessionId || selectedSessionId) {
       return;
     }
     setSelectedSessionId(activeSessionId);
-  }, [activeSessionId, preserveComposerDraft, selectedSessionId]);
+  }, [activeSessionId, selectedSessionId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -361,11 +361,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
 
   useEffect(() => {
-    if (!activeSessionId || selectedSessionId) {
+    if (preserveComposerDraft || !activeSessionId || selectedSessionId) {
       return;
     }
     setSelectedSessionId(activeSessionId);
-  }, [activeSessionId, selectedSessionId]);
+  }, [activeSessionId, preserveComposerDraft, selectedSessionId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -912,6 +912,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 showTypingIndicator={showTypingIndicator}
               />
               <Composer
+                key={activeSessionId ?? selectedSessionId ?? 'anonymous'}
                 connectionStatus={connectionStatus}
                 clearedFailedDraft={clearedFailedDraft}
                 disabled={status === 'connecting' || status === 'sending' || status === 'streaming'}

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -243,7 +243,7 @@ describe('useChatSession error banners', () => {
     });
   });
 
-  it('does not optimistically echo fallback HTTP messages before the server transcript refreshes', async () => {
+  it('optimistically appends fallback HTTP messages, then replaces with refreshed transcript', async () => {
     const fallbackSend = deferred<Response>();
     const fetch = vi.fn()
       .mockResolvedValueOnce(jsonResponse(sessionResponse()))
@@ -273,7 +273,13 @@ describe('useChatSession error banners', () => {
       sendPromise = result.current.send('launch beast');
     });
 
-    expect(result.current.messages).toEqual([]);
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'launch beast',
+        receipt: 'sending',
+      }),
+    ]);
 
     await act(async () => {
       fallbackSend.resolve(jsonResponse({ data: { tier: 'cheap' } }));
@@ -284,6 +290,7 @@ describe('useChatSession error banners', () => {
       expect.objectContaining({ id: 'server-user-1', role: 'user', content: 'launch beast' }),
     ]);
   });
+
 
   it('does not offer retry for invalid socket payload errors', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -40,6 +40,16 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('useChatSession error banners', () => {
   afterEach(() => {
     cleanup();
@@ -231,6 +241,48 @@ describe('useChatSession error banners', () => {
       code: 'session_refresh_failed',
       actionLabel: 'Refresh chat',
     });
+  });
+
+  it('does not optimistically echo fallback HTTP messages before the server transcript refreshes', async () => {
+    const fallbackSend = deferred<Response>();
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
+      .mockReturnValueOnce(fallbackSend.promise)
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({
+        transcript: [
+          {
+            id: 'server-user-1',
+            role: 'user',
+            content: 'launch beast',
+            timestamp: '2026-07-06T00:00:00.000Z',
+          },
+        ],
+      })));
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    MockWebSocket.instances[0]!.readyState = 0;
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send('launch beast');
+    });
+
+    expect(result.current.messages).toEqual([]);
+
+    await act(async () => {
+      fallbackSend.resolve(jsonResponse({ data: { tier: 'cheap' } }));
+      await sendPromise;
+    });
+
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({ id: 'server-user-1', role: 'user', content: 'launch beast' }),
+    ]);
   });
 
   it('does not offer retry for invalid socket payload errors', async () => {

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -243,7 +243,7 @@ describe('useChatSession error banners', () => {
     });
   });
 
-  it('optimistically appends fallback HTTP messages, then replaces with refreshed transcript', async () => {
+  it('waits for fallback HTTP refresh before adding the sent message', async () => {
     const fallbackSend = deferred<Response>();
     const fetch = vi.fn()
       .mockResolvedValueOnce(jsonResponse(sessionResponse()))
@@ -273,13 +273,7 @@ describe('useChatSession error banners', () => {
       sendPromise = result.current.send('launch beast');
     });
 
-    expect(result.current.messages).toEqual([
-      expect.objectContaining({
-        role: 'user',
-        content: 'launch beast',
-        receipt: 'sending',
-      }),
-    ]);
+    expect(result.current.messages).toEqual([]);
 
     await act(async () => {
       fallbackSend.resolve(jsonResponse({ data: { tier: 'cheap' } }));
@@ -289,6 +283,48 @@ describe('useChatSession error banners', () => {
     expect(result.current.messages).toEqual([
       expect.objectContaining({ id: 'server-user-1', role: 'user', content: 'launch beast' }),
     ]);
+  });
+
+  it('keeps failed fallback HTTP messages retryable in the transcript', async () => {
+    const fallbackSend = deferred<Response>();
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
+      .mockReturnValueOnce(fallbackSend.promise);
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    MockWebSocket.instances[0]!.readyState = 0;
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send('launch beast');
+    });
+
+    expect(result.current.messages).toEqual([]);
+
+    await act(async () => {
+      fallbackSend.reject(new Error('fallback offline'));
+      await sendPromise.catch(() => undefined);
+    });
+
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'launch beast',
+        receipt: 'failed',
+        error: 'fallback offline',
+        canRetry: true,
+      }),
+    ]);
+    expect(result.current.errorBanners[0]).toMatchObject({
+      title: 'Message was not sent',
+      actionLabel: 'Retry last message',
+    });
   });
 
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -763,21 +763,25 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     const clientMessageId = makeId('user');
+    const optimisticMessage: ChatMessage = {
+      id: clientMessageId,
+      role: 'user',
+      content,
+      timestamp: new Date().toISOString(),
+      receipt: 'sending',
+    };
+    const optimisticAdd = Boolean(socket && socket.readyState === 1);
     lastMessageRef.current = { clientMessageId, content };
     setErrorBanners((current) => current.filter((item) => item.action !== 'retry-message'));
-    setMessages((current) => [
-      ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
-      {
-        id: clientMessageId,
-        role: 'user',
-        content,
-        timestamp: new Date().toISOString(),
-        receipt: 'sending',
-      },
-    ]);
+    if (optimisticAdd) {
+      setMessages((current) => [
+        ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+        optimisticMessage,
+      ]);
+    }
     setStatus('sending');
 
-    if (!socket || socket.readyState !== 1) {
+    if (!optimisticAdd) {
       try {
         const result = await clientRef.current.sendMessage(sessionId, content);
         setTier(result.tier);
@@ -793,7 +797,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setCostUsd(refreshed.costUsd);
           setStatus('idle');
         } catch (error) {
-          setMessages((current) => updateReceipt(current, clientMessageId, 'accepted'));
+          setMessages((current) => [
+            ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+            { ...optimisticMessage, receipt: 'accepted' },
+          ]);
           addErrorBanner(makeBanner(
             'Message sent; refresh failed',
             errorMessage(error, 'The message was accepted, but the updated transcript could not be loaded.'),
@@ -821,13 +828,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       return;
     }
 
+    const liveSocket = socket as WebSocket;
     await new Promise<void>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         failPendingSend(clientMessageId, new Error('Server did not acknowledge the message. Your draft was kept.'));
       }, SOCKET_SEND_ACK_TIMEOUT_MS);
       pendingSendsRef.current.set(clientMessageId, { timeoutId, resolve, reject });
       try {
-        socket.send(JSON.stringify({
+        liveSocket.send(JSON.stringify({
           type: 'message.send',
           clientMessageId,
           content,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -773,12 +773,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     const optimisticAdd = Boolean(socket && socket.readyState === 1);
     lastMessageRef.current = { clientMessageId, content };
     setErrorBanners((current) => current.filter((item) => item.action !== 'retry-message'));
-    if (optimisticAdd) {
-      setMessages((current) => [
-        ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
-        optimisticMessage,
-      ]);
-    }
+    setMessages((current) => [
+      ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+      optimisticMessage,
+    ]);
     setStatus('sending');
 
     if (!optimisticAdd) {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -231,6 +231,10 @@ function markMessageFailed(messages: ChatMessage[], messageId: string, error: st
   ));
 }
 
+function isFailedUserDraftForContent(message: ChatMessage, content: string): boolean {
+  return message.role === 'user' && message.receipt === 'failed' && message.content === content;
+}
+
 function applySessionSnapshot(session: ChatSession): ChatMessage[] {
   return normalizeTranscript(session.transcript);
 }
@@ -775,7 +779,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setErrorBanners((current) => current.filter((item) => item.action !== 'retry-message'));
     if (optimisticAdd) {
       setMessages((current) => [
-        ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+        ...current.filter((message) => !isFailedUserDraftForContent(message, content)),
         optimisticMessage,
       ]);
     }
@@ -789,7 +793,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           const refreshed = await clientRef.current.getSession(sessionId);
           readyRef.current = true;
           setMessages((current) => mergeSessionSnapshot(
-            current.filter((message) => message.id !== clientMessageId),
+            current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
             refreshed,
           ));
           setPendingApproval(refreshed.pendingApproval ?? null);
@@ -798,7 +802,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setStatus('idle');
         } catch (error) {
           setMessages((current) => [
-            ...current.filter((message) => message.id !== clientMessageId),
+            ...current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
             { ...optimisticMessage, receipt: 'accepted' },
           ]);
           addErrorBanner(makeBanner(
@@ -815,7 +819,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           ? error
           : new Error('The fallback chat request failed before the turn could start.');
         setMessages((current) => [
-          ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+          ...current.filter((message) => !isFailedUserDraftForContent(message, content)),
           { ...optimisticMessage, receipt: 'failed', error: sendError.message, canRetry: true },
         ]);
         addErrorBanner(makeBanner(

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -773,10 +773,12 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     const optimisticAdd = Boolean(socket && socket.readyState === 1);
     lastMessageRef.current = { clientMessageId, content };
     setErrorBanners((current) => current.filter((item) => item.action !== 'retry-message'));
-    setMessages((current) => [
-      ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
-      optimisticMessage,
-    ]);
+    if (optimisticAdd) {
+      setMessages((current) => [
+        ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+        optimisticMessage,
+      ]);
+    }
     setStatus('sending');
 
     if (!optimisticAdd) {
@@ -796,7 +798,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setStatus('idle');
         } catch (error) {
           setMessages((current) => [
-            ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+            ...current.filter((message) => message.id !== clientMessageId),
             { ...optimisticMessage, receipt: 'accepted' },
           ]);
           addErrorBanner(makeBanner(
@@ -812,7 +814,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         const sendError = error instanceof Error
           ? error
           : new Error('The fallback chat request failed before the turn could start.');
-        setMessages((current) => markMessageFailed(current, clientMessageId, sendError.message));
+        setMessages((current) => [
+          ...current.filter((message) => !(message.role === 'user' && message.receipt === 'failed' && message.content === content)),
+          { ...optimisticMessage, receipt: 'failed', error: sendError.message, canRetry: true },
+        ]);
         addErrorBanner(makeBanner(
           'Message was not sent',
           sendError.message,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -362,6 +362,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   useEffect(() => {
     clientRef.current = new ChatApiClient(opts.baseUrl);
   }, [opts.baseUrl]);
+  const activeSessionIdRef = useRef<string | null>(sessionId);
   const readyRef = useRef(false);
   const socketRef = useRef<WebSocket | null>(null);
   const pendingSendsRef = useRef<Map<string, PendingSend>>(new Map());
@@ -377,6 +378,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   function dismissError(id: string) {
     errorActionRef.current.delete(id);
     setErrorBanners((current) => current.filter((item) => item.id !== id));
+  }
+
+  function sessionStillCurrent(capturedSessionId: string): boolean {
+    return activeSessionIdRef.current === capturedSessionId;
   }
 
   function notifyClearedFailedDrafts(contents: string[]) {
@@ -468,6 +473,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     updateApprovalResolving(false);
     setMessages([]);
     lastMessageRef.current = null;
+    activeSessionIdRef.current = null;
     setSessionId(null);
     setSocketToken(null);
     setPendingApproval(null);
@@ -490,6 +496,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           return;
         }
 
+        activeSessionIdRef.current = session.id;
         setSocketToken(session.socketToken);
         setSessionId(session.id);
         setProjectId(session.projectId);
@@ -788,9 +795,15 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     if (!optimisticAdd) {
       try {
         const result = await clientRef.current.sendMessage(sessionId, content);
+        if (!sessionStillCurrent(sessionId)) {
+          return;
+        }
         setTier(result.tier);
         try {
           const refreshed = await clientRef.current.getSession(sessionId);
+          if (!sessionStillCurrent(sessionId)) {
+            return;
+          }
           readyRef.current = true;
           setMessages((current) => mergeSessionSnapshot(
             current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
@@ -801,6 +814,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setCostUsd(refreshed.costUsd);
           setStatus('idle');
         } catch (error) {
+          if (!sessionStillCurrent(sessionId)) {
+            return;
+          }
           setMessages((current) => [
             ...current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
             { ...optimisticMessage, receipt: 'accepted' },
@@ -815,6 +831,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setStatus('idle');
         }
       } catch (error) {
+        if (!sessionStillCurrent(sessionId)) {
+          return;
+        }
         const sendError = error instanceof Error
           ? error
           : new Error('The fallback chat request failed before the turn could start.');

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -279,6 +279,40 @@ describe('useChatSession', () => {
     expect(result.current.messages).not.toContainEqual(expect.objectContaining({ receipt: 'failed' }));
   });
 
+  it('removes stale failed drafts when an HTTP composer retry succeeds but refresh fails', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    mockSendMessage.mockRejectedValueOnce(new Error('network down'));
+    await act(async () => {
+      await expect(result.current.send('retry over HTTP')).rejects.toThrow('network down');
+    });
+    expect(result.current.messages).toContainEqual(expect.objectContaining({
+      content: 'retry over HTTP',
+      receipt: 'failed',
+      canRetry: true,
+    }));
+
+    mockGetSession.mockRejectedValueOnce(new Error('refresh failed'));
+    await act(async () => {
+      await result.current.send('retry over HTTP');
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.messages.filter((message) => message.content === 'retry over HTTP')).toHaveLength(1);
+    expect(result.current.messages).toContainEqual(expect.objectContaining({
+      content: 'retry over HTTP',
+      receipt: 'accepted',
+    }));
+    expect(result.current.messages).not.toContainEqual(expect.objectContaining({
+      content: 'retry over HTTP',
+      receipt: 'failed',
+    }));
+  });
+
   it('drops unmatched optimistic HTTP sends after the server snapshot refreshes', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 


### PR DESCRIPTION
## Summary
- Preserve the chat Composer instance with a stable session-scoped key.
- Only add optimistic local user messages when the live WebSocket is open; HTTP fallback now waits for the server transcript before rendering the sent text.
- Add a regression test covering the fallback path so duplicate echo behavior does not return.

## Test Plan
- npm run build --workspace @franken/types
- npm --workspace @franken/web run test -- src/hooks/use-chat-session.test.tsx -t "does not optimistically echo fallback HTTP messages"
- npm --workspace @franken/web run test
- npm --workspace @franken/web run typecheck
- npm --workspace @franken/web run build
- npm run lint:any

Closes #859
