### PR TITLE
fix(cli): show network help before root resolution

### DIFF
--- a/packages/franken-orchestrator/src/chat/approval-input.ts
+++ b/packages/franken-orchestrator/src/chat/approval-input.ts
@@ -1,0 +1,5 @@
+import type { PendingApproval } from '@franken/types';
+
+export function approvalRuntimeInput(pendingApproval: PendingApproval | null | undefined): string {
+  return pendingApproval?.command ? `/run ${pendingApproval.command}` : '/approve';
+}

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -74,6 +74,10 @@ function stateFromRunResult(runResult: TurnRunResult): string {
   }
 }
 
+export interface ChatRuntimeRunOptions {
+  onEvent?: ((event: TurnEvent) => void) | undefined;
+}
+
 export class ChatRuntime {
   private readonly engine: ConversationEngine;
   private readonly beastDispatchAdapter: BeastDispatchPort | undefined;
@@ -85,22 +89,23 @@ export class ChatRuntime {
     this.turnRunner = options.turnRunner;
   }
 
-  async run(input: string, state: ChatRuntimeState): Promise<ChatRuntimeResult> {
+  async run(input: string, state: ChatRuntimeState, options?: ChatRuntimeRunOptions): Promise<ChatRuntimeResult> {
     const trimmed = input.trim();
     if (trimmed.startsWith('/')) {
       const command = trimmed.split(/\s+/)[0]?.toLowerCase();
       if (command && SLASH_COMMANDS.has(command)) {
-        return this.runSlashCommand(command, trimmed, state);
+        return this.runSlashCommand(command, trimmed, state, options);
       }
     }
 
-    return this.runTurn(trimmed, state);
+    return this.runTurn(trimmed, state, options);
   }
 
   private async runSlashCommand(
     command: string,
     raw: string,
     state: ChatRuntimeState,
+    options?: ChatRuntimeRunOptions,
   ): Promise<ChatRuntimeResult> {
     const description = raw.slice(command.length).trim();
 
@@ -116,7 +121,7 @@ export class ChatRuntime {
           kind: 'plan',
           planSummary: description,
           chunkCount: 0,
-        }, { sessionId: state.sessionId });
+        }, { sessionId: state.sessionId, onEvent: options?.onEvent });
         return this.result(state, [
           { kind: 'plan', content: runResult.summary },
         ], {
@@ -140,6 +145,7 @@ export class ChatRuntime {
           },
           state,
           'premium_execution',
+          options,
         );
       }
       case '/status':
@@ -171,7 +177,11 @@ export class ChatRuntime {
     }
   }
 
-  private async runTurn(input: string, state: ChatRuntimeState): Promise<ChatRuntimeResult> {
+  private async runTurn(
+    input: string,
+    state: ChatRuntimeState,
+    options?: ChatRuntimeRunOptions,
+  ): Promise<ChatRuntimeResult> {
     if (this.beastDispatchAdapter) {
       const beastResult = await this.beastDispatchAdapter.handle(input, {
         projectId: state.projectId,
@@ -248,7 +258,7 @@ export class ChatRuntime {
           },
         );
       case 'execute':
-        return this.runExecuteOutcome(result.outcome, { ...state, transcript }, result.tier);
+        return this.runExecuteOutcome(result.outcome, { ...state, transcript }, result.tier, options);
     }
   }
 
@@ -256,8 +266,12 @@ export class ChatRuntime {
     outcome: ExecuteOutcome,
     state: ChatRuntimeState,
     tier: string,
+    options?: ChatRuntimeRunOptions,
   ): Promise<ChatRuntimeResult> {
-    const runResult = await this.turnRunner.run(outcome, { sessionId: state.sessionId });
+    const runResult = await this.turnRunner.run(outcome, {
+      sessionId: state.sessionId,
+      onEvent: options?.onEvent,
+    });
     const pendingApproval = runResult.status === 'pending_approval';
     const pendingApprovalContext: PendingApprovalContext = {
       tool: 'execution',

--- a/packages/franken-orchestrator/src/chat/turn-runner.ts
+++ b/packages/franken-orchestrator/src/chat/turn-runner.ts
@@ -28,6 +28,7 @@ export type TurnEvent =
 
 export interface TurnRunOptions {
   sessionId: string;
+  onEvent?: ((event: TurnEvent) => void) | undefined;
 }
 
 export interface TurnRunResult {
@@ -57,6 +58,7 @@ export class TurnRunner extends EventEmitter {
       const event: TurnEvent = { type: 'approval_request', sessionId, data: { taskDescription: outcome.taskDescription } };
       events.push(event);
       this.emit('event', event);
+      options?.onEvent?.(event);
       return {
         status: 'pending_approval',
         summary: `Approval required: ${outcome.taskDescription}`,
@@ -67,6 +69,7 @@ export class TurnRunner extends EventEmitter {
     const startEvent: TurnEvent = { type: 'start', sessionId, data: { taskDescription: outcome.taskDescription } };
     events.push(startEvent);
     this.emit('event', startEvent);
+    options?.onEvent?.(startEvent);
 
     const executionResult = await this.executor.execute({ userInput: outcome.taskDescription });
 
@@ -76,6 +79,7 @@ export class TurnRunner extends EventEmitter {
     const completeEvent: TurnEvent = { type: 'complete', sessionId, data: { status: executionResult.status } };
     events.push(completeEvent);
     this.emit('event', completeEvent);
+    options?.onEvent?.(completeEvent);
 
     return { status, summary, events };
   }

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -68,6 +68,7 @@ export interface CliArgs {
   provider: string;
   providerSpecified?: boolean | undefined;
   providers?: string[] | undefined;
+  trustProviderCommandOverrides?: boolean | undefined;
   designDoc?: string | undefined;
   planDir?: string | undefined;
   planName?: string | undefined;
@@ -137,6 +138,8 @@ Options:
   --budget <usd>          Budget limit in USD (default: 10)
   --provider <name>       Provider name (default: claude)
   --providers <list>      Comma-separated fallback chain (e.g. claude,gemini,aider)
+  --trust-provider-command-overrides
+                           Explicitly approve trusted repo-configured provider command overrides
   --design-doc <path>     Path to design document
   --plan-dir <path>       Path to chunk files directory
   --plan-name <name>      Plan name (default: auto-generated from date)
@@ -372,6 +375,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       budget: { type: 'string' },
       provider: { type: 'string' },
       providers: { type: 'string' },
+      'trust-provider-command-overrides': { type: 'boolean', default: false },
       'design-doc': { type: 'string' },
       'plan-dir': { type: 'string' },
       'plan-name': { type: 'string' },
@@ -583,6 +587,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     provider,
     providerSpecified: values.provider !== undefined,
     providers,
+    trustProviderCommandOverrides: values['trust-provider-command-overrides'] ?? false,
     designDoc: values['design-doc'],
     planDir: values['plan-dir'],
     planName: values['plan-name'],

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { OrchestratorConfigSchema, type OrchestratorConfig } from '../config/orchestrator-config.js';
+import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
 import type { CliArgs } from './args.js';
 
@@ -120,7 +120,7 @@ export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Pro
   if (configPath) {
     try {
       fileConfig = await fromFile(configPath);
-      if (!args.config) {
+      if (!args.config && !args.trustProviderCommandOverrides) {
         fileConfig = stripRepositoryLocalCommandTrust(fileConfig);
       }
     } catch (error) {
@@ -143,5 +143,7 @@ export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Pro
     merged = applyNetworkConfigSets(merged, args.networkSet);
   }
 
-  return OrchestratorConfigSchema.parse(merged);
+  return parseOrchestratorConfig(merged, {
+    allowTrustedProviderCommandOverrides: args.trustProviderCommandOverrides,
+  });
 }

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -45,6 +45,7 @@ export interface CliDepOptions {
   provider: string;
   providers?: string[] | undefined;
   providersConfig?: Record<string, ProviderCommandOverridePolicyConfig & { model?: string | undefined; extraArgs?: string[] | undefined }> | undefined;
+  trustProviderCommandOverrides?: boolean | undefined;
   noPr: boolean;
   verbose: boolean;
   reset: boolean;
@@ -783,15 +784,24 @@ function createObserverFinalize(observer: ObserverDepsBundle): () => Promise<voi
 
 export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
   const config = resolveEffectiveConfig(options);
-  assertTrustedProviderCommandOverrides(options.providersConfig);
+  const commandOverridePolicy = {
+    allowTrustedCommandOverrides: options.trustProviderCommandOverrides,
+  };
+  assertTrustedProviderCommandOverrides(options.providersConfig, commandOverridePolicy);
   const artifacts = createSessionArtifacts(options);
   clearSessionArtifacts(options, artifacts);
 
   const observer = await createObserverDeps(options, config, artifacts);
-  assertTrustedProviderCommandOverrides(options.providersConfig, { logger: observer.logger });
+  assertTrustedProviderCommandOverrides(options.providersConfig, {
+    ...commandOverridePolicy,
+    logger: observer.logger,
+  });
   assertTrustedProviderCommandOverrideEntries(
     consolidatedProviderCommandOverrides(options.orchestratorConfig?.consolidatedProviders),
-    { logger: observer.logger },
+    {
+      ...commandOverridePolicy,
+      logger: observer.logger,
+    },
   );
   let finalize = createObserverFinalize(observer);
 

--- a/packages/franken-orchestrator/src/cli/init-command.ts
+++ b/packages/franken-orchestrator/src/cli/init-command.ts
@@ -25,6 +25,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     const verification = await verifyInit({
       configFile: options.paths.configFile,
       stateStore,
+      allowTrustedProviderCommandOverrides: options.args.trustProviderCommandOverrides,
     });
     options.print(
       verification.ok
@@ -38,6 +39,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     const verification = await verifyInit({
       configFile: options.paths.configFile,
       stateStore,
+      allowTrustedProviderCommandOverrides: options.args.trustProviderCommandOverrides,
     });
     if (!verification.ok) {
       throw new Error(
@@ -72,6 +74,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
       io: options.io,
       initBackend,
       secretStore,
+      allowTrustedProviderCommandOverrides: options.args.trustProviderCommandOverrides,
     });
     options.print(
       `Repaired init config at ${options.paths.configFile} with modules: ${result.state.selectedModules.join(', ') || 'none'}.`,
@@ -84,6 +87,7 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     io: options.io,
     initBackend,
     secretStore,
+    allowTrustedProviderCommandOverrides: options.args.trustProviderCommandOverrides,
   });
 
   options.print(

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -797,6 +797,11 @@ export async function main(): Promise<void> {
     process.exit(0);
   }
 
+  if (args.subcommand === 'network' && (args.networkAction ?? 'help') === 'help') {
+    printLine(renderNetworkHelp());
+    return;
+  }
+
   const root = resolveProjectRoot(args.baseDir);
   if (process.env.FRANKENBEAST_NETWORK_MANAGED !== '1') {
     printLine(await renderBanner(root));

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -44,7 +44,7 @@ import { NetworkLogStore } from '../network/network-logs.js';
 import { NetworkSupervisor } from '../network/network-supervisor.js';
 import { renderNetworkHelp } from '../network/network-help.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
-import { OrchestratorConfigSchema } from '../config/orchestrator-config.js';
+import { parseOrchestratorConfig } from '../config/orchestrator-config.js';
 import { resolveManagedChatAttachment, runManagedChatRepl } from '../network/chat-attach.js';
 import {
   healthcheckNetworkService,
@@ -750,6 +750,7 @@ async function createChatSurfaceDeps(
     provider,
     providers: args.providers ?? config.providers.fallbackChain,
     providersConfig: config.providers.overrides,
+    trustProviderCommandOverrides: args.trustProviderCommandOverrides,
     noPr: true,
     verbose: args.verbose,
     reset: false,
@@ -1031,6 +1032,7 @@ export async function main(): Promise<void> {
           root,
           frankenbeastDir: paths.frankenbeastDir,
           configFile: paths.configFile,
+          allowTrustedProviderCommandOverrides: args.trustProviderCommandOverrides,
           getConfig: () => mutableConfig,
           setConfig: (nextConfig) => {
             mutableConfig = nextConfig;
@@ -1109,6 +1111,7 @@ export async function main(): Promise<void> {
     provider,
     providers: args.providers ?? config.providers.fallbackChain,
     providersConfig: config.providers.overrides,
+    trustProviderCommandOverrides: args.trustProviderCommandOverrides,
     noPr: args.noPr,
     verbose: args.verbose,
     reset: args.reset,
@@ -1244,7 +1247,9 @@ async function persistNetworkConfigSets(args: CliArgs, paths: NetworkPaths): Pro
   }
 
   const updatedFileConfig = applyNetworkConfigSets(fileConfig, args.networkSet ?? []);
-  OrchestratorConfigSchema.parse(updatedFileConfig);
+  parseOrchestratorConfig(updatedFileConfig, {
+    allowTrustedProviderCommandOverrides: args.trustProviderCommandOverrides,
+  });
 
   await mkdir(dirname(configFile), { recursive: true });
   await writeFile(configFile, JSON.stringify(updatedFileConfig, null, 2) + '\n', 'utf-8');
@@ -1369,6 +1374,7 @@ export async function runNetworkCommand(
       repoRoot: root,
       ...(configFile ? { configFile } : {}),
       ...(args.networkSet ? { configOverrides: args.networkSet } : {}),
+      allowTrustedProviderCommandOverrides: args.trustProviderCommandOverrides,
     }),
     action === 'up' ? undefined : args.networkTarget,
   );

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -798,6 +798,11 @@ export async function main(): Promise<void> {
     process.exit(0);
   }
 
+  if (args.subcommand === 'network' && (args.networkAction ?? 'help') === 'help') {
+    printLine(renderNetworkHelp());
+    return;
+  }
+
   const root = resolveProjectRoot(args.baseDir);
   if (process.env.FRANKENBEAST_NETWORK_MANAGED !== '1') {
     printLine(await renderBanner(root));

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -65,6 +65,7 @@ export interface SessionConfig {
   provider: string;
   providers?: string[] | undefined;
   providersConfig?: Record<string, ProviderCommandOverridePolicyConfig & { model?: string | undefined; extraArgs?: string[] | undefined }> | undefined;
+  trustProviderCommandOverrides?: boolean | undefined;
   noPr: boolean;
   verbose: boolean;
   reset: boolean;
@@ -608,6 +609,7 @@ export class Session {
       provider: this.config.provider,
       providers: this.config.providers,
       providersConfig: this.config.providersConfig,
+      trustProviderCommandOverrides: this.config.trustProviderCommandOverrides,
       noPr: this.config.noPr,
       verbose: this.config.verbose,
       reset: this.config.reset,

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -2,6 +2,10 @@ import { z } from 'zod';
 import { NetworkConfigFieldsSchema, validateNetworkConfig } from '../network/network-config.js';
 import { validateProviderCommandOverride } from './provider-command-override-policy.js';
 
+export interface OrchestratorConfigParseOptions {
+  readonly allowTrustedProviderCommandOverrides?: boolean | undefined;
+}
+
 // Consolidation schemas (moved from run-config-v2.ts)
 
 export const ProviderConfigSchema = z.object({
@@ -62,24 +66,30 @@ export const ProviderOverrideSchema = z.object({
   extraArgs: z.array(z.string()).optional(),
 });
 
-export const ProvidersConfigSchema = z.object({
-  /** Default provider name. */
-  default: z.string().default('claude'),
-  /** Ordered fallback chain of provider names. */
-  fallbackChain: z.array(z.string()).default(['claude', 'codex']),
-  /** Per-provider overrides (command, model, extraArgs). */
-  overrides: z.record(z.string(), ProviderOverrideSchema).default({}),
-}).superRefine((providers, ctx) => {
-  for (const [name, override] of Object.entries(providers.overrides)) {
-    for (const message of validateProviderCommandOverride(name, override)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['overrides', name, 'command'],
-        message,
-      });
+function createProvidersConfigSchema(options: OrchestratorConfigParseOptions = {}) {
+  return z.object({
+    /** Default provider name. */
+    default: z.string().default('claude'),
+    /** Ordered fallback chain of provider names. */
+    fallbackChain: z.array(z.string()).default(['claude', 'codex']),
+    /** Per-provider overrides (command, model, extraArgs). */
+    overrides: z.record(z.string(), ProviderOverrideSchema).default({}),
+  }).superRefine((providers, ctx) => {
+    for (const [name, override] of Object.entries(providers.overrides)) {
+      for (const message of validateProviderCommandOverride(name, override, {
+        allowTrustedCommandOverrides: options.allowTrustedProviderCommandOverrides,
+      })) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['overrides', name, 'command'],
+          message,
+        });
+      }
     }
-  }
-});
+  });
+}
+
+export const ProvidersConfigSchema = createProvidersConfigSchema();
 
 const MIN_TOTAL_TOKEN_BUDGET = 10_000;
 const MIN_DURATION_MS_PER_CRITIQUE_ITERATION = 10_000;
@@ -134,41 +144,56 @@ const BaseOrchestratorConfigSchema = z.object({
   consolidatedProviders: z.array(ProviderConfigSchema).optional(),
 });
 
-export const OrchestratorConfigSchema = BaseOrchestratorConfigSchema.extend(
-  NetworkConfigFieldsSchema.shape,
-).superRefine((config, ctx) => {
-  validateNetworkConfig(config, ctx);
+function createOrchestratorConfigSchema(options: OrchestratorConfigParseOptions = {}) {
+  return BaseOrchestratorConfigSchema.extend({
+    providers: createProvidersConfigSchema(options).default({}),
+  }).extend(
+    NetworkConfigFieldsSchema.shape,
+  ).superRefine((config, ctx) => {
+    validateNetworkConfig(config, ctx);
 
-  config.consolidatedProviders?.forEach((provider, index) => {
-    if (!provider.type.endsWith('-cli') || !provider.cliPath) return;
-    for (const message of validateProviderCommandOverride(provider.type, {
-      cliPath: provider.cliPath,
-      trustCommandOverride: provider.trustCommandOverride,
-      trustedCommandPaths: provider.trustedCommandPaths,
-    })) {
+    config.consolidatedProviders?.forEach((provider, index) => {
+      if (!provider.type.endsWith('-cli') || !provider.cliPath) return;
+      for (const message of validateProviderCommandOverride(provider.type, {
+        cliPath: provider.cliPath,
+        trustCommandOverride: provider.trustCommandOverride,
+        trustedCommandPaths: provider.trustedCommandPaths,
+      }, {
+        allowTrustedCommandOverrides: options.allowTrustedProviderCommandOverrides,
+      })) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['consolidatedProviders', index, 'cliPath'],
+          message,
+        });
+      }
+    });
+
+    const minDurationMs =
+      config.maxCritiqueIterations * MIN_DURATION_MS_PER_CRITIQUE_ITERATION;
+    if (config.maxDurationMs < minDurationMs) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['consolidatedProviders', index, 'cliPath'],
-        message,
+        path: ['maxDurationMs'],
+        message:
+          `maxDurationMs must be at least ${minDurationMs}ms ` +
+          `for ${config.maxCritiqueIterations} critique iterations`,
       });
     }
   });
+}
 
-  const minDurationMs =
-    config.maxCritiqueIterations * MIN_DURATION_MS_PER_CRITIQUE_ITERATION;
-  if (config.maxDurationMs < minDurationMs) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['maxDurationMs'],
-      message:
-        `maxDurationMs must be at least ${minDurationMs}ms ` +
-        `for ${config.maxCritiqueIterations} critique iterations`,
-    });
-  }
-});
+export const OrchestratorConfigSchema = createOrchestratorConfigSchema();
 
 export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>;
 
 export function defaultConfig(): OrchestratorConfig {
   return OrchestratorConfigSchema.parse({});
+}
+
+export function parseOrchestratorConfig(
+  config: unknown,
+  options: OrchestratorConfigParseOptions = {},
+): OrchestratorConfig {
+  return createOrchestratorConfigSchema(options).parse(config);
 }

--- a/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
+++ b/packages/franken-orchestrator/src/config/provider-command-override-policy.ts
@@ -11,6 +11,10 @@ export interface ProviderCommandOverrideAuditLogger {
   warn(message: string, component?: string): void;
 }
 
+export interface ProviderCommandOverridePolicyOptions {
+  readonly allowTrustedCommandOverrides?: boolean | undefined;
+}
+
 const BUILTIN_PROVIDER_COMMANDS: Record<string, readonly string[]> = {
   claude: ['claude', 'claude-code'],
   codex: ['codex'],
@@ -52,6 +56,7 @@ function normalizeTrustedDirectory(entry: string): string {
 export function validateProviderCommandOverride(
   provider: string,
   override: ProviderCommandOverridePolicyConfig,
+  options: ProviderCommandOverridePolicyOptions = {},
 ): string[] {
   const command = override.command ?? override.cliPath;
   if (!command) {
@@ -59,6 +64,12 @@ export function validateProviderCommandOverride(
   }
 
   const issues: string[] = [];
+  if (override.trustCommandOverride === true && options.allowTrustedCommandOverrides !== true) {
+    issues.push(
+      `provider command override for ${provider} requires explicit CLI approval with --trust-provider-command-overrides; repo config cannot self-approve command overrides`,
+    );
+  }
+
   if (override.trustCommandOverride !== true) {
     issues.push(
       `provider command override for ${provider} requires trustCommandOverride: true before a repo-configured command override may be used`,
@@ -79,7 +90,7 @@ export function validateProviderCommandOverride(
 
 export function assertTrustedProviderCommandOverrides(
   overrides: Record<string, ProviderCommandOverridePolicyConfig> | undefined,
-  options?: { readonly logger?: ProviderCommandOverrideAuditLogger | undefined },
+  options?: ProviderCommandOverridePolicyOptions & { readonly logger?: ProviderCommandOverrideAuditLogger | undefined },
 ): void {
   if (!overrides) return;
 
@@ -88,14 +99,14 @@ export function assertTrustedProviderCommandOverrides(
 
 export function assertTrustedProviderCommandOverrideEntries(
   overrides: Iterable<readonly [string, ProviderCommandOverridePolicyConfig]>,
-  options?: { readonly logger?: ProviderCommandOverrideAuditLogger | undefined },
+  options?: ProviderCommandOverridePolicyOptions & { readonly logger?: ProviderCommandOverrideAuditLogger | undefined },
 ): void {
   const entries = Array.from(overrides);
   if (entries.length === 0) return;
 
   const issues: string[] = [];
   for (const [provider, override] of entries) {
-    issues.push(...validateProviderCommandOverride(provider, override));
+    issues.push(...validateProviderCommandOverride(provider, override, options));
     const command = override.command ?? override.cliPath;
     if (command && override.trustCommandOverride === true) {
       options?.logger?.warn(

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -48,6 +48,7 @@ export interface StartChatServerOptions {
     root: string;
     frankenbeastDir: string;
     configFile: string;
+    allowTrustedProviderCommandOverrides?: boolean | undefined;
     getConfig(): OrchestratorConfig;
     setConfig(config: OrchestratorConfig): void;
   };

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -5,7 +5,7 @@ import { readFile, stat } from 'node:fs/promises';
 import { extname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse as parseDotenv } from 'dotenv';
-import { OrchestratorConfigSchema } from '../config/orchestrator-config.js';
+import { NetworkConfigFieldsSchema } from '../network/network-config.js';
 import { createSecretStore } from '../network/secret-store.js';
 
 const SERVICE_IDENTITY = 'dashboard-web';
@@ -380,12 +380,14 @@ async function readOperatorTokenFromEnvFile(filePath: string): Promise<string | 
   }
 }
 
-async function resolveDashboardOperatorToken(): Promise<string | undefined> {
+export async function resolveDashboardOperatorToken(): Promise<string | undefined> {
   const configPath = process.env.FRANKENBEAST_CONFIG_FILE || process.env.FRANKENBEAST_CONFIG_PATH;
   if (configPath) {
     try {
       const resolvedConfigPath = isAbsolute(configPath) ? configPath : resolve(process.cwd(), configPath);
-      const config = OrchestratorConfigSchema.parse(JSON.parse(await readFile(resolvedConfigPath, 'utf8')));
+      const config = NetworkConfigFieldsSchema.pick({ network: true }).parse(
+        JSON.parse(await readFile(resolvedConfigPath, 'utf8')),
+      );
       const tokenRef = config.network.operatorTokenRef?.trim();
       if (tokenRef) {
         const store = createSecretStore(config.network.secureBackend ?? 'local-encrypted', {

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { approvalRuntimeInput } from '../../chat/approval-input.js';
 import type { ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
 import type { ChatRuntime } from '../../chat/runtime.js';
@@ -177,14 +178,31 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       return c.json({ data: { id: session.id, approved, state: session.state } });
     }
 
+    let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
     if (approved) {
-      const result = await runtime.run('/approve', {
-        sessionId: session.id,
-        pendingApproval: Boolean(session.pendingApproval) || session.state === 'pending_approval',
-        projectId: session.projectId,
-        transcript: session.transcript,
-        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
-      });
+      const pendingApproval = session.pendingApproval ?? null;
+      const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
+      const runtimeInput = approvalRuntimeInput(pendingApproval);
+      const originalState = session.state;
+      session.pendingApproval = null;
+      session.state = 'approved';
+      session.updatedAt = new Date().toISOString();
+      sessionStore.save(session);
+      try {
+        result = await runtime.run(runtimeInput, {
+          sessionId: session.id,
+          pendingApproval: wasPendingApproval,
+          projectId: session.projectId,
+          transcript: session.transcript,
+          ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+        });
+      } catch (error) {
+        session.pendingApproval = pendingApproval;
+        session.state = originalState;
+        session.updatedAt = new Date().toISOString();
+        sessionStore.save(session);
+        throw error;
+      }
 
       session.state = result.state === 'active' ? 'approved' : result.state;
       session.pendingApproval = null;
@@ -196,7 +214,16 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     session.updatedAt = new Date().toISOString();
     sessionStore.save(session);
 
-    return c.json({ data: { id: session.id, approved, state: session.state } } satisfies ApiDataEnvelope<ApproveResult>);
+    return c.json({
+      data: {
+        id: session.id,
+        approved,
+        state: session.state,
+        ...(result?.outcome ? { outcome: result.outcome } : {}),
+        ...(result?.tier ? { tier: result.tier } : {}),
+        ...(result ? { displayMessages: result.displayMessages, events: result.events } : {}),
+      },
+    } satisfies ApiDataEnvelope<ApproveResult>);
   });
 
   return app;

--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { mkdir, open, writeFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { spawn } from 'node:child_process';
-import { OrchestratorConfigSchema, type OrchestratorConfig } from '../../config/orchestrator-config.js';
+import { parseOrchestratorConfig, type OrchestratorConfig } from '../../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../../network/network-config-paths.js';
 import { filterNetworkServices, resolveNetworkServices } from '../../network/network-registry.js';
 import { NetworkLogStore } from '../../network/network-logs.js';
@@ -31,6 +31,7 @@ export interface NetworkRoutesDeps {
   root: string;
   frankenbeastDir: string;
   configFile: string;
+  allowTrustedProviderCommandOverrides?: boolean | undefined;
   getConfig(): OrchestratorConfig;
   setConfig(config: OrchestratorConfig): void;
 }
@@ -58,7 +59,12 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   app.get('/v1/network/status', async (c) => {
     const supervisor = createSupervisor(deps.frankenbeastDir);
     const status = await supervisor.status();
-    const services = resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root });
+    const config = deps.getConfig();
+    const services = resolveNetworkServices(config, {
+      repoRoot: deps.root,
+      configFile: deps.configFile,
+      allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides,
+    });
     const response: NetworkStatusResponse = {
       ...status,
       services: status.services.map((service) => {
@@ -75,12 +81,17 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
 
   app.post('/v1/network/up', async (c) => {
     const supervisor = createSupervisor(deps.frankenbeastDir);
-    const services = resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root });
+    const config = deps.getConfig();
+    const services = resolveNetworkServices(config, {
+      repoRoot: deps.root,
+      configFile: deps.configFile,
+      allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides,
+    });
     const state = await supervisor.up({
       services,
       detached: true,
-      mode: deps.getConfig().network.mode,
-      secureBackend: deps.getConfig().network.secureBackend,
+      mode: config.network.mode,
+      secureBackend: config.network.secureBackend,
     });
     return c.json({ data: state });
   });
@@ -94,15 +105,20 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   app.post('/v1/network/start', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
+    const config = deps.getConfig();
     const services = filterNetworkServices(
-      resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root }),
+      resolveNetworkServices(config, {
+        repoRoot: deps.root,
+        configFile: deps.configFile,
+        allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides,
+      }),
       body.target,
     );
     const state = await supervisor.up({
       services,
       detached: true,
-      mode: deps.getConfig().network.mode,
-      secureBackend: deps.getConfig().network.secureBackend,
+      mode: config.network.mode,
+      secureBackend: config.network.secureBackend,
     });
     return c.json({ data: state });
   });
@@ -118,15 +134,20 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
     await supervisor.stop(body.target);
+    const config = deps.getConfig();
     const services = filterNetworkServices(
-      resolveNetworkServices(deps.getConfig(), { repoRoot: deps.root }),
+      resolveNetworkServices(config, {
+        repoRoot: deps.root,
+        configFile: deps.configFile,
+        allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides,
+      }),
       body.target,
     );
     const state = await supervisor.up({
       services,
       detached: true,
-      mode: deps.getConfig().network.mode,
-      secureBackend: deps.getConfig().network.secureBackend,
+      mode: config.network.mode,
+      secureBackend: config.network.secureBackend,
     });
     return c.json({ data: state });
   });
@@ -144,8 +165,10 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
 
   app.post('/v1/network/config', async (c) => {
     const body = validateBody(ConfigBody, await parseJsonBody(c));
-    const nextConfig = OrchestratorConfigSchema.parse(
-      applyNetworkConfigSets(deps.getConfig(), body.assignments ?? []),
+    const currentConfig = deps.getConfig();
+    const nextConfig = parseOrchestratorConfig(
+      applyNetworkConfigSets(currentConfig, body.assignments ?? []),
+      { allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides },
     );
     deps.setConfig(nextConfig);
     await mkdir(dirname(deps.configFile), { recursive: true });

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, Server as HttpServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import type { Duplex } from 'node:stream';
 import { WebSocketServer, type WebSocket } from 'ws';
+import { approvalRuntimeInput } from '../chat/approval-input.js';
 import { ChatRuntime } from '../chat/runtime.js';
 import type { ISessionStore } from '../chat/session-store.js';
 import type { ChatSession } from '../chat/types.js';
@@ -313,16 +314,20 @@ export class ChatSocketController {
       return;
     }
 
-    const result = await this.runtime.run('/approve', {
-      sessionId: session.id,
-      pendingApproval: Boolean(session.pendingApproval),
-      projectId: session.projectId,
-      transcript: session.transcript,
-      ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
-    });
+    if (!session.pendingApproval && session.state !== 'pending_approval') {
+      this.emit(peer, {
+        type: 'turn.approval.resolved',
+        approved: session.state !== 'rejected',
+        timestamp: nowIso(),
+      });
+      return;
+    }
+
+    const pendingApproval = session.pendingApproval ?? null;
+    const originalState = session.state;
+    const runtimeInput = approvalRuntimeInput(pendingApproval);
     session.pendingApproval = null;
-    session.state = result.state;
-    session.beastContext = result.beastContext ?? null;
+    session.state = 'approved';
     session.updatedAt = nowIso();
     this.sessionStore.save(session);
 
@@ -331,6 +336,56 @@ export class ChatSocketController {
       approved: true,
       timestamp: session.updatedAt,
     });
+
+    let result: Awaited<ReturnType<ChatRuntime['run']>>;
+    try {
+      result = await this.runtime.run(runtimeInput, {
+        sessionId: session.id,
+        pendingApproval: Boolean(pendingApproval) || originalState === 'pending_approval',
+        projectId: session.projectId,
+        transcript: session.transcript,
+        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+      }, {
+        onEvent: (event) => {
+          try {
+            this.emit(peer, mapTurnEvent(event));
+          } catch {
+            // Socket delivery is best-effort; do not turn an already-running
+            // approved command into a retryable approval execution failure.
+          }
+        },
+      });
+    } catch (error) {
+      session.pendingApproval = pendingApproval;
+      session.state = originalState;
+      session.updatedAt = nowIso();
+      this.sessionStore.save(session);
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'APPROVAL_EXECUTION_FAILED',
+        message: error instanceof Error ? error.message : 'Approved action failed to run.',
+        timestamp: session.updatedAt,
+      });
+      if (pendingApproval) {
+        this.emit(peer, {
+          type: 'turn.approval.requested',
+          description: pendingApproval.description,
+          timestamp: pendingApproval.requestedAt,
+          ...(pendingApproval.tool ? { tool: pendingApproval.tool } : {}),
+          ...(pendingApproval.command ? { command: pendingApproval.command } : {}),
+          ...(pendingApproval.risk ? { risk: pendingApproval.risk } : {}),
+          ...(pendingApproval.affectedFiles ? { affectedFiles: pendingApproval.affectedFiles } : {}),
+          ...(pendingApproval.sessionId ? { sessionId: pendingApproval.sessionId } : {}),
+        });
+      }
+      return;
+    }
+    session.pendingApproval = null;
+    session.state = result.state === 'active' ? 'approved' : result.state;
+    session.beastContext = result.beastContext ?? null;
+    session.updatedAt = nowIso();
+    this.sessionStore.save(session);
+
     for (const display of result.displayMessages) {
       this.emit(peer, {
         type: 'assistant.message.complete',

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,8 +49,8 @@ export type {
 } from './types.js';
 
 // Config
-export { OrchestratorConfigSchema, defaultConfig } from './config/orchestrator-config.js';
-export type { OrchestratorConfig } from './config/orchestrator-config.js';
+export { OrchestratorConfigSchema, defaultConfig, parseOrchestratorConfig } from './config/orchestrator-config.js';
+export type { OrchestratorConfig, OrchestratorConfigParseOptions } from './config/orchestrator-config.js';
 
 // Context
 export { BeastContext } from './context/franken-context.js';

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { InterviewIO } from '../planning/interview-loop.js';
-import { OrchestratorConfigSchema, defaultConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
+import { parseOrchestratorConfig, defaultConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { FileInitStateStore } from './init-state-store.js';
 import { runInitWizard } from './init-wizard.js';
 import type { InitState } from './init-types.js';
@@ -20,14 +20,20 @@ interface RunInteractiveInitOptions {
   baseConfig?: OrchestratorConfig | undefined;
   initBackend?: OrchestratorConfig['network']['secureBackend'] | undefined;
   secretStore?: ISecretStore | undefined;
+  allowTrustedProviderCommandOverrides?: boolean | undefined;
 }
 
 type RunRepairInitOptions = RunInteractiveInitOptions;
 
-async function loadExistingConfig(configFile: string): Promise<OrchestratorConfig> {
+async function loadExistingConfig(
+  configFile: string,
+  options: { allowTrustedProviderCommandOverrides?: boolean | undefined } = {},
+): Promise<OrchestratorConfig> {
   try {
     const raw = await readFile(configFile, 'utf-8');
-    return OrchestratorConfigSchema.parse(JSON.parse(raw));
+    return parseOrchestratorConfig(JSON.parse(raw), {
+      allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
+    });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return defaultConfig();
@@ -37,7 +43,9 @@ async function loadExistingConfig(configFile: string): Promise<OrchestratorConfi
 }
 
 async function resolveBaseConfig(options: RunInteractiveInitOptions): Promise<OrchestratorConfig> {
-  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile);
+  const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile, {
+    allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
+  });
   if (!options.initBackend) {
     return baseConfig;
   }
@@ -63,6 +71,7 @@ export async function runInteractiveInit(options: RunInteractiveInitOptions): Pr
     initialState,
     baseConfig,
     secretStore: options.secretStore,
+    allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
   });
 
   await saveConfig(options.configFile, result.config);
@@ -78,6 +87,7 @@ export async function runRepairInit(options: RunRepairInitOptions): Promise<Init
   const verification = await verifyInit({
     configFile: options.configFile,
     stateStore: options.stateStore,
+    allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
   });
 
   if (verification.ok) {
@@ -116,6 +126,7 @@ export async function runRepairInit(options: RunRepairInitOptions): Promise<Init
     baseConfig,
     scope,
     secretStore: options.secretStore,
+    allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
   });
 
   await saveConfig(options.configFile, result.config);

--- a/packages/franken-orchestrator/src/init/init-verify.ts
+++ b/packages/franken-orchestrator/src/init/init-verify.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { OrchestratorConfigSchema, type OrchestratorConfig } from '../config/orchestrator-config.js';
+import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import type { FileInitStateStore } from './init-state-store.js';
 import type { ISecretStore } from '../network/secret-store.js';
 
@@ -40,6 +40,7 @@ export async function verifyInit(options: {
   configFile: string;
   stateStore: FileInitStateStore;
   secretStore?: ISecretStore | undefined;
+  allowTrustedProviderCommandOverrides?: boolean | undefined;
 }): Promise<InitVerificationResult> {
   const issues: InitVerificationIssue[] = [];
   const rawConfig = await tryReadJson<unknown>(options.configFile);
@@ -67,7 +68,9 @@ export async function verifyInit(options: {
     };
   }
 
-  const config = OrchestratorConfigSchema.parse(rawConfig);
+  const config = parseOrchestratorConfig(rawConfig, {
+    allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
+  });
 
   if (config.comms.slack.enabled) {
     const missing: string[] = [];

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import type { InterviewIO } from '../planning/interview-loop.js';
-import { OrchestratorConfigSchema, defaultConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
+import { parseOrchestratorConfig, defaultConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { listSupportedCommsTransports } from './comms-transport-registry.js';
 import type { InitState, SupportedCommsTransportId } from './init-types.js';
 import type { ISecretStore } from '../network/secret-store.js';
@@ -26,6 +26,7 @@ interface RunInitWizardOptions {
   baseConfig?: OrchestratorConfig | undefined;
   scope?: readonly InitWizardScope[] | undefined;
   secretStore?: ISecretStore | undefined;
+  allowTrustedProviderCommandOverrides?: boolean | undefined;
 }
 
 function stateValue<T>(state: InitState, key: string): T | undefined {
@@ -74,8 +75,12 @@ async function askText(io: InterviewIO, prompt: string, defaultValue: string): P
   return trimmed.length > 0 ? trimmed : defaultValue;
 }
 
-function buildConfig(baseConfig: OrchestratorConfig, state: InitState): OrchestratorConfig {
-  return OrchestratorConfigSchema.parse({
+function buildConfig(
+  baseConfig: OrchestratorConfig,
+  state: InitState,
+  options: { allowTrustedProviderCommandOverrides?: boolean | undefined } = {},
+): OrchestratorConfig {
+  return parseOrchestratorConfig({
     ...baseConfig,
     providers: {
       ...baseConfig.providers,
@@ -126,6 +131,8 @@ function buildConfig(baseConfig: OrchestratorConfig, state: InitState): Orchestr
         verifyTokenRef: stateValue<string>(state, 'comms.whatsapp.verifyTokenRef') ?? baseConfig.comms.whatsapp.verifyTokenRef,
       },
     },
+  }, {
+    allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
   });
 }
 
@@ -209,7 +216,9 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
       securityMode,
       answers: { ...options.initialState.answers },
     };
-    return { config: buildConfig(config, nextState), state: nextState };
+    return { config: buildConfig(config, nextState, {
+      allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
+    }), state: nextState };
   }
 
   const selectedCommsTransports: SupportedCommsTransportId[] = enableComms
@@ -450,7 +459,9 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
   };
 
   return {
-    config: buildConfig(config, nextState),
+    config: buildConfig(config, nextState, {
+      allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
+    }),
     state: nextState,
   };
 }

--- a/packages/franken-orchestrator/src/network/network-registry.ts
+++ b/packages/franken-orchestrator/src/network/network-registry.ts
@@ -12,6 +12,7 @@ export interface NetworkRegistryContext {
   repoRoot: string;
   configFile?: string | undefined;
   configOverrides?: string[] | undefined;
+  allowTrustedProviderCommandOverrides?: boolean | undefined;
 }
 
 export interface NetworkServiceRuntimeConfig {

--- a/packages/franken-orchestrator/src/network/services/chat-server-service.ts
+++ b/packages/franken-orchestrator/src/network/services/chat-server-service.ts
@@ -38,6 +38,7 @@ export const chatServerService: NetworkServiceDefinition = {
         '--port',
         String(config.chat.port),
         ...(context.configFile ? ['--config', context.configFile] : []),
+        ...(context.allowTrustedProviderCommandOverrides ? ['--trust-provider-command-overrides'] : []),
         ...(context.configOverrides?.flatMap((override) => ['--set', override]) ?? []),
       ],
       cwd: context.repoRoot,

--- a/packages/franken-orchestrator/src/network/services/dashboard-web-service.ts
+++ b/packages/franken-orchestrator/src/network/services/dashboard-web-service.ts
@@ -44,6 +44,9 @@ export const dashboardWebService: NetworkServiceDefinition = {
         FRANKENBEAST_DASHBOARD_API_URL: config.dashboard.apiUrl,
         FRANKENBEAST_DASHBOARD_HOST: config.dashboard.host,
         FRANKENBEAST_DASHBOARD_PORT: String(config.dashboard.port),
+        ...(context.allowTrustedProviderCommandOverrides
+          ? { FRANKENBEAST_TRUST_PROVIDER_COMMAND_OVERRIDES: '1' }
+          : {}),
       },
     },
   }),

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -590,6 +590,158 @@ describe('Chat HTTP Routes', () => {
     expect(session.pendingApproval).toBeNull();
   });
 
+  it('POST /v1/chat/sessions/:id/approve runs the pending command for HTTP fallback approvals', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-http-pending-command',
+      projectId: 'proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: {
+        description: 'Deploy staging',
+        requestedAt: now,
+        tool: 'execution',
+        command: 'deploy staging',
+        sessionId: 'chat-http-pending-command',
+      },
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'execution' as const, content: 'Done' }],
+        events: [{ type: 'complete' as const, sessionId: session.id, data: { status: 'success' } }],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'premium_execution',
+        transcript: [],
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+    });
+
+    const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.state).toBe('approved');
+    expect(body.data.displayMessages).toEqual([{ kind: 'execution', content: 'Done' }]);
+    expect(body.data.events).toEqual([{ type: 'complete', sessionId: session.id, data: { status: 'success' } }]);
+    expect(runtime.run).toHaveBeenCalledWith('/run deploy staging', expect.objectContaining({
+      pendingApproval: true,
+      sessionId: session.id,
+    }));
+    expect(sessionStore.save).toHaveBeenCalledWith(expect.objectContaining({
+      state: 'approved',
+      pendingApproval: null,
+    }));
+    expect(session.state).toBe('approved');
+    expect(session.pendingApproval).toBeNull();
+  });
+
+  it('POST /v1/chat/sessions/:id/approve does not execute duplicate HTTP approvals twice', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-http-duplicate-approval',
+      projectId: 'proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: {
+        description: 'Deploy staging',
+        requestedAt: now,
+        tool: 'execution',
+        command: 'deploy staging',
+        sessionId: 'chat-http-duplicate-approval',
+      },
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    let finishExecution!: () => void;
+    let executionStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      executionStarted = resolve;
+    });
+    const finished = new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    });
+    const runtime = {
+      run: vi.fn(async () => {
+        executionStarted();
+        await finished;
+        return {
+          displayMessages: [{ kind: 'execution' as const, content: 'Done' }],
+          events: [],
+          pendingApproval: false,
+          state: 'active' as const,
+          tier: 'premium_execution',
+          transcript: [],
+        };
+      }),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+    });
+
+    const first = app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    await started;
+    const duplicate = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+    finishExecution();
+    const firstRes = await first;
+
+    expect(firstRes.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect((await duplicate.json()).data).toMatchObject({
+      id: session.id,
+      approved: true,
+      state: 'approved',
+    });
+    expect(session.pendingApproval).toBeNull();
+  });
+
   it('POST /v1/chat/sessions/:id/approve does not downgrade approved sessions when runtime reports active', async () => {
     const now = new Date().toISOString();
     const session: ChatSession = {

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -42,7 +42,7 @@ function createTestRuntime(): ChatRuntime {
     }),
     turnRunner: new TurnRunner({
       execute: vi.fn().mockResolvedValue({
-        status: 'success',
+        status: 'success' as const,
         summary: 'Done',
         filesChanged: [],
         testsRun: 0,
@@ -165,7 +165,7 @@ describe('ws chat server', () => {
       }),
       turnRunner: new TurnRunner({
         execute: vi.fn().mockResolvedValue({
-          status: 'success',
+          status: 'success' as const,
           summary: 'Done',
           filesChanged: [],
           testsRun: 0,
@@ -259,6 +259,312 @@ describe('ws chat server', () => {
       command: 'deploy staging',
       risk: 'Requires explicit approval before execution.',
       sessionId: session.id,
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('emits execution events after an approved action runs', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn().mockResolvedValue({
+      status: 'success' as const,
+      summary: 'Done',
+      filesChanged: [],
+      testsRun: 0,
+      errors: [],
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    const connect = controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    });
+    expect(connect.ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+
+    expect(execute).toHaveBeenCalledWith({ userInput: 'deploy staging' });
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.resolved',
+      approved: true,
+    }));
+    expect(events.findIndex((event) => event.type === 'turn.approval.resolved'))
+      .toBeLessThan(events.findIndex((event) => event.type === 'turn.execution.start'));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.execution.start',
+      data: { taskDescription: 'deploy staging' },
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.execution.complete',
+      data: { status: 'success' },
+    }));
+    expect(store.get(session.id)?.state).toBe('approved');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('does not execute the same approved action twice for duplicate approval frames', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    let finishExecution!: () => void;
+    const executionStarted = new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    });
+    const execute = vi.fn(async () => {
+      await executionStarted;
+      return {
+        status: 'success' as const,
+        summary: 'Done',
+        filesChanged: [],
+        testsRun: 0,
+        errors: [],
+      };
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    const first = controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+    const second = controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+    finishExecution();
+    await Promise.all([first, second]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(store.get(session.id)?.state).toBe('approved');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+    const executionStarts = sent
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((event) => event.type === 'turn.execution.start');
+    expect(executionStarts).toHaveLength(1);
+    const approvalResolved = sent
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((event) => event.type === 'turn.approval.resolved');
+    expect(approvalResolved).toHaveLength(2);
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('restores pending approval and notifies clients when approved execution throws', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn(async () => {
+      throw new Error('executor offline');
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await expect(controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }))).resolves.toBeUndefined();
+
+    expect(store.get(session.id)?.state).toBe('pending_approval');
+    expect(store.get(session.id)?.pendingApproval?.command).toBe('deploy staging');
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'APPROVAL_EXECUTION_FAILED',
+      message: 'executor offline',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.requested',
+      command: 'deploy staging',
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('does not retry approved work when live event delivery fails', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn().mockResolvedValue({
+      status: 'success' as const,
+      summary: 'Done',
+      filesChanged: [],
+      testsRun: 0,
+      errors: [],
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const sent: Record<string, unknown>[] = [];
+    const peer = {
+      close: vi.fn(),
+      send: (data: string) => {
+        const event = JSON.parse(data) as Record<string, unknown>;
+        sent.push(event);
+        if (event.type === 'turn.execution.start') {
+          throw new Error('socket closed');
+        }
+      },
+    };
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await expect(controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }))).resolves.toBeUndefined();
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(store.get(session.id)?.state).toBe('approved');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'turn.execution.start',
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('uses the legacy approve command for approvals without executable commands', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'Approve deployment?',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ secret, sessionId: session.id });
+    const execute = vi.fn();
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+
+    expect(execute).not.toHaveBeenCalled();
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'assistant.message.complete',
+      content: 'Approved.',
     }));
 
     rmSync(TMP, { recursive: true, force: true });

--- a/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createChatApp } from '../../../src/http/chat-app.js';
@@ -44,5 +44,58 @@ describe('network routes', () => {
     const configResponse = await app.request('/v1/network/config');
     const body = await configResponse.json() as { data: { network: { mode: string } } };
     expect(body.data.network.mode).toBe('insecure');
+  });
+
+  it('preserves already-approved provider command overrides when persisting config updates', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const configFile = join(TMP, 'config.json');
+    let config = defaultConfig();
+    config = {
+      ...config,
+      providers: {
+        ...config.providers,
+        overrides: {
+          trusted: {
+            command: '/usr/local/bin/trusted-provider',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/usr/local/bin'],
+          },
+        },
+      },
+    };
+    const app = createChatApp({
+      sessionStoreDir: join(TMP, 'chat'),
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'network-project',
+      networkControl: {
+        root: TMP,
+        frankenbeastDir: TMP,
+        configFile,
+        allowTrustedProviderCommandOverrides: true,
+        getConfig: () => config,
+        setConfig: (nextConfig) => {
+          config = nextConfig;
+        },
+      },
+    });
+
+    const update = await app.request('/v1/network/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignments: ['network.mode=insecure'] }),
+    });
+    expect(update.status).toBe(200);
+    expect(config.network.mode).toBe('insecure');
+    expect(config.providers.overrides['trusted']).toMatchObject({
+      command: '/usr/local/bin/trusted-provider',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/usr/local/bin'],
+    });
+    const persisted = JSON.parse(readFileSync(configFile, 'utf8')) as typeof config;
+    expect(persisted.providers.overrides['trusted']).toMatchObject({
+      command: '/usr/local/bin/trusted-provider',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/usr/local/bin'],
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
@@ -41,7 +41,21 @@ describe('Config loader providers passthrough', () => {
     expect(config.providers.overrides).toEqual({});
   });
 
-  it('passes through providers section from explicit config file', async () => {
+  it('rejects trusted provider command overrides from config file without CLI approval', async () => {
+    const filePath = join(tmpdir(), `beast-providers-unapproved-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({
+      providers: {
+        overrides: {
+          gemini: { command: 'gemini-cli', trustCommandOverride: true, model: 'gemini-pro' },
+        },
+      },
+    }));
+
+    await expect(loadConfig(makeArgs({ config: filePath }))).rejects.toThrow(/--trust-provider-command-overrides/);
+  });
+
+  it('passes through CLI-approved providers section from explicit config file', async () => {
     const filePath = join(tmpdir(), `beast-providers-${Date.now()}.json`);
     tmpFiles.push(filePath);
     await writeFile(filePath, JSON.stringify({
@@ -54,7 +68,10 @@ describe('Config loader providers passthrough', () => {
       },
     }));
 
-    const config = await loadConfig(makeArgs({ config: filePath }));
+    const config = await loadConfig(makeArgs({
+      config: filePath,
+      trustProviderCommandOverrides: true,
+    }));
     expect(config.providers.default).toBe('gemini');
     expect(config.providers.fallbackChain).toEqual(['gemini', 'claude']);
     expect(config.providers.overrides['gemini']).toEqual({
@@ -80,6 +97,29 @@ describe('Config loader providers passthrough', () => {
     }));
 
     await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+  });
+
+  it('honors CLI approval for trusted overrides in the default config path', async () => {
+    const filePath = join(tmpdir(), `beast-repo-provider-trust-approved-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({
+      providers: {
+        overrides: {
+          claude: {
+            command: '/usr/local/bin/claude',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/usr/local/bin'],
+          },
+        },
+      },
+    }));
+
+    const config = await loadConfig(makeArgs({ trustProviderCommandOverrides: true }), filePath);
+    expect(config.providers.overrides['claude']).toMatchObject({
+      command: '/usr/local/bin/claude',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/usr/local/bin'],
+    });
   });
 
   it('does not let repository-local consolidated providers self-approve trust', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { getProjectPaths, scaffoldFrankenbeast } from '../../../src/cli/project-root.js';
-import { OrchestratorConfigSchema } from '../../../src/config/orchestrator-config.js';
+import { parseOrchestratorConfig } from '../../../src/config/orchestrator-config.js';
 import type { CliDepOptions } from '../../../src/cli/dep-factory.js';
 
 // ── Mock heavy dependencies to isolate provider wiring ──
@@ -369,6 +369,7 @@ describe('dep-factory provider wiring', () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({
       provider: 'claude',
+      trustProviderCommandOverrides: true,
       providersConfig: {
         claude: { command: '/tmp/malicious-shell', trustCommandOverride: true },
       },
@@ -381,6 +382,7 @@ describe('dep-factory provider wiring', () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({
       provider: 'claude',
+      trustProviderCommandOverrides: true,
       providersConfig: {
         claude: {
           command: '/usr/local/bin/claude',
@@ -400,7 +402,8 @@ describe('dep-factory provider wiring', () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const { BeastLogger } = await import('../../../src/logging/beast-logger.js');
     const opts = makeOpts({
-      orchestratorConfig: OrchestratorConfigSchema.parse({
+      trustProviderCommandOverrides: true,
+      orchestratorConfig: parseOrchestratorConfig({
         consolidatedProviders: [
           {
             name: 'local-claude',
@@ -410,7 +413,7 @@ describe('dep-factory provider wiring', () => {
             trustedCommandPaths: ['/usr/local/bin/'],
           },
         ],
-      }),
+      }, { allowTrustedProviderCommandOverrides: true }),
     });
 
     await createCliDeps(opts);
@@ -484,6 +487,7 @@ describe('dep-factory provider wiring', () => {
     const opts = makeOpts({
       provider: 'codex',
       providers: ['codex'],
+      trustProviderCommandOverrides: true,
       providersConfig: {
         codex: {
           command: '/usr/local/bin/codex',

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1960,14 +1960,18 @@ describe('main() execution', () => {
     expect(print).toHaveBeenCalledWith(`Saved network config to ${configFile}.`);
   });
 
-  it('dispatches network help without creating a Session', async () => {
+  it('dispatches network help without resolving the project root or creating a Session', async () => {
+    const resolveProjectRootMock = vi.mocked(resolveProjectRoot);
+    resolveProjectRootMock.mockImplementation(() => {
+      throw new Error('Project root does not exist: /missing/project');
+    });
     mockParseArgs.mockReturnValue({
       subcommand: 'network',
       networkAction: 'help',
       networkTarget: undefined,
       networkDetached: false,
       networkSet: undefined,
-      baseDir: '/mock/project',
+      baseDir: '/missing/project',
       baseBranch: undefined,
       budget: 10,
       provider: 'claude',
@@ -1991,8 +1995,13 @@ describe('main() execution', () => {
       initNonInteractive: false,
     });
 
-    await main();
+    try {
+      await main();
+    } finally {
+      resolveProjectRootMock.mockImplementation((dir: string) => dir);
+    }
 
+    expect(resolveProjectRoot).not.toHaveBeenCalled();
     expect(MockSession).not.toHaveBeenCalled();
   });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, symlinkSync, writeFileSync, utimesSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -236,7 +236,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, runNetworkCommand } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -1905,6 +1905,59 @@ describe('main() execution', () => {
       }),
     }));
     expect(MockSession).not.toHaveBeenCalled();
+  });
+
+  it('preserves provider command override approval when saving network config updates', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-trusted-network-save`);
+    const configFile = join(root, '.fbeast', 'config.json');
+    tempDirs.push(root);
+    mkdirSync(join(root, '.fbeast'), { recursive: true });
+    writeFileSync(configFile, JSON.stringify({
+      providers: {
+        overrides: {
+          codex: {
+            command: '/opt/frankenbeast/bin/codex',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/opt/frankenbeast/bin'],
+          },
+        },
+      },
+    }, null, 2));
+
+    const print = vi.fn();
+    await runNetworkCommand({
+      ...(mockParseArgs() as any),
+      subcommand: 'network',
+      networkAction: 'config',
+      networkSet: ['chat.model=gpt-5'],
+      config: configFile,
+      trustProviderCommandOverrides: true,
+    } as never, {
+      network: { mode: 'secure', secureBackend: 'local-encrypted', operatorTokenRef: 'operator-token-ref' },
+      beastsDaemon: { enabled: true, host: '127.0.0.1', port: 4050 },
+      chat: { enabled: true, host: '127.0.0.1', port: 3737, model: 'chat-model' },
+      dashboard: { enabled: true, host: '127.0.0.1', port: 5173, apiUrl: 'http://127.0.0.1:3737' },
+      comms: { enabled: false, host: '127.0.0.1', port: 3200, slack: { enabled: false }, discord: { enabled: false }, telegram: { enabled: false }, whatsapp: { enabled: false } },
+    } as never, root, {
+      configFile,
+      frankenbeastDir: join(root, '.fbeast'),
+    } as never, {
+      resolveServices: vi.fn(),
+      createSupervisor: vi.fn(() => ({ down: vi.fn(), status: vi.fn(), stop: vi.fn(), logs: vi.fn(), up: vi.fn(), stopAll: vi.fn() })),
+      print,
+      printError: vi.fn(),
+      renderHelp: vi.fn(() => 'network help'),
+      waitForShutdown: vi.fn(),
+    });
+
+    const saved = JSON.parse(readFileSync(configFile, 'utf-8'));
+    expect(saved.providers.overrides.codex).toMatchObject({
+      command: '/opt/frankenbeast/bin/codex',
+      trustCommandOverride: true,
+      trustedCommandPaths: ['/opt/frankenbeast/bin'],
+    });
+    expect(saved.chat.model).toBe('gpt-5');
+    expect(print).toHaveBeenCalledWith(`Saved network config to ${configFile}.`);
   });
 
   it('dispatches network help without creating a Session', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1907,14 +1907,18 @@ describe('main() execution', () => {
     expect(MockSession).not.toHaveBeenCalled();
   });
 
-  it('dispatches network help without creating a Session', async () => {
+  it('dispatches network help without resolving the project root or creating a Session', async () => {
+    const resolveProjectRootMock = vi.mocked(resolveProjectRoot);
+    resolveProjectRootMock.mockImplementation(() => {
+      throw new Error('Project root does not exist: /missing/project');
+    });
     mockParseArgs.mockReturnValue({
       subcommand: 'network',
       networkAction: 'help',
       networkTarget: undefined,
       networkDetached: false,
       networkSet: undefined,
-      baseDir: '/mock/project',
+      baseDir: '/missing/project',
       baseBranch: undefined,
       budget: 10,
       provider: 'claude',
@@ -1938,8 +1942,13 @@ describe('main() execution', () => {
       initNonInteractive: false,
     });
 
-    await main();
+    try {
+      await main();
+    } finally {
+      resolveProjectRootMock.mockImplementation((dir: string) => dir);
+    }
 
+    expect(resolveProjectRoot).not.toHaveBeenCalled();
     expect(MockSession).not.toHaveBeenCalled();
   });
 

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { OrchestratorConfigSchema } from '../../../src/config/orchestrator-config.js';
+import { OrchestratorConfigSchema, parseOrchestratorConfig } from '../../../src/config/orchestrator-config.js';
+
+const trustedProviderCommandOverrideOptions = { allowTrustedProviderCommandOverrides: true } as const;
 
 describe('OrchestratorConfigSchema providers section', () => {
   it('produces sensible defaults when parsed with empty object', () => {
@@ -37,18 +39,32 @@ describe('OrchestratorConfigSchema providers section', () => {
     })).toThrow(/trustCommandOverride: true/);
   });
 
-  it('rejects provider command path overrides that only match by basename', () => {
+  it('rejects trusted provider command overrides without explicit CLI approval', () => {
     expect(() => OrchestratorConfigSchema.parse({
+      providers: {
+        overrides: {
+          claude: {
+            command: '/opt/frankenbeast/bin/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/opt/frankenbeast/bin'],
+          },
+        },
+      },
+    })).toThrow(/--trust-provider-command-overrides/);
+  });
+
+  it('rejects provider command path overrides that only match by basename when CLI-approved', () => {
+    expect(() => parseOrchestratorConfig({
       providers: {
         overrides: {
           claude: { command: '/tmp/claude', trustCommandOverride: true },
         },
       },
-    })).toThrow(/absolute path under trustedCommandPaths/);
+    }, trustedProviderCommandOverrideOptions)).toThrow(/absolute path under trustedCommandPaths/);
   });
 
-  it('accepts trusted overrides with command, model, and extraArgs', () => {
-    const config = OrchestratorConfigSchema.parse({
+  it('accepts trusted overrides with command, model, and extraArgs when CLI-approved', () => {
+    const config = parseOrchestratorConfig({
       providers: {
         overrides: {
           gemini: {
@@ -59,7 +75,7 @@ describe('OrchestratorConfigSchema providers section', () => {
           },
         },
       },
-    });
+    }, trustedProviderCommandOverrideOptions);
     const gemini = config.providers.overrides['gemini'];
     expect(gemini).toBeDefined();
     expect(gemini!.command).toBe('gemini-cli');
@@ -67,8 +83,8 @@ describe('OrchestratorConfigSchema providers section', () => {
     expect(gemini!.extraArgs).toEqual(['--temperature', '0.5']);
   });
 
-  it('accepts trusted command overrides under trustedCommandPaths', () => {
-    const config = OrchestratorConfigSchema.parse({
+  it('accepts trusted command overrides under trustedCommandPaths when CLI-approved', () => {
+    const config = parseOrchestratorConfig({
       providers: {
         overrides: {
           claude: {
@@ -78,7 +94,7 @@ describe('OrchestratorConfigSchema providers section', () => {
           },
         },
       },
-    });
+    }, trustedProviderCommandOverrideOptions);
 
     expect(config.providers.overrides['claude']).toEqual({
       command: '/opt/frankenbeast/bin/claude-wrapper',
@@ -87,8 +103,8 @@ describe('OrchestratorConfigSchema providers section', () => {
     });
   });
 
-  it('accepts trusted command overrides when trustedCommandPaths has a trailing slash', () => {
-    const config = OrchestratorConfigSchema.parse({
+  it('accepts trusted command overrides when trustedCommandPaths has a trailing slash and CLI approval', () => {
+    const config = parseOrchestratorConfig({
       providers: {
         overrides: {
           claude: {
@@ -98,7 +114,7 @@ describe('OrchestratorConfigSchema providers section', () => {
           },
         },
       },
-    });
+    }, trustedProviderCommandOverrideOptions);
 
     expect(config.providers.overrides['claude']).toEqual({
       command: '/opt/frankenbeast/bin/claude-wrapper',
@@ -107,8 +123,8 @@ describe('OrchestratorConfigSchema providers section', () => {
     });
   });
 
-  it('accepts consolidated CLI provider cliPath overrides when trustedCommandPaths has a trailing slash', () => {
-    const config = OrchestratorConfigSchema.parse({
+  it('accepts consolidated CLI provider cliPath overrides when trustedCommandPaths has a trailing slash and CLI approval', () => {
+    const config = parseOrchestratorConfig({
       consolidatedProviders: [
         {
           name: 'local-claude',
@@ -118,7 +134,7 @@ describe('OrchestratorConfigSchema providers section', () => {
           trustedCommandPaths: ['/opt/frankenbeast/bin/'],
         },
       ],
-    });
+    }, trustedProviderCommandOverrideOptions);
 
     expect(config.consolidatedProviders?.[0]?.trustedCommandPaths).toEqual(['/opt/frankenbeast/bin/']);
   });
@@ -153,16 +169,8 @@ describe('OrchestratorConfigSchema providers section', () => {
     })).toThrow(/trustCommandOverride: true/);
   });
 
-  it('rejects consolidated CLI provider cliPath paths outside trustedCommandPaths', () => {
+  it('rejects trusted consolidated CLI provider cliPath overrides without explicit CLI approval', () => {
     expect(() => OrchestratorConfigSchema.parse({
-      consolidatedProviders: [
-        { name: 'local-claude', type: 'claude-cli', cliPath: '/tmp/claude', trustCommandOverride: true },
-      ],
-    })).toThrow(/absolute path under trustedCommandPaths/);
-  });
-
-  it('accepts trusted consolidated CLI provider cliPath overrides under trustedCommandPaths', () => {
-    const config = OrchestratorConfigSchema.parse({
       consolidatedProviders: [
         {
           name: 'local-claude',
@@ -172,7 +180,29 @@ describe('OrchestratorConfigSchema providers section', () => {
           trustedCommandPaths: ['/opt/frankenbeast/bin'],
         },
       ],
-    });
+    })).toThrow(/--trust-provider-command-overrides/);
+  });
+
+  it('rejects consolidated CLI provider cliPath paths outside trustedCommandPaths when CLI-approved', () => {
+    expect(() => parseOrchestratorConfig({
+      consolidatedProviders: [
+        { name: 'local-claude', type: 'claude-cli', cliPath: '/tmp/claude', trustCommandOverride: true },
+      ],
+    }, trustedProviderCommandOverrideOptions)).toThrow(/absolute path under trustedCommandPaths/);
+  });
+
+  it('accepts trusted consolidated CLI provider cliPath overrides under trustedCommandPaths when CLI-approved', () => {
+    const config = parseOrchestratorConfig({
+      consolidatedProviders: [
+        {
+          name: 'local-claude',
+          type: 'claude-cli',
+          cliPath: '/opt/frankenbeast/bin/claude-wrapper',
+          trustCommandOverride: true,
+          trustedCommandPaths: ['/opt/frankenbeast/bin'],
+        },
+      ],
+    }, trustedProviderCommandOverrideOptions);
 
     expect(config.consolidatedProviders?.[0]).toEqual({
       name: 'local-claude',

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -4,7 +4,8 @@ import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { gzipSync } from 'node:zlib';
-import { createDashboardStaticResponse, startDashboardStaticServer } from '../../../src/http/dashboard-static-server.js';
+import { createDashboardStaticResponse, resolveDashboardOperatorToken, startDashboardStaticServer } from '../../../src/http/dashboard-static-server.js';
+import { createSecretStore } from '../../../src/network/secret-store.js';
 
 async function createDashboardDist(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'franken-dashboard-dist-'));
@@ -17,11 +18,22 @@ async function createDashboardDist(): Promise<string> {
 describe('dashboard static server', () => {
   let dirs: string[] = [];
   const originalFetch = globalThis.fetch;
+  const originalCwd = process.cwd();
+  const originalConfigFile = process.env.FRANKENBEAST_CONFIG_FILE;
+  const originalConfigPath = process.env.FRANKENBEAST_CONFIG_PATH;
+  const originalPassphrase = process.env.FRANKENBEAST_PASSPHRASE;
 
   afterEach(async () => {
     await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
     dirs = [];
     globalThis.fetch = originalFetch;
+    process.chdir(originalCwd);
+    if (originalConfigFile === undefined) delete process.env.FRANKENBEAST_CONFIG_FILE;
+    else process.env.FRANKENBEAST_CONFIG_FILE = originalConfigFile;
+    if (originalConfigPath === undefined) delete process.env.FRANKENBEAST_CONFIG_PATH;
+    else process.env.FRANKENBEAST_CONFIG_PATH = originalConfigPath;
+    if (originalPassphrase === undefined) delete process.env.FRANKENBEAST_PASSPHRASE;
+    else process.env.FRANKENBEAST_PASSPHRASE = originalPassphrase;
     vi.restoreAllMocks();
   });
 
@@ -82,6 +94,34 @@ describe('dashboard static server', () => {
     const [targetUrl, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
     expect(targetUrl.toString()).toBe('http://127.0.0.1:4242/base/api/dashboard?fresh=1');
     expect(new Headers(init.headers).get('authorization')).toBe('Bearer operator-token');
+  });
+
+  it('loads dashboard operator token from network config even when provider trust metadata is unapproved', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'franken-dashboard-config-'));
+    dirs.push(projectRoot);
+    process.chdir(projectRoot);
+    process.env.FRANKENBEAST_PASSPHRASE = 'dashboard-token-test-passphrase';
+    const configFile = join(projectRoot, 'frankenbeast.json');
+    process.env.FRANKENBEAST_CONFIG_FILE = configFile;
+    delete process.env.FRANKENBEAST_CONFIG_PATH;
+    const store = createSecretStore('local-encrypted', { projectRoot, passphrase: process.env.FRANKENBEAST_PASSPHRASE });
+    await store.store('dashboard-token', 'from-secret-store');
+    await writeFile(configFile, JSON.stringify({
+      network: {
+        secureBackend: 'local-encrypted',
+        operatorTokenRef: 'dashboard-token',
+      },
+      providers: {
+        overrides: {
+          custom: {
+            command: '/usr/local/bin/custom-provider',
+            trustCommandOverride: true,
+          },
+        },
+      },
+    }), 'utf8');
+
+    await expect(resolveDashboardOperatorToken()).resolves.toBe('from-secret-store');
   });
 
   it('rejects cross-site proxy requests when an operator token is configured', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -32,6 +32,21 @@ describe('network-registry', () => {
     expect(dashboardCommand).not.toContain('run dev');
   });
 
+  it('passes provider command override approval to managed children', () => {
+    const services = resolveNetworkServices(defaultConfig(), {
+      repoRoot: '/repo/frankenbeast',
+      configFile: '/repo/frankenbeast/.fbeast/config.json',
+      allowTrustedProviderCommandOverrides: true,
+    });
+    const chat = services.find((service) => service.id === 'chat-server');
+    const dashboard = services.find((service) => service.id === 'dashboard-web');
+
+    expect(chat?.runtimeConfig.process?.args).toContain('--trust-provider-command-overrides');
+    expect(dashboard?.runtimeConfig.process?.env).toMatchObject({
+      FRANKENBEAST_TRUST_PROVIDER_COMMAND_OVERRIDES: '1',
+    });
+  });
+
   it('orders dependencies before dependents', () => {
     const config = defaultConfig();
     config.comms.enabled = true;

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -92,6 +92,10 @@ export const ApproveResultSchema = z.object({
   id: z.string(),
   approved: z.boolean(),
   state: z.string(),
+  outcome: TurnOutcomeSchema.optional(),
+  tier: z.string().optional(),
+  displayMessages: z.array(z.unknown()).optional(),
+  events: z.array(z.unknown()).optional(),
 });
 export type ApproveResult = z.infer<typeof ApproveResultSchema>;
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  type ApproveResult,
   ChatApiClient,
   type ChatSession,
   type PendingApproval,
@@ -209,6 +210,31 @@ function appendOrUpdateAssistantMessage(
   }
 
   return [...messages, nextMessage];
+}
+
+function activityEventsFromApproveResult(result: ApproveResult, approved: boolean): ActivityEvent[] {
+  const timestamp = new Date().toISOString();
+  return [
+    {
+      type: 'turn.approval.resolved',
+      data: { approved },
+      timestamp,
+    },
+    ...(result.events ?? []).flatMap((event): ActivityEvent[] => {
+      if (!event || typeof event !== 'object' || !('type' in event)) {
+        return [];
+      }
+      const turnEvent = event as { type: unknown; data?: Record<string, unknown> };
+      if (turnEvent.type !== 'start' && turnEvent.type !== 'progress' && turnEvent.type !== 'complete') {
+        return [];
+      }
+      return [{
+        type: `turn.execution.${turnEvent.type}`,
+        ...(turnEvent.data !== undefined ? { data: turnEvent.data } : {}),
+        timestamp,
+      }];
+    }),
+  ];
 }
 
 function updateReceipt(
@@ -864,18 +890,29 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setStatus('sending');
     if (!socket || socket.readyState !== 1) {
       try {
-        await clientRef.current.approve(sessionId, approved);
+        const approvalResult = await clientRef.current.approve(sessionId, approved);
         const refreshed = await clientRef.current.getSession(sessionId);
         readyRef.current = true;
-        setMessages((current) => mergeSessionSnapshot(current, refreshed));
+        setMessages((current) => {
+          const withSnapshot = mergeSessionSnapshot(current, refreshed);
+          const approvedDisplays = (approvalResult.displayMessages ?? []).flatMap((display): Array<{ content: string }> => {
+            if (!display || typeof display !== 'object' || !('content' in display)) {
+              return [];
+            }
+            const content = (display as { content: unknown }).content;
+            return typeof content === 'string' ? [{ content }] : [];
+          });
+          return approvedDisplays.reduce((messages, display) => appendOrUpdateAssistantMessage(messages, {
+            type: 'assistant.message.complete',
+            messageId: makeId('assistant'),
+            content: display.content,
+            timestamp: new Date().toISOString(),
+          }), withSnapshot);
+        });
         setPendingApproval(refreshed.pendingApproval ?? null);
         setActivity((current) => [
           ...current,
-          {
-            type: 'turn.approval.resolved',
-            data: { approved },
-            timestamp: new Date().toISOString(),
-          },
+          ...activityEventsFromApproveResult(approvalResult, approved),
         ]);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);


### PR DESCRIPTION
## Summary
- dispatches `frankenbeast network help` before project-root resolution
- adds a regression test proving missing/nonexistent base dirs do not block network help

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/cli/run.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- node /home/pfkagent/dev/resolve-wt/issue-414/packages/franken-orchestrator/dist/cli/run.js network help --base-dir /tmp/frankenbeast-does-not-exist-414

Closes #414