### PR TITLE
docs(providers): clarify historical adapter status

### DIFF
--- a/docs/guides/add-llm-provider.md
+++ b/docs/guides/add-llm-provider.md
@@ -43,3 +43,5 @@ npm --workspace @franken/orchestrator test
 ## What not to follow
 
 Older docs may mention `frankenfirewall/src/adapters`, `BaseAdapter`, `guardrails.config.json`, or a standalone firewall proxy. Those were pre-consolidation surfaces and are not the current provider extension path in this repo.
+
+Historical `GeminiAdapter` and `MistralAdapter` references belonged to the deleted `frankenfirewall` package. They were placeholder adapter shells, remained unimplemented, and are not supported public APIs in the current monorepo. Do not import, document, or extend those class names for new provider work. `GeminiProvider` is the supported Gemini CLI provider under `packages/franken-orchestrator/src/skills/providers/`. There is no supported Mistral provider until a new current-surface provider is implemented and registered there.

--- a/docs/issues/011-firewall-exports-unimplemented-adapters.md
+++ b/docs/issues/011-firewall-exports-unimplemented-adapters.md
@@ -7,6 +7,8 @@ Area: `frankenfirewall`
 
 The package root exports `GeminiAdapter` and `MistralAdapter`, but both classes are unfinished adapter shells that throw on every interface method.
 
+**Current status (2026-07)**: this is a historical `frankenfirewall` finding. The `frankenfirewall` package was removed during consolidation, and the old `GeminiAdapter` / `MistralAdapter` class names are not supported public APIs in the current monorepo. They should be treated as unimplemented historical placeholders, not as experimental adapters to build on. Current provider work belongs in `@franken/orchestrator` (for example, the supported `GeminiProvider` CLI provider); there is no supported Mistral provider today.
+
 ## Intended Behavior
 
 Anything exported from the package root should either be supported or clearly marked as internal/experimental and excluded from the main public API.
@@ -32,3 +34,8 @@ Anything exported from the package root should either be supported or clearly ma
 
 - Either implement these adapters, move them behind an experimental entrypoint, or stop exporting them from the package root.
 - Document support status explicitly.
+
+## Resolution note
+
+- The obsolete package no longer exports these adapter shells.
+- Their historical unimplemented / not supported status is documented here and in `docs/guides/add-llm-provider.md` so current contributors do not mistake the names for supported extension points.

--- a/tests/docs-issue-1092.test.ts
+++ b/tests/docs-issue-1092.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+describe('issue #1092 adapter status documentation', () => {
+  it('documents the historical GeminiAdapter and MistralAdapter status', () => {
+    const providerGuide = readDoc('docs/guides/add-llm-provider.md');
+    const historicalIssue = readDoc('docs/issues/011-firewall-exports-unimplemented-adapters.md');
+
+    for (const doc of [providerGuide, historicalIssue]) {
+      expect(doc).toContain('GeminiAdapter');
+      expect(doc).toContain('MistralAdapter');
+      expect(doc).toContain('unimplemented');
+      expect(doc).toContain('not supported');
+    }
+
+    expect(providerGuide).toContain('`GeminiProvider` is the supported Gemini CLI provider');
+    expect(providerGuide).toContain('There is no supported Mistral provider');
+    expect(historicalIssue).toContain('**Current status (2026-07)**');
+  });
+});


### PR DESCRIPTION
## Summary
- Document `GeminiAdapter` and `MistralAdapter` as historical, unimplemented `frankenfirewall` placeholders rather than supported current APIs
- Point provider contributors to the current `@franken/orchestrator` provider surfaces and supported `GeminiProvider`
- Add a docs regression test for issue #1092

## Test Plan
- npm run test:root -- tests/docs-issue-1092.test.ts
- npm run typecheck

Closes #1092