### PR TITLE
test(planner): cover missing raw DAG dependencies

### DIFF
--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -180,6 +180,23 @@ describe('PlanGraph — cycle detection', () => {
 
     expect(() => g.topoSort()).toThrow(/unknown dependency node 'missing'/);
   });
+
+  it('hasCycle rejects missing raw edge ids instead of reporting a spurious cycle', () => {
+    const a = makeTask('a');
+    const b = makeTask('b');
+    const missing = createTaskId('missing');
+    const nodes = new Map([
+      [a.id, a],
+      [b.id, b],
+    ]);
+    const edges = new Map([
+      [a.id, new Set<Task['id']>()],
+      [b.id, new Set([missing])],
+    ]);
+    const g = PlanGraph.createWithRawEdges(nodes, edges);
+
+    expect(() => g.hasCycle()).toThrow(/unknown dependency node 'missing'/);
+  });
 });
 
 // ─── Mutations ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a regression test for `PlanGraph.hasCycle()` with raw edges referencing missing task IDs.
- Verifies missing raw dependencies throw a clear validation error instead of being misreported as a cycle.

## Test Plan
- npm test --workspace @franken/planner -- tests/unit/core/dag.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/planner
- npm run build --workspace @franken/planner
- npx turbo run test --filter=@franken/planner
- npm run lint --workspace @franken/planner

Closes #916
