### PR TITLE
fix: remove unsafe eval test fixtures in critique tests

### DIFF
--- a/packages/franken-critique/tests/integration/critique-loop-full.test.ts
+++ b/packages/franken-critique/tests/integration/critique-loop-full.test.ts
@@ -4,16 +4,16 @@ import type { GuardrailsPort, MemoryPort, ObservabilityPort } from '../../src/ty
 import type { EvaluationInput } from '../../src/types/evaluation.js';
 import type { LoopConfig } from '../../src/types/loop.js';
 
-const unsafeDynamicCallName = ['ev', 'al'].join('');
-const unsafeDynamicCallPattern = `${unsafeDynamicCallName}\\(`;
+const forbiddenInvocationName = 'unsafeCall';
+const forbiddenInvocationPattern = `${forbiddenInvocationName}\\(`;
 
 function createMockGuardrailsPort(): GuardrailsPort {
   return {
     getSafetyRules: vi.fn().mockResolvedValue([
       {
-        id: `no-${unsafeDynamicCallName}`,
-        description: `no ${unsafeDynamicCallName}`,
-        pattern: unsafeDynamicCallPattern,
+        id: `no-${forbiddenInvocationName}`,
+        description: `no ${forbiddenInvocationName}`,
+        pattern: forbiddenInvocationPattern,
         severity: 'block',
       },
     ]),
@@ -87,7 +87,7 @@ describe('Full Critique Loop Integration', () => {
     });
 
     const result = await reviewer.review(
-      createInput(`${unsafeDynamicCallName}("malicious code")`),
+      createInput(`${forbiddenInvocationName}("malicious code")`),
       createLoopConfig({ maxIterations: 1 }),
     );
 

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -23,10 +23,10 @@ function createInput(content: string): EvaluationInput {
   return { content, metadata: {} };
 }
 
-const unsafeDynamicCallName = ['ev', 'al'].join('');
-const unsafeDynamicCallPattern = `${unsafeDynamicCallName}\\(`;
-function unsafeDynamicCall(argument: string): string {
-  return `${unsafeDynamicCallName}(${argument})`;
+const forbiddenInvocationName = 'unsafeCall';
+const forbiddenInvocationPattern = `${forbiddenInvocationName}\\(`;
+function forbiddenInvocation(argument: string): string {
+  return `${forbiddenInvocationName}(${argument})`;
 }
 
 describe('SafetyEvaluator', () => {
@@ -42,8 +42,8 @@ describe('SafetyEvaluator', () => {
     const port = createMockGuardrailsPort([
       {
         id: 'r1',
-        description: `no ${unsafeDynamicCallName}`,
-        pattern: unsafeDynamicCallPattern,
+        description: `no ${forbiddenInvocationName}`,
+        pattern: forbiddenInvocationPattern,
         severity: 'block',
       },
     ]);
@@ -60,20 +60,20 @@ describe('SafetyEvaluator', () => {
     const port = createMockGuardrailsPort([
       {
         id: 'r1',
-        description: `no ${unsafeDynamicCallName}`,
-        pattern: unsafeDynamicCallPattern,
+        description: `no ${forbiddenInvocationName}`,
+        pattern: forbiddenInvocationPattern,
         severity: 'block',
       },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
-    const result = await evaluator.evaluate(createInput(unsafeDynamicCall('"code"')));
+    const result = await evaluator.evaluate(createInput(forbiddenInvocation('"code"')));
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]!.severity).toBe('critical');
-    expect(result.findings[0]!.message).toContain(`no ${unsafeDynamicCallName}`);
+    expect(result.findings[0]!.message).toContain(`no ${forbiddenInvocationName}`);
   });
 
   it('warns but passes on warning-severity rules', async () => {
@@ -243,8 +243,8 @@ describe('SafetyEvaluator', () => {
     const port = createMockGuardrailsPort([
       {
         id: 'r1',
-        description: `no ${unsafeDynamicCallName}`,
-        pattern: unsafeDynamicCallPattern,
+        description: `no ${forbiddenInvocationName}`,
+        pattern: forbiddenInvocationPattern,
         severity: 'block',
       },
       {
@@ -257,7 +257,7 @@ describe('SafetyEvaluator', () => {
     const evaluator = new SafetyEvaluator(port);
 
     const result = await evaluator.evaluate(
-      createInput(`${unsafeDynamicCall('\"x\"')}; exec("y")`),
+      createInput(`${forbiddenInvocation('"code"')}; exec("y")`),
     );
 
     expect(result.verdict).toBe('fail');
@@ -280,7 +280,7 @@ describe('SafetyEvaluator', () => {
       {
         id: 'bad-regex',
         description: 'bad regex',
-        pattern: `${unsafeDynamicCallName}(`,
+        pattern: `${forbiddenInvocationName}(`,
         severity: 'block',
       },
     ]);

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -55,7 +55,7 @@ describe('LessonRecorder', () => {
   });
 
   it('records a lesson when multi-iteration pass occurs (fail then pass)', async () => {
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
+    const forbiddenInvocationName = 'unsafeCall';
 
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);
@@ -63,7 +63,7 @@ describe('LessonRecorder', () => {
     const result: CritiqueLoopResult = {
       verdict: 'pass',
       iterations: [
-        createIteration(0, 'fail', 'safety', [{ message: `${unsafeDynamicCallName}() detected`, severity: 'critical' }]),
+        createIteration(0, 'fail', 'safety', [{ message: `${forbiddenInvocationName}() detected`, severity: 'critical' }]),
         createIteration(1, 'pass'),
       ],
     };
@@ -74,7 +74,7 @@ describe('LessonRecorder', () => {
     expect(port.recordLesson).toHaveBeenCalledWith(
       expect.objectContaining({
         evaluatorName: 'safety',
-        failureDescription: expect.stringContaining(`${unsafeDynamicCallName}()`),
+        failureDescription: expect.stringContaining(`${forbiddenInvocationName}()`),
         taskId: 'test-task',
       }),
     );

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -129,7 +129,7 @@ describe('CritiquePipeline', () => {
   });
 
   it('short-circuits on safety evaluator failure', async () => {
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
+    const forbiddenInvocationName = 'unsafeCall';
 
     const safety = createMockEvaluator('safety', 'deterministic', {
       verdict: 'fail',
@@ -139,7 +139,7 @@ describe('CritiquePipeline', () => {
     const other = createMockEvaluator('other', 'heuristic');
 
     const pipeline = new CritiquePipeline([safety, other]);
-    const result = await pipeline.run(createInput(`${unsafeDynamicCallName}("hack")`));
+    const result = await pipeline.run(createInput(`${forbiddenInvocationName}("hack")`));
 
     expect(result.verdict).toBe('fail');
     expect(result.shortCircuited).toBe(true);

--- a/packages/franken-critique/tests/unit/reviewer.test.ts
+++ b/packages/franken-critique/tests/unit/reviewer.test.ts
@@ -118,14 +118,14 @@ describe('createReviewer', () => {
   });
 
   it('handles safety failure with short-circuit', async () => {
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
+    const forbiddenInvocationName = 'unsafeCall';
 
     const guardrails: GuardrailsPort = {
       getSafetyRules: vi.fn().mockResolvedValue([
         {
-          id: `no-${unsafeDynamicCallName}`,
-          description: `no ${unsafeDynamicCallName}`,
-          pattern: `${unsafeDynamicCallName}\\(`,
+          id: `no-${forbiddenInvocationName}`,
+          description: `no ${forbiddenInvocationName}`,
+          pattern: `${forbiddenInvocationName}\\(`,
           severity: 'block' as const,
         },
       ]),
@@ -134,7 +134,7 @@ describe('createReviewer', () => {
       }),
     };
     const reviewer = createReviewer(makeConfig({ guardrails }));
-    const input = makeInput(`${unsafeDynamicCallName}("dangerous")`);
+    const input = makeInput(`${forbiddenInvocationName}("dangerous")`);
     const result = await reviewer.review(input, makeLoopConfig());
     expect(result.verdict).toBe('fail');
   });

--- a/tasks/resolve-issues-503-progress.md
+++ b/tasks/resolve-issues-503-progress.md
@@ -1,0 +1,9 @@
+# Resolve issue 503 Progress
+
+- [x] Read shared lessons before starting (resolve-issues-503 and lessons files)
+- [x] Load issue context and identify affected test fixtures
+- [x] Remove direct `eval(` usage patterns from `@franken/critique` test inputs
+- [x] Replace dynamic eval fixture text with neutral `unsafeCall` fixture token
+- [x] Run targeted test commands for modified `@franken/critique` tests (blocked: dependency `acorn-typescript` missing in environment)
+- [ ] Complete post-change verification and close loop
+- [ ] Final handoff to next worker / card transition


### PR DESCRIPTION
## Summary
- remove direct eval fixture text from critique tests in unit/integration suites
- replace runtime-assembled eval-like tokens with neutral  fixtures
- update shared issue progress checklist

Closes #503