### PR TITLE
docs: refresh README project tree guides description

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ frankenbeast/
 │   ├── CONTRACT_MATRIX.md       # Port interface compatibility matrix
 │   ├── beast-loop-explained.md  # Iteration mechanics deep dive
 │   ├── adr/                     # Architecture Decision Records
-│   ├── guides/                  # Quickstart, add-provider, wrap-agent, run-dashboard-chat
+│   ├── guides/                  # Quickstart, run/deploy, provider, agent, verification, and issue-workflow guides
 │   └── plans/                   # Design docs and implementation plans
 ├── tests/                       # Root-level integration tests
 ├── scripts/                     # seed.ts, verify-setup.ts


### PR DESCRIPTION
## Overview

Refreshes the top-level README project tree so the `docs/guides/` description matches the current guide inventory more accurately.

The ADR entry on current `main` already avoids the stale hard-coded count, so this keeps the change scoped to the remaining stale guide description.

The new wording avoids listing every file individually while covering the current guide categories: quickstart, run/deploy, provider, agent, verification, and issue-workflow docs.

Closes #1139