### PR TITLE
fix(planner): preserve recursive subgraph dependencies

### DIFF
--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -1,6 +1,6 @@
-import { RecursionDepthExceededError } from '../core/errors.js';
+import { DuplicateTaskError, RecursionDepthExceededError } from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
-import type { PlanResult, TaskResult } from '../core/types.js';
+import type { PlanResult, Task, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
 /**
@@ -45,7 +45,7 @@ export class RecursivePlanner implements PlanningStrategy {
       }
 
       if (result.expand === true) {
-        const subGraph = PlanGraph.fromTasks(result.newTasks);
+        const subGraph = this._buildSubGraph(result.newTasks);
         const subResult = await this._exec(subGraph, context, depth + 1);
         if (subResult.status !== 'completed') {
           return subResult;
@@ -57,6 +57,27 @@ export class RecursivePlanner implements PlanningStrategy {
     }
 
     return { status: 'completed', taskResults: allResults };
+  }
+
+  private _buildSubGraph(tasks: Task[]): PlanGraph {
+    const nodes = new Map<Task['id'], Task>();
+
+    for (const task of tasks) {
+      if (nodes.has(task.id)) {
+        throw new DuplicateTaskError(task.id);
+      }
+      nodes.set(task.id, task);
+    }
+
+    const edges = new Map<Task['id'], Set<Task['id']>>();
+    const tasksWithInternalDependencies = tasks.map((task) => {
+      const internalDependencies = task.dependsOn.filter((dependencyId) => nodes.has(dependencyId));
+      edges.set(task.id, new Set(internalDependencies));
+      return { ...task, dependsOn: internalDependencies };
+    });
+
+    PlanGraph.fromTasks(tasksWithInternalDependencies, { reason: 'recursive expansion' });
+    return PlanGraph.createWithRawEdges(nodes, edges, 0, 'recursive expansion');
   }
 
 }

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -1,6 +1,6 @@
 import { DuplicateTaskError, RecursionDepthExceededError } from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
-import type { PlanResult, Task, TaskResult } from '../core/types.js';
+import type { PlanResult, Task, TaskId, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
 /**
@@ -45,7 +45,11 @@ export class RecursivePlanner implements PlanningStrategy {
       }
 
       if (result.expand === true) {
-        const subGraph = this._buildSubGraph(result.newTasks);
+        const completedTaskIds = new Set<TaskId>([
+          ...allResults.map((taskResult) => taskResult.taskId),
+          task.id,
+        ]);
+        const subGraph = this._buildSubGraph(result.newTasks, completedTaskIds);
         const subResult = await this._exec(subGraph, context, depth + 1);
         if (subResult.status !== 'completed') {
           return subResult;
@@ -59,7 +63,7 @@ export class RecursivePlanner implements PlanningStrategy {
     return { status: 'completed', taskResults: allResults };
   }
 
-  private _buildSubGraph(tasks: Task[]): PlanGraph {
+  private _buildSubGraph(tasks: Task[], completedTaskIds: ReadonlySet<TaskId>): PlanGraph {
     const nodes = new Map<Task['id'], Task>();
 
     for (const task of tasks) {
@@ -71,11 +75,21 @@ export class RecursivePlanner implements PlanningStrategy {
 
     const edges = new Map<Task['id'], Set<Task['id']>>();
     const tasksWithInternalDependencies = tasks.map((task) => {
-      const internalDependencies = task.dependsOn.filter((dependencyId) => nodes.has(dependencyId));
+      const internalDependencies: TaskId[] = [];
+      for (const dependencyId of task.dependsOn) {
+        if (nodes.has(dependencyId)) {
+          internalDependencies.push(dependencyId);
+          continue;
+        }
+        if (!completedTaskIds.has(dependencyId)) {
+          throw new Error(
+            `Recursive task '${task.id}' depends on unresolved external dependency '${dependencyId}'`
+          );
+        }
+      }
       edges.set(task.id, new Set(internalDependencies));
       return { ...task, dependsOn: internalDependencies };
     });
-
     PlanGraph.fromTasks(tasksWithInternalDependencies, { reason: 'recursive expansion' });
     return PlanGraph.createWithRawEdges(nodes, edges, 0, 'recursive expansion');
   }

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -16,13 +16,14 @@ export class RecursivePlanner implements PlanningStrategy {
   constructor(private readonly maxDepth = 10) {}
 
   execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
-    return this._exec(graph, context, 0);
+    return this._exec(graph, context, 0, new Set());
   }
 
   private async _exec(
     graph: PlanGraph,
     context: PlanContext,
-    depth: number
+    depth: number,
+    completedTaskIds: ReadonlySet<TaskId>
   ): Promise<PlanResult> {
     if (depth > this.maxDepth) {
       throw new RecursionDepthExceededError(depth);
@@ -45,12 +46,13 @@ export class RecursivePlanner implements PlanningStrategy {
       }
 
       if (result.expand === true) {
-        const completedTaskIds = new Set<TaskId>([
+        const completedTaskIdsForExpansion = new Set<TaskId>([
+          ...completedTaskIds,
           ...allResults.map((taskResult) => taskResult.taskId),
           task.id,
         ]);
-        const subGraph = this._buildSubGraph(result.newTasks, completedTaskIds);
-        const subResult = await this._exec(subGraph, context, depth + 1);
+        const subGraph = this._buildSubGraph(result.newTasks, completedTaskIdsForExpansion);
+        const subResult = await this._exec(subGraph, context, depth + 1, completedTaskIdsForExpansion);
         if (subResult.status !== 'completed') {
           return subResult;
         }

--- a/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
@@ -160,6 +160,36 @@ describe('Integration — RecursivePlanner', () => {
     ]);
   });
 
+  it('allows nested expanded tasks to depend on completed ancestor-frame tasks', async () => {
+    const prerequisite = makeTask('prerequisite');
+    const parent = makeTask('parent');
+    const child = makeTask('child');
+    const grandchild = makeTask('grandchild', {
+      dependsOn: [createTaskId('prerequisite'), createTaskId('parent')],
+    });
+    const graph = PlanGraph.empty()
+      .addTask(prerequisite)
+      .addTask(parent, [createTaskId('prerequisite')]);
+
+    const callOrder: string[] = [];
+    const executor = vi.fn().mockImplementation((t: Task) => {
+      callOrder.push(t.id);
+      if (t.id === createTaskId('parent')) return Promise.resolve(expand('parent', [child]));
+      if (t.id === createTaskId('child')) return Promise.resolve(expand('child', [grandchild]));
+      return Promise.resolve(ok(t.id));
+    });
+
+    const result = await buildRecursivePlanner(graph, executor).plan('...');
+
+    expect(result.status).toBe('completed');
+    expect(callOrder).toEqual([
+      createTaskId('prerequisite'),
+      createTaskId('parent'),
+      createTaskId('child'),
+      createTaskId('grandchild'),
+    ]);
+  });
+
   it('rejects expanded tasks that depend on external tasks not completed yet', async () => {
     const parent = makeTask('parent');
     const laterSibling = makeTask('later-sibling');

--- a/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
@@ -13,8 +13,15 @@ import type { GuardrailsModule } from '../../src/modules/mod01';
 import type { GraphBuilder, TaskExecutor } from '../../src/planners/types';
 import type { MemoryModule } from '../../src/modules/mod03';
 
-function makeTask(id: string): Task {
-  return { id: createTaskId(id), objective: `Objective for ${id}`, requiredSkills: [], dependsOn: [], status: 'pending' };
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id: createTaskId(id),
+    objective: `Objective for ${id}`,
+    requiredSkills: [],
+    dependsOn: [],
+    status: 'pending',
+    ...overrides,
+  };
 }
 function ok(id: string): TaskResult { return { status: 'success', taskId: createTaskId(id) }; }
 function expand(id: string, newTasks: Task[]): TaskResult {
@@ -110,7 +117,7 @@ describe('Integration — RecursivePlanner', () => {
 
   it('sub-tasks respect their declared dependency order', async () => {
     const sub1 = makeTask('sub-1');
-    const sub2: Task = { ...makeTask('sub-2'), dependsOn: [createTaskId('sub-1')] };
+    const sub2 = makeTask('sub-2', { dependsOn: [createTaskId('sub-1')] });
     const parent = makeTask('parent');
     const graph = PlanGraph.empty().addTask(parent);
 
@@ -125,6 +132,47 @@ describe('Integration — RecursivePlanner', () => {
 
     expect(callOrder.indexOf(createTaskId('sub-1'))).toBeLessThan(
       callOrder.indexOf(createTaskId('sub-2'))
+    );
+  });
+
+  it('allows expanded tasks to depend on already completed external tasks', async () => {
+    const prerequisite = makeTask('prerequisite');
+    const parent = makeTask('parent');
+    const sub = makeTask('sub', { dependsOn: [createTaskId('prerequisite')] });
+    const graph = PlanGraph.empty()
+      .addTask(prerequisite)
+      .addTask(parent, [createTaskId('prerequisite')]);
+
+    const callOrder: string[] = [];
+    const executor = vi.fn().mockImplementation((t: Task) => {
+      callOrder.push(t.id);
+      if (t.id === createTaskId('parent')) return Promise.resolve(expand('parent', [sub]));
+      return Promise.resolve(ok(t.id));
+    });
+
+    const result = await buildRecursivePlanner(graph, executor).plan('...');
+
+    expect(result.status).toBe('completed');
+    expect(callOrder).toEqual([
+      createTaskId('prerequisite'),
+      createTaskId('parent'),
+      createTaskId('sub'),
+    ]);
+  });
+
+  it('rejects expanded tasks that depend on external tasks not completed yet', async () => {
+    const parent = makeTask('parent');
+    const laterSibling = makeTask('later-sibling');
+    const sub = makeTask('sub', { dependsOn: [createTaskId('later-sibling')] });
+    const graph = PlanGraph.empty().addTask(parent).addTask(laterSibling);
+
+    const executor = vi.fn().mockImplementation((t: Task) => {
+      if (t.id === createTaskId('parent')) return Promise.resolve(expand('parent', [sub]));
+      return Promise.resolve(ok(t.id));
+    });
+
+    await expect(buildRecursivePlanner(graph, executor).plan('...')).rejects.toThrow(
+      /unresolved external dependency 'later-sibling'/
     );
   });
 });

--- a/packages/franken-planner/tests/unit/planners/recursive.test.ts
+++ b/packages/franken-planner/tests/unit/planners/recursive.test.ts
@@ -133,6 +133,27 @@ describe('RecursivePlanner — happy path', () => {
     );
   });
 
+  it('allows expanded sub-tasks to depend on already executed parent tasks outside the sub-graph', async () => {
+    const parent = makeTask('parent');
+    const child: Task = {
+      ...makeTask('child'),
+      dependsOn: [createTaskId('parent')],
+    };
+    const graph = PlanGraph.empty().addTask(parent);
+
+    const callOrder: string[] = [];
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      callOrder.push(task.id);
+      if (task.id === createTaskId('parent')) return Promise.resolve(expand('parent', [child]));
+      return Promise.resolve(success(task.id));
+    });
+
+    const result = await new RecursivePlanner().execute(graph, { executor });
+
+    expect(result.status).toBe('completed');
+    expect(callOrder).toEqual([createTaskId('parent'), createTaskId('child')]);
+  });
+
   it('handles nested expansion (depth 2)', async () => {
     const grandchild = makeTask('grandchild');
     const child = makeTask('child');


### PR DESCRIPTION
## Summary
- Build recursive expansion subgraphs using only dependencies internal to the expanded task subset for scheduling
- Preserve the original expanded task objects so external dependency metadata is not discarded
- Add a regression test for an expanded task depending on its already-executed parent

## Test Plan
- npm test -- --run tests/unit/planners/recursive.test.ts
- npm test (in packages/franken-planner)
- npm run typecheck (root)
- npm run build (root)
- npm run lint (in packages/franken-planner)

Closes #549