### PR TITLE
fix(security): guard hard-coded example secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "lint:any": "node scripts/audit-explicit-any.mjs",
-    "lint:security": "node scripts/check-plain-http.mjs",
+    "lint:security": "node scripts/check-plain-http.mjs && node scripts/check-hardcoded-secrets.mjs",
     "test": "turbo run test",
     "test:root": "vitest run",
     "test:root:watch": "vitest",

--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const defaultRoot = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const root = process.env.FRANKENBEAST_SECRETS_SCAN_ROOT ?? defaultRoot;
+const scannedExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const sourceRoots = ['packages', 'scripts'];
+const ignoredPathParts = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'coverage',
+  '.turbo',
+  '.vite',
+  'test',
+  'tests',
+  '__tests__',
+  'fixtures',
+]);
+
+const sensitiveEnvNames = [
+  ['AWS', 'ACCESS', 'KEY', 'ID'],
+  ['AWS', 'SECRET', 'ACCESS', 'KEY'],
+  ['JWT', 'SECRET'],
+  ['SECRET', 'KEY'],
+].map((parts) => parts.join('_'));
+
+const sensitiveNamePattern = new RegExp(`\\b(?:${sensitiveEnvNames.join('|')})\\b`, 'i');
+const stringLiteralPattern = /(['"`])((?:\\.|(?!\1).)*)\1/g;
+
+function printLine(...args) {
+  console.info(...args);
+}
+
+function extensionOf(path) {
+  const match = /\.[^.]+$/.exec(path);
+  return match?.[0] ?? '';
+}
+
+function toRepoPath(path) {
+  return relative(root, path).split(sep).join('/');
+}
+
+function shouldScanSource(path) {
+  const rel = toRepoPath(path);
+  const parts = rel.split('/');
+  if (parts.some((part) => ignoredPathParts.has(part))) {
+    return false;
+  }
+  if (/\.(test|spec)\.[cm]?[jt]sx?$/.test(path)) {
+    return false;
+  }
+  return scannedExtensions.has(extensionOf(path));
+}
+
+async function* walk(dir, shouldScan) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!ignoredPathParts.has(entry.name)) {
+        yield* walk(fullPath, shouldScan);
+      }
+      continue;
+    }
+    if (entry.isFile() && shouldScan(fullPath)) {
+      yield fullPath;
+    }
+  }
+}
+
+async function collectEnvironmentExampleFiles() {
+  const files = [];
+  for await (const file of walk(root, (path) => /(^|\/)\.env(?:\.[^/]*)?example$|(^|\/)example\.env$/i.test(path))) {
+    files.push(file);
+  }
+  return files;
+}
+
+function hasHardcodedSensitiveEnvValue(line) {
+  const trimmed = line.trimStart();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return false;
+  }
+  const match = trimmed.match(/^([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS)[A-Z0-9_]*)=(.*)$/);
+  if (!match) {
+    return false;
+  }
+  const [, name, value] = match;
+  return sensitiveNamePattern.test(name) && value.trim().length > 0;
+}
+
+function hasHardcodedSensitiveSourceValue(line) {
+  const trimmed = line.trimStart();
+  if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('*')) {
+    return false;
+  }
+  if (!sensitiveNamePattern.test(line)) {
+    return false;
+  }
+
+  for (const match of line.matchAll(stringLiteralPattern)) {
+    const literal = match[2].trim();
+    if (!literal || sensitiveEnvNames.some((name) => name.toLowerCase() === literal.toLowerCase())) {
+      continue;
+    }
+    const prefix = line.slice(0, match.index);
+    if (/(=|:|\?\?|\|\|)\s*$/.test(prefix) || /process\.env\./.test(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function scanFile(file, predicate, findings) {
+  const content = await readFile(file, 'utf8');
+  const lines = content.split(/\r?\n/);
+  for (const [index, line] of lines.entries()) {
+    if (predicate(line)) {
+      findings.push(`${toRepoPath(file)}:${index + 1}: ${line.trim()}`);
+    }
+  }
+}
+
+const findings = [];
+
+for (const file of await collectEnvironmentExampleFiles()) {
+  await scanFile(file, hasHardcodedSensitiveEnvValue, findings);
+}
+
+for (const scanRoot of sourceRoots) {
+  for await (const file of walk(join(root, scanRoot), shouldScanSource)) {
+    if (fileURLToPath(import.meta.url) === file) {
+      continue;
+    }
+    await scanFile(file, hasHardcodedSensitiveSourceValue, findings);
+  }
+}
+
+if (findings.length > 0) {
+  console.error('Hard-coded example secret values are not allowed. Read them from the environment or leave example values commented/blank.');
+  for (const finding of findings) {
+    console.error(`- ${finding}`);
+  }
+  process.exit(1);
+}
+
+printLine('No hard-coded example secret values found in environment examples or production sources.');

--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -27,8 +27,9 @@ const sensitiveEnvNames = [
   ['SECRET', 'KEY'],
 ].map((parts) => parts.join('_'));
 
-const sensitiveNamePattern = new RegExp(`\\b(?:${sensitiveEnvNames.join('|')})\\b`, 'i');
+const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN)|[A-Z0-9_]*SECRET_KEY|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
 const stringLiteralPattern = /(['"`])((?:\\.|(?!\1).)*)\1/g;
+const fallbackOperatorPattern = /(?:=|:|\?\?|\|\|)\s*$/;
 
 function printLine(...args) {
   console.info(...args);
@@ -86,55 +87,166 @@ async function collectEnvironmentExampleFiles() {
   return files;
 }
 
-function hasHardcodedSensitiveEnvValue(line) {
+function redactEnvLine(line) {
+  return line.replace(/=(.*)$/, '=<redacted>');
+}
+
+function redactSourceLine(line) {
+  return line.replace(stringLiteralPattern, (literal, quote) => `${quote}<redacted>${quote}`);
+}
+
+function hardcodedSensitiveEnvFinding(line) {
   const trimmed = line.trimStart();
   if (!trimmed || trimmed.startsWith('#')) {
-    return false;
+    return null;
   }
   const match = trimmed.match(/^([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS)[A-Z0-9_]*)=(.*)$/);
   if (!match) {
-    return false;
+    return null;
   }
   const [, name, value] = match;
-  return sensitiveNamePattern.test(name) && value.trim().length > 0;
+  if (!sensitiveIdentifierPattern.test(name) || value.trim().length === 0) {
+    return null;
+  }
+  return redactEnvLine(trimmed);
 }
 
-function hasHardcodedSensitiveSourceValue(line) {
-  const trimmed = line.trimStart();
-  if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('*')) {
-    return false;
-  }
-  if (!sensitiveNamePattern.test(line)) {
-    return false;
-  }
+function stripComments(line, state) {
+  let remaining = line;
+  let output = '';
 
-  for (const match of line.matchAll(stringLiteralPattern)) {
-    const literal = match[2].trim();
-    if (!literal || sensitiveEnvNames.some((name) => name.toLowerCase() === literal.toLowerCase())) {
+  while (remaining.length > 0) {
+    if (state.inBlockComment) {
+      const end = remaining.indexOf('*/');
+      if (end === -1) {
+        return output;
+      }
+      remaining = remaining.slice(end + 2);
+      state.inBlockComment = false;
       continue;
     }
-    const prefix = line.slice(0, match.index);
-    if (/(=|:|\?\?|\|\|)\s*$/.test(prefix) || /process\.env\./.test(prefix)) {
+
+    const lineComment = remaining.indexOf('//');
+    const blockComment = remaining.indexOf('/*');
+
+    if (lineComment !== -1 && (blockComment === -1 || lineComment < blockComment)) {
+      output += remaining.slice(0, lineComment);
+      return output;
+    }
+
+    if (blockComment !== -1) {
+      output += remaining.slice(0, blockComment);
+      remaining = remaining.slice(blockComment + 2);
+      state.inBlockComment = true;
+      continue;
+    }
+
+    output += remaining;
+    return output;
+  }
+
+  return output;
+}
+
+function isSensitiveLiteralName(literal) {
+  return /^[A-Z0-9_]+$/.test(literal) && (
+    sensitiveEnvNames.some((name) => name === literal)
+    || sensitiveIdentifierPattern.test(literal)
+  );
+}
+
+function isSecretLikeLiteral(literal) {
+  return /(?:secret|token|password|api[_-]?key|access[_-]?key|private[_-]?key|credential|bearer)/i.test(literal);
+}
+
+function hasNonNameStringLiteral(line) {
+  for (const match of line.matchAll(stringLiteralPattern)) {
+    const literal = match[2].trim();
+    if (!literal || isSensitiveLiteralName(literal) || !isSecretLikeLiteral(literal)) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function hasSensitiveEnvAccess(line) {
+  const envAccessPattern = /process\.env(?:\.([A-Z0-9_]+)|\[['"`]([^'"`]+)['"`]\])/gi;
+  for (const match of line.matchAll(envAccessPattern)) {
+    const name = match[1] ?? match[2] ?? '';
+    if (sensitiveIdentifierPattern.test(name)) {
       return true;
     }
   }
   return false;
 }
 
-async function scanFile(file, predicate, findings) {
+function hasSensitiveConstantAssignment(prefix) {
+  return /(?:^|\b)(?:export\s+)?(?:const|let|var)\s+[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN)\b[^=]*=\s*$/.test(prefix);
+}
+
+function hasInlineHardcodedSensitiveSourceValue(line) {
+  for (const match of line.matchAll(stringLiteralPattern)) {
+    const literal = match[2].trim();
+    if (!literal || isSensitiveLiteralName(literal) || !isSecretLikeLiteral(literal)) {
+      continue;
+    }
+    const prefix = line.slice(0, match.index);
+    if (fallbackOperatorPattern.test(prefix) && (hasSensitiveEnvAccess(prefix) || hasSensitiveConstantAssignment(prefix))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function leavesSensitiveFallbackOpen(line) {
+  const trimmed = line.trimEnd();
+  return fallbackOperatorPattern.test(trimmed) && (hasSensitiveEnvAccess(trimmed) || hasSensitiveConstantAssignment(trimmed));
+}
+
+async function scanEnvironmentFile(file, findings) {
   const content = await readFile(file, 'utf8');
   const lines = content.split(/\r?\n/);
   for (const [index, line] of lines.entries()) {
-    if (predicate(line)) {
-      findings.push(`${toRepoPath(file)}:${index + 1}: ${line.trim()}`);
+    const redacted = hardcodedSensitiveEnvFinding(line);
+    if (redacted) {
+      findings.push(`${toRepoPath(file)}:${index + 1}: ${redacted}`);
     }
+  }
+}
+
+async function scanSourceFile(file, findings) {
+  const content = await readFile(file, 'utf8');
+  const lines = content.split(/\r?\n/);
+  const commentState = { inBlockComment: false };
+  let pendingSensitiveFallbackLine = null;
+
+  for (const [index, line] of lines.entries()) {
+    const code = stripComments(line, commentState).trim();
+    if (!code) {
+      continue;
+    }
+
+    if (pendingSensitiveFallbackLine && hasNonNameStringLiteral(code)) {
+      findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(code)}`);
+      pendingSensitiveFallbackLine = null;
+      continue;
+    }
+
+    if (hasInlineHardcodedSensitiveSourceValue(code)) {
+      findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(code)}`);
+      pendingSensitiveFallbackLine = null;
+      continue;
+    }
+
+    pendingSensitiveFallbackLine = leavesSensitiveFallbackOpen(code) ? index + 1 : null;
   }
 }
 
 const findings = [];
 
 for (const file of await collectEnvironmentExampleFiles()) {
-  await scanFile(file, hasHardcodedSensitiveEnvValue, findings);
+  await scanEnvironmentFile(file, findings);
 }
 
 for (const scanRoot of sourceRoots) {
@@ -142,7 +254,7 @@ for (const scanRoot of sourceRoots) {
     if (fileURLToPath(import.meta.url) === file) {
       continue;
     }
-    await scanFile(file, hasHardcodedSensitiveSourceValue, findings);
+    await scanSourceFile(file, findings);
   }
 }
 

--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -27,7 +27,7 @@ const sensitiveEnvNames = [
   ['SECRET', 'KEY'],
 ].map((parts) => parts.join('_'));
 
-const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN|PRIVATE_KEY)|[A-Z0-9_]*(?:SECRET_KEY|ACCESS_KEY)|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
+const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN|PRIVATE_KEY|PASSPHRASE)|[A-Z0-9_]*(?:SECRET_KEY|ACCESS_KEY)|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
 const stringLiteralPattern = /(['"`])((?:\\.|(?!\1).)*)\1/g;
 const fallbackOperatorPattern = /(?:=|:|\?\?|\|\|)\s*$/;
 
@@ -87,8 +87,8 @@ async function collectEnvironmentExampleFiles() {
   return files;
 }
 
-function redactEnvLine(line) {
-  return line.replace(/=(.*)$/, '=<redacted>');
+function redactEnvAssignment(name) {
+  return `${name}=<redacted>`;
 }
 
 function redactSourceLine(line) {
@@ -100,7 +100,7 @@ function hardcodedSensitiveEnvFinding(line) {
   if (!trimmed || trimmed.startsWith('#')) {
     return null;
   }
-  const match = trimmed.match(/^(?:export\s+)?([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS)[A-Z0-9_]*)=(.*)$/);
+  const match = trimmed.match(/^(?:export\s+)?([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS|PASSPHRASE)[A-Z0-9_]*)\s*=\s*(.*)$/);
   if (!match) {
     return null;
   }
@@ -108,41 +108,55 @@ function hardcodedSensitiveEnvFinding(line) {
   if (!sensitiveIdentifierPattern.test(name) || value.trim().length === 0) {
     return null;
   }
-  return redactEnvLine(trimmed);
+  return redactEnvAssignment(name);
 }
 
 function stripComments(line, state) {
-  let remaining = line;
   let output = '';
+  let quote = null;
+  let escaped = false;
 
-  while (remaining.length > 0) {
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const next = line[index + 1];
+
     if (state.inBlockComment) {
-      const end = remaining.indexOf('*/');
-      if (end === -1) {
-        return output;
+      if (char === '*' && next === '/') {
+        state.inBlockComment = false;
+        index += 1;
       }
-      remaining = remaining.slice(end + 2);
-      state.inBlockComment = false;
       continue;
     }
 
-    const lineComment = remaining.indexOf('//');
-    const blockComment = remaining.indexOf('/*');
+    if (quote) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
 
-    if (lineComment !== -1 && (blockComment === -1 || lineComment < blockComment)) {
-      output += remaining.slice(0, lineComment);
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      output += char;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
       return output;
     }
 
-    if (blockComment !== -1) {
-      output += remaining.slice(0, blockComment);
-      remaining = remaining.slice(blockComment + 2);
+    if (char === '/' && next === '*') {
       state.inBlockComment = true;
+      index += 1;
       continue;
     }
 
-    output += remaining;
-    return output;
+    output += char;
   }
 
   return output;
@@ -171,7 +185,7 @@ function hasHardcodedSourceLiteral(line) {
 }
 
 function hasSensitiveEnvAccess(line) {
-  const envAccessPattern = /(?:process\.env|import\.meta\.env)(?:\.([A-Z0-9_]+)|\[['"`]([^'"`]+)['"`]\])/gi;
+  const envAccessPattern = /(?:(?:\(?process\.env\)?|import\.meta\.env)\??(?:\.([A-Z0-9_]+)|\[['"`]([^'"`]+)['"`]\]))/gi;
   for (const match of line.matchAll(envAccessPattern)) {
     const name = match[1] ?? match[2] ?? '';
     if (sensitiveIdentifierPattern.test(name)) {
@@ -181,14 +195,18 @@ function hasSensitiveEnvAccess(line) {
   return false;
 }
 
-const sensitiveAssignmentNamePattern = /(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|PRIVATE_KEY|ACCESS_KEY)|[A-Z0-9_]*(?:AUTH|OPERATOR|BEARER)_TOKEN|[A-Za-z_$][\w$]*(?:ApiKey|Secret|Password|PrivateKey|AccessKey|AuthToken|OperatorToken|BearerToken))\b/;
+const sensitiveAssignmentNamePattern = /(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|PRIVATE_KEY|ACCESS_KEY|PASSPHRASE)|[A-Z0-9_]*(?:AUTH|OPERATOR|BEARER|ACCESS|REFRESH)_TOKEN|(?:accessToken|refreshToken|authToken|operatorToken|bearerToken)|[A-Za-z_$][\w$]*(?:ApiKey|Secret|Password|PrivateKey|AccessKey|AuthToken|OperatorToken|BearerToken|AccessToken|RefreshToken)|[a-z_$][\w$]*(?:_secret|_token|_password|_api_key|_access_key))\b/;
 
 function hasSensitiveConstantAssignment(prefix) {
   return new RegExp(`(?:^|\\b)(?:export\\s+)?(?:const|let|var)\\s+${sensitiveAssignmentNamePattern.source}[^=]*=\\s*$`).test(prefix);
 }
 
 function hasSensitiveDestructuredDefault(prefix) {
-  return new RegExp(`[{,]\\s*(?:[A-Za-z_$][\\w$]*\\s*:\\s*)?${sensitiveAssignmentNamePattern.source}\\s*=\\s*$`).test(prefix);
+  return new RegExp(`(?:^|[{,])\\s*(?:[A-Za-z_$][\\w$]*\\s*:\\s*)?${sensitiveAssignmentNamePattern.source}\\s*=\\s*$`).test(prefix);
+}
+
+function hasSensitiveObjectPropertyAssignment(prefix) {
+  return new RegExp(`(?:^|[{,])\\s*${sensitiveAssignmentNamePattern.source}\\s*:\\s*$`).test(prefix);
 }
 
 function hasEnvObjectAccess(line) {
@@ -211,7 +229,8 @@ function hasInlineHardcodedSensitiveSourceValue(line) {
       && (
         hasSensitiveEnvAccess(prefix)
         || hasSensitiveConstantAssignment(prefix)
-        || (hasSensitiveDestructuredDefault(prefix) && hasEnvObjectAccess(line.slice(match.index)))
+        || hasSensitiveObjectPropertyAssignment(prefix)
+        || hasSensitiveDestructuredDefault(prefix)
       )
     ) {
       return true;
@@ -222,7 +241,7 @@ function hasInlineHardcodedSensitiveSourceValue(line) {
 
 function leavesSensitiveFallbackOpen(line) {
   const trimmed = line.trimEnd();
-  return fallbackOperatorPattern.test(trimmed) && (hasSensitiveEnvAccess(trimmed) || hasSensitiveConstantAssignment(trimmed));
+  return fallbackOperatorPattern.test(trimmed) && (hasSensitiveEnvAccess(trimmed) || hasSensitiveConstantAssignment(trimmed) || hasSensitiveObjectPropertyAssignment(trimmed));
 }
 
 async function scanEnvironmentFile(file, findings) {

--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -27,7 +27,7 @@ const sensitiveEnvNames = [
   ['SECRET', 'KEY'],
 ].map((parts) => parts.join('_'));
 
-const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN)|[A-Z0-9_]*SECRET_KEY|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
+const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN|PRIVATE_KEY)|[A-Z0-9_]*(?:SECRET_KEY|ACCESS_KEY)|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
 const stringLiteralPattern = /(['"`])((?:\\.|(?!\1).)*)\1/g;
 const fallbackOperatorPattern = /(?:=|:|\?\?|\|\|)\s*$/;
 
@@ -100,7 +100,7 @@ function hardcodedSensitiveEnvFinding(line) {
   if (!trimmed || trimmed.startsWith('#')) {
     return null;
   }
-  const match = trimmed.match(/^([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS)[A-Z0-9_]*)=(.*)$/);
+  const match = trimmed.match(/^(?:export\s+)?([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS)[A-Z0-9_]*)=(.*)$/);
   if (!match) {
     return null;
   }
@@ -155,14 +155,14 @@ function isSensitiveLiteralName(literal) {
   );
 }
 
-function isSecretLikeLiteral(literal) {
-  return /(?:secret|token|password|api[_-]?key|access[_-]?key|private[_-]?key|credential|bearer)/i.test(literal);
+function isAllowedSourceLiteral(literal) {
+  return isSensitiveLiteralName(literal) || /^\[?<?redacted>?\]?$/i.test(literal);
 }
 
-function hasNonNameStringLiteral(line) {
+function hasHardcodedSourceLiteral(line) {
   for (const match of line.matchAll(stringLiteralPattern)) {
     const literal = match[2].trim();
-    if (!literal || isSensitiveLiteralName(literal) || !isSecretLikeLiteral(literal)) {
+    if (!literal || isAllowedSourceLiteral(literal)) {
       continue;
     }
     return true;
@@ -171,7 +171,7 @@ function hasNonNameStringLiteral(line) {
 }
 
 function hasSensitiveEnvAccess(line) {
-  const envAccessPattern = /process\.env(?:\.([A-Z0-9_]+)|\[['"`]([^'"`]+)['"`]\])/gi;
+  const envAccessPattern = /(?:process\.env|import\.meta\.env)(?:\.([A-Z0-9_]+)|\[['"`]([^'"`]+)['"`]\])/gi;
   for (const match of line.matchAll(envAccessPattern)) {
     const name = match[1] ?? match[2] ?? '';
     if (sensitiveIdentifierPattern.test(name)) {
@@ -181,18 +181,39 @@ function hasSensitiveEnvAccess(line) {
   return false;
 }
 
+const sensitiveAssignmentNamePattern = /(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|PRIVATE_KEY|ACCESS_KEY)|[A-Z0-9_]*(?:AUTH|OPERATOR|BEARER)_TOKEN|[A-Za-z_$][\w$]*(?:ApiKey|Secret|Password|PrivateKey|AccessKey|AuthToken|OperatorToken|BearerToken))\b/;
+
 function hasSensitiveConstantAssignment(prefix) {
-  return /(?:^|\b)(?:export\s+)?(?:const|let|var)\s+[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN)\b[^=]*=\s*$/.test(prefix);
+  return new RegExp(`(?:^|\\b)(?:export\\s+)?(?:const|let|var)\\s+${sensitiveAssignmentNamePattern.source}[^=]*=\\s*$`).test(prefix);
+}
+
+function hasSensitiveDestructuredDefault(prefix) {
+  return new RegExp(`[{,]\\s*(?:[A-Za-z_$][\\w$]*\\s*:\\s*)?${sensitiveAssignmentNamePattern.source}\\s*=\\s*$`).test(prefix);
+}
+
+function hasEnvObjectAccess(line) {
+  return /(?:process\.env|import\.meta\.env)\b/.test(line);
+}
+
+function isFormattingOnlyLine(line) {
+  return /^[([{,;]*$/.test(line.trim());
 }
 
 function hasInlineHardcodedSensitiveSourceValue(line) {
   for (const match of line.matchAll(stringLiteralPattern)) {
     const literal = match[2].trim();
-    if (!literal || isSensitiveLiteralName(literal) || !isSecretLikeLiteral(literal)) {
+    if (!literal || isAllowedSourceLiteral(literal)) {
       continue;
     }
     const prefix = line.slice(0, match.index);
-    if (fallbackOperatorPattern.test(prefix) && (hasSensitiveEnvAccess(prefix) || hasSensitiveConstantAssignment(prefix))) {
+    if (
+      fallbackOperatorPattern.test(prefix)
+      && (
+        hasSensitiveEnvAccess(prefix)
+        || hasSensitiveConstantAssignment(prefix)
+        || (hasSensitiveDestructuredDefault(prefix) && hasEnvObjectAccess(line.slice(match.index)))
+      )
+    ) {
       return true;
     }
   }
@@ -227,9 +248,13 @@ async function scanSourceFile(file, findings) {
       continue;
     }
 
-    if (pendingSensitiveFallbackLine && hasNonNameStringLiteral(code)) {
+    if (pendingSensitiveFallbackLine && hasHardcodedSourceLiteral(code)) {
       findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(code)}`);
       pendingSensitiveFallbackLine = null;
+      continue;
+    }
+
+    if (pendingSensitiveFallbackLine && isFormattingOnlyLine(code)) {
       continue;
     }
 

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -36,19 +36,21 @@ describe('hard-coded example secret scanner', () => {
     execFileSync(process.execPath, [SCRIPT], { cwd: ROOT, stdio: 'pipe' });
   });
 
-  it('rejects uncommented secret values in environment examples', () => {
+  it('rejects and redacts uncommented secret values in environment examples', () => {
     const root = makeFixtureRoot();
     const placeholder = ['replace', 'me'].join('-');
-    writeFileSync(join(root, '.env.example'), `${sensitiveName('SECRET', 'KEY')}=${placeholder}\n`, 'utf8');
+    writeFileSync(join(root, '.env.example'), `${sensitiveName('OPENAI', 'API', 'KEY')}=${placeholder}\n`, 'utf8');
 
     const result = runScanner(root);
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('.env.example:1');
+    expect(result.stderr).toContain('OPENAI_API_KEY=<redacted>');
+    expect(result.stderr).not.toContain(placeholder);
     expect(result.stderr).toContain('Hard-coded example secret values are not allowed');
   });
 
-  it('rejects hard-coded sensitive fallback values in production sources', () => {
+  it('rejects and redacts hard-coded sensitive fallback values in production sources', () => {
     const root = makeFixtureRoot();
     const sourceDir = join(root, 'packages', 'example', 'src');
     mkdirSync(sourceDir, { recursive: true });
@@ -63,6 +65,60 @@ describe('hard-coded example secret scanner', () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).toContain("'<redacted>'");
+    expect(result.stderr).not.toContain(fallback);
+  });
+
+  it('rejects formatted multiline sensitive fallback values in production sources', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    const fallback = ['dev', 'secret'].join('-');
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        `export const value = process.env.${sensitiveName('JWT', 'SECRET')} ??`,
+        `  '${fallback}';`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:2');
+    expect(result.stderr).not.toContain(fallback);
+  });
+
+  it('allows sensitive env checks with ordinary diagnostic strings', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      `if (!process.env.${sensitiveName('JWT', 'SECRET')}) throw new Error('required');\n`,
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
+  });
+
+  it('allows sensitive-looking examples inside block comments', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    const fallback = ['comment', 'secret'].join('-');
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      `/* use process.env.${sensitiveName('JWT', 'SECRET')} ?? '${fallback}' only in tests */\n`,
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
   });
 
   it('allows environment-backed production reads without literal fallbacks', () => {

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -173,6 +173,91 @@ describe('hard-coded example secret scanner', () => {
     expect(result.stderr).toContain('packages/example/src/config.ts:3');
   });
 
+  it('rejects comment markers inside hard-coded secret literals', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(join(sourceDir, 'config.ts'), `const jwtSecret = 'abc//def';\n`, 'utf8');
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).not.toContain('abc//def');
+  });
+
+  it('rejects sensitive object properties and common token variable names', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        `export const cfg = { jwtSecret: 'dev-secret' };`,
+        `const accessToken = 'dev-token';`,
+        `const jwt_secret = 'dev-secret';`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).toContain('packages/example/src/config.ts:2');
+    expect(result.stderr).toContain('packages/example/src/config.ts:3');
+  });
+
+  it('rejects passphrase env examples with dotenv spacing', () => {
+    const root = makeFixtureRoot();
+    writeFileSync(join(root, '.env.example'), `${sensitiveName('FRANKENBEAST', 'PASSPHRASE')} = replace-me\n`, 'utf8');
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('FRANKENBEAST_PASSPHRASE=<redacted>');
+  });
+
+  it('rejects optional-chained and parenthesized env fallbacks', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        `const one = process.env?.${sensitiveName('JWT', 'SECRET')} ?? 'dev-secret';`,
+        `const two = (process.env).${sensitiveName('JWT', 'SECRET')} ?? 'dev-secret';`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).toContain('packages/example/src/config.ts:2');
+  });
+
+  it('rejects multiline destructured defaults', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        'const {',
+        `  ${sensitiveName('JWT', 'SECRET')} = 'dev-secret',`,
+        '} = process.env;',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:2');
+  });
+
   it('allows sensitive env checks with ordinary diagnostic strings', () => {
     const root = makeFixtureRoot();
     const sourceDir = join(root, 'packages', 'example', 'src');

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -90,6 +90,89 @@ describe('hard-coded example secret scanner', () => {
     expect(result.stderr).not.toContain(fallback);
   });
 
+  it('rejects ordinary placeholders in sensitive fallback contexts', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      `export const value = process.env.${sensitiveName('JWT', 'SECRET')} ?? 'changeme';\n`,
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("'<redacted>'");
+    expect(result.stderr).not.toContain('changeme');
+  });
+
+  it('rejects camelCase sensitive constant assignments', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    const fallback = ['local', 'secret'].join('-');
+    writeFileSync(join(sourceDir, 'config.ts'), `const jwtSecret = '${fallback}';\n`, 'utf8');
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).not.toContain(fallback);
+  });
+
+  it('rejects exported private key values in environment examples', () => {
+    const root = makeFixtureRoot();
+    const placeholder = ['begin', 'private', 'key'].join('-');
+    writeFileSync(join(root, '.env.example'), `export ${sensitiveName('PRIVATE', 'KEY')}=${placeholder}\n`, 'utf8');
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('PRIVATE_KEY=<redacted>');
+    expect(result.stderr).not.toContain(placeholder);
+  });
+
+  it('rejects destructured env defaults and Vite env fallbacks', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        `const { ${sensitiveName('JWT', 'SECRET')} = 'dev' } = process.env;`,
+        `const viteToken = import.meta.env.${sensitiveName('VITE', 'BEAST', 'OPERATOR', 'TOKEN')} ?? 'dev';`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).toContain('packages/example/src/config.ts:2');
+  });
+
+  it('rejects parenthesized multiline sensitive fallback values', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        `export const value = process.env.${sensitiveName('JWT', 'SECRET')} ??`,
+        '  (',
+        `    'dev';`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:3');
+  });
+
   it('allows sensitive env checks with ordinary diagnostic strings', () => {
     const root = makeFixtureRoot();
     const sourceDir = join(root, 'packages', 'example', 'src');

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/check-hardcoded-secrets.mjs');
+
+function sensitiveName(...parts: string[]) {
+  return parts.join('_');
+}
+
+function makeFixtureRoot() {
+  return mkdtempSync(join(tmpdir(), 'franken-secret-scan-'));
+}
+
+function runScanner(root: string) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    cwd: ROOT,
+    env: { ...process.env, FRANKENBEAST_SECRETS_SCAN_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+describe('hard-coded example secret scanner', () => {
+  it('is included in the root security lint script', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['lint:security']).toContain('node scripts/check-hardcoded-secrets.mjs');
+  });
+
+  it('passes the repository fixtures that keep secret examples commented or env-backed', () => {
+    execFileSync(process.execPath, [SCRIPT], { cwd: ROOT, stdio: 'pipe' });
+  });
+
+  it('rejects uncommented secret values in environment examples', () => {
+    const root = makeFixtureRoot();
+    const placeholder = ['replace', 'me'].join('-');
+    writeFileSync(join(root, '.env.example'), `${sensitiveName('SECRET', 'KEY')}=${placeholder}\n`, 'utf8');
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('.env.example:1');
+    expect(result.stderr).toContain('Hard-coded example secret values are not allowed');
+  });
+
+  it('rejects hard-coded sensitive fallback values in production sources', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    const fallback = ['local', 'secret'].join('-');
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      `export const value = process.env.${sensitiveName('JWT', 'SECRET')} ?? '${fallback}';\n`,
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+  });
+
+  it('allows environment-backed production reads without literal fallbacks', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      `export const value = process.env.${sensitiveName('AWS', 'ACCESS', 'KEY', 'ID')};\n`,
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('No hard-coded example secret values found');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a repository security scanner for hard-coded example secret values in env examples and production JS/TS sources
- Wire the scanner into `npm run lint:security` after the existing plain-HTTP check
- Add root Vitest coverage for clean env-backed usage and rejected hard-coded examples

## Test Plan
- npm run test:root -- tests/unit/hardcoded-secrets.test.ts
- npm run lint:security
- npm run typecheck
- npm run build
- npm test

Note: `npm run test:root` currently has pre-existing unrelated failures in `tests/integration/phase3-execution.test.ts` and `tests/integration/e2e-beast-loop.test.ts` around HITL/TruncationStrategy.

Closes #501