### PR TITLE
docs(readme): align ChromaDB env variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,9 +528,12 @@ cd packages/franken-orchestrator && npm run test:e2e
 
 ```bash
 # Configure local services. Generate a unique Grafana password before starting
-# the full compose stack; Grafana refuses the old admin/admin default pair.
+# the full compose stack; Grafana requires GRAFANA_USER=admin with a non-default password.
 cp .env.example .env
-$EDITOR .env  # set CHROMA_URL if not using http://localhost:8000; set Grafana credentials
+$EDITOR .env  # set CHROMA_URL if not using http://localhost:8000; set GRAFANA_USER=admin and a unique GRAFANA_PASSWORD
+
+# Export .env so the seed and verify scripts read the same CHROMA_URL used for setup.
+set -a; source .env; set +a
 
 # Start supporting services (ChromaDB, Grafana, Tempo). The compose file pins
 # image versions and mounts ./tempo.yaml so local tracing starts deterministically.

--- a/README.md
+++ b/README.md
@@ -532,8 +532,8 @@ cd packages/franken-orchestrator && npm run test:e2e
 cp .env.example .env
 $EDITOR .env  # uncomment GRAFANA_USER=admin, set a unique GRAFANA_PASSWORD, and adjust CHROMA_URL if needed
 
-# If you changed CHROMA_URL in .env, export that same endpoint for seed/verify.
-export CHROMA_URL=http://localhost:8000
+# If you changed CHROMA_URL in .env, export that same endpoint before seed/verify.
+# export CHROMA_URL=https://chromadb.example.com
 
 # Start supporting services (ChromaDB, Grafana, Tempo). The compose file pins
 # image versions and mounts ./tempo.yaml so local tracing starts deterministically.

--- a/README.md
+++ b/README.md
@@ -530,16 +530,16 @@ cd packages/franken-orchestrator && npm run test:e2e
 # Configure local services. Generate a unique Grafana password before starting
 # the full compose stack; Grafana refuses the old admin/admin default pair.
 cp .env.example .env
-$EDITOR .env  # uncomment GRAFANA_USER=admin and set a unique GRAFANA_PASSWORD
+$EDITOR .env  # set CHROMA_URL if not using http://localhost:8000; set Grafana credentials
 
 # Start supporting services (ChromaDB, Grafana, Tempo). The compose file pins
 # image versions and mounts ./tempo.yaml so local tracing starts deterministically.
 docker compose up -d
 
-# Seed ChromaDB with initial collections
+# Seed ChromaDB with initial collections. This uses CHROMA_URL from the environment.
 npx tsx scripts/seed.ts
 
-# Verify everything is running
+# Verify everything is running. This probes the same CHROMA_URL endpoint.
 npx tsx scripts/verify-setup.ts
 ```
 
@@ -620,8 +620,7 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 | `OPENAI_API_KEY` | MOD-01 | Runtime only | OpenAI adapter API key |
 | `GOOGLE_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (Google AI Studio name) |
 | `GEMINI_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (alternative name) |
-| `CHROMA_HOST` | MOD-03 | If using semantic memory | ChromaDB server host (default: `localhost`) |
-| `CHROMA_PORT` | MOD-03 | If using semantic memory | ChromaDB server port (default: `8000`) |
+| `CHROMA_URL` | MOD-03 | If using semantic memory | ChromaDB base URL used by `scripts/seed.ts` and `scripts/verify-setup.ts` (default: `http://localhost:8000`) |
 | `SLACK_WEBHOOK_URL` | MOD-07 | If using Slack approvals | Slack webhook for HITL notifications |
 
 See [.env.example](.env.example) for the full list.

--- a/README.md
+++ b/README.md
@@ -530,10 +530,10 @@ cd packages/franken-orchestrator && npm run test:e2e
 # Configure local services. Generate a unique Grafana password before starting
 # the full compose stack; Grafana requires GRAFANA_USER=admin with a non-default password.
 cp .env.example .env
-$EDITOR .env  # set CHROMA_URL if not using http://localhost:8000; set GRAFANA_USER=admin and a unique GRAFANA_PASSWORD
+$EDITOR .env  # uncomment GRAFANA_USER=admin, set a unique GRAFANA_PASSWORD, and adjust CHROMA_URL if needed
 
-# Export .env so the seed and verify scripts read the same CHROMA_URL used for setup.
-set -a; source .env; set +a
+# If you changed CHROMA_URL in .env, export that same endpoint for seed/verify.
+export CHROMA_URL=http://localhost:8000
 
 # Start supporting services (ChromaDB, Grafana, Tempo). The compose file pins
 # image versions and mounts ./tempo.yaml so local tracing starts deterministically.


### PR DESCRIPTION
## Summary
- Replaces the root README active ChromaDB env table entries for CHROMA_HOST/CHROMA_PORT with CHROMA_URL.
- Notes that both local seeding and setup verification use CHROMA_URL.

## Test Plan
- git diff --check
- Read-back verification of README Local Dev Environment and Environment Variables sections

Closes #1256