### PR TITLE
fix(cli): reject zero budget values

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -301,7 +301,7 @@ function splitSkillAddArgs(args: string[]): { isSkillAdd: boolean; parsedFlagArg
   };
 }
 
-function parseFiniteDecimalOption(name: string, value: string, options: { min?: number } = {}): number {
+function parseFiniteDecimalOption(name: string, value: string, options: { min?: number; minExclusive?: number } = {}): number {
   const trimmed = value.trim();
   if (!DECIMAL_PATTERN.test(trimmed)) {
     throw new TypeError(`Invalid ${name}: expected a finite number, got '${value}'`);
@@ -314,6 +314,9 @@ function parseFiniteDecimalOption(name: string, value: string, options: { min?: 
 
   if (options.min !== undefined && parsed < options.min) {
     throw new TypeError(`Invalid ${name}: expected a value >= ${options.min}, got ${value}`);
+  }
+  if (options.minExclusive !== undefined && parsed <= options.minExclusive) {
+    throw new TypeError(`Invalid ${name}: expected a value > ${options.minExclusive}, got ${value}`);
   }
 
   return parsed;
@@ -539,7 +542,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   }
 
   const budget = values.budget !== undefined
-    ? parseFiniteDecimalOption('--budget', values.budget, { min: 0 })
+    ? parseFiniteDecimalOption('--budget', values.budget, { minExclusive: 0 })
     : 10;
   const port = values.port !== undefined
     ? parseIntegerOption('--port', values.port, { min: 0, max: 65535 })

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -545,7 +545,8 @@ describe('parseArgs', () => {
       expect(() => parseArgs(['--budget', value])).toThrow(/Invalid --budget/);
     });
 
-    it('rejects a negative budget value', () => {
+    it('rejects zero and negative budget values before they can reach budget rendering', () => {
+      expect(() => parseArgs(['--budget', '0'])).toThrow(/Invalid --budget/);
       expect(() => parseArgs(['--budget=-0.01'])).toThrow(/Invalid --budget/);
     });
 


### PR DESCRIPTION
## Summary
- reject zero-dollar CLI budgets during argument parsing
- keep malformed budget/port validation in args.ts before runtime code sees invalid numbers
- add a regression test for zero budget values reaching budget rendering

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/cli/args.test.ts
- npm run test --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #672