### PR TITLE
test(orchestrator): fail config cleanup errors loudly

### DIFF
--- a/packages/franken-orchestrator/tests/unit/beasts/execution/config-passthrough.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/config-passthrough.test.ts
@@ -23,9 +23,9 @@ describe('Config file passthrough', () => {
   let configFilePaths: string[] = [];
 
   afterEach(async () => {
-    // Clean up any config files written to cwd
+    // Clean up any config files written to cwd; fail loudly if cleanup itself breaks.
     for (const p of configFilePaths) {
-      try { if (existsSync(p)) { const { unlinkSync } = await import('node:fs'); unlinkSync(p); } } catch {}
+      await rm(p, { force: true });
     }
     configFilePaths = [];
     if (workDir) {


### PR DESCRIPTION
## Summary
- Replaces the empty cleanup catch block in config passthrough tests with an explicit force removal.
- Makes cleanup failures surface through the test runner instead of being silently swallowed.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/execution/config-passthrough.test.ts
- npm run typecheck -- --filter=@franken/orchestrator
- npm --prefix packages/franken-orchestrator run lint
- npm run build -- --filter=@franken/orchestrator

Closes #1215