### PR TITLE
fix(web): hide placeholder dashboard routes

### DIFF
--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -67,7 +67,8 @@ describe('ActivityPane', () => {
     expect(screen.getByText('Execution complete')).toBeTruthy();
     expect(screen.getByText('Failed')).toBeTruthy();
     expect(screen.getByText('Tests failed')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Session session-7' }).getAttribute('href')).toBe('#/sessions');
+    expect(screen.getByText('Session session-7')).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Session session-7' })).toBeNull();
     expect(screen.getByRole('link', { name: 'Run run-42' }).getAttribute('href')).toBe('#/beasts');
     expect(screen.getByText('Artifact /tmp/report.md')).toBeTruthy();
     expect(screen.queryByText('{"taskDescription":"Deploy agent"}')).toBeNull();

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -146,7 +146,7 @@ function activityLinks(data: Record<string, unknown>): ActivityLink[] {
   const artifactPath = stringValue(data, 'artifactPath') ?? stringValue(data, 'artifact');
 
   if (sessionId) {
-    links.push({ label: `Session ${sessionId}`, href: '#/sessions' });
+    links.push({ label: `Session ${sessionId}` });
   }
   if (runId) {
     links.push({ label: `Run ${runId}`, href: '#/beasts' });

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -140,4 +140,13 @@ describe('ChatShell route heading', () => {
     expect(navigation.queryByRole('link', { name: /Settings/ })).toBeNull();
     expect(navigation.queryByText('Soon')).toBeNull();
   });
+
+  it('redirects direct placeholder hashes back to the live chat route', () => {
+    window.location.hash = '#/sessions';
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Chat' })).toBeTruthy();
+    expect(screen.queryByRole('heading', { level: 2, name: 'Sessions' })).toBeNull();
+  });
 });

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatShell } from './chat-shell';
 
 vi.mock('../hooks/use-chat-session', () => ({
@@ -101,6 +101,10 @@ vi.mock('./cost-badge', () => ({
 }));
 
 describe('ChatShell route heading', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     window.location.hash = '#/network';
     window.matchMedia = vi.fn().mockReturnValue({
@@ -118,5 +122,22 @@ describe('ChatShell route heading', () => {
     expect(screen.getByText('Project: default')).toBeTruthy();
     expect(screen.getByText('Service controls')).toBeTruthy();
     expect(screen.queryByText('Chat is the only live section in this first Frankenbeast dashboard cut.')).toBeNull();
+  });
+
+  it('keeps placeholder modules out of the primary dashboard navigation', () => {
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+
+    const navigation = within(screen.getByRole('navigation', { name: 'Dashboard navigation' }));
+    expect(navigation.getByRole('link', { name: /Overview/ })).toBeTruthy();
+    expect(navigation.getByRole('link', { name: /Chat/ })).toBeTruthy();
+    expect(navigation.getByRole('link', { name: /Beasts/ })).toBeTruthy();
+    expect(navigation.getByRole('link', { name: /Network/ })).toBeTruthy();
+    expect(navigation.getByRole('link', { name: /Analytics/ })).toBeTruthy();
+
+    expect(navigation.queryByRole('link', { name: /Sessions/ })).toBeNull();
+    expect(navigation.queryByRole('link', { name: /Costs/ })).toBeNull();
+    expect(navigation.queryByRole('link', { name: /Safety/ })).toBeNull();
+    expect(navigation.queryByRole('link', { name: /Settings/ })).toBeNull();
+    expect(navigation.queryByText('Soon')).toBeNull();
   });
 });

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -148,5 +148,6 @@ describe('ChatShell route heading', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: 'Chat' })).toBeTruthy();
     expect(screen.queryByRole('heading', { level: 2, name: 'Sessions' })).toBeNull();
+    expect(window.location.hash).toBe('#/chat');
   });
 });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -47,6 +47,8 @@ const ROUTES: Array<{ id: RouteId; label: string; summary: string; live: boolean
   { id: 'settings', label: 'Settings', summary: 'Operator configuration and launch profiles', live: false },
 ];
 
+const PRIMARY_NAV_ROUTES = ROUTES.filter((route) => route.live);
+
 function formatSessionCount(count: number): string {
   return `${count} ${count === 1 ? 'message' : 'messages'}`;
 }
@@ -743,7 +745,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         </div>
 
         <nav className="sidebar__nav" aria-label="Dashboard navigation">
-          {ROUTES.map((item) => (
+          {PRIMARY_NAV_ROUTES.map((item) => (
             <a
               aria-current={route === item.id ? 'page' : undefined}
               key={item.id}
@@ -754,7 +756,6 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 <strong>{item.label}</strong>
                 <small>{item.summary}</small>
               </span>
-              {!item.live && <span className="sidebar__status">Soon</span>}
             </a>
           ))}
         </nav>

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -632,17 +632,21 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   }, [route, beastClient]);
 
   useEffect(() => {
-    if (!window.location.hash) {
-      window.location.hash = '/chat';
-    }
+    function syncRouteFromHash() {
+      const nextRoute = routeFromHash(window.location.hash);
+      const nextHash = `#/${nextRoute}`;
 
-    function handleHashChange() {
-      setRoute(routeFromHash(window.location.hash));
+      if (window.location.hash !== nextHash) {
+        window.history.replaceState(null, '', nextHash);
+      }
+
+      setRoute(nextRoute);
       setIsSidebarOpen(false);
     }
 
-    window.addEventListener('hashchange', handleHashChange);
-    return () => window.removeEventListener('hashchange', handleHashChange);
+    syncRouteFromHash();
+    window.addEventListener('hashchange', syncRouteFromHash);
+    return () => window.removeEventListener('hashchange', syncRouteFromHash);
   }, []);
 
   useEffect(() => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -110,7 +110,7 @@ function formatSessionOptionLabel(session: ChatSessionSummary): string {
 
 function routeFromHash(hash: string): RouteId {
   const candidate = hash.replace(/^#\/?/, '') as RouteId;
-  return ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
+  return PRIMARY_NAV_ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
 }
 
 function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -332,18 +332,6 @@ button {
   line-height: 1.35;
 }
 
-.sidebar__status {
-  flex-shrink: 0;
-  padding: 0.28rem 0.58rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-muted);
-  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .sidebar__link:hover,
 .sidebar__link--active {
   transform: translateX(4px);

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -451,8 +451,12 @@ describe('ChatShell', () => {
     expect(nav?.textContent).toContain('Overview');
     expect(nav?.textContent).toContain('Chat');
     expect(nav?.textContent).toContain('Beasts');
-    expect(nav?.textContent).toContain('Sessions');
+    expect(nav?.textContent).toContain('Network');
     expect(nav?.textContent).toContain('Analytics');
+    expect(nav?.textContent).not.toContain('Sessions');
+    expect(nav?.textContent).not.toContain('Costs');
+    expect(nav?.textContent).not.toContain('Safety');
+    expect(nav?.textContent).not.toContain('Settings');
   });
 
   it('mounts the dashboard overview as a first-class navigation route', async () => {


### PR DESCRIPTION
## Summary
- Limits the dashboard primary navigation to live modules only
- Removes the unused Soon status chip styling
- Updates chat shell regression coverage for hidden placeholder modules

## Test Plan
- npm test --workspace @franken/web -- chat-shell.test.tsx
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #410