### PR TITLE
fix(mcp): surface unknown model costs

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import Database from 'better-sqlite3';
 import { createGovernorAdapter } from './governor-adapter.js';
 
 function tmpDbPath(): string {
@@ -90,5 +91,43 @@ describe('GovernorAdapter', () => {
       context: '{"value":"delete drop truncate rm -rf /"}',
     });
     expect(result.decision).toBe('approved');
+  });
+
+  it('reprices zero-cost known model rows in budget status', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const governor = createGovernorAdapter(dbPath);
+
+    const db = new Database(dbPath);
+    db.prepare(`
+      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('sess-known', 'gpt-4o', 1_000_000, 1_000_000, 0);
+    db.close();
+
+    await expect(governor.budgetStatus()).resolves.toEqual({
+      totalSpendUsd: 20,
+      byModel: [{ model: 'gpt-4o', costUsd: 20 }],
+    });
+  });
+
+  it('marks zero-cost unknown model rows in budget status', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const governor = createGovernorAdapter(dbPath);
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const db = new Database(dbPath);
+    db.prepare(`
+      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('sess-unknown', 'new-model-not-in-pricing', 1000, 500, 0);
+    db.close();
+
+    await expect(governor.budgetStatus()).resolves.toEqual({
+      totalSpendUsd: 0,
+      byModel: [{ model: 'new-model-not-in-pricing', costUsd: 0, unknownModel: true }],
+    });
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown model "new-model-not-in-pricing"'));
+
+    writeSpy.mockRestore();
   });
 });

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -134,6 +134,23 @@ describe('GovernorAdapter', () => {
     });
   });
 
+  it('preserves explicit zero-cost rows in budget status', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const governor = createGovernorAdapter(dbPath);
+
+    const db = new Database(dbPath);
+    db.prepare(`
+      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd, cost_source)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run('sess-free-known', 'gpt-4o', 1_000_000, 1_000_000, 0, 'explicit');
+    db.close();
+
+    await expect(governor.budgetStatus()).resolves.toEqual({
+      totalSpendUsd: 0,
+      byModel: [{ model: 'gpt-4o', costUsd: 0 }],
+    });
+  });
+
   it('marks zero-cost unknown model rows in budget status', async () => {
     const dbPath = tracked(tmpDbPath());
     const governor = createGovernorAdapter(dbPath);

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -110,6 +110,30 @@ describe('GovernorAdapter', () => {
     });
   });
 
+  it('reprices zero-cost rows before grouping budget status by model', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const governor = createGovernorAdapter(dbPath);
+
+    const db = new Database(dbPath);
+    const insert = db.prepare(`
+      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    insert.run('sess-known-legacy', 'gpt-4o', 1_000_000, 1_000_000, 0);
+    insert.run('sess-known-explicit', 'gpt-4o', 0, 0, 3.5);
+    insert.run('sess-unknown-legacy', 'new-model-not-in-pricing', 1000, 500, 0);
+    insert.run('sess-unknown-explicit', 'new-model-not-in-pricing', 0, 0, 1.25);
+    db.close();
+
+    await expect(governor.budgetStatus()).resolves.toEqual({
+      totalSpendUsd: 24.75,
+      byModel: [
+        { model: 'gpt-4o', costUsd: 23.5 },
+        { model: 'new-model-not-in-pricing', costUsd: 1.25, unknownModel: true },
+      ],
+    });
+  });
+
   it('marks zero-cost unknown model rows in budget status', async () => {
     const dbPath = tracked(tmpDbPath());
     const governor = createGovernorAdapter(dbPath);

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -1,5 +1,6 @@
 import { SkillTrigger, TriggerRegistry } from '@franken/governor';
 import type { TriggerResult, TriggerSeverity } from '@franken/governor';
+import { CostCalculator, DEFAULT_PRICING } from '@franken/observer';
 
 import { createSqliteStore } from '../shared/sqlite-store.js';
 
@@ -87,7 +88,7 @@ export interface GovernorCheckResult {
 
 export interface GovernorBudgetStatus {
   totalSpendUsd: number;
-  byModel: Array<{ model: string; costUsd: number }>;
+  byModel: Array<{ model: string; costUsd: number; unknownModel?: boolean }>;
 }
 
 export interface GovernorAdapter {
@@ -166,6 +167,11 @@ function assessAction(action: string, context: string): GovernorCheckResult {
 
 export function createGovernorAdapter(dbPath: string): GovernorAdapter {
   const store = createSqliteStore(dbPath);
+  const costCalculator = new CostCalculator(DEFAULT_PRICING, {
+    onUnknownModel: (model) => {
+      process.stderr.write(`[fbeast-governor] Unknown model "${model}" — budget status will report $0.0000 until pricing is configured.\n`);
+    },
+  });
 
   return {
     async check(input) {
@@ -181,14 +187,31 @@ export function createGovernorAdapter(dbPath: string): GovernorAdapter {
 
     async budgetStatus() {
       const rows = store.db.prepare(`
-        SELECT model, SUM(cost_usd) as total_cost
+        SELECT model, SUM(prompt_tokens) as prompt_tokens, SUM(completion_tokens) as completion_tokens, SUM(cost_usd) as total_cost
         FROM cost_ledger
         GROUP BY model
-      `).all() as Array<{ model: string; total_cost: number }>;
+      `).all() as Array<{ model: string; prompt_tokens: number; completion_tokens: number; total_cost: number }>;
+
+      const byModel = rows.map((row) => {
+        const hasPricing = DEFAULT_PRICING[row.model] !== undefined;
+        const costUsd = row.total_cost > 0
+          ? row.total_cost
+          : costCalculator.calculate({
+              model: row.model,
+              promptTokens: row.prompt_tokens,
+              completionTokens: row.completion_tokens,
+            });
+
+        return {
+          model: row.model,
+          costUsd,
+          ...(hasPricing || row.total_cost > 0 ? {} : { unknownModel: true }),
+        };
+      });
 
       return {
-        totalSpendUsd: rows.reduce((sum, row) => sum + row.total_cost, 0),
-        byModel: rows.map((row) => ({ model: row.model, costUsd: row.total_cost })),
+        totalSpendUsd: byModel.reduce((sum, row) => sum + row.costUsd, 0),
+        byModel,
       };
     },
   };

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -187,15 +187,15 @@ export function createGovernorAdapter(dbPath: string): GovernorAdapter {
 
     async budgetStatus() {
       const rows = store.db.prepare(`
-        SELECT model, prompt_tokens, completion_tokens, cost_usd
+        SELECT model, prompt_tokens, completion_tokens, cost_usd, cost_source
         FROM cost_ledger
-      `).all() as Array<{ model: string; prompt_tokens: number; completion_tokens: number; cost_usd: number }>;
+      `).all() as Array<{ model: string; prompt_tokens: number; completion_tokens: number; cost_usd: number; cost_source: string }>;
 
       const grouped = new Map<string, { model: string; costUsd: number; unknownModel?: boolean }>();
 
       for (const row of rows) {
         const hasPricing = DEFAULT_PRICING[row.model] !== undefined;
-        const costUsd = row.cost_usd > 0
+        const costUsd = row.cost_source === 'explicit' || row.cost_usd > 0
           ? row.cost_usd
           : costCalculator.calculate({
               model: row.model,
@@ -205,7 +205,7 @@ export function createGovernorAdapter(dbPath: string): GovernorAdapter {
         const current = grouped.get(row.model) ?? { model: row.model, costUsd: 0 };
 
         current.costUsd += costUsd;
-        if (row.cost_usd <= 0 && !hasPricing) {
+        if (row.cost_source !== 'explicit' && row.cost_usd <= 0 && !hasPricing) {
           current.unknownModel = true;
         }
 

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -187,27 +187,32 @@ export function createGovernorAdapter(dbPath: string): GovernorAdapter {
 
     async budgetStatus() {
       const rows = store.db.prepare(`
-        SELECT model, SUM(prompt_tokens) as prompt_tokens, SUM(completion_tokens) as completion_tokens, SUM(cost_usd) as total_cost
+        SELECT model, prompt_tokens, completion_tokens, cost_usd
         FROM cost_ledger
-        GROUP BY model
-      `).all() as Array<{ model: string; prompt_tokens: number; completion_tokens: number; total_cost: number }>;
+      `).all() as Array<{ model: string; prompt_tokens: number; completion_tokens: number; cost_usd: number }>;
 
-      const byModel = rows.map((row) => {
+      const grouped = new Map<string, { model: string; costUsd: number; unknownModel?: boolean }>();
+
+      for (const row of rows) {
         const hasPricing = DEFAULT_PRICING[row.model] !== undefined;
-        const costUsd = row.total_cost > 0
-          ? row.total_cost
+        const costUsd = row.cost_usd > 0
+          ? row.cost_usd
           : costCalculator.calculate({
               model: row.model,
               promptTokens: row.prompt_tokens,
               completionTokens: row.completion_tokens,
             });
+        const current = grouped.get(row.model) ?? { model: row.model, costUsd: 0 };
 
-        return {
-          model: row.model,
-          costUsd,
-          ...(hasPricing || row.total_cost > 0 ? {} : { unknownModel: true }),
-        };
-      });
+        current.costUsd += costUsd;
+        if (row.cost_usd <= 0 && !hasPricing) {
+          current.unknownModel = true;
+        }
+
+        grouped.set(row.model, current);
+      }
+
+      const byModel = Array.from(grouped.values());
 
       return {
         totalSpendUsd: byModel.reduce((sum, row) => sum + row.costUsd, 0),

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -132,6 +132,16 @@ function matchesDangerousPattern(action: string, context: string): boolean {
   return matchesDangerousActionName(action) || DANGEROUS_CONTEXT_PATTERNS.some((p) => p.test(combined));
 }
 
+function shouldRepriceStoredCost(row: { cost_source: string; cost_usd: number; model: string }): boolean {
+  if (row.cost_usd > 0 || row.cost_source === 'explicit') {
+    return false;
+  }
+  if (row.cost_source === 'legacy') {
+    return DEFAULT_PRICING[row.model] === undefined;
+  }
+  return true;
+}
+
 function assessAction(action: string, context: string): GovernorCheckResult {
   // Non-executing tools are approved without payload governance, so this
   // exemption holds on every path that reaches the shared governor (hook,
@@ -195,13 +205,13 @@ export function createGovernorAdapter(dbPath: string): GovernorAdapter {
 
       for (const row of rows) {
         const hasPricing = DEFAULT_PRICING[row.model] !== undefined;
-        const costUsd = row.cost_source === 'explicit' || row.cost_usd > 0
-          ? row.cost_usd
-          : costCalculator.calculate({
+        const costUsd = shouldRepriceStoredCost(row)
+          ? costCalculator.calculate({
               model: row.model,
               promptTokens: row.prompt_tokens,
               completionTokens: row.completion_tokens,
-            });
+            })
+          : row.cost_usd;
         const current = grouped.get(row.model) ?? { model: row.model, costUsd: 0 };
 
         current.costUsd += costUsd;

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -447,4 +447,28 @@ describe('ObserverAdapter', () => {
 
     writeSpy.mockRestore();
   });
+
+  it('preserves explicitly logged zero-cost rows in cost summaries', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const observer = createObserverAdapter(dbPath);
+
+    const logged = await observer.logCost({
+      sessionId: 'sess-explicit-zero',
+      model: 'gpt-4o',
+      promptTokens: 1_000_000,
+      completionTokens: 1_000_000,
+      costUsd: 0,
+    });
+    const summary = await observer.cost({ sessionId: 'sess-explicit-zero' });
+
+    expect(logged).toEqual({ costUsd: 0, unknownModel: false });
+    expect(summary.byModel).toEqual([
+      {
+        model: 'gpt-4o',
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        costUsd: 0,
+      },
+    ]);
+  });
 });

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -418,5 +418,33 @@ describe('ObserverAdapter', () => {
 
     expect(verification.ok).toBe(false);
     expect(verification.firstInvalid?.index).toBe(0);
+  });
+
+  it('warns and marks unknown auto-priced model costs as unpriced', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const observer = createObserverAdapter(dbPath);
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const logged = await observer.logCost({
+      sessionId: 'sess-unknown',
+      model: 'new-model-not-in-pricing',
+      promptTokens: 1000,
+      completionTokens: 500,
+    });
+    const summary = await observer.cost({ sessionId: 'sess-unknown' });
+
+    expect(logged).toEqual({ costUsd: 0, unknownModel: true });
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown model "new-model-not-in-pricing"'));
+    expect(summary.byModel).toEqual([
+      {
+        model: 'new-model-not-in-pricing',
+        promptTokens: 1000,
+        completionTokens: 500,
+        costUsd: 0,
+        unknownModel: true,
+      },
+    ]);
+
+    writeSpy.mockRestore();
   });
 });

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -26,6 +26,7 @@ export interface ObserverCostSummary {
     promptTokens: number;
     completionTokens: number;
     costUsd: number;
+    unknownModel?: boolean;
   }>;
 }
 
@@ -57,18 +58,29 @@ export interface ObserverCostInput {
   costUsd?: number;
 }
 
+export interface ObserverCostLogResult {
+  costUsd: number;
+  unknownModel: boolean;
+}
+
 export interface ObserverAdapter {
   log(input: ObserverLogInput): Promise<ObserverLogResult>;
-  logCost(input: ObserverCostInput): Promise<void>;
+  logCost(input: ObserverCostInput): Promise<ObserverCostLogResult>;
   cost(input: { sessionId?: string }): Promise<ObserverCostSummary>;
   trail(sessionId: string): Promise<ObserverTrailEntry[]>;
   verify(sessionId: string): Promise<ObserverVerifyResult>;
 }
 
+function hasDefaultPricing(model: string): boolean {
+  return DEFAULT_PRICING[model] !== undefined;
+}
+
 export function createObserverAdapter(dbPath: string): ObserverAdapter {
   const store = createSqliteStore(dbPath);
   const costCalculator = new CostCalculator(DEFAULT_PRICING, {
-    onUnknownModel: () => {},
+    onUnknownModel: (model) => {
+      process.stderr.write(`[fbeast-observer] Unknown model "${model}" — cost will be recorded as $0.0000 until pricing is configured.\n`);
+    },
   });
 
   return {
@@ -109,6 +121,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
     },
 
     async logCost(input) {
+      const unknownModel = input.costUsd === undefined && !hasDefaultPricing(input.model);
       const costUsd = input.costUsd ?? costCalculator.calculate({
         model: input.model,
         promptTokens: input.promptTokens,
@@ -118,6 +131,8 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
         VALUES (?, ?, ?, ?, ?)
       `).run(input.sessionId, input.model, input.promptTokens, input.completionTokens, costUsd);
+
+      return { costUsd, unknownModel };
     },
 
     async cost(input) {
@@ -139,12 +154,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         cost_usd: number;
       }>;
 
-      const grouped = new Map<string, {
-        model: string;
-        promptTokens: number;
-        completionTokens: number;
-        costUsd: number;
-      }>();
+      const grouped = new Map<string, ObserverCostSummary['byModel'][number]>();
 
       for (const row of rows) {
         const current = grouped.get(row.model) ?? {
@@ -156,6 +166,9 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
 
         current.promptTokens += row.prompt_tokens;
         current.completionTokens += row.completion_tokens;
+        if (row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
+          current.unknownModel = true;
+        }
         current.costUsd += row.cost_usd > 0
           ? row.cost_usd
           : costCalculator.calculate({

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -128,16 +128,16 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         completionTokens: input.completionTokens,
       });
       store.db.prepare(`
-        INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
-        VALUES (?, ?, ?, ?, ?)
-      `).run(input.sessionId, input.model, input.promptTokens, input.completionTokens, costUsd);
+        INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd, cost_source)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(input.sessionId, input.model, input.promptTokens, input.completionTokens, costUsd, input.costUsd === undefined ? 'computed' : 'explicit');
 
       return { costUsd, unknownModel };
     },
 
     async cost(input) {
       let sql = `
-        SELECT model, prompt_tokens, completion_tokens, cost_usd
+        SELECT model, prompt_tokens, completion_tokens, cost_usd, cost_source
         FROM cost_ledger
       `;
       const params: unknown[] = [];
@@ -152,6 +152,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         prompt_tokens: number;
         completion_tokens: number;
         cost_usd: number;
+        cost_source: string;
       }>;
 
       const grouped = new Map<string, ObserverCostSummary['byModel'][number]>();
@@ -166,10 +167,10 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
 
         current.promptTokens += row.prompt_tokens;
         current.completionTokens += row.completion_tokens;
-        if (row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
+        if (row.cost_source !== 'explicit' && row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
           current.unknownModel = true;
         }
-        current.costUsd += row.cost_usd > 0
+        current.costUsd += row.cost_source === 'explicit' || row.cost_usd > 0
           ? row.cost_usd
           : costCalculator.calculate({
               model: row.model,

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -75,6 +75,16 @@ function hasDefaultPricing(model: string): boolean {
   return DEFAULT_PRICING[model] !== undefined;
 }
 
+function shouldRepriceStoredCost(row: { cost_source: string; cost_usd: number; model: string }): boolean {
+  if (row.cost_usd > 0 || row.cost_source === 'explicit') {
+    return false;
+  }
+  if (row.cost_source === 'legacy') {
+    return !hasDefaultPricing(row.model);
+  }
+  return true;
+}
+
 export function createObserverAdapter(dbPath: string): ObserverAdapter {
   const store = createSqliteStore(dbPath);
   const costCalculator = new CostCalculator(DEFAULT_PRICING, {
@@ -170,13 +180,13 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         if (row.cost_source !== 'explicit' && row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
           current.unknownModel = true;
         }
-        current.costUsd += row.cost_source === 'explicit' || row.cost_usd > 0
-          ? row.cost_usd
-          : costCalculator.calculate({
+        current.costUsd += shouldRepriceStoredCost(row)
+          ? costCalculator.calculate({
               model: row.model,
               promptTokens: row.prompt_tokens,
               completionTokens: row.completion_tokens,
-            });
+            })
+          : row.cost_usd;
 
         grouped.set(row.model, current);
       }

--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -26,7 +26,7 @@ describe('Observer Server', () => {
   it('delegates log, logCost, cost, and trail calls to the observer adapter', async () => {
     const observer = {
       log: vi.fn().mockResolvedValue({ id: 42, hash: 'abc123' }),
-      logCost: vi.fn().mockResolvedValue(undefined),
+      logCost: vi.fn().mockResolvedValue({ costUsd: 0, unknownModel: true }),
       cost: vi.fn().mockResolvedValue({
         totalPromptTokens: 3000,
         totalCompletionTokens: 1300,
@@ -72,6 +72,8 @@ describe('Observer Server', () => {
       sessionId: 'sess-1', model: 'gpt-4o', promptTokens: 1000, completionTokens: 200,
     });
     expect(logCostResult.content[0]!.text).toContain('1000');
+    expect(logCostResult.content[0]!.text).toContain('$0.0000');
+    expect(logCostResult.content[0]!.text).toContain('unknown model');
 
     const costResult = await costTool.handler({ sessionId: 'sess-1' });
     expect(observer.cost).toHaveBeenCalledWith({ sessionId: 'sess-1' });

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import Database from 'better-sqlite3';
 
 function tmpDbPath(): string {
   const dir = join(tmpdir(), `fbeast-test-${randomUUID()}`);
@@ -62,6 +63,31 @@ describe('SqliteStore', () => {
     const timeout = store.db.pragma('busy_timeout', { simple: true });
     expect(timeout).toBe(5000);
 
+    store.close();
+  });
+
+  it('migrates existing cost ledgers with explicit source for legacy rows', () => {
+    const dbPath = tracked(tmpDbPath());
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE cost_ledger (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        prompt_tokens INTEGER NOT NULL DEFAULT 0,
+        completion_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_usd REAL NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
+      VALUES ('legacy', 'gpt-4o', 1000, 1000, 0);
+    `);
+    db.close();
+
+    const store = createSqliteStore(dbPath);
+    const row = store.db.prepare('SELECT cost_source FROM cost_ledger WHERE session_id = ?').get('legacy') as { cost_source: string };
+
+    expect(row.cost_source).toBe('explicit');
     store.close();
   });
 

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
@@ -46,6 +46,9 @@ describe('SqliteStore', () => {
     expect(tables).toContain('firewall_log');
     expect(tables).not.toContain('skill_state');
 
+    const costColumns = store.db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
+    expect(costColumns.map((column) => column.name)).toContain('cost_source');
+
     const walMode = store.db.pragma('journal_mode', { simple: true });
     expect(walMode).toBe('wal');
 

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
@@ -66,7 +66,7 @@ describe('SqliteStore', () => {
     store.close();
   });
 
-  it('migrates existing cost ledgers with explicit source for legacy rows', () => {
+  it('migrates existing cost ledgers with legacy source for pre-column rows', () => {
     const dbPath = tracked(tmpDbPath());
     const db = new Database(dbPath);
     db.exec(`
@@ -87,7 +87,7 @@ describe('SqliteStore', () => {
     const store = createSqliteStore(dbPath);
     const row = store.db.prepare('SELECT cost_source FROM cost_ledger WHERE session_id = ?').get('legacy') as { cost_source: string };
 
-    expect(row.cost_source).toBe('explicit');
+    expect(row.cost_source).toBe('legacy');
     store.close();
   });
 

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -75,7 +75,7 @@ export function createSqliteStore(dbPath: string): SqliteStore {
   const costColumns = db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
   if (!costColumns.some((column) => column.name === 'cost_source')) {
     try {
-      db.exec("ALTER TABLE cost_ledger ADD COLUMN cost_source TEXT NOT NULL DEFAULT 'explicit'");
+      db.exec("ALTER TABLE cost_ledger ADD COLUMN cost_source TEXT NOT NULL DEFAULT 'legacy'");
     } catch (error) {
       if (!(error instanceof Error) || !/duplicate column name: cost_source/i.test(error.message)) {
         throw error;

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -43,6 +43,7 @@ const SCHEMA = `
     prompt_tokens INTEGER NOT NULL DEFAULT 0,
     completion_tokens INTEGER NOT NULL DEFAULT 0,
     cost_usd REAL NOT NULL DEFAULT 0,
+    cost_source TEXT NOT NULL DEFAULT 'computed',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
 
@@ -71,6 +72,10 @@ export function createSqliteStore(dbPath: string): SqliteStore {
   db.pragma('journal_mode = WAL');
   db.pragma('busy_timeout = 5000');
   db.exec(SCHEMA);
+  const costColumns = db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
+  if (!costColumns.some((column) => column.name === 'cost_source')) {
+    db.exec("ALTER TABLE cost_ledger ADD COLUMN cost_source TEXT NOT NULL DEFAULT 'computed'");
+  }
 
   return {
     db,

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -74,7 +74,13 @@ export function createSqliteStore(dbPath: string): SqliteStore {
   db.exec(SCHEMA);
   const costColumns = db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
   if (!costColumns.some((column) => column.name === 'cost_source')) {
-    db.exec("ALTER TABLE cost_ledger ADD COLUMN cost_source TEXT NOT NULL DEFAULT 'computed'");
+    try {
+      db.exec("ALTER TABLE cost_ledger ADD COLUMN cost_source TEXT NOT NULL DEFAULT 'explicit'");
+    } catch (error) {
+      if (!(error instanceof Error) || !/duplicate column name: cost_source/i.test(error.message)) {
+        throw error;
+      }
+    }
   }
 
   return {

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -340,8 +340,9 @@ const TOOLS: ToolFull[] = [
       const promptTokens = Number(args['promptTokens']);
       const completionTokens = Number(args['completionTokens']);
       const costUsdArg = args['costUsd'] != null ? Number(args['costUsd']) : undefined;
-      await observer.logCost({ sessionId, model, promptTokens, completionTokens, ...(costUsdArg != null ? { costUsd: costUsdArg } : {}) });
-      return { content: [{ type: 'text', text: `Logged cost: ${promptTokens}+${completionTokens} tokens for ${model}` }] };
+      const result = await observer.logCost({ sessionId, model, promptTokens, completionTokens, ...(costUsdArg != null ? { costUsd: costUsdArg } : {}) });
+      const pricingNote = result.unknownModel ? ' (unknown model — not priced)' : '';
+      return { content: [{ type: 'text', text: `Logged cost: ${promptTokens}+${completionTokens} tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}` }] };
     },
   },
   {
@@ -360,7 +361,7 @@ const TOOLS: ToolFull[] = [
       if (summary.byModel.length === 0) {
         return { content: [{ type: 'text', text: 'No cost data recorded.' }] };
       }
-      const lines = [`## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`, '', ...summary.byModel.map((row) => `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion = $${row.costUsd.toFixed(4)}`), '', `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion = $${summary.totalCostUsd.toFixed(4)}`];
+      const lines = [`## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`, '', ...summary.byModel.map((row) => `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`), '', `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion = $${summary.totalCostUsd.toFixed(4)}`];
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     },
   },
@@ -439,7 +440,7 @@ const TOOLS: ToolFull[] = [
       if (summary.byModel.length === 0) {
         return { content: [{ type: 'text', text: 'No cost data recorded yet.' }] };
       }
-      const lines = [`## Budget Status`, '', ...summary.byModel.map((row) => `- ${row.model}: $${row.costUsd.toFixed(4)}`), '', `**Total spend:** $${summary.totalSpendUsd.toFixed(4)}`];
+      const lines = [`## Budget Status`, '', ...summary.byModel.map((row) => `- ${row.model}: $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`), '', `**Total spend:** $${summary.totalSpendUsd.toFixed(4)}`];
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     },
   },


### PR DESCRIPTION
## Summary
- emit stderr warnings when MCP observer/governor encounter unknown auto-priced models instead of silently swallowing them
- include explicit `$0.0000 (unknown model — not priced)` markers in observer log/cost and governor budget tool output
- align governor budget status with observer cost summaries by repricing zero-cost known-model rows and marking unknown zero-cost rows

## Test Plan
- npm test --workspace @franken/mcp-suite -- src/adapters/observer-adapter.test.ts src/adapters/governor-adapter.test.ts src/servers/observer.test.ts src/servers/governor.test.ts
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite
- npm run lint:any -- --scope packages/franken-mcp-suite
- npm test --workspace @franken/mcp-suite

Closes #1163
