### PR TITLE
fix(planner): isolate recovery attempts per task

### DIFF
--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -67,7 +67,7 @@ export class Planner {
 
     // 5. Execute with self-correction loop (ADR-007)
     let currentGraph = graph;
-    let attempt = 1;
+    const recoveryAttemptsByTask = new Map<TaskId, number>();
 
     for (;;) {
       let result: PlanResult;
@@ -84,6 +84,7 @@ export class Planner {
       if (result.status !== 'failed') return result; // defensive: unexpected status
 
       // result.status === 'failed' — attempt recovery
+      const attempt = (recoveryAttemptsByTask.get(result.failedTaskId) ?? 0) + 1;
       try {
         currentGraph = await this.recovery.recover(
           result.failedTaskId,
@@ -91,7 +92,7 @@ export class Planner {
           currentGraph,
           attempt
         );
-        attempt++;
+        recoveryAttemptsByTask.set(result.failedTaskId, attempt);
       } catch (recoveryErr) {
         if (
           recoveryErr instanceof MaxRecoveryAttemptsError ||

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -84,7 +84,8 @@ export class Planner {
       if (result.status !== 'failed') return result; // defensive: unexpected status
 
       // result.status === 'failed' — attempt recovery
-      const attempt = (recoveryAttemptsByTask.get(result.failedTaskId) ?? 0) + 1;
+      const failedTaskLineage = Planner.getRecoveryLineageRoot(result.failedTaskId);
+      const attempt = (recoveryAttemptsByTask.get(failedTaskLineage) ?? 0) + 1;
       try {
         currentGraph = await this.recovery.recover(
           result.failedTaskId,
@@ -92,7 +93,7 @@ export class Planner {
           currentGraph,
           attempt
         );
-        recoveryAttemptsByTask.set(result.failedTaskId, attempt);
+        recoveryAttemptsByTask.set(failedTaskLineage, attempt);
       } catch (recoveryErr) {
         if (
           recoveryErr instanceof MaxRecoveryAttemptsError ||
@@ -103,5 +104,26 @@ export class Planner {
         throw recoveryErr;
       }
     }
+  }
+
+  /**
+   * Collapse recovery-generated task IDs to their original lineage.
+   *
+   * Recovery tasks are named as:
+   *   `fix-<failedTaskId>-attempt-<n>`
+   * and can be generated repeatedly from prior recovery tasks. For attempt
+   * accounting, we track only the root task to avoid unbounded retries.
+   */
+  private static getRecoveryLineageRoot(taskId: TaskId): TaskId {
+    const recoveryPattern = /^fix-(.+)-attempt-\d+$/;
+
+    let current = taskId;
+    while (recoveryPattern.test(current)) {
+      const match = current.match(recoveryPattern);
+      if (!match?.[1]) break;
+      current = createTaskId(match[1]);
+    }
+
+    return current;
   }
 }

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -4,8 +4,9 @@ import { LinearPlanner } from '../../src/planners/linear';
 import { StubHITLGate } from '../../src/hitl/stub-hitl-gate';
 import { RecoveryController } from '../../src/recovery/recovery-controller';
 import { PlanGraph } from '../../src/core/dag';
+import { MaxRecoveryAttemptsError } from '../../src/core/errors';
 import { createTaskId } from '../../src/core/types';
-import type { Task, TaskResult, Intent, KnownError } from '../../src/core/types';
+import type { Task, TaskResult, Intent, KnownError, TaskId } from '../../src/core/types';
 import type { GuardrailsModule } from '../../src/modules/mod01';
 import type { SelfCritiqueModule } from '../../src/modules/mod07';
 import type { GraphBuilder, TaskExecutor } from '../../src/planners/types';
@@ -57,6 +58,9 @@ interface PlannerOptions {
   memory?: MemoryModule;
   selfCritique?: SelfCritiqueModule;
   maxRecoveryAttempts?: number;
+  recovery?: {
+    recover(failedTaskId: TaskId, error: Error, graph: PlanGraph, attempt: number): Promise<PlanGraph>;
+  };
 }
 
 function buildPlanner(opts: PlannerOptions = {}): {
@@ -68,7 +72,9 @@ function buildPlanner(opts: PlannerOptions = {}): {
   const executor = opts.executor ?? vi.fn().mockResolvedValue(success('t-1'));
   const hitlGate = opts.hitlGate ?? new StubHITLGate();
   const memory = opts.memory ?? makeMemory();
-  const recovery = new RecoveryController(memory, undefined, undefined, opts.maxRecoveryAttempts ?? 3);
+  const recovery =
+    opts.recovery ??
+    new RecoveryController(memory, undefined, undefined, opts.maxRecoveryAttempts ?? 3);
   const guardrails = makeGuardrails();
   const graphBuilder = makeGraphBuilder(graph);
 
@@ -241,6 +247,52 @@ describe('Planner — self-correction loop', () => {
     expect(executor).toHaveBeenCalledWith(
       expect.objectContaining({ id: createTaskId('fix-t-2-attempt-1') })
     );
+  });
+
+  it('counts recovery attempts by original failed-task lineage', async () => {
+    const graph = PlanGraph.empty().addTask(makeTask('t-1'));
+    const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
+    const memory = makeMemory([ke]);
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('fix-fix-t-1-attempt-1-attempt-1')) {
+        return Promise.resolve(success(task.id));
+      }
+      return Promise.resolve(failure(task.id, 'disk full'));
+    });
+
+    const recoverCalls: Array<{ failedTaskId: TaskId; attempt: number }> = [];
+
+    const recovery = {
+      recover: vi.fn(async (failedTaskId: TaskId, _err: Error, graph: PlanGraph, attempt: number) => {
+        recoverCalls.push({ failedTaskId, attempt });
+
+        if (failedTaskId.startsWith('fix-') && attempt > 1) {
+          throw new MaxRecoveryAttemptsError(failedTaskId, 1);
+        }
+        if (recoverCalls.length >= 3) {
+          throw new MaxRecoveryAttemptsError(failedTaskId, 1);
+        }
+
+        const fixTask = {
+          id: createTaskId(`fix-${failedTaskId}-attempt-${attempt}`),
+          objective: `Attempt-${attempt} fix for ${failedTaskId}`,
+          requiredSkills: [],
+          dependsOn: [],
+          status: 'pending' as const,
+        };
+
+        return graph.insertFixItTask(failedTaskId, fixTask);
+      }),
+    };
+
+    const { planner } = buildPlanner({ graph, executor, memory, recovery });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    expect(recoverCalls).toEqual([
+      { failedTaskId: createTaskId('t-1'), attempt: 1 },
+      { failedTaskId: createTaskId('fix-t-1-attempt-1'), attempt: 2 },
+    ]);
   });
 
   it('returns failed when error is unknown (no known fix)', async () => {

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -216,6 +216,33 @@ describe('Planner — self-correction loop', () => {
     expect(result.status).toBe('failed');
   });
 
+  it('tracks recovery attempts independently for each failed task', async () => {
+    const t1 = makeTask('t-1');
+    const t2 = makeTask('t-2');
+    const graph = PlanGraph.empty().addTask(t1).addTask(t2);
+    const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
+    const memory = makeMemory([ke]);
+    const failedOnce = new Set<string>();
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if ((task.id === createTaskId('t-1') || task.id === createTaskId('t-2')) && !failedOnce.has(task.id)) {
+        failedOnce.add(task.id);
+        return Promise.resolve(failure(task.id, 'disk full'));
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const { planner } = buildPlanner({ graph, executor, memory, maxRecoveryAttempts: 1 });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledWith(
+      expect.objectContaining({ id: createTaskId('fix-t-1-attempt-1') })
+    );
+    expect(executor).toHaveBeenCalledWith(
+      expect.objectContaining({ id: createTaskId('fix-t-2-attempt-1') })
+    );
+  });
+
   it('returns failed when error is unknown (no known fix)', async () => {
     const graph = PlanGraph.empty().addTask(makeTask('t-1'));
     const memory = makeMemory([]); // no known errors


### PR DESCRIPTION
## Summary
- Track planner recovery attempts per failed task instead of sharing one global counter across the whole plan loop.
- Add a regression test proving two unrelated tasks can each use their first recovery attempt when the max is one.

## Test Plan
- npm test --workspace @franken/planner -- --run tests/unit/planner.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/planner
- npm run build --workspace @franken/planner
- npx turbo run test --filter=@franken/planner
- npm run lint --workspace @franken/planner

Closes #771
