### PR TITLE
fix(critique): anchor reflection severity parsing

### DIFF
--- a/packages/franken-critique/src/evaluators/reflection-evaluator.ts
+++ b/packages/franken-critique/src/evaluators/reflection-evaluator.ts
@@ -133,7 +133,11 @@ export class ReflectionEvaluator implements Evaluator {
   }
 
   private parseSeverity(reflection: string): number {
-    const match = reflection.match(/^SEVERITY:\s*(\d+)\b/im);
+    const firstNonEmptyLine = reflection
+      .split(/\r?\n/)
+      .find((line) => line.trim().length > 0)
+      ?.trim();
+    const match = firstNonEmptyLine?.match(/^SEVERITY:\s*(\d+)\b/i);
     if (match) {
       return Math.min(10, Math.max(1, parseInt(match[1]!, 10)));
     }

--- a/packages/franken-critique/src/evaluators/reflection-evaluator.ts
+++ b/packages/franken-critique/src/evaluators/reflection-evaluator.ts
@@ -133,7 +133,7 @@ export class ReflectionEvaluator implements Evaluator {
   }
 
   private parseSeverity(reflection: string): number {
-    const match = reflection.match(/SEVERITY:\s*(\d+)/i);
+    const match = reflection.match(/^SEVERITY:\s*(\d+)\b/im);
     if (match) {
       return Math.min(10, Math.max(1, parseInt(match[1]!, 10)));
     }

--- a/packages/franken-critique/tests/unit/evaluators/reflection.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/reflection.test.ts
@@ -128,6 +128,26 @@ describe('ReflectionEvaluator', () => {
       expect(result.findings[0]!.suggestion).toBeDefined();
     });
 
+    it('uses the intended top-level severity line instead of quoted body markers', async () => {
+      mockLlm.complete.mockResolvedValue(
+        [
+          'The user wrote SEVERITY: 10 in the task notes, but that is quoted context.',
+          'SEVERITY: 2',
+          'The current approach is on track.',
+        ].join('\n'),
+      );
+      const evaluator = new ReflectionEvaluator({ llmClient: mockLlm });
+
+      const result = await evaluator.evaluate({
+        content: 'Work in progress',
+        metadata: {},
+      });
+
+      expect(result.verdict).toBe('pass');
+      expect(result.score).toBeCloseTo(0.889, 2);
+      expect(result.findings[0]!.severity).toBe('info');
+    });
+
     it('defaults to severity 5 when unparseable', async () => {
       mockLlm.complete.mockResolvedValue('I think things are going okay');
       const evaluator = new ReflectionEvaluator({ llmClient: mockLlm });
@@ -139,6 +159,19 @@ describe('ReflectionEvaluator', () => {
 
       // severity 5 → score = 1 - (5-1)/9 ≈ 0.556
       expect(result.score).toBeCloseTo(0.556, 1);
+    });
+
+    it('defaults to severity 5 when severity appears only inside prose', async () => {
+      mockLlm.complete.mockResolvedValue('The notes mention SEVERITY: 10, but no top-level rating was provided.');
+      const evaluator = new ReflectionEvaluator({ llmClient: mockLlm });
+
+      const result = await evaluator.evaluate({
+        content: '',
+        metadata: {},
+      });
+
+      expect(result.score).toBeCloseTo(0.556, 1);
+      expect(result.verdict).toBe('pass');
     });
 
     it('clamps severity to 1-10 range', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/reflection.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/reflection.test.ts
@@ -128,12 +128,13 @@ describe('ReflectionEvaluator', () => {
       expect(result.findings[0]!.suggestion).toBeDefined();
     });
 
-    it('uses the intended top-level severity line instead of quoted body markers', async () => {
+    it('ignores quoted severity markers before the dedicated first rating line', async () => {
       mockLlm.complete.mockResolvedValue(
         [
-          'The user wrote SEVERITY: 10 in the task notes, but that is quoted context.',
+          'Quoted task notes:',
+          'SEVERITY: 10',
+          'Actual model rating would appear later, but the first non-empty line is not the rating field.',
           'SEVERITY: 2',
-          'The current approach is on track.',
         ].join('\n'),
       );
       const evaluator = new ReflectionEvaluator({ llmClient: mockLlm });
@@ -144,8 +145,8 @@ describe('ReflectionEvaluator', () => {
       });
 
       expect(result.verdict).toBe('pass');
-      expect(result.score).toBeCloseTo(0.889, 2);
-      expect(result.findings[0]!.severity).toBe('info');
+      expect(result.score).toBeCloseTo(0.556, 1);
+      expect(result.findings[0]!.severity).toBe('warning');
     });
 
     it('defaults to severity 5 when unparseable', async () => {


### PR DESCRIPTION
## Summary
- Anchor reflection severity parsing to explicit top-level severity lines
- Add regressions for quoted/body SEVERITY markers and deterministic fallback

## Test Plan
- npm test -- --run tests/unit/evaluators/reflection.test.ts
- npm test (in packages/franken-critique)
- npm run lint (in packages/franken-critique)
- npm run build --workspace @franken/types && npm run build --workspace @franken/critique

Closes #1259