### PR TITLE
fix(orchestrator): log cli hard-kill failures

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -451,7 +451,15 @@ export class CliLlmAdapter implements IAdapter {
         timedOut = true;
         child.kill('SIGTERM');
         hardKillTimer = setTimeout(() => {
-          try { child.kill('SIGKILL'); } catch {}
+          try {
+            child.kill('SIGKILL');
+          } catch (error) {
+            console.warn('[CliLlmAdapter] Failed to hard-kill timed-out CLI process', {
+              signal: 'SIGKILL',
+              pid: child.pid,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
         }, 5_000);
         // Don't keep the event loop alive waiting on the hard-kill fallback;
         // short-lived invocations should exit promptly after a timeout reject.

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -474,6 +474,51 @@ describe('CliLlmAdapter', () => {
         }
       });
 
+      it('warns when the timeout hard-kill fallback fails', async () => {
+        vi.useFakeTimers();
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+          const killError = new Error('operation not permitted');
+          const spawnFn = (): ChildProcess => {
+            const proc = new EventEmitter() as ChildProcess;
+            Object.defineProperty(proc, 'stdin', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'stdout', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'stderr', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'pid', { value: 24680, writable: false });
+            Object.defineProperty(proc, 'kill', {
+              value: vi.fn((signal?: NodeJS.Signals | number) => {
+                if (signal === 'SIGKILL') throw killError;
+                return true;
+              }),
+              writable: false,
+            });
+            return proc;
+          };
+          const adapter = new CliLlmAdapter(
+            claudeProvider,
+            { ...baseOpts, timeoutMs: 50 },
+            spawnFn,
+          );
+
+          const result = adapter.execute({ prompt: 'test', maxTurns: 1 });
+          const assertion = expect(result).rejects.toThrow('CLI timeout after 50ms');
+
+          await vi.advanceTimersByTimeAsync(50);
+          await assertion;
+          await vi.advanceTimersByTimeAsync(5_000);
+
+          expect(warnSpy).toHaveBeenCalledWith('[CliLlmAdapter] Failed to hard-kill timed-out CLI process', {
+            signal: 'SIGKILL',
+            pid: 24680,
+            error: 'operation not permitted',
+          });
+        } finally {
+          warnSpy.mockRestore();
+          vi.useRealTimers();
+        }
+      });
+
       it('sets cwd to opts.workingDir', async () => {
         const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
         const adapter = new CliLlmAdapter(


### PR DESCRIPTION
## Summary
- replace the empty SIGKILL catch in CliLlmAdapter timeout cleanup with a warning that includes signal, pid, and error details
- add a regression test for failed hard-kill fallback logging

## Test Plan
- npm --workspace @franken/orchestrator test -- tests/unit/adapters/cli-llm-adapter.test.ts
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor && npm --workspace @franken/orchestrator run typecheck && npm --workspace @franken/orchestrator run build && npm --workspace @franken/orchestrator run lint

Closes #1213