### PR TITLE
fix(mcp): avoid global settings path crossover

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -630,6 +630,17 @@ describe('Claude Code hook scripts', () => {
       }
     }
     tempRoots.length = 0;
+  });
+
+  it('uses cwd-relative DB paths in global Claude hook scripts', () => {
+    const root = makeTempRoot();
+    tempRoots.push(root);
+    const { preTool, postTool } = writeHookScripts(root, 'claude');
+
+    expect(readFileSync(preTool, 'utf8')).toContain(`DB_PATH=${JSON.stringify(join('.fbeast', 'beast.db'))}`);
+    expect(readFileSync(postTool, 'utf8')).toContain(`DB_PATH=${JSON.stringify(join('.fbeast', 'beast.db'))}`);
+    expect(readFileSync(preTool, 'utf8')).not.toContain(root);
+    expect(readFileSync(postTool, 'utf8')).not.toContain(root);
   });
 
   it('returns Claude block reason on stderr with exit 2 when the pre-tool hook blocks an action', () => {

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -55,6 +55,20 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+if [[ "$DB_PATH" != /* ]]; then
+  SEARCH_DIR="$PWD"
+  while true; do
+    if [ -d "$SEARCH_DIR/.fbeast" ]; then
+      DB_PATH="$SEARCH_DIR/.fbeast/beast.db"
+      break
+    fi
+    PARENT_DIR=$(cd "$SEARCH_DIR/.." && pwd -P)
+    if [ "$PARENT_DIR" = "$SEARCH_DIR" ]; then
+      break
+    fi
+    SEARCH_DIR="$PARENT_DIR"
+  done
+fi
 NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
@@ -108,6 +122,20 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+if [[ "$DB_PATH" != /* ]]; then
+  SEARCH_DIR="$PWD"
+  while true; do
+    if [ -d "$SEARCH_DIR/.fbeast" ]; then
+      DB_PATH="$SEARCH_DIR/.fbeast/beast.db"
+      break
+    fi
+    PARENT_DIR=$(cd "$SEARCH_DIR/.." && pwd -P)
+    if [ "$PARENT_DIR" = "$SEARCH_DIR" ]; then
+      break
+    fi
+    SEARCH_DIR="$PARENT_DIR"
+  done
+fi
 NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
@@ -153,6 +181,20 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+if [[ "$DB_PATH" != /* ]]; then
+  SEARCH_DIR="$PWD"
+  while true; do
+    if [ -d "$SEARCH_DIR/.fbeast" ]; then
+      DB_PATH="$SEARCH_DIR/.fbeast/beast.db"
+      break
+    fi
+    PARENT_DIR=$(cd "$SEARCH_DIR/.." && pwd -P)
+    if [ "$PARENT_DIR" = "$SEARCH_DIR" ]; then
+      break
+    fi
+    SEARCH_DIR="$PARENT_DIR"
+  done
+fi
 NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
@@ -205,6 +247,20 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+if [[ "$DB_PATH" != /* ]]; then
+  SEARCH_DIR="$PWD"
+  while true; do
+    if [ -d "$SEARCH_DIR/.fbeast" ]; then
+      DB_PATH="$SEARCH_DIR/.fbeast/beast.db"
+      break
+    fi
+    PARENT_DIR=$(cd "$SEARCH_DIR/.." && pwd -P)
+    if [ "$PARENT_DIR" = "$SEARCH_DIR" ]; then
+      break
+    fi
+    SEARCH_DIR="$PARENT_DIR"
+  done
+fi
 NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
@@ -250,6 +306,20 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+if [[ "$DB_PATH" != /* ]]; then
+  SEARCH_DIR="$PWD"
+  while true; do
+    if [ -d "$SEARCH_DIR/.fbeast" ]; then
+      DB_PATH="$SEARCH_DIR/.fbeast/beast.db"
+      break
+    fi
+    PARENT_DIR=$(cd "$SEARCH_DIR/.." && pwd -P)
+    if [ "$PARENT_DIR" = "$SEARCH_DIR" ]; then
+      break
+    fi
+    SEARCH_DIR="$PARENT_DIR"
+  done
+fi
 NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
@@ -303,6 +373,20 @@ if [ "\${FRANKENBEAST_SPAWNED:-}" = "1" ] || [ "\${FBEAST_DISABLE_HOOKS:-}" = "1
 fi
 
 DB_PATH=${JSON.stringify(dbPath)}
+if [[ "$DB_PATH" != /* ]]; then
+  SEARCH_DIR="$PWD"
+  while true; do
+    if [ -d "$SEARCH_DIR/.fbeast" ]; then
+      DB_PATH="$SEARCH_DIR/.fbeast/beast.db"
+      break
+    fi
+    PARENT_DIR=$(cd "$SEARCH_DIR/.." && pwd -P)
+    if [ "$PARENT_DIR" = "$SEARCH_DIR" ]; then
+      break
+    fi
+    SEARCH_DIR="$PARENT_DIR"
+  done
+fi
 NODE_BIN=${JSON.stringify(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 

--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -21,7 +21,11 @@ export function writeHookScripts(root: string, client: 'claude' | 'gemini' | 'co
     : join(root, '.fbeast', 'hooks');
   mkdirSync(hooksDir, { recursive: true });
 
-  const dbPath = join(root, '.fbeast', 'beast.db');
+  // Claude/Gemini hook entries can live in a global settings.json and be reused
+  // across project roots. Keep their database path cwd-relative so hooks govern
+  // the same project database as the globally registered MCP servers. Codex
+  // hooks remain project-scoped under <root>/.codex and can keep absolute paths.
+  const dbPath = client === 'codex' ? join(root, '.fbeast', 'beast.db') : join('.fbeast', 'beast.db');
 
   if (client === 'gemini') {
     return writeGeminiScripts(hooksDir, dbPath);

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -373,8 +373,14 @@ describe('fbeast init', () => {
       ...JSON.parse(readFileSync(join(globalConfigDir, 'settings.json'), 'utf-8')),
       hooks: {
         PreToolUse: [
-          { matcher: '*', hooks: [{ type: 'command', command: shellQuote(join(rootA, '.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')) }] },
-          { matcher: '*', hooks: [{ type: 'command', command: '/usr/local/bin/my-pre-hook' }] },
+          {
+            matcher: '*',
+            hooks: [
+              { type: 'command', command: shellQuote(join(rootA, '.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')) },
+              { type: 'command', command: '/usr/local/bin/my-pre-hook' },
+            ],
+          },
+          { command: 'fbeast-hook pre-tool --db /old/project/.fbeast/beast.db' },
         ],
       },
     };

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -369,22 +369,6 @@ describe('fbeast init', () => {
     dirs.push(globalConfigDir, rootA, rootB);
 
     runInit({ root: rootA, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
-    const staleHookSettings = {
-      ...JSON.parse(readFileSync(join(globalConfigDir, 'settings.json'), 'utf-8')),
-      hooks: {
-        PreToolUse: [
-          {
-            matcher: '*',
-            hooks: [
-              { type: 'command', command: shellQuote(join(rootA, '.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')) },
-              { type: 'command', command: '/usr/local/bin/my-pre-hook' },
-            ],
-          },
-          { command: 'fbeast-hook pre-tool --db /old/project/.fbeast/beast.db' },
-        ],
-      },
-    };
-    writeFileSync(join(globalConfigDir, 'settings.json'), JSON.stringify(staleHookSettings));
 
     runInit({ root: rootB, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
 
@@ -395,8 +379,6 @@ describe('fbeast init', () => {
     });
     expect(JSON.stringify(settings.mcpServers)).not.toContain(rootA);
     expect(JSON.stringify(settings.mcpServers)).not.toContain(rootB);
-    expect(JSON.stringify(settings.hooks)).not.toContain('fbeast');
-    expect(JSON.stringify(settings.hooks)).toContain('/usr/local/bin/my-pre-hook');
   });
 
   it('proxy mode writes single fbeast-proxy entry (not 7) for claude client', () => {

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -362,6 +362,24 @@ describe('fbeast init', () => {
     ).toThrow('failed to remove legacy Codex MCP server fbeast-memory');
   });
 
+  it('uses cwd-relative database paths for global Claude settings across project roots', () => {
+    const globalConfigDir = tmpDir();
+    const rootA = tmpDir();
+    const rootB = tmpDir();
+    dirs.push(globalConfigDir, rootA, rootB);
+
+    runInit({ root: rootA, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
+    runInit({ root: rootB, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
+
+    const settings = JSON.parse(readFileSync(join(globalConfigDir, 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers['fbeast-memory']).toEqual({
+      command: 'fbeast-memory',
+      args: ['--db', join('.fbeast', 'beast.db')],
+    });
+    expect(JSON.stringify(settings.mcpServers)).not.toContain(rootA);
+    expect(JSON.stringify(settings.mcpServers)).not.toContain(rootB);
+  });
+
   it('proxy mode writes single fbeast-proxy entry (not 7) for claude client', () => {
     const root = tmpDir();
     dirs.push(root);
@@ -371,7 +389,7 @@ describe('fbeast init', () => {
     const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
     const keys = Object.keys(settings.mcpServers);
     expect(keys).toEqual(['fbeast-proxy']);
-    expect(settings.mcpServers['fbeast-proxy']).toEqual({ command: 'fbeast-proxy', args: ['--db', join(root, '.fbeast', 'beast.db'), '--root', root] });
+    expect(settings.mcpServers['fbeast-proxy']).toEqual({ command: 'fbeast-proxy', args: ['--db', join('.fbeast', 'beast.db')] });
     expect(settings.mcpServers['fbeast-memory']).toBeUndefined();
   });
 

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -369,6 +369,17 @@ describe('fbeast init', () => {
     dirs.push(globalConfigDir, rootA, rootB);
 
     runInit({ root: rootA, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
+    const staleHookSettings = {
+      ...JSON.parse(readFileSync(join(globalConfigDir, 'settings.json'), 'utf-8')),
+      hooks: {
+        PreToolUse: [
+          { matcher: '*', hooks: [{ type: 'command', command: shellQuote(join(rootA, '.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')) }] },
+          { matcher: '*', hooks: [{ type: 'command', command: '/usr/local/bin/my-pre-hook' }] },
+        ],
+      },
+    };
+    writeFileSync(join(globalConfigDir, 'settings.json'), JSON.stringify(staleHookSettings));
+
     runInit({ root: rootB, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
 
     const settings = JSON.parse(readFileSync(join(globalConfigDir, 'settings.json'), 'utf-8'));
@@ -378,6 +389,8 @@ describe('fbeast init', () => {
     });
     expect(JSON.stringify(settings.mcpServers)).not.toContain(rootA);
     expect(JSON.stringify(settings.mcpServers)).not.toContain(rootB);
+    expect(JSON.stringify(settings.hooks)).not.toContain('fbeast');
+    expect(JSON.stringify(settings.hooks)).toContain('/usr/local/bin/my-pre-hook');
   });
 
   it('proxy mode writes single fbeast-proxy entry (not 7) for claude client', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -95,10 +95,12 @@ function initJsonClient(options: {
     settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
   }
 
-  // Add MCP server entries
+  // Add MCP server entries. Claude/Gemini settings.json can be global, so keep
+  // project paths cwd-relative instead of pinning the first initialized checkout
+  // into every future client session.
   const mcpServers = (settings['mcpServers'] as Record<string, unknown>) ?? {};
-  const dbPath = join(root, '.fbeast', 'beast.db');
-  const proxyArgs = ['--db', dbPath, '--root', root];
+  const dbPath = join('.fbeast', 'beast.db');
+  const proxyArgs = ['--db', dbPath];
   if (mode === 'proxy') {
     mcpServers['fbeast-proxy'] = { command: 'fbeast-proxy', args: proxyArgs };
   } else {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -123,12 +123,6 @@ function initJsonClient(options: {
       config.hooks = true;
       config.save();
     }
-  } else if (settings['hooks'] !== undefined) {
-    // A global settings.json can already contain fbeast hook commands generated
-    // by an older project. When this init is not explicitly enabling hooks for
-    // the current project, remove only fbeast-owned hook entries so stale hooks
-    // do not keep governing/logging tool calls against the first project's DB.
-    settings['hooks'] = stripFbeastHooks(settings['hooks']);
   }
 
   writeJsonFileAtomic(settingsPath, settings);
@@ -443,35 +437,6 @@ function isFbeastHook(value: unknown): boolean {
   return inner.some(
     (h) => isObjectRecord(h) && typeof h['command'] === 'string' && h['command'].includes('fbeast'),
   );
-}
-
-function stripFbeastHooks(existing: unknown): Record<string, unknown[]> | unknown {
-  if (!isObjectRecord(existing)) return existing;
-  const hooks: Record<string, unknown[]> = {};
-  for (const [hookType, value] of Object.entries(existing)) {
-    if (Array.isArray(value)) {
-      hooks[hookType] = value
-        .map(pruneFbeastFromHookEntry)
-        .filter((entry): entry is unknown => entry !== null);
-    }
-  }
-  return hooks;
-}
-
-function pruneFbeastFromHookEntry(entry: unknown): unknown | null {
-  if (!isObjectRecord(entry)) return entry;
-  if (typeof entry['command'] === 'string') return entry['command'].includes('fbeast') ? null : entry;
-  if (typeof entry['description'] === 'string' && entry['description'].includes('fbeast')) return null;
-
-  const inner = entry['hooks'];
-  if (!Array.isArray(inner)) return entry;
-
-  const remaining = inner.filter((hook) => {
-    if (!isObjectRecord(hook)) return true;
-    return !(typeof hook['command'] === 'string' && hook['command'].includes('fbeast'));
-  });
-  if (remaining.length === 0) return null;
-  return { ...entry, hooks: remaining };
 }
 
 function shellQuote(value: string): string {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -449,9 +449,29 @@ function stripFbeastHooks(existing: unknown): Record<string, unknown[]> | unknow
   if (!isObjectRecord(existing)) return existing;
   const hooks: Record<string, unknown[]> = {};
   for (const [hookType, value] of Object.entries(existing)) {
-    if (Array.isArray(value)) hooks[hookType] = value.filter((entry) => !isFbeastHook(entry));
+    if (Array.isArray(value)) {
+      hooks[hookType] = value
+        .map(pruneFbeastFromHookEntry)
+        .filter((entry): entry is unknown => entry !== null);
+    }
   }
   return hooks;
+}
+
+function pruneFbeastFromHookEntry(entry: unknown): unknown | null {
+  if (!isObjectRecord(entry)) return entry;
+  if (typeof entry['command'] === 'string') return entry['command'].includes('fbeast') ? null : entry;
+  if (typeof entry['description'] === 'string' && entry['description'].includes('fbeast')) return null;
+
+  const inner = entry['hooks'];
+  if (!Array.isArray(inner)) return entry;
+
+  const remaining = inner.filter((hook) => {
+    if (!isObjectRecord(hook)) return true;
+    return !(typeof hook['command'] === 'string' && hook['command'].includes('fbeast'));
+  });
+  if (remaining.length === 0) return null;
+  return { ...entry, hooks: remaining };
 }
 
 function shellQuote(value: string): string {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -123,6 +123,12 @@ function initJsonClient(options: {
       config.hooks = true;
       config.save();
     }
+  } else if (settings['hooks'] !== undefined) {
+    // A global settings.json can already contain fbeast hook commands generated
+    // by an older project. When this init is not explicitly enabling hooks for
+    // the current project, remove only fbeast-owned hook entries so stale hooks
+    // do not keep governing/logging tool calls against the first project's DB.
+    settings['hooks'] = stripFbeastHooks(settings['hooks']);
   }
 
   writeJsonFileAtomic(settingsPath, settings);
@@ -437,6 +443,15 @@ function isFbeastHook(value: unknown): boolean {
   return inner.some(
     (h) => isObjectRecord(h) && typeof h['command'] === 'string' && h['command'].includes('fbeast'),
   );
+}
+
+function stripFbeastHooks(existing: unknown): Record<string, unknown[]> | unknown {
+  if (!isObjectRecord(existing)) return existing;
+  const hooks: Record<string, unknown[]> = {};
+  for (const [hookType, value] of Object.entries(existing)) {
+    if (Array.isArray(value)) hooks[hookType] = value.filter((entry) => !isFbeastHook(entry));
+  }
+  return hooks;
 }
 
 function shellQuote(value: string): string {

--- a/packages/franken-mcp-suite/src/servers/critique.ts
+++ b/packages/franken-mcp-suite/src/servers/critique.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createCritiqueAdapter, type CritiqueAdapter } from '../adapters/critique-adapter.js';
 import { parseArgs } from 'node:util';
+import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface CritiqueServerDeps {
   critique: CritiqueAdapter;
@@ -19,8 +20,9 @@ if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
   });
+  const dbPath = resolveProjectDbPath(values['db']!);
   const critique = createCritiqueAdapter();
-  const server = createCritiqueServer({ critique }, createCentralOptions(values['db']!));
+  const server = createCritiqueServer({ critique }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-critique failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/servers/firewall.ts
+++ b/packages/franken-mcp-suite/src/servers/firewall.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createFirewallAdapter, type FirewallAdapter } from '../adapters/firewall-adapter.js';
 import { parseArgs } from 'node:util';
+import { deriveProjectRootFromDbPath, resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface FirewallServerDeps {
   firewall: FirewallAdapter;
@@ -23,10 +24,10 @@ if (isMain(import.meta.url)) {
     },
   });
   const tier = values['tier'] === 'strict' ? 'strict' : 'standard';
-  const firewall = createFirewallAdapter(values['db']!, tier, {
-    root: process.env['FBEAST_ROOT'] ?? process.cwd(),
-  });
-  const server = createFirewallServer({ firewall }, createCentralOptions(values['db']!));
+  const dbPath = resolveProjectDbPath(values['db']!);
+  const root = process.env['FBEAST_ROOT'] ?? deriveProjectRootFromDbPath(values['db']!) ?? process.cwd();
+  const firewall = createFirewallAdapter(dbPath, tier, { root });
+  const server = createFirewallServer({ firewall }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-firewall failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/servers/governor.ts
+++ b/packages/franken-mcp-suite/src/servers/governor.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createGovernorAdapter, type GovernorAdapter } from '../adapters/governor-adapter.js';
 import { parseArgs } from 'node:util';
+import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface GovernorServerDeps {
   governor: GovernorAdapter;
@@ -19,8 +20,9 @@ if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
   });
-  const governor = createGovernorAdapter(values['db']!);
-  const server = createGovernorServer({ governor }, createCentralOptions(values['db']!));
+  const dbPath = resolveProjectDbPath(values['db']!);
+  const governor = createGovernorAdapter(dbPath);
+  const server = createGovernorServer({ governor }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-governor failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createBrainAdapter, type BrainAdapter } from '../adapters/brain-adapter.js';
 import { parseArgs } from 'node:util';
+import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface MemoryServerDeps {
   brain: BrainAdapter;
@@ -19,8 +20,9 @@ if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
   });
-  const brain = createBrainAdapter(values['db']!);
-  const server = createMemoryServer({ brain }, createCentralOptions(values['db']!));
+  const dbPath = resolveProjectDbPath(values['db']!);
+  const brain = createBrainAdapter(dbPath);
+  const server = createMemoryServer({ brain }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-memory failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/servers/observer.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createObserverAdapter, type ObserverAdapter } from '../adapters/observer-adapter.js';
 import { parseArgs } from 'node:util';
+import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface ObserverServerDeps {
   observer: ObserverAdapter;
@@ -19,8 +20,9 @@ if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
   });
-  const observer = createObserverAdapter(values['db']!);
-  const server = createObserverServer({ observer }, createCentralOptions(values['db']!));
+  const dbPath = resolveProjectDbPath(values['db']!);
+  const observer = createObserverAdapter(dbPath);
+  const server = createObserverServer({ observer }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-observer failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/servers/planner.ts
+++ b/packages/franken-mcp-suite/src/servers/planner.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
 import { parseArgs } from 'node:util';
+import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface PlannerServerDeps {
   planner: PlannerAdapter;
@@ -19,8 +20,9 @@ if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
   });
-  const planner = createPlannerAdapter(values['db']!);
-  const server = createPlannerServer({ planner }, createCentralOptions(values['db']!));
+  const dbPath = resolveProjectDbPath(values['db']!);
+  const planner = createPlannerAdapter(dbPath);
+  const server = createPlannerServer({ planner }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-planner failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -123,6 +123,35 @@ describe('proxy server', () => {
       expect(mockCreateAdapterSet).toHaveBeenCalledWith('/tmp/legacy-project/.fbeast/beast.db', { root: '/tmp/legacy-project' });
     });
 
+    it('walks up from nested cwd to derive root for relative proxy registrations', async () => {
+      const originalCwd = process.cwd();
+      const projectRoot = await import('node:fs').then(({ mkdtempSync, mkdirSync, writeFileSync }) => {
+        const root = mkdtempSync('/tmp/fbeast-proxy-relative-');
+        mkdirSync(`${root}/.fbeast`, { recursive: true });
+        mkdirSync(`${root}/packages/app`, { recursive: true });
+        writeFileSync(`${root}/.fbeast/beast.db`, '');
+        return root;
+      });
+      try {
+        process.chdir(`${projectRoot}/packages/app`);
+        const relativeServer = createProxyServer({
+          dbPath: '.fbeast/beast.db',
+          governance: { check: gateCheck },
+          audit: { record: auditRecord },
+        });
+        const relativeExecuteTool = relativeServer.tools.find((t) => t.name === 'execute_tool')!;
+        const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+        vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);
+
+        await relativeExecuteTool.handler({ tool: 'test_tool', args: { key: 'val' } });
+
+        expect(mockCreateAdapterSet).toHaveBeenCalledWith('.fbeast/beast.db', { root: projectRoot });
+      } finally {
+        process.chdir(originalCwd);
+        await import('node:fs').then(({ rmSync }) => rmSync(projectRoot, { recursive: true, force: true }));
+      }
+    });
+
     it('returns isError response for unknown tool', async () => {
       const result = await executeToolDef.handler({ tool: 'nonexistent_tool', args: {} }) as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(result.isError).toBe(true);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -145,7 +145,7 @@ describe('proxy server', () => {
 
         await relativeExecuteTool.handler({ tool: 'test_tool', args: { key: 'val' } });
 
-        expect(mockCreateAdapterSet).toHaveBeenCalledWith('.fbeast/beast.db', { root: projectRoot });
+        expect(mockCreateAdapterSet).toHaveBeenCalledWith(`${projectRoot}/.fbeast/beast.db`, { root: projectRoot });
       } finally {
         process.chdir(originalCwd);
         await import('node:fs').then(({ rmSync }) => rmSync(projectRoot, { recursive: true, force: true }));

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -4,33 +4,12 @@ import { isMain } from '../shared/is-main.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
 import { createGovernanceGate } from '../shared/governance-gate.js';
 import { createAuditSink } from '../shared/central-enforcement.js';
-import { existsSync } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
+import { deriveProjectRootFromDbPath, resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export function deriveProxyRoot(dbPath: string, explicitRoot?: string | undefined): string | undefined {
-  if (explicitRoot) {
-    return resolve(explicitRoot);
-  }
-
-  if (!isAbsolute(dbPath)) {
-    let candidateRoot = process.cwd();
-    while (true) {
-      if (existsSync(resolve(candidateRoot, dbPath))) {
-        return candidateRoot;
-      }
-      const parent = dirname(candidateRoot);
-      if (parent === candidateRoot) break;
-      candidateRoot = parent;
-    }
-  }
-
-  const dbDir = dirname(resolve(dbPath));
-  if (basename(dbDir) === '.fbeast') {
-    return dirname(dbDir);
-  }
-
-  return undefined;
+  return deriveProjectRootFromDbPath(dbPath, explicitRoot);
 }
 
 export interface ProxyServerDeps {
@@ -45,9 +24,7 @@ export interface ProxyServerDeps {
 
 export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
   const root = deriveProxyRoot(deps.dbPath, deps.root);
-  const dbPath = !isAbsolute(deps.dbPath) && root && basename(dirname(deps.dbPath)) === '.fbeast'
-    ? resolve(root, deps.dbPath)
-    : deps.dbPath;
+  const dbPath = resolveProjectDbPath(deps.dbPath, root);
   let cachedAdapters: AdapterSet | undefined;
   // Govern/audit the *resolved* target tool, not the `execute_tool` wrapper, so
   // policy and audit are keyed by the real high-risk action (ADR-035, finding

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -4,12 +4,25 @@ import { isMain } from '../shared/is-main.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
 import { createGovernanceGate } from '../shared/governance-gate.js';
 import { createAuditSink } from '../shared/central-enforcement.js';
-import { basename, dirname, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, dirname, isAbsolute, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
 export function deriveProxyRoot(dbPath: string, explicitRoot?: string | undefined): string | undefined {
   if (explicitRoot) {
     return resolve(explicitRoot);
+  }
+
+  if (!isAbsolute(dbPath)) {
+    let candidateRoot = process.cwd();
+    while (true) {
+      if (existsSync(resolve(candidateRoot, dbPath))) {
+        return candidateRoot;
+      }
+      const parent = dirname(candidateRoot);
+      if (parent === candidateRoot) break;
+      candidateRoot = parent;
+    }
   }
 
   const dbDir = dirname(resolve(dbPath));

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -44,8 +44,10 @@ export interface ProxyServerDeps {
 }
 
 export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
-  const { dbPath } = deps;
-  const root = deriveProxyRoot(dbPath, deps.root);
+  const root = deriveProxyRoot(deps.dbPath, deps.root);
+  const dbPath = !isAbsolute(deps.dbPath) && root && basename(dirname(deps.dbPath)) === '.fbeast'
+    ? resolve(root, deps.dbPath)
+    : deps.dbPath;
   let cachedAdapters: AdapterSet | undefined;
   // Govern/audit the *resolved* target tool, not the `execute_tool` wrapper, so
   // policy and audit are keyed by the real high-risk action (ADR-035, finding

--- a/packages/franken-mcp-suite/src/servers/skills.ts
+++ b/packages/franken-mcp-suite/src/servers/skills.ts
@@ -5,6 +5,7 @@ import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
 import { parseArgs } from 'node:util';
+import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
 
 export interface SkillsServerDeps {
   skills: SkillsAdapter;
@@ -19,8 +20,9 @@ if (isMain(import.meta.url)) {
   const { values } = parseArgs({
     options: { db: { type: 'string', default: '.fbeast/beast.db' } },
   });
-  const skills = createSkillsAdapter(values['db']!);
-  const server = createSkillsServer({ skills }, createCentralOptions(values['db']!));
+  const dbPath = resolveProjectDbPath(values['db']!);
+  const skills = createSkillsAdapter(dbPath);
+  const server = createSkillsServer({ skills }, createCentralOptions(dbPath));
   server.start().catch((err) => {
     console.error('fbeast-skills failed to start:', err);
     process.exit(1);

--- a/packages/franken-mcp-suite/src/shared/resolve-db-path.ts
+++ b/packages/franken-mcp-suite/src/shared/resolve-db-path.ts
@@ -1,0 +1,52 @@
+import { existsSync } from 'node:fs';
+import { basename, dirname, isAbsolute, resolve } from 'node:path';
+
+export function deriveProjectRootFromDbPath(dbPath: string, explicitRoot?: string | undefined): string | undefined {
+  if (explicitRoot) {
+    return resolve(explicitRoot);
+  }
+
+  if (!isAbsolute(dbPath)) {
+    let candidateRoot = process.cwd();
+    while (true) {
+      const candidateDb = resolve(candidateRoot, dbPath);
+      const projectRoot = projectRootFromDb(candidateDb);
+      if (projectRoot && (existsSync(dirname(candidateDb)) || existsSync(candidateDb))) {
+        return projectRoot;
+      }
+      const parent = dirname(candidateRoot);
+      if (parent === candidateRoot) break;
+      candidateRoot = parent;
+    }
+  }
+
+  return projectRootFromDb(resolve(dbPath));
+}
+
+export function resolveProjectDbPath(dbPath: string, explicitRoot?: string | undefined): string {
+  if (isAbsolute(dbPath)) {
+    return dbPath;
+  }
+  const projectRelativePath = dbPathFromProjectRoot(dbPath);
+  if (!projectRelativePath) {
+    return dbPath;
+  }
+  const root = deriveProjectRootFromDbPath(dbPath, explicitRoot);
+  return root ? resolve(root, projectRelativePath) : dbPath;
+}
+
+function projectRootFromDb(dbPath: string): string | undefined {
+  const dbDir = dirname(dbPath);
+  if (basename(dbDir) !== '.fbeast') return undefined;
+  return dirname(dbDir);
+}
+
+function dbPathFromProjectRoot(dbPath: string): string | undefined {
+  const normalized = dbPath.replace(/\\/g, '/');
+  const marker = '.fbeast/';
+  const markerIndex = normalized.lastIndexOf(marker);
+  if (markerIndex >= 0) {
+    return normalized.slice(markerIndex);
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- keep Claude/Gemini settings.json MCP database args cwd-relative instead of project-absolute
- stop writing a project-specific --root into global proxy entries so proxy derives the active checkout root from .fbeast/beast.db
- add a regression covering shared global settings initialized from two project roots

## Test Plan
- npm --workspace @franken/mcp-suite test -- src/cli/init.test.ts
- npm --workspace @franken/mcp-suite test
- npm --workspace @franken/mcp-suite run typecheck
- npm --workspace @franken/mcp-suite run build
- npx turbo run test --filter=@franken/mcp-suite -- --run src/cli/init.test.ts

Closes #1044