### PR TITLE
fix(orchestrator): rate limit chat REST mutations

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -11,6 +11,7 @@ import { agentRoutes } from './routes/agent-routes.js';
 import { AgentInitService } from '../beasts/services/agent-init-service.js';
 import { createBeastSseRoutes } from './routes/beast-sse-routes.js';
 import { beastRoutes, type BeastRoutesDeps } from './routes/beast-routes.js';
+import type { BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
 import { chatRoutes } from './routes/chat-routes.js';
 import { networkRoutes } from './routes/network-routes.js';
 import { commsRoutes } from './routes/comms-routes.js';
@@ -67,11 +68,14 @@ export interface ChatAppOptions {
   analyticsDeps?: AnalyticsRouteDeps;
   /** Optional owner-managed ticket store for browser EventSource chat streams. */
   chatStreamTicketStore?: SseConnectionTicketStore;
+  /** Rate/concurrency guard for chat message and approval REST mutations. */
+  chatRateLimit?: BeastRateLimitOptions;
   /** Optional gateway compatibility proxy for /v1/beasts/* now owned by beasts-daemon. */
   beastDaemon?: { baseUrl: string; operatorToken?: string | undefined };
 }
 
 const DEFAULT_MAX_BODY_SIZE = 16 * 1024;
+const DEFAULT_CHAT_RATE_LIMIT: BeastRateLimitOptions = { windowMs: 60_000, max: 20 };
 const CORS_ALLOW_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 const CORS_ALLOW_HEADERS = ['authorization', 'content-type', 'x-frankenbeast-operator-token'];
 
@@ -213,6 +217,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     turnRunner: runtimeBundle.turnRunner,
     operatorToken: effectiveOperatorToken,
     streamTicketStore: chatStreamTicketStore,
+    chatRateLimit: opts.chatRateLimit ?? opts.beastControl?.rateLimit ?? DEFAULT_CHAT_RATE_LIMIT,
     issueSocketToken: (sessionId) => issueSessionToken({
       expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS,
       secret: sessionTokenSecret,

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -71,15 +71,19 @@ function requestAddress(c: Context): string {
     ?? 'unknown';
 }
 
-function principalHash(c: Context): string {
-  const credential = c.req.header('authorization')?.trim()
-    ?? c.req.header('x-frankenbeast-operator-token')?.trim()
-    ?? `ip:${requestAddress(c)}`;
-  return createHash('sha256').update(credential).digest('hex').slice(0, 24);
+function hashPrincipal(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
 }
 
-function chatAdmissionKey(c: Context, sessionId: string): string {
-  return `session:${sessionId}:principal:${principalHash(c)}`;
+function chatPrincipalKey(c: Context, operatorToken: string | undefined): string {
+  if (operatorToken) {
+    return `operator:${hashPrincipal(operatorToken)}`;
+  }
+  return `ip:${hashPrincipal(requestAddress(c))}`;
+}
+
+function chatMutationKey(sessionId: string): string {
+  return `session:${sessionId}`;
 }
 
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
@@ -94,19 +98,20 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     sessionId: string,
     run: () => Promise<T>,
   ): Promise<T> {
-    const key = chatAdmissionKey(c, sessionId);
-    const result = limiter.take(`${kind}:${key}`);
+    const principalKey = chatPrincipalKey(c, operatorToken);
+    const mutationKey = chatMutationKey(sessionId);
+    const result = limiter.take(`${kind}:principal:${principalKey}`);
     if (!result.allowed) {
       throw new HttpError(429, 'RATE_LIMITED', 'Rate limit exceeded');
     }
-    if (inFlightMutations.has(key)) {
+    if (inFlightMutations.has(mutationKey)) {
       throw new HttpError(429, 'RATE_LIMITED', 'Chat mutation already in progress');
     }
-    inFlightMutations.add(key);
+    inFlightMutations.add(mutationKey);
     try {
       return await run();
     } finally {
-      inFlightMutations.delete(key);
+      inFlightMutations.delete(mutationKey);
     }
   }
 

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -43,8 +43,6 @@ export interface ChatRoutesDeps {
   chatRateLimit: BeastRateLimitOptions;
 }
 
-type ChatMutationKind = 'message' | 'approval';
-
 function getSessionOrThrow(store: ISessionStore, id: string) {
   const session = store.get(id);
   if (!session) {
@@ -65,10 +63,11 @@ function firstForwardedAddress(header: string | undefined): string | undefined {
 }
 
 function requestAddress(c: Context): string {
-  return firstForwardedAddress(c.req.header('x-forwarded-for'))
-    ?? c.req.header('x-real-ip')?.trim()
-    ?? c.req.header('cf-connecting-ip')?.trim()
-    ?? 'unknown';
+  return c.req.header('x-frankenbeast-remote-address')?.trim()
+    || firstForwardedAddress(c.req.header('x-forwarded-for'))
+    || c.req.header('x-real-ip')?.trim()
+    || c.req.header('cf-connecting-ip')?.trim()
+    || 'unknown';
 }
 
 function hashPrincipal(value: string): string {
@@ -94,13 +93,12 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
 
   async function withChatMutationAdmission<T>(
     c: Context,
-    kind: ChatMutationKind,
     sessionId: string,
     run: () => Promise<T>,
   ): Promise<T> {
     const principalKey = chatPrincipalKey(c, operatorToken);
     const mutationKey = chatMutationKey(sessionId);
-    const result = limiter.take(`${kind}:principal:${principalKey}`);
+    const result = limiter.take(`chat:principal:${principalKey}`);
     if (!result.allowed) {
       throw new HttpError(429, 'RATE_LIMITED', 'Rate limit exceeded');
     }
@@ -162,7 +160,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { content, executionMode } = validateBody(SubmitMessageBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
-    return withChatMutationAdmission(c, 'message', session.id, async () => {
+    return withChatMutationAdmission(c, session.id, async () => {
       const result = await runtime.run(content, {
         sessionId: session.id,
         pendingApproval: Boolean(session.pendingApproval),
@@ -232,7 +230,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { approved } = validateBody(ApproveBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
-    return withChatMutationAdmission(c, 'approval', session.id, async () => {
+    return withChatMutationAdmission(c, session.id, async () => {
       if (!session.pendingApproval && session.state !== 'pending_approval') {
         return c.json({ data: { id: session.id, approved, state: session.state } });
       }

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,4 +1,5 @@
-import { Hono } from 'hono';
+import { createHash } from 'node:crypto';
+import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { approvalRuntimeInput } from '../../chat/approval-input.js';
 import type { ISessionStore } from '../../chat/session-store.js';
@@ -16,6 +17,7 @@ import type {
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
+import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
 
 const CreateSessionBody = z.object({
   projectId: z.string().min(1),
@@ -38,7 +40,10 @@ export interface ChatRoutesDeps {
   issueSocketToken: (sessionId: string) => string;
   operatorToken?: string | undefined;
   streamTicketStore?: SseConnectionTicketStore | undefined;
+  chatRateLimit: BeastRateLimitOptions;
 }
+
+type ChatMutationKind = 'message' | 'approval';
 
 function getSessionOrThrow(store: ISessionStore, id: string) {
   const session = store.get(id);
@@ -55,9 +60,55 @@ function sessionResponse(
   return { ...session, socketToken };
 }
 
+function firstForwardedAddress(header: string | undefined): string | undefined {
+  return header?.split(',')[0]?.trim() || undefined;
+}
+
+function requestAddress(c: Context): string {
+  return firstForwardedAddress(c.req.header('x-forwarded-for'))
+    ?? c.req.header('x-real-ip')?.trim()
+    ?? c.req.header('cf-connecting-ip')?.trim()
+    ?? 'unknown';
+}
+
+function principalHash(c: Context): string {
+  const credential = c.req.header('authorization')?.trim()
+    ?? c.req.header('x-frankenbeast-operator-token')?.trim()
+    ?? `ip:${requestAddress(c)}`;
+  return createHash('sha256').update(credential).digest('hex').slice(0, 24);
+}
+
+function chatAdmissionKey(c: Context, sessionId: string): string {
+  return `session:${sessionId}:principal:${principalHash(c)}`;
+}
+
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
   const { sessionStore, runtime, turnRunner, issueSocketToken, operatorToken, streamTicketStore } = deps;
   const app = new Hono();
+  const limiter = new InMemoryRateLimiter(deps.chatRateLimit);
+  const inFlightMutations = new Set<string>();
+
+  async function withChatMutationAdmission<T>(
+    c: Context,
+    kind: ChatMutationKind,
+    sessionId: string,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const key = chatAdmissionKey(c, sessionId);
+    const result = limiter.take(`${kind}:${key}`);
+    if (!result.allowed) {
+      throw new HttpError(429, 'RATE_LIMITED', 'Rate limit exceeded');
+    }
+    if (inFlightMutations.has(key)) {
+      throw new HttpError(429, 'RATE_LIMITED', 'Chat mutation already in progress');
+    }
+    inFlightMutations.add(key);
+    try {
+      return await run();
+    } finally {
+      inFlightMutations.delete(key);
+    }
+  }
 
   // Health check
   app.get('/health', (c) => {
@@ -106,42 +157,44 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { content, executionMode } = validateBody(SubmitMessageBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
-    const result = await runtime.run(content, {
-      sessionId: session.id,
-      pendingApproval: Boolean(session.pendingApproval),
-      projectId: session.projectId,
-      transcript: session.transcript,
-      ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
-      ...(executionMode ? { executionMode } : {}),
+    return withChatMutationAdmission(c, 'message', session.id, async () => {
+      const result = await runtime.run(content, {
+        sessionId: session.id,
+        pendingApproval: Boolean(session.pendingApproval),
+        projectId: session.projectId,
+        transcript: session.transcript,
+        ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+        ...(executionMode ? { executionMode } : {}),
+      });
+
+      session.transcript = result.transcript;
+      session.state = result.state;
+      session.pendingApproval = result.pendingApproval && result.pendingApprovalDescription
+        ? {
+            description: result.pendingApprovalDescription,
+            requestedAt: new Date().toISOString(),
+            ...result.pendingApprovalContext,
+          }
+        : null;
+      session.beastContext = result.beastContext ?? null;
+      session.updatedAt = new Date().toISOString();
+      sessionStore.save(session);
+
+      const outcome: TurnOutcome = result.outcome ?? {
+        kind: 'reply',
+        content: result.displayMessages.map((message) => message.content).join('\n'),
+        modelTier: result.tier ?? 'unknown',
+      };
+
+      const response = {
+        data: {
+          outcome,
+          tier: result.tier ?? 'unknown',
+          state: session.state,
+        },
+      } satisfies ApiDataEnvelope<MessageResult>;
+      return c.json(response);
     });
-
-    session.transcript = result.transcript;
-    session.state = result.state;
-    session.pendingApproval = result.pendingApproval && result.pendingApprovalDescription
-      ? {
-          description: result.pendingApprovalDescription,
-          requestedAt: new Date().toISOString(),
-          ...result.pendingApprovalContext,
-        }
-      : null;
-    session.beastContext = result.beastContext ?? null;
-    session.updatedAt = new Date().toISOString();
-    sessionStore.save(session);
-
-    const outcome: TurnOutcome = result.outcome ?? {
-      kind: 'reply',
-      content: result.displayMessages.map((message) => message.content).join('\n'),
-      modelTier: result.tier ?? 'unknown',
-    };
-
-    const response = {
-      data: {
-        outcome,
-        tier: result.tier ?? 'unknown',
-        state: session.state,
-      },
-    } satisfies ApiDataEnvelope<MessageResult>;
-    return c.json(response);
   });
 
   // Browser EventSource cannot attach Authorization headers. Authenticated
@@ -174,56 +227,58 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { approved } = validateBody(ApproveBody, body);
     const session = getSessionOrThrow(sessionStore, id);
 
-    if (!session.pendingApproval && session.state !== 'pending_approval') {
-      return c.json({ data: { id: session.id, approved, state: session.state } });
-    }
-
-    let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
-    if (approved) {
-      const pendingApproval = session.pendingApproval ?? null;
-      const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
-      const runtimeInput = approvalRuntimeInput(pendingApproval);
-      const originalState = session.state;
-      session.pendingApproval = null;
-      session.state = 'approved';
-      session.updatedAt = new Date().toISOString();
-      sessionStore.save(session);
-      try {
-        result = await runtime.run(runtimeInput, {
-          sessionId: session.id,
-          pendingApproval: wasPendingApproval,
-          projectId: session.projectId,
-          transcript: session.transcript,
-          ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
-        });
-      } catch (error) {
-        session.pendingApproval = pendingApproval;
-        session.state = originalState;
-        session.updatedAt = new Date().toISOString();
-        sessionStore.save(session);
-        throw error;
+    return withChatMutationAdmission(c, 'approval', session.id, async () => {
+      if (!session.pendingApproval && session.state !== 'pending_approval') {
+        return c.json({ data: { id: session.id, approved, state: session.state } });
       }
 
-      session.state = result.state === 'active' ? 'approved' : result.state;
-      session.pendingApproval = null;
-      session.beastContext = result.beastContext ?? null;
-    } else {
-      session.state = 'rejected';
-      session.pendingApproval = null;
-    }
-    session.updatedAt = new Date().toISOString();
-    sessionStore.save(session);
+      let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
+      if (approved) {
+        const pendingApproval = session.pendingApproval ?? null;
+        const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
+        const runtimeInput = approvalRuntimeInput(pendingApproval);
+        const originalState = session.state;
+        session.pendingApproval = null;
+        session.state = 'approved';
+        session.updatedAt = new Date().toISOString();
+        sessionStore.save(session);
+        try {
+          result = await runtime.run(runtimeInput, {
+            sessionId: session.id,
+            pendingApproval: wasPendingApproval,
+            projectId: session.projectId,
+            transcript: session.transcript,
+            ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
+          });
+        } catch (error) {
+          session.pendingApproval = pendingApproval;
+          session.state = originalState;
+          session.updatedAt = new Date().toISOString();
+          sessionStore.save(session);
+          throw error;
+        }
 
-    return c.json({
-      data: {
-        id: session.id,
-        approved,
-        state: session.state,
-        ...(result?.outcome ? { outcome: result.outcome } : {}),
-        ...(result?.tier ? { tier: result.tier } : {}),
-        ...(result ? { displayMessages: result.displayMessages, events: result.events } : {}),
-      },
-    } satisfies ApiDataEnvelope<ApproveResult>);
+        session.state = result.state === 'active' ? 'approved' : result.state;
+        session.pendingApproval = null;
+        session.beastContext = result.beastContext ?? null;
+      } else {
+        session.state = 'rejected';
+        session.pendingApproval = null;
+      }
+      session.updatedAt = new Date().toISOString();
+      sessionStore.save(session);
+
+      return c.json({
+        data: {
+          id: session.id,
+          approved,
+          state: session.state,
+          ...(result?.outcome ? { outcome: result.outcome } : {}),
+          ...(result?.tier ? { tier: result.tier } : {}),
+          ...(result ? { displayMessages: result.displayMessages, events: result.events } : {}),
+        },
+      } satisfies ApiDataEnvelope<ApproveResult>);
+    });
   });
 
   return app;

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -485,7 +485,93 @@ describe('Chat HTTP Routes', () => {
     expect(llmComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects concurrent chat mutations for the same token and session', async () => {
+  it('uses the client address for unauthenticated rate limits even when auth headers vary', async () => {
+    app = createChatApp({
+      sessionStoreDir: TMP,
+      llm: { complete: llmComplete },
+      projectName: 'test-project',
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+
+    const firstCreate = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: firstSession } = await firstCreate.json();
+    const secondCreate = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: secondSession } = await secondCreate.json();
+
+    const allowed = await app.request(`/v1/chat/sessions/${firstSession.id}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Basic attacker-controlled-a',
+        'x-forwarded-for': '203.0.113.7',
+      },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+    expect(allowed.status).toBe(200);
+
+    const limited = await app.request(`/v1/chat/sessions/${secondSession.id}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Basic attacker-controlled-b',
+        'x-frankenbeast-operator-token': 'attacker-controlled-c',
+        'x-forwarded-for': '203.0.113.7',
+      },
+      body: JSON.stringify({ content: 'second' }),
+    });
+
+    expect(limited.status).toBe(429);
+    expect((await limited.json()).error.code).toBe('RATE_LIMITED');
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys authenticated rate limits to the configured operator credential, not ignored auth headers', async () => {
+    app = createChatApp({
+      sessionStoreDir: TMP,
+      llm: { complete: llmComplete },
+      projectName: 'test-project',
+      operatorToken: 'operator-a',
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-frankenbeast-operator-token': 'operator-a' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+
+    const allowed = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-frankenbeast-operator-token': 'operator-a' },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+    expect(allowed.status).toBe(200);
+
+    const limited = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Basic ignored-attacker-value',
+        'x-frankenbeast-operator-token': 'operator-a',
+      },
+      body: JSON.stringify({ content: 'second' }),
+    });
+
+    expect(limited.status).toBe(429);
+    expect((await limited.json()).error.code).toBe('RATE_LIMITED');
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects concurrent chat mutations for the same session across valid auth forms', async () => {
     const now = new Date().toISOString();
     const session: ChatSession = {
       id: 'chat-concurrent-message',
@@ -519,12 +605,13 @@ describe('Chat HTTP Routes', () => {
       runtime: runtime as never,
       turnRunner: {} as never,
       sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+      operatorToken: 'operator-a',
       chatRateLimit: { windowMs: 60_000, max: 20 },
     });
 
     const first = app.request(`/v1/chat/sessions/${session.id}/messages`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      headers: { 'Content-Type': 'application/json', 'x-frankenbeast-operator-token': 'operator-a' },
       body: JSON.stringify({ content: 'first' }),
     });
     await vi.waitFor(() => expect(runtime.run).toHaveBeenCalledTimes(1));

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -511,6 +511,7 @@ describe('Chat HTTP Routes', () => {
       headers: {
         'Content-Type': 'application/json',
         authorization: 'Basic attacker-controlled-a',
+        'x-frankenbeast-remote-address': '10.0.0.7',
         'x-forwarded-for': '203.0.113.7',
       },
       body: JSON.stringify({ content: 'hello' }),
@@ -523,7 +524,8 @@ describe('Chat HTTP Routes', () => {
         'Content-Type': 'application/json',
         authorization: 'Basic attacker-controlled-b',
         'x-frankenbeast-operator-token': 'attacker-controlled-c',
-        'x-forwarded-for': '203.0.113.7',
+        'x-frankenbeast-remote-address': '10.0.0.7',
+        'x-forwarded-for': '198.51.100.9',
       },
       body: JSON.stringify({ content: 'second' }),
     });
@@ -569,6 +571,69 @@ describe('Chat HTTP Routes', () => {
     expect(limited.status).toBe(429);
     expect((await limited.json()).error.code).toBe('RATE_LIMITED');
     expect(llmComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one quota across message and approval mutations for the same principal', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-shared-mutation-quota',
+      projectId: 'proj',
+      transcript: [],
+      state: 'active',
+      pendingApproval: null,
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'reply' as const, content: 'done' }],
+        events: [],
+        pendingApproval: false,
+        state: 'active',
+        tier: null,
+        transcript: [],
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+
+    const message = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-frankenbeast-remote-address': '10.0.0.9' },
+      body: JSON.stringify({ content: 'first' }),
+    });
+    expect(message.status).toBe(200);
+
+    session.state = 'pending_approval';
+    session.pendingApproval = { description: 'Deploy?', requestedAt: now };
+    const approval = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-frankenbeast-remote-address': '10.0.0.9' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(approval.status).toBe(429);
+    expect((await approval.json()).error.code).toBe('RATE_LIMITED');
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect(session.state).toBe('pending_approval');
+    expect(session.pendingApproval).toEqual({ description: 'Deploy?', requestedAt: now });
   });
 
   it('rejects concurrent chat mutations for the same session across valid auth forms', async () => {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -452,6 +452,104 @@ describe('Chat HTTP Routes', () => {
     expect(llmComplete).toHaveBeenNthCalledWith(2, 'second');
   });
 
+  it('rate limits repeated message submissions before invoking the runtime', async () => {
+    app = createChatApp({
+      sessionStoreDir: TMP,
+      llm: { complete: llmComplete },
+      projectName: 'test-project',
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+
+    const allowed = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+    expect(allowed.status).toBe(200);
+
+    const limited = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ content: 'second' }),
+    });
+
+    expect(limited.status).toBe(429);
+    expect((await limited.json()).error.code).toBe('RATE_LIMITED');
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects concurrent chat mutations for the same token and session', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-concurrent-message',
+      projectId: 'proj',
+      transcript: [],
+      state: 'active',
+      pendingApproval: null,
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    let resolveRun: ((value: unknown) => void) | undefined;
+    const runtime = {
+      run: vi.fn(() => new Promise((resolve) => {
+        resolveRun = resolve;
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+      chatRateLimit: { windowMs: 60_000, max: 20 },
+    });
+
+    const first = app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ content: 'first' }),
+    });
+    await vi.waitFor(() => expect(runtime.run).toHaveBeenCalledTimes(1));
+
+    const second = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ content: 'second' }),
+    });
+
+    expect(second.status).toBe(429);
+    expect((await second.json()).error.code).toBe('RATE_LIMITED');
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+
+    resolveRun?.({
+      displayMessages: [{ kind: 'reply', content: 'done' }],
+      events: [],
+      pendingApproval: false,
+      state: 'active',
+      tier: null,
+      transcript: [],
+    });
+    expect((await first).status).toBe(200);
+  });
+
   it('POST /v1/chat/sessions/:id/messages returns 404 for unknown session', async () => {
     const res = await app.request('/v1/chat/sessions/nonexistent/messages', {
       method: 'POST',
@@ -533,6 +631,70 @@ describe('Chat HTTP Routes', () => {
     const sessionBody = await sessionRes.json();
     expect(sessionBody.data.state).toBe('approved');
     expect(sessionBody.data.pendingApproval).toBeNull();
+  });
+
+  it('rate limits approval requests before mutating pending approval state', async () => {
+    const now = new Date().toISOString();
+    const session: ChatSession = {
+      id: 'chat-rate-limit-approval',
+      projectId: 'proj',
+      transcript: [],
+      state: 'active',
+      pendingApproval: null,
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const sessionStore = {
+      create: vi.fn(),
+      get: vi.fn(() => session),
+      save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+      list: vi.fn(() => [session.id]),
+      listSessions: vi.fn(() => [session]),
+      delete: vi.fn(),
+    };
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'approval' as const, content: 'Approved.' }],
+        events: [],
+        pendingApproval: false,
+        state: 'approved',
+        tier: null,
+        transcript: [],
+      })),
+    };
+
+    app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+
+    const warmup = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ approved: false }),
+    });
+    expect(warmup.status).toBe(200);
+
+    session.state = 'pending_approval';
+    session.pendingApproval = { description: 'Deploy?', requestedAt: now };
+    const limited = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', authorization: 'Bearer operator-a' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(limited.status).toBe(429);
+    expect((await limited.json()).error.code).toBe('RATE_LIMITED');
+    expect(runtime.run).not.toHaveBeenCalled();
+    expect(session.state).toBe('pending_approval');
+    expect(session.pendingApproval).toEqual({ description: 'Deploy?', requestedAt: now });
+    expect(sessionStore.save).not.toHaveBeenCalled();
   });
 
   it('POST /v1/chat/sessions/:id/approve handles state-only pending approvals', async () => {
@@ -659,7 +821,7 @@ describe('Chat HTTP Routes', () => {
     expect(session.pendingApproval).toBeNull();
   });
 
-  it('POST /v1/chat/sessions/:id/approve does not execute duplicate HTTP approvals twice', async () => {
+  it('POST /v1/chat/sessions/:id/approve rejects concurrent HTTP approvals before duplicate execution', async () => {
     const now = new Date().toISOString();
     const session: ChatSession = {
       id: 'chat-http-duplicate-approval',
@@ -732,13 +894,9 @@ describe('Chat HTTP Routes', () => {
     const firstRes = await first;
 
     expect(firstRes.status).toBe(200);
-    expect(duplicate.status).toBe(200);
+    expect(duplicate.status).toBe(429);
     expect(runtime.run).toHaveBeenCalledTimes(1);
-    expect((await duplicate.json()).data).toMatchObject({
-      id: session.id,
-      approved: true,
-      state: 'approved',
-    });
+    expect((await duplicate.json()).error.code).toBe('RATE_LIMITED');
     expect(session.pendingApproval).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- Add per-principal/session rate limiting and in-flight concurrency admission for chat REST message and approval mutations
- Reuse the existing beast rate-limit configuration when available, with a chat default of 20 mutations/minute
- Add integration coverage for message rate limits, approval rate limits before state mutation, and concurrent approval/message rejection

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-routes.test.ts
- npm run build
- npm run typecheck
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings)

Closes #606
