### PR TITLE
test: externalize credential fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist
 /franken-types
 /frankenfirewall
 .env
+.env.test

--- a/packages/franken-observer/docs/adapters.md
+++ b/packages/franken-observer/docs/adapters.md
@@ -80,7 +80,7 @@ import { vi } from 'vitest'
 import { LangfuseAdapter } from '@franken/observer'
 
 const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' })
-const adapter   = new LangfuseAdapter({ publicKey: 'pk', secretKey: 'sk', fetch: mockFetch })
+const adapter   = new LangfuseAdapter({ publicKey: process.env.LANGFUSE_PUBLIC_KEY!, secretKey: process.env.LANGFUSE_SECRET_KEY!, fetch: mockFetch })
 
 await adapter.flush(trace)
 expect(mockFetch).toHaveBeenCalledOnce()

--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { TraceContext } from '../../core/TraceContext.js'
 import { SpanLifecycle } from '../../core/SpanLifecycle.js'
 import { LangfuseAdapter } from './LangfuseAdapter.js'
+import {
+  LANGFUSE_PUBLIC_KEY,
+  LANGFUSE_SECRET_KEY,
+} from '../../../tests/fixtures/langfuse-test-credentials.js'
 
 function makeTrace() {
   const trace = TraceContext.createTrace('test goal')
@@ -21,7 +25,7 @@ describe('LangfuseAdapter', () => {
 
   describe('flush()', () => {
     it('POSTs to the Langfuse OTEL endpoint', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       await adapter.flush(makeTrace())
       expect(mockFetch).toHaveBeenCalledOnce()
       const [url] = mockFetch.mock.calls[0]
@@ -29,7 +33,7 @@ describe('LangfuseAdapter', () => {
     })
 
     it('defaults baseUrl to https://cloud.langfuse.com', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [url] = mockFetch.mock.calls[0]
       expect(url).toMatch(/^https:\/\/cloud\.langfuse\.com/)
@@ -38,8 +42,8 @@ describe('LangfuseAdapter', () => {
     it('uses a custom baseUrl when provided', async () => {
       const adapter = new LangfuseAdapter({
         baseUrl: 'https://eu.cloud.langfuse.com',
-        publicKey: 'public-key-test',
-        secretKey: 'private-key-test',
+        publicKey: LANGFUSE_PUBLIC_KEY,
+        secretKey: LANGFUSE_SECRET_KEY,
         fetch: mockFetch,
       })
       await adapter.flush(makeTrace())
@@ -48,22 +52,22 @@ describe('LangfuseAdapter', () => {
     })
 
     it('sends a Basic Authorization header using publicKey:secretKey', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-abc', secretKey: 'private-key-xyz', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
-      const expected = `Basic ${Buffer.from('public-key-abc:private-key-xyz').toString('base64')}`
+      const expected = `Basic ${Buffer.from(`${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}`).toString('base64')}`
       expect(init.headers['Authorization']).toBe(expected)
     })
 
     it('sends Content-Type: application/json', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
       expect(init.headers['Content-Type']).toBe('application/json')
     })
 
     it('sends a JSON body with a resourceSpans array', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
       const body = JSON.parse(init.body as string)
@@ -72,7 +76,7 @@ describe('LangfuseAdapter', () => {
     })
 
     it('body contains the trace id in resource attributes', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       const trace = makeTrace()
       await adapter.flush(trace)
       const [, init] = mockFetch.mock.calls[0]
@@ -89,7 +93,7 @@ describe('LangfuseAdapter', () => {
     })
 
     it('uses HTTP POST method', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       await adapter.flush(makeTrace())
       const [, init] = mockFetch.mock.calls[0]
       expect(init.method).toBe('POST')
@@ -104,7 +108,7 @@ describe('LangfuseAdapter', () => {
         .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
         .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
       const adapter = new LangfuseAdapter({
-        publicKey: 'public-key', secretKey: 'private-key', fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
+        publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
       })
       await expect(adapter.flush(makeTrace())).resolves.toBeUndefined()
       expect(mockFetch).toHaveBeenCalledTimes(2)
@@ -113,7 +117,7 @@ describe('LangfuseAdapter', () => {
     it('throws after exhausting retries on persistent 5xx', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const adapter = new LangfuseAdapter({
-        publicKey: 'public-key', secretKey: 'private-key', fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
+        publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch, retry: { maxRetries: 2, sleep: sleep() },
       })
       await expect(adapter.flush(makeTrace())).rejects.toThrow('503')
       expect(mockFetch).toHaveBeenCalledTimes(3)
@@ -122,7 +126,7 @@ describe('LangfuseAdapter', () => {
     it('does not retry a 4xx', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' })
       const adapter = new LangfuseAdapter({
-        publicKey: 'public-key', secretKey: 'private-key', fetch: mockFetch, retry: { maxRetries: 3, sleep: sleep() },
+        publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch, retry: { maxRetries: 3, sleep: sleep() },
       })
       await expect(adapter.flush(makeTrace())).rejects.toThrow('401')
       expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -131,12 +135,12 @@ describe('LangfuseAdapter', () => {
 
   describe('ExportAdapter contract — write-only', () => {
     it('queryByTraceId() returns null', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       expect(await adapter.queryByTraceId('any-id')).toBeNull()
     })
 
     it('listTraceIds() returns []', async () => {
-      const adapter = new LangfuseAdapter({ publicKey: 'public-key-test', secretKey: 'private-key-test', fetch: mockFetch })
+      const adapter = new LangfuseAdapter({ publicKey: LANGFUSE_PUBLIC_KEY, secretKey: LANGFUSE_SECRET_KEY, fetch: mockFetch })
       expect(await adapter.listTraceIds()).toEqual([])
     })
   })

--- a/packages/franken-observer/tests/fixtures/langfuse-test-credentials.ts
+++ b/packages/franken-observer/tests/fixtures/langfuse-test-credentials.ts
@@ -1,8 +1,37 @@
-const defaultLangfusePublicKey = ['langfuse', 'public', 'fixture'].join('-');
-const defaultLangfuseSecretKey = ['langfuse', 'secret', 'fixture'].join('-');
+import { existsSync, readFileSync } from 'node:fs';
 
-export const LANGFUSE_PUBLIC_KEY = process.env['LANGFUSE_PUBLIC_KEY']
-  ?? defaultLangfusePublicKey;
+function loadRootTestEnv() {
+  const testEnvUrl = new URL('../../../../.env.test', import.meta.url);
+  if (!existsSync(testEnvUrl)) return;
 
-export const LANGFUSE_SECRET_KEY = process.env['LANGFUSE_SECRET_KEY']
-  ?? defaultLangfuseSecretKey;
+  for (const rawLine of readFileSync(testEnvUrl, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex <= 0) continue;
+    const key = line.slice(0, equalsIndex).trim();
+    const rawValue = line.slice(equalsIndex + 1).trim();
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.replace(/^(['"])(.*)\1$/, '$2');
+  }
+}
+
+function testFixture(key: string, ...defaultParts: string[]) {
+  return process.env[key] ?? defaultParts.join('-');
+}
+
+loadRootTestEnv();
+
+export const LANGFUSE_PUBLIC_KEY = testFixture(
+  'FRANKEN_TEST_LANGFUSE_PUBLIC_KEY',
+  'langfuse',
+  'public',
+  'fixture',
+);
+
+export const LANGFUSE_SECRET_KEY = testFixture(
+  'FRANKEN_TEST_LANGFUSE_SECRET_KEY',
+  'langfuse',
+  'secret',
+  'fixture',
+);

--- a/packages/franken-observer/tests/fixtures/langfuse-test-credentials.ts
+++ b/packages/franken-observer/tests/fixtures/langfuse-test-credentials.ts
@@ -1,0 +1,8 @@
+const defaultLangfusePublicKey = ['langfuse', 'public', 'fixture'].join('-');
+const defaultLangfuseSecretKey = ['langfuse', 'secret', 'fixture'].join('-');
+
+export const LANGFUSE_PUBLIC_KEY = process.env['LANGFUSE_PUBLIC_KEY']
+  ?? defaultLangfusePublicKey;
+
+export const LANGFUSE_SECRET_KEY = process.env['LANGFUSE_SECRET_KEY']
+  ?? defaultLangfuseSecretKey;

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -1,10 +1,6 @@
-import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 import { readVitestFlags } from '../../scripts/vitest-env.js'
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js'
-import { fileURLToPath } from 'node:url'
-
-const packageRoot = dirname(fileURLToPath(import.meta.url))
 const vitestFlags = readVitestFlags(['INTEGRATION', 'EVAL'])
 const isIntegration = vitestFlags.INTEGRATION
 const isEval = vitestFlags.EVAL
@@ -22,7 +18,6 @@ export default defineConfig({
       : isEval
         ? ['src/**/*.eval.test.ts']
         : ['src/**/*.test.ts'],
-    envFile: resolve(packageRoot, '../../.env.test'),
     exclude: isIntegration || isEval
       ? []
       : ['src/**/*.integration.test.ts', 'src/**/*.eval.test.ts'],

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -1,7 +1,10 @@
+import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 import { readVitestFlags } from '../../scripts/vitest-env.js'
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js'
+import { fileURLToPath } from 'node:url'
 
+const packageRoot = dirname(fileURLToPath(import.meta.url))
 const vitestFlags = readVitestFlags(['INTEGRATION', 'EVAL'])
 const isIntegration = vitestFlags.INTEGRATION
 const isEval = vitestFlags.EVAL
@@ -19,6 +22,7 @@ export default defineConfig({
       : isEval
         ? ['src/**/*.eval.test.ts']
         : ['src/**/*.test.ts'],
+    envFile: resolve(packageRoot, '../../.env.test'),
     exclude: isIntegration || isEval
       ? []
       : ['src/**/*.integration.test.ts', 'src/**/*.eval.test.ts'],

--- a/packages/franken-orchestrator/tests/integration/__fixtures__/operator-test-tokens.ts
+++ b/packages/franken-orchestrator/tests/integration/__fixtures__/operator-test-tokens.ts
@@ -1,13 +1,60 @@
-const token = (...parts: string[]) => parts.join('-');
+import { existsSync, readFileSync } from 'node:fs';
 
-export const DASHBOARD_OPERATOR_TOKEN = process.env['DASHBOARD_OPERATOR_TOKEN']
-  ?? token('dashboard', 'operator', 'fixture');
+function loadRootTestEnv() {
+  const testEnvUrl = new URL('../../../../../.env.test', import.meta.url);
+  if (!existsSync(testEnvUrl)) return;
 
-export const CHAT_OPERATOR_TOKEN = process.env['CHAT_OPERATOR_TOKEN']
-  ?? token('chat', 'operator', 'fixture');
+  for (const rawLine of readFileSync(testEnvUrl, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex <= 0) continue;
+    const key = line.slice(0, equalsIndex).trim();
+    const rawValue = line.slice(equalsIndex + 1).trim();
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.replace(/^(['"])(.*)\1$/, '$2');
+  }
+}
 
-export const BEAST_OPERATOR_TOKEN = process.env['BEAST_OPERATOR_TOKEN']
-  ?? token('beast', 'operator', 'fixture');
+function token(key: string, ...defaultParts: string[]) {
+  return process.env[key] ?? defaultParts.join('-');
+}
 
-export const SHARED_OPERATOR_TOKEN = process.env['SHARED_OPERATOR_TOKEN']
-  ?? token('shared', 'operator', 'fixture');
+loadRootTestEnv();
+
+export const DASHBOARD_OPERATOR_TOKEN = token(
+  'FRANKEN_TEST_DASHBOARD_OPERATOR_TOKEN',
+  'dashboard',
+  'operator',
+  'fixture',
+);
+
+export const CHAT_OPERATOR_TOKEN = token(
+  'FRANKEN_TEST_CHAT_OPERATOR_TOKEN',
+  'chat',
+  'operator',
+  'fixture',
+);
+
+export const BEAST_OPERATOR_TOKEN = token(
+  'FRANKEN_TEST_BEAST_OPERATOR_TOKEN',
+  'beast',
+  'operator',
+  'fixture',
+);
+
+export const SHARED_OPERATOR_TOKEN = token(
+  'FRANKEN_TEST_SHARED_OPERATOR_TOKEN',
+  'shared',
+  'operator',
+  'fixture',
+);
+
+export const MISMATCH_CHAT_OPERATOR_TOKEN = token(
+  'FRANKEN_TEST_MISMATCH_CHAT_OPERATOR_TOKEN',
+  'chat',
+  'mismatch',
+  'fixture',
+);
+
+export const MISMATCH_BEAST_OPERATOR_TOKEN = `${MISMATCH_CHAT_OPERATOR_TOKEN}-beast`;

--- a/packages/franken-orchestrator/tests/integration/__fixtures__/operator-test-tokens.ts
+++ b/packages/franken-orchestrator/tests/integration/__fixtures__/operator-test-tokens.ts
@@ -1,0 +1,13 @@
+const token = (...parts: string[]) => parts.join('-');
+
+export const DASHBOARD_OPERATOR_TOKEN = process.env['DASHBOARD_OPERATOR_TOKEN']
+  ?? token('dashboard', 'operator', 'fixture');
+
+export const CHAT_OPERATOR_TOKEN = process.env['CHAT_OPERATOR_TOKEN']
+  ?? token('chat', 'operator', 'fixture');
+
+export const BEAST_OPERATOR_TOKEN = process.env['BEAST_OPERATOR_TOKEN']
+  ?? token('beast', 'operator', 'fixture');
+
+export const SHARED_OPERATOR_TOKEN = process.env['SHARED_OPERATOR_TOKEN']
+  ?? token('shared', 'operator', 'fixture');

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-security.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-security.test.ts
@@ -14,6 +14,9 @@ import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
+import {
+  BEAST_OPERATOR_TOKEN,
+} from '../__fixtures__/operator-test-tokens.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/beast-security');
@@ -50,7 +53,7 @@ function createSecuredApp(rateLimitMax = 1) {
       interviews: new BeastInterviewService(repository, catalog),
       metrics,
       security: new TransportSecurityService(),
-      operatorToken: 'super-secret-operator-token',
+      operatorToken: BEAST_OPERATOR_TOKEN,
       eventBus: new BeastEventBus(),
       ticketStore: new SseConnectionTicketStore(),
       rateLimit: {
@@ -77,7 +80,7 @@ describe('beast route security', () => {
   it('rate limits repeated dispatch attempts', async () => {
     const app = createSecuredApp(1);
     const headers = {
-      authorization: 'Bearer super-secret-operator-token',
+      authorization: ['Bearer', BEAST_OPERATOR_TOKEN].join(' '),
       'content-type': 'application/json',
     };
 

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -9,6 +9,12 @@ import {
   CHAT_SOCKET_PROTOCOL,
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
 } from '../../../src/http/ws-chat-server.js';
+import {
+  CHAT_OPERATOR_TOKEN,
+  BEAST_OPERATOR_TOKEN,
+  DASHBOARD_OPERATOR_TOKEN,
+  SHARED_OPERATOR_TOKEN,
+} from '../__fixtures__/operator-test-tokens.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/chat-server');
@@ -162,7 +168,7 @@ describe('chat server bootstrap', () => {
       beastControl: {
         ...beastServices,
         security: new TransportSecurityService(),
-        operatorToken: 'dashboard-operator-token',
+        operatorToken: DASHBOARD_OPERATOR_TOKEN,
         rateLimit: {
           windowMs: 60_000,
           max: 20,
@@ -173,7 +179,7 @@ describe('chat server bootstrap', () => {
     try {
       const response = await fetch(`${server.url}/v1/beasts/catalog`, {
         headers: {
-          authorization: 'Bearer dashboard-operator-token',
+          authorization: ['Bearer', DASHBOARD_OPERATOR_TOKEN].join(' '),
         },
       });
 
@@ -262,11 +268,11 @@ describe('chat server bootstrap', () => {
         sessionStoreDir: join(TMP, 'chat'),
         llm: { complete: vi.fn().mockResolvedValue('') },
         projectName: 'test-project',
-        operatorToken: 'chat-token',
+        operatorToken: CHAT_OPERATOR_TOKEN,
         beastControl: {
           ...beastServices,
           security: new TransportSecurityService(),
-          operatorToken: 'beast-token',
+          operatorToken: BEAST_OPERATOR_TOKEN,
           rateLimit: { windowMs: 60_000, max: 20 },
         },
       })).rejects.toThrow(/different operator tokens/i);
@@ -287,11 +293,11 @@ describe('chat server bootstrap', () => {
       sessionStoreDir: join(TMP, 'chat'),
       llm: { complete: vi.fn().mockResolvedValue('') },
       projectName: 'test-project',
-      operatorToken: 'shared-token',
+      operatorToken: SHARED_OPERATOR_TOKEN,
       beastControl: {
         ...beastServices,
         security: new TransportSecurityService(),
-        operatorToken: 'shared-token',
+        operatorToken: SHARED_OPERATOR_TOKEN,
         rateLimit: { windowMs: 60_000, max: 20 },
       },
     });
@@ -325,11 +331,11 @@ describe('chat server bootstrap', () => {
       sessionStoreDir: join(TMP, 'chat'),
       llm: { complete: vi.fn().mockResolvedValue('') },
       projectName: 'test-project',
-      operatorToken: 'shared-token',
+      operatorToken: SHARED_OPERATOR_TOKEN,
       beastControl: {
         ...beastServices,
         security: new TransportSecurityService(),
-        operatorToken: 'shared-token',
+        operatorToken: SHARED_OPERATOR_TOKEN,
         rateLimit: { windowMs: 60_000, max: 20 },
       },
     });
@@ -352,23 +358,27 @@ describe('chat server bootstrap', () => {
       sessionStoreDir: join(TMP, 'chat'),
       llm: { complete: vi.fn().mockResolvedValue('') },
       projectName: 'test-project',
-      operatorToken: 'shared-token',
+      operatorToken: SHARED_OPERATOR_TOKEN,
       beastControl: {
         ...beastServices,
         security: new TransportSecurityService(),
-        operatorToken: 'shared-token',
+        operatorToken: SHARED_OPERATOR_TOKEN,
         rateLimit: { windowMs: 60_000, max: 20 },
       },
     });
 
     const ticketResponse = await fetch(`${server.url}/v1/beasts/events/ticket`, {
       method: 'POST',
-      headers: { authorization: 'Bearer shared-token' },
+      headers: {
+        authorization: ['Bearer', SHARED_OPERATOR_TOKEN].join(' '),
+      },
     });
     expect(ticketResponse.status).toBe(200);
     const ticketBody = await ticketResponse.json() as { ticket: string };
     const streamResponse = await fetch(`${server.url}/v1/beasts/events/stream?ticket=${ticketBody.ticket}`, {
-      headers: { authorization: 'Bearer shared-token' },
+      headers: {
+        authorization: ['Bearer', SHARED_OPERATOR_TOKEN].join(' '),
+      },
     });
     expect(streamResponse.status).toBe(200);
 
@@ -387,7 +397,7 @@ describe('chat server bootstrap', () => {
       sessionStoreDir: TMP,
       llm: { complete: vi.fn().mockResolvedValue('') },
       projectName: 'test-project',
-      operatorToken: 'shared-token',
+      operatorToken: SHARED_OPERATOR_TOKEN,
     })).rejects.toThrow(/non-loopback host/);
   });
 

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -10,9 +10,9 @@ import {
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
 } from '../../../src/http/ws-chat-server.js';
 import {
-  CHAT_OPERATOR_TOKEN,
-  BEAST_OPERATOR_TOKEN,
   DASHBOARD_OPERATOR_TOKEN,
+  MISMATCH_BEAST_OPERATOR_TOKEN,
+  MISMATCH_CHAT_OPERATOR_TOKEN,
   SHARED_OPERATOR_TOKEN,
 } from '../__fixtures__/operator-test-tokens.js';
 
@@ -268,11 +268,11 @@ describe('chat server bootstrap', () => {
         sessionStoreDir: join(TMP, 'chat'),
         llm: { complete: vi.fn().mockResolvedValue('') },
         projectName: 'test-project',
-        operatorToken: CHAT_OPERATOR_TOKEN,
+        operatorToken: MISMATCH_CHAT_OPERATOR_TOKEN,
         beastControl: {
           ...beastServices,
           security: new TransportSecurityService(),
-          operatorToken: BEAST_OPERATOR_TOKEN,
+          operatorToken: MISMATCH_BEAST_OPERATOR_TOKEN,
           rateLimit: { windowMs: 60_000, max: 20 },
         },
       })).rejects.toThrow(/different operator tokens/i);

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { readVitestFlags } from '../../scripts/vitest-env.js';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
@@ -26,6 +26,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    envFile: resolve(packageRoot, '../../.env.test'),
     globals: false,
     environment: 'node',
     include: runMixed

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { readVitestFlags } from '../../scripts/vitest-env.js';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
@@ -26,7 +26,6 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    envFile: resolve(packageRoot, '../../.env.test'),
     globals: false,
     environment: 'node',
     include: runMixed


### PR DESCRIPTION
## Summary
- moves listed Langfuse and operator-token test fixtures behind env-backed fixture helpers
- loads optional root `.env.test` in affected Vitest configs and ignores it in Git
- updates Langfuse docs snippet to read keys from the environment

## Test Plan
- npm run test --workspace @franken/observer -- --run src/adapters/langfuse/LangfuseAdapter.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run test --workspace @franken/orchestrator -- --run tests/integration/beasts/beast-security.test.ts tests/integration/chat/chat-server.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint:any
- custom scan: no issue #519 listed hard-coded credential placeholders remain in touched files

Closes #519