### PR TITLE
docs(network): document managed network marker

### DIFF
--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -66,7 +66,7 @@ npm --workspace @franken/orchestrator run chat-server -- --provider codex
 npm --workspace @franken/orchestrator run chat-server -- --allow-origin http://localhost:5173
 ```
 
-If you bind to a non-loopback host or run in managed network mode, the server refuses to start without an operator token.
+If you bind to a non-loopback host, the server refuses to start without an operator token. The same fail-closed rule applies when `chat-server` is launched by `frankenbeast network`: the supervisor sets the internal `FRANKENBEAST_NETWORK_MANAGED=1` child-process marker, and managed `chat-server` requires an operator token even on loopback. Do not export this marker for normal standalone debugging; unset it for local standalone `chat-server` runs, or provide `FRANKENBEAST_BEAST_OPERATOR_TOKEN` / the configured secret-store token when intentionally exercising managed semantics.
 
 ## 2. Start the dashboard
 

--- a/docs/guides/run-network-operator.md
+++ b/docs/guides/run-network-operator.md
@@ -66,6 +66,24 @@ If the managed chat service is healthy, `frankenbeast chat` now attaches to that
 
 If the managed chat service is not healthy, `frankenbeast chat` falls back to standalone mode.
 
+## Managed Child-Process Marker
+
+`frankenbeast network` owns the internal `FRANKENBEAST_NETWORK_MANAGED=1` marker. The network supervisor sets it only for managed child services such as `chat-server`; operators normally should not export it before running standalone commands.
+
+Managed children use this marker for user-visible runtime behavior:
+
+- CLI children suppress the normal Frankenbeast startup banner so supervised logs stay focused on service output.
+- `chat-server` treats managed mode as exposed even when it binds to loopback (`127.0.0.1` or `localhost`) and fails closed unless an operator token is configured.
+
+If a standalone local `chat-server` run unexpectedly fails with an operator-token error on loopback, check for an inherited `FRANKENBEAST_NETWORK_MANAGED=1` and unset it before debugging standalone mode:
+
+```bash
+unset FRANKENBEAST_NETWORK_MANAGED
+npm --workspace @franken/orchestrator run chat-server
+```
+
+When intentionally running `chat-server` with managed semantics, keep `FRANKENBEAST_NETWORK_MANAGED=1` and provide the configured operator token, for example through `FRANKENBEAST_BEAST_OPERATOR_TOKEN` or the repo's configured secret-store token reference.
+
 ## Config Updates
 
 Inspect current operator-facing config:

--- a/packages/franken-orchestrator/src/network/network-help.ts
+++ b/packages/franken-orchestrator/src/network/network-help.ts
@@ -20,6 +20,14 @@ DESCRIPTION
   directly. Detached mode persists operator state so later commands can manage
   the same services.
 
+MANAGED CHILDREN
+  frankenbeast network sets FRANKENBEAST_NETWORK_MANAGED=1 for managed child
+  services. Treat it as a supervisor-owned marker, not a normal user toggle.
+  Managed children suppress the CLI banner, and managed chat-server fails closed
+  without an operator token even on loopback. Unset the marker for standalone
+  chat-server debugging, or provide FRANKENBEAST_BEAST_OPERATOR_TOKEN when
+  intentionally running with managed semantics.
+
 SECURITY MODES
   secure    Recommended. Uses operator-managed secret refs and stronger backends.
   insecure  Local-development convenience mode with redaction and no plaintext

--- a/packages/franken-orchestrator/tests/unit/network/network-help.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-help.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { renderNetworkHelp } from '../../../src/network/network-help.js';
+
+describe('renderNetworkHelp', () => {
+  it('documents the supervisor-owned managed network marker and side effects', () => {
+    const help = renderNetworkHelp();
+
+    expect(help).toContain('FRANKENBEAST_NETWORK_MANAGED=1');
+    expect(help).toContain('supervisor-owned marker');
+    expect(help).toContain('suppress the CLI banner');
+    expect(help).toContain('fails closed');
+    expect(help).toContain('FRANKENBEAST_BEAST_OPERATOR_TOKEN');
+  });
+});


### PR DESCRIPTION
## Summary
- Documents `FRANKENBEAST_NETWORK_MANAGED=1` as a supervisor-owned marker in the network operator guide.
- Explains managed child side effects: banner suppression and loopback `chat-server` token fail-closed behavior.
- Links deploy-beasts and `frankenbeast network help` language to the concrete env marker, with standalone troubleshooting guidance.

## Test Plan
- `npm --workspace @franken/orchestrator test -- --run tests/unit/network/network-help.test.ts tests/unit/cli/run.test.ts tests/integration/chat/chat-server.test.ts`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run build`

Closes #1257
