### PR TITLE
fix(orchestrator): rate limit websocket chat execution

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -37,6 +37,7 @@ import { createSkillRoutes } from './routes/skill-routes.js';
 import { createDashboardRoutes, type DashboardRouteDeps } from './routes/dashboard-routes.js';
 import { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
 import { createAnalyticsRoutes, type AnalyticsRouteDeps } from './routes/analytics-routes.js';
+import { DEFAULT_CHAT_RATE_LIMIT } from './chat-rate-limit.js';
 
 export interface ChatAppOptions {
   sessionStoreDir?: string;
@@ -80,7 +81,6 @@ export interface ChatAppOptions {
   beastDaemon?: { baseUrl: string; operatorToken?: string | undefined };
 }
 
-const DEFAULT_CHAT_RATE_LIMIT: BeastRateLimitOptions = { windowMs: 60_000, max: 20 };
 const CORS_ALLOW_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 const CORS_ALLOW_HEADERS = ['authorization', 'content-type', 'x-frankenbeast-operator-token'];
 

--- a/packages/franken-orchestrator/src/http/chat-rate-limit.ts
+++ b/packages/franken-orchestrator/src/http/chat-rate-limit.ts
@@ -1,0 +1,13 @@
+import { createHash } from 'node:crypto';
+import type { BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
+
+export const DEFAULT_CHAT_RATE_LIMIT: BeastRateLimitOptions = { windowMs: 60_000, max: 20 };
+
+export function hashChatRateLimitPrincipal(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
+}
+
+export function chatRateLimitPrincipalFromAddress(address: string | undefined): string {
+  const normalized = address?.trim();
+  return normalized ? `ip:${hashChatRateLimitPrincipal(normalized)}` : 'anonymous';
+}

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -1,5 +1,4 @@
 import { createServer, type Server as HttpServer } from 'node:http';
-import type { AddressInfo } from 'node:net';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -329,6 +328,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     sessionStore,
     tokenSecret,
     ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
+    ...(options.beastControl?.rateLimit ? { chatRateLimit: options.beastControl.rateLimit } : {}),
   });
 
   await new Promise<void>((resolve, reject) => {

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { approvalRuntimeInput } from '../../chat/approval-input.js';
@@ -18,6 +17,7 @@ import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
+import { hashChatRateLimitPrincipal } from '../chat-rate-limit.js';
 
 const CreateSessionBody = z.object({
   projectId: z.string().min(1),
@@ -71,7 +71,7 @@ function requestAddress(c: Context): string {
 }
 
 function hashPrincipal(value: string): string {
-  return createHash('sha256').update(value).digest('hex').slice(0, 24);
+  return hashChatRateLimitPrincipal(value);
 }
 
 function chatPrincipalKey(c: Context, operatorToken: string | undefined): string {

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -16,6 +16,7 @@ import {
   type ClientSocketEvent,
   type ServerSocketEvent,
 } from '@franken/types';
+import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
 
 export interface ChatSocketPeer {
   close(code?: number, reason?: string): void;
@@ -24,6 +25,7 @@ export interface ChatSocketPeer {
 
 interface ConnectionState {
   sessionId: string;
+  remoteAddress?: string | undefined;
 }
 
 export interface ChatSocketControllerOptions {
@@ -32,12 +34,15 @@ export interface ChatSocketControllerOptions {
   sessionStore: ISessionStore;
   ticketStore?: ChatSocketSessionTicketStore;
   tokenSecret: string;
+  chatRateLimit?: BeastRateLimitOptions;
+  chatRateLimiter?: InMemoryRateLimiter;
 }
 
 export interface ChatSocketConnectRequest {
   origin: string | null;
   sessionId: string;
   token: string | null;
+  remoteAddress?: string | undefined;
 }
 
 export interface AttachChatWebSocketServerOptions extends ChatSocketControllerOptions {
@@ -85,9 +90,10 @@ function messageIdFromSession(session: ChatSession): string {
 function createPeerState(
   peer: ChatSocketPeer,
   sessionId: string,
+  remoteAddress: string | undefined,
   controller: ChatSocketController,
 ): ConnectionState {
-  const state = { sessionId };
+  const state = { sessionId, remoteAddress };
   controller.connections.set(peer, state);
   return state;
 }
@@ -99,6 +105,7 @@ export class ChatSocketController {
   private readonly sessionStore: ISessionStore;
   private readonly ticketStore: ChatSocketSessionTicketStore;
   private readonly tokenSecret: string;
+  private readonly chatRateLimiter: InMemoryRateLimiter;
 
   constructor(options: ChatSocketControllerOptions) {
     this.allowedOrigins = options.allowedOrigins ?? [];
@@ -106,6 +113,7 @@ export class ChatSocketController {
     this.sessionStore = options.sessionStore;
     this.ticketStore = options.ticketStore ?? new ChatSocketSessionTicketStore();
     this.tokenSecret = options.tokenSecret;
+    this.chatRateLimiter = options.chatRateLimiter ?? new InMemoryRateLimiter(options.chatRateLimit ?? { windowMs: 60_000, max: 30 });
   }
 
   authorize(request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
@@ -149,7 +157,7 @@ export class ChatSocketController {
       return { ok: false, status: 404 };
     }
 
-    createPeerState(peer, request.sessionId, this);
+    createPeerState(peer, request.sessionId, request.remoteAddress, this);
     this.emit(peer, {
       type: 'session.ready',
       sessionId: session.id,
@@ -207,6 +215,9 @@ export class ChatSocketController {
 
     switch (event.type) {
       case 'message.send':
+        if (!this.takeChatRateLimit(peer, connection, 'message')) {
+          return;
+        }
         await this.handleMessageSend(
           peer,
           session,
@@ -216,6 +227,9 @@ export class ChatSocketController {
         );
         return;
       case 'approval.respond':
+        if ((session.pendingApproval || session.state === 'pending_approval') && !this.takeChatRateLimit(peer, connection, 'approval')) {
+          return;
+        }
         await this.handleApproval(peer, session, event.approved);
         return;
       case 'message.read':
@@ -320,6 +334,25 @@ export class ChatSocketController {
         timestamp: nowIso(),
       });
     }
+  }
+
+  private takeChatRateLimit(
+    peer: ChatSocketPeer,
+    connection: ConnectionState,
+    action: 'message' | 'approval',
+  ): boolean {
+    const principal = connection.remoteAddress?.trim() || connection.sessionId;
+    const result = this.chatRateLimiter.take(`chat:ws:${action}:${connection.sessionId}:${principal}`);
+    if (result.allowed) {
+      return true;
+    }
+    this.emit(peer, {
+      type: 'turn.error',
+      code: 'RATE_LIMITED',
+      message: 'Rate limit exceeded',
+      timestamp: nowIso(),
+    });
+    return false;
   }
 
   private async handleApproval(
@@ -494,6 +527,7 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
       origin: requestOrigin(request),
       sessionId,
       token,
+      remoteAddress: request.socket.remoteAddress,
     });
     if (!auth.ok) {
       closeUnauthorized(socket, auth.status);
@@ -507,6 +541,7 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
         origin: requestOrigin(request),
         sessionId,
         token,
+        remoteAddress: request.socket.remoteAddress,
       });
       if (!result.ok) {
         ws.close();

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -17,6 +17,7 @@ import {
   type ServerSocketEvent,
 } from '@franken/types';
 import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
+import { DEFAULT_CHAT_RATE_LIMIT, chatRateLimitPrincipalFromAddress } from './chat-rate-limit.js';
 
 export interface ChatSocketPeer {
   close(code?: number, reason?: string): void;
@@ -113,7 +114,7 @@ export class ChatSocketController {
     this.sessionStore = options.sessionStore;
     this.ticketStore = options.ticketStore ?? new ChatSocketSessionTicketStore();
     this.tokenSecret = options.tokenSecret;
-    this.chatRateLimiter = options.chatRateLimiter ?? new InMemoryRateLimiter(options.chatRateLimit ?? { windowMs: 60_000, max: 30 });
+    this.chatRateLimiter = options.chatRateLimiter ?? new InMemoryRateLimiter(options.chatRateLimit ?? DEFAULT_CHAT_RATE_LIMIT);
   }
 
   authorize(request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
@@ -215,7 +216,7 @@ export class ChatSocketController {
 
     switch (event.type) {
       case 'message.send':
-        if (!this.takeChatRateLimit(peer, connection, 'message')) {
+        if (!this.takeChatRateLimit(peer, connection)) {
           return;
         }
         await this.handleMessageSend(
@@ -227,7 +228,7 @@ export class ChatSocketController {
         );
         return;
       case 'approval.respond':
-        if ((session.pendingApproval || session.state === 'pending_approval') && !this.takeChatRateLimit(peer, connection, 'approval')) {
+        if ((session.pendingApproval || session.state === 'pending_approval') && !this.takeChatRateLimit(peer, connection)) {
           return;
         }
         await this.handleApproval(peer, session, event.approved);
@@ -339,10 +340,9 @@ export class ChatSocketController {
   private takeChatRateLimit(
     peer: ChatSocketPeer,
     connection: ConnectionState,
-    action: 'message' | 'approval',
   ): boolean {
-    const principal = connection.remoteAddress?.trim() || connection.sessionId;
-    const result = this.chatRateLimiter.take(`chat:ws:${action}:${connection.sessionId}:${principal}`);
+    const principal = chatRateLimitPrincipalFromAddress(connection.remoteAddress);
+    const result = this.chatRateLimiter.take(`chat:ws:principal:${principal}`);
     if (result.allowed) {
       return true;
     }

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -485,6 +485,98 @@ describe('Chat HTTP Routes', () => {
     expect(llmComplete).toHaveBeenCalledTimes(1);
   });
 
+  it('allows below-limit REST chat messages and rejects the over-limit request for the same client', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T00:00:00.000Z'));
+    try {
+      const now = new Date().toISOString();
+      const session: ChatSession = {
+        id: 'chat-rest-rate-limit-message',
+        projectId: 'proj',
+        transcript: [],
+        state: 'active',
+        pendingApproval: null,
+        tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+        costUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const sessionStore = {
+        create: vi.fn(),
+        get: vi.fn(() => session),
+        save: vi.fn((updated: ChatSession) => Object.assign(session, updated)),
+        list: vi.fn(() => [session.id]),
+        listSessions: vi.fn(() => [session]),
+        delete: vi.fn(),
+      };
+      const runtime = {
+        run: vi.fn(async (content: string) => ({
+          displayMessages: [{ kind: 'reply' as const, content: `reply:${content}` }],
+          events: [],
+          pendingApproval: false,
+          state: 'active' as const,
+          tier: null,
+          transcript: [
+            ...session.transcript,
+            { role: 'user' as const, content },
+            { role: 'assistant' as const, content: `reply:${content}` },
+          ],
+        })),
+      };
+
+      app = createChatApp({
+        sessionStore,
+        engine: {} as never,
+        runtime: runtime as never,
+        turnRunner: {} as never,
+        sessionTokenSecret: ['test', 'http', 'fixture'].join('-'),
+        chatRateLimit: { windowMs: 60_000, max: 2 },
+      });
+
+      const headers = { 'Content-Type': 'application/json', 'x-frankenbeast-remote-address': '192.0.2.44' };
+      const first = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ content: 'first below limit' }),
+      });
+      const second = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ content: 'second below limit' }),
+      });
+      const overLimit = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ content: 'third over limit' }),
+      });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(overLimit.status).toBe(429);
+      expect((await overLimit.json()).error).toMatchObject({
+        code: 'RATE_LIMITED',
+        message: 'Rate limit exceeded',
+      });
+      expect(runtime.run).toHaveBeenCalledTimes(2);
+      expect(runtime.run).toHaveBeenNthCalledWith(1, 'first below limit', expect.objectContaining({
+        sessionId: session.id,
+        projectId: 'proj',
+      }));
+      expect(runtime.run).toHaveBeenNthCalledWith(2, 'second below limit', expect.objectContaining({
+        sessionId: session.id,
+        projectId: 'proj',
+      }));
+      expect(session.transcript.map((message) => message.content)).toEqual([
+        'first below limit',
+        'reply:first below limit',
+        'second below limit',
+        'reply:second below limit',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('uses the client address for unauthenticated rate limits even when auth headers vary', async () => {
     app = createChatApp({
       sessionStoreDir: TMP,

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -661,6 +661,121 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('shares websocket rate limits across sessions for the same client address', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const firstSession = store.create('proj');
+    const secondSession = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const firstToken = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: firstSession.id });
+    const secondToken = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: secondSession.id });
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'reply' as const, content: 'ok' }],
+        events: [],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'cheap',
+        transcript: [],
+      })),
+    };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+    const first = createPeer();
+    const second = createPeer();
+    const remoteAddress = '198.51.100.20';
+
+    expect(controller.connect(first.peer, {
+      origin: null,
+      sessionId: firstSession.id,
+      token: firstToken,
+      remoteAddress,
+    }).ok).toBe(true);
+    expect(controller.connect(second.peer, {
+      origin: null,
+      sessionId: secondSession.id,
+      token: secondToken,
+      remoteAddress,
+    }).ok).toBe(true);
+
+    await controller.receive(first.peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-1',
+      content: 'run expensive work',
+    }));
+    await controller.receive(second.peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-2',
+      content: 'run more expensive work',
+    }));
+
+    const secondEvents = second.sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
+    expect(secondEvents).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'RATE_LIMITED',
+    }));
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('uses the REST chat default rate limit for websocket messages', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'reply' as const, content: 'ok' }],
+        events: [],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'cheap',
+        transcript: [],
+      })),
+    };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+      remoteAddress: '198.51.100.21',
+    }).ok).toBe(true);
+
+    for (let index = 0; index < 20; index += 1) {
+      await controller.receive(peer, JSON.stringify({
+        type: 'message.send',
+        clientMessageId: `client-${index}`,
+        content: `run expensive work ${index}`,
+      }));
+    }
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-over-limit',
+      content: 'run too much expensive work',
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'RATE_LIMITED',
+    }));
+    expect(runtime.run).toHaveBeenCalledTimes(20);
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('rate limits websocket approvals before mutating approval state', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -313,7 +313,7 @@ describe('ws chat server', () => {
     };
     store.save(session);
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const execute = vi.fn().mockResolvedValue({
       status: 'success' as const,
       summary: 'Done',
@@ -380,7 +380,7 @@ describe('ws chat server', () => {
     };
     store.save(session);
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     let finishExecution!: () => void;
     const executionStarted = new Promise<void>((resolve) => {
       finishExecution = resolve;
@@ -452,7 +452,7 @@ describe('ws chat server', () => {
     };
     store.save(session);
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const execute = vi.fn(async () => {
       throw new Error('executor offline');
     });
@@ -508,7 +508,7 @@ describe('ws chat server', () => {
     };
     store.save(session);
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const execute = vi.fn().mockResolvedValue({
       status: 'success' as const,
       summary: 'Done',
@@ -571,7 +571,7 @@ describe('ws chat server', () => {
     };
     store.save(session);
     const secret = createSessionTokenSecret();
-    const token = issueSessionToken({ secret, sessionId: session.id });
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const execute = vi.fn();
     const runtime = new ChatRuntime({
       engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
@@ -601,6 +601,110 @@ describe('ws chat server', () => {
       type: 'assistant.message.complete',
       content: 'Approved.',
     }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('rate limits websocket message turns after allowing below-limit execution', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'reply' as const, content: 'ok' }],
+        events: [],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'cheap',
+        transcript: [],
+      })),
+    };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+      chatRateLimit: { windowMs: 60_000, max: 1 },
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-1',
+      content: 'run expensive work',
+    }));
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect(sent.map((raw) => JSON.parse(raw) as { type: string })).toContainEqual(expect.objectContaining({
+      type: 'assistant.message.complete',
+    }));
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-2',
+      content: 'run more expensive work',
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'RATE_LIMITED',
+    }));
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('rate limits websocket approvals before mutating approval state', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = { run: vi.fn() };
+    const rateLimiter = { take: vi.fn(() => ({ allowed: false, remaining: 0 })) };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+      chatRateLimiter: rateLimiter as never,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'RATE_LIMITED',
+    }));
+    expect(runtime.run).not.toHaveBeenCalled();
+    expect(store.get(session.id)?.state).toBe('pending_approval');
+    expect(store.get(session.id)?.pendingApproval).toEqual(expect.objectContaining({ command: 'deploy staging' }));
 
     rmSync(TMP, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- Adds WebSocket chat rate limiting before expensive `message.send` execution.
- Applies the same admission guard to pending `approval.respond` without mutating approval state on rejection.
- Reuses the Beast chat rate limit configuration from `startChatServer` so REST and WebSocket paths stay consistent.

## Test Plan
- `npm test -- --run tests/integration/chat/ws-chat-server.test.ts tests/integration/chat/chat-routes.test.ts`
- `npm run typecheck -- --filter=@franken/orchestrator`

Closes #574