### PR TITLE
fix(mcp-suite): use node for hook script json parsing

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -51,11 +51,11 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
-NODE_BIN="${JSON.stringify(process.execPath)}"
+NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 # Extract only policy-relevant COMMAND text as governor context. It is passed to
 # fbeast-hook via the FBEAST_TOOL_CONTEXT env var (never argv), so it cannot be
 # parsed as a CLI flag. It is not truncated; an over-limit command fails the exec
@@ -64,7 +64,7 @@ TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); 
 # string so patterns like 'rm -rf' still match. Path and file-content fields are
 # excluded to avoid false positives and persisting secrets. apply_patch patch
 # bodies (carried in tool_input.command) are also excluded for the same reason.
-TOOL_CONTEXT=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
+TOOL_CONTEXT=$(printf '%s' "$INPUT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 
 # Fail closed: a missing/unparseable tool name means we cannot govern the call.
 if [ -z "$TOOL_NAME" ]; then
@@ -86,7 +86,7 @@ set -e
 # denial, timeout (124), timeout-internal failure (125/126), kill (137), and
 # missing binary (127). Fail-open is never the default for the enforcement path.
 if [ "$STATUS" -ne 0 ]; then
-  SAFE_RESULT=$(printf '%s' "$RESULT" | $NODE_BIN -e "const fs = require('node:fs'); try { process.stdout.write(JSON.stringify(fs.readFileSync(0, 'utf8'))); } catch { process.stdout.write('\\"blocked by fbeast governor\\"'); }" 2>/dev/null || echo '"blocked by fbeast governor"')
+  SAFE_RESULT=$(printf '%s' "$RESULT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { process.stdout.write(JSON.stringify(fs.readFileSync(0, 'utf8'))); } catch { process.stdout.write('\\"blocked by fbeast governor\\"'); }" 2>/dev/null || echo '"blocked by fbeast governor"')
   printf '{"decision":"deny","reason":%s}\\n' "$SAFE_RESULT" >&1
   exit 2
 fi
@@ -104,7 +104,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
-NODE_BIN="${JSON.stringify(process.execPath)}"
+NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
@@ -112,8 +112,8 @@ PAYLOAD_FILE=""
 trap 'rm -f "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
 PAYLOAD_FILE=$(mktemp -t fbeast-hook-response.XXXXXX) || exit 0
 cat > "$INPUT_FILE" || exit 0
-TOOL_NAME=$($NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
-if ! $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+TOOL_NAME=$("$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
+if ! "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
   printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
 fi
 
@@ -149,11 +149,11 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
-NODE_BIN="${JSON.stringify(process.execPath)}"
+NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 # Extract only policy-relevant COMMAND text as governor context. It is passed to
 # fbeast-hook via the FBEAST_TOOL_CONTEXT env var (never argv), so it cannot be
 # parsed as a CLI flag. It is not truncated; an over-limit command fails the exec
@@ -162,7 +162,7 @@ TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); 
 # string so patterns like 'rm -rf' still match. Path and file-content fields are
 # excluded to avoid false positives and persisting secrets. apply_patch patch
 # bodies (carried in tool_input.command) are also excluded for the same reason.
-TOOL_CONTEXT=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
+TOOL_CONTEXT=$(printf '%s' "$INPUT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 
 # Fail closed: a missing/unparseable tool name means we cannot govern the call.
 if [ -z "$TOOL_NAME" ]; then
@@ -201,7 +201,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
-NODE_BIN="${JSON.stringify(process.execPath)}"
+NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
@@ -209,8 +209,8 @@ PAYLOAD_FILE=""
 trap 'rm -f "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
 PAYLOAD_FILE=$(mktemp -t fbeast-hook-response.XXXXXX) || exit 0
 cat > "$INPUT_FILE" || exit 0
-TOOL_NAME=$($NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
-if ! $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+TOOL_NAME=$("$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
+if ! "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
   printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
 fi
 
@@ -246,11 +246,11 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
-NODE_BIN="${JSON.stringify(process.execPath)}"
+NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 # Extract only policy-relevant COMMAND text as governor context. It is passed to
 # fbeast-hook via the FBEAST_TOOL_CONTEXT env var (never argv), so it cannot be
 # parsed as a CLI flag. It is not truncated; an over-limit command fails the exec
@@ -259,7 +259,7 @@ TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); 
 # string so patterns like 'rm -rf' still match. Path and file-content fields are
 # excluded to avoid false positives and persisting secrets. apply_patch patch
 # bodies (carried in tool_input.command) are also excluded for the same reason.
-TOOL_CONTEXT=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
+TOOL_CONTEXT=$(printf '%s' "$INPUT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 
 # Fail closed: a missing/unparseable tool name means we cannot govern the call.
 if [ -z "$TOOL_NAME" ]; then
@@ -281,7 +281,7 @@ set -e
 # denial, timeout (124), timeout-internal failure (125/126), kill (137), and
 # missing binary (127). Fail-open is never the default for the enforcement path.
 if [ "$STATUS" -ne 0 ]; then
-  SAFE_REASON=$(printf '%s' "$RESULT" | $NODE_BIN -e "const fs = require('node:fs'); try { process.stdout.write(JSON.stringify(fs.readFileSync(0, 'utf8'))); } catch { process.stdout.write('\\"blocked by fbeast governor\\"'); }" 2>/dev/null || echo '"blocked by fbeast governor"')
+  SAFE_REASON=$(printf '%s' "$RESULT" | "$NODE_BIN" -e "const fs = require('node:fs'); try { process.stdout.write(JSON.stringify(fs.readFileSync(0, 'utf8'))); } catch { process.stdout.write('\\"blocked by fbeast governor\\"'); }" 2>/dev/null || echo '"blocked by fbeast governor"')
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\\n' "$SAFE_REASON" >&1
   exit 2
 fi
@@ -299,7 +299,7 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
-NODE_BIN="${JSON.stringify(process.execPath)}"
+NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
@@ -307,8 +307,8 @@ PAYLOAD_FILE=""
 trap 'rm -f "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
 PAYLOAD_FILE=$(mktemp -t fbeast-hook-response.XXXXXX) || exit 0
 cat > "$INPUT_FILE" || exit 0
-TOOL_NAME=$($NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
-if ! $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+TOOL_NAME=$("$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
+if ! "$NODE_BIN" -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
   printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
 fi
 

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -51,10 +51,11 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+NODE_BIN="${JSON.stringify(process.execPath)}"
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 # Extract only policy-relevant COMMAND text as governor context. It is passed to
 # fbeast-hook via the FBEAST_TOOL_CONTEXT env var (never argv), so it cannot be
 # parsed as a CLI flag. It is not truncated; an over-limit command fails the exec
@@ -63,7 +64,7 @@ TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.
 # string so patterns like 'rm -rf' still match. Path and file-content fields are
 # excluded to avoid false positives and persisting secrets. apply_patch patch
 # bodies (carried in tool_input.command) are also excluded for the same reason.
-TOOL_CONTEXT=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); ti=d.get('tool_input',{}); tn=d.get('tool_name',''); ks=('command','cmd','commands','args','argv','script'); body=(ti if isinstance(ti,str) else (' '.join((' '.join(map(str,ti[k])) if isinstance(ti[k],list) else (ti[k] if isinstance(ti[k],str) else json.dumps(ti[k]))) for k in ks if k in ti) if isinstance(ti,dict) else '')); out=('' if tn=='apply_patch' else body); sys.stdout.write(out)" 2>/dev/null || echo "")
+TOOL_CONTEXT=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 
 # Fail closed: a missing/unparseable tool name means we cannot govern the call.
 if [ -z "$TOOL_NAME" ]; then
@@ -85,7 +86,7 @@ set -e
 # denial, timeout (124), timeout-internal failure (125/126), kill (137), and
 # missing binary (127). Fail-open is never the default for the enforcement path.
 if [ "$STATUS" -ne 0 ]; then
-  SAFE_RESULT=$(printf '%s' "$RESULT" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo '"blocked by fbeast governor"')
+  SAFE_RESULT=$(printf '%s' "$RESULT" | $NODE_BIN -e "const fs = require('node:fs'); try { process.stdout.write(JSON.stringify(fs.readFileSync(0, 'utf8'))); } catch { process.stdout.write('\\"blocked by fbeast governor\\"'); }" 2>/dev/null || echo '"blocked by fbeast governor"')
   printf '{"decision":"deny","reason":%s}\\n' "$SAFE_RESULT" >&1
   exit 2
 fi
@@ -103,15 +104,16 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+NODE_BIN="${JSON.stringify(process.execPath)}"
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()") || exit 0
+INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
 PAYLOAD_FILE=""
-trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:] if p]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
-PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()") || exit 0
+trap 'rm -f "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+PAYLOAD_FILE=$(mktemp -t fbeast-hook-response.XXXXXX) || exit 0
 cat > "$INPUT_FILE" || exit 0
-TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
-if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+TOOL_NAME=$($NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
+if ! $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
   printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
 fi
 
@@ -147,10 +149,11 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+NODE_BIN="${JSON.stringify(process.execPath)}"
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 # Extract only policy-relevant COMMAND text as governor context. It is passed to
 # fbeast-hook via the FBEAST_TOOL_CONTEXT env var (never argv), so it cannot be
 # parsed as a CLI flag. It is not truncated; an over-limit command fails the exec
@@ -159,7 +162,7 @@ TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.
 # string so patterns like 'rm -rf' still match. Path and file-content fields are
 # excluded to avoid false positives and persisting secrets. apply_patch patch
 # bodies (carried in tool_input.command) are also excluded for the same reason.
-TOOL_CONTEXT=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); ti=d.get('tool_input',{}); tn=d.get('tool_name',''); ks=('command','cmd','commands','args','argv','script'); body=(ti if isinstance(ti,str) else (' '.join((' '.join(map(str,ti[k])) if isinstance(ti[k],list) else (ti[k] if isinstance(ti[k],str) else json.dumps(ti[k]))) for k in ks if k in ti) if isinstance(ti,dict) else '')); out=('' if tn=='apply_patch' else body); sys.stdout.write(out)" 2>/dev/null || echo "")
+TOOL_CONTEXT=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 
 # Fail closed: a missing/unparseable tool name means we cannot govern the call.
 if [ -z "$TOOL_NAME" ]; then
@@ -198,15 +201,16 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+NODE_BIN="${JSON.stringify(process.execPath)}"
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()") || exit 0
+INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
 PAYLOAD_FILE=""
-trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:] if p]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
-PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()") || exit 0
+trap 'rm -f "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+PAYLOAD_FILE=$(mktemp -t fbeast-hook-response.XXXXXX) || exit 0
 cat > "$INPUT_FILE" || exit 0
-TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
-if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+TOOL_NAME=$($NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
+if ! $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
   printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
 fi
 
@@ -242,10 +246,11 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+NODE_BIN="${JSON.stringify(process.execPath)}"
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 # Extract only policy-relevant COMMAND text as governor context. It is passed to
 # fbeast-hook via the FBEAST_TOOL_CONTEXT env var (never argv), so it cannot be
 # parsed as a CLI flag. It is not truncated; an over-limit command fails the exec
@@ -254,7 +259,7 @@ TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.
 # string so patterns like 'rm -rf' still match. Path and file-content fields are
 # excluded to avoid false positives and persisting secrets. apply_patch patch
 # bodies (carried in tool_input.command) are also excluded for the same reason.
-TOOL_CONTEXT=$(printf '%s' "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); ti=d.get('tool_input',{}); tn=d.get('tool_name',''); ks=('command','cmd','commands','args','argv','script'); body=(ti if isinstance(ti,str) else (' '.join((' '.join(map(str,ti[k])) if isinstance(ti[k],list) else (ti[k] if isinstance(ti[k],str) else json.dumps(ti[k]))) for k in ks if k in ti) if isinstance(ti,dict) else '')); out=('' if tn=='apply_patch' else body); sys.stdout.write(out)" 2>/dev/null || echo "")
+TOOL_CONTEXT=$(printf '%s' "$INPUT" | $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(0, 'utf8')); const ti = d?.tool_input; const tn = d?.tool_name || ''; const keys = ['command', 'cmd', 'commands', 'args', 'argv', 'script']; let out = ''; if (typeof ti === 'string') { out = ti; } else if (ti && typeof ti === 'object' && !Array.isArray(ti) && tn !== 'apply_patch') { const parts = []; for (const key of keys) { const value = ti[key]; if (value === undefined) continue; if (Array.isArray(value)) { parts.push(value.map(String).join(' ')); } else if (typeof value === 'string') { parts.push(value); } else { parts.push(JSON.stringify(value)); } } out = parts.join(' '); } process.stdout.write(tn === 'apply_patch' ? '' : out); } catch { process.stdout.write(''); }" 2>/dev/null || echo "")
 
 # Fail closed: a missing/unparseable tool name means we cannot govern the call.
 if [ -z "$TOOL_NAME" ]; then
@@ -276,7 +281,7 @@ set -e
 # denial, timeout (124), timeout-internal failure (125/126), kill (137), and
 # missing binary (127). Fail-open is never the default for the enforcement path.
 if [ "$STATUS" -ne 0 ]; then
-  SAFE_REASON=$(printf '%s' "$RESULT" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo '"blocked by fbeast governor"')
+  SAFE_REASON=$(printf '%s' "$RESULT" | $NODE_BIN -e "const fs = require('node:fs'); try { process.stdout.write(JSON.stringify(fs.readFileSync(0, 'utf8'))); } catch { process.stdout.write('\\"blocked by fbeast governor\\"'); }" 2>/dev/null || echo '"blocked by fbeast governor"')
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\\n' "$SAFE_REASON" >&1
   exit 2
 fi
@@ -294,15 +299,16 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+NODE_BIN="${JSON.stringify(process.execPath)}"
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
-INPUT_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-input.', delete=False); print(f.name); f.close()") || exit 0
+INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
 PAYLOAD_FILE=""
-trap 'python3 -c "import os,sys; [os.path.exists(p) and os.unlink(p) for p in sys.argv[1:] if p]" "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
-PAYLOAD_FILE=$(python3 -c "import tempfile; f=tempfile.NamedTemporaryFile(prefix='fbeast-hook-response.', delete=False); print(f.name); f.close()") || exit 0
+trap 'rm -f "$INPUT_FILE" "$PAYLOAD_FILE"' EXIT
+PAYLOAD_FILE=$(mktemp -t fbeast-hook-response.XXXXXX) || exit 0
 cat > "$INPUT_FILE" || exit 0
-TOOL_NAME=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('tool_name',''))" "$INPUT_FILE" 2>/dev/null || echo "")
-if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.stdout.write(json.dumps(d.get('tool_response',{})))" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
+TOOL_NAME=$($NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(d?.tool_name || '')); } catch { process.stdout.write(''); }" "$INPUT_FILE" 2>/dev/null || echo "")
+if ! $NODE_BIN -e "const fs = require('node:fs'); try { const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(JSON.stringify(d?.tool_response || {})); } catch { process.exit(1); }" "$INPUT_FILE" > "$PAYLOAD_FILE" 2>/dev/null; then
   printf '{}' > "$PAYLOAD_FILE" 2>/dev/null || exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Replaced pre-tool and post-tool  JSON parsing in mcp-suite generated hook scripts with  helpers.
- Replaced  temporary-file creation/teardown with shell /tmp/tmp.hpvNpCGHhq/.
- Kept deny/allow output behavior unchanged while eliminating silent governance bypass when Python 3 is missing.

Closes #489