### PR TITLE
fix(web): require explicit chat socket token TTL

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -17,7 +17,7 @@ import { commsRoutes } from './routes/comms-routes.js';
 import { createSecurityRoutes } from './routes/security-routes.js';
 import type { SecurityConfig } from '../middleware/security-profiles.js';
 import { errorHandler, requestId, requestSizeLimit } from './middleware.js';
-import { createSessionTokenSecret, issueSessionToken } from './ws-chat-auth.js';
+import { CHAT_SOCKET_TOKEN_TTL_MS, createSessionTokenSecret, issueSessionToken } from './ws-chat-auth.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import { TransportSecurityService } from './security/transport-security.js';
 import { requireOperatorAuth } from './operator-auth.js';
@@ -214,6 +214,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     operatorToken: effectiveOperatorToken,
     streamTicketStore: chatStreamTicketStore,
     issueSocketToken: (sessionId) => issueSessionToken({
+      expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS,
       secret: sessionTokenSecret,
       sessionId,
     }),

--- a/packages/franken-orchestrator/src/http/ws-chat-auth.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-auth.ts
@@ -1,7 +1,9 @@
 import { TransportSecurityService } from './security/transport-security.js';
 
+export const CHAT_SOCKET_TOKEN_TTL_MS = 5 * 60 * 1000;
+
 export interface IssueSessionTokenOptions {
-  expiresInMs?: number;
+  expiresInMs: number;
   secret: string;
   sessionId: string;
 }
@@ -28,11 +30,15 @@ export function createSessionTokenSecret(): string {
 }
 
 export function issueSessionToken(options: IssueSessionTokenOptions): string {
+  if (!Number.isFinite(options.expiresInMs) || options.expiresInMs <= 0) {
+    throw new Error('expiresInMs must be a positive finite number');
+  }
+
   return transportSecurity.issueSignedToken({
     secret: options.secret,
     subject: options.sessionId,
     scope: SESSION_SCOPE,
-    ...(options.expiresInMs !== undefined ? { expiresInMs: options.expiresInMs } : {}),
+    expiresInMs: options.expiresInMs,
   });
 }
 

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-auth.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CHAT_SOCKET_TOKEN_TTL_MS,
   createSessionTokenSecret,
   issueSessionToken,
   verifyChatSocketRequest,
 } from '../../../src/http/ws-chat-auth.js';
 
 describe('websocket chat auth', () => {
+  it('requires callers to provide an explicit socket-token TTL', () => {
+    expect(() => issueSessionToken({
+      secret: createSessionTokenSecret(),
+      sessionId: 'sess-1',
+    } as Parameters<typeof issueSessionToken>[0])).toThrow(/expiresInMs/);
+  });
+
   it('rejects a connection when the Origin header is not allowlisted', () => {
     const secret = createSessionTokenSecret();
     const token = issueSessionToken({
+      expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS,
       secret,
       sessionId: 'sess-1',
     });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -15,6 +15,7 @@ import {
   attachChatWebSocketServer,
 } from '../../../src/http/ws-chat-server.js';
 import {
+  CHAT_SOCKET_TOKEN_TTL_MS,
   createSessionTokenSecret,
   issueSessionToken,
 } from '../../../src/http/ws-chat-auth.js';
@@ -75,7 +76,7 @@ describe('ws chat server', () => {
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const httpServer = createServer();
     attachChatWebSocketServer({
       runtime: createTestRuntime(),
@@ -103,7 +104,7 @@ describe('ws chat server', () => {
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const httpServer = createServer();
     attachChatWebSocketServer({
       runtime: createTestRuntime(),
@@ -131,7 +132,7 @@ describe('ws chat server', () => {
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const httpServer = createServer();
     attachChatWebSocketServer({
       runtime: createTestRuntime(),
@@ -156,7 +157,7 @@ describe('ws chat server', () => {
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const runtime = new ChatRuntime({
       engine: new ConversationEngine({
         llm: { complete: vi.fn().mockResolvedValue('Working on it right now.') },
@@ -205,7 +206,7 @@ describe('ws chat server', () => {
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const engine = {
       processTurn: vi.fn().mockResolvedValue({
         tier: 'premium_execution',


### PR DESCRIPTION
## Summary
- Require chat WebSocket session tokens to be issued with an explicit TTL.
- Pass the shared 5-minute socket token TTL from the chat app handshake-token issuer.
- Add regression coverage for missing TTL rejection and update WebSocket auth fixtures.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/integration/chat/ws-chat-auth.test.ts tests/integration/chat/ws-chat-server.test.ts tests/integration/chat/chat-routes.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)
- npm run build --workspace @franken/orchestrator
- npx turbo run test --filter=@franken/orchestrator

Closes #770