### PR TITLE
docs: document Gemini API env keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The shipped Hono HTTP surface is integrated in `@franken/orchestrator`'s chat se
 ### Optional
 
 - **ChromaDB** — required for semantic memory (MOD-03). Not needed for unit/integration tests.
-- **LLM API key** — `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` for runtime use. Not needed for tests (mocked).
+- **LLM API key** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY` for runtime use. Not needed for tests (mocked).
 - **Docker** — for running the local dev stack (ChromaDB, Grafana, Tempo).
 
 ## Quick Start
@@ -598,6 +598,8 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 |----------|--------|----------|-------------|
 | `ANTHROPIC_API_KEY` | MOD-01 | Runtime only | Claude adapter API key |
 | `OPENAI_API_KEY` | MOD-01 | Runtime only | OpenAI adapter API key |
+| `GOOGLE_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (Google AI Studio name) |
+| `GEMINI_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (alternative name) |
 | `CHROMA_HOST` | MOD-03 | If using semantic memory | ChromaDB server host (default: `localhost`) |
 | `CHROMA_PORT` | MOD-03 | If using semantic memory | ChromaDB server port (default: `8000`) |
 | `SLACK_WEBHOOK_URL` | MOD-07 | If using Slack approvals | Slack webhook for HITL notifications |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -29,7 +29,9 @@ npm run audit:security
 
 ```bash
 cp .env.example .env
-# Edit .env with provider API keys or local runtime settings as needed.
+# Edit .env with provider API keys or local runtime settings as needed:
+#   ANTHROPIC_API_KEY for Claude, OPENAI_API_KEY for OpenAI,
+#   or GOOGLE_API_KEY / GEMINI_API_KEY for Gemini.
 # Before starting the full Docker stack, uncomment GRAFANA_USER=admin and set a
 # unique GRAFANA_PASSWORD; Grafana refuses the old admin/admin default pair.
 ```

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -12,11 +12,11 @@ The beast harness is split across two CLIs. This guide covers both.
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26`
-- An API key for at least one provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or a local Ollama instance
+- An API key for at least one API provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`
 
 ```bash
 cp .env.example .env
-# Set ANTHROPIC_API_KEY (or OPENAI_API_KEY / OLLAMA_BASE_URL)
+# Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY / GEMINI_API_KEY
 ```
 
 ---

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -12,11 +12,14 @@ The beast harness is split across two CLIs. This guide covers both.
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26`
-- An API key for at least one API provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`
+- For API-backed `frankenbeast` provider registry runs, an API key for at least one supported provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`
+- For `fbeast mcp beast` preset activation, a supported Beast provider path: `anthropic-api` with `ANTHROPIC_API_KEY`, or an installed/logged-in `claude` / `codex` CLI for `claude-cli` / `codex-cli`
 
 ```bash
 cp .env.example .env
-# Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY / GEMINI_API_KEY
+# For API-backed runs, set ANTHROPIC_API_KEY, OPENAI_API_KEY,
+# or GOOGLE_API_KEY / GEMINI_API_KEY.
+# For fbeast mcp beast --provider=anthropic-api, set ANTHROPIC_API_KEY.
 ```
 
 ---

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -93,6 +93,9 @@ describe('local setup scripts', () => {
 
   it('.env.example documents current local env vars without removed service knobs', () => {
     const envExample = read('.env.example');
+    const readme = read('README.md');
+    const quickstart = read('docs/guides/quickstart.md');
+    const runCliBeastGuide = read('docs/guides/run-cli-beast.md');
 
     for (const required of [
       'ANTHROPIC_API_KEY',
@@ -130,5 +133,12 @@ describe('local setup scripts', () => {
     expect(envExample).not.toMatch(/^GRAFANA_USER=admin$/m);
     expect(envExample).not.toMatch(/^GRAFANA_PASSWORD=admin$/m);
     expect(envExample).toContain('Generate a unique local password before uncommenting');
+
+    for (const doc of [readme, quickstart, runCliBeastGuide]) {
+      expect(doc).toContain('ANTHROPIC_API_KEY');
+      expect(doc).toContain('OPENAI_API_KEY');
+      expect(doc).toContain('GOOGLE_API_KEY');
+      expect(doc).toContain('GEMINI_API_KEY');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Document Gemini provider env keys in README optional setup and environment variable reference
- Add GOOGLE_API_KEY / GEMINI_API_KEY guidance to quickstart and CLI beast setup docs
- Extend local setup docs regression coverage for provider key guidance

## Test Plan
- npm run test:root -- --run tests/local-setup-scripts.test.ts
- npm run lint:security
- npm run typecheck
- npm run build
- npm test

Closes #1157