### PR TITLE
fix(orchestrator): handle CLI provider result frames

### DIFF
--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -158,7 +158,8 @@ export class ClaudeCliAdapter implements ILlmProvider {
           typeof parsed['error'] === 'string'
             ? parsed['error']
             : ((parsed['error'] as Record<string, unknown> | undefined)?.['message'] as string | undefined) ?? '';
-        const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error';
+        const subtype = parsed['subtype'] as string | undefined;
+        const isErrorResult = parsed['is_error'] === true || subtype === 'error' || subtype?.startsWith('error_') === true;
         if (isErrorResult) {
           const message = resultText.trim() || errorText.trim() || 'claude returned an error result frame';
           yield {
@@ -176,6 +177,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
         if (usage) {
           totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
           totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
+        } else {
+          totalInputTokens = (parsed['total_input_tokens'] as number | undefined) ?? totalInputTokens;
+          totalOutputTokens = (parsed['total_output_tokens'] as number | undefined) ?? totalOutputTokens;
         }
         if (!emittedText) {
           yield {

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -300,14 +300,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
           message.includes('rate') || message.includes('overloaded');
         yield { type: 'error', error: message, retryable };
         return;
-      } else if (!emittedText && type !== 'message') {
-        const parts: string[] = [];
-        tryExtractTextFromNode(parsed, parts);
-        const text = parts.join('').trim();
-        if (text.length > 0) {
-          yield { type: 'text', content: text };
-          emittedText = true;
-        }
       }
     }
 

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -12,6 +12,7 @@ import type {
 } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
+import { tryExtractTextFromNode } from '../skills/providers/stream-json-utils.js';
 
 export interface ClaudeCliOptions {
   binaryPath?: string;
@@ -97,7 +98,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
   }
 
   buildArgs(request: LlmRequest): string[] {
-    const args = ['-p', '--output-format', 'stream-json'];
+    const args = ['-p', '--output-format', 'stream-json', '--verbose'];
     if (request.systemPrompt) {
       args.push('--append-system-prompt', request.systemPrompt);
     }
@@ -138,6 +139,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
       null;
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let emittedText = false;
 
     for await (const line of rl) {
       if (!line.trim()) continue;
@@ -150,7 +152,44 @@ export class ClaudeCliAdapter implements ILlmProvider {
 
       const type = parsed['type'] as string;
 
-      if (type === 'content_block_start') {
+      if (type === 'result') {
+        const resultText = typeof parsed['result'] === 'string' ? parsed['result'] : '';
+        const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error';
+        if (isErrorResult) {
+          yield {
+            type: 'error',
+            error: resultText.trim() || 'claude returned an error result frame',
+            retryable: resultText.includes('rate') || resultText.includes('overloaded'),
+          };
+          return;
+        }
+        if (resultText.trim().length > 0 && !emittedText) {
+          yield { type: 'text', content: resultText };
+          emittedText = true;
+        }
+        const usage = parsed['usage'] as Record<string, number> | undefined;
+        if (usage) {
+          totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
+          totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
+        }
+        if (!emittedText) {
+          yield {
+            type: 'error',
+            error: 'claude result frame contained no text output',
+            retryable: false,
+          };
+          return;
+        }
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            totalTokens: totalInputTokens + totalOutputTokens,
+          },
+        };
+        return;
+      } else if (type === 'content_block_start') {
         const block = parsed['content_block'] as Record<string, unknown>;
         if (block?.['type'] === 'tool_use') {
           currentToolUse = {
@@ -163,6 +202,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
         const delta = parsed['delta'] as Record<string, unknown>;
         if (delta?.['type'] === 'text_delta') {
           yield { type: 'text', content: delta['text'] as string };
+          emittedText = true;
         } else if (
           delta?.['type'] === 'input_json_delta' &&
           currentToolUse
@@ -216,6 +256,14 @@ export class ClaudeCliAdapter implements ILlmProvider {
           message.includes('rate') || message.includes('overloaded');
         yield { type: 'error', error: message, retryable };
         return;
+      } else if (!emittedText) {
+        const parts: string[] = [];
+        tryExtractTextFromNode(parsed, parts);
+        const text = parts.join('').trim();
+        if (text.length > 0) {
+          yield { type: 'text', content: text };
+          emittedText = true;
+        }
       }
     }
 
@@ -227,6 +275,12 @@ export class ClaudeCliAdapter implements ILlmProvider {
       yield {
         type: 'error',
         error: `claude process exited with code ${exitCode}`,
+        retryable: false,
+      };
+    } else if (!emittedText) {
+      yield {
+        type: 'error',
+        error: 'claude process exited without producing a result frame or text output',
         retryable: false,
       };
     }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -170,7 +170,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
           };
           return;
         }
-        if (resultText.trim().length > 0) {
+        if (resultText.trim().length > 0 && !emittedText) {
           yield { type: 'text', content: resultText };
           emittedText = true;
         }
@@ -252,8 +252,24 @@ export class ClaudeCliAdapter implements ILlmProvider {
           totalInputTokens = usage['input_tokens'] ?? 0;
         }
       } else if (type === 'assistant') {
+        const message = parsed['message'] as Record<string, unknown> | undefined;
+        const content = (message?.['content'] ?? parsed['content']) as unknown;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (!block || typeof block !== 'object') continue;
+            const record = block as Record<string, unknown>;
+            if (record['type'] === 'tool_use') {
+              yield {
+                type: 'tool_use',
+                id: (record['id'] as string) ?? crypto.randomUUID(),
+                name: record['name'] as string,
+                input: record['input'] ?? {},
+              };
+            }
+          }
+        }
         const parts: string[] = [];
-        tryExtractTextFromNode(parsed['message'] ?? parsed['content'] ?? parsed, parts);
+        tryExtractTextFromNode(content ?? message ?? parsed, parts);
         const text = parts.join('').trim();
         if (text.length > 0) {
           yield { type: 'text', content: text };

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -154,12 +154,17 @@ export class ClaudeCliAdapter implements ILlmProvider {
 
       if (type === 'result') {
         const resultText = typeof parsed['result'] === 'string' ? parsed['result'] : '';
+        const errorText =
+          typeof parsed['error'] === 'string'
+            ? parsed['error']
+            : ((parsed['error'] as Record<string, unknown> | undefined)?.['message'] as string | undefined) ?? '';
         const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error';
         if (isErrorResult) {
+          const message = resultText.trim() || errorText.trim() || 'claude returned an error result frame';
           yield {
             type: 'error',
-            error: resultText.trim() || 'claude returned an error result frame',
-            retryable: resultText.includes('rate') || resultText.includes('overloaded'),
+            error: message,
+            retryable: message.includes('rate') || message.includes('overloaded'),
           };
           return;
         }
@@ -238,6 +243,16 @@ export class ClaudeCliAdapter implements ILlmProvider {
         if (usage) {
           totalInputTokens = usage['input_tokens'] ?? 0;
         }
+      } else if (type === 'assistant') {
+        const parts: string[] = [];
+        tryExtractTextFromNode(parsed['message'] ?? parsed['content'] ?? parsed, parts);
+        const text = parts.join('').trim();
+        if (text.length > 0) {
+          yield { type: 'text', content: text };
+          emittedText = true;
+        }
+      } else if (type === 'user') {
+        continue;
       } else if (type === 'message_stop') {
         yield {
           type: 'done',
@@ -256,7 +271,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
           message.includes('rate') || message.includes('overloaded');
         yield { type: 'error', error: message, retryable };
         return;
-      } else if (!emittedText) {
+      } else if (!emittedText && type !== 'message') {
         const parts: string[] = [];
         tryExtractTextFromNode(parsed, parts);
         const text = parts.join('').trim();

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -140,6 +140,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let emittedText = false;
+    let emittedToolUse = false;
 
     for await (const line of rl) {
       if (!line.trim()) continue;
@@ -170,7 +171,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
           };
           return;
         }
-        if (resultText.trim().length > 0 && !emittedText) {
+        if (resultText.length > 0 && !emittedText) {
           yield { type: 'text', content: resultText };
           emittedText = true;
         }
@@ -185,7 +186,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
           usage?.['outputTokens'] ??
           (parsed['total_output_tokens'] as number | undefined) ??
           totalOutputTokens;
-        if (!emittedText) {
+        if (!emittedText && !emittedToolUse) {
           yield {
             type: 'error',
             error: 'claude result frame contained no text output',
@@ -236,6 +237,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
             name: currentToolUse.name,
             input,
           };
+          emittedToolUse = true;
           currentToolUse = null;
         }
       } else if (type === 'message_delta') {
@@ -263,26 +265,39 @@ export class ClaudeCliAdapter implements ILlmProvider {
           for (const block of content) {
             if (!block || typeof block !== 'object') continue;
             const record = block as Record<string, unknown>;
-            if (record['type'] === 'tool_use') {
+            if (record['type'] === 'text' && typeof record['text'] === 'string') {
+              yield { type: 'text', content: record['text'] };
+              emittedText = true;
+            } else if (record['type'] === 'tool_use') {
               yield {
                 type: 'tool_use',
                 id: (record['id'] as string) ?? crypto.randomUUID(),
                 name: record['name'] as string,
                 input: record['input'] ?? {},
               };
+              emittedToolUse = true;
             }
           }
-        }
-        const parts: string[] = [];
-        tryExtractTextFromNode(content ?? message ?? parsed, parts);
-        const text = parts.join('');
-        if (text.trim().length > 0) {
-          yield { type: 'text', content: text };
-          emittedText = true;
+        } else {
+          const parts: string[] = [];
+          tryExtractTextFromNode(content ?? message ?? parsed, parts);
+          const text = parts.join('');
+          if (text.length > 0) {
+            yield { type: 'text', content: text };
+            emittedText = true;
+          }
         }
       } else if (type === 'user') {
         continue;
       } else if (type === 'message_stop') {
+        if (!emittedText && !emittedToolUse) {
+          yield {
+            type: 'error',
+            error: 'claude stream completed without parseable text',
+            retryable: true,
+          };
+          return;
+        }
         yield {
           type: 'done',
           usage: {

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -253,6 +253,11 @@ export class ClaudeCliAdapter implements ILlmProvider {
         }
       } else if (type === 'assistant') {
         const message = parsed['message'] as Record<string, unknown> | undefined;
+        const usage = message?.['usage'] as Record<string, number> | undefined;
+        if (usage) {
+          totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
+          totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
+        }
         const content = (message?.['content'] ?? parsed['content']) as unknown;
         if (Array.isArray(content)) {
           for (const block of content) {
@@ -270,8 +275,8 @@ export class ClaudeCliAdapter implements ILlmProvider {
         }
         const parts: string[] = [];
         tryExtractTextFromNode(content ?? message ?? parsed, parts);
-        const text = parts.join('').trim();
-        if (text.length > 0) {
+        const text = parts.join('');
+        if (text.trim().length > 0) {
           yield { type: 'text', content: text };
           emittedText = true;
         }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -158,10 +158,11 @@ export class ClaudeCliAdapter implements ILlmProvider {
           typeof parsed['error'] === 'string'
             ? parsed['error']
             : ((parsed['error'] as Record<string, unknown> | undefined)?.['message'] as string | undefined) ?? '';
+        const errors = Array.isArray(parsed['errors']) ? parsed['errors'].filter((value): value is string => typeof value === 'string') : [];
         const subtype = parsed['subtype'] as string | undefined;
         const isErrorResult = parsed['is_error'] === true || subtype === 'error' || subtype?.startsWith('error_') === true;
         if (isErrorResult) {
-          const message = resultText.trim() || errorText.trim() || 'claude returned an error result frame';
+          const message = resultText.trim() || errorText.trim() || errors.join('\n').trim() || 'claude returned an error result frame';
           yield {
             type: 'error',
             error: message,
@@ -169,18 +170,21 @@ export class ClaudeCliAdapter implements ILlmProvider {
           };
           return;
         }
-        if (resultText.trim().length > 0 && !emittedText) {
+        if (resultText.trim().length > 0) {
           yield { type: 'text', content: resultText };
           emittedText = true;
         }
         const usage = parsed['usage'] as Record<string, number> | undefined;
-        if (usage) {
-          totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
-          totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
-        } else {
-          totalInputTokens = (parsed['total_input_tokens'] as number | undefined) ?? totalInputTokens;
-          totalOutputTokens = (parsed['total_output_tokens'] as number | undefined) ?? totalOutputTokens;
-        }
+        totalInputTokens =
+          usage?.['input_tokens'] ??
+          usage?.['inputTokens'] ??
+          (parsed['total_input_tokens'] as number | undefined) ??
+          totalInputTokens;
+        totalOutputTokens =
+          usage?.['output_tokens'] ??
+          usage?.['outputTokens'] ??
+          (parsed['total_output_tokens'] as number | undefined) ??
+          totalOutputTokens;
         if (!emittedText) {
           yield {
             type: 'error',

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -180,6 +180,7 @@ export class GeminiCliAdapter implements ILlmProvider {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let emittedText = false;
+    let emittedToolUse = false;
     let sawTerminalFrame = false;
 
     for await (const line of rl) {
@@ -263,7 +264,16 @@ export class GeminiCliAdapter implements ILlmProvider {
             name: block['name'] as string,
             input: block['input'] ?? {},
           };
+          emittedToolUse = true;
         }
+      } else if (type === 'tool_use') {
+        yield {
+          type: 'tool_use',
+          id: (parsed['tool_id'] as string) ?? (parsed['id'] as string) ?? crypto.randomUUID(),
+          name: (parsed['tool_name'] as string) ?? (parsed['name'] as string),
+          input: parsed['parameters'] ?? parsed['input'] ?? {},
+        };
+        emittedToolUse = true;
       } else if (type === 'message_delta') {
         const usage = parsed['usage'] as Record<string, number> | undefined;
         if (usage) {
@@ -289,7 +299,7 @@ export class GeminiCliAdapter implements ILlmProvider {
         }
       } else if (type === 'message_stop') {
         sawTerminalFrame = true;
-        if (!emittedText) {
+        if (!emittedText && !emittedToolUse) {
           yield {
             type: 'error',
             error: 'gemini stream completed without parseable text',
@@ -337,7 +347,7 @@ export class GeminiCliAdapter implements ILlmProvider {
         error: `gemini process exited with code ${exitCode}`,
         retryable: false,
       };
-    } else if (sawTerminalFrame && emittedText) {
+    } else if (sawTerminalFrame && (emittedText || emittedToolUse)) {
       yield {
         type: 'done',
         usage: {

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -281,8 +281,8 @@ export class GeminiCliAdapter implements ILlmProvider {
         if (role === 'assistant') {
           const parts: string[] = [];
           tryExtractTextFromNode(message?.['content'] ?? parsed['content'] ?? parsed['parts'] ?? parsed, parts);
-          const text = parts.join('').trim();
-          if (text.length > 0) {
+          const text = parts.join('');
+          if (text.trim().length > 0) {
             yield { type: 'text', content: text };
             emittedText = true;
           }
@@ -306,6 +306,8 @@ export class GeminiCliAdapter implements ILlmProvider {
           retryable: message.includes('rate') || message.includes('RESOURCE_EXHAUSTED'),
         };
         return;
+      } else if (type === 'tool_result') {
+        continue;
       } else if (!emittedText) {
         const parts: string[] = [];
         tryExtractTextFromNode(parsed, parts);

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -196,7 +196,7 @@ export class GeminiCliAdapter implements ILlmProvider {
       if (type === 'result') {
         const parts: string[] = [];
         tryExtractTextFromNode(parsed['result'] ?? parsed, parts);
-        const text = parts.join('').trim();
+        const text = parts.join('');
         const error = parsed['error'] as Record<string, unknown> | string | undefined;
         const errorText = typeof error === 'string' ? error : ((error?.['message'] as string | undefined) ?? '');
         const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error' || parsed['status'] === 'error';
@@ -209,7 +209,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           };
           return;
         }
-        if (text.length > 0 && !emittedText) {
+        if (text.trim().length > 0 && !emittedText) {
           yield { type: 'text', content: text };
           emittedText = true;
         }

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -289,6 +289,14 @@ export class GeminiCliAdapter implements ILlmProvider {
         }
       } else if (type === 'message_stop') {
         sawTerminalFrame = true;
+        if (!emittedText) {
+          yield {
+            type: 'error',
+            error: 'gemini stream completed without parseable text',
+            retryable: true,
+          };
+          return;
+        }
         yield {
           type: 'done',
           usage: {

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -15,6 +15,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
+import { tryExtractTextFromNode } from '../skills/providers/stream-json-utils.js';
 
 const MANAGED_START = '<!-- FRANKENBEAST MANAGED SECTION - DO NOT EDIT -->';
 const MANAGED_END = '<!-- END FRANKENBEAST SECTION -->';
@@ -178,6 +179,8 @@ export class GeminiCliAdapter implements ILlmProvider {
     const rl = createInterface({ input: proc.stdout! });
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let emittedText = false;
+    let sawTerminalFrame = false;
 
     for await (const line of rl) {
       if (!line.trim()) continue;
@@ -190,10 +193,51 @@ export class GeminiCliAdapter implements ILlmProvider {
 
       const type = parsed['type'] as string;
 
-      if (type === 'content_block_delta') {
+      if (type === 'result') {
+        const parts: string[] = [];
+        tryExtractTextFromNode(parsed['result'] ?? parsed, parts);
+        const text = parts.join('').trim();
+        const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error';
+        if (isErrorResult) {
+          yield {
+            type: 'error',
+            error: text || 'gemini returned an error result frame',
+            retryable: text.includes('rate') || text.includes('RESOURCE_EXHAUSTED'),
+          };
+          return;
+        }
+        if (text.length > 0 && !emittedText) {
+          yield { type: 'text', content: text };
+          emittedText = true;
+        }
+        const usage = parsed['usage'] as Record<string, number> | undefined;
+        if (usage) {
+          totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
+          totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
+        }
+        if (!emittedText) {
+          yield {
+            type: 'error',
+            error: 'gemini result frame contained no text output',
+            retryable: false,
+          };
+          return;
+        }
+        sawTerminalFrame = true;
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            totalTokens: totalInputTokens + totalOutputTokens,
+          },
+        };
+        return;
+      } else if (type === 'content_block_delta') {
         const delta = parsed['delta'] as Record<string, unknown>;
         if (delta?.['type'] === 'text_delta') {
           yield { type: 'text', content: delta['text'] as string };
+          emittedText = true;
         }
       } else if (type === 'content_block_start') {
         const block = parsed['content_block'] as Record<string, unknown>;
@@ -217,6 +261,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           totalInputTokens = usage['input_tokens'] ?? 0;
         }
       } else if (type === 'message_stop') {
+        sawTerminalFrame = true;
         yield {
           type: 'done',
           usage: {
@@ -234,6 +279,14 @@ export class GeminiCliAdapter implements ILlmProvider {
           retryable: message.includes('rate') || message.includes('RESOURCE_EXHAUSTED'),
         };
         return;
+      } else if (!emittedText) {
+        const parts: string[] = [];
+        tryExtractTextFromNode(parsed, parts);
+        const text = parts.join('').trim();
+        if (text.length > 0) {
+          yield { type: 'text', content: text };
+          emittedText = true;
+        }
       }
     }
 
@@ -247,7 +300,7 @@ export class GeminiCliAdapter implements ILlmProvider {
         error: `gemini process exited with code ${exitCode}`,
         retryable: false,
       };
-    } else {
+    } else if (sawTerminalFrame && emittedText) {
       yield {
         type: 'done',
         usage: {
@@ -255,6 +308,12 @@ export class GeminiCliAdapter implements ILlmProvider {
           outputTokens: totalOutputTokens,
           totalTokens: totalInputTokens + totalOutputTokens,
         },
+      };
+    } else {
+      yield {
+        type: 'error',
+        error: 'gemini process exited without producing a result frame or text output',
+        retryable: false,
       };
     }
   }

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -210,7 +210,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           };
           return;
         }
-        if (text.trim().length > 0 && !emittedText) {
+        if (text.length > 0 && !emittedText) {
           yield { type: 'text', content: text };
           emittedText = true;
         }
@@ -231,7 +231,7 @@ export class GeminiCliAdapter implements ILlmProvider {
             usage['totalOutputTokens'] ??
             totalOutputTokens;
         }
-        if (!emittedText) {
+        if (!emittedText && !emittedToolUse) {
           yield {
             type: 'error',
             error: 'gemini result frame contained no text output',
@@ -289,12 +289,29 @@ export class GeminiCliAdapter implements ILlmProvider {
         const message = parsed['message'] as Record<string, unknown> | undefined;
         const role = (message?.['role'] ?? parsed['role']) as string | undefined;
         if (role === 'assistant') {
-          const parts: string[] = [];
-          tryExtractTextFromNode(message?.['content'] ?? parsed['content'] ?? parsed['parts'] ?? parsed, parts);
-          const text = parts.join('');
-          if (text.trim().length > 0) {
-            yield { type: 'text', content: text };
-            emittedText = true;
+          const content = message?.['content'] ?? parsed['content'] ?? parsed['parts'];
+          if (Array.isArray(content)) {
+            const parts = content
+              .map((part) => (part && typeof part === 'object' ? (part as Record<string, unknown>)['text'] : part))
+              .filter((part): part is string => typeof part === 'string');
+            const text = parts.join('');
+            if (text.length > 0) {
+              yield { type: 'text', content: text };
+              emittedText = true;
+            }
+          } else if (typeof content === 'string') {
+            if (content.length > 0) {
+              yield { type: 'text', content };
+              emittedText = true;
+            }
+          } else {
+            const parts: string[] = [];
+            tryExtractTextFromNode(parsed, parts);
+            const text = parts.join('');
+            if (text.length > 0) {
+              yield { type: 'text', content: text };
+              emittedText = true;
+            }
           }
         }
       } else if (type === 'message_stop') {

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -197,12 +197,15 @@ export class GeminiCliAdapter implements ILlmProvider {
         const parts: string[] = [];
         tryExtractTextFromNode(parsed['result'] ?? parsed, parts);
         const text = parts.join('').trim();
-        const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error';
+        const error = parsed['error'] as Record<string, unknown> | string | undefined;
+        const errorText = typeof error === 'string' ? error : ((error?.['message'] as string | undefined) ?? '');
+        const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error' || parsed['status'] === 'error';
         if (isErrorResult) {
+          const message = text || errorText || 'gemini returned an error result frame';
           yield {
             type: 'error',
-            error: text || 'gemini returned an error result frame',
-            retryable: text.includes('rate') || text.includes('RESOURCE_EXHAUSTED'),
+            error: message,
+            retryable: message.includes('rate') || message.includes('RESOURCE_EXHAUSTED'),
           };
           return;
         }
@@ -210,10 +213,22 @@ export class GeminiCliAdapter implements ILlmProvider {
           yield { type: 'text', content: text };
           emittedText = true;
         }
-        const usage = parsed['usage'] as Record<string, number> | undefined;
+        const usage = (parsed['usage'] ?? parsed['stats']) as Record<string, number> | undefined;
         if (usage) {
-          totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
-          totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
+          totalInputTokens =
+            usage['input_tokens'] ??
+            usage['inputTokens'] ??
+            usage['prompt_tokens'] ??
+            usage['promptTokenCount'] ??
+            usage['totalInputTokens'] ??
+            totalInputTokens;
+          totalOutputTokens =
+            usage['output_tokens'] ??
+            usage['outputTokens'] ??
+            usage['completion_tokens'] ??
+            usage['candidatesTokenCount'] ??
+            usage['totalOutputTokens'] ??
+            totalOutputTokens;
         }
         if (!emittedText) {
           yield {
@@ -259,6 +274,18 @@ export class GeminiCliAdapter implements ILlmProvider {
         const usage = message?.['usage'] as Record<string, number> | undefined;
         if (usage) {
           totalInputTokens = usage['input_tokens'] ?? 0;
+        }
+      } else if (type === 'message') {
+        const message = parsed['message'] as Record<string, unknown> | undefined;
+        const role = (message?.['role'] ?? parsed['role']) as string | undefined;
+        if (role === 'assistant') {
+          const parts: string[] = [];
+          tryExtractTextFromNode(message?.['content'] ?? parsed['content'] ?? parsed['parts'] ?? parsed, parts);
+          const text = parts.join('').trim();
+          if (text.length > 0) {
+            yield { type: 'text', content: text };
+            emittedText = true;
+          }
         }
       } else if (type === 'message_stop') {
         sawTerminalFrame = true;

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -156,6 +156,22 @@ describe('ClaudeCliAdapter', () => {
       ]);
     });
 
+    it('reads top-level Claude result token totals', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'result', result: 'Final answer', total_input_tokens: 21, total_output_tokens: 8 }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 21, outputTokens: 8, totalTokens: 29 } });
+    });
+
+    it('treats Claude error result subtypes as failures', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'result', subtype: 'error_max_turns', result: '', error: 'turn limit reached' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'error', error: 'turn limit reached', retryable: false });
+    });
+
     it('ignores Claude user tool-result frames before the final result', async () => {
       mockSpawn([
         JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content: 'secret tool stdout' }] } }),

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -156,6 +156,23 @@ describe('ClaudeCliAdapter', () => {
       ]);
     });
 
+    it('ignores Claude user tool-result frames before the final result', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content: 'secret tool stdout' }] } }),
+        JSON.stringify({ type: 'result', result: 'Final assistant answer' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: 'Final assistant answer' });
+    });
+
+    it('preserves Claude result-frame error messages', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'result', is_error: true, result: '', error: 'permission denied' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'error', error: 'permission denied', retryable: false });
+    });
+
     it('errors when a successful process produces no parseable text or result frame', async () => {
       mockSpawn([], 0);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -182,6 +182,21 @@ describe('ClaudeCliAdapter', () => {
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 } });
     });
 
+    it('allows Claude tool-only result frames to complete without text', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ type: 'tool_use', id: 'tool-only', name: 'Read', input: { file_path: 'README.md' } }] },
+        }),
+        JSON.stringify({ type: 'result', result: '', total_input_tokens: 5, total_output_tokens: 0 }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'tool_use', id: 'tool-only', name: 'Read', input: { file_path: 'README.md' } },
+        { type: 'done', usage: { inputTokens: 5, outputTokens: 0, totalTokens: 5 } },
+      ]);
+    });
+
     it('emits Claude tool-use blocks from assistant frames', async () => {
       mockSpawn([
         JSON.stringify({
@@ -193,6 +208,29 @@ describe('ClaudeCliAdapter', () => {
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } });
       expect(events[1]).toEqual({ type: 'text', content: 'done' });
+    });
+
+    it('emits Claude assistant-frame content in provider order', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'I will read ' },
+              { type: 'tool_use', id: 'tool-ordered', name: 'Read', input: { file_path: 'README.md' } },
+              { type: 'text', text: ' after that.' },
+            ],
+          },
+        }),
+        JSON.stringify({ type: 'result', result: '' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'text', content: 'I will read ' },
+        { type: 'tool_use', id: 'tool-ordered', name: 'Read', input: { file_path: 'README.md' } },
+        { type: 'text', content: ' after that.' },
+        { type: 'done', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+      ]);
     });
 
     it('preserves Claude assistant-frame whitespace and usage', async () => {
@@ -248,6 +286,15 @@ describe('ClaudeCliAdapter', () => {
         error: 'claude process exited without producing a result frame or text output',
         retryable: false,
       });
+    });
+
+    it('fails closed when Claude message_stop arrives without text or tools', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'message_start', message: { usage: { input_tokens: 3 } } }),
+        JSON.stringify({ type: 'message_stop' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
+      expect(events[0]).toEqual({ type: 'error', error: 'claude stream completed without parseable text', retryable: true });
     });
 
     it('parses tool_use events with accumulated input', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -70,11 +70,12 @@ describe('ClaudeCliAdapter', () => {
   });
 
   describe('buildArgs()', () => {
-    it('includes -p and --output-format stream-json', () => {
+    it('includes -p, --output-format stream-json, and --verbose', () => {
       const args = adapter.buildArgs({ systemPrompt: '', messages: [] });
       expect(args).toContain('-p');
       expect(args).toContain('--output-format');
       expect(args).toContain('stream-json');
+      expect(args).toContain('--verbose');
     });
 
     it('adds --append-system-prompt when provided', () => {
@@ -138,6 +139,31 @@ describe('ClaudeCliAdapter', () => {
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'text', content: 'Hello world' });
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 50, outputTokens: 10, totalTokens: 60 } });
+    });
+
+    it('parses Claude CLI result wrapper frames', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'result',
+          result: 'Final Claude CLI answer',
+          usage: { input_tokens: 12, output_tokens: 7 },
+        }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'text', content: 'Final Claude CLI answer' },
+        { type: 'done', usage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 } },
+      ]);
+    });
+
+    it('errors when a successful process produces no parseable text or result frame', async () => {
+      mockSpawn([], 0);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
+      expect(events[0]).toEqual({
+        type: 'error',
+        error: 'claude process exited without producing a result frame or text output',
+        retryable: false,
+      });
     });
 
     it('parses tool_use events with accumulated input', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -158,7 +158,7 @@ describe('ClaudeCliAdapter', () => {
 
     it('reads top-level Claude result token totals', async () => {
       mockSpawn([
-        JSON.stringify({ type: 'result', result: 'Final answer', total_input_tokens: 21, total_output_tokens: 8 }),
+        JSON.stringify({ type: 'result', result: 'Final answer', usage: {}, total_input_tokens: 21, total_output_tokens: 8 }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 21, outputTokens: 8, totalTokens: 29 } });
@@ -166,10 +166,21 @@ describe('ClaudeCliAdapter', () => {
 
     it('treats Claude error result subtypes as failures', async () => {
       mockSpawn([
-        JSON.stringify({ type: 'result', subtype: 'error_max_turns', result: '', error: 'turn limit reached' }),
+        JSON.stringify({ type: 'result', subtype: 'error_max_turns', result: '', errors: ['turn limit reached'] }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'error', error: 'turn limit reached', retryable: false });
+    });
+
+    it('emits Claude result text even after assistant deltas', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'intermediate narration' } }),
+        JSON.stringify({ type: 'result', result: 'final answer', total_input_tokens: 4, total_output_tokens: 2 }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: 'intermediate narration' });
+      expect(events[1]).toEqual({ type: 'text', content: 'final answer' });
+      expect(events[2]).toEqual({ type: 'done', usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 } });
     });
 
     it('ignores Claude user tool-result frames before the final result', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -195,6 +195,22 @@ describe('ClaudeCliAdapter', () => {
       expect(events[1]).toEqual({ type: 'text', content: 'done' });
     });
 
+    it('preserves Claude assistant-frame whitespace and usage', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            usage: { input_tokens: 12, output_tokens: 6 },
+            content: [{ type: 'text', text: '  formatted answer\n' }],
+          },
+        }),
+        JSON.stringify({ type: 'message_stop' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: '  formatted answer\n' });
+      expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 12, outputTokens: 6, totalTokens: 18 } });
+    });
+
     it('ignores Claude user tool-result frames before the final result', async () => {
       mockSpawn([
         JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content: 'secret tool stdout' }] } }),

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -220,6 +220,18 @@ describe('ClaudeCliAdapter', () => {
       expect(events[0]).toEqual({ type: 'text', content: 'Final assistant answer' });
     });
 
+    it('ignores Claude system frames before the final result', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'system', subtype: 'hook_progress', output: 'internal hook status' }),
+        JSON.stringify({ type: 'result', result: 'Final assistant answer' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'text', content: 'Final assistant answer' },
+        { type: 'done', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+      ]);
+    });
+
     it('preserves Claude result-frame error messages', async () => {
       mockSpawn([
         JSON.stringify({ type: 'result', is_error: true, result: '', error: 'permission denied' }),

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -172,15 +172,27 @@ describe('ClaudeCliAdapter', () => {
       expect(events[0]).toEqual({ type: 'error', error: 'turn limit reached', retryable: false });
     });
 
-    it('emits Claude result text even after assistant deltas', async () => {
+    it('does not duplicate Claude result text after assistant deltas', async () => {
       mockSpawn([
-        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'intermediate narration' } }),
+        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'final answer' } }),
         JSON.stringify({ type: 'result', result: 'final answer', total_input_tokens: 4, total_output_tokens: 2 }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
-      expect(events[0]).toEqual({ type: 'text', content: 'intermediate narration' });
-      expect(events[1]).toEqual({ type: 'text', content: 'final answer' });
-      expect(events[2]).toEqual({ type: 'done', usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 } });
+      expect(events[0]).toEqual({ type: 'text', content: 'final answer' });
+      expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 } });
+    });
+
+    it('emits Claude tool-use blocks from assistant frames', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } }] },
+        }),
+        JSON.stringify({ type: 'result', result: 'done' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } });
+      expect(events[1]).toEqual({ type: 'text', content: 'done' });
     });
 
     it('ignores Claude user tool-result frames before the final result', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -136,11 +136,13 @@ describe('GeminiCliAdapter', () => {
       mockSpawn([
         JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ text: 'hello ' }] } }),
         JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ text: 'world\n\n' }] } }),
+        JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ text: '  \n' }] } }),
         JSON.stringify({ type: 'result', stats: { promptTokenCount: 1, candidatesTokenCount: 2 } }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'text', content: 'hello ' });
       expect(events[1]).toEqual({ type: 'text', content: 'world\n\n' });
+      expect(events[2]).toEqual({ type: 'text', content: '  \n' });
     });
 
     it('fails closed when Gemini message_stop arrives without text', async () => {
@@ -173,6 +175,18 @@ describe('GeminiCliAdapter', () => {
       const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'tool_use', id: 'tool-2', name: 'search', input: { query: 'docs' } });
       expect(events[1]).toEqual({ type: 'text', content: 'done' });
+    });
+
+    it('allows top-level Gemini tool-only result frames to complete without text', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'tool_use', tool_id: 'tool-3', tool_name: 'search', parameters: { query: 'docs' } }),
+        JSON.stringify({ type: 'result', stats: { promptTokenCount: 4, candidatesTokenCount: 0 } }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'tool_use', id: 'tool-3', name: 'search', input: { query: 'docs' } },
+        { type: 'done', usage: { inputTokens: 4, outputTokens: 0, totalTokens: 4 } },
+      ]);
     });
 
     it('ignores Gemini tool result output before final result text', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -143,6 +143,15 @@ describe('GeminiCliAdapter', () => {
       expect(events[1]).toEqual({ type: 'text', content: 'world\n\n' });
     });
 
+    it('fails closed when Gemini message_stop arrives without text', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'message_start', message: { usage: { input_tokens: 3 } } }),
+        JSON.stringify({ type: 'message_stop' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'error', error: 'gemini stream completed without parseable text', retryable: true });
+    });
+
     it('ignores Gemini tool result output before final result text', async () => {
       mockSpawn([
         JSON.stringify({ type: 'tool_result', output: 'raw tool stdout' }),

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -91,17 +91,25 @@ describe('GeminiCliAdapter', () => {
         JSON.stringify({
           type: 'result',
           result: { response: { text: 'Gemini wrapper answer' } },
-          usage: { input_tokens: 9, output_tokens: 4 },
+          usage: { input_tokens: 8, output_tokens: 3 },
         }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events).toEqual([
         { type: 'text', content: 'Gemini wrapper answer' },
-        { type: 'done', usage: { inputTokens: 9, outputTokens: 4, totalTokens: 13 } },
+        { type: 'done', usage: { inputTokens: 8, outputTokens: 3, totalTokens: 11 } },
       ]);
     });
 
-    it('parses Gemini result stats token totals', async () => {
+    it('preserves whitespace in Gemini result wrapper frames', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'result', result: { response: { text: '  code block\n' } } }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: '  code block\n' });
+    });
+
+    it('reads Gemini stats token totals from result frames', async () => {
       mockSpawn([
         JSON.stringify({
           type: 'result',

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -152,6 +152,29 @@ describe('GeminiCliAdapter', () => {
       expect(events[0]).toEqual({ type: 'error', error: 'gemini stream completed without parseable text', retryable: true });
     });
 
+    it('allows tool-only Gemini turns to complete without text', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'content_block_start', content_block: { type: 'tool_use', id: 'tool-1', name: 'read_file', input: { path: 'README.md' } } }),
+        JSON.stringify({ type: 'message_stop' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'tool_use', id: 'tool-1', name: 'read_file', input: { path: 'README.md' } },
+        { type: 'done', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+      ]);
+    });
+
+    it('emits top-level Gemini tool_use events', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'tool_use', tool_id: 'tool-2', tool_name: 'search', parameters: { query: 'docs' } }),
+        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'done' } }),
+        JSON.stringify({ type: 'message_stop' }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'tool_use', id: 'tool-2', name: 'search', input: { query: 'docs' } });
+      expect(events[1]).toEqual({ type: 'text', content: 'done' });
+    });
+
     it('ignores Gemini tool result output before final result text', async () => {
       mockSpawn([
         JSON.stringify({ type: 'tool_result', output: 'raw tool stdout' }),

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -124,6 +124,26 @@ describe('GeminiCliAdapter', () => {
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 } });
     });
 
+    it('preserves whitespace in Gemini assistant message chunks', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ text: 'hello ' }] } }),
+        JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ text: 'world\n\n' }] } }),
+        JSON.stringify({ type: 'result', stats: { promptTokenCount: 1, candidatesTokenCount: 2 } }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: 'hello ' });
+      expect(events[1]).toEqual({ type: 'text', content: 'world\n\n' });
+    });
+
+    it('ignores Gemini tool result output before final result text', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'tool_result', output: 'raw tool stdout' }),
+        JSON.stringify({ type: 'result', result: { response: { text: 'final text' } } }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: 'final text' });
+    });
+
     it('treats Gemini status error result frames as failures', async () => {
       mockSpawn([
         JSON.stringify({ type: 'result', status: 'error', error: { message: 'RESOURCE_EXHAUSTED quota' } }),

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -101,6 +101,37 @@ describe('GeminiCliAdapter', () => {
       ]);
     });
 
+    it('parses Gemini result stats token totals', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'result',
+          result: { response: { text: 'Gemini stats answer' } },
+          stats: { promptTokenCount: 11, candidatesTokenCount: 5 },
+        }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 11, outputTokens: 5, totalTokens: 16 } });
+    });
+
+    it('emits only assistant Gemini message chunks', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'message', message: { role: 'user', content: [{ text: 'echoed prompt' }] } }),
+        JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ text: 'assistant answer' }] } }),
+        JSON.stringify({ type: 'result', stats: { promptTokenCount: 1, candidatesTokenCount: 2 } }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'text', content: 'assistant answer' });
+      expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 } });
+    });
+
+    it('treats Gemini status error result frames as failures', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'result', status: 'error', error: { message: 'RESOURCE_EXHAUSTED quota' } }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events[0]).toEqual({ type: 'error', error: 'RESOURCE_EXHAUSTED quota', retryable: true });
+    });
+
     it('errors instead of returning empty success when the stream has no parseable text', async () => {
       mockSpawn([], 0);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -86,11 +86,38 @@ describe('GeminiCliAdapter', () => {
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 30, outputTokens: 8, totalTokens: 38 } });
     });
 
+    it('parses Gemini CLI result wrapper frames', async () => {
+      mockSpawn([
+        JSON.stringify({
+          type: 'result',
+          result: { response: { text: 'Gemini wrapper answer' } },
+          usage: { input_tokens: 9, output_tokens: 4 },
+        }),
+      ]);
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+      expect(events).toEqual([
+        { type: 'text', content: 'Gemini wrapper answer' },
+        { type: 'done', usage: { inputTokens: 9, outputTokens: 4, totalTokens: 13 } },
+      ]);
+    });
+
+    it('errors instead of returning empty success when the stream has no parseable text', async () => {
+      mockSpawn([], 0);
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
+      expect(events[0]).toEqual({
+        type: 'error',
+        error: 'gemini process exited without producing a result frame or text output',
+        retryable: false,
+      });
+    });
+
     it('emits error on non-zero exit code', async () => {
       mockSpawn([], 2);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
-      expect(events[0]!.type).toBe('error');
-      expect((events[0] as any).error).toContain('gemini process exited with code 2');
+      expect(events[0]).toMatchObject({
+        type: 'error',
+        error: expect.stringContaining('gemini process exited with code 2'),
+      });
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
@@ -107,6 +107,7 @@ describe('createLlmProvider', () => {
       '-p',
       '--output-format',
       'stream-json',
+      '--verbose',
       '--append-system-prompt',
       'test',
       '--model',

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -7,3 +7,6 @@
 
 ## 2026-07-08 — Externalized test credential edge cases
 - When replacing hard-coded test credentials with configurable helpers, treat blank env values as unset, derive invalid/negative auth tokens from the active configured token so they cannot collide, and avoid test-only env overrides that can turn an invalid value into a valid one.
+
+## 2026-07-08 — CLI provider stream-json edge cases
+- When normalizing Claude/Gemini CLI stream-json events, track tool emission separately from text so tool-only successful turns do not fail closed. Preserve provider content order for mixed text/tool blocks, preserve whitespace-only assistant text chunks, and add regressions for terminal frames with no text before retriggering Codex.


### PR DESCRIPTION
## Summary
- Add Claude CLI `--verbose` for `stream-json` print mode so registry-routed Claude invocations are accepted by the CLI.
- Parse actual CLI `result` wrapper frames for Claude and Gemini adapters, including token usage and error result frames.
- Fail closed when successful Claude/Gemini CLI processes produce no parseable text/result instead of returning empty success.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/providers/claude-cli-adapter.test.ts tests/unit/providers/gemini-cli-adapter.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings)
- npm run build
- git diff --check

Closes #1162
