### PR TITLE
fix(orchestrator): validate network subprocess specs

### DIFF
--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { open } from 'node:fs/promises';
 import { Socket } from 'node:net';
-import { dirname, delimiter, join } from 'node:path';
+import { dirname, delimiter, join, sep } from 'node:path';
 import type { ManagedNetworkServiceState } from './network-state-store.js';
 import type { ResolvedNetworkService } from './network-registry.js';
 import type { PreflightServiceResult, StartServiceOptions } from './network-supervisor.js';
@@ -136,14 +136,53 @@ function validateNetworkServiceEnv(service: ResolvedNetworkService): void {
   }
 }
 
+// Resolve the `npm` binary on PATH to its real target. Distro packages that
+// ship npm separately from node (e.g. Debian's /usr/bin/npm) symlink the
+// launcher to the real `npm-cli.js`, so following the link yields a trusted
+// CLI script we can run directly with node — without spawning a shell or an
+// npm shim. Returns null if npm is absent or does not resolve to an npm-cli.js.
+function resolveNpmCliFromPath(): string | null {
+  const pathDirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  for (const dir of pathDirs) {
+    const candidate = join(dir, 'npm');
+    if (!existsSync(candidate)) continue;
+    try {
+      const real = realpathSync(candidate);
+      if (real.endsWith(`${sep}npm-cli.js`) && existsSync(real)) {
+        return real;
+      }
+    } catch {
+      // ignore unreadable/broken symlinks and keep searching
+    }
+  }
+  return null;
+}
+
 function resolveNpmCliPath(): string {
+  const execDir = dirname(process.execPath);
+  // Also consider the realpath of node itself (nvm/distro symlink node into a
+  // versioned dir); npm is colocated relative to the real binary, not the link.
+  let realExecDir = execDir;
+  try {
+    realExecDir = dirname(realpathSync(process.execPath));
+  } catch {
+    // fall back to the symlinked location
+  }
   const npmCliPathCandidates = [
-    join(dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-    join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    // Bundled node+npm (nvm, official installers, most images).
+    join(execDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(execDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(realExecDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(realExecDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    // Common distro layouts where npm is packaged separately from node.
+    join('/usr', 'share', 'nodejs', 'npm', 'bin', 'npm-cli.js'),
+    join('/usr', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
   ];
-  const npmCliPath = npmCliPathCandidates.find((candidate) => existsSync(candidate));
+  const npmCliPath = npmCliPathCandidates.find((candidate) => existsSync(candidate)) ?? resolveNpmCliFromPath();
   if (!npmCliPath) {
-    throw new Error(`Unable to locate trusted npm CLI next to ${process.execPath}`);
+    throw new Error(
+      `Unable to locate a trusted npm CLI (checked locations relative to ${process.execPath}, common distro paths, and the npm launcher on PATH)`,
+    );
   }
   return npmCliPath;
 }

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { open } from 'node:fs/promises';
 import { Socket } from 'node:net';
+import { dirname, join } from 'node:path';
 import type { ManagedNetworkServiceState } from './network-state-store.js';
 import type { ResolvedNetworkService } from './network-registry.js';
 import type { PreflightServiceResult, StartServiceOptions } from './network-supervisor.js';
@@ -15,9 +17,62 @@ const ALLOWED_NETWORK_SERVICE_COMMANDS: Partial<Record<ResolvedNetworkService['i
   'dashboard-web': ['node', 'node.exe'],
 };
 
+const ALLOWED_NETWORK_SERVICE_ENV_KEYS: Partial<Record<ResolvedNetworkService['id'], readonly string[]>> = {
+  'beasts-daemon': ['FRANKENBEAST_NETWORK_MANAGED', 'FRANKENBEAST_BEAST_DAEMON_URL'],
+  'chat-server': ['FRANKENBEAST_NETWORK_MANAGED', 'FRANKENBEAST_BEAST_DAEMON_URL'],
+  'dashboard-web': [
+    'FRANKENBEAST_CONFIG_FILE',
+    'FRANKENBEAST_DASHBOARD_API_URL',
+    'FRANKENBEAST_DASHBOARD_HOST',
+    'FRANKENBEAST_DASHBOARD_PORT',
+  ],
+};
+
+interface ValidatedProcessSpec {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}
+
 function assertSafeProcessValue(serviceId: string, field: string, value: string): void {
   if (!SAFE_PROCESS_VALUE_RE.test(value)) {
     throw new Error(`Unsafe network service ${field} for ${serviceId}`);
+  }
+}
+
+function assertExpectedArg(condition: boolean, serviceId: string): void {
+  if (!condition) {
+    throw new Error(`Unsafe network service arguments for ${serviceId}`);
+  }
+}
+
+function assertPortArg(serviceId: string, value: string): void {
+  assertExpectedArg(/^\d+$/.test(value), serviceId);
+}
+
+function validateNpmServiceArgs(serviceId: 'beasts-daemon' | 'chat-server', args: string[]): void {
+  assertExpectedArg(args.length >= 10, serviceId);
+  assertExpectedArg(args[0] === '--silent', serviceId);
+  assertExpectedArg(args[1] === '--workspace', serviceId);
+  assertExpectedArg(args[2] === '@franken/orchestrator', serviceId);
+  assertExpectedArg(args[3] === 'run', serviceId);
+  assertExpectedArg(args[4] === serviceId, serviceId);
+  assertExpectedArg(args[5] === '--', serviceId);
+  assertExpectedArg(args[6] === '--host', serviceId);
+  assertExpectedArg(args[8] === '--port', serviceId);
+  assertPortArg(serviceId, args[9] ?? '');
+
+  if (serviceId === 'beasts-daemon') {
+    assertExpectedArg(args.length === 10, serviceId);
+    return;
+  }
+
+  for (let index = 10; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    assertExpectedArg(value !== undefined, serviceId);
+    assertExpectedArg(flag === '--config' || flag === '--set', serviceId);
   }
 }
 
@@ -32,6 +87,98 @@ function validateDashboardBuildCommand(service: ResolvedNetworkService): void {
   if (!buildCommand || !['npm', 'npm.cmd'].includes(buildCommand)) {
     throw new Error(`Unsafe dashboard build command for ${service.id}: ${buildCommand ?? '<missing>'}`);
   }
+}
+
+function validateDashboardArgs(args: string[]): void {
+  const serviceId = 'dashboard-web';
+  assertExpectedArg(args.length === 16, serviceId);
+  assertExpectedArg(args[0] === 'packages/franken-orchestrator/dist/http/dashboard-static-server.js', serviceId);
+  assertExpectedArg(args[1] === '--host', serviceId);
+  assertExpectedArg(args[3] === '--port', serviceId);
+  assertPortArg(serviceId, args[4] ?? '');
+  assertExpectedArg(args[5] === '--static-dir', serviceId);
+  assertExpectedArg(args[6] === 'packages/franken-web/dist', serviceId);
+  assertExpectedArg(args[7] === '--api-target', serviceId);
+  assertExpectedArg(args[9] === '--build-command', serviceId);
+  assertExpectedArg(args[11] === '--build-args', serviceId);
+  assertExpectedArg(args[12] === '--workspace', serviceId);
+  assertExpectedArg(args[13] === '@franken/web', serviceId);
+  assertExpectedArg(args[14] === 'run', serviceId);
+  assertExpectedArg(args[15] === 'build', serviceId);
+}
+
+function validateNetworkServiceArgs(service: ResolvedNetworkService): void {
+  const processSpec = service.runtimeConfig.process;
+  if (!processSpec) {
+    return;
+  }
+  if (service.id === 'beasts-daemon' || service.id === 'chat-server') {
+    validateNpmServiceArgs(service.id, processSpec.args);
+    return;
+  }
+  if (service.id === 'dashboard-web') {
+    validateDashboardArgs(processSpec.args);
+  }
+}
+
+function validateNetworkServiceEnv(service: ResolvedNetworkService): void {
+  const processSpec = service.runtimeConfig.process;
+  if (!processSpec) {
+    return;
+  }
+  const allowedKeys = ALLOWED_NETWORK_SERVICE_ENV_KEYS[service.id] ?? [];
+  for (const [key, value] of Object.entries(processSpec.env ?? {})) {
+    if (key.includes('=') || !allowedKeys.includes(key)) {
+      throw new Error(`Unsafe network service environment key ${key} for ${service.id}`);
+    }
+    assertSafeProcessValue(service.id, `environment key ${key}`, key);
+    assertSafeProcessValue(service.id, `environment value ${key}`, value);
+  }
+}
+
+function resolveNpmCliPath(): string {
+  const npmCliPath = join(dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+  if (!existsSync(npmCliPath)) {
+    throw new Error(`Unable to locate trusted npm CLI next to ${process.execPath}`);
+  }
+  return npmCliPath;
+}
+
+function buildNetworkProcessEnv(processSpecEnv: Record<string, string> | undefined): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.NODE_OPTIONS;
+  delete env.npm_config_node_options;
+  return {
+    ...env,
+    ...processSpecEnv,
+    PATH: `${dirname(process.execPath)}:/usr/bin:/bin`,
+  };
+}
+
+function buildValidatedProcessSpec(service: ResolvedNetworkService): ValidatedProcessSpec {
+  validateNetworkProcessSpec(service);
+  const processSpec = service.runtimeConfig.process;
+  if (!processSpec) {
+    throw new Error(`Service ${service.id} does not have a runnable entrypoint yet`);
+  }
+  const env = buildNetworkProcessEnv(processSpec.env);
+  if (processSpec.command === 'npm' || processSpec.command === 'npm.cmd') {
+    return {
+      command: process.execPath,
+      args: [resolveNpmCliPath(), ...processSpec.args],
+      cwd: processSpec.cwd,
+      env,
+    };
+  }
+  if (processSpec.command === 'node' || processSpec.command === 'node.exe') {
+    return {
+      command: process.execPath,
+      args: processSpec.args,
+      cwd: processSpec.cwd,
+      env,
+    };
+  }
+  throw new Error(`Unsafe network service command for ${service.id}: ${processSpec.command}`);
 }
 
 function validateNetworkProcessSpec(service: ResolvedNetworkService): void {
@@ -49,13 +196,8 @@ function validateNetworkProcessSpec(service: ResolvedNetworkService): void {
     assertSafeProcessValue(service.id, 'argument', arg);
   }
   assertSafeProcessValue(service.id, 'working directory', processSpec.cwd);
-  for (const [key, value] of Object.entries(processSpec.env ?? {})) {
-    if (key.includes('=')) {
-      throw new Error(`Unsafe network service environment key ${key} for ${service.id}`);
-    }
-    assertSafeProcessValue(service.id, `environment key ${key}`, key);
-    assertSafeProcessValue(service.id, `environment value ${key}`, value);
-  }
+  validateNetworkServiceArgs(service);
+  validateNetworkServiceEnv(service);
   validateDashboardBuildCommand(service);
 }
 
@@ -67,16 +209,13 @@ export async function startNetworkService(
   if (!processSpec) {
     throw new Error(`Service ${service.id} does not have a runnable entrypoint yet`);
   }
-  validateNetworkProcessSpec(service);
+  const validatedProcessSpec = buildValidatedProcessSpec(service);
 
   if (options.detached) {
     const handle = await open(options.logFile ?? '/dev/null', 'a');
-    const child = spawn(processSpec.command, processSpec.args, {
-      cwd: processSpec.cwd,
-      env: {
-        ...process.env,
-        ...processSpec.env,
-      },
+    const child = spawn(validatedProcessSpec.command, validatedProcessSpec.args, {
+      cwd: validatedProcessSpec.cwd,
+      env: validatedProcessSpec.env,
       detached: true,
       stdio: ['ignore', handle.fd, handle.fd],
     });
@@ -91,12 +230,9 @@ export async function startNetworkService(
     return { pid: child.pid };
   }
 
-  const child = spawn(processSpec.command, processSpec.args, {
-    cwd: processSpec.cwd,
-    env: {
-      ...process.env,
-      ...processSpec.env,
-    },
+  const child = spawn(validatedProcessSpec.command, validatedProcessSpec.args, {
+    cwd: validatedProcessSpec.cwd,
+    env: validatedProcessSpec.env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -7,6 +7,57 @@ import type { PreflightServiceResult, StartServiceOptions } from './network-supe
 
 const PORT_CHECK_TIMEOUT_MS = 300;
 const HTTP_CHECK_TIMEOUT_MS = 1_000;
+const SAFE_PROCESS_VALUE_RE = /^[^\x00-\x1f\x7f]*$/;
+
+const ALLOWED_NETWORK_SERVICE_COMMANDS: Partial<Record<ResolvedNetworkService['id'], readonly string[]>> = {
+  'beasts-daemon': ['npm', 'npm.cmd'],
+  'chat-server': ['npm', 'npm.cmd'],
+  'dashboard-web': ['node', 'node.exe'],
+};
+
+function assertSafeProcessValue(serviceId: string, field: string, value: string): void {
+  if (!SAFE_PROCESS_VALUE_RE.test(value)) {
+    throw new Error(`Unsafe network service ${field} for ${serviceId}`);
+  }
+}
+
+function validateDashboardBuildCommand(service: ResolvedNetworkService): void {
+  if (service.id !== 'dashboard-web') {
+    return;
+  }
+
+  const processSpec = service.runtimeConfig.process;
+  const buildCommandIndex = processSpec?.args.indexOf('--build-command') ?? -1;
+  const buildCommand = buildCommandIndex >= 0 ? processSpec?.args[buildCommandIndex + 1] : undefined;
+  if (!buildCommand || !['npm', 'npm.cmd'].includes(buildCommand)) {
+    throw new Error(`Unsafe dashboard build command for ${service.id}: ${buildCommand ?? '<missing>'}`);
+  }
+}
+
+function validateNetworkProcessSpec(service: ResolvedNetworkService): void {
+  const processSpec = service.runtimeConfig.process;
+  if (!processSpec) {
+    return;
+  }
+
+  const allowedCommands = ALLOWED_NETWORK_SERVICE_COMMANDS[service.id] ?? [];
+  if (!allowedCommands.includes(processSpec.command)) {
+    throw new Error(`Unsafe network service command for ${service.id}: ${processSpec.command}`);
+  }
+
+  for (const arg of processSpec.args) {
+    assertSafeProcessValue(service.id, 'argument', arg);
+  }
+  assertSafeProcessValue(service.id, 'working directory', processSpec.cwd);
+  for (const [key, value] of Object.entries(processSpec.env ?? {})) {
+    if (key.includes('=')) {
+      throw new Error(`Unsafe network service environment key ${key} for ${service.id}`);
+    }
+    assertSafeProcessValue(service.id, `environment key ${key}`, key);
+    assertSafeProcessValue(service.id, `environment value ${key}`, value);
+  }
+  validateDashboardBuildCommand(service);
+}
 
 export async function startNetworkService(
   service: ResolvedNetworkService,
@@ -16,6 +67,7 @@ export async function startNetworkService(
   if (!processSpec) {
     throw new Error(`Service ${service.id} does not have a runnable entrypoint yet`);
   }
+  validateNetworkProcessSpec(service);
 
   if (options.detached) {
     const handle = await open(options.logFile ?? '/dev/null', 'a');

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { open } from 'node:fs/promises';
 import { Socket } from 'node:net';
-import { dirname, join } from 'node:path';
+import { dirname, delimiter, join } from 'node:path';
 import type { ManagedNetworkServiceState } from './network-state-store.js';
 import type { ResolvedNetworkService } from './network-registry.js';
 import type { PreflightServiceResult, StartServiceOptions } from './network-supervisor.js';
@@ -137,21 +137,45 @@ function validateNetworkServiceEnv(service: ResolvedNetworkService): void {
 }
 
 function resolveNpmCliPath(): string {
-  const npmCliPath = join(dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
-  if (!existsSync(npmCliPath)) {
+  const npmCliPathCandidates = [
+    join(dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ];
+  const npmCliPath = npmCliPathCandidates.find((candidate) => existsSync(candidate));
+  if (!npmCliPath) {
     throw new Error(`Unable to locate trusted npm CLI next to ${process.execPath}`);
   }
   return npmCliPath;
 }
 
+function deleteUnsafeInheritedProcessEnv(env: NodeJS.ProcessEnv): void {
+  const deniedKeys = new Set([
+    'node_options',
+    'npm_config_node_options',
+    'npm_config_script_shell',
+    'npm_config_userconfig',
+  ]);
+  for (const key of Object.keys(env)) {
+    if (deniedKeys.has(key.toLowerCase())) {
+      delete env[key];
+    }
+  }
+}
+
+function buildNetworkProcessPath(): string {
+  const pathEntries = process.platform === 'win32'
+    ? [dirname(process.execPath)]
+    : [dirname(process.execPath), '/usr/bin', '/bin'];
+  return pathEntries.join(delimiter);
+}
+
 function buildNetworkProcessEnv(processSpecEnv: Record<string, string> | undefined): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
-  delete env.NODE_OPTIONS;
-  delete env.npm_config_node_options;
+  deleteUnsafeInheritedProcessEnv(env);
   return {
     ...env,
     ...processSpecEnv,
-    PATH: `${dirname(process.execPath)}:/usr/bin:/bin`,
+    PATH: buildNetworkProcessPath(),
   };
 }
 

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -2,7 +2,11 @@ import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { startNetworkService, stopNetworkService } from '../../../src/network/network-supervisor-runtime.js';
 import type { ResolvedNetworkService } from '../../../src/network/network-registry.js';
 
-function makeService(command: string): ResolvedNetworkService {
+function makeService(
+  command: string,
+  overrides: Partial<ResolvedNetworkService['runtimeConfig']['process']> = {},
+  serviceOverrides: Partial<ResolvedNetworkService> = {},
+): ResolvedNetworkService {
   return {
     id: 'chat-server',
     displayName: 'Chat Server',
@@ -13,11 +17,13 @@ function makeService(command: string): ResolvedNetworkService {
     describe: () => 'test service',
     buildRuntimeConfig: () => ({}),
     explanation: 'test service',
+    ...serviceOverrides,
     runtimeConfig: {
       process: {
         command,
         args: [],
         cwd: process.cwd(),
+        ...overrides,
       },
     },
   };
@@ -30,18 +36,69 @@ describe('startNetworkService', () => {
     errorSpy.mockClear();
   });
 
+  it('rejects service commands outside the registry allowlist before spawning', async () => {
+    await expect(startNetworkService(makeService('sh'), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service command for chat-server: sh');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('rejects control characters in configured service arguments before spawning', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      args: ['run', 'chat-server', 'bad\n--extra-flag'],
+    }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service argument for chat-server');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
   afterAll(() => {
     errorSpy.mockRestore();
   });
 
-  it('handles child process error events for missing foreground services without crashing', async () => {
+  it('rejects absolute service commands not owned by the network registry before spawning', async () => {
     await expect(startNetworkService(makeService('/definitely/not-a-real-command-franken-698'), {
       detached: false,
-    })).rejects.toThrow(/Failed to start service chat-server/);
+    })).rejects.toThrow('Unsafe network service command for chat-server');
 
-    await vi.waitFor(() => {
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
-    }, { timeout: 5000 });
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('rejects absolute paths that end in an allowed command basename', async () => {
+    await expect(startNetworkService(makeService('/tmp/npm'), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service command for chat-server: /tmp/npm');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('rejects environment keys that can be serialized as another variable name', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      env: { 'NODE_OPTIONS=--require /tmp/hook': 'x' },
+    }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service environment key NODE_OPTIONS=--require /tmp/hook for chat-server');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('rejects dashboard build commands outside the nested build allowlist', async () => {
+    await expect(startNetworkService(makeService('node', {
+      args: [
+        'packages/franken-orchestrator/dist/http/dashboard-static-server.js',
+        '--build-command',
+        'sh',
+        '--build-args',
+        '-c',
+        'touch /tmp/pwned',
+      ],
+    }, { id: 'dashboard-web' }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe dashboard build command for dashboard-web: sh');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -2,6 +2,38 @@ import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { startNetworkService, stopNetworkService } from '../../../src/network/network-supervisor-runtime.js';
 import type { ResolvedNetworkService } from '../../../src/network/network-registry.js';
 
+const CHAT_SERVER_ARGS = [
+  '--silent',
+  '--workspace',
+  '@franken/orchestrator',
+  'run',
+  'chat-server',
+  '--',
+  '--host',
+  '127.0.0.1',
+  '--port',
+  '4567',
+];
+
+const DASHBOARD_ARGS = [
+  'packages/franken-orchestrator/dist/http/dashboard-static-server.js',
+  '--host',
+  '127.0.0.1',
+  '--port',
+  '5173',
+  '--static-dir',
+  'packages/franken-web/dist',
+  '--api-target',
+  'http://127.0.0.1:4567',
+  '--build-command',
+  'npm',
+  '--build-args',
+  '--workspace',
+  '@franken/web',
+  'run',
+  'build',
+];
+
 function makeService(
   command: string,
   overrides: Partial<ResolvedNetworkService['runtimeConfig']['process']> = {},
@@ -21,7 +53,7 @@ function makeService(
     runtimeConfig: {
       process: {
         command,
-        args: [],
+        args: CHAT_SERVER_ARGS,
         cwd: process.cwd(),
         ...overrides,
       },
@@ -46,7 +78,7 @@ describe('startNetworkService', () => {
 
   it('rejects control characters in configured service arguments before spawning', async () => {
     await expect(startNetworkService(makeService('npm', {
-      args: ['run', 'chat-server', 'bad\n--extra-flag'],
+      args: [...CHAT_SERVER_ARGS, '--set', 'bad\n--extra-flag'],
     }), {
       detached: false,
     })).rejects.toThrow('Unsafe network service argument for chat-server');
@@ -84,15 +116,42 @@ describe('startNetworkService', () => {
     expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
   });
 
+  it('rejects process environment overrides that can redirect launcher resolution', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      env: { PATH: '/tmp/malicious-bin' },
+    }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service environment key PATH for chat-server');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('rejects Node option environment overrides before launching npm services', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      env: { NODE_OPTIONS: '--require /tmp/hook' },
+    }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service environment key NODE_OPTIONS for chat-server');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('rejects unexpected npm launcher subcommands for managed services', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      args: ['exec', 'sh', '-c', 'touch /tmp/pwned'],
+    }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service arguments for chat-server');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
   it('rejects dashboard build commands outside the nested build allowlist', async () => {
     await expect(startNetworkService(makeService('node', {
       args: [
-        'packages/franken-orchestrator/dist/http/dashboard-static-server.js',
-        '--build-command',
+        ...DASHBOARD_ARGS.slice(0, 10),
         'sh',
-        '--build-args',
-        '-c',
-        'touch /tmp/pwned',
+        ...DASHBOARD_ARGS.slice(11),
       ],
     }, { id: 'dashboard-web' }), {
       detached: false,


### PR DESCRIPTION
## Summary
- Adds a network service subprocess allowlist for managed runtime process specs.
- Rejects unsafe commands plus control-character arguments/environment before spawning.
- Updates network supervisor runtime tests for the new fail-closed behavior.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/network/network-supervisor-runtime.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #500