### PR TITLE
docs(readme): document module env toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,13 +47,14 @@ FRANKEN_MIN_CRITIQUE_SCORE=0.7
 
 # ── Safety/module escape hatches ──
 # Leave safety modules enabled unless you intentionally disable one for local debugging.
+# Only the literal value "false" disables these modules; unset/any other value leaves them enabled by default.
 # FRANKENBEAST_MODULE_MEMORY=true
 # FRANKENBEAST_MODULE_PLANNER=true
 # FRANKENBEAST_MODULE_CRITIQUE=true
 # FRANKENBEAST_MODULE_GOVERNOR=true
-# Unsafe: allow missing safety packages to fall back to stubs.
+# Unsafe: only literal "1" allows missing safety packages to fall back to stubs.
 # FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=0
-# Trusted CI/headless only: allow required HITL gates without an interactive TTY.
+# Trusted CI/headless only: only literal "1" allows required HITL gates without an interactive TTY.
 # FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=0
 
 # ── Advanced local diagnostics ──

--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,8 @@ FRANKEN_MIN_CRITIQUE_SCORE=0.7
 
 # ── Safety/module escape hatches ──
 # Leave safety modules enabled unless you intentionally disable one for local debugging.
-# Only the literal value "false" disables these modules; unset/any other value leaves them enabled by default.
+# Memory/planner values feed config snapshots/child env; current local CLI adapter wiring is not disabled by them.
+# Only the literal value "false" disables active critique/governor gates when their explicit config keys are unset.
 # FRANKENBEAST_MODULE_MEMORY=true
 # FRANKENBEAST_MODULE_PLANNER=true
 # FRANKENBEAST_MODULE_CRITIQUE=true

--- a/README.md
+++ b/README.md
@@ -634,12 +634,24 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 | `GEMINI_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (alternative name) |
 | `CHROMA_URL` | MOD-03 | If using semantic memory | ChromaDB base URL used by `scripts/seed.ts` and `scripts/verify-setup.ts` (default: `http://localhost:8000`) |
 | `SLACK_WEBHOOK_URL` | MOD-07 | If using Slack approvals | Slack webhook for HITL notifications |
+| `FRANKENBEAST_MODULE_MEMORY` | MOD-03 | Optional | Memory module toggle. Only the literal value `false` disables it; any other value, unset included, leaves it enabled when no explicit config is provided. |
+| `FRANKENBEAST_MODULE_PLANNER` | MOD-04 | Optional | Planner module toggle. Only literal `false` disables it; otherwise it is enabled by default when no explicit config is provided. |
+| `FRANKENBEAST_MODULE_CRITIQUE` | MOD-06 | Optional | Critique safety module toggle. Only literal `false` disables it; otherwise it is enabled by default when no explicit config is provided. |
+| `FRANKENBEAST_MODULE_GOVERNOR` | MOD-07 | Optional | Governor safety module toggle. Only literal `false` disables it; otherwise it is enabled by default when no explicit config is provided. |
+| `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES` | MOD-06/MOD-07 | Unsafe override | Set to literal `1` to allow enabled critique/governor packages that cannot be imported to fall back to all-pass stubs. Leave unset unless intentionally accepting degraded safety in local/debug runs. |
+| `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL` | MOD-07 | Trusted CI/headless only | Set to literal `1` to allow required HITL approvals in non-interactive runs. Without it, required HITL gates fail closed outside an interactive TTY. |
 
-See [.env.example](.env.example) for the full list.
+See [.env.example](.env.example) for the full local-development list. Keep `.env.example` and this table aligned when adding operator-facing environment controls.
 
 ### Module Configuration
 
-All modules use **dependency injection** — configuration is passed via constructor arguments, not globals or environment variables.
+Runtime modules use **dependency injection** first: explicit constructor, CLI, or run-config inputs win over environment variables. For the local CLI path, selected operator controls then fall back to environment variables, and defaults apply last. Module enablement precedence is:
+
+1. Explicit module config (`modules` in run config or CLI dependency options).
+2. `FRANKENBEAST_MODULE_MEMORY`, `FRANKENBEAST_MODULE_PLANNER`, `FRANKENBEAST_MODULE_CRITIQUE`, or `FRANKENBEAST_MODULE_GOVERNOR` when no explicit module config is present.
+3. Enabled-by-default behavior when neither explicit config nor a literal `false` env toggle is provided.
+
+Safety-critical critique/governor imports fail closed when the module is enabled but its package is missing. `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` is the explicit unsafe escape hatch that keeps the run going with passthrough stubs; prefer installing the package or setting an explicit module config instead.
 
 ```typescript
 // Orchestrator — via config file or CLI flags

--- a/README.md
+++ b/README.md
@@ -634,11 +634,11 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 | `GEMINI_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (alternative name) |
 | `CHROMA_URL` | MOD-03 | If using semantic memory | ChromaDB base URL used by `scripts/seed.ts` and `scripts/verify-setup.ts` (default: `http://localhost:8000`) |
 | `SLACK_WEBHOOK_URL` | MOD-07 | If using Slack approvals | Slack webhook for HITL notifications |
-| `FRANKENBEAST_MODULE_MEMORY` | MOD-03 | Optional | Memory module toggle. Only the literal value `false` disables it; any other value, unset included, leaves it enabled when no explicit config is provided. |
-| `FRANKENBEAST_MODULE_PLANNER` | MOD-04 | Optional | Planner module toggle. Only literal `false` disables it; otherwise it is enabled by default when no explicit config is provided. |
-| `FRANKENBEAST_MODULE_CRITIQUE` | MOD-06 | Optional | Critique safety module toggle. Only literal `false` disables it; otherwise it is enabled by default when no explicit config is provided. |
-| `FRANKENBEAST_MODULE_GOVERNOR` | MOD-07 | Optional | Governor safety module toggle. Only literal `false` disables it; otherwise it is enabled by default when no explicit config is provided. |
-| `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES` | MOD-06/MOD-07 | Unsafe override | Set to literal `1` to allow enabled critique/governor packages that cannot be imported to fall back to all-pass stubs. Leave unset unless intentionally accepting degraded safety in local/debug runs. |
+| `FRANKENBEAST_MODULE_MEMORY` | MOD-03 | Optional | Memory module config fallback and Beast child-env toggle. Only the literal value `false` records it as disabled when the `memory` config key is unset; current local CLI wiring still constructs the real memory adapter. |
+| `FRANKENBEAST_MODULE_PLANNER` | MOD-04 | Optional | Planner module config fallback and Beast child-env toggle. Only literal `false` records it as disabled when the `planner` config key is unset; current local CLI wiring still uses the graph-builder path. |
+| `FRANKENBEAST_MODULE_CRITIQUE` | MOD-06 | Optional | Active critique safety-module toggle. Only literal `false` disables critique when the `critique` config key is unset; otherwise it is enabled by default. |
+| `FRANKENBEAST_MODULE_GOVERNOR` | MOD-07 | Optional | Active governor safety-module toggle. Only literal `false` disables governor when the `governor` config key is unset; otherwise it is enabled by default. |
+| `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES` | MOD-06/MOD-07 | Unsafe override | Set to literal `1` to allow enabled critique/governor packages that are not installed to fall back to all-pass stubs. Leave unset unless intentionally accepting degraded safety in local/debug runs. |
 | `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL` | MOD-07 | Trusted CI/headless only | Set to literal `1` to allow required HITL approvals in non-interactive runs. Without it, required HITL gates fail closed outside an interactive TTY. |
 
 See [.env.example](.env.example) for the full local-development list. Keep `.env.example` and this table aligned when adding operator-facing environment controls.
@@ -647,9 +647,9 @@ See [.env.example](.env.example) for the full local-development list. Keep `.env
 
 Runtime modules use **dependency injection** first: explicit constructor, CLI, or run-config inputs win over environment variables. For the local CLI path, selected operator controls then fall back to environment variables, and defaults apply last. Module enablement precedence is:
 
-1. Explicit module config (`modules` in run config or CLI dependency options).
-2. `FRANKENBEAST_MODULE_MEMORY`, `FRANKENBEAST_MODULE_PLANNER`, `FRANKENBEAST_MODULE_CRITIQUE`, or `FRANKENBEAST_MODULE_GOVERNOR` when no explicit module config is present.
-3. Enabled-by-default behavior when neither explicit config nor a literal `false` env toggle is provided.
+1. Explicit value for that module key (`modules.memory`, `modules.planner`, `modules.critique`, or `modules.governor`) in run config or CLI dependency options.
+2. The matching environment fallback (`FRANKENBEAST_MODULE_MEMORY`, `FRANKENBEAST_MODULE_PLANNER`, `FRANKENBEAST_MODULE_CRITIQUE`, or `FRANKENBEAST_MODULE_GOVERNOR`) when that specific module key is unset.
+3. Enabled-by-default behavior when neither the module key nor a literal `false` env toggle is provided.
 
 Safety-critical critique/governor imports fail closed when the module is enabled but its package is missing. `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` is the explicit unsafe escape hatch that keeps the run going with passthrough stubs; prefer installing the package or setting an explicit module config instead.
 


### PR DESCRIPTION
## Summary
- Document live FRANKENBEAST_MODULE_* toggles in the root README
- Add safety override semantics for missing safety modules and non-interactive HITL approvals
- Clarify module configuration precedence and align .env.example comments

## Test Plan
- npm run check:package-manager
- grep README/.env.example for FRANKENBEAST_MODULE_* and FRANKENBEAST_ALLOW_* coverage
- git diff --check

Closes #1248