### PR TITLE
fix(mcp): configure BrainAdapter sqlite pragmas

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { databaseInstances } = vi.hoisted(() => {
+  const databaseInstances: Array<{
+    pragma: ReturnType<typeof vi.fn>;
+    prepare: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    options: unknown;
+  }> = [];
+  return { databaseInstances };
+});
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(function MockDatabase(this: unknown, _dbPath: string, options?: unknown) {
+    const db = {
+      pragma: vi.fn(),
+      prepare: vi.fn(() => ({ all: vi.fn(() => []) })),
+      close: vi.fn(),
+      options,
+    };
+    databaseInstances.push(db);
+    Object.assign(this as object, db);
+  }),
+}));
+
+vi.mock('@franken/brain', () => ({
+  SqliteBrain: vi.fn(function MockSqliteBrain(this: unknown) {
+    Object.assign(this as object, {
+      working: {
+        restore: vi.fn(),
+        snapshot: vi.fn(() => ({})),
+        set: vi.fn(),
+        has: vi.fn(() => false),
+        delete: vi.fn(),
+      },
+      episodic: {
+        recall: vi.fn(() => []),
+        recent: vi.fn(() => []),
+        record: vi.fn(),
+      },
+      flush: vi.fn(),
+    });
+  }),
+}));
+
+import { createBrainAdapter } from './brain-adapter.js';
+
+describe('createBrainAdapter', () => {
+  beforeEach(() => {
+    databaseInstances.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('configures WAL and a busy timeout on the adapter read connection before rehydrating memory', () => {
+    createBrainAdapter('/tmp/beast.db');
+
+    expect(databaseInstances).toHaveLength(1);
+    const readDb = databaseInstances[0];
+    expect(readDb.options).toBeUndefined();
+    expect(readDb.pragma).toHaveBeenNthCalledWith(1, 'journal_mode = WAL');
+    expect(readDb.pragma).toHaveBeenNthCalledWith(2, 'busy_timeout = 5000');
+    expect(readDb.prepare).toHaveBeenCalledWith('SELECT key, value FROM working_memory');
+    expect(readDb.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -1,6 +1,11 @@
 import { SqliteBrain } from '@franken/brain';
 import Database from 'better-sqlite3';
 
+function configureBrainAdapterDb(db: Database.Database): void {
+  db.pragma('journal_mode = WAL');
+  db.pragma('busy_timeout = 5000');
+}
+
 export interface BrainQueryInput {
   query: string;
   type?: string;
@@ -32,7 +37,8 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
   // Rehydrate working memory from SQLite so entries survive process restarts.
   // SqliteBrain's constructor starts with an empty in-memory Map; flush() writes
   // to the working_memory table but construction doesn't read it back.
-  const readDb = new Database(dbPath, { readonly: true });
+  const readDb = new Database(dbPath);
+  configureBrainAdapterDb(readDb);
   try {
     const rows = readDb.prepare('SELECT key, value FROM working_memory').all() as Array<{ key: string; value: string }>;
     const snap: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Configure the BrainAdapter rehydration SQLite connection with WAL mode and a 5000ms busy timeout before reading working memory.
- Add a focused regression test that verifies the adapter connection applies the SQLite pragmas before querying `working_memory`.

## Test Plan
- `npm ci`
- `npm test --workspace @franken/mcp-suite -- --run src/adapters/brain-adapter.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm test --workspace @franken/mcp-suite`
- `npm run build --workspace @franken/mcp-suite`
- `npx turbo run test --filter=@franken/mcp-suite`

Closes #919
