### PR TITLE
fix(mcp-suite): remove Windows shell passthrough

### DIFF
--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -204,7 +204,18 @@ describe('fbeast main CLI', () => {
     const mockSpawnSync = vi.fn().mockReturnValue({ status: 0, signal: null, error: undefined });
     vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
 
-    process.argv = ['node', 'fbeast', 'network', 'up', 'name&whoami', '100%literal%', 'C:\\tmp\\', 'with space'];
+    process.argv = [
+      'node',
+      'fbeast',
+      'network',
+      'up',
+      'name&whoami',
+      '100%literal%',
+      'C:\\tmp\\',
+      'with space',
+      '--set=a" b',
+      '(group)|pipe',
+    ];
 
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('process.exit'); }) as never);
 
@@ -214,7 +225,7 @@ describe('fbeast main CLI', () => {
       // process.exit throws in test
     }
 
-    const commandLine = `"${shimPath}" "network" "up" "name^&whoami" "100%%literal%%" "C:\\tmp\\\\" "with space"`;
+    const commandLine = `"${shimPath}" "network" "up" "name&whoami" "100^%literal^%" "C:\\tmp\\" "with space" "--set=a"" b" "(group)|pipe"`;
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'C:\\Windows\\System32\\cmd.exe',
       ['/d', '/s', '/c', `"${commandLine}"`],

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -204,7 +204,7 @@ describe('fbeast main CLI', () => {
     const mockSpawnSync = vi.fn().mockReturnValue({ status: 0, signal: null, error: undefined });
     vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
 
-    process.argv = ['node', 'fbeast', 'network', 'up', 'name&whoami', '100%literal%'];
+    process.argv = ['node', 'fbeast', 'network', 'up', 'name&whoami', '100%literal%', 'C:\\tmp\\', 'with space'];
 
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('process.exit'); }) as never);
 
@@ -216,8 +216,8 @@ describe('fbeast main CLI', () => {
 
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'C:\\Windows\\System32\\cmd.exe',
-      ['/d', '/s', '/c', `"${shimPath}" "network" "up" "name^&whoami" "100^%literal^%"`],
-      expect.objectContaining({ stdio: 'inherit', shell: false }),
+      ['/d', '/c', `"${shimPath}" "network" "up" "name^&whoami" "100^%literal^%" "C:\\tmp\\\\" "with space"`],
+      expect.objectContaining({ stdio: 'inherit', shell: false, windowsVerbatimArguments: true }),
     );
     mockExit.mockRestore();
     platformSpy.mockRestore();

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -18,6 +18,7 @@ describe('fbeast main CLI', () => {
   afterEach(() => {
     process.argv = originalArgv;
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     vi.resetModules();
     vi.doUnmock('./init.js');
     vi.doUnmock('./uninstall.js');
@@ -170,6 +171,7 @@ describe('fbeast main CLI', () => {
   });
 
   it('passes through non-mcp commands to frankenbeast', async () => {
+    vi.stubEnv('PATH', '');
     const mockSpawnSync = vi.fn().mockReturnValue({ status: 0, signal: null, error: undefined });
     vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
 
@@ -186,17 +188,23 @@ describe('fbeast main CLI', () => {
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'frankenbeast',
       ['network', 'up'],
-      expect.objectContaining({ stdio: 'inherit', shell: process.platform === 'win32' }),
+      expect.objectContaining({ stdio: 'inherit', shell: false }),
     );
     mockExit.mockRestore();
   });
 
-  it('uses shell on Windows so npm .cmd shims are resolved', async () => {
+  it('launches Windows .cmd shims through cmd.exe without enabling shell mode', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    const binDir = tmpDir();
+    const shimPath = join(binDir, 'frankenbeast.CMD');
+    writeFileSync(shimPath, '@echo off\r\n');
+    vi.stubEnv('PATH', binDir);
+    vi.stubEnv('PATHEXT', '.COM;.EXE;.BAT;.CMD');
+    vi.stubEnv('ComSpec', 'C:\\Windows\\System32\\cmd.exe');
     const mockSpawnSync = vi.fn().mockReturnValue({ status: 0, signal: null, error: undefined });
     vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
 
-    process.argv = ['node', 'fbeast', 'network', 'up'];
+    process.argv = ['node', 'fbeast', 'network', 'up', 'name&whoami', '100%literal%'];
 
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('process.exit'); }) as never);
 
@@ -207,9 +215,9 @@ describe('fbeast main CLI', () => {
     }
 
     expect(mockSpawnSync).toHaveBeenCalledWith(
-      'frankenbeast',
-      ['network', 'up'],
-      expect.objectContaining({ shell: true }),
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/s', '/c', `"${shimPath}" "network" "up" "name^&whoami" "100^%literal^%"`],
+      expect.objectContaining({ stdio: 'inherit', shell: false }),
     );
     mockExit.mockRestore();
     platformSpy.mockRestore();
@@ -242,12 +250,13 @@ describe('fbeast main CLI', () => {
   it('maps Windows missing mcp beast handoff binary output to standalone install help', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir());
+    const enoent: NodeJS.ErrnoException = Object.assign(new Error('spawn frankenbeast ENOENT'), { code: 'ENOENT' });
     const mockSpawnSync = vi.fn().mockReturnValue({
-      status: 1,
+      status: null,
       signal: null,
-      error: undefined,
+      error: enoent,
       stdout: '',
-      stderr: "'frankenbeast' is not recognized as an internal or external command",
+      stderr: '',
     });
     vi.doMock('node:child_process', () => ({ spawnSync: mockSpawnSync }));
 
@@ -261,7 +270,7 @@ describe('fbeast main CLI', () => {
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'frankenbeast',
       ['beasts', 'catalog'],
-      expect.objectContaining({ stdio: 'pipe', shell: true, encoding: 'utf8' }),
+      expect.objectContaining({ stdio: 'pipe', shell: false, encoding: 'utf8' }),
     );
     expect(message).toContain('npm install -g @franken/orchestrator');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -214,9 +214,10 @@ describe('fbeast main CLI', () => {
       // process.exit throws in test
     }
 
+    const commandLine = `"${shimPath}" "network" "up" "name^&whoami" "100%%literal%%" "C:\\tmp\\\\" "with space"`;
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'C:\\Windows\\System32\\cmd.exe',
-      ['/d', '/c', `"${shimPath}" "network" "up" "name^&whoami" "100^%literal^%" "C:\\tmp\\\\" "with space"`],
+      ['/d', '/s', '/c', `"${commandLine}"`],
       expect.objectContaining({ stdio: 'inherit', shell: false, windowsVerbatimArguments: true }),
     );
     mockExit.mockRestore();
@@ -250,6 +251,12 @@ describe('fbeast main CLI', () => {
   it('maps Windows missing mcp beast handoff binary output to standalone install help', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir());
+    const binDir = tmpDir();
+    const shimPath = join(binDir, 'frankenbeast.CMD');
+    writeFileSync(shimPath, '@echo off\r\n');
+    vi.stubEnv('PATH', binDir);
+    vi.stubEnv('PATHEXT', '.COM;.EXE;.BAT;.CMD');
+    vi.stubEnv('ComSpec', 'C:\\Windows\\System32\\cmd.exe');
     const enoent: NodeJS.ErrnoException = Object.assign(new Error('spawn frankenbeast ENOENT'), { code: 'ENOENT' });
     const mockSpawnSync = vi.fn().mockReturnValue({
       status: null,
@@ -267,10 +274,11 @@ describe('fbeast main CLI', () => {
     await import('./main.js');
 
     const message = mockLog.mock.calls.map((c) => c.join(' ')).join('\n');
+    const commandLine = `"${shimPath}" "beasts" "catalog"`;
     expect(mockSpawnSync).toHaveBeenCalledWith(
-      'frankenbeast',
-      ['beasts', 'catalog'],
-      expect.objectContaining({ stdio: 'pipe', shell: false, encoding: 'utf8' }),
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/s', '/c', `"${commandLine}"`],
+      expect.objectContaining({ stdio: 'pipe', shell: false, encoding: 'utf8', windowsVerbatimArguments: true }),
     );
     expect(message).toContain('npm install -g @franken/orchestrator');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -64,27 +64,10 @@ function resolveExecutable(command: string): string {
 }
 
 function quoteCmdArg(arg: string): string {
-  let quoted = '"';
-  let backslashes = 0;
-
-  for (const char of arg) {
-    if (char === '\\') {
-      backslashes += 1;
-      continue;
-    }
-
-    if (char === '"') {
-      quoted += `${'\\'.repeat(backslashes * 2 + 1)}"`;
-      backslashes = 0;
-      continue;
-    }
-
-    quoted += `${'\\'.repeat(backslashes)}${char}`;
-    backslashes = 0;
-  }
-
-  quoted += `${'\\'.repeat(backslashes * 2)}"`;
-  return quoted.replace(/%/g, '%%').replace(/[\^&|<>()!]/g, (char) => `^${char}`);
+  // This string is parsed first by cmd.exe and then forwarded by the npm .cmd shim
+  // via %*. Keep metacharacters literal by grouping every argv entry in quotes,
+  // not by caret-escaping characters that would then leak into the child argv.
+  return `"${arg.replace(/"/g, '""').replace(/%/g, '^%')}"`;
 }
 
 function isWindowsShellShim(command: string): boolean {

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -84,7 +84,7 @@ function quoteCmdArg(arg: string): string {
   }
 
   quoted += `${'\\'.repeat(backslashes * 2)}"`;
-  return quoted.replace(/[\^&|<>()%!]/g, (char) => `^${char}`);
+  return quoted.replace(/%/g, '%%').replace(/[\^&|<>()!]/g, (char) => `^${char}`);
 }
 
 function isWindowsShellShim(command: string): boolean {
@@ -100,7 +100,7 @@ function resolveCommand(command: string, args: string[]): ResolvedCommand {
 
   const comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe';
   const commandLine = [executable, ...args].map(quoteCmdArg).join(' ');
-  return { command: comspec, args: ['/d', '/c', commandLine], windowsVerbatimArguments: true };
+  return { command: comspec, args: ['/d', '/s', '/c', `"${commandLine}"`], windowsVerbatimArguments: true };
 }
 
 function resolveClient(): McpClient {
@@ -237,7 +237,7 @@ switch (subcommand) {
           resolved.command,
           resolved.args,
           process.platform === 'win32'
-            ? { stdio: 'pipe', shell: false, encoding: 'utf8' }
+            ? { stdio: 'pipe', shell: false, encoding: 'utf8', windowsVerbatimArguments: resolved.windowsVerbatimArguments }
             : { stdio: 'inherit', shell: false },
         );
         if (result.error) {

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -19,6 +19,7 @@ const MCP_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
 type ResolvedCommand = {
   command: string;
   args: string[];
+  windowsVerbatimArguments?: boolean;
 };
 
 function getEnvPath(env: NodeJS.ProcessEnv): string {
@@ -63,8 +64,27 @@ function resolveExecutable(command: string): string {
 }
 
 function quoteCmdArg(arg: string): string {
-  if (arg === '') return '""';
-  return `"${arg.replace(/["^&|<>()%!]/g, (char) => `^${char}`)}"`;
+  let quoted = '"';
+  let backslashes = 0;
+
+  for (const char of arg) {
+    if (char === '\\') {
+      backslashes += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      quoted += `${'\\'.repeat(backslashes * 2 + 1)}"`;
+      backslashes = 0;
+      continue;
+    }
+
+    quoted += `${'\\'.repeat(backslashes)}${char}`;
+    backslashes = 0;
+  }
+
+  quoted += `${'\\'.repeat(backslashes * 2)}"`;
+  return quoted.replace(/[\^&|<>()%!]/g, (char) => `^${char}`);
 }
 
 function isWindowsShellShim(command: string): boolean {
@@ -80,7 +100,7 @@ function resolveCommand(command: string, args: string[]): ResolvedCommand {
 
   const comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe';
   const commandLine = [executable, ...args].map(quoteCmdArg).join(' ');
-  return { command: comspec, args: ['/d', '/s', '/c', commandLine] };
+  return { command: comspec, args: ['/d', '/c', commandLine], windowsVerbatimArguments: true };
 }
 
 function resolveClient(): McpClient {
@@ -97,10 +117,11 @@ function reportMcpInitError(error: unknown): never {
 
 function passthrough(): never {
   const passthroughArgs = process.argv.slice(2);
-  const { command, args } = resolveCommand('frankenbeast', passthroughArgs);
+  const { command, args, windowsVerbatimArguments } = resolveCommand('frankenbeast', passthroughArgs);
   const result = spawnSync(command, args, {
     stdio: 'inherit',
     shell: false,
+    windowsVerbatimArguments,
   });
   if (result.error) {
     const isNotFound = (result.error as NodeJS.ErrnoException).code === 'ENOENT';

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -6,6 +6,7 @@ function printLine(...args: unknown[]): void {
 
 import { existsSync } from 'node:fs';
 import { constants, homedir } from 'node:os';
+import { win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { resolveInitOptions } from './init-options.js';
@@ -14,6 +15,73 @@ const command = process.argv[2];
 const FRANKENBEAST_INSTALL_HELP = "install @franken/orchestrator with 'npm install -g @franken/orchestrator'";
 const TOP_LEVEL_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
 const MCP_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
+
+type ResolvedCommand = {
+  command: string;
+  args: string[];
+};
+
+function getEnvPath(env: NodeJS.ProcessEnv): string {
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+  return pathKey ? env[pathKey] ?? '' : '';
+}
+
+function windowsCommandCandidates(command: string): string[] {
+  const pathext = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .map((ext) => ext.trim())
+    .filter(Boolean);
+  const hasWindowsPathSeparator = command.includes('/') || command.includes('\\');
+  const commandHasExt = win32.extname(command) !== '';
+
+  if (hasWindowsPathSeparator || win32.isAbsolute(command)) {
+    const directory = win32.dirname(command);
+    const file = win32.basename(command);
+    return commandHasExt ? [command] : pathext.map((ext) => win32.join(directory, `${file}${ext}`));
+  }
+
+  const pathEntries = getEnvPath(process.env).split(win32.delimiter).filter(Boolean);
+  const names = commandHasExt ? [command] : pathext.map((ext) => `${command}${ext}`);
+  return pathEntries.flatMap((entry) => names.map((name) => joinWindowsPathEntry(entry, name)));
+}
+
+function joinWindowsPathEntry(entry: string, name: string): string {
+  // Tests can mock process.platform to win32 while running on POSIX paths.
+  // Preserve those host paths so existsSync can exercise the Windows branch.
+  if (entry.includes('/')) return `${entry.replace(/[\\/]+$/, '')}/${name}`;
+  return win32.join(entry, name);
+}
+
+function resolveExecutable(command: string): string {
+  if (process.platform !== 'win32') return command;
+
+  for (const candidate of windowsCommandCandidates(command)) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return command;
+}
+
+function quoteCmdArg(arg: string): string {
+  if (arg === '') return '""';
+  return `"${arg.replace(/["^&|<>()%!]/g, (char) => `^${char}`)}"`;
+}
+
+function isWindowsShellShim(command: string): boolean {
+  const extension = win32.extname(command).toLowerCase();
+  return extension === '.cmd' || extension === '.bat';
+}
+
+function resolveCommand(command: string, args: string[]): ResolvedCommand {
+  const executable = resolveExecutable(command);
+  if (process.platform !== 'win32' || !isWindowsShellShim(executable)) {
+    return { command: executable, args };
+  }
+
+  const comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe';
+  const commandLine = [executable, ...args].map(quoteCmdArg).join(' ');
+  return { command: comspec, args: ['/d', '/s', '/c', commandLine] };
+}
 
 function resolveClient(): McpClient {
   const clientArg = parseMcpClient(process.argv.find((a) => a.startsWith('--client='))?.split('=')[1]);
@@ -28,9 +96,11 @@ function reportMcpInitError(error: unknown): never {
 }
 
 function passthrough(): never {
-  const result = spawnSync('frankenbeast', process.argv.slice(2), {
+  const passthroughArgs = process.argv.slice(2);
+  const { command, args } = resolveCommand('frankenbeast', passthroughArgs);
+  const result = spawnSync(command, args, {
     stdio: 'inherit',
-    shell: process.platform === 'win32',
+    shell: false,
   });
   if (result.error) {
     const isNotFound = (result.error as NodeJS.ErrnoException).code === 'ENOENT';
@@ -141,12 +211,12 @@ switch (subcommand) {
         });
       },
       exec: async (cmd, args) => {
-        const isWindows = process.platform === 'win32';
+        const resolved = resolveCommand(cmd, args);
         const result = spawn(
-          cmd,
-          args,
-          isWindows
-            ? { stdio: 'pipe', shell: true, encoding: 'utf8' }
+          resolved.command,
+          resolved.args,
+          process.platform === 'win32'
+            ? { stdio: 'pipe', shell: false, encoding: 'utf8' }
             : { stdio: 'inherit', shell: false },
         );
         if (result.error) {
@@ -160,15 +230,6 @@ switch (subcommand) {
         if (result.status !== 0) {
           const stdout = result.stdout ? String(result.stdout) : '';
           const stderr = result.stderr ? String(result.stderr) : '';
-          const shellOutput = `${stdout}\n${stderr}`.toLowerCase();
-          const isWindowsCommandNotFound =
-            isWindows &&
-            (shellOutput.includes('is not recognized') ||
-              shellOutput.includes('not recognized as an internal or external command') ||
-              shellOutput.includes('command not found'));
-          if (isWindowsCommandNotFound) {
-            throw new Error(`${cmd}: binary not found — ${FRANKENBEAST_INSTALL_HELP}`);
-          }
           if (stdout) process.stdout.write(stdout);
           if (stderr) process.stderr.write(stderr);
           throw new Error(


### PR DESCRIPTION
## Summary
- Remove the Windows `shell: true` passthrough for `fbeast` CLI forwarding and `mcp beast` handoff execution.
- Resolve Windows `.cmd`/`.bat` style shims explicitly through `PATH`/`PATHEXT` before spawning with `shell: false`.
- Add regression coverage that shell metacharacters remain literal argv entries while `.cmd` shims still resolve.

## Test Plan
- `npm ci`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/orchestrator`
- `npm run build --workspace @franken/planner`
- `npm run test --workspace @franken/mcp-suite -- src/cli/main.test.ts`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run build --workspace @franken/mcp-suite`
- `npm run test --workspace @franken/mcp-suite`

Closes #591
