### PR TITLE
fix(cli): print PR URL in run summary

### DIFF
--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -546,6 +546,9 @@ export class Session {
     if (result.error) {
       printLine(`  ${A.dim}Warning:${A.reset}   ${result.error.message}`);
     }
+    if (result.prUrl) {
+      printLine(`  ${A.dim}PR:${A.reset}        ${result.prUrl}`);
+    }
     if (result.taskResults?.length) {
       printLine(`\n  ${A.dim}Chunks:${A.reset}`);
       for (const t of result.taskResults) {

--- a/packages/franken-orchestrator/tests/unit/cli/session.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session.test.ts
@@ -283,6 +283,21 @@ describe('Session', () => {
 
       expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Result: 1 passed, 1 failed'));
     });
+
+    it('prints the created PR URL in the build summary when present', async () => {
+      const { Session } = await import('../../../src/cli/session.js');
+      mockBeastRun.mockResolvedValueOnce({
+        ...mockBeastResult,
+        prUrl: 'https://github.com/org/repo/pull/123',
+      });
+      const config = makeConfig({ entryPhase: 'execute' });
+
+      await new Session(config).start();
+
+      expect(console.info).toHaveBeenCalledWith(
+        expect.stringContaining('PR:        https://github.com/org/repo/pull/123'),
+      );
+    });
   });
 
   describe('phase chaining', () => {


### PR DESCRIPTION
## Summary
- Print the created PR URL in the standard run build summary when `BeastResult.prUrl` is present.
- Add a Session regression test covering run-mode PR URL output.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/cli/session.test.ts -t "prints the created PR URL"
- npm --prefix packages/franken-orchestrator test -- tests/unit/cli/session.test.ts
- npm run build
- npm run typecheck
- npm --prefix packages/franken-orchestrator run lint

Closes #745
