### PR TITLE
fix(planner): support linear and parallel expansions

### DIFF
--- a/packages/franken-planner/src/planners/linear.ts
+++ b/packages/franken-planner/src/planners/linear.ts
@@ -1,16 +1,27 @@
 import { PlanGraph } from '../core/dag.js';
+import { RecursionDepthExceededError } from '../core/errors.js';
 import type { PlanResult, PlanningStrategyName, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
 export class LinearPlanner implements PlanningStrategy {
   readonly name: PlanningStrategyName = 'linear';
 
+  constructor(private readonly maxExpansionDepth = 10) {}
+
   /**
    * Executes tasks one-by-one in topological order.
    * Stops on the first failure and returns a 'failed' PlanResult.
    * All results accumulated up to and including the failing task are preserved.
    */
-  async execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
+  execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
+    return this._exec(graph, context, 0);
+  }
+
+  private async _exec(graph: PlanGraph, context: PlanContext, depth: number): Promise<PlanResult> {
+    if (depth > this.maxExpansionDepth) {
+      throw new RecursionDepthExceededError(depth);
+    }
+
     const tasks = graph.topoSort();
     const taskResults: TaskResult[] = [];
 
@@ -29,11 +40,13 @@ export class LinearPlanner implements PlanningStrategy {
 
       if (result.expand === true) {
         const subGraph = PlanGraph.fromTasks(result.newTasks);
-        const subResult = await this.execute(subGraph, context);
+        const subResult = await this._exec(subGraph, context, depth + 1);
         if (subResult.status === 'failed') {
           return {
-            ...subResult,
+            status: 'failed',
             taskResults: [...taskResults, ...subResult.taskResults],
+            failedTaskId: result.taskId,
+            error: subResult.error,
           };
         }
         if (subResult.status !== 'completed') {

--- a/packages/franken-planner/src/planners/linear.ts
+++ b/packages/franken-planner/src/planners/linear.ts
@@ -1,5 +1,5 @@
+import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, PlanningStrategyName, TaskResult } from '../core/types.js';
-import type { PlanGraph } from '../core/dag.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
 export class LinearPlanner implements PlanningStrategy {
@@ -25,6 +25,21 @@ export class LinearPlanner implements PlanningStrategy {
           failedTaskId: task.id,
           error: result.error,
         };
+      }
+
+      if (result.expand === true) {
+        const subGraph = PlanGraph.fromTasks(result.newTasks);
+        const subResult = await this.execute(subGraph, context);
+        if (subResult.status === 'failed') {
+          return {
+            ...subResult,
+            taskResults: [...taskResults, ...subResult.taskResults],
+          };
+        }
+        if (subResult.status !== 'completed') {
+          return subResult;
+        }
+        taskResults.push(...subResult.taskResults);
       }
     }
 

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -92,21 +92,27 @@ export class ParallelPlanner implements PlanningStrategy {
         }
       }
 
+      const expansionResults = await Promise.all(
+        waveResults
+          .filter((r) => r.status === 'success' && r.expand === true)
+          .map(async (r) => {
+            const subGraph = PlanGraph.fromTasks(r.newTasks);
+            const subResult = await this._exec(subGraph, context, depth + 1);
+            return { parentTaskId: r.taskId, subResult };
+          })
+      );
+
       let firstExpansionFailure: { taskId: TaskId; error: Error } | undefined;
-      for (const r of waveResults) {
-        if (r.status === 'success' && r.expand === true) {
-          const subGraph = PlanGraph.fromTasks(r.newTasks);
-          const subResult = await this._exec(subGraph, context, depth + 1);
-          if (subResult.status === 'failed') {
-            allResults.push(...subResult.taskResults);
-            firstExpansionFailure ??= { taskId: r.taskId, error: subResult.error };
-            continue;
-          }
-          if (subResult.status !== 'completed') {
-            return subResult;
-          }
+      for (const { parentTaskId, subResult } of expansionResults) {
+        if (subResult.status === 'failed') {
           allResults.push(...subResult.taskResults);
+          firstExpansionFailure ??= { taskId: parentTaskId, error: subResult.error };
+          continue;
         }
+        if (subResult.status !== 'completed') {
+          return subResult;
+        }
+        allResults.push(...subResult.taskResults);
       }
 
       if (firstExpansionFailure) {

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -1,6 +1,6 @@
 import { RationaleRejectedError } from '../core/errors.js';
+import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, TaskId, TaskResult } from '../core/types.js';
-import type { PlanGraph } from '../core/dag.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
 /**
@@ -79,6 +79,23 @@ export class ParallelPlanner implements PlanningStrategy {
             failedTaskId: first.taskId,
             error: first.error,
           };
+        }
+      }
+
+      for (const r of waveResults) {
+        if (r.status === 'success' && r.expand === true) {
+          const subGraph = PlanGraph.fromTasks(r.newTasks);
+          const subResult = await this.execute(subGraph, context);
+          if (subResult.status === 'failed') {
+            return {
+              ...subResult,
+              taskResults: [...allResults, ...subResult.taskResults],
+            };
+          }
+          if (subResult.status !== 'completed') {
+            return subResult;
+          }
+          allResults.push(...subResult.taskResults);
         }
       }
 

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -92,7 +92,7 @@ export class ParallelPlanner implements PlanningStrategy {
         }
       }
 
-      const expansionResults = await Promise.all(
+      const settledExpansionResults = await Promise.allSettled(
         waveResults
           .filter((r) => r.status === 'success' && r.expand === true)
           .map(async (r) => {
@@ -101,6 +101,28 @@ export class ParallelPlanner implements PlanningStrategy {
             return { parentTaskId: r.taskId, subResult };
           })
       );
+
+      const rejectedExpansionRationale = settledExpansionResults.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected' && result.reason instanceof RationaleRejectedError
+      );
+      if (rejectedExpansionRationale) {
+        throw rejectedExpansionRationale.reason;
+      }
+
+      const rejectedExpansion = settledExpansionResults.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+      );
+      if (rejectedExpansion) {
+        throw rejectedExpansion.reason;
+      }
+
+      const expansionResults = settledExpansionResults.map((result) => {
+        if (result.status === 'fulfilled') {
+          return result.value;
+        }
+        throw result.reason;
+      });
 
       let firstExpansionFailure: { taskId: TaskId; error: Error } | undefined;
       for (const { parentTaskId, subResult } of expansionResults) {

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -1,4 +1,4 @@
-import { RationaleRejectedError } from '../core/errors.js';
+import { RationaleRejectedError, RecursionDepthExceededError } from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, TaskId, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
@@ -12,7 +12,17 @@ import type { PlanContext, PlanningStrategy } from './types.js';
 export class ParallelPlanner implements PlanningStrategy {
   readonly name = 'parallel' as const;
 
-  async execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
+  constructor(private readonly maxExpansionDepth = 10) {}
+
+  execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
+    return this._exec(graph, context, 0);
+  }
+
+  private async _exec(graph: PlanGraph, context: PlanContext, depth: number): Promise<PlanResult> {
+    if (depth > this.maxExpansionDepth) {
+      throw new RecursionDepthExceededError(depth);
+    }
+
     // Validate the DAG up front so cyclic plans fail loudly instead of
     // deadlocking the wave scheduler and returning partial success.
     const tasks = graph.topoSort();
@@ -82,21 +92,30 @@ export class ParallelPlanner implements PlanningStrategy {
         }
       }
 
+      let firstExpansionFailure: { taskId: TaskId; error: Error } | undefined;
       for (const r of waveResults) {
         if (r.status === 'success' && r.expand === true) {
           const subGraph = PlanGraph.fromTasks(r.newTasks);
-          const subResult = await this.execute(subGraph, context);
+          const subResult = await this._exec(subGraph, context, depth + 1);
           if (subResult.status === 'failed') {
-            return {
-              ...subResult,
-              taskResults: [...allResults, ...subResult.taskResults],
-            };
+            allResults.push(...subResult.taskResults);
+            firstExpansionFailure ??= { taskId: r.taskId, error: subResult.error };
+            continue;
           }
           if (subResult.status !== 'completed') {
             return subResult;
           }
           allResults.push(...subResult.taskResults);
         }
+      }
+
+      if (firstExpansionFailure) {
+        return {
+          status: 'failed',
+          taskResults: allResults,
+          failedTaskId: firstExpansionFailure.taskId,
+          error: firstExpansionFailure.error,
+        };
       }
 
       for (const r of waveResults) {

--- a/packages/franken-planner/tests/unit/planners/linear.test.ts
+++ b/packages/franken-planner/tests/unit/planners/linear.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { LinearPlanner } from '../../../src/planners/linear';
 import { PlanGraph } from '../../../src/core/dag';
+import { RecursionDepthExceededError } from '../../../src/core/errors';
 import { createTaskId } from '../../../src/core/types';
 import type { Task, TaskResult } from '../../../src/core/types';
 import type { PlanContext } from '../../../src/planners/types';
@@ -159,5 +160,38 @@ describe('LinearPlanner — failure handling', () => {
     expect(result.taskResults).toHaveLength(2);
     expect(result.taskResults[0]?.status).toBe('success');
     expect(result.taskResults[1]?.status).toBe('failure');
+  });
+
+  it('returns the expanding parent as failed when an expanded sub-task fails', async () => {
+    const parent = makeTask('parent');
+    const sub = makeTask('sub');
+    const graph = PlanGraph.empty().addTask(parent);
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [sub]))
+      .mockResolvedValueOnce(failure('sub', 'sub exploded'));
+
+    const result = await new LinearPlanner().execute(graph, { executor });
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('parent'));
+    expect(result.error.message).toBe('sub exploded');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('parent'),
+      createTaskId('sub'),
+    ]);
+  });
+
+  it('throws RecursionDepthExceededError when nested expansions exceed max depth', async () => {
+    const child = makeTask('child');
+    const parent = makeTask('parent');
+    const graph = PlanGraph.empty().addTask(parent);
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [child]))
+      .mockResolvedValue(success('child'));
+
+    await expect(new LinearPlanner(0).execute(graph, { executor })).rejects.toBeInstanceOf(
+      RecursionDepthExceededError
+    );
   });
 });

--- a/packages/franken-planner/tests/unit/planners/linear.test.ts
+++ b/packages/franken-planner/tests/unit/planners/linear.test.ts
@@ -19,6 +19,10 @@ function success(id: string): TaskResult {
   return { status: 'success', taskId: createTaskId(id) };
 }
 
+function expand(id: string, newTasks: Task[]): TaskResult {
+  return { status: 'success', taskId: createTaskId(id), expand: true, newTasks };
+}
+
 function failure(id: string, message = 'task failed'): TaskResult {
   return { status: 'failure', taskId: createTaskId(id), error: new Error(message) };
 }
@@ -78,6 +82,35 @@ describe('LinearPlanner — happy path', () => {
 
     if (result.status !== 'completed') throw new Error('unexpected status');
     expect(result.taskResults).toHaveLength(2);
+  });
+
+  it('executes expanded sub-tasks before continuing the linear plan', async () => {
+    const parent = makeTask('parent');
+    const sibling = makeTask('sibling');
+    const sub1 = makeTask('sub-1');
+    const sub2: Task = { ...makeTask('sub-2'), dependsOn: [createTaskId('sub-1')] };
+    const graph = PlanGraph.empty().addTask(parent).addTask(sibling);
+    const callOrder: string[] = [];
+
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      callOrder.push(task.id);
+      if (task.id === createTaskId('parent')) {
+        return Promise.resolve(expand('parent', [sub1, sub2]));
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const result = await new LinearPlanner().execute(graph, { executor });
+
+    expect(result.status).toBe('completed');
+    expect(callOrder).toEqual([
+      createTaskId('parent'),
+      createTaskId('sub-1'),
+      createTaskId('sub-2'),
+      createTaskId('sibling'),
+    ]);
+    if (result.status !== 'completed') throw new Error('unexpected status');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual(callOrder);
   });
 });
 

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -19,6 +19,10 @@ function success(id: string): TaskResult {
   return { status: 'success', taskId: createTaskId(id) };
 }
 
+function expand(id: string, newTasks: Task[]): TaskResult {
+  return { status: 'success', taskId: createTaskId(id), expand: true, newTasks };
+}
+
 function failure(id: string, message = 'task failed'): TaskResult {
   return { status: 'failure', taskId: createTaskId(id), error: new Error(message) };
 }
@@ -134,6 +138,37 @@ describe('ParallelPlanner — happy path', () => {
 
     if (result.status !== 'completed') throw new Error('unexpected status');
     expect(result.taskResults).toHaveLength(2);
+  });
+
+  it('executes expanded sub-tasks before starting dependent waves', async () => {
+    const parent = makeTask('parent');
+    const dependent = makeTask('dependent');
+    const sub1 = makeTask('sub-1');
+    const sub2: Task = { ...makeTask('sub-2'), dependsOn: [createTaskId('sub-1')] };
+    const graph = PlanGraph.empty()
+      .addTask(parent)
+      .addTask(dependent, [createTaskId('parent')]);
+    const callOrder: string[] = [];
+
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      callOrder.push(task.id);
+      if (task.id === createTaskId('parent')) {
+        return Promise.resolve(expand('parent', [sub1, sub2]));
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const result = await new ParallelPlanner().execute(graph, { executor });
+
+    expect(result.status).toBe('completed');
+    expect(callOrder).toEqual([
+      createTaskId('parent'),
+      createTaskId('sub-1'),
+      createTaskId('sub-2'),
+      createTaskId('dependent'),
+    ]);
+    if (result.status !== 'completed') throw new Error('unexpected status');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual(callOrder);
   });
 });
 

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ParallelPlanner } from '../../../src/planners/parallel';
 import { PlanGraph } from '../../../src/core/dag';
-import { CyclicDependencyError, RecursionDepthExceededError } from '../../../src/core/errors';
+import { CyclicDependencyError, RationaleRejectedError, RecursionDepthExceededError } from '../../../src/core/errors';
 import { createTaskId } from '../../../src/core/types';
 import type { Task, TaskId, TaskResult } from '../../../src/core/types';
 
@@ -207,6 +207,41 @@ describe('ParallelPlanner — happy path', () => {
     expect(resolveSub1).toBeDefined();
     resolveSub1?.(success('sub-1'));
     await expect(execution).resolves.toMatchObject({ status: 'completed' });
+  });
+
+  it('waits for sibling expansions before propagating an expansion rejection', async () => {
+    const parent1 = makeTask('parent-1');
+    const parent2 = makeTask('parent-2');
+    const sub1 = makeTask('sub-1');
+    const sub2 = makeTask('sub-2');
+    const graph = PlanGraph.empty().addTask(parent1).addTask(parent2);
+    let resolveSub2: ((result: TaskResult) => void) | undefined;
+    let rejected = false;
+
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('parent-1')) return Promise.resolve(expand('parent-1', [sub1]));
+      if (task.id === createTaskId('parent-2')) return Promise.resolve(expand('parent-2', [sub2]));
+      if (task.id === createTaskId('sub-1')) {
+        return Promise.reject(new RationaleRejectedError('sub-1', 'bad rationale'));
+      }
+      if (task.id === createTaskId('sub-2')) {
+        return new Promise<TaskResult>((resolve) => {
+          resolveSub2 = resolve;
+        });
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const execution = new ParallelPlanner().execute(graph, { executor });
+    execution.catch(() => {
+      rejected = true;
+    });
+    await vi.waitFor(() => expect(resolveSub2).toBeDefined());
+    await Promise.resolve();
+
+    expect(rejected).toBe(false);
+    resolveSub2?.(success('sub-2'));
+    await expect(execution).rejects.toBeInstanceOf(RationaleRejectedError);
   });
 });
 

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -170,6 +170,44 @@ describe('ParallelPlanner — happy path', () => {
     if (result.status !== 'completed') throw new Error('unexpected status');
     expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual(callOrder);
   });
+
+  it('starts same-wave expansion subgraphs concurrently', async () => {
+    const parent1 = makeTask('parent-1');
+    const parent2 = makeTask('parent-2');
+    const sub1 = makeTask('sub-1');
+    const sub2 = makeTask('sub-2');
+    const graph = PlanGraph.empty().addTask(parent1).addTask(parent2);
+    let sub2Started = false;
+    let markSub1Started: (() => void) | undefined;
+    let resolveSub1: ((result: TaskResult) => void) | undefined;
+    const sub1Started = new Promise<void>((resolve) => {
+      markSub1Started = resolve;
+    });
+
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('parent-1')) return Promise.resolve(expand('parent-1', [sub1]));
+      if (task.id === createTaskId('parent-2')) return Promise.resolve(expand('parent-2', [sub2]));
+      if (task.id === createTaskId('sub-1')) {
+        markSub1Started?.();
+        return new Promise<TaskResult>((resolve) => {
+          resolveSub1 = resolve;
+        });
+      }
+      if (task.id === createTaskId('sub-2')) {
+        sub2Started = true;
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const execution = new ParallelPlanner().execute(graph, { executor });
+    await sub1Started;
+    await Promise.resolve();
+
+    expect(sub2Started).toBe(true);
+    expect(resolveSub1).toBeDefined();
+    resolveSub1?.(success('sub-1'));
+    await expect(execution).resolves.toMatchObject({ status: 'completed' });
+  });
 });
 
 // ─── Cycle handling ───────────────────────────────────────────────────────────

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ParallelPlanner } from '../../../src/planners/parallel';
 import { PlanGraph } from '../../../src/core/dag';
-import { CyclicDependencyError } from '../../../src/core/errors';
+import { CyclicDependencyError, RecursionDepthExceededError } from '../../../src/core/errors';
 import { createTaskId } from '../../../src/core/types';
 import type { Task, TaskId, TaskResult } from '../../../src/core/types';
 
@@ -231,6 +231,66 @@ describe('ParallelPlanner — failure handling', () => {
     expect(result.taskResults).toHaveLength(2);
     expect(result.taskResults[0]?.status).toBe('success');
     expect(result.taskResults[1]?.status).toBe('failure');
+  });
+
+  it('returns the expanding parent as failed when an expanded sub-task fails', async () => {
+    const parent = makeTask('parent');
+    const sub = makeTask('sub');
+    const graph = PlanGraph.empty().addTask(parent);
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [sub]))
+      .mockResolvedValueOnce(failure('sub', 'sub exploded'));
+
+    const result = await new ParallelPlanner().execute(graph, { executor });
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('parent'));
+    expect(result.error.message).toBe('sub exploded');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('parent'),
+      createTaskId('sub'),
+    ]);
+  });
+
+  it('finishes same-wave expansions before returning an expansion failure', async () => {
+    const parent1 = makeTask('parent-1');
+    const parent2 = makeTask('parent-2');
+    const sub1 = makeTask('sub-1');
+    const sub2 = makeTask('sub-2');
+    const graph = PlanGraph.empty().addTask(parent1).addTask(parent2);
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('parent-1')) return Promise.resolve(expand('parent-1', [sub1]));
+      if (task.id === createTaskId('parent-2')) return Promise.resolve(expand('parent-2', [sub2]));
+      if (task.id === createTaskId('sub-1')) return Promise.resolve(failure('sub-1', 'sub failed'));
+      return Promise.resolve(success(task.id));
+    });
+
+    const result = await new ParallelPlanner().execute(graph, { executor });
+
+    expect(executor).toHaveBeenCalledWith(sub2);
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('parent-1'));
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('parent-1'),
+      createTaskId('parent-2'),
+      createTaskId('sub-1'),
+      createTaskId('sub-2'),
+    ]);
+  });
+
+  it('throws RecursionDepthExceededError when nested expansions exceed max depth', async () => {
+    const child = makeTask('child');
+    const parent = makeTask('parent');
+    const graph = PlanGraph.empty().addTask(parent);
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [child]))
+      .mockResolvedValue(success('child'));
+
+    await expect(new ParallelPlanner(0).execute(graph, { executor })).rejects.toBeInstanceOf(
+      RecursionDepthExceededError
+    );
   });
 
   it('returns first failure when multiple tasks fail in the same wave', async () => {


### PR DESCRIPTION
## Summary
- Add dynamic expansion handling to LinearPlanner and ParallelPlanner.
- Execute returned `newTasks` as nested planner subgraphs before continuing the parent plan.
- Add regression coverage proving expanded sub-tasks run before subsequent/dependent tasks.

## Test Plan
- `npm --prefix packages/franken-planner test -- tests/unit/planners/linear.test.ts tests/unit/planners/parallel.test.ts`
- `npx turbo run test --filter=@franken/planner`
- `npx turbo run typecheck --filter=@franken/planner`
- `npx turbo run build --filter=@franken/planner`
- `npm --prefix packages/franken-planner run lint`
- `git diff --check`

Closes #851
