### PR TITLE
docs: refresh package project outlines

### DIFF
--- a/packages/franken-brain/project-outline.md
+++ b/packages/franken-brain/project-outline.md
@@ -3,6 +3,8 @@
 ## 1. Overview
 MOD-03 provides the "tiered" memory architecture for the Frankenbeast. It ensures that the agent can recall past successes/failures, adhere to architectural standards, and maintain context without hitting token limits.
 
+Current status: this outline preserves the original MOD-era framing as historical design context. Treat the root `README.md`, root `package.json` workspaces, `@franken/orchestrator`, and `@franken/mcp-suite` as the authoritative current implementation map.
+
 ## 2. The Tiered Memory Architecture
 
 ### 2.1 Working Memory (The Context Window)
@@ -12,7 +14,7 @@ MOD-03 provides the "tiered" memory architecture for the Frankenbeast. It ensure
 
 ### 2.2 Episodic Memory (The Execution Trace)
 - **Role:** A history of specific actions taken and their results.
-- **Logic:** If a skill from `@djm204/agent-skills` fails (e.g., a build error), the result is stored here. 
+- **Logic:** If an orchestrator step, MCP tool, or provider-backed skill fails (e.g., a build error), the result is stored here.
 - **Recall:** Before starting a new task, the Planner queries Episodic Memory: *"Have I tried to fix this bug before? What was the outcome?"*
 
 ### 2.3 Semantic Memory (The Knowledge Base)

--- a/packages/franken-critique/project-outline.md
+++ b/packages/franken-critique/project-outline.md
@@ -3,6 +3,8 @@
 ## 1. Overview
 MOD-06 implements the reviewer side of the "Reflexion" pattern. It evaluates plans or generated content before they reach the user or production environment. Its goal is to identify safety issues, hallucinations, logic flaws, complexity bloat, and architectural drift.
 
+Current status: this outline preserves the original MOD-era framing as historical design context. Current critique execution is implemented through `@franken/critique`, with orchestration and MCP exposure handled by `@franken/orchestrator` and `@franken/mcp-suite`. Treat the root `README.md` and root `package.json` workspaces as authoritative.
+
 ## 2. The Critique Loop
 The wider system can operate in a "Generator-Reviewer" cycle:
 1. **Initial Draft:** The Actor agent proposes code or a plan.
@@ -16,7 +18,7 @@ Current implementation note: `CritiqueLoop` does not call the Actor itself. It c
 
 ### 3.1 The "Naysayer" Persona
 The Reviewer is prompted as a "Senior Technical Architect" with a bias toward skepticism. It specifically looks for:
-- **Ghost Dependencies:** Package imports not present in the `@djm204/agent-skills` registry.
+- **Ghost Dependencies:** Package imports or tool claims not present in the current workspace/package manifest or orchestrator/MCP tool registry.
 - **Complexity Bloat:** Code that violates your preference for 0-to-1 build simplicity.
 - **Logic Loops:** Infinite recursions or improper error handling.
 - **ADR Non-Compliance:** Code that ignores the architecture rules stored in memory.

--- a/packages/franken-governor/project-outline.md
+++ b/packages/franken-governor/project-outline.md
@@ -3,10 +3,12 @@
 ## 1. Overview
 MOD-07 is the "Safety Valve." It provides the infrastructure for the agent to pause, export its state, and wait for human intervention. It ensures that high-stakes actions (deployments, destructive operations, or high-cost tasks) never happen without your explicit **ACK**.
 
+Current status: this outline preserves the original MOD-era framing as historical design context. Current governance and HITL flows are implemented through `@franken/governor` and `@franken/orchestrator`, with MCP-facing tooling exposed by `@franken/mcp-suite`. Treat the root `README.md` and root `package.json` workspaces as authoritative.
+
 ## 2. Trigger Conditions (When to Pause)
 The agent is programmed to trigger an HITL exception in the following scenarios:
 - **Low Confidence:** When the **Self-Critique (MOD-06)** module flags a high probability of hallucination.
-- **High-Stakes Skills:** Any skill in **MOD-02** marked with `requires_hitl: true`.
+- **High-Stakes Skills:** Any orchestrator capability, provider-backed skill, or MCP tool that requires explicit HITL approval.
 - **Budget Breaches:** When **MOD-05 (Observability)** detects a token spend exceeding the per-task limit.
 - **Ambiguity:** When the **Planner (MOD-04)** cannot resolve a dependency or finds a conflict in the **ADRs (MOD-03)**.
 

--- a/packages/franken-observer/project-outline.md
+++ b/packages/franken-observer/project-outline.md
@@ -3,11 +3,13 @@
 ## 1. Overview
 MOD-05 provides the "Flight Data Recorder" for the Frankenbeast. It captures every trace, monitors token burn-rates in real-time, and runs "Agent Unit Tests" (Evals) to ensure that code refactors don't break established skills.
 
+Current status: this outline preserves the original MOD-era framing as historical design context. Current observer and audit surfaces are implemented through `@franken/observer`, `@franken/orchestrator`, and `@franken/mcp-suite`; the root `README.md` and root `package.json` workspaces are the authoritative package map.
+
 ## 2. Real-Time Tracing (The Trace-Map)
 Traditional logging is insufficient for agents. MOD-05 implements **Hierarchical Tracing**:
 - **Root Trace:** The high-level user goal.
 - **Spans:** Individual steps taken by the **Planner (MOD-04)**.
-- **Sub-Spans:** Each call to a tool in `@djm204/agent-skills` or an LLM adapter in **MOD-01**.
+- **Sub-Spans:** Calls to orchestrator skills/providers, MCP suite tools, or LLM adapters.
 - **Metadata:** Captures latency, token counts, and "Thought Blocks" for every step.
 
 
@@ -22,9 +24,9 @@ We move beyond string-matching tests. We use **"LLM-as-a-Judge"** and **Determin
 
 | Eval Type | Logic | Purpose |
 | :--- | :--- | :--- |
-| **Tool Call Accuracy** | Does the agent pass the *correct* params to the `@djm204/agent-skills` package? | Prevent "Ghost Param" hallucinations. |
+| **Tool Call Accuracy** | Does the agent pass the *correct* params to the current orchestrator or MCP tool surface? | Prevent "Ghost Param" hallucinations. |
 | **Architectural Adherence**| Does the output follow the **ADR** rules stored in **MOD-03**? | Ensure TS/React standards are met. |
-| **Regression Testing** | Rerunning a successful "Golden Trace" from the past against a new model version. | Ensure "GPT-5" doesn't lose skills GPT-4 had. |
+| **Regression Testing** | Rerunning a successful "Golden Trace" from the past against a new model version. | Ensure new model versions do not lose established behavior. |
 
 ## 5. Implementation Strategy: Open-Source First
 To keep the system modular and AI-agnostic, MOD-05 is designed to export data in **OpenTelemetry (OTEL)** format. This allows you to plug into:

--- a/packages/franken-planner/project-outline.md
+++ b/packages/franken-planner/project-outline.md
@@ -4,6 +4,8 @@
 
 MOD-04 is responsible for high-level reasoning. It takes a complex goal (e.g., "Implement Multi-Currency UI for Staples") and decomposes it into a sequence of actionable sub-tasks. It ensures the agent doesn't "hallucinate spirals" by maintaining a structured state of progress.
 
+Current status: this outline preserves the original MOD-era framing as historical design context. Current planning execution is implemented through `@franken/orchestrator`, and MCP-exposed planning tools live in `@franken/mcp-suite`. Treat the root `README.md` and root `package.json` workspaces as the authoritative package map.
+
 ## 2. The Planning Logic
 
 ### 2.1 Task Decomposition (The DAG)
@@ -11,7 +13,7 @@ MOD-04 is responsible for high-level reasoning. It takes a complex goal (e.g., "
 The Planner converts a user prompt into a **Directed Acyclic Graph (DAG)** of tasks. Each task includes:
 
 - **Objective:** What needs to be achieved.
-- **Required Skills:** Which tools from `@djm204/agent-skills` are needed.
+- **Required Capabilities:** Which orchestrator capabilities, MCP tools, or provider-backed skills are needed.
 - **Dependencies:** Which tasks must be completed first (e.g., "Define Schema" before "Generate Component").
 
 ### 2.2 Dynamic Replanning
@@ -34,7 +36,7 @@ Before selecting a tool, the Planner must output a "Rationale" block. This allow
 
 - **Input:** Sanitized intent from **MOD-01**.
 - **Context:** ADRs and project rules pulled from **MOD-03 Semantic Memory**.
-- **Tooling:** Available capabilities discovered via **MOD-02 (@djm204/agent-skills)**.
+- **Tooling:** Available capabilities come from the orchestrator provider/skill plumbing and the `@franken/mcp-suite` tool registry, not a standalone MOD-02 skills package.
 
 ## 5. Human-in-the-Loop (HITL) Integration
 


### PR DESCRIPTION
## Overview

Refreshes package-level `project-outline.md` files that still pointed readers toward legacy MOD-era runtime/tooling claims.

Changes:
- Adds current-status notes that mark the MOD framing as historical design context.
- Points contributors to the current authoritative surfaces: root `README.md`, root `package.json` workspaces, `@franken/orchestrator`, and `@franken/mcp-suite`.
- Replaces stale `@djm204/agent-skills` references with current orchestrator/MCP/provider wording.
- Updates observer/critique/governor wording so the docs no longer imply runtime skills come from the old standalone skills package.

Files updated:
- `packages/franken-brain/project-outline.md`
- `packages/franken-planner/project-outline.md`
- `packages/franken-observer/project-outline.md`
- `packages/franken-critique/project-outline.md`
- `packages/franken-governor/project-outline.md`

Closes #1141