### PR TITLE
docs(beasts): document FBEAST_ROOT override

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,13 +327,12 @@ The shipped Hono HTTP surface is integrated in `@franken/orchestrator`'s chat se
 
 ### Beast project-root override
 
-Beast services normally anchor runtime state and child execution to the project root supplied by the caller. The supported fallback order is:
+Beast runtime code has two related project-root decisions:
 
-1. explicit runtime paths such as `paths.root`, `config.projectRoot`, or CLI flags such as `--base-dir` when a command exposes one;
-2. `FBEAST_ROOT`;
-3. the current working directory (`process.cwd()`).
+- **Service root:** `createBeastServices()` resolves `paths.root ?? process.env.FBEAST_ROOT ?? process.cwd()`. This root controls Beast service construction, host-process `cwd` containment, container `workspaceHostPath` mounts, worktree isolation, and run-config snapshots under `.fbeast/.build/run-configs`.
+- **Per-run child working directory:** built-in Beast definitions resolve `config.projectRoot ?? process.env.FBEAST_ROOT ?? process.cwd()` for the child process `cwd` when the run config omits `projectRoot`.
 
-Set `FBEAST_ROOT=/absolute/path/to/project` only when a wrapper, daemon, or service manager starts `frankenbeast chat-server`, `frankenbeast network`, `frankenbeast beasts-daemon`, or Beast dispatch commands from a directory that is not the intended project root and the command path does not pass an explicit root. This override affects Beast service construction, host-process `cwd` containment, container `workspaceHostPath` mounts, run-config snapshots under `.fbeast/.build/run-configs`, and the default working directory used by built-in Beast definitions when their config omits `projectRoot`. Historical ADRs and plan documents may mention `FBEAST_ROOT`, but this section is the operator-facing supported configuration reference.
+For CLI entrypoints such as `frankenbeast chat-server`, `frankenbeast network`, and `frankenbeast beasts-daemon`, prefer passing the explicit project root (`--base-dir /absolute/path/to/project`) because the CLI parses `--base-dir` with a `process.cwd()` default before constructing services. Use `FBEAST_ROOT=/absolute/path/to/project` only for callers that construct Beast services or dispatch built-in Beast runs without an explicit `paths.root`/`config.projectRoot`, and keep it aligned with `--base-dir` when both are present so the service root and child `cwd` stay inside the same checkout. Historical ADRs and plan documents may mention `FBEAST_ROOT`, but this section is the operator-facing supported configuration reference.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,16 @@ The shipped Hono HTTP surface is integrated in `@franken/orchestrator`'s chat se
 - **LLM API key** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY` for runtime use. Not needed for tests (mocked).
 - **Docker** — for running the local dev stack (ChromaDB, Grafana, Tempo).
 
+### Beast project-root override
+
+Beast services normally anchor runtime state and child execution to the project root supplied by the caller. The supported fallback order is:
+
+1. explicit runtime paths such as `paths.root`, `config.projectRoot`, or CLI flags such as `--base-dir` when a command exposes one;
+2. `FBEAST_ROOT`;
+3. the current working directory (`process.cwd()`).
+
+Set `FBEAST_ROOT=/absolute/path/to/project` only when a wrapper, daemon, or service manager starts `frankenbeast chat-server`, `frankenbeast network`, `frankenbeast beasts-daemon`, or Beast dispatch commands from a directory that is not the intended project root and the command path does not pass an explicit root. This override affects Beast service construction, host-process `cwd` containment, container `workspaceHostPath` mounts, run-config snapshots under `.fbeast/.build/run-configs`, and the default working directory used by built-in Beast definitions when their config omits `projectRoot`. Historical ADRs and plan documents may mention `FBEAST_ROOT`, but this section is the operator-facing supported configuration reference.
+
 ## Quick Start
 
 ```bash

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -66,7 +66,7 @@ npm --workspace @franken/orchestrator run chat-server -- --provider codex
 npm --workspace @franken/orchestrator run chat-server -- --allow-origin http://localhost:5173
 ```
 
-If the daemon or chat server is launched by a wrapper from outside the intended checkout, pass an explicit project-root option such as `--base-dir` when available. Otherwise, set `FBEAST_ROOT=/absolute/path/to/project`; the README's [Beast project-root override](../../README.md#beast-project-root-override) documents its precedence before `process.cwd()` and the affected Beast service, process/container, run-config snapshot, and child working-directory surfaces.
+If the daemon or chat server is launched by a wrapper from outside the intended checkout, pass the explicit CLI root with `--base-dir /absolute/path/to/project`. The README's [Beast project-root override](../../README.md#beast-project-root-override) documents the narrower `FBEAST_ROOT` fallback used by Beast service construction and built-in run configs when no explicit root is supplied; keep it aligned with `--base-dir` if both are set.
 
 If you bind to a non-loopback host or run in managed network mode, the server refuses to start without an operator token.
 

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -66,6 +66,8 @@ npm --workspace @franken/orchestrator run chat-server -- --provider codex
 npm --workspace @franken/orchestrator run chat-server -- --allow-origin http://localhost:5173
 ```
 
+If the daemon or chat server is launched by a wrapper from outside the intended checkout, pass an explicit project-root option such as `--base-dir` when available. Otherwise, set `FBEAST_ROOT=/absolute/path/to/project`; the README's [Beast project-root override](../../README.md#beast-project-root-override) documents its precedence before `process.cwd()` and the affected Beast service, process/container, run-config snapshot, and child working-directory surfaces.
+
 If you bind to a non-loopback host or run in managed network mode, the server refuses to start without an operator token.
 
 ## 2. Start the dashboard

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -58,7 +58,7 @@ fbeast mcp init --client=codex           # target Codex CLI
 
 This writes MCP entries into your client config (`~/.claude/settings.json`, `~/.gemini/settings.json`, etc.) and creates `.fbeast/beast.db`.
 
-If a daemon or wrapper starts the CLI from outside the target project, see the README's [Beast project-root override](../../README.md#beast-project-root-override) for the supported `FBEAST_ROOT` fallback. Prefer an explicit project-root option such as `--base-dir` when the command exposes one; otherwise `FBEAST_ROOT` is resolved before `process.cwd()` and controls Beast service state, process/container execution roots, run-config snapshots, and built-in Beast child working directories.
+`fbeast mcp init` and `fbeast mcp beast` operate on the current working directory. Run them from the target project checkout rather than relying on `FBEAST_ROOT`.
 
 ---
 
@@ -108,6 +108,8 @@ frankenbeast interview                                # interview only, saves de
 frankenbeast plan --design-doc design.md              # planning only, saves chunks
 frankenbeast run                                      # execute chunks from .fbeast/
 ```
+
+When a wrapper or service manager starts `frankenbeast` from outside the target project, pass `--base-dir /absolute/path/to/project` for CLI-managed roots. See the README's [Beast project-root override](../../README.md#beast-project-root-override) for the narrower `FBEAST_ROOT` fallback used by Beast service construction and built-in run configs when no explicit root is supplied.
 
 ---
 

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -58,6 +58,8 @@ fbeast mcp init --client=codex           # target Codex CLI
 
 This writes MCP entries into your client config (`~/.claude/settings.json`, `~/.gemini/settings.json`, etc.) and creates `.fbeast/beast.db`.
 
+If a daemon or wrapper starts the CLI from outside the target project, see the README's [Beast project-root override](../../README.md#beast-project-root-override) for the supported `FBEAST_ROOT` fallback. Prefer an explicit project-root option such as `--base-dir` when the command exposes one; otherwise `FBEAST_ROOT` is resolved before `process.cwd()` and controls Beast service state, process/container execution roots, run-config snapshots, and built-in Beast child working directories.
+
 ---
 
 ## 3. Activate beast mode (`fbeast mcp beast`)

--- a/docs/guides/run-network-operator.md
+++ b/docs/guides/run-network-operator.md
@@ -6,7 +6,7 @@ This guide starts Frankenbeast through the new `frankenbeast network` operator i
 
 `frankenbeast network up` selects services from canonical config and starts the enabled request-serving surfaces.
 
-When running `network up` from a service manager or wrapper whose current directory is not the target project, set the project root explicitly where available or use the supported `FBEAST_ROOT` fallback documented in the README's [Beast project-root override](../../README.md#beast-project-root-override). That root is used before `process.cwd()` for Beast services, run-config snapshots, process/container execution roots, and built-in Beast child working directories.
+When running `network up` from a service manager or wrapper whose current directory is not the target project, pass the project root explicitly with `--base-dir /absolute/path/to/project`. The README's [Beast project-root override](../../README.md#beast-project-root-override) documents the narrower `FBEAST_ROOT` fallback for Beast service construction and built-in run configs when no explicit root is supplied; keep it aligned with `--base-dir` if both are set.
 
 Current default local surface:
 

--- a/docs/guides/run-network-operator.md
+++ b/docs/guides/run-network-operator.md
@@ -6,6 +6,8 @@ This guide starts Frankenbeast through the new `frankenbeast network` operator i
 
 `frankenbeast network up` selects services from canonical config and starts the enabled request-serving surfaces.
 
+When running `network up` from a service manager or wrapper whose current directory is not the target project, set the project root explicitly where available or use the supported `FBEAST_ROOT` fallback documented in the README's [Beast project-root override](../../README.md#beast-project-root-override). That root is used before `process.cwd()` for Beast services, run-config snapshots, process/container execution roots, and built-in Beast child working directories.
+
 Current default local surface:
 
 - `beasts-daemon` (standalone Beast control plane on `:4050`)


### PR DESCRIPTION
## Summary
- Document `FBEAST_ROOT` as the supported Beast project-root override in the README
- Link CLI, network operator, and dashboard Beast deployment guides to the operator-facing reference
- Clarify precedence and affected service/execution/run-config/child working-directory surfaces

## Test Plan
- `python3` docs assertion for README anchor, guide links, and `FBEAST_ROOT` coverage
- `git diff --check`

Closes #1251
