### PR TITLE
fix(orchestrator): allow trusted override network launches

### DIFF
--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -25,6 +25,7 @@ const ALLOWED_NETWORK_SERVICE_ENV_KEYS: Partial<Record<ResolvedNetworkService['i
     'FRANKENBEAST_DASHBOARD_API_URL',
     'FRANKENBEAST_DASHBOARD_HOST',
     'FRANKENBEAST_DASHBOARD_PORT',
+    'FRANKENBEAST_TRUST_PROVIDER_COMMAND_OVERRIDES',
   ],
 };
 
@@ -68,11 +69,20 @@ function validateNpmServiceArgs(serviceId: 'beasts-daemon' | 'chat-server', args
     return;
   }
 
-  for (let index = 10; index < args.length; index += 2) {
+  let trustedOverrideFlagSeen = false;
+  for (let index = 10; index < args.length;) {
     const flag = args[index];
+    if (flag === '--trust-provider-command-overrides') {
+      assertExpectedArg(!trustedOverrideFlagSeen, serviceId);
+      trustedOverrideFlagSeen = true;
+      index += 1;
+      continue;
+    }
+
     const value = args[index + 1];
     assertExpectedArg(value !== undefined, serviceId);
     assertExpectedArg(flag === '--config' || flag === '--set', serviceId);
+    index += 2;
   }
 }
 

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -1,6 +1,19 @@
+import { spawn } from 'node:child_process';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { startNetworkService, stopNetworkService } from '../../../src/network/network-supervisor-runtime.js';
 import type { ResolvedNetworkService } from '../../../src/network/network-registry.js';
+
+const spawnMock = vi.hoisted(() => vi.fn(() => ({
+  pid: 4242,
+  stdout: { on: vi.fn() },
+  stderr: { on: vi.fn() },
+  once: vi.fn(),
+  unref: vi.fn(),
+})));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
 
 const CHAT_SERVER_ARGS = [
   '--silent',
@@ -66,6 +79,7 @@ describe('startNetworkService', () => {
 
   afterEach(() => {
     errorSpy.mockClear();
+    spawnMock.mockClear();
   });
 
   it('rejects service commands outside the registry allowlist before spawning', async () => {
@@ -144,6 +158,54 @@ describe('startNetworkService', () => {
     })).rejects.toThrow('Unsafe network service arguments for chat-server');
 
     expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('allows approved trust-override flags for managed chat services', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      args: [
+        ...CHAT_SERVER_ARGS,
+        '--config',
+        '/repo/frankenbeast/.fbeast/config.json',
+        '--trust-provider-command-overrides',
+        '--set',
+        'providers.openai.enabled=true',
+      ],
+    }), {
+      detached: false,
+    })).resolves.toEqual({ pid: 4242 });
+
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  it('rejects duplicate trust-override flags for managed chat services', async () => {
+    await expect(startNetworkService(makeService('npm', {
+      args: [
+        ...CHAT_SERVER_ARGS,
+        '--trust-provider-command-overrides',
+        '--trust-provider-command-overrides',
+      ],
+    }), {
+      detached: false,
+    })).rejects.toThrow('Unsafe network service arguments for chat-server');
+
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));
+  });
+
+  it('allows the approved trust-override environment for managed dashboard services', async () => {
+    await expect(startNetworkService(makeService('node', {
+      args: DASHBOARD_ARGS,
+      env: {
+        FRANKENBEAST_CONFIG_FILE: '/repo/frankenbeast/.fbeast/config.json',
+        FRANKENBEAST_DASHBOARD_API_URL: 'http://127.0.0.1:3737',
+        FRANKENBEAST_DASHBOARD_HOST: '127.0.0.1',
+        FRANKENBEAST_DASHBOARD_PORT: '5173',
+        FRANKENBEAST_TRUST_PROVIDER_COMMAND_OVERRIDES: '1',
+      },
+    }, { id: 'dashboard-web' }), {
+      detached: false,
+    })).resolves.toEqual({ pid: 4242 });
+
+    expect(spawn).toHaveBeenCalledOnce();
   });
 
   it('rejects dashboard build commands outside the nested build allowlist', async () => {


### PR DESCRIPTION
## Summary
- Allows the approved chat-server `--trust-provider-command-overrides` flag through network process validation.
- Allows the approved dashboard `FRANKENBEAST_TRUST_PROVIDER_COMMAND_OVERRIDES` env flag through managed process env validation.
- Adds regression coverage for both late Codex findings from PR #912.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/network/network-supervisor-runtime.test.ts
- npm run test --workspace @franken/orchestrator -- tests/unit/network/network-registry.test.ts tests/unit/network/network-supervisor-runtime.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Follow-up for late Codex findings on #912 / #500.