### PR TITLE
fix(security): pin Anthropic SDK override

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
   "overrides": {
+    "@anthropic-ai/sdk": "^0.110.0",
     "esbuild": "^0.28.1",
     "hono": "^4.12.27",
     "protobufjs": "^7.6.5",

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -47,6 +47,11 @@ describe('npm workspaces configuration', () => {
       expect(isAtLeast(rootPkg.overrides.vite, '8.1.3')).toBe(true);
     });
 
+    it('pins Anthropic SDK above the vulnerable memory-tool advisory ranges', () => {
+      expect(rootPkg.overrides?.['@anthropic-ai/sdk']).toBeDefined();
+      expect(isAtLeast(rootPkg.overrides['@anthropic-ai/sdk'], '0.110.0')).toBe(true);
+    });
+
     it('keeps Turbo above the local execution/session advisory range', () => {
       expect(rootPkg.devDependencies?.turbo).toBeDefined();
       expect(isAtLeast(rootPkg.devDependencies.turbo, '2.10.3')).toBe(true);
@@ -145,6 +150,10 @@ describe('npm workspaces configuration', () => {
       for (const [packageName, minimumVersion] of Object.entries(packageFloors)) {
         const lockedEntries = Object.entries(lockfile.packages ?? {})
           .filter(([path]) => path === `node_modules/${packageName}` || path.endsWith(`/node_modules/${packageName}`));
+
+        if (packageName === '@anthropic-ai/sdk') {
+          expect(lockedEntries.length, `${packageName} missing from package-lock.json`).toBeGreaterThan(0);
+        }
 
         for (const [path, packageDetails] of lockedEntries) {
           const lockedVersion = (packageDetails as { version?: string }).version;


### PR DESCRIPTION
## Summary
- add a root npm override that pins @anthropic-ai/sdk to the patched 0.110.x floor across workspaces
- add workspace regression checks so the override and lockfile entry remain present and above the vulnerable memory-tool advisory range

## Test Plan
- npm run test:root -- tests/workspaces.test.ts
- npm --workspace packages/franken-orchestrator test
- npm --workspace packages/franken-orchestrator run typecheck
- npm --workspace packages/franken-orchestrator run build
- npm run typecheck
- npm --workspace packages/franken-orchestrator run lint (passes with existing warnings)
- npm run lint:any
- npm run lint:security
- npm audit --audit-level=moderate

Closes #587