### PR TITLE
test(critique): make safety timeout test deterministic

### DIFF
--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -964,14 +964,20 @@ describe('SafetyEvaluator', () => {
     ]);
   });
 
-  it('terminates catastrophic regex evaluation that reaches the runtime matcher', async () => {
+  it('terminates regex evaluation when the runtime matcher exceeds its timeout', async () => {
+    vi.useFakeTimers();
     const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
       regexMatchesWithTimeout(pattern: string, content: string): Promise<boolean | 'timeout'>;
     };
 
-    await expect(
-      evaluator.regexMatchesWithTimeout('(a+)+$', `${'a'.repeat(100)}!`),
-    ).resolves.toBe('timeout');
+    try {
+      const result = evaluator.regexMatchesWithTimeout('(a+)+$', `${'a'.repeat(100)}!`);
+      await vi.advanceTimersByTimeAsync(2_001);
+
+      await expect(result).resolves.toBe('timeout');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rejects genuinely unsafe nested quantifiers without catastrophic backtracking', async () => {


### PR DESCRIPTION
## Summary
- Replace the SafetyEvaluator timeout regression's real wall-clock wait with Vitest fake timers
- Keep coverage for the runtime matcher timeout path while avoiding loaded-CI timing flakiness

## Test Plan
- npm --workspace @franken/critique test -- tests/unit/evaluators/safety.test.ts
- npm --workspace @franken/types run build
- npm --workspace @franken/critique run build
- npm --workspace @franken/critique run lint

Closes #1216