### PR TITLE
fix: harden hook DB path quoting

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
@@ -164,6 +164,64 @@ function runScript(
   });
 }
 
+function singleQuoteShell(value: string): string {
+  return `'${value.split("'").join("'\\''")}'`;
+}
+
+describe('Hook script shell path escaping', () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tempRoots) {
+      if (existsSync(root)) {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+    tempRoots.length = 0;
+  });
+
+  it('writes DB_PATH as a shell-safe single-quoted literal for every client', () => {
+    const root = join(tmpdir(), `fbeast-hook-scripts-quote-${randomUUID()}-\'special`);
+    mkdirSync(root, { recursive: true });
+    tempRoots.push(root);
+
+    for (const client of ['codex', 'claude', 'gemini'] as const) {
+      const dbPath = client === 'codex' ? join(root, '.fbeast', 'beast.db') : join('.fbeast', 'beast.db');
+      const expectedDbPath = singleQuoteShell(dbPath);
+      const { preTool, postTool } = writeHookScripts(root, client);
+      const scriptContent = [readFileSync(preTool, 'utf8'), readFileSync(postTool, 'utf8')].join('\n');
+
+      expect(scriptContent).toContain(`DB_PATH=${expectedDbPath}`);
+      expect(scriptContent).not.toContain(`DB_PATH=${JSON.stringify(dbPath)}`);
+      expect(scriptContent).not.toContain(`DB_PATH=${dbPath}`);
+    }
+  });
+
+  it('keeps shell metacharacters in root paths from executing as command substitutions', () => {
+    const marker = join(tmpdir(), `fbeast-hook-path-injection-${randomUUID()}`);
+    const root = join(tmpdir(), `fbeast-hook-scripts-$(touch ${marker})-${randomUUID()}`);
+    const expected = `${join(root, '.fbeast', 'beast.db')}`;
+
+    if (existsSync(marker)) {
+      rmSync(marker);
+    }
+
+    mkdirSync(root, { recursive: true });
+    tempRoots.push(root);
+    const binDir = installFakeHook(root);
+    const { preTool } = writeHookScripts(root, 'codex');
+
+    const result = runScript(preTool, {
+      tool_name: 'exec_command',
+      session_id: 'sess-1',
+      tool_input: {},
+    }, binDir);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(marker), `unexpected command-substitution side effect in script: ${expected}`).toBe(false);
+  });
+});
+
 describe('Codex hook scripts', () => {
   const tempRoots: string[] = [];
 
@@ -236,7 +294,7 @@ describe('Codex hook scripts', () => {
     // would both false-positive on diff text and persist secrets in governor_log.
     const result = runScript(preTool, {
       tool_name: 'apply_patch',
-      tool_input: { command: '*** Begin Patch\n+ rm -rf / and SECRET_TOKEN=abc\n*** End Patch' },
+      tool_input: { command: '*** Begin Patch\n rm -rf / and SECRET_TOKEN=abc\n*** End Patch' },
       session_id: 'sess-1',
     }, binDir);
 
@@ -637,8 +695,8 @@ describe('Claude Code hook scripts', () => {
     tempRoots.push(root);
     const { preTool, postTool } = writeHookScripts(root, 'claude');
 
-    expect(readFileSync(preTool, 'utf8')).toContain(`DB_PATH=${JSON.stringify(join('.fbeast', 'beast.db'))}`);
-    expect(readFileSync(postTool, 'utf8')).toContain(`DB_PATH=${JSON.stringify(join('.fbeast', 'beast.db'))}`);
+    expect(readFileSync(preTool, 'utf8')).toContain(`DB_PATH=${singleQuoteShell(join('.fbeast', 'beast.db'))}`);
+    expect(readFileSync(postTool, 'utf8')).toContain(`DB_PATH=${singleQuoteShell(join('.fbeast', 'beast.db'))}`);
     expect(readFileSync(preTool, 'utf8')).not.toContain(root);
     expect(readFileSync(postTool, 'utf8')).not.toContain(root);
   });

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -6,6 +6,10 @@
 import { mkdirSync, writeFileSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 
+function shellSingleQuote(value: string): string {
+  return `'${value.split(`'`).join(`'\\''`)}'`;
+}
+
 export interface HookScriptPaths {
   preTool: string;
   postTool: string;
@@ -54,7 +58,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
   exit 0
 fi
 
-DB_PATH=${JSON.stringify(dbPath)}
+DB_PATH=${shellSingleQuote(dbPath)}
 if [[ "$DB_PATH" != /* ]]; then
   SEARCH_DIR="$PWD"
   while true; do
@@ -121,7 +125,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
   exit 0
 fi
 
-DB_PATH=${JSON.stringify(dbPath)}
+DB_PATH=${shellSingleQuote(dbPath)}
 if [[ "$DB_PATH" != /* ]]; then
   SEARCH_DIR="$PWD"
   while true; do
@@ -180,7 +184,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
   exit 0
 fi
 
-DB_PATH=${JSON.stringify(dbPath)}
+DB_PATH=${shellSingleQuote(dbPath)}
 if [[ "$DB_PATH" != /* ]]; then
   SEARCH_DIR="$PWD"
   while true; do
@@ -246,7 +250,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
   exit 0
 fi
 
-DB_PATH=${JSON.stringify(dbPath)}
+DB_PATH=${shellSingleQuote(dbPath)}
 if [[ "$DB_PATH" != /* ]]; then
   SEARCH_DIR="$PWD"
   while true; do
@@ -305,7 +309,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
   exit 0
 fi
 
-DB_PATH=${JSON.stringify(dbPath)}
+DB_PATH=${shellSingleQuote(dbPath)}
 if [[ "$DB_PATH" != /* ]]; then
   SEARCH_DIR="$PWD"
   while true; do
@@ -372,7 +376,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
   exit 0
 fi
 
-DB_PATH=${JSON.stringify(dbPath)}
+DB_PATH=${shellSingleQuote(dbPath)}
 if [[ "$DB_PATH" != /* ]]; then
   SEARCH_DIR="$PWD"
   while true; do

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,6 +1,10 @@
+# Resolve Issues Shared Lessons
 
 ## 2026-07-06 — Critique scanner edge cases
 - Dependency/comment/string scanners that manually skip regex literals must cover keyword-prefixed regexes (including await), postfix-operator division, JSX closing tags, template interpolations, and import trivia comments. Add regression tests for each Codex-reported lexical edge case before re-triggering review.
+
+## 2026-07-06 — Hook script DB path quoting
+- Hook script generation must never interpolate DB path via raw JSON/string values. Use shell-safe single-quote encoding (`'\''`-style escaping) for shell assignments so workspace names containing `$`, backticks, spaces, or single quotes cannot execute arbitrary command-substitution when hooks run.
 
 ## 2026-07-08 — Late Codex follow-ups after merge
 - After merging a PR that had an asynchronous `@codex review` in flight, audit the merged PR again for post-merge Codex comments/inline findings. If Codex reports current-head findings after merge, open a narrowly scoped follow-up PR against main, run the normal CI + `@codex review` gates on that PR, and merge only after the follow-up is clean.


### PR DESCRIPTION
## Summary
- Add shell-safe quoting for DB path in generated Gemini/Claude/Codex hook scripts.
- Write regression tests to ensure DB_PATH is rendered as a quoted literal and command-substitution payloads in workspace root do not execute.
- Add shared-lesson note for this issue flow.

## Test plan
- Targeted unit coverage:  added assertions for path quoting and command-injection side effects.
- Full test run and install are blocked in this environment due private dependency resolution ( unavailable), so full automated checks couldn't be executed.

Closes #768