### PR TITLE
fix(critique): track failure history internally

### DIFF
--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -81,7 +81,7 @@ export class CritiqueLoop {
   }
 
   private async checkBreakers(
-    state: LoopState,
+    state: InternalLoopState,
     config: LoopConfig,
     phase: 'pre' | 'post',
   ): Promise<CritiqueLoopResult | null> {
@@ -92,7 +92,7 @@ export class CritiqueLoop {
       if (breakerPhase !== phase && breakerPhase !== 'both') continue;
       // Sequential await preserves breaker ordering (e.g. halt short-circuits
       // before escalate). Do not parallelize.
-      const result = await breaker.check(state, config);
+      const result = await breaker.check(this.toPublicState(state), config);
       if (result.tripped) {
         if (result.action === 'escalate') {
           return {
@@ -109,6 +109,14 @@ export class CritiqueLoop {
       }
     }
     return null;
+  }
+
+  private toPublicState(state: InternalLoopState): LoopState {
+    return {
+      iterationCount: state.iterationCount,
+      iterations: [...state.iterations],
+      failureHistory: new Map(state.failureHistory),
+    };
   }
 
   private buildCorrection(

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -11,6 +11,10 @@ import type { EscalationRequest } from '../types/contracts.js';
 import type { CritiquePipeline } from '../pipeline/critique-pipeline.js';
 import { hasReachedMaxIterations } from './iteration-limit.js';
 
+interface InternalLoopState extends LoopState {
+  failureHistory: Map<string, number>;
+}
+
 export class CritiqueLoop {
   private readonly pipeline: CritiquePipeline;
   private readonly breakers: readonly CircuitBreaker[];
@@ -21,7 +25,7 @@ export class CritiqueLoop {
   }
 
   async run(input: EvaluationInput, config: LoopConfig): Promise<CritiqueLoopResult> {
-    const state: LoopState = {
+    const state: InternalLoopState = {
       iterationCount: 0,
       iterations: [],
       failureHistory: new Map(),
@@ -60,7 +64,7 @@ export class CritiqueLoop {
       for (const result of critiqueResult.results) {
         if (result.verdict === 'fail') {
           const current = state.failureHistory.get(result.evaluatorName) ?? 0;
-          (state.failureHistory as Map<string, number>).set(result.evaluatorName, current + 1);
+          state.failureHistory.set(result.evaluatorName, current + 1);
         }
       }
 

--- a/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
+++ b/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
@@ -156,6 +156,23 @@ describe('CritiqueLoop', () => {
     expect(result.iterations).toHaveLength(1);
   });
 
+  it('tracks failure history across iterations without mutating the public readonly contract', async () => {
+    const observedFailures: number[] = [];
+    const breaker: CircuitBreaker = {
+      name: 'failure-history-observer',
+      check: vi.fn().mockImplementation(async (state: LoopState) => {
+        observedFailures.push(state.failureHistory.get('mock') ?? 0);
+        return { tripped: false };
+      }),
+    };
+
+    const loop = new CritiqueLoop(createFailingPipeline(), [breaker]);
+    const result = await loop.run(createInput('bad code'), createConfig({ maxIterations: 2 }));
+
+    expect(result.verdict).toBe('fail');
+    expect(observedFailures).toEqual([0, 1]);
+  });
+
   it('re-checks spend breakers after the terminal iteration (post phase)', async () => {
     // A phase:'both' breaker that is under budget before the iteration but trips
     // once the iteration's spend is recorded. Without the post-iteration check a

--- a/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
+++ b/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
@@ -34,12 +34,19 @@ function createPassingPipeline(): CritiquePipeline {
   return new CritiquePipeline([evaluator]);
 }
 
-function createFailingPipeline(findings: readonly EvaluationFinding[] = [{ message: 'issue found', severity: 'warning' }]): CritiquePipeline {
+interface FailingPipelineOptions {
+  readonly evaluatorName?: string;
+  readonly findings?: readonly EvaluationFinding[];
+}
+
+function createFailingPipeline(options: FailingPipelineOptions = {}): CritiquePipeline {
+  const evaluatorName = options.evaluatorName ?? 'mock';
+  const findings = options.findings ?? [{ message: 'issue found', severity: 'warning' }];
   const evaluator: Evaluator = {
-    name: 'mock',
+    name: evaluatorName,
     category: 'deterministic',
     evaluate: vi.fn().mockResolvedValue({
-      evaluatorName: 'mock',
+      evaluatorName,
       verdict: 'fail',
       score: 0.3,
       findings,
@@ -157,16 +164,45 @@ describe('CritiqueLoop', () => {
   });
 
   it('tracks failure history across iterations without mutating the public readonly contract', async () => {
+    const evaluatorName = 'failure-history-evaluator';
     const observedFailures: number[] = [];
     const breaker: CircuitBreaker = {
       name: 'failure-history-observer',
       check: vi.fn().mockImplementation(async (state: LoopState) => {
-        observedFailures.push(state.failureHistory.get('mock') ?? 0);
+        observedFailures.push(state.failureHistory.get(evaluatorName) ?? 0);
         return { tripped: false };
       }),
     };
 
-    const loop = new CritiqueLoop(createFailingPipeline(), [breaker]);
+    const loop = new CritiqueLoop(createFailingPipeline({ evaluatorName }), [breaker]);
+    const result = await loop.run(createInput('bad code'), createConfig({ maxIterations: 2 }));
+
+    expect(result.verdict).toBe('fail');
+    expect(observedFailures).toEqual([0, 1]);
+  });
+
+  it('isolates internal failure history from runtime breaker mutation', async () => {
+    const evaluatorName = 'isolated-evaluator';
+    const observedFailures: number[] = [];
+    const mutatingBreaker: CircuitBreaker = {
+      name: 'mutating-breaker',
+      check: vi.fn().mockImplementation(async (state: LoopState) => {
+        (state.failureHistory as Map<string, number>).set(evaluatorName, 999);
+        return { tripped: false };
+      }),
+    };
+    const observingBreaker: CircuitBreaker = {
+      name: 'observing-breaker',
+      check: vi.fn().mockImplementation(async (state: LoopState) => {
+        observedFailures.push(state.failureHistory.get(evaluatorName) ?? 0);
+        return { tripped: false };
+      }),
+    };
+
+    const loop = new CritiqueLoop(createFailingPipeline({ evaluatorName }), [
+      mutatingBreaker,
+      observingBreaker,
+    ]);
     const result = await loop.run(createInput('bad code'), createConfig({ maxIterations: 2 }));
 
     expect(result.verdict).toBe('fail');
@@ -213,7 +249,7 @@ describe('CritiqueLoop', () => {
       { message: 'security issue', severity: 'critical' as const },
       { message: 'style issue', severity: 'info' as const },
     ];
-    const loop = new CritiqueLoop(createFailingPipeline(findings), []);
+    const loop = new CritiqueLoop(createFailingPipeline({ findings }), []);
     const result = await loop.run(createInput('code'), createConfig({ maxIterations: 1 }));
 
     expect(result.verdict).toBe('fail');


### PR DESCRIPTION
## Summary

- replace the `ReadonlyMap` mutation cast with an internal mutable loop state
- keep the public `LoopState.failureHistory` contract readonly for circuit breakers
- add CritiqueLoop coverage for failure history across iterations

## Verification

- `npm test --workspace packages/franken-critique`
- `npm run build -- --filter=@franken/critique`

Fixes #56
