### PR TITLE
fix(orchestrator): stop SSE ticket retry loops

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -6,13 +6,20 @@ interface TicketEntry {
   expiresAt: number;
 }
 
+interface ConsumedTicketEntry {
+  expiresAt: number;
+}
+
 export interface SseConnectionTicketStoreOptions {
   ttlMs?: number;
   cleanupIntervalMs?: number;
 }
 
+export type SseTicketStatus = 'valid' | 'invalid' | 'reused';
+
 export class SseConnectionTicketStore {
   private readonly tickets = new Map<string, TicketEntry>();
+  private readonly consumedTickets = new Map<string, ConsumedTicketEntry>();
   private readonly ttlMs: number;
   private readonly cleanupInterval: ReturnType<typeof setInterval>;
 
@@ -33,20 +40,46 @@ export class SseConnectionTicketStore {
     return ticket;
   }
 
-  validate(ticket: string, operatorToken: string, scope?: string | undefined): boolean {
+  consume(ticket: string, operatorToken: string, scope?: string | undefined): SseTicketStatus {
     const entry = this.tickets.get(ticket);
-    if (!entry) return false;
+    if (!entry) {
+      const consumed = this.consumedTickets.get(ticket);
+      if (consumed && consumed.expiresAt > Date.now()) {
+        return 'reused';
+      }
+      if (consumed) {
+        this.consumedTickets.delete(ticket);
+      }
+      return 'invalid';
+    }
 
     this.tickets.delete(ticket);
 
-    if (Date.now() > entry.expiresAt) return false;
-    if (entry.scope !== scope) return false;
+    if (Date.now() > entry.expiresAt) {
+      return 'invalid';
+    }
+    if (entry.scope !== scope) {
+      return 'invalid';
+    }
 
-    // Verify the ticket was issued for this operator token
     const bufA = Buffer.from(entry.token);
     const bufB = Buffer.from(operatorToken);
-    if (bufA.length !== bufB.length) return false;
-    return timingSafeEqual(bufA, bufB);
+    if (bufA.length !== bufB.length) {
+      return 'invalid';
+    }
+
+    if (!timingSafeEqual(bufA, bufB)) {
+      return 'invalid';
+    }
+
+    this.consumedTickets.set(ticket, {
+      expiresAt: Date.now() + this.ttlMs,
+    });
+    return 'valid';
+  }
+
+  validate(ticket: string, operatorToken: string, scope?: string | undefined): boolean {
+    return this.consume(ticket, operatorToken, scope) === 'valid';
   }
 
   private cleanup(): void {
@@ -54,6 +87,11 @@ export class SseConnectionTicketStore {
     for (const [ticket, entry] of this.tickets) {
       if (now > entry.expiresAt) {
         this.tickets.delete(ticket);
+      }
+    }
+    for (const [ticket, entry] of this.consumedTickets) {
+      if (now > entry.expiresAt) {
+        this.consumedTickets.delete(ticket);
       }
     }
   }

--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -10,18 +10,33 @@ interface TicketEntry {
 export interface SseConnectionTicketStoreOptions {
   ttlMs?: number;
   cleanupIntervalMs?: number;
+  /**
+   * How long a consumed ticket is remembered (for reused → 204 detection)
+   * after it is burned. Defaults to well beyond the issue TTL so long-lived
+   * EventSource reconnects still resolve as `reused`.
+   */
+  consumedRetentionMs?: number;
 }
 
 export type SseTicketStatus = 'valid' | 'invalid' | 'reused';
 
 export class SseConnectionTicketStore {
   private readonly tickets = new Map<string, TicketEntry>();
-  private readonly consumedTickets = new Set<string>();
+  // Consumed tickets are remembered past the issue TTL so that an EventSource
+  // reconnecting on a long-lived stream is recognized as `reused` (→ 204) and
+  // its native retry loop stops, instead of falling through to `invalid` (401)
+  // and looping. Retention is bounded (well beyond any realistic reconnect
+  // window) so the set does not grow without limit. Maps ticket → expiry ts.
+  private readonly consumedTickets = new Map<string, number>();
   private readonly ttlMs: number;
+  private readonly consumedRetentionMs: number;
   private readonly cleanupInterval: ReturnType<typeof setInterval>;
 
   constructor(options?: SseConnectionTicketStoreOptions) {
     this.ttlMs = options?.ttlMs ?? 30_000;
+    // Cover EventSource's reconnect behaviour comfortably (>> ttl) while still
+    // bounding memory: at least 10 minutes, or 20× the issue TTL if larger.
+    this.consumedRetentionMs = options?.consumedRetentionMs ?? Math.max(this.ttlMs * 20, 600_000);
     const cleanupMs = options?.cleanupIntervalMs ?? 60_000;
     this.cleanupInterval = setInterval(() => this.cleanup(), cleanupMs);
     this.cleanupInterval.unref?.();
@@ -40,9 +55,13 @@ export class SseConnectionTicketStore {
   consume(ticket: string, operatorToken: string, scope?: string | undefined): SseTicketStatus {
     const entry = this.tickets.get(ticket);
     if (!entry) {
-      const consumed = this.consumedTickets.has(ticket);
-      if (consumed) {
-        return 'reused';
+      const consumedExpiry = this.consumedTickets.get(ticket);
+      if (consumedExpiry !== undefined) {
+        if (Date.now() <= consumedExpiry) {
+          return 'reused';
+        }
+        // Retention window elapsed — forget it and treat as invalid.
+        this.consumedTickets.delete(ticket);
       }
       return 'invalid';
     }
@@ -66,7 +85,7 @@ export class SseConnectionTicketStore {
       return 'invalid';
     }
 
-    this.consumedTickets.add(ticket);
+    this.consumedTickets.set(ticket, Date.now() + this.consumedRetentionMs);
     return 'valid';
   }
 
@@ -81,7 +100,11 @@ export class SseConnectionTicketStore {
         this.tickets.delete(ticket);
       }
     }
-    
+    for (const [ticket, expiry] of this.consumedTickets) {
+      if (now > expiry) {
+        this.consumedTickets.delete(ticket);
+      }
+    }
   }
 
   destroy(): void {

--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -6,9 +6,6 @@ interface TicketEntry {
   expiresAt: number;
 }
 
-interface ConsumedTicketEntry {
-  expiresAt: number;
-}
 
 export interface SseConnectionTicketStoreOptions {
   ttlMs?: number;
@@ -19,7 +16,7 @@ export type SseTicketStatus = 'valid' | 'invalid' | 'reused';
 
 export class SseConnectionTicketStore {
   private readonly tickets = new Map<string, TicketEntry>();
-  private readonly consumedTickets = new Map<string, ConsumedTicketEntry>();
+  private readonly consumedTickets = new Set<string>();
   private readonly ttlMs: number;
   private readonly cleanupInterval: ReturnType<typeof setInterval>;
 
@@ -43,12 +40,9 @@ export class SseConnectionTicketStore {
   consume(ticket: string, operatorToken: string, scope?: string | undefined): SseTicketStatus {
     const entry = this.tickets.get(ticket);
     if (!entry) {
-      const consumed = this.consumedTickets.get(ticket);
-      if (consumed && consumed.expiresAt > Date.now()) {
-        return 'reused';
-      }
+      const consumed = this.consumedTickets.has(ticket);
       if (consumed) {
-        this.consumedTickets.delete(ticket);
+        return 'reused';
       }
       return 'invalid';
     }
@@ -72,9 +66,7 @@ export class SseConnectionTicketStore {
       return 'invalid';
     }
 
-    this.consumedTickets.set(ticket, {
-      expiresAt: Date.now() + this.ttlMs,
-    });
+    this.consumedTickets.add(ticket);
     return 'valid';
   }
 
@@ -89,11 +81,7 @@ export class SseConnectionTicketStore {
         this.tickets.delete(ticket);
       }
     }
-    for (const [ticket, entry] of this.consumedTickets) {
-      if (now > entry.expiresAt) {
-        this.consumedTickets.delete(ticket);
-      }
-    }
+    
   }
 
   destroy(): void {

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -53,8 +53,12 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
     if (!ticket) {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }
-    if (!ticketStore.validate(ticket, operatorToken)) {
+    const ticketStatus = ticketStore.consume(ticket, operatorToken);
+    if (ticketStatus === 'reused') {
       return c.body(null, 204);
+    }
+    if (ticketStatus === 'invalid') {
+      return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }
 
     const lastEventId = c.req.header('Last-Event-ID') ?? c.req.query('lastEventId');

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -50,8 +50,11 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
 
   app.get('/v1/beasts/events/stream', (c) => {
     const ticket = c.req.query('ticket');
-    if (!ticket || !ticketStore.validate(ticket, operatorToken)) {
+    if (!ticket) {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+    }
+    if (!ticketStore.validate(ticket, operatorToken)) {
+      return c.body(null, 204);
     }
 
     const lastEventId = c.req.header('Last-Event-ID') ?? c.req.query('lastEventId');

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -58,11 +58,17 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   // GET /api/dashboard/events — ticket-authenticated SSE stream for real-time dashboard updates
   app.get('/events', (c) => {
     const ticket = c.req.query('ticket');
-    if (operatorToken && (!ticketStore || !ticket)) {
-      return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
-    }
-    if (operatorToken && ticketStore && ticket && !ticketStore.validate(ticket, operatorToken)) {
-      return c.body(null, 204);
+    if (operatorToken) {
+      if (!ticketStore || !ticket) {
+        return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+      }
+      const ticketStatus = ticketStore.consume(ticket, operatorToken);
+      if (ticketStatus === 'reused') {
+        return c.body(null, 204);
+      }
+      if (ticketStatus === 'invalid') {
+        return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+      }
     }
 
     return streamSSE(c, async (stream) => {

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -58,8 +58,11 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   // GET /api/dashboard/events — ticket-authenticated SSE stream for real-time dashboard updates
   app.get('/events', (c) => {
     const ticket = c.req.query('ticket');
-    if (operatorToken && (!ticketStore || !ticket || !ticketStore.validate(ticket, operatorToken))) {
+    if (operatorToken && (!ticketStore || !ticket)) {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
+    }
+    if (operatorToken && ticketStore && ticket && !ticketStore.validate(ticket, operatorToken)) {
+      return c.body(null, 204);
     }
 
     return streamSSE(c, async (stream) => {

--- a/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
@@ -28,6 +28,13 @@ describe('SseConnectionTicketStore', () => {
     expect(store.validate(ticket, 'operator-token-123')).toBe(false); // burned
   });
 
+  it('marks a validly used ticket as reused on second request', () => {
+    const ticket = store.issue('operator-token-123');
+
+    expect(store.consume(ticket, 'operator-token-123')).toBe('valid');
+    expect(store.consume(ticket, 'operator-token-123')).toBe('reused');
+  });
+
   it('rejects expired tickets', async () => {
     const shortStore = new SseConnectionTicketStore({ ttlMs: 50 });
     const ticket = shortStore.issue('operator-token-123');

--- a/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
@@ -35,6 +35,29 @@ describe('SseConnectionTicketStore', () => {
     expect(store.consume(ticket, 'operator-token-123')).toBe('reused');
   });
 
+  it('still reports reused after the issue TTL elapses (long-lived stream reconnect)', async () => {
+    // ttl=30ms for issuance, but the consumed marker is retained much longer,
+    // so a reconnect well past ttl is recognized as reused (→204), not invalid.
+    const s = new SseConnectionTicketStore({ ttlMs: 30 });
+    const ticket = s.issue('op');
+    expect(s.consume(ticket, 'op')).toBe('valid');
+    await new Promise((r) => setTimeout(r, 60));
+    expect(s.consume(ticket, 'op')).toBe('reused');
+    s.destroy();
+  });
+
+  it('forgets a consumed ticket once the retention window elapses (bounded memory)', async () => {
+    // With a tiny retention, a reconnect after the window reads as invalid,
+    // proving consumedTickets does not grow without limit.
+    const s = new SseConnectionTicketStore({ ttlMs: 5, consumedRetentionMs: 30 });
+    const ticket = s.issue('op');
+    expect(s.consume(ticket, 'op')).toBe('valid');
+    expect(s.consume(ticket, 'op')).toBe('reused');
+    await new Promise((r) => setTimeout(r, 60));
+    expect(s.consume(ticket, 'op')).toBe('invalid');
+    s.destroy();
+  });
+
   it('rejects expired tickets', async () => {
     const shortStore = new SseConnectionTicketStore({ ttlMs: 50 });
     const ticket = shortStore.issue('operator-token-123');

--- a/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
+import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
+import { createBeastSseRoutes } from '../../../src/http/routes/beast-sse-routes.js';
+
+describe('beast SSE routes', () => {
+  const stores: SseConnectionTicketStore[] = [];
+
+  afterEach(() => {
+    while (stores.length > 0) {
+      stores.pop()?.destroy();
+    }
+  });
+
+  function createRoutes() {
+    const ticketStore = new SseConnectionTicketStore();
+    stores.push(ticketStore);
+    return createBeastSseRoutes({
+      bus: new BeastEventBus(),
+      ticketStore,
+      operatorToken: 'operator-token',
+    });
+  }
+
+  it('returns no content for a reused stream ticket so EventSource stops native retries', async () => {
+    const app = createRoutes();
+    const ticketRes = await app.request('/v1/beasts/events/ticket', {
+      method: 'POST',
+      headers: { authorization: 'Bearer operator-token' },
+    });
+    const { ticket } = await ticketRes.json() as { ticket: string };
+
+    const first = await app.request(`/v1/beasts/events/stream?ticket=${ticket}`);
+    expect(first.status).toBe(200);
+    await first.body?.cancel();
+
+    const second = await app.request(`/v1/beasts/events/stream?ticket=${ticket}`);
+    expect(second.status).toBe(204);
+    expect(await second.text()).toBe('');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
@@ -38,4 +38,14 @@ describe('beast SSE routes', () => {
     expect(second.status).toBe(204);
     expect(await second.text()).toBe('');
   });
+
+  it('returns unauthorized for invalid stream tickets', async () => {
+    const app = createRoutes();
+
+    const res = await app.request('/v1/beasts/events/stream?ticket=bogus');
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: { message: string } };
+    expect(body.error.message).toBe('Invalid or expired ticket');
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -142,7 +142,7 @@ describe('dashboard routes', () => {
       await res.body?.cancel();
     });
 
-    it('rejects a reused stream ticket', async () => {
+    it('returns no content for a reused stream ticket so EventSource stops native retries', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
       const ticketRes = await app.request('/events/ticket', { method: 'POST' });
@@ -153,7 +153,8 @@ describe('dashboard routes', () => {
       await first.body?.cancel();
 
       const second = await app.request(`/events?ticket=${ticket}`);
-      expect(second.status).toBe(401);
+      expect(second.status).toBe(204);
+      expect(await second.text()).toBe('');
     });
 
     it('sends initial snapshot event in the stream', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -142,7 +142,7 @@ describe('dashboard routes', () => {
       await res.body?.cancel();
     });
 
-    it('returns no content for a reused stream ticket so EventSource stops native retries', async () => {
+    it('rejects a reused stream ticket so EventSource stops retries', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
       const ticketRes = await app.request('/events/ticket', { method: 'POST' });
@@ -155,6 +155,17 @@ describe('dashboard routes', () => {
       const second = await app.request(`/events?ticket=${ticket}`);
       expect(second.status).toBe(204);
       expect(await second.text()).toBe('');
+    });
+
+    it('rejects invalid stream tickets', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+
+      const res = await app.request('/events?ticket=bogus');
+
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: { message: string } };
+      expect(body.error.message).toBe('Invalid or expired ticket');
     });
 
     it('sends initial snapshot event in the stream', async () => {


### PR DESCRIPTION
## Summary
- Return HTTP 204 for already-consumed dashboard SSE stream tickets so EventSource stops reconnect retry loops.
- Apply the same reused-ticket behavior to beast SSE streams.
- Add regression coverage for dashboard and beast SSE ticket reuse.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/http/dashboard-routes.test.ts tests/unit/http/beast-sse-routes.test.ts
- npx turbo run typecheck --filter=@franken/orchestrator
- npx turbo run build --filter=@franken/orchestrator
- npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/execution/process-supervisor.test.ts
- npx turbo run test --filter=@franken/web (cache hit; 396 tests passed)

Note: full `npx turbo run test --filter=@franken/orchestrator` had 1 unrelated/flaky failure in `tests/unit/beasts/execution/process-supervisor.test.ts` during the full suite run; the same test file passed when rerun directly.

Closes #852
