### PR TITLE
fix(orchestrator): escape Beast metric label values

### DIFF
--- a/packages/franken-orchestrator/src/beasts/telemetry/prometheus-beast-metrics.ts
+++ b/packages/franken-orchestrator/src/beasts/telemetry/prometheus-beast-metrics.ts
@@ -1,10 +1,17 @@
 import type { BeastDispatchSource } from '../types.js';
 import type { BeastMetrics } from './beast-metrics.js';
 
+function escapeLabelValue(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/"/g, '\\"');
+}
+
 function key(parts: Record<string, string>): string {
   return Object.entries(parts)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, value]) => `${name}="${value}"`)
+    .map(([name, value]) => `${name}="${escapeLabelValue(value)}"`)
     .join(',');
 }
 

--- a/packages/franken-orchestrator/tests/unit/beasts/prometheus-beast-metrics.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/prometheus-beast-metrics.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
+import type { BeastDispatchSource } from '../../../src/beasts/types.js';
+
+describe('PrometheusBeastMetrics', () => {
+  it('escapes reserved characters in label values', () => {
+    const metrics = new PrometheusBeastMetrics();
+
+    metrics.recordRunCreated(
+      'bad"name',
+      'dash\\board\napi' as BeastDispatchSource,
+    );
+    metrics.recordRunStopped('stop\\bad"name\n');
+
+    const output = metrics.render();
+
+    expect(output).toContain(
+      'beast_runs_created_total{definition_id="bad\\"name",source="dash\\\\board\\napi"} 1',
+    );
+    expect(output).toContain(
+      'beast_run_stops_total{definition_id="stop\\\\bad\\"name\\n"} 1',
+    );
+  });
+
+  it('keeps existing happy-path label output unchanged', () => {
+    const metrics = new PrometheusBeastMetrics();
+
+    metrics.recordRunCreated('martin-loop', 'dashboard');
+
+    expect(metrics.render()).toContain(
+      'beast_runs_created_total{definition_id="martin-loop",source="dashboard"} 1',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Escape Prometheus label values before rendering Beast metrics.
- Cover quotes, backslashes, and newlines in `definition_id` / `source` label values.
- Keep the existing happy-path metric output unchanged.

Closes #1007.

## Tests

- `npm run build`
- `npm --workspace @franken/orchestrator run build`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator test -- prometheus-beast-metrics.test.ts`
- `TMPDIR=/private/var/folders/s7/lgd2nwwd447624mlx15dxlvw0000gn/T/ npm --workspace @franken/orchestrator test`
- `npm --workspace @franken/orchestrator run lint`
- `git diff --check HEAD~1 HEAD`
