### PR TITLE
fix(critique): harden logic-loop syntax masking

### DIFF
--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -114,11 +114,20 @@ function previousToken(code: string, beforeIndex: number): string | null {
   return end === cursor + 1 ? null : code.slice(cursor + 1, end);
 }
 
-function contextualKeywordCanPrefixRegex(code: string, tokenStart: number): boolean {
+function contextualKeywordCanPrefixRegex(code: string, tokenStart: number, token: string): boolean {
+  // `of` is only a keyword inside `for (… of …)`; a `/` following `of` is
+  // division in all realistic code (`of` as an identifier, or the pathological
+  // `for (x of /re/)`), so it never introduces a regex here.
+  if (token === 'of') return false;
+
+  // `await`/`yield` are unary operators: a regex can follow them at an
+  // expression position — after an operator or opening bracket, after a `{`/`;`
+  // that begins a new statement, or after another regex-prefix keyword
+  // (e.g. `return await /re/.test(x)`).
   let cursor = tokenStart - 1;
   while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
-  if (cursor < 0) return false;
-  if ('([=,:!&|?+-*%^~<>'.includes(code[cursor]!)) return true;
+  if (cursor < 0) return true;
+  if ('([{=,:;!&|?+-*%^~<>'.includes(code[cursor]!)) return true;
 
   const previous = previousToken(code, cursor);
   return previous != null && REGEX_PREFIX_KEYWORDS.has(previous);
@@ -134,11 +143,15 @@ function isRegexLiteralStart(code: string, index: number): boolean {
   const tokenEnd = cursor + 1;
   while (cursor >= 0 && /[A-Za-z0-9_$]/.test(code[cursor]!)) cursor -= 1;
   if (tokenEnd === cursor + 1 || code[cursor] === '.') return false;
+  // The token scan above is ASCII-only. If the run is preceded by a Unicode
+  // identifier character, the apparent keyword is really the tail of a longer
+  // identifier (e.g. `πreturn`), so the following `/` is division, not a regex.
+  if (cursor >= 0 && /[\p{ID_Continue}\u200C\u200D]/u.test(code[cursor]!)) return false;
 
   const token = code.slice(cursor + 1, tokenEnd);
   if (!REGEX_PREFIX_KEYWORDS.has(token)) return false;
   if (CONTEXTUAL_REGEX_PREFIX_KEYWORDS.has(token)) {
-    return contextualKeywordCanPrefixRegex(code, cursor + 1);
+    return contextualKeywordCanPrefixRegex(code, cursor + 1, token);
   }
   return true;
 }
@@ -820,7 +833,11 @@ function fallbackRecursionFindings(code: string): EvaluationFinding[] {
     const selfCall = new RegExp(`\\b${escapeRegExpLiteral(fnName)}\\s*\\(`).exec(snippet.slice(match[0].length));
     if (!selfCall) continue;
     const beforeCall = snippet.slice(0, match[0].length + selfCall.index);
-    if (/\b(if|return|throw)\b/.test(beforeCall)) continue;
+    // Unicode-aware keyword boundaries: ASCII `\b` treats a non-ASCII letter as
+    // a word boundary, so `\breturn\b` would false-match inside an identifier
+    // like `πreturn` and wrongly treat it as a base-case guard. Require the
+    // keyword not to be adjacent to any identifier-continue character.
+    if (/(?<![\p{ID_Continue}$])(?:if|return|throw)(?![\p{ID_Continue}$])/u.test(beforeCall)) continue;
     findings.push({
       message: `Potential unguarded recursion detected: "${fnName}" calls itself without a visible base case`,
       severity: 'critical',

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -121,13 +121,18 @@ function contextualKeywordCanPrefixRegex(code: string, tokenStart: number, token
   if (token === 'of') return false;
 
   // `await`/`yield` are unary operators: a regex can follow them at an
-  // expression position — after an operator or opening bracket, after a `{`/`;`
-  // that begins a new statement, or after another regex-prefix keyword
-  // (e.g. `return await /re/.test(x)`).
+  // expression position — after an operator or opening bracket, after a block
+  // open `{`, or after another regex-prefix keyword (e.g. `return await /re/`).
+  //
+  // `;` is deliberately excluded: after a statement terminator these words may
+  // be plain identifiers in malformed/sloppy snippets (e.g.
+  // `var await = 1; await / loop() / 2`), where the `/` is division. Since a
+  // recursion detector must not hide a self-call, the ambiguous statement-start
+  // case is treated as division rather than masking it as a regex operand.
   let cursor = tokenStart - 1;
   while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
   if (cursor < 0) return true;
-  if ('([{=,:;!&|?+-*%^~<>'.includes(code[cursor]!)) return true;
+  if ('([{=,:!&|?+-*%^~<>'.includes(code[cursor]!)) return true;
 
   const previous = previousToken(code, cursor);
   return previous != null && REGEX_PREFIX_KEYWORDS.has(previous);

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -113,7 +113,7 @@ function isRegexLiteralStart(code: string, index: number): boolean {
 
   const tokenEnd = cursor + 1;
   while (cursor >= 0 && /[A-Za-z0-9_$]/.test(code[cursor]!)) cursor -= 1;
-  if (tokenEnd === cursor + 1) return false;
+  if (tokenEnd === cursor + 1 || code[cursor] === '.') return false;
 
   const token = code.slice(cursor + 1, tokenEnd);
   return REGEX_PREFIX_KEYWORDS.has(token) && hasKeywordBoundary(code, token, cursor + 1);

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -88,12 +88,155 @@ function fenceRanges(code: string): Range[] {
   }));
 }
 
+const REGEX_PREFIX_KEYWORDS = new Set([
+  'case',
+  'delete',
+  'else',
+  'in',
+  'instanceof',
+  'new',
+  'of',
+  'return',
+  'throw',
+  'typeof',
+  'void',
+  'yield',
+  'await',
+]);
+
 function isRegexLiteralStart(code: string, index: number): boolean {
   let cursor = index - 1;
   while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
   if (cursor < 0) return true;
 
-  return '([{=,:;!&|?+-*%^~<>'.includes(code[cursor]!);
+  if ('([{=,:;!&|?+-*%^~<>'.includes(code[cursor]!)) return true;
+
+  const tokenEnd = cursor + 1;
+  while (cursor >= 0 && /[A-Za-z0-9_$]/.test(code[cursor]!)) cursor -= 1;
+  if (tokenEnd === cursor + 1) return false;
+
+  const token = code.slice(cursor + 1, tokenEnd);
+  return REGEX_PREFIX_KEYWORDS.has(token) && hasKeywordBoundary(code, token, cursor + 1);
+}
+
+function scanQuotedRange(code: string, index: number, ranges: Range[]): number {
+  const quote = code[index];
+  const start = index;
+  index += 1;
+  while (index < code.length) {
+    if (code[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (code[index] === quote) {
+      index += 1;
+      break;
+    }
+    index += 1;
+  }
+  ranges.push({ start, end: index });
+  return index;
+}
+
+function scanLineCommentRange(code: string, index: number, ranges: Range[]): number {
+  const start = index;
+  index = code.indexOf('\n', index + 2);
+  if (index < 0) index = code.length;
+  ranges.push({ start, end: index });
+  return index;
+}
+
+function scanBlockCommentRange(code: string, index: number, ranges: Range[]): number {
+  const start = index;
+  const end = code.indexOf('*/', index + 2);
+  index = end < 0 ? code.length : end + 2;
+  ranges.push({ start, end: index });
+  return index;
+}
+
+function scanRegexRange(code: string, index: number, ranges: Range[]): number {
+  const start = index;
+  index += 1;
+  let inCharacterClass = false;
+  while (index < code.length) {
+    if (code[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (code[index] === '[') inCharacterClass = true;
+    if (code[index] === ']') inCharacterClass = false;
+    if (code[index] === '/' && !inCharacterClass) {
+      index += 1;
+      while (/[a-z]/i.test(code[index] ?? '')) index += 1;
+      break;
+    }
+    index += 1;
+  }
+  ranges.push({ start, end: index });
+  return index;
+}
+
+function scanTemplateRange(code: string, index: number, ranges: Range[]): number {
+  let segmentStart = index;
+  index += 1;
+
+  while (index < code.length) {
+    if (code[index] === '\\') {
+      index += 2;
+      continue;
+    }
+
+    if (code[index] === '$' && code[index + 1] === '{') {
+      ranges.push({ start: segmentStart, end: index + 2 });
+      index += 2;
+      let expressionDepth = 1;
+
+      while (index < code.length && expressionDepth > 0) {
+        const char = code[index];
+        const next = code[index + 1];
+
+        if (char === '\\') {
+          index += 2;
+          continue;
+        }
+        if (char === '\'' || char === '"') {
+          index = scanQuotedRange(code, index, ranges);
+          continue;
+        }
+        if (char === '`') {
+          index = scanTemplateRange(code, index, ranges);
+          continue;
+        }
+        if (char === '/' && next === '/') {
+          index = scanLineCommentRange(code, index, ranges);
+          continue;
+        }
+        if (char === '/' && next === '*') {
+          index = scanBlockCommentRange(code, index, ranges);
+          continue;
+        }
+        if (char === '/' && isRegexLiteralStart(code, index)) {
+          index = scanRegexRange(code, index, ranges);
+          continue;
+        }
+        if (char === '{') expressionDepth += 1;
+        if (char === '}') expressionDepth -= 1;
+        index += 1;
+      }
+
+      segmentStart = index - 1;
+      continue;
+    }
+
+    if (code[index] === '`') {
+      index += 1;
+      break;
+    }
+    index += 1;
+  }
+
+  ranges.push({ start: segmentStart, end: index });
+  return index;
 }
 
 function ignoredSyntaxRanges(code: string, includeFences = false): Range[] {
@@ -106,98 +249,36 @@ function ignoredSyntaxRanges(code: string, includeFences = false): Range[] {
       index = fenced.end;
       continue;
     }
+    if (isIndexInRanges(ranges, index)) {
+      index += 1;
+      continue;
+    }
 
     const char = code[index];
     const next = code[index + 1];
 
-    if ((char === '\'' || char === '"') && !isIndexInRanges(ranges, index)) {
-      const quote = char;
-      const start = index;
-      index += 1;
-      while (index < code.length) {
-        if (code[index] === '\\') {
-          index += 2;
-          continue;
-        }
-        if (code[index] === quote) {
-          index += 1;
-          break;
-        }
-        index += 1;
-      }
-      ranges.push({ start, end: index });
+    if (char === '\'' || char === '"') {
+      index = scanQuotedRange(code, index, ranges);
       continue;
     }
 
-    if (char === '`' && !isIndexInRanges(ranges, index)) {
-      let segmentStart = index;
-      index += 1;
-      while (index < code.length) {
-        if (code[index] === '\\') {
-          index += 2;
-          continue;
-        }
-        if (code[index] === '$' && code[index + 1] === '{') {
-          ranges.push({ start: segmentStart, end: index + 2 });
-          index += 2;
-          let expressionDepth = 1;
-          while (index < code.length && expressionDepth > 0) {
-            if (code[index] === '\\') {
-              index += 2;
-              continue;
-            }
-            if (code[index] === '{') expressionDepth += 1;
-            if (code[index] === '}') expressionDepth -= 1;
-            index += 1;
-          }
-          segmentStart = index - 1;
-          continue;
-        }
-        if (code[index] === '`') {
-          index += 1;
-          break;
-        }
-        index += 1;
-      }
-      ranges.push({ start: segmentStart, end: index });
+    if (char === '`') {
+      index = scanTemplateRange(code, index, ranges);
       continue;
     }
 
     if (char === '/' && next === '/') {
-      const start = index;
-      index = code.indexOf('\n', index + 2);
-      if (index < 0) index = code.length;
-      ranges.push({ start, end: index });
+      index = scanLineCommentRange(code, index, ranges);
       continue;
     }
 
     if (char === '/' && next === '*') {
-      const start = index;
-      const end = code.indexOf('*/', index + 2);
-      index = end < 0 ? code.length : end + 2;
-      ranges.push({ start, end: index });
+      index = scanBlockCommentRange(code, index, ranges);
       continue;
     }
 
     if (char === '/' && isRegexLiteralStart(code, index)) {
-      const start = index;
-      index += 1;
-      let inCharacterClass = false;
-      while (index < code.length) {
-        if (code[index] === '\\') {
-          index += 2;
-          continue;
-        }
-        if (code[index] === '[') inCharacterClass = true;
-        if (code[index] === ']') inCharacterClass = false;
-        if (code[index] === '/' && !inCharacterClass) {
-          index += 1;
-          while (/[a-z]/i.test(code[index] ?? '')) index += 1;
-          break;
-        }
-        index += 1;
-      }
-      ranges.push({ start, end: index });
+      index = scanRegexRange(code, index, ranges);
       continue;
     }
 

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -104,6 +104,26 @@ const REGEX_PREFIX_KEYWORDS = new Set([
   'await',
 ]);
 
+const CONTEXTUAL_REGEX_PREFIX_KEYWORDS = new Set(['await', 'yield', 'of']);
+
+function previousToken(code: string, beforeIndex: number): string | null {
+  let cursor = beforeIndex;
+  while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
+  const end = cursor + 1;
+  while (cursor >= 0 && /[A-Za-z0-9_$]/.test(code[cursor]!)) cursor -= 1;
+  return end === cursor + 1 ? null : code.slice(cursor + 1, end);
+}
+
+function contextualKeywordCanPrefixRegex(code: string, tokenStart: number): boolean {
+  let cursor = tokenStart - 1;
+  while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
+  if (cursor < 0) return false;
+  if ('([=,:!&|?+-*%^~<>'.includes(code[cursor]!)) return true;
+
+  const previous = previousToken(code, cursor);
+  return previous != null && REGEX_PREFIX_KEYWORDS.has(previous);
+}
+
 function isRegexLiteralStart(code: string, index: number): boolean {
   let cursor = index - 1;
   while (cursor >= 0 && /\s/.test(code[cursor]!)) cursor -= 1;
@@ -116,7 +136,11 @@ function isRegexLiteralStart(code: string, index: number): boolean {
   if (tokenEnd === cursor + 1 || code[cursor] === '.') return false;
 
   const token = code.slice(cursor + 1, tokenEnd);
-  return REGEX_PREFIX_KEYWORDS.has(token) && hasKeywordBoundary(code, token, cursor + 1);
+  if (!REGEX_PREFIX_KEYWORDS.has(token)) return false;
+  if (CONTEXTUAL_REGEX_PREFIX_KEYWORDS.has(token)) {
+    return contextualKeywordCanPrefixRegex(code, cursor + 1);
+  }
+  return true;
 }
 
 function scanQuotedRange(code: string, index: number, ranges: Range[]): number {

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -263,6 +263,15 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('recursion');
   });
 
+  it('does not mask division after contextual keyword-like identifiers', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { const of = 1; of / loop() / 2; bad(; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('ignores keywords inside template interpolation strings while fallback scanning', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = 'while (true) { log(`${({ value: "break }" })}`); doWork(); not javascript';

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -294,6 +294,17 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('recursion');
   });
 
+  it('keeps division visible when await is a sloppy-mode identifier after a semicolon', async () => {
+    // `var await = 1; await / loop() / 2` — here `await` is an identifier, so
+    // the slashes are division and `loop()` must remain a visible self-call.
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { var await = 1; await / loop() / 2; bad(; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('recognizes a regex after await at the start of a block in fallback scanning', async () => {
     // `{ await /if/.test(value); loop(); }` — `/if/` is a regex operand of the
     // await operator, so `if` inside it must NOT be seen as a base-case guard;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -237,6 +237,41 @@ describe('LogicLoopEvaluator', () => {
     expect(result.verdict).toBe('pass');
   });
 
+  it('masks regex literals after control-flow keywords in fallback loop scanning', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function unfinished() { while (true) { throw /break/.test(reason); doWork(); `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('masks regex literals after keyword-prefixed await before fallback recursion scanning', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `Analysis notes:\nfunction loop() { const helper = async () => await /if/.test(value); loop(); not javascript`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('ignores keywords inside template interpolation strings while fallback scanning', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { log(`${({ value: "break }" })}`); doWork(); not javascript';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
+  it('ignores keywords inside template interpolation comments while fallback scanning', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = 'while (true) { log(`${({ value: /* break } */ 1 })}`); doWork(); not javascript';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('infinite loop');
+  });
+
   it('does not treat exits inside class methods as exits from the containing loop', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = `while (true) { class Worker { run() { return work(); } } doWork(); }`;

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -254,6 +254,15 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('recursion');
   });
 
+  it('does not mask division after keyword-like member names in fallback recursion scanning', async () => {
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { timer.await / loop() / 2; bad(; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('ignores keywords inside template interpolation strings while fallback scanning', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = 'while (true) { log(`${({ value: "break }" })}`); doWork(); not javascript';

--- a/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/logic-loop.test.ts
@@ -272,6 +272,40 @@ describe('LogicLoopEvaluator', () => {
     expect(result.findings[0]!.message).toContain('recursion');
   });
 
+  it('does not treat `of` after another keyword as a regex prefix in fallback scanning', async () => {
+    // `new of / loop() / 2` — `of` is an identifier here, so the slashes are
+    // division and `loop()` must stay visible as an unguarded self-call.
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { new of / loop() / 2; bad(; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('does not treat a keyword suffix of a Unicode identifier as a regex prefix', async () => {
+    // `πreturn` is a single identifier; the trailing `return` must not be read
+    // as a keyword, so `/ loop() /` is division and the self-call stays visible.
+    const evaluator = new LogicLoopEvaluator();
+    const content = `function loop() { πreturn / loop() / 2; bad(; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
+  it('recognizes a regex after await at the start of a block in fallback scanning', async () => {
+    // `{ await /if/.test(value); loop(); }` — `/if/` is a regex operand of the
+    // await operator, so `if` inside it must NOT be seen as a base-case guard;
+    // the unguarded self-call `loop()` must be reported.
+    const evaluator = new LogicLoopEvaluator();
+    const content = `async function loop() { await /if/.test(value); loop(); bad(; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings[0]!.message).toContain('recursion');
+  });
+
   it('ignores keywords inside template interpolation strings while fallback scanning', async () => {
     const evaluator = new LogicLoopEvaluator();
     const content = 'while (true) { log(`${({ value: "break }" })}`); doWork(); not javascript';


### PR DESCRIPTION
## Summary
- handle strings, comments, regexes, and nested templates while scanning template interpolation syntax masks
- recognize regex literals after keyword prefixes such as await/throw/return
- add regression coverage for issue #691 fallback parsing cases

## Test Plan
- npm run test --workspace @franken/critique -- tests/unit/evaluators/logic-loop.test.ts
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/types
- npm run build --workspace @franken/critique
- npm run test --workspace @franken/critique

Closes #691