### PR TITLE
refactor(mcp): source standalone tools from registry

### DIFF
--- a/packages/franken-mcp-suite/src/servers/critique.ts
+++ b/packages/franken-mcp-suite/src/servers/critique.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createCritiqueAdapter, type CritiqueAdapter } from '../adapters/critique-adapter.js';
@@ -10,77 +11,7 @@ export interface CritiqueServerDeps {
 }
 
 export function createCritiqueServer(deps: CritiqueServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { critique } = deps;
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_critique_evaluate',
-      description: 'Evaluate content against criteria. Returns verdict (pass/warn/fail), score (0-1), and findings.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          content: { type: 'string', description: 'Code or text to evaluate' },
-          criteria: { type: 'string', description: 'Comma-separated criteria: correctness, readability, security, complexity' },
-          evaluators: { type: 'string', description: 'Comma-separated evaluator names (e.g. logic-loop, complexity)' },
-        },
-        required: ['content'],
-      },
-      async handler(args) {
-        const content = String(args['content']);
-        const criteria = splitCsvArg(args['criteria']) ?? ['correctness', 'readability', 'security', 'complexity'];
-        const evaluators = splitCsvArg(args['evaluators']);
-        const result = await critique.evaluate(evaluators ? { content, criteria, evaluators } : { content, criteria });
-
-        const findingsText = result.findings.length > 0
-          ? result.findings.map((f) => `  [${f.severity}] ${f.message}`).join('\n')
-          : '  None';
-
-        const text = [
-          `## Critique Result`,
-          ``,
-          `**verdict:** ${result.verdict}`,
-          `**score:** ${result.score.toFixed(2)}`,
-          `**findings:**`,
-          findingsText,
-        ].join('\n');
-
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-    {
-      name: 'fbeast_critique_compare',
-      description: 'Compare original and revised content. Shows improvement delta.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          original: { type: 'string', description: 'Original content' },
-          revised: { type: 'string', description: 'Revised content' },
-        },
-        required: ['original', 'revised'],
-      },
-      async handler(args) {
-        const original = String(args['original']);
-        const revised = String(args['revised']);
-        const result = await critique.compare({ original, revised });
-
-        const text = [
-          `## Comparison`,
-          ``,
-          `**original score:** ${result.originalScore.toFixed(2)}`,
-          `**revised score:** ${result.revisedScore.toFixed(2)}`,
-          `**delta:** ${result.delta >= 0 ? '+' : ''}${result.delta.toFixed(2)} (${result.direction})`,
-          ``,
-          `### Original findings (${result.originalFindings.length})`,
-          ...result.originalFindings.map((f) => `- [${f.severity}] ${f.message}`),
-          ``,
-          `### Revised findings (${result.revisedFindings.length})`,
-          ...result.revisedFindings.map((f) => `- [${f.severity}] ${f.message}`),
-        ].join('\n');
-
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('critique', deps);
   return createMcpServer('fbeast-critique', '0.1.0', tools, options);
 }
 
@@ -94,17 +25,4 @@ if (isMain(import.meta.url)) {
     console.error('fbeast-critique failed to start:', err);
     process.exit(1);
   });
-}
-
-function splitCsvArg(value: unknown, fallback?: string[]): string[] | undefined {
-  if (value === undefined) {
-    return fallback;
-  }
-
-  const parsed = String(value)
-    .split(',')
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0);
-
-  return parsed.length > 0 ? parsed : fallback;
 }

--- a/packages/franken-mcp-suite/src/servers/firewall.ts
+++ b/packages/franken-mcp-suite/src/servers/firewall.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createFirewallAdapter, type FirewallAdapter } from '../adapters/firewall-adapter.js';
@@ -10,67 +11,7 @@ export interface FirewallServerDeps {
 }
 
 export function createFirewallServer(deps: FirewallServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { firewall } = deps;
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_firewall_scan',
-      description: 'Scan text input for prompt injection patterns. Returns clean or flagged with matched patterns.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          input: { type: 'string', description: 'Text to scan for injection patterns' },
-        },
-        required: ['input'],
-      },
-      async handler(args) {
-        const input = String(args['input']);
-        const result = await firewall.scanText(input);
-
-        if (result.verdict === 'clean') {
-          return { content: [{ type: 'text', text: 'Scan result: clean. No injection patterns detected.' }] };
-        }
-        return {
-          content: [{
-            type: 'text',
-            text: `Scan result: flagged\nMatched patterns: ${result.matchedPatterns.join(', ')}\n\nThis input may contain prompt injection. Review before processing.`,
-          }],
-        };
-      },
-    },
-    {
-      name: 'fbeast_firewall_scan_file',
-      description: 'Read a file and scan its contents for prompt injection patterns.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          path: { type: 'string', description: 'File path to scan' },
-        },
-        required: ['path'],
-      },
-      async handler(args) {
-        const filePath = String(args['path']);
-        try {
-          const result = await firewall.scanFile(filePath);
-
-          if (result.verdict === 'clean') {
-            return { content: [{ type: 'text', text: `File scan (${filePath}): clean. No injection patterns detected.` }] };
-          }
-          return {
-            content: [{
-              type: 'text',
-              text: `File scan (${filePath}): flagged\nMatched patterns: ${result.matchedPatterns.join(', ')}\n\nThis file may contain prompt injection. Review before processing.`,
-            }],
-          };
-        } catch (err) {
-          return {
-            content: [{ type: 'text', text: `Error reading file: ${err instanceof Error ? err.message : String(err)}` }],
-            isError: true,
-          };
-        }
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('firewall', deps);
   return createMcpServer('fbeast-firewall', '0.1.0', tools, options);
 }
 

--- a/packages/franken-mcp-suite/src/servers/governor.ts
+++ b/packages/franken-mcp-suite/src/servers/governor.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createGovernorAdapter, type GovernorAdapter } from '../adapters/governor-adapter.js';
@@ -10,55 +11,7 @@ export interface GovernorServerDeps {
 }
 
 export function createGovernorServer(deps: GovernorServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { governor } = deps;
-
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_governor_check',
-      description: 'Check if an action should be approved or needs human review. Flags destructive operations.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          action: { type: 'string', description: 'Action name or description (e.g., delete_file, push_to_main)' },
-          context: { type: 'string', description: 'JSON context about the action (target, scope, etc.)' },
-        },
-        required: ['action', 'context'],
-      },
-      async handler(args) {
-        const action = String(args['action']);
-        const context = String(args['context']);
-        const { decision, reason } = await governor.check({ action, context });
-
-        return { content: [{ type: 'text', text: `**Decision:** ${decision}\n**Reason:** ${reason}` }] };
-      },
-    },
-    {
-      name: 'fbeast_governor_budget',
-      description: 'Get current spend vs budget status.',
-      inputSchema: {
-        type: 'object',
-        properties: {},
-      },
-      async handler(_args) {
-        const summary = await governor.budgetStatus();
-
-        if (summary.byModel.length === 0) {
-          return { content: [{ type: 'text', text: 'No cost data recorded yet.' }] };
-        }
-
-        const lines = [
-          `## Budget Status`,
-          '',
-          ...summary.byModel.map((row) => `- ${row.model}: $${row.costUsd.toFixed(4)}`),
-          '',
-          `**Total spend:** $${summary.totalSpendUsd.toFixed(4)}`,
-        ];
-
-        return { content: [{ type: 'text', text: lines.join('\n') }] };
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('governor', deps);
   return createMcpServer('fbeast-governor', '0.1.0', tools, options);
 }
 

--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -14,14 +14,13 @@ describe('Memory Server', () => {
 
     const names = server.tools.map((t) => t.name);
     expect(names).toEqual([
-      'fbeast_memory_query',
       'fbeast_memory_store',
+      'fbeast_memory_query',
       'fbeast_memory_frontload',
       'fbeast_memory_forget',
     ]);
     const storeTool = server.tools.find((t) => t.name === 'fbeast_memory_store')!;
-    expect(storeTool.description).toContain('Working/recovery memory updates by key');
-    expect(storeTool.description).toContain('episodic memory appends an event');
+    expect(storeTool.description).toBe('Store key/value in working or episodic memory');
   });
 
   it('delegates memory store/query/frontload/forget to the brain adapter', async () => {

--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createBrainAdapter, type BrainAdapter } from '../adapters/brain-adapter.js';
@@ -10,105 +11,10 @@ export interface MemoryServerDeps {
 }
 
 export function createMemoryServer(deps: MemoryServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { brain } = deps;
-
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_memory_query',
-      description: 'Query memory for stored entries. Searches keys and values by substring match.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          query: { type: 'string', description: 'Search query (substring match on key and value)' },
-          type: { type: 'string', description: 'Filter by type: working, episodic, recovery', enum: ['working', 'episodic', 'recovery'] },
-          limit: { type: 'string', description: 'Max results (default 20)' },
-        },
-        required: ['query'],
-      },
-      async handler(args) {
-        const query = String(args['query']);
-        const type = args['type'] ? String(args['type']) : undefined;
-        const limit = args['limit'] ? Number(args['limit']) : 20;
-        const rows = await brain.query(type ? { query, type, limit } : { query, limit });
-
-        if (rows.length === 0) {
-          return { content: [{ type: 'text', text: `No memory entries found for query: "${query}"` }] };
-        }
-
-        const text = rows
-          .map((row) => formatMemoryEntry(row))
-          .join('\n');
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-    {
-      name: 'fbeast_memory_store',
-      description: 'Store a memory entry. Working/recovery memory updates by key; episodic memory appends an event.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          key: { type: 'string', description: 'Unique key for this memory entry' },
-          value: { type: 'string', description: 'Content to store' },
-          type: { type: 'string', description: 'Memory type: working, episodic, or recovery', enum: ['working', 'episodic', 'recovery'] },
-        },
-        required: ['key', 'value', 'type'],
-      },
-      async handler(args) {
-        const key = String(args['key']);
-        const value = String(args['value']);
-        const type = String(args['type']);
-        await brain.store({ key, value, type });
-        return { content: [{ type: 'text', text: `Stored memory: ${key}` }] };
-      },
-    },
-    {
-      name: 'fbeast_memory_frontload',
-      description: 'Load all memory entries from this database. Returns everything stored.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          projectId: { type: 'string', description: 'Optional legacy project identifier; frontload is database-scoped' },
-        },
-      },
-      async handler(_args) {
-        const sections = await brain.frontload();
-
-        if (sections.length === 0) {
-          return { content: [{ type: 'text', text: 'No memory entries stored yet.' }] };
-        }
-
-        const text = sections
-          .map((section) => `## ${section.type}\n${section.entries.map((entry) => `  ${entry}`).join('\n')}`)
-          .join('\n\n');
-
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-    {
-      name: 'fbeast_memory_forget',
-      description: 'Remove a memory entry by key.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          key: { type: 'string', description: 'Key of the memory entry to remove' },
-        },
-        required: ['key'],
-      },
-      async handler(args) {
-        const key = String(args['key']);
-        const removed = await brain.forget(key);
-        if (!removed) {
-          return { content: [{ type: 'text', text: `No memory entry found with key: ${key}` }] };
-        }
-        return { content: [{ type: 'text', text: `Removed memory: ${key}` }] };
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('memory', deps);
   return createMcpServer('fbeast-memory', '0.1.0', tools, options);
 }
 
-// CLI entry point
 if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
@@ -119,11 +25,4 @@ if (isMain(import.meta.url)) {
     console.error('fbeast-memory failed to start:', err);
     process.exit(1);
   });
-}
-
-function formatMemoryEntry(row: { key: string; value: string; type: string; createdAt?: string }): string {
-  if (row.createdAt) {
-    return `[${row.type}] ${row.key}: ${row.value} (${row.createdAt})`;
-  }
-  return `[${row.type}] ${row.key}: ${row.value}`;
 }

--- a/packages/franken-mcp-suite/src/servers/observer.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createObserverAdapter, type ObserverAdapter } from '../adapters/observer-adapter.js';
@@ -10,140 +11,7 @@ export interface ObserverServerDeps {
 }
 
 export function createObserverServer(deps: ObserverServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { observer } = deps;
-
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_observer_log',
-      description: 'Log an event to the audit trail. Returns the trace entry ID.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          event: { type: 'string', description: 'Event type (e.g., file_edit, tool_call, decision)' },
-          metadata: { type: 'string', description: 'JSON metadata for this event' },
-          sessionId: { type: 'string', description: 'Session identifier' },
-        },
-        required: ['event', 'metadata', 'sessionId'],
-      },
-      async handler(args) {
-        const event = String(args['event']);
-        const metadata = String(args['metadata']);
-        const sessionId = String(args['sessionId']);
-        const result = await observer.log({ event, metadata, sessionId });
-
-        return {
-          content: [{ type: 'text', text: `Logged event: ${event} (id: ${result.id}, hash: ${result.hash})` }],
-        };
-      },
-    },
-    {
-      name: 'fbeast_observer_log_cost',
-      description: 'Record token usage and cost for an LLM call. Call this after each significant model invocation you make.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          sessionId: { type: 'string', description: 'Session identifier' },
-          model: { type: 'string', description: 'Model name (e.g. gpt-4o, claude-opus-4-5)' },
-          promptTokens: { type: 'number', description: 'Input/prompt token count' },
-          completionTokens: { type: 'number', description: 'Output/completion token count' },
-          costUsd: { type: 'number', description: 'Actual cost in USD if known — omit to auto-calculate from pricing table' },
-        },
-        required: ['sessionId', 'model', 'promptTokens', 'completionTokens'],
-      },
-      async handler(args) {
-        const sessionId = String(args['sessionId']);
-        const model = String(args['model']);
-        const promptTokens = Number(args['promptTokens']);
-        const completionTokens = Number(args['completionTokens']);
-        const costUsdArg = args['costUsd'] != null ? Number(args['costUsd']) : undefined;
-        await observer.logCost({ sessionId, model, promptTokens, completionTokens, ...(costUsdArg != null ? { costUsd: costUsdArg } : {}) });
-        return {
-          content: [{ type: 'text', text: `Logged cost: ${promptTokens}+${completionTokens} tokens for ${model}` }],
-        };
-      },
-    },
-    {
-      name: 'fbeast_observer_cost',
-      description: 'Get token usage and cost summary for a session or all sessions.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          sessionId: { type: 'string', description: 'Session ID to filter (omit for all sessions)' },
-        },
-      },
-      async handler(args) {
-        const sessionId = args['sessionId'] ? String(args['sessionId']) : undefined;
-        const summary = await observer.cost(sessionId ? { sessionId } : {});
-
-        if (summary.byModel.length === 0) {
-          return { content: [{ type: 'text', text: 'No cost data recorded.' }] };
-        }
-
-        const lines = [
-          `## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`,
-          '',
-          ...summary.byModel.map((row) =>
-            `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion = $${row.costUsd.toFixed(4)}`),
-          '',
-          `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion = $${summary.totalCostUsd.toFixed(4)}`,
-        ];
-
-        return { content: [{ type: 'text', text: lines.join('\n') }] };
-      },
-    },
-    {
-      name: 'fbeast_observer_trail',
-      description: 'Get the full audit trail for a session.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          sessionId: { type: 'string', description: 'Session identifier' },
-        },
-        required: ['sessionId'],
-      },
-      async handler(args) {
-        const sessionId = String(args['sessionId']);
-        const rows = await observer.trail(sessionId);
-
-        if (rows.length === 0) {
-          return { content: [{ type: 'text', text: `No audit trail for session: ${sessionId}` }] };
-        }
-
-        const text = rows
-          .map((row, index) => `${index + 1}. [${row.createdAt}] ${row.eventType} (${row.hash ?? 'no-hash'})\n   ${row.payload}`)
-          .join('\n');
-
-        return { content: [{ type: 'text', text: `## Audit Trail (${rows.length} events)\n\n${text}` }] };
-      },
-    },
-    {
-      name: 'fbeast_observer_verify',
-      description: 'Verify the full audit hash chain for a session.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          sessionId: { type: 'string', description: 'Session identifier' },
-        },
-        required: ['sessionId'],
-      },
-      async handler(args) {
-        const sessionId = String(args['sessionId']);
-        const result = await observer.verify(sessionId);
-        if (result.ok) {
-          return { content: [{ type: 'text', text: `Audit chain verified for session ${sessionId}: ${result.checked} events checked.` }] };
-        }
-
-        return {
-          content: [{
-            type: 'text',
-            text: `Audit chain verification failed for session ${sessionId} at index ${result.firstInvalid?.index ?? 'unknown'}.`,
-          }],
-          isError: true,
-        };
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('observer', deps);
   return createMcpServer('fbeast-observer', '0.1.0', tools, options);
 }
 

--- a/packages/franken-mcp-suite/src/servers/planner.ts
+++ b/packages/franken-mcp-suite/src/servers/planner.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
@@ -10,109 +11,7 @@ export interface PlannerServerDeps {
 }
 
 export function createPlannerServer(deps: PlannerServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { planner } = deps;
-
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_plan_decompose',
-      description: 'Create a generic scaffold DAG for an objective. Stores the plan for later reference. Returns provenance so callers know it is not an objective-specific decomposition.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          objective: { type: 'string', description: 'What needs to be accomplished' },
-          constraints: { type: 'string', description: 'Constraints or requirements (optional)' },
-        },
-        required: ['objective'],
-      },
-      async handler(args) {
-        const objective = String(args['objective']);
-        const constraints = args['constraints'] ? String(args['constraints']) : undefined;
-        const result = await planner.decompose(constraints ? { objective, constraints } : { objective });
-
-        const taskList = result.tasks
-          .map((t) => `  ${t.id}: ${t.title}${t.deps.length > 0 ? ` (after: ${t.deps.join(', ')})` : ''}`)
-          .join('\n');
-
-        const text = [
-          `## Plan created: ${result.planId}`,
-          ``,
-          `**Objective:** ${result.objective}`,
-          constraints ? `**Constraints:** ${constraints}` : '',
-          `**Provenance:** ${result.provenance}`,
-          `**Provenance note:** ${result.provenanceNote}`,
-          ``,
-          `**Tasks:**`,
-          taskList,
-          ``,
-          `Use fbeast_plan_visualize with planId "${result.planId}" to see the DAG.`,
-          `Use fbeast_plan_validate with planId "${result.planId}" to check for issues.`,
-        ].filter(Boolean).join('\n');
-
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-    {
-      name: 'fbeast_plan_status',
-      description: 'Get status of all steps in current plan.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          planId: { type: 'string', description: 'Plan ID returned by fbeast_plan_decompose' },
-        },
-        required: ['planId'],
-      },
-      async handler(args) {
-        const planId = String(args['planId']);
-        const mermaid = await planner.visualize(planId);
-
-        if (!mermaid) {
-          return { content: [{ type: 'text', text: `Plan not found: ${planId}` }], isError: true };
-        }
-
-        const text = [
-          `## Plan: ${planId}`,
-          ``,
-          '```mermaid',
-          mermaid,
-          '```',
-        ].join('\n');
-
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-    {
-      name: 'fbeast_plan_validate',
-      description: 'Validate an existing plan: check for cycles, missing dependencies, and structural issues.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          planId: { type: 'string', description: 'Plan ID to validate' },
-        },
-        required: ['planId'],
-      },
-      async handler(args) {
-        const planId = String(args['planId']);
-        const validation = await planner.validate(planId);
-
-        if (!validation) {
-          return { content: [{ type: 'text', text: `Plan not found: ${planId}` }], isError: true };
-        }
-        const text = [
-          `## Validation: ${validation.verdict}`,
-          ``,
-          `**Plan:** ${planId}`,
-          `**Issues:** ${validation.issues.length}`,
-          '',
-          validation.issues.length > 0
-            ? validation.issues.map((i) => `- ${i}`).join('\n')
-            : 'No issues found.',
-        ].join('\n');
-
-        return { content: [{ type: 'text', text }] };
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('planner', deps);
   return createMcpServer('fbeast-planner', '0.1.0', tools, options);
 }
 

--- a/packages/franken-mcp-suite/src/servers/skills.ts
+++ b/packages/franken-mcp-suite/src/servers/skills.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } from '../shared/server-factory.js';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
@@ -10,98 +11,7 @@ export interface SkillsServerDeps {
 }
 
 export function createSkillsServer(deps: SkillsServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
-  const { skills } = deps;
-
-  const tools: ToolDef[] = [
-    {
-      name: 'fbeast_skills_list',
-      description: 'List all registered skills. Optionally filter by enabled status.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          enabled: { type: 'string', description: 'Filter: "true" for enabled only, "false" for disabled only', enum: ['true', 'false'] },
-        },
-      },
-      async handler(args) {
-        const enabled = args['enabled'] !== undefined ? String(args['enabled']) === 'true' : undefined;
-        const rows = await skills.list(enabled === undefined ? {} : { enabled });
-
-        if (rows.length === 0) {
-          return { content: [{ type: 'text', text: 'No skills registered.' }] };
-        }
-
-        const lines = rows.map((r) => {
-          const status = r.enabled ? 'enabled' : 'disabled';
-          return `- **${r.name}** [${status}] (updated: ${r.updatedAt ?? 'unknown'})`;
-        });
-
-        return { content: [{ type: 'text', text: `## Skills (${rows.length})\n\n${lines.join('\n')}` }] };
-      },
-    },
-    {
-      name: 'fbeast_skills_discover',
-      description: 'Search for skills by name or description keyword.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          query: { type: 'string', description: 'Search keyword (matches name and config description)' },
-        },
-      },
-      async handler(args) {
-        const query = args['query'] ? String(args['query']) : '';
-        const rows = await skills.list({});
-        const normalizedQuery = query.trim().toLowerCase();
-        const matches = normalizedQuery.length === 0
-          ? rows
-          : rows.filter((row) =>
-              row.name.toLowerCase().includes(normalizedQuery)
-              || row.description.toLowerCase().includes(normalizedQuery));
-
-        if (matches.length === 0) {
-          return { content: [{ type: 'text', text: query ? `No skills matching "${query}".` : 'No skills registered.' }] };
-        }
-
-        const lines = matches.map((row) => {
-          return `- **${row.name}**: ${row.description}`;
-        });
-
-        return { content: [{ type: 'text', text: `## Discovered Skills (${matches.length})\n\n${lines.join('\n')}` }] };
-      },
-    },
-    {
-      name: 'fbeast_skills_load',
-      description: 'Load full skill content by name.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          skillId: { type: 'string', description: 'Skill name/ID' },
-        },
-        required: ['skillId'],
-      },
-      async handler(args) {
-        const skillId = String(args['skillId']);
-        const info = await skills.info(skillId);
-        if (!info) {
-          return { content: [{ type: 'text', text: `Skill not found: ${skillId}` }], isError: true };
-        }
-
-        const lines = [
-          `## Skill: ${skillId}`,
-          '',
-          `**Status:** ${info['enabled'] ? 'enabled' : 'disabled'}`,
-          `**Updated:** ${typeof info['updatedAt'] === 'string' ? info['updatedAt'] : 'unknown'}`,
-          '',
-          '**Config:**',
-          '```json',
-          JSON.stringify(info, null, 2),
-          '```',
-        ];
-
-        return { content: [{ type: 'text', text: lines.join('\n') }] };
-      },
-    },
-  ];
-
+  const tools = createToolDefsForServer('skills', deps);
   return createMcpServer('fbeast-skills', '0.1.0', tools, options);
 }
 

--- a/packages/franken-mcp-suite/src/servers/standalone-registry.test.ts
+++ b/packages/franken-mcp-suite/src/servers/standalone-registry.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TOOL_REGISTRY } from '../shared/tool-registry.js';
+import { createCritiqueServer } from './critique.js';
+import { createFirewallServer } from './firewall.js';
+import { createGovernorServer } from './governor.js';
+import { createMemoryServer } from './memory.js';
+import { createObserverServer } from './observer.js';
+import { createPlannerServer } from './planner.js';
+import { createSkillsServer } from './skills.js';
+
+const standaloneServers = [
+  {
+    registryServer: 'memory',
+    createServer: () => createMemoryServer({
+      brain: { query: vi.fn(), store: vi.fn(), frontload: vi.fn(), forget: vi.fn() },
+    }),
+  },
+  {
+    registryServer: 'planner',
+    createServer: () => createPlannerServer({
+      planner: { decompose: vi.fn(), visualize: vi.fn(), validate: vi.fn() },
+    }),
+  },
+  {
+    registryServer: 'critique',
+    createServer: () => createCritiqueServer({
+      critique: { evaluate: vi.fn(), compare: vi.fn() },
+    }),
+  },
+  {
+    registryServer: 'firewall',
+    createServer: () => createFirewallServer({
+      firewall: { scanText: vi.fn(), scanFile: vi.fn() },
+    }),
+  },
+  {
+    registryServer: 'observer',
+    createServer: () => createObserverServer({
+      observer: { log: vi.fn(), logCost: vi.fn(), cost: vi.fn(), trail: vi.fn(), verify: vi.fn() },
+    }),
+  },
+  {
+    registryServer: 'governor',
+    createServer: () => createGovernorServer({
+      governor: { check: vi.fn(), budgetStatus: vi.fn() },
+    }),
+  },
+  {
+    registryServer: 'skills',
+    createServer: () => createSkillsServer({
+      skills: { list: vi.fn(), info: vi.fn() },
+    }),
+  },
+] as const;
+
+describe('standalone MCP servers', () => {
+  it('exposes the same tool metadata as the shared registry', () => {
+    for (const { registryServer, createServer } of standaloneServers) {
+      const serverTools = createServer().tools.map(({ name, description, inputSchema }) => ({
+        name,
+        description,
+        inputSchema,
+      }));
+      const registryTools = [...TOOL_REGISTRY.values()]
+        .filter((tool) => tool.server === registryServer)
+        .map(({ name, description, inputSchema }) => ({
+          name,
+          description,
+          inputSchema,
+        }));
+
+      expect(serverTools, `${registryServer} standalone tools drifted from TOOL_REGISTRY`).toEqual(registryTools);
+    }
+  });
+});

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -5,9 +5,7 @@ import { createGovernorAdapter, type GovernorAdapter } from '../adapters/governo
 import { createObserverAdapter, type ObserverAdapter } from '../adapters/observer-adapter.js';
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
-import type { ToolInputSchema } from './server-factory.js';
-
-export type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+import type { ToolDef, ToolInputSchema, ToolResult } from './server-factory.js';
 
 export interface AdapterSet {
   brain: BrainAdapter;
@@ -19,9 +17,11 @@ export interface AdapterSet {
   skills: SkillsAdapter;
 }
 
+export type ToolServer = 'memory' | 'planner' | 'critique' | 'firewall' | 'observer' | 'governor' | 'skills';
+
 interface ToolStub {
   name: string;
-  server: 'memory' | 'planner' | 'critique' | 'firewall' | 'observer' | 'governor' | 'skills';
+  server: ToolServer;
   description: string;
 }
 
@@ -29,6 +29,8 @@ interface ToolFull extends ToolStub {
   inputSchema: ToolInputSchema;
   makeHandler: (adapters: AdapterSet) => (args: Record<string, unknown>) => Promise<ToolResult>;
 }
+
+export type ServerAdapterDeps = Partial<AdapterSet>;
 
 function splitCsvArg(value: unknown, fallback?: string[]): string[] | undefined {
   if (value === undefined) return fallback;
@@ -514,6 +516,17 @@ const TOOLS: ToolFull[] = [
 export const TOOL_STUBS: ToolStub[] = TOOLS.map(({ name, server, description }) => ({ name, server, description }));
 
 export const TOOL_REGISTRY: Map<string, ToolFull> = new Map(TOOLS.map((t) => [t.name, t]));
+
+export function createToolDefsForServer(server: ToolServer, adapters: ServerAdapterDeps): ToolDef[] {
+  return TOOLS
+    .filter((tool) => tool.server === server)
+    .map(({ name, description, inputSchema, makeHandler }) => ({
+      name,
+      description,
+      inputSchema,
+      handler: makeHandler(adapters as AdapterSet),
+    }));
+}
 
 export function searchTools(query?: string): ToolStub[] {
   if (!query) return TOOL_STUBS;


### PR DESCRIPTION
## Summary
- Adds a shared `createToolDefsForServer` helper so standalone MCP servers bind tools from `TOOL_REGISTRY` instead of hand-copied definitions.
- Refactors memory/planner/critique/firewall/observer/governor/skills standalone servers to use the canonical registry.
- Adds a regression test that compares standalone server tool metadata against `TOOL_REGISTRY` for all seven standalone servers.

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/servers/standalone-registry.test.ts src/servers/memory.test.ts src/servers/planner.test.ts src/servers/critique.test.ts src/servers/firewall.test.ts src/servers/observer.test.ts src/servers/governor.test.ts src/servers/skills.test.ts src/shared/tool-registry.test.ts
- npm run build
- npm --prefix packages/franken-mcp-suite test
- npm run typecheck
- npm run lint:any

Closes #1166