### PR TITLE
docs: clarify operator token header example

### DIFF
--- a/docs/adr/034-control-plane-operator-auth.md
+++ b/docs/adr/034-control-plane-operator-auth.md
@@ -63,7 +63,7 @@ that present no token or an incorrect token are rejected with `401` via
   clients remain same-origin and do not receive the long-lived operator token.
 - Trade-off: Non-browser first-party callers of the network/comms/security/
   skills/dashboard/analytics APIs must send the operator token
-  (`Authorization: Bearer <token>` or `x-frankenbeast-operator-token`) once a token
+  (`Authorization: Bearer <token>` or `x-frankenbeast-operator-token: <token>`) once a token
   is configured. Vite dev browser requests rely on the server-side proxy to
   attach the token.
 - Trade-off: Mirroring ADR-034, when no operator token is configured the gate


### PR DESCRIPTION
## Overview

Clarifies the operator-token header example in `docs/adr/034-control-plane-operator-auth.md`.

The `Authorization` example already showed the expected token value shape, but the `x-frankenbeast-operator-token` example only showed the header name. This updates it to show the full accepted format:

`x-frankenbeast-operator-token: <token>`

The README and other ADR references already render correctly on `main`, so this keeps the change scoped to the remaining header example.

Closes #1079