### PR TITLE
fix(web): remove outdated chat placeholder warning

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -117,5 +117,6 @@ describe('ChatShell route heading', () => {
     expect(screen.queryByRole('heading', { level: 1, name: 'default' })).toBeNull();
     expect(screen.getByText('Project: default')).toBeTruthy();
     expect(screen.getByText('Service controls')).toBeTruthy();
+    expect(screen.queryByText('Chat is the only live section in this first Frankenbeast dashboard cut.')).toBeNull();
   });
 });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -119,7 +119,6 @@ function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {
       <p className="eyebrow">Dashboard Module</p>
       <h2>{route.label}</h2>
       <p>{route.summary}</p>
-      <span>Chat is the only live section in this first Frankenbeast dashboard cut.</span>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the obsolete placeholder copy that said chat was the only live dashboard section.
- Add a ChatShell regression assertion so the stale warning does not reappear on live routes.

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- src/components/chat-shell.test.tsx
- npm run typecheck --workspace @franken/web
- npm run lint:any -- --scope packages/franken-web/src/components/chat-shell.tsx packages/franken-web/src/components/chat-shell.test.tsx
- npm run build --workspace @franken/web
- npm test --workspace @franken/web

Closes #676