### PR TITLE
fix(orchestrator): redact beast run config snapshots

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -114,7 +114,7 @@ function redactRunConfigValue(
   }
 
   if (typeof input === 'string') {
-    return redactBeastLogLine(input, configuredSecrets);
+    return redactConfiguredSecretValues(input, configuredSecrets);
   }
 
   if (Array.isArray(input)) {

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -17,7 +17,7 @@ const STDERR_BUFFER_SIZE = 50;
 const REDACTED_SECRET = '[REDACTED]';
 const MIN_CONFIGURED_SECRET_LENGTH = 6;
 
-const SENSITIVE_CONFIG_KEY_PATTERN = /(?:password|passwd|pwd|secret|clientsecret|token|apikey|accesskey|privatekey|auth|credential|webhookurl)/i;
+const SENSITIVE_CONFIG_KEY_PATTERN = /(?:password|passwd|pwd|secret|clientsecret|token|apikey|accesskey|privatekey|auth|credential|webhook)/i;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -94,6 +94,39 @@ function redactBeastLogLine(line: string, configuredSecrets: readonly string[] =
 
 function redactFailureStderrTail(stderrTail: readonly string[], configuredSecrets: readonly string[]): string[] {
   return stderrTail.map(line => redactBeastLogLine(line, configuredSecrets));
+}
+
+function redactRunConfigValue(
+  input: unknown,
+  configuredSecrets: readonly string[],
+  path: readonly string[] = [],
+): unknown {
+  if (path.length > 0 && isConfiguredSecretKey(path.join('.'))) {
+    return REDACTED_SECRET;
+  }
+
+  if (typeof input === 'string') {
+    return redactBeastLogLine(input, configuredSecrets);
+  }
+
+  if (Array.isArray(input)) {
+    return input.map(item => redactRunConfigValue(item, configuredSecrets, path));
+  }
+
+  if (!input || typeof input !== 'object') return input;
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    redacted[key] = redactRunConfigValue(value, configuredSecrets, [...path, key]);
+  }
+  return redacted;
+}
+
+function redactRunConfigSnapshot(
+  configSnapshot: Readonly<Record<string, unknown>>,
+  configuredSecrets: readonly string[],
+): Readonly<Record<string, unknown>> {
+  return redactRunConfigValue(configSnapshot, configuredSecrets) as Readonly<Record<string, unknown>>;
 }
 
 function moduleConfigToEnv(config?: ModuleConfig): Record<string, string> {
@@ -226,7 +259,6 @@ export class ProcessBeastExecutor implements BeastExecutor {
     );
     mkdirSync(configDir, { recursive: true });
     const configFilePath = join(configDir, `${run.id}.json`);
-    writeFileSync(configFilePath, JSON.stringify(isolatedConfigSnapshot, null, 2));
     this.pendingConfigFilePaths.set(run.id, configFilePath);
 
     const mergedSpec = {
@@ -245,6 +277,8 @@ export class ProcessBeastExecutor implements BeastExecutor {
       mergedSpec.env,
       spawnedSpec.env,
     );
+    const redactedConfigSnapshot = redactRunConfigSnapshot(isolatedConfigSnapshot, configuredSecrets);
+    writeFileSync(configFilePath, JSON.stringify(redactedConfigSnapshot, null, 2));
 
     // eslint-disable-next-line prefer-const -- reassigned after attempt creation (line 162)
     let attemptId: string | undefined;

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -102,6 +102,14 @@ function redactRunConfigValue(
   path: readonly string[] = [],
 ): unknown {
   if (path.length > 0 && isConfiguredSecretKey(path.join('.'))) {
+    // Non-string scalar config values (e.g. numeric token budgets like
+    // `maxTotalTokens`, which matches the generic `token` key pattern) cannot
+    // carry string secrets and must keep their original type so the spawned
+    // CLI's RunConfigSchema validation still passes. Redact everything else —
+    // strings, objects, and arrays — wholesale. See PR #1064 Codex review.
+    if (input !== null && typeof input !== 'object' && typeof input !== 'string') {
+      return input;
+    }
     return REDACTED_SECRET;
   }
 

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -832,6 +832,7 @@ describe('ProcessBeastExecutor', () => {
           provider: 'claude',
           objective: 'keep this user-visible objective',
           chunkDirectory: '/tmp/chunks',
+          maxTotalTokens: 50000,
           nested: {
             apiKey: sensitiveTokenValue,
             authorization: `Bearer ${sensitiveTokenValue}`,
@@ -855,6 +856,9 @@ describe('ProcessBeastExecutor', () => {
         provider: 'claude',
         objective: 'keep this user-visible objective',
         chunkDirectory: '/tmp/chunks',
+        // Numeric token-budget field must survive redaction as a number even
+        // though its key matches the generic `token` secret pattern (PR #1064).
+        maxTotalTokens: 50000,
         nested: {
           apiKey: '[REDACTED]',
           authorization: '[REDACTED]',
@@ -864,6 +868,7 @@ describe('ProcessBeastExecutor', () => {
         tokenRefs: '[REDACTED]',
         notes: 'call [REDACTED] with [REDACTED]',
       });
+      expect(typeof persisted.maxTotalTokens).toBe('number');
       expect(serializedPersisted).not.toContain(sensitiveTokenValue);
       expect(serializedPersisted).not.toContain(sensitiveWebhookUrl);
       expect(serializedPersisted).not.toContain(sensitivePrivateCredential);

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -841,6 +841,9 @@ describe('ProcessBeastExecutor', () => {
           },
           tokenRefs: ['op://vault/item/token', { privateKey: sensitivePrivateCredential }],
           notes: `call ${sensitiveWebhookUrl} with ${sensitiveTokenValue}`,
+          promptConfig: {
+            text: `Read https://docs.example.test/webhook/setup and use ${sensitiveTokenValue}`,
+          },
         },
         dispatchedBy: 'cli',
         dispatchedByUser: 'pfk',
@@ -867,6 +870,9 @@ describe('ProcessBeastExecutor', () => {
         },
         tokenRefs: '[REDACTED]',
         notes: 'call [REDACTED] with [REDACTED]',
+        promptConfig: {
+          text: 'Read https://docs.example.test/webhook/setup and use [REDACTED]',
+        },
       });
       expect(typeof persisted.maxTotalTokens).toBe('number');
       expect(serializedPersisted).not.toContain(sensitiveTokenValue);

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -814,6 +814,61 @@ describe('ProcessBeastExecutor', () => {
       expect(existsSync(configPath)).toBe(false);
     });
 
+    it('redacts sensitive keys and secret-shaped values before writing run config files', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const runConfigDir = join(workDir, 'project-root', '.fbeast', '.build', 'run-configs');
+      const supervisor = createSupervisorMock();
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { runConfigDir });
+      const sensitiveTokenValue = 'configured-token-value-12345';
+      const sensitiveWebhookUrl = 'https://discord.com/api/webhooks/1234567890/opaque-webhook-value';
+      const sensitivePrivateCredential = 'opaque-private-material-abc123';
+      const run = repo.createRun({
+        definitionId: 'martin-loop',
+        definitionVersion: 1,
+        executionMode: 'process',
+        configSnapshot: {
+          provider: 'claude',
+          objective: 'keep this user-visible objective',
+          chunkDirectory: '/tmp/chunks',
+          nested: {
+            apiKey: sensitiveTokenValue,
+            authorization: `Bearer ${sensitiveTokenValue}`,
+            webhook: sensitiveWebhookUrl,
+            visible: 'safe-value',
+          },
+          tokenRefs: ['op://vault/item/token', { privateKey: sensitivePrivateCredential }],
+          notes: `call ${sensitiveWebhookUrl} with ${sensitiveTokenValue}`,
+        },
+        dispatchedBy: 'cli',
+        dispatchedByUser: 'pfk',
+        createdAt: '2026-03-10T00:00:00.000Z',
+      });
+
+      await executor.start(run, martinLoopDefinition);
+
+      const configPath = join(runConfigDir, `${run.id}.json`);
+      const persisted = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      const serializedPersisted = JSON.stringify(persisted);
+      expect(persisted).toMatchObject({
+        provider: 'claude',
+        objective: 'keep this user-visible objective',
+        chunkDirectory: '/tmp/chunks',
+        nested: {
+          apiKey: '[REDACTED]',
+          authorization: '[REDACTED]',
+          webhook: '[REDACTED]',
+          visible: 'safe-value',
+        },
+        tokenRefs: '[REDACTED]',
+        notes: 'call [REDACTED] with [REDACTED]',
+      });
+      expect(serializedPersisted).not.toContain(sensitiveTokenValue);
+      expect(serializedPersisted).not.toContain(sensitiveWebhookUrl);
+      expect(serializedPersisted).not.toContain(sensitivePrivateCredential);
+    });
+
     it('passes ProcessCallbacks to supervisor.spawn()', async () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));


### PR DESCRIPTION
## Summary
- Redact sensitive run config snapshot keys before persisting Beast run config files
- Reuse configured secret value redaction for non-sensitive string fields that mention configured sensitive values
- Add a ProcessBeastExecutor regression test covering nested sensitive keys, token refs, and notes

## Test Plan
- npm test -- tests/unit/beasts/process-beast-executor.test.ts (from packages/franken-orchestrator)
- npm run typecheck -- --filter=@franken/orchestrator
- npm run build -- --filter=@franken/orchestrator
- npm run lint (from packages/franken-orchestrator; exits 0 with existing warnings)

Closes #603