### PR TITLE
fix(planner): limit parallel wave concurrency

### DIFF
--- a/packages/franken-planner/src/index.ts
+++ b/packages/franken-planner/src/index.ts
@@ -51,6 +51,7 @@ export type {
 } from './planners/types.js';
 export { LinearPlanner } from './planners/linear.js';
 export { ParallelPlanner } from './planners/parallel.js';
+export type { ParallelPlannerOptions } from './planners/parallel.js';
 export { RecursivePlanner } from './planners/recursive.js';
 
 // ── Chain-of-Thought ───────────────────────────────────────────────

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -1,7 +1,7 @@
 import { RationaleRejectedError, RecursionDepthExceededError } from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
-import type { PlanResult, TaskId, TaskResult } from '../core/types.js';
-import type { PlanContext, PlanningStrategy } from './types.js';
+import type { PlanResult, Task, TaskId, TaskResult } from '../core/types.js';
+import type { PlanContext, PlanningStrategy, TaskExecutor } from './types.js';
 
 export interface ParallelPlannerOptions {
   /** Maximum recursive dynamic-expansion depth. Defaults to 10. */
@@ -45,7 +45,14 @@ export class ParallelPlanner implements PlanningStrategy {
   }
 
   execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
-    return this._exec(graph, context, 0);
+    return this._exec(
+      graph,
+      {
+        ...context,
+        executor: createLimitedExecutor(context.executor, this.maxWaveConcurrency),
+      },
+      0
+    );
   }
 
   private async _exec(graph: PlanGraph, context: PlanContext, depth: number): Promise<PlanResult> {
@@ -72,18 +79,20 @@ export class ParallelPlanner implements PlanningStrategy {
       // Run all ready tasks concurrently; convert ordinary task exceptions into
       // failures, but let governance rejections propagate to the Planner so they
       // retain first-class non-retryable semantics across strategies.
-      const settledWaveResults = await this.runWaveSettled(ready, (task) =>
-        context.executor(task).catch((err: unknown) => {
-          if (err instanceof RationaleRejectedError) {
-            throw err;
-          }
+      const settledWaveResults = await Promise.allSettled(
+        ready.map((task) =>
+          context.executor(task).catch((err: unknown) => {
+            if (err instanceof RationaleRejectedError) {
+              throw err;
+            }
 
-          return {
-            status: 'failure' as const,
-            taskId: task.id,
-            error: err instanceof Error ? err : new Error(String(err)),
-          };
-        })
+            return {
+              status: 'failure' as const,
+              taskId: task.id,
+              error: err instanceof Error ? err : new Error(String(err)),
+            };
+          })
+        )
       );
 
       const rejectedRationale = settledWaveResults.find(
@@ -181,22 +190,6 @@ export class ParallelPlanner implements PlanningStrategy {
 
     return { status: 'completed', taskResults: allResults };
   }
-
-  private async runWaveSettled<T, R>(
-    items: readonly T[],
-    runner: (item: T) => Promise<R>
-  ): Promise<PromiseSettledResult<R>[]> {
-    if (this.maxWaveConcurrency >= items.length) {
-      return Promise.allSettled(items.map((item) => runner(item)));
-    }
-
-    const settledResults: PromiseSettledResult<R>[] = [];
-    for (let start = 0; start < items.length; start += this.maxWaveConcurrency) {
-      const batch = items.slice(start, start + this.maxWaveConcurrency);
-      settledResults.push(...(await Promise.allSettled(batch.map((item) => runner(item)))));
-    }
-    return settledResults;
-  }
 }
 
 function normalizeMaxWaveConcurrency(value: number | undefined): number {
@@ -209,4 +202,42 @@ function normalizeMaxWaveConcurrency(value: number | undefined): number {
   }
 
   return value;
+}
+
+function createLimitedExecutor(executor: TaskExecutor, maxConcurrency: number): TaskExecutor {
+  if (!Number.isFinite(maxConcurrency)) {
+    return executor;
+  }
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const acquire = (): Promise<void> =>
+    new Promise((resolve) => {
+      const start = () => {
+        active += 1;
+        resolve();
+      };
+
+      if (active < maxConcurrency) {
+        start();
+        return;
+      }
+
+      queue.push(start);
+    });
+
+  const release = () => {
+    active -= 1;
+    queue.shift()?.();
+  };
+
+  return async (task: Task) => {
+    await acquire();
+    try {
+      return await executor(task);
+    } finally {
+      release();
+    }
+  };
 }

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -3,16 +3,46 @@ import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, TaskId, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
+export interface ParallelPlannerOptions {
+  /** Maximum recursive dynamic-expansion depth. Defaults to 10. */
+  maxExpansionDepth?: number;
+
+  /**
+   * Maximum number of ready tasks to execute at once inside a dependency wave.
+   * Omit for the historical fully-parallel behavior.
+   */
+  maxWaveConcurrency?: number;
+}
+
 /**
  * Executes tasks in concurrent waves.
- * Within each wave every ready task (all deps completed) runs via Promise.all.
+ * Within each wave every ready task (all deps completed) runs with an optional concurrency limit.
  * Stops after a wave that contains at least one failure — subsequent waves are skipped.
  * All results accumulated up to and including the failing wave are preserved.
  */
 export class ParallelPlanner implements PlanningStrategy {
   readonly name = 'parallel' as const;
 
-  constructor(private readonly maxExpansionDepth = 10) {}
+  private readonly maxExpansionDepth: number;
+  private readonly maxWaveConcurrency: number;
+
+  constructor(maxExpansionDepth?: number, options?: ParallelPlannerOptions);
+  constructor(options?: ParallelPlannerOptions);
+  constructor(
+    maxExpansionDepthOrOptions: number | ParallelPlannerOptions = 10,
+    options: ParallelPlannerOptions = {}
+  ) {
+    if (typeof maxExpansionDepthOrOptions === 'number') {
+      this.maxExpansionDepth = maxExpansionDepthOrOptions;
+      this.maxWaveConcurrency = normalizeMaxWaveConcurrency(options.maxWaveConcurrency);
+      return;
+    }
+
+    this.maxExpansionDepth = maxExpansionDepthOrOptions.maxExpansionDepth ?? 10;
+    this.maxWaveConcurrency = normalizeMaxWaveConcurrency(
+      maxExpansionDepthOrOptions.maxWaveConcurrency
+    );
+  }
 
   execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
     return this._exec(graph, context, 0);
@@ -42,20 +72,18 @@ export class ParallelPlanner implements PlanningStrategy {
       // Run all ready tasks concurrently; convert ordinary task exceptions into
       // failures, but let governance rejections propagate to the Planner so they
       // retain first-class non-retryable semantics across strategies.
-      const settledWaveResults = await Promise.allSettled(
-        ready.map((task) =>
-          context.executor(task).catch((err: unknown) => {
-            if (err instanceof RationaleRejectedError) {
-              throw err;
-            }
+      const settledWaveResults = await this.runWaveSettled(ready, (task) =>
+        context.executor(task).catch((err: unknown) => {
+          if (err instanceof RationaleRejectedError) {
+            throw err;
+          }
 
-            return {
-              status: 'failure' as const,
-              taskId: task.id,
-              error: err instanceof Error ? err : new Error(String(err)),
-            };
-          })
-        )
+          return {
+            status: 'failure' as const,
+            taskId: task.id,
+            error: err instanceof Error ? err : new Error(String(err)),
+          };
+        })
       );
 
       const rejectedRationale = settledWaveResults.find(
@@ -153,4 +181,32 @@ export class ParallelPlanner implements PlanningStrategy {
 
     return { status: 'completed', taskResults: allResults };
   }
+
+  private async runWaveSettled<T, R>(
+    items: readonly T[],
+    runner: (item: T) => Promise<R>
+  ): Promise<PromiseSettledResult<R>[]> {
+    if (this.maxWaveConcurrency >= items.length) {
+      return Promise.allSettled(items.map((item) => runner(item)));
+    }
+
+    const settledResults: PromiseSettledResult<R>[] = [];
+    for (let start = 0; start < items.length; start += this.maxWaveConcurrency) {
+      const batch = items.slice(start, start + this.maxWaveConcurrency);
+      settledResults.push(...(await Promise.allSettled(batch.map((item) => runner(item)))));
+    }
+    return settledResults;
+  }
+}
+
+function normalizeMaxWaveConcurrency(value: number | undefined): number {
+  if (value === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError('ParallelPlanner maxWaveConcurrency must be a positive integer');
+  }
+
+  return value;
 }

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -277,6 +277,35 @@ describe('ParallelPlanner — happy path', () => {
     await expect(execution).resolves.toMatchObject({ status: 'completed' });
   });
 
+  it('applies the wave concurrency cap across sibling expansion subgraphs', async () => {
+    const parent1 = makeTask('parent-1');
+    const parent2 = makeTask('parent-2');
+    const sub1 = makeTask('sub-1');
+    const sub2 = makeTask('sub-2');
+    const graph = PlanGraph.empty().addTask(parent1).addTask(parent2);
+    let active = 0;
+    let maxActive = 0;
+
+    const executor = vi.fn().mockImplementation(async (task: Task) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+
+      if (task.id === createTaskId('parent-1')) return expand('parent-1', [sub1]);
+      if (task.id === createTaskId('parent-2')) return expand('parent-2', [sub2]);
+      return success(task.id);
+    });
+
+    const result = await new ParallelPlanner({ maxWaveConcurrency: 1 }).execute(graph, {
+      executor,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledTimes(4);
+    expect(maxActive).toBe(1);
+  });
+
   it('waits for sibling expansions before propagating an expansion rejection', async () => {
     const parent1 = makeTask('parent-1');
     const parent2 = makeTask('parent-2');

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ParallelPlanner } from '../../../src/planners/parallel';
 import { PlanGraph } from '../../../src/core/dag';
-import { CyclicDependencyError, RationaleRejectedError, RecursionDepthExceededError } from '../../../src/core/errors';
+import {
+  CyclicDependencyError,
+  RationaleRejectedError,
+  RecursionDepthExceededError,
+} from '../../../src/core/errors';
 import { createTaskId } from '../../../src/core/types';
 import type { Task, TaskId, TaskResult } from '../../../src/core/types';
 
@@ -87,6 +91,73 @@ describe('ParallelPlanner — happy path', () => {
     expect(callOrder).toContain(createTaskId('b'));
   });
 
+  it('limits same-wave task execution to the configured concurrency', async () => {
+    const tasks = ['a', 'b', 'c', 'd'].map(makeTask);
+    const graph = tasks.reduce(
+      (currentGraph, task) => currentGraph.addTask(task),
+      PlanGraph.empty()
+    );
+    let active = 0;
+    let maxActive = 0;
+    const executor = vi.fn().mockImplementation(async (task: Task) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return success(task.id);
+    });
+
+    const result = await new ParallelPlanner({ maxWaveConcurrency: 2 }).execute(graph, {
+      executor,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledTimes(4);
+    expect(maxActive).toBe(2);
+  });
+
+  it('preserves maxExpansionDepth constructor compatibility while limiting waves', async () => {
+    const tasks = ['a', 'b', 'c'].map(makeTask);
+    const graph = tasks.reduce(
+      (currentGraph, task) => currentGraph.addTask(task),
+      PlanGraph.empty()
+    );
+    let active = 0;
+    let maxActive = 0;
+    const executor = vi.fn().mockImplementation(async (task: Task) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return success(task.id);
+    });
+
+    const result = await new ParallelPlanner(10, { maxWaveConcurrency: 1 }).execute(graph, {
+      executor,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(maxActive).toBe(1);
+  });
+
+  it('rejects invalid wave concurrency limits', () => {
+    expect(() => new ParallelPlanner({ maxWaveConcurrency: 0 })).toThrow(RangeError);
+    expect(() => new ParallelPlanner({ maxWaveConcurrency: 1.5 })).toThrow(RangeError);
+  });
+
+  it('supports maxExpansionDepth in the options object', async () => {
+    const child = makeTask('child');
+    const parent = makeTask('parent');
+    const graph = PlanGraph.empty().addTask(parent);
+    const executor = vi.fn().mockResolvedValueOnce(expand('parent', [child]));
+
+    await expect(
+      new ParallelPlanner({ maxExpansionDepth: 0, maxWaveConcurrency: 1 }).execute(graph, {
+        executor,
+      })
+    ).rejects.toBeInstanceOf(RecursionDepthExceededError);
+  });
+
   it('respects task dependencies — dependent runs after its prereq', async () => {
     const a = makeTask('a');
     const b = makeTask('b');
@@ -102,9 +173,7 @@ describe('ParallelPlanner — happy path', () => {
 
     await new ParallelPlanner().execute(graph, { executor });
 
-    expect(callOrder.indexOf(createTaskId('a'))).toBeLessThan(
-      callOrder.indexOf(createTaskId('b'))
-    );
+    expect(callOrder.indexOf(createTaskId('a'))).toBeLessThan(callOrder.indexOf(createTaskId('b')));
   });
 
   it('diamond A→{B,C}→D: B and C run concurrently', async () => {
@@ -118,9 +187,7 @@ describe('ParallelPlanner — happy path', () => {
       .addTask(c, [createTaskId('a')])
       .addTask(d, [createTaskId('b'), createTaskId('c')]);
 
-    const executor = vi.fn().mockImplementation((task: Task) =>
-      Promise.resolve(success(task.id))
-    );
+    const executor = vi.fn().mockImplementation((task: Task) => Promise.resolve(success(task.id)));
 
     const result = await new ParallelPlanner().execute(graph, { executor });
 
@@ -130,7 +197,8 @@ describe('ParallelPlanner — happy path', () => {
 
   it('collects all task results on full success', async () => {
     const graph = PlanGraph.empty().addTask(makeTask('t-1')).addTask(makeTask('t-2'));
-    const executor = vi.fn()
+    const executor = vi
+      .fn()
       .mockResolvedValueOnce(success('t-1'))
       .mockResolvedValueOnce(success('t-2'));
 
@@ -294,7 +362,8 @@ describe('ParallelPlanner — failure handling', () => {
       .addTask(a)
       .addTask(b, [createTaskId('a')]);
 
-    const executor = vi.fn()
+    const executor = vi
+      .fn()
       .mockResolvedValueOnce(success('a'))
       .mockResolvedValueOnce(failure('b'));
 
@@ -310,7 +379,8 @@ describe('ParallelPlanner — failure handling', () => {
     const parent = makeTask('parent');
     const sub = makeTask('sub');
     const graph = PlanGraph.empty().addTask(parent);
-    const executor = vi.fn()
+    const executor = vi
+      .fn()
       .mockResolvedValueOnce(expand('parent', [sub]))
       .mockResolvedValueOnce(failure('sub', 'sub exploded'));
 
@@ -357,7 +427,8 @@ describe('ParallelPlanner — failure handling', () => {
     const child = makeTask('child');
     const parent = makeTask('parent');
     const graph = PlanGraph.empty().addTask(parent);
-    const executor = vi.fn()
+    const executor = vi
+      .fn()
       .mockResolvedValueOnce(expand('parent', [child]))
       .mockResolvedValue(success('child'));
 
@@ -371,7 +442,8 @@ describe('ParallelPlanner — failure handling', () => {
     const b = makeTask('b');
     const graph = PlanGraph.empty().addTask(a).addTask(b);
 
-    const executor = vi.fn()
+    const executor = vi
+      .fn()
       .mockResolvedValueOnce(failure('a', 'a-failed'))
       .mockResolvedValueOnce(failure('b', 'b-failed'));
 


### PR DESCRIPTION
## Summary
- Add `ParallelPlannerOptions` with configurable `maxWaveConcurrency` and options-object `maxExpansionDepth` support.
- Execute ready tasks in concurrency-limited batches while preserving previous default fully-parallel behavior.
- Cover wave concurrency limits, legacy constructor compatibility, invalid limits, and options-based expansion depth in unit tests.

## Test Plan
- `npm run test --workspace @franken/planner -- --run tests/unit/planners/parallel.test.ts`
- `npm run test --workspace @franken/planner`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/planner`
- `npm run build --workspace @franken/planner`
- `npm run lint --workspace @franken/planner`
- `npx turbo run test --filter=@franken/planner`

Closes #1048
