### PR TITLE
fix(orchestrator): report cleanup artifact failures

### DIFF
--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -264,23 +264,57 @@ function createSessionArtifacts(options: CliDepOptions): SessionArtifacts {
   };
 }
 
+type CleanupWarningLogger = Pick<BeastLogger, 'warn'> | ((message: string, scope?: string) => void);
+
+type SessionArtifactRemover = (targetPath: string) => void;
+
+function warnSessionArtifactCleanupFailure(
+  artifactPath: string,
+  error: unknown,
+  warn: CleanupWarningLogger,
+): void {
+  const message = `Failed to remove session artifact ${artifactPath}: ${errorMessage(error)}`;
+  if (typeof warn === 'function') {
+    warn(message, 'dep-factory');
+    return;
+  }
+  warn.warn(message, 'dep-factory');
+}
+
+export function removeSessionArtifactIfPresent(
+  artifactPath: string,
+  remove: SessionArtifactRemover,
+  warn: CleanupWarningLogger = console.warn,
+): boolean {
+  try {
+    if (!existsSync(artifactPath)) return false;
+    remove(artifactPath);
+    return true;
+  } catch (error) {
+    warnSessionArtifactCleanupFailure(artifactPath, error, warn);
+    return false;
+  }
+}
+
 function clearSessionArtifacts(options: CliDepOptions, artifacts: SessionArtifacts): void {
   const { paths } = options;
   const checkpointOutputDir = `${artifacts.checkpointFile}.outputs`;
+  const removeFile = (targetPath: string) => unlinkSync(targetPath);
+  const removeDir = (targetPath: string) => rmSync(targetPath, { recursive: true, force: true });
   if (options.reset) {
     const memoryDbPath = resolve(paths.buildDir, 'memory.db');
     for (const f of [artifacts.checkpointFile, paths.tracesDb, memoryDbPath]) {
-      try { if (existsSync(f)) unlinkSync(f); } catch {}
+      removeSessionArtifactIfPresent(f, removeFile);
     }
-    try { if (existsSync(checkpointOutputDir)) rmSync(checkpointOutputDir, { recursive: true, force: true }); } catch {}
+    removeSessionArtifactIfPresent(checkpointOutputDir, removeDir);
     for (const dir of [resolve(paths.buildDir, 'issues'), paths.chunkSessionsDir, paths.chunkSessionSnapshotsDir]) {
-      try { if (existsSync(dir)) rmSync(dir, { recursive: true, force: true }); } catch {}
+      removeSessionArtifactIfPresent(dir, removeDir);
     }
   } else if (!options.resume) {
-    try { if (existsSync(artifacts.checkpointFile)) unlinkSync(artifacts.checkpointFile); } catch {}
-    try { if (existsSync(checkpointOutputDir)) rmSync(checkpointOutputDir, { recursive: true, force: true }); } catch {}
+    removeSessionArtifactIfPresent(artifacts.checkpointFile, removeFile);
+    removeSessionArtifactIfPresent(checkpointOutputDir, removeDir);
     for (const dir of [paths.chunkSessionsDir, paths.chunkSessionSnapshotsDir]) {
-      try { if (existsSync(dir)) rmSync(dir, { recursive: true, force: true }); } catch {}
+      removeSessionArtifactIfPresent(dir, removeDir);
     }
   }
 }

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { getProjectPaths, scaffoldFrankenbeast } from '../../../src/cli/project-root.js';
 import { parseOrchestratorConfig } from '../../../src/config/orchestrator-config.js';
 import type { CliDepOptions } from '../../../src/cli/dep-factory.js';
@@ -253,6 +253,32 @@ describe('dep-factory provider wiring', () => {
     optionalModuleMocks.governorError = undefined;
     traceViewerMocks.stop.mockClear();
     mockBridgeReplayManifest.length = 0;
+  });
+
+  it('reports session artifact cleanup failures instead of swallowing them', async () => {
+    const { removeSessionArtifactIfPresent } = await import('../../../src/cli/dep-factory.js');
+    const testDir = resolve(tmpdir(), `fb-cleanup-warning-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const artifactPath = resolve(testDir, 'session.checkpoint');
+    const warn = vi.fn();
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(artifactPath, 'checkpoint data');
+
+    try {
+      const removed = removeSessionArtifactIfPresent(
+        artifactPath,
+        () => { throw new Error('permission denied'); },
+        warn,
+      );
+
+      expect(removed).toBe(false);
+      expect(existsSync(artifactPath)).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to remove session artifact ${artifactPath}: permission denied`),
+        'dep-factory',
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
   });
 
   it('throws descriptive error for unknown provider name', async () => {


### PR DESCRIPTION
## Summary
- Replaces silent dep-factory session cleanup catches with a shared removal helper that logs failed artifact cleanup attempts.
- Adds regression coverage proving cleanup failures are reported and artifacts are left intact when removal fails.

## Test Plan
- npm test -- --run tests/unit/cli/dep-factory-providers.test.ts -t "reports session artifact cleanup failures"
- npm test -- --run tests/unit/cli/dep-factory-providers.test.ts
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1214
