### PR TITLE
fix(orchestrator): bound CLI rate-limit retries

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -70,6 +70,8 @@ export interface CliLlmAdapterOpts {
   registry?: ProviderRegistry | undefined;
   /** Per-provider command/model overrides. */
   providerOverrides?: Record<string, ProviderOverride> | undefined;
+  /** Maximum all-provider rate-limit retry cycles before surfacing a terminal error. */
+  maxRateLimitRetries?: number | undefined;
   /** @internal Injectable sleep for tests. */
   _sleepFn?: ((durationMs: number) => Promise<void>) | undefined;
 }
@@ -87,6 +89,7 @@ export class CliLlmAdapter implements IAdapter {
     replayRunId?: ReplayRunId | undefined;
     providers?: readonly string[] | undefined;
     providerOverrides?: Record<string, ProviderOverride> | undefined;
+    maxRateLimitRetries: number;
     _sleepFn?: ((durationMs: number) => Promise<void>) | undefined;
   };
   private readonly _spawn: SpawnFn;
@@ -112,6 +115,7 @@ export class CliLlmAdapter implements IAdapter {
       ...(opts.replayRunId !== undefined ? { replayRunId: opts.replayRunId } : {}),
       ...(opts.providers !== undefined ? { providers: opts.providers } : {}),
       ...(opts.providerOverrides !== undefined ? { providerOverrides: opts.providerOverrides } : {}),
+      maxRateLimitRetries: normalizeRateLimitRetryLimit(opts.maxRateLimitRetries),
       ...(opts._sleepFn !== undefined ? { _sleepFn: opts._sleepFn } : {}),
     };
     this._spawn = _spawnFn ?? (nodeSpawn as SpawnFn);
@@ -156,6 +160,7 @@ export class CliLlmAdapter implements IAdapter {
     const sleepFn = this.opts._sleepFn ?? defaultSleep;
     const initialProvider = this.provider.name;
     let activeProvider = initialProvider;
+    let rateLimitRetryCycles = 0;
 
     while (true) {
       const provider = this.resolveProvider(activeProvider);
@@ -214,8 +219,14 @@ export class CliLlmAdapter implements IAdapter {
             continue;
           }
           if (hasRateLimitedProvider(exhaustedProviders)) {
+            if (rateLimitRetryCycles >= this.opts.maxRateLimitRetries) {
+              throw new Error(buildRateLimitRetryExhaustedSummary(exhaustedProviders, rateLimitRetryCycles), {
+                cause: lastRateLimitedFailure(exhaustedProviders),
+              });
+            }
             const sleepMs = this.resolveSleepMs(exhaustedProviders);
             await sleepFn(sleepMs);
+            rateLimitRetryCycles++;
             exhaustedProviders.clear();
             activeProvider = initialProvider;
             continue;
@@ -285,7 +296,13 @@ export class CliLlmAdapter implements IAdapter {
       }
 
       const sleepMs = this.resolveSleepMs(exhaustedProviders);
+      if (rateLimitRetryCycles >= this.opts.maxRateLimitRetries) {
+        throw new Error(buildRateLimitRetryExhaustedSummary(exhaustedProviders, rateLimitRetryCycles), {
+          cause: lastRateLimitedFailure(exhaustedProviders),
+        });
+      }
       await sleepFn(sleepMs);
+      rateLimitRetryCycles++;
       exhaustedProviders.clear();
       activeProvider = initialProvider;
     }
@@ -477,6 +494,34 @@ function normalizeProviderChain(
 
 function hasRateLimitedProvider(exhaustedProviders: Map<string, CommandFailure>): boolean {
   return [...exhaustedProviders.values()].some((failure) => failure.rateLimited);
+}
+
+function lastRateLimitedFailure(exhaustedProviders: Map<string, CommandFailure>): CommandFailure | undefined {
+  return [...exhaustedProviders.values()].reverse().find((failure) => failure.rateLimited);
+}
+
+function normalizeRateLimitRetryLimit(limit: number | undefined): number {
+  if (limit === undefined) return 3;
+  if (!Number.isFinite(limit)) return 3;
+  return Math.max(0, Math.floor(limit));
+}
+
+function buildRateLimitRetryExhaustedSummary(
+  exhaustedProviders: Map<string, CommandFailure>,
+  retryCycles: number,
+): string {
+  const providerSummaries = [...exhaustedProviders.entries()]
+    .map(([provider, failure]) => {
+      const retryAfter = failure.retryAfterMs !== undefined ? `; retry after ${failure.retryAfterMs}ms` : '';
+      return `${provider}: ${failure.summary}${retryAfter}`;
+    })
+    .join(' | ');
+  const cycleLabel = retryCycles === 1 ? 'retry cycle' : 'retry cycles';
+  return [
+    `All configured LLM providers remained rate limited after ${retryCycles} ${cycleLabel}.`,
+    providerSummaries ? `Last failures: ${providerSummaries}.` : '',
+    'Wait for provider quota reset, reduce request concurrency, or configure an available fallback provider.',
+  ].filter(Boolean).join(' ');
 }
 
 function buildNoCliProvidersAvailableSummary(exhaustedProviders: Map<string, CommandFailure>): string {

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -668,6 +668,32 @@ describe('CliLlmAdapter', () => {
         expect(calls[2]!.cmd).toBe('claude');
       });
 
+      it('stops retrying when every configured provider remains rate limited beyond the retry cap', async () => {
+        const sleepFn = vi.fn(async () => {});
+        const { spawnFn, calls } = createQueuedSpawn([
+          { stderr: 'claude retry-after: 1', exitCode: 1 },
+          { stderr: 'codex retry-after: 1', exitCode: 1 },
+          { stderr: 'claude still rate limited retry-after: 1', exitCode: 1 },
+          { stderr: 'codex still rate limited retry-after: 1', exitCode: 1 },
+          { stdout: 'would only happen if retry loop is unbounded', exitCode: 0 },
+        ]);
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providers: ['claude', 'codex'],
+            maxRateLimitRetries: 1,
+            _sleepFn: sleepFn,
+          } as never,
+          spawnFn,
+        );
+
+        await expect(adapter.execute({ prompt: 'test', maxTurns: 1 }))
+          .rejects.toThrow('All configured LLM providers remained rate limited after 1 retry cycle');
+        expect(sleepFn).toHaveBeenCalledTimes(1);
+        expect(calls).toHaveLength(4);
+      });
+
       it('does not forward the selected provider model to fallback providers in chat mode', async () => {
         const { spawnFn, calls } = createQueuedSpawn([
           { stderr: 'rate limit exceeded', exitCode: 1 },


### PR DESCRIPTION
## Summary
- Adds a bounded all-provider rate-limit retry cap to CliLlmAdapter.
- Surfaces an actionable terminal error after the cap is exceeded.
- Adds a regression test proving the adapter stops before an otherwise unbounded retry loop can recover.

## Test Plan
- npm test -- --run tests/unit/adapters/cli-llm-adapter.test.ts --testNamePattern 'stops retrying when every configured provider remains rate limited'
- npm test -- --run tests/unit/adapters/cli-llm-adapter.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm run typecheck (packages/franken-orchestrator)
- npm run build (packages/franken-orchestrator)
- npm run lint (packages/franken-orchestrator; warnings only, pre-existing)
- npm test (packages/franken-orchestrator)

Closes #758