### PR TITLE
fix(orchestrator): limit comms webhook request bodies

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -53,6 +53,7 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   app.get('/comms/health', (c) => c.json({ status: 'ok' }));
   app.use('/v1/comms', requestSizeLimit(DEFAULT_GENERIC_COMMS_BODY_SIZE));
   app.use('/v1/comms/*', requestSizeLimit(DEFAULT_GENERIC_COMMS_BODY_SIZE));
+  app.use('/webhooks/*', requestSizeLimit(DEFAULT_GENERIC_COMMS_BODY_SIZE));
 
   const slack = config.channels.slack;
   if (slack?.enabled && slack.token && slack.signingSecret) {

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -367,6 +367,36 @@ describe('commsRoutes', () => {
     await expect(corrupt.json()).resolves.toEqual(corruptError);
   });
 
+  it('rejects oversized webhook JSON before provider parsing when content length is unknown', async () => {
+    const app = commsRoutes({
+      config: enabledWebhookConfig(),
+      runtime: mockRuntime(),
+      webhookSignaturePolicy: 'local-dev-unsigned',
+    });
+    const oversizedBody = JSON.stringify({
+      type: 'url_verification',
+      challenge: 'blocked',
+      padding: 'x'.repeat(20 * 1024),
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversizedBody.slice(0, 512)));
+        controller.enqueue(new TextEncoder().encode(oversizedBody.slice(512)));
+        controller.close();
+      },
+    });
+
+    const res = await app.request('http://localhost/webhooks/slack/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: stream,
+      duplex: 'half',
+    } as RequestInit);
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ error: { code: 'PAYLOAD_TOO_LARGE' } });
+  });
+
   it('throws when runtime is not provided', () => {
     expect(() => commsRoutes({ config: minimalConfig() })).toThrow('CommsRuntimePort');
   });


### PR DESCRIPTION
## Summary
- Apply the existing 16 KiB request body limiter to provider webhook routes before channel parsers run.
- Add a regression test for oversized chunked webhook JSON without Content-Length.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/http/comms-routes.test.ts
- npm --prefix packages/franken-orchestrator test -- tests/unit/http/comms-routes.test.ts tests/unit/http/skill-routes-mounting.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator run lint

Closes #573