### PR TITLE
test(web): guard dev-server dependency upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: npm run audit:security
 
-      - run: npm run test:root -- tests/workspaces.test.ts
+      - run: npm run test:root -- tests/workspaces.test.ts tests/unit/web-dev-server-dependency-policy.test.ts
 
       - run: npm run lint:security
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Validate release before creating tags
         run: |
-          npm run test:root -- tests/workspaces.test.ts tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts
+          npm run test:root -- tests/workspaces.test.ts tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/web-dev-server-dependency-policy.test.ts
           npm run lint:security
           npx turbo run build typecheck lint
           npx turbo run test

--- a/tests/unit/web-dev-server-dependency-policy.test.ts
+++ b/tests/unit/web-dev-server-dependency-policy.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFileSync(resolve(ROOT, relativePath), 'utf-8')) as T;
+}
+
+function parseVersion(versionRange: string): [number, number, number] {
+  const match = versionRange.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error(`Could not parse semver from ${versionRange}`);
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isAtLeast(versionRange: string, minimum: [number, number, number]): boolean {
+  const version = parseVersion(versionRange);
+
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (version[index] > minimum[index]) {
+      return true;
+    }
+    if (version[index] < minimum[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+describe('web dev-server dependency policy', () => {
+  it('pins the Vite/esbuild dev-server chain to patched versions', () => {
+    const rootPackage = readJson<{
+      overrides?: Record<string, string>;
+    }>('package.json');
+    const webPackage = readJson<{
+      devDependencies?: Record<string, string>;
+    }>('packages/franken-web/package.json');
+
+    expect(webPackage.devDependencies?.vite).toBe(rootPackage.overrides?.vite);
+    expect(rootPackage.overrides?.esbuild).toBeTruthy();
+    expect(isAtLeast(rootPackage.overrides?.vite ?? '', [8, 1, 3])).toBe(true);
+    expect(isAtLeast(rootPackage.overrides?.esbuild ?? '', [0, 28, 1])).toBe(true);
+  });
+
+  it('keeps the lockfile resolved to the patched Vite and esbuild versions used by npm audit', () => {
+    const rootPackage = readJson<{
+      overrides?: Record<string, string>;
+    }>('package.json');
+    const lockfile = readJson<{
+      packages?: Record<string, { version?: string }>;
+    }>('package-lock.json');
+
+    const lockedVite = lockfile.packages?.['node_modules/vite']?.version;
+    const lockedEsbuild = lockfile.packages?.['node_modules/esbuild']?.version;
+
+    expect(lockedVite).toBe(rootPackage.overrides?.vite?.replace(/^\D+/, ''));
+    expect(lockedEsbuild).toBe(rootPackage.overrides?.esbuild?.replace(/^\D+/, ''));
+  });
+});

--- a/tests/unit/web-dev-server-dependency-policy.test.ts
+++ b/tests/unit/web-dev-server-dependency-policy.test.ts
@@ -4,21 +4,39 @@ import { describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
 
+// Patched floors that carry the audited Vite/esbuild dev-server fixes.
+const VITE_FLOOR: [number, number, number] = [8, 1, 3];
+const ESBUILD_FLOOR: [number, number, number] = [0, 28, 1];
+
 function readJson<T>(relativePath: string): T {
   return JSON.parse(readFileSync(resolve(ROOT, relativePath), 'utf-8')) as T;
 }
 
-function parseVersion(versionRange: string): [number, number, number] {
-  const match = versionRange.match(/(\d+)\.(\d+)\.(\d+)/);
+interface ParsedVersion {
+  version: [number, number, number];
+  prerelease: boolean;
+}
+
+function parseVersion(versionRange: string): ParsedVersion {
+  const match = versionRange.match(/(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?/);
   if (!match) {
     throw new Error(`Could not parse semver from ${versionRange}`);
   }
 
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+  return {
+    version: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: Boolean(match[4]),
+  };
 }
 
 function isAtLeast(versionRange: string, minimum: [number, number, number]): boolean {
-  const version = parseVersion(versionRange);
+  const { version, prerelease } = parseVersion(versionRange);
+
+  // Prereleases have lower semver precedence than the associated final release
+  // and may not contain the audited fix, so they must never satisfy the floor.
+  if (prerelease) {
+    return false;
+  }
 
   for (let index = 0; index < minimum.length; index += 1) {
     if (version[index] > minimum[index]) {
@@ -43,14 +61,11 @@ describe('web dev-server dependency policy', () => {
 
     expect(webPackage.devDependencies?.vite).toBe(rootPackage.overrides?.vite);
     expect(rootPackage.overrides?.esbuild).toBeTruthy();
-    expect(isAtLeast(rootPackage.overrides?.vite ?? '', [8, 1, 3])).toBe(true);
-    expect(isAtLeast(rootPackage.overrides?.esbuild ?? '', [0, 28, 1])).toBe(true);
+    expect(isAtLeast(rootPackage.overrides?.vite ?? '', VITE_FLOOR)).toBe(true);
+    expect(isAtLeast(rootPackage.overrides?.esbuild ?? '', ESBUILD_FLOOR)).toBe(true);
   });
 
   it('keeps the lockfile resolved to the patched Vite and esbuild versions used by npm audit', () => {
-    const rootPackage = readJson<{
-      overrides?: Record<string, string>;
-    }>('package.json');
     const lockfile = readJson<{
       packages?: Record<string, { version?: string }>;
     }>('package-lock.json');
@@ -58,7 +73,11 @@ describe('web dev-server dependency policy', () => {
     const lockedVite = lockfile.packages?.['node_modules/vite']?.version;
     const lockedEsbuild = lockfile.packages?.['node_modules/esbuild']?.version;
 
-    expect(lockedVite).toBe(rootPackage.overrides?.vite?.replace(/^\D+/, ''));
-    expect(lockedEsbuild).toBe(rootPackage.overrides?.esbuild?.replace(/^\D+/, ''));
+    expect(lockedVite).toBeTruthy();
+    expect(lockedEsbuild).toBeTruthy();
+    // Accept any newer patched release that npm may resolve within the manifest
+    // ranges, while still enforcing the audited patched floor.
+    expect(isAtLeast(lockedVite ?? '', VITE_FLOOR)).toBe(true);
+    expect(isAtLeast(lockedEsbuild ?? '', ESBUILD_FLOOR)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- adds a regression test that keeps @franken/web on the patched Vite dev-server range
- verifies the root esbuild override and lockfile resolved versions stay aligned with the audited dependency chain
- confirms the current workspace audit reports zero vulnerabilities for the Vite/esbuild chain

## Test Plan
- npm ci
- npx vitest run tests/unit/web-dev-server-dependency-policy.test.ts
- npm test (packages/franken-web)
- npm run typecheck (packages/franken-web, after dependency package build)
- npx turbo run build --filter=@franken/types --filter=@franken/orchestrator --filter=@franken/web
- npm run lint:security
- npm run audit:security

Closes #586