### PR TITLE
fix(planner): reject invalid LLM dependency references

### DIFF
--- a/packages/franken-orchestrator/src/skills/llm-planner.ts
+++ b/packages/franken-orchestrator/src/skills/llm-planner.ts
@@ -10,6 +10,8 @@ type RawTask = {
   dependsOn?: unknown;
 };
 
+class PlanStructureError extends Error {}
+
 export class LlmPlanner implements IPlannerModule {
   private readonly llmClient: ILlmClient;
 
@@ -59,7 +61,10 @@ export class LlmPlanner implements IPlannerModule {
       }
 
       return { tasks };
-    } catch {
+    } catch (error) {
+      if (error instanceof PlanStructureError) {
+        throw error;
+      }
       return fallback;
     }
   }
@@ -89,8 +94,18 @@ export class LlmPlanner implements IPlannerModule {
     const dependsOn = Array.isArray(raw?.dependsOn)
       ? raw.dependsOn
         .filter((dep): dep is string => typeof dep === 'string')
-        .map(dep => idMap.get(dep))
-        .filter((dep): dep is string => typeof dep === 'string')
+        .map((dep) => {
+          const mappedDep = idMap.get(dep);
+          if (mappedDep === undefined) {
+            const taskId = typeof raw?.id === 'string' && raw.id.trim().length > 0
+              ? raw.id.trim()
+              : `t${index + 1}`;
+            throw new PlanStructureError(
+              `Invalid plan structure: task '${taskId}' depends on unknown task '${dep}'`,
+            );
+          }
+          return mappedDep;
+        })
       : [];
 
     return {

--- a/packages/franken-orchestrator/src/skills/llm-planner.ts
+++ b/packages/franken-orchestrator/src/skills/llm-planner.ts
@@ -91,21 +91,25 @@ export class LlmPlanner implements IPlannerModule {
     const objective = typeof raw?.objective === 'string' && raw.objective.trim().length > 0
       ? raw.objective.trim()
       : fallbackObjective;
+    const taskId = typeof raw?.id === 'string' && raw.id.trim().length > 0
+      ? raw.id.trim()
+      : `t${index + 1}`;
     const dependsOn = Array.isArray(raw?.dependsOn)
-      ? raw.dependsOn
-        .filter((dep): dep is string => typeof dep === 'string')
-        .map((dep) => {
-          const mappedDep = idMap.get(dep);
-          if (mappedDep === undefined) {
-            const taskId = typeof raw?.id === 'string' && raw.id.trim().length > 0
-              ? raw.id.trim()
-              : `t${index + 1}`;
-            throw new PlanStructureError(
-              `Invalid plan structure: task '${taskId}' depends on unknown task '${dep}'`,
-            );
-          }
-          return mappedDep;
-        })
+      ? raw.dependsOn.map((dep, depIndex) => {
+        if (typeof dep !== 'string') {
+          throw new PlanStructureError(
+            `Invalid plan structure: task '${taskId}' has non-string dependency at index ${depIndex}`,
+          );
+        }
+        const normalizedDep = dep.trim();
+        const mappedDep = idMap.get(normalizedDep);
+        if (mappedDep === undefined) {
+          throw new PlanStructureError(
+            `Invalid plan structure: task '${taskId}' depends on unknown task '${normalizedDep}'`,
+          );
+        }
+        return mappedDep;
+      })
       : [];
 
     return {

--- a/packages/franken-orchestrator/tests/unit/skills/llm-planner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/llm-planner.test.ts
@@ -59,6 +59,24 @@ describe('LlmPlanner', () => {
     });
   });
 
+  it('fails plan creation when a task depends on an unknown task id', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          tasks: [
+            { id: 'prep', objective: 'Prep', dependsOn: [] },
+            { id: 'ship', objective: 'Ship', dependsOn: ['missing'] },
+          ],
+        }),
+      ),
+    };
+    const planner = new LlmPlanner(llmClient);
+
+    await expect(planner.createPlan(intent)).rejects.toThrow(
+      "Invalid plan structure: task 'ship' depends on unknown task 'missing'",
+    );
+  });
+
   it('falls back to a single task plan when tasks contain a cycle', async () => {
     const llmClient = {
       complete: vi.fn().mockResolvedValue(

--- a/packages/franken-orchestrator/tests/unit/skills/llm-planner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/llm-planner.test.ts
@@ -77,6 +77,42 @@ describe('LlmPlanner', () => {
     );
   });
 
+  it('fails plan creation when a task dependency is not a string', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          tasks: [
+            { id: 'prep', objective: 'Prep', dependsOn: [] },
+            { id: 'ship', objective: 'Ship', dependsOn: [42] },
+          ],
+        }),
+      ),
+    };
+    const planner = new LlmPlanner(llmClient);
+
+    await expect(planner.createPlan(intent)).rejects.toThrow(
+      "Invalid plan structure: task 'ship' has non-string dependency at index 0",
+    );
+  });
+
+  it('normalizes whitespace around dependency ids before validation', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          tasks: [
+            { id: ' prep ', objective: 'Prep', dependsOn: [] },
+            { id: 'ship', objective: 'Ship', dependsOn: [' prep '] },
+          ],
+        }),
+      ),
+    };
+    const planner = new LlmPlanner(llmClient);
+
+    const plan = await planner.createPlan(intent);
+
+    expect(plan.tasks[1]?.dependsOn).toEqual(['t1']);
+  });
+
   it('falls back to a single task plan when tasks contain a cycle', async () => {
     const llmClient = {
       complete: vi.fn().mockResolvedValue(


### PR DESCRIPTION
## Summary
- Reject LlmPlanner JSON plans that reference dependency task IDs not present in the generated plan.
- Preserve malformed JSON/empty/cyclic fallback behavior while failing invalid dependency references explicitly.
- Add a regression test for an unknown `dependsOn` ID.

## Test Plan
- `npm test -- tests/unit/skills/llm-planner.test.ts`
- `npx turbo run test --filter=@franken/orchestrator`
- `npx turbo run typecheck --filter=@franken/orchestrator`
- `npx turbo run lint --filter=@franken/orchestrator` (passes with existing warnings)
- `npx turbo run build --filter=@franken/orchestrator`

Closes #850
