### PR TITLE
fix(orchestrator): surface beast daemon dispatch failures

### DIFF
--- a/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
@@ -59,12 +59,7 @@ export class BeastDaemonDispatchAdapter {
       return null;
     }
 
-    let definitions: BeastDefinitionSummary[];
-    try {
-      definitions = await this.listDefinitions();
-    } catch {
-      return null;
-    }
+    const definitions = await this.listDefinitions();
     const definition = this.matchDefinition(input, definitions);
     if (!definition) {
       return null;

--- a/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
@@ -106,4 +106,38 @@ describe('BeastDaemonDispatchAdapter', () => {
     })).resolves.toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('propagates daemon catalog failures for launch requests', async () => {
+    const fetchMock = vi.fn(async () => Response.json({ error: 'unauthorized' }, { status: 401, statusText: 'Unauthorized' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new BeastDaemonDispatchAdapter({
+      baseUrl: 'http://127.0.0.1:4050',
+      operatorToken: 'daemon-token',
+    });
+
+    await expect(adapter.handle('spawn a martin beast', {
+      projectId: 'project',
+      sessionId: 'session-1',
+      transcript: [],
+    })).rejects.toThrow('Beast daemon request failed: 401 Unauthorized');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for launch requests only after a reachable daemon has no matching definition', async () => {
+    const fetchMock = vi.fn(async () => Response.json({ data: [{ id: 'chunk-plan', label: 'Chunk Plan' }] }));
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new BeastDaemonDispatchAdapter({
+      baseUrl: 'http://127.0.0.1:4050',
+      operatorToken: 'daemon-token',
+    });
+
+    await expect(adapter.handle('spawn a martin beast', {
+      projectId: 'project',
+      sessionId: 'session-1',
+      transcript: [],
+    })).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- propagate Beast daemon catalog failures for launch-like chat requests instead of converting them to a no-match null result
- keep ordinary chat turns and reachable-daemon no-match launch requests on the existing null path
- add targeted BeastDaemonDispatchAdapter coverage for failure vs no-match behavior

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
- npm run build
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint

Closes #1164
