### PR TITLE
fix(critique): detect ghost dependencies in re-exports

### DIFF
--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -110,6 +110,15 @@ function extractDependencySpecifiers(content: string): string[] {
       continue;
     }
 
+    if (startsWithKeyword(content, i, 'export')) {
+      const reexported = readStaticImportSpecifier(content, i + 'export'.length);
+      if (reexported) {
+        specifiers.push(reexported.value);
+        i = reexported.endIndex;
+      }
+      continue;
+    }
+
     if (startsWithKeyword(content, i, 'require')) {
       const required = readRequireSpecifier(content, i + 'require'.length);
       if (required) {

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -93,6 +93,35 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('detects ghost dependencies in named re-exports', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `export { pluginFactory } from 'ghost-package';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('detects ghost dependencies in namespace re-exports', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `export * from 'unknown-lib';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('unknown-lib');
+  });
+
+  it('continues to explicitly skip dynamic import expressions', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const plugin = await import('ghost-package');`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('ignores object-literal import keys', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const cfg = { import: { from: 'ghost-package' } };`;


### PR DESCRIPTION
## Summary
- scan static re-export declarations for package specifiers alongside imports
- add regression coverage for named and namespace re-exports
- document the current dynamic import skip with an explicit regression test

## Test Plan
- npm test -- --run tests/unit/evaluators/ghost-dependency.test.ts -t "re-exports|dynamic import" (fails before fix, passes after)
- npm test -- --run tests/unit/evaluators/ghost-dependency.test.ts
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/types
- npm run build --workspace @franken/critique

Closes #1165