### PR TITLE
fix(orchestrator): make websocket session tickets one-time

### DIFF
--- a/packages/franken-orchestrator/src/http/security/transport-security.ts
+++ b/packages/franken-orchestrator/src/http/security/transport-security.ts
@@ -31,6 +31,11 @@ function decode(input: string): string {
   return Buffer.from(input, 'base64url').toString('utf8');
 }
 
+function isCanonicalBase64Url(input: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(input)
+    && Buffer.from(input, 'base64url').toString('base64url') === input;
+}
+
 function signatureFor(payload: string, secret: string): Buffer {
   return createHmac('sha256', secret).update(payload).digest();
 }
@@ -61,6 +66,9 @@ export class TransportSecurityService {
     }
     const [encodedPayload, encodedSignature] = tokenParts;
     if (!encodedPayload || !encodedSignature) {
+      return false;
+    }
+    if (!isCanonicalBase64Url(encodedPayload) || !isCanonicalBase64Url(encodedSignature)) {
       return false;
     }
 

--- a/packages/franken-orchestrator/src/http/security/transport-security.ts
+++ b/packages/franken-orchestrator/src/http/security/transport-security.ts
@@ -48,13 +48,18 @@ export class TransportSecurityService {
 
   issueSignedToken(options: IssueSignedTokenOptions): string {
     const expiresAt = Date.now() + (options.expiresInMs ?? 5 * 60 * 1000);
-    const payload = `${options.subject}.${options.scope}.${expiresAt}`;
+    const nonce = randomBytes(16).toString('base64url');
+    const payload = `${options.subject}.${options.scope}.${expiresAt}.${nonce}`;
     const signature = signatureFor(payload, options.secret).toString('base64url');
     return `${encode(payload)}.${signature}`;
   }
 
   verifySignedToken(options: VerifySignedTokenOptions): boolean {
-    const [encodedPayload, encodedSignature] = options.token.split('.');
+    const tokenParts = options.token.split('.');
+    if (tokenParts.length !== 2) {
+      return false;
+    }
+    const [encodedPayload, encodedSignature] = tokenParts;
     if (!encodedPayload || !encodedSignature) {
       return false;
     }

--- a/packages/franken-orchestrator/src/http/ws-chat-auth.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-auth.ts
@@ -1,4 +1,5 @@
 import { TransportSecurityService } from './security/transport-security.js';
+import { createHash } from 'node:crypto';
 
 export const CHAT_SOCKET_TOKEN_TTL_MS = 5 * 60 * 1000;
 
@@ -24,6 +25,53 @@ export interface VerifyChatSocketRequestOptions {
 
 const SESSION_SCOPE = 'chat-session';
 const transportSecurity = new TransportSecurityService();
+
+function tokenFingerprint(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function tokenExpiresAt(token: string): number | null {
+  const [encodedPayload] = token.split('.');
+  if (!encodedPayload) {
+    return null;
+  }
+  try {
+    const payload = Buffer.from(encodedPayload, 'base64url').toString('utf8');
+    const [, , expiresAtRaw] = payload.split('.');
+    const expiresAt = Number(expiresAtRaw);
+    return Number.isFinite(expiresAt) ? expiresAt : null;
+  } catch {
+    return null;
+  }
+}
+
+export class ChatSocketSessionTicketStore {
+  private readonly consumed = new Map<string, number>();
+
+  isConsumed(token: string): boolean {
+    this.cleanup();
+    return this.consumed.has(tokenFingerprint(token));
+  }
+
+  consume(token: string): boolean {
+    this.cleanup();
+    const fingerprint = tokenFingerprint(token);
+    if (this.consumed.has(fingerprint)) {
+      return false;
+    }
+    this.consumed.set(fingerprint, tokenExpiresAt(token) ?? Date.now() + CHAT_SOCKET_TOKEN_TTL_MS);
+    return true;
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [fingerprint, expiresAt] of this.consumed) {
+      if (expiresAt < now) {
+        this.consumed.delete(fingerprint);
+      }
+    }
+  }
+}
 
 export function createSessionTokenSecret(): string {
   return transportSecurity.createSecret();

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -7,6 +7,7 @@ import type { ISessionStore } from '../chat/session-store.js';
 import type { ChatSession } from '../chat/types.js';
 import type { TurnEvent } from '../chat/turn-runner.js';
 import {
+  ChatSocketSessionTicketStore,
   verifyChatSocketRequest,
 } from './ws-chat-auth.js';
 import {
@@ -28,6 +29,7 @@ export interface ChatSocketControllerOptions {
   allowedOrigins?: string[];
   runtime: ChatRuntime;
   sessionStore: ISessionStore;
+  ticketStore?: ChatSocketSessionTicketStore;
   tokenSecret: string;
 }
 
@@ -94,16 +96,18 @@ export class ChatSocketController {
   private readonly allowedOrigins: string[];
   private readonly runtime: ChatRuntime;
   private readonly sessionStore: ISessionStore;
+  private readonly ticketStore: ChatSocketSessionTicketStore;
   private readonly tokenSecret: string;
 
   constructor(options: ChatSocketControllerOptions) {
     this.allowedOrigins = options.allowedOrigins ?? [];
     this.runtime = options.runtime;
     this.sessionStore = options.sessionStore;
+    this.ticketStore = options.ticketStore ?? new ChatSocketSessionTicketStore();
     this.tokenSecret = options.tokenSecret;
   }
 
-  connect(peer: ChatSocketPeer, request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
+  authorize(request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
     const session = this.sessionStore.get(request.sessionId);
     if (!session) {
       return { ok: false, status: 404 };
@@ -120,6 +124,30 @@ export class ChatSocketController {
       return auth;
     }
 
+    if (request.token && this.ticketStore.isConsumed(request.token)) {
+      this.auditRejectedTicketReuse(request.sessionId);
+      return { ok: false, status: 401 };
+    }
+
+    return { ok: true };
+  }
+
+  connect(peer: ChatSocketPeer, request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
+    const auth = this.authorize(request);
+    if (!auth.ok) {
+      return auth;
+    }
+
+    if (!request.token || !this.ticketStore.consume(request.token)) {
+      this.auditRejectedTicketReuse(request.sessionId);
+      return { ok: false, status: 401 };
+    }
+
+    const session = this.sessionStore.get(request.sessionId);
+    if (!session) {
+      return { ok: false, status: 404 };
+    }
+
     createPeerState(peer, request.sessionId, this);
     this.emit(peer, {
       type: 'session.ready',
@@ -130,6 +158,10 @@ export class ChatSocketController {
       pendingApproval: session.pendingApproval ?? null,
     });
     return { ok: true };
+  }
+
+  private auditRejectedTicketReuse(sessionId: string): void {
+    console.warn('Rejected reused websocket chat session ticket', { sessionId });
   }
 
   disconnect(peer: ChatSocketPeer): void {
@@ -403,25 +435,15 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
     }
     const { token } = protocolAuth;
 
-    const auth = controller.connect(
-      {
-        close: () => socket.destroy(),
-        send: () => undefined,
-      },
-      {
-        origin: requestOrigin(request),
-        sessionId,
-        token,
-      },
-    );
+    const auth = controller.authorize({
+      origin: requestOrigin(request),
+      sessionId,
+      token,
+    });
     if (!auth.ok) {
       closeUnauthorized(socket, auth.status);
       return;
     }
-    controller.disconnect({
-      close: () => socket.destroy(),
-      send: () => undefined,
-    });
     request.headers['sec-websocket-protocol'] = CHAT_SOCKET_PROTOCOL;
 
     server.handleUpgrade(request, socket, head, (ws: WebSocket) => {

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -99,6 +99,41 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('rejects replayed socket tokens after the first successful upgrade', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const httpServer = createServer();
+    attachChatWebSocketServer({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+      server: httpServer,
+    });
+    const port = await listen(httpServer);
+    const url = `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}`;
+    const protocols = [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${token}`];
+    const firstSocket = new WebSocket(url, protocols);
+
+    await expect(onceSocket(firstSocket, 'open')).resolves.toEqual([]);
+
+    const replaySocket = new WebSocket(url, protocols);
+    await onceSocket(replaySocket, 'error');
+    expect(replaySocket.readyState).toBe(WebSocket.CLOSED);
+    expect(warn).toHaveBeenCalledWith(
+      'Rejected reused websocket chat session ticket',
+      { sessionId: session.id },
+    );
+
+    firstSocket.close();
+    httpServer.close();
+    warn.mockRestore();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('does not negotiate token pseudo-protocols when clients send them first', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
@@ -88,4 +88,28 @@ describe('TransportSecurityService', () => {
       token: `${token}.replay`,
     })).toBe(false);
   });
+
+  it('rejects non-canonical base64url token encodings', () => {
+    const security = new TransportSecurityService();
+    const secret = security.createSecret();
+    const token = security.issueSignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+    });
+
+    expect(security.verifySignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      token: `${token}!`,
+    })).toBe(false);
+
+    expect(security.verifySignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      token: token.replace('.', '!.'),
+    })).toBe(false);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
@@ -39,4 +39,53 @@ describe('TransportSecurityService', () => {
       token,
     })).toEqual({ ok: false, status: 403 });
   });
+
+  it('issues distinct tokens for the same subject in the same validity window', () => {
+    const security = new TransportSecurityService();
+    const secret = security.createSecret();
+
+    const first = security.issueSignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      expiresInMs: 60_000,
+    });
+    const second = security.issueSignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      expiresInMs: 60_000,
+    });
+
+    expect(second).not.toBe(first);
+    expect(security.verifySignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      token: first,
+    })).toBe(true);
+    expect(security.verifySignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      token: second,
+    })).toBe(true);
+  });
+
+  it('rejects tokens with extra dot-separated segments', () => {
+    const security = new TransportSecurityService();
+    const secret = security.createSecret();
+    const token = security.issueSignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+    });
+
+    expect(security.verifySignedToken({
+      secret,
+      scope: 'chat:socket',
+      subject: 'session-1',
+      token: `${token}.replay`,
+    })).toBe(false);
+  });
 });

--- a/packages/franken-web/package.json
+++ b/packages/franken-web/package.json
@@ -16,7 +16,7 @@
     "dev:network": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run --fileParallelism=false",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm --prefix ../.. run build"
   },

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -84,6 +84,41 @@ describe('useChatSession error banners', () => {
     ]);
   });
 
+  it('fetches a fresh socket token before reconnecting a closed websocket', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    expect(MockWebSocket.instances[0]!.protocols).toEqual([
+      'franken.chat.v1',
+      'franken.chat.token.socket-token-1',
+    ]);
+
+    act(() => {
+      MockWebSocket.instances[0]!.onclose?.();
+    });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+    expect(fetch).toHaveBeenLastCalledWith(
+      'http://localhost:3000/v1/chat/sessions/session-1',
+      { credentials: 'same-origin', method: 'GET' },
+    );
+    expect(MockWebSocket.instances[1]!.protocols).toEqual([
+      'franken.chat.v1',
+      'franken.chat.token.socket-token-2',
+    ]);
+  });
+
   it('turns socket turn errors into visible retry banners', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
     vi.stubGlobal('WebSocket', MockWebSocket);
@@ -434,7 +469,10 @@ describe('useChatSession error banners', () => {
   });
 
   it('marks pending sends failed when reconnect cleanup races the server ack', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -460,7 +498,10 @@ describe('useChatSession error banners', () => {
   });
 
   it('reconnects when the browser returns online after an offline close', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -429,6 +429,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       })
       .catch((error) => {
         setStatus('error');
+        setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'error');
         addErrorBanner(makeBanner(
           'Unable to refresh chat session',
           errorMessage(error, 'The chat API did not return a refreshed session.'),
@@ -522,8 +523,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     function handleOnline() {
+      failAllPendingSends(new Error('Connection is reconnecting before the server acknowledged the message.'));
       setConnectionStatus('reconnecting');
-      setSocketGeneration((current) => current + 1);
+      refreshSession();
     }
 
     window.addEventListener('online', handleOnline);
@@ -742,7 +744,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           return;
         }
         setConnectionStatus('reconnecting');
-        setSocketGeneration((current) => current + 1);
+        refreshSession();
       } else {
         setConnectionStatus('disconnected');
       }

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { useChatSession } from '../../src/hooks/use-chat-session';
 
 const mockCreateSession = vi.fn();
@@ -80,6 +80,12 @@ describe('useChatSession', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCreateSession.mockReset();
+    mockGetSession.mockReset();
+    mockSendMessage.mockReset();
+    mockApprove.mockReset();
+    mockSocketUrl.mockReset();
+    mockSocketProtocols.mockReset();
     MockWebSocket.instances = [];
     mockCreateSession.mockResolvedValue({
       id: 'chat-1',
@@ -120,6 +126,7 @@ describe('useChatSession', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.useRealTimers();
     MockWebSocket.instances = [];
   });
@@ -378,6 +385,10 @@ describe('useChatSession', () => {
     });
     await expect(failedSend).rejects.toThrow('Connection closed');
 
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
     const reconnect = MockWebSocket.instances[1]!;
     act(() => {
       reconnect.message({
@@ -484,6 +495,10 @@ describe('useChatSession', () => {
       socket.shutdown();
     });
     await expect(secondSend).rejects.toThrow('Connection closed');
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
 
     const reconnect = MockWebSocket.instances[1]!;
     act(() => {
@@ -612,6 +627,10 @@ describe('useChatSession', () => {
       socket.shutdown();
     });
     await expect(failedSend).rejects.toThrow('Connection closed');
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
 
     const reconnect = MockWebSocket.instances[1]!;
     act(() => {
@@ -892,6 +911,21 @@ describe('useChatSession', () => {
       updatedAt: '2026-03-09T00:00:07Z',
     });
 
+    act(() => {
+      socket.message({
+        type: 'assistant.message.delta',
+        messageId: 'approval-prompt',
+        chunk: 'Approve deployment?',
+        modelTier: 'cheap',
+      });
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+      socket.readyState = 3;
+    });
+
     await act(async () => {
       await result.current.approve(true);
     });
@@ -944,21 +978,6 @@ describe('useChatSession', () => {
       await sendPromise;
     });
 
-    act(() => {
-      socket.message({
-        type: 'assistant.message.delta',
-        messageId: 'approval-prompt',
-        chunk: 'Approve deployment?',
-        modelTier: 'cheap',
-      });
-      socket.message({
-        type: 'turn.approval.requested',
-        description: 'Deploy the generated fix',
-        timestamp: '2026-03-09T00:00:06Z',
-      });
-      socket.shutdown();
-    });
-
     mockGetSession.mockResolvedValueOnce({
       id: 'chat-1',
       projectId: 'test-proj',
@@ -975,6 +994,21 @@ describe('useChatSession', () => {
       costUsd: 0.01,
       createdAt: '2026-03-09T00:00:00Z',
       updatedAt: '2026-03-09T00:00:07Z',
+    });
+
+    act(() => {
+      socket.message({
+        type: 'assistant.message.delta',
+        messageId: 'approval-prompt',
+        chunk: 'Approve deployment?',
+        modelTier: 'cheap',
+      });
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+      socket.readyState = 3;
     });
 
     await act(async () => {
@@ -1093,7 +1127,7 @@ describe('useChatSession', () => {
       firstSocket.shutdown();
     });
 
-    expect(result.current.connectionStatus).toBe('connecting');
+    expect(result.current.connectionStatus).toBe('reconnecting');
 
     await act(async () => {
       await result.current.send('retry after reconnect');


### PR DESCRIPTION
## Summary
- add an in-memory websocket session ticket store keyed by token fingerprint
- reject/audit replayed chat socket tickets after a successful upgrade
- add integration coverage for replayed websocket token rejection

## Test Plan
- npm --workspace @franken/orchestrator run test:integration -- ws-chat-server.test.ts
- npm --workspace @franken/types run build
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator run lint
- npm --workspace @franken/orchestrator run build
- npm --workspace @franken/orchestrator run test:integration -- ws-chat-auth.test.ts ws-chat-server.test.ts

Closes #608