### PR TITLE
docs(cli): document plain banner env toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,10 @@ frankenbeast issues --label bug --repo owner/repo
 --allow-origin <url>    CORS origin for dashboard
 ```
 
+### Operator environment variables
+
+Set `FRANKENBEAST_PLAIN_BANNER=1` to force the CLI startup banner to use the plain text fallback instead of the graphic/ANSI banner. This is useful for CI logs, terminals with limited ANSI or Unicode support, and log processors that should receive simple text. Leave the variable unset, or set it to any value other than `1`, to keep the normal graphic banner path.
+
 ### Project Layout
 
 Running `frankenbeast` in any project creates:

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ frankenbeast issues --label bug --repo owner/repo
 
 ### Operator environment variables
 
-Set `FRANKENBEAST_PLAIN_BANNER=1` to force the CLI startup banner to use the plain text fallback instead of the graphic/ANSI banner. This is useful for CI logs, terminals with limited ANSI or Unicode support, and log processors that should receive simple text. Leave the variable unset, or set it to any value other than `1`, to keep the normal graphic banner path.
+Set `FRANKENBEAST_PLAIN_BANNER=1` to force the CLI startup banner to use the plain ASCII fallback instead of the image-rendered graphic banner. This is useful for CI logs, terminals with limited image rendering support, and log processors that should receive a text-only banner layout. The fallback banner may still include ANSI color codes; leave the variable unset, or set it to any value other than `1`, to keep the normal graphic banner path.
 
 ### Project Layout
 


### PR DESCRIPTION
## Summary
- Document FRANKENBEAST_PLAIN_BANNER=1 in the root README operator environment variables section
- Clarify CI/log-processor use cases and that unset/non-1 values keep the normal graphic banner path

## Test Plan
- npm run typecheck
- npm run build
- npm run lint:security
- npm test

Closes #1264