### PR TITLE
fix(observer): flush only new dirty spans

### DIFF
--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -88,6 +88,21 @@ describe('PrometheusAdapter', () => {
       )
     })
 
+    it('bounds repeated-flush dedupe memory with a recent-span cap', async () => {
+      const adapter = new PrometheusAdapter({ maxDedupeSpans: 1 })
+      const first = makeTrace('claude-sonnet-4-6', 100, 0)
+      const second = makeTrace('claude-sonnet-4-6', 200, 0)
+
+      await adapter.flush(first)
+      await adapter.flush(second)
+      await adapter.flush(second)
+
+      const out = adapter.scrape()
+      expect(out).toMatch(
+        /franken_observer_tokens_total\{model="claude-sonnet-4-6",type="prompt"\}\s+300/,
+      )
+    })
+
     it('tracks multiple models independently', async () => {
       const adapter = new PrometheusAdapter()
       await adapter.flush(makeTrace('claude-sonnet-4-6', 100, 50))

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -73,6 +73,21 @@ describe('PrometheusAdapter', () => {
       )
     })
 
+    it('does not count the same trace span twice when a trace is flushed repeatedly', async () => {
+      const adapter = new PrometheusAdapter()
+      const trace = makeTrace('claude-sonnet-4-6', 100, 50)
+      await adapter.flush(trace)
+      await adapter.flush(trace)
+
+      const out = adapter.scrape()
+      expect(out).toMatch(
+        /franken_observer_tokens_total\{model="claude-sonnet-4-6",type="prompt"\}\s+100/,
+      )
+      expect(out).toMatch(
+        /franken_observer_tokens_total\{model="claude-sonnet-4-6",type="completion"\}\s+50/,
+      )
+    })
+
     it('tracks multiple models independently', async () => {
       const adapter = new PrometheusAdapter()
       await adapter.flush(makeTrace('claude-sonnet-4-6', 100, 50))
@@ -111,6 +126,16 @@ describe('PrometheusAdapter', () => {
     it('counts completed spans', async () => {
       const adapter = new PrometheusAdapter()
       await adapter.flush(makeTrace())
+      const out = adapter.scrape()
+      expect(out).toMatch(/franken_observer_spans_total\{status="completed"\}\s+1/)
+    })
+
+    it('does not double-count spans when the same trace is flushed repeatedly', async () => {
+      const adapter = new PrometheusAdapter()
+      const trace = makeTrace()
+      await adapter.flush(trace)
+      await adapter.flush(trace)
+      await adapter.flush(trace)
       const out = adapter.scrape()
       expect(out).toMatch(/franken_observer_spans_total\{status="completed"\}\s+1/)
     })

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -31,6 +31,7 @@ export class PrometheusAdapter implements ExportAdapter {
   private tokenCounters = new Map<string, TokenCounts>()
   private spanCounters = new Map<string, number>()
   private costCounters = new Map<string, number>()
+  private flushedSpanIds = new Set<string>()
 
   constructor(options: PrometheusAdapterOptions = {}) {
     this.pricingTable = options.pricingTable
@@ -39,6 +40,9 @@ export class PrometheusAdapter implements ExportAdapter {
   async flush(trace: Trace): Promise<void> {
     warnIfTraceHasActiveSpans(trace, 'PrometheusAdapter')
     for (const span of trace.spans) {
+      const spanKey = `${trace.id}\u0000${span.id}`
+      if (this.flushedSpanIds.has(spanKey) || span.status === 'active') continue
+
       // Span status counter
       this.spanCounters.set(span.status, (this.spanCounters.get(span.status) ?? 0) + 1)
 
@@ -70,6 +74,8 @@ export class PrometheusAdapter implements ExportAdapter {
           this.costCounters.set(model, (this.costCounters.get(model) ?? 0) + cost)
         }
       }
+
+      this.flushedSpanIds.add(spanKey)
     }
   }
 
@@ -120,6 +126,7 @@ export class PrometheusAdapter implements ExportAdapter {
     this.tokenCounters.clear()
     this.spanCounters.clear()
     this.costCounters.clear()
+    this.flushedSpanIds.clear()
   }
 
   async queryByTraceId(_traceId: string): Promise<Trace | null> {

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -6,6 +6,8 @@ import type { PricingTable } from '../../cost/defaultPricing.js'
 export interface PrometheusAdapterOptions {
   /** Optional pricing table for cost metrics. If absent, cost lines are omitted. */
   pricingTable?: PricingTable
+  /** Maximum recent span ids retained to make repeated trace flushes idempotent. */
+  maxDedupeSpans?: number
 }
 
 interface TokenCounts {
@@ -28,13 +30,15 @@ function escapePrometheusLabelValue(value: string): string {
  */
 export class PrometheusAdapter implements ExportAdapter {
   private readonly pricingTable: PricingTable | undefined
+  private readonly maxDedupeSpans: number
   private tokenCounters = new Map<string, TokenCounts>()
   private spanCounters = new Map<string, number>()
   private costCounters = new Map<string, number>()
-  private flushedSpanIds = new Set<string>()
+  private flushedSpanIds = new Map<string, undefined>()
 
   constructor(options: PrometheusAdapterOptions = {}) {
     this.pricingTable = options.pricingTable
+    this.maxDedupeSpans = Math.max(0, Math.floor(options.maxDedupeSpans ?? 10_000))
   }
 
   async flush(trace: Trace): Promise<void> {
@@ -75,7 +79,17 @@ export class PrometheusAdapter implements ExportAdapter {
         }
       }
 
-      this.flushedSpanIds.add(spanKey)
+      this.rememberFlushedSpan(spanKey)
+    }
+  }
+
+  private rememberFlushedSpan(spanKey: string): void {
+    if (this.maxDedupeSpans === 0) return
+    this.flushedSpanIds.set(spanKey, undefined)
+    while (this.flushedSpanIds.size > this.maxDedupeSpans) {
+      const oldest = this.flushedSpanIds.keys().next().value as string | undefined
+      if (oldest === undefined) break
+      this.flushedSpanIds.delete(oldest)
     }
   }
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -22,6 +22,8 @@ vi.mock('better-sqlite3', () => ({
 }))
 
 import { SQLiteAdapter } from './SQLiteAdapter.js'
+import { TraceContext } from '../../core/TraceContext.js'
+import { SpanLifecycle } from '../../core/SpanLifecycle.js'
 
 describe('SQLiteAdapter', () => {
   beforeEach(() => {
@@ -35,5 +37,40 @@ describe('SQLiteAdapter', () => {
     expect(pragmaMock).toHaveBeenCalledWith('busy_timeout = 5000')
 
     adapter.close()
+  })
+
+  it('only upserts new or dirty spans on repeated flushes', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+    const trace = TraceContext.createTrace('goal')
+    const first = TraceContext.startSpan(trace, { name: 'first' })
+    SpanLifecycle.setMetadata(first, { step: 1 })
+    TraceContext.endSpan(first)
+
+    await adapter.flush(trace)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(1)
+
+    await adapter.flush(trace)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(1)
+
+    const second = TraceContext.startSpan(trace, { name: 'second' })
+    SpanLifecycle.setMetadata(second, { step: 2 })
+    TraceContext.endSpan(second)
+    await adapter.flush(trace)
+
+    expect(upsertSpanRun).toHaveBeenCalledTimes(2)
+    expect(upsertSpanRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: second.id, metadata: JSON.stringify({ step: 2 }) }),
+    )
   })
 })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -49,6 +49,8 @@ describe('SQLiteAdapter', () => {
       .mockReturnValueOnce({ run: upsertSpanRun })
       .mockReturnValueOnce({ run: upsertTraceRun })
       .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
     transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
 
     const adapter = new SQLiteAdapter('/tmp/traces.db')
@@ -63,6 +65,17 @@ describe('SQLiteAdapter', () => {
     await adapter.flush(trace)
     expect(upsertSpanRun).toHaveBeenCalledTimes(1)
 
+    const clonedTrace = {
+      ...trace,
+      spans: trace.spans.map(span => ({
+        ...span,
+        metadata: { ...span.metadata },
+        thoughtBlocks: [...span.thoughtBlocks],
+      })),
+    }
+    await adapter.flush(clonedTrace)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(1)
+
     const second = TraceContext.startSpan(trace, { name: 'second' })
     SpanLifecycle.setMetadata(second, { step: 2 })
     TraceContext.endSpan(second)
@@ -72,5 +85,36 @@ describe('SQLiteAdapter', () => {
     expect(upsertSpanRun).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: second.id, metadata: JSON.stringify({ step: 2 }) }),
     )
+  })
+
+  it('does not update the flushed-span cache when the SQLite transaction rolls back', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('write failed')
+      })
+      .mockImplementation(() => undefined)
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+    const trace = TraceContext.createTrace('goal')
+    const first = TraceContext.startSpan(trace, { name: 'first' })
+    const second = TraceContext.startSpan(trace, { name: 'second' })
+    TraceContext.endSpan(first)
+    TraceContext.endSpan(second)
+
+    await expect(adapter.flush(trace)).rejects.toThrow('write failed')
+    await adapter.flush(trace)
+
+    expect(upsertSpanRun).toHaveBeenCalledTimes(4)
+    expect(upsertSpanRun.mock.calls[2]?.[0]).toEqual(expect.objectContaining({ id: first.id }))
+    expect(upsertSpanRun.mock.calls[3]?.[0]).toEqual(expect.objectContaining({ id: second.id }))
   })
 })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -49,8 +49,10 @@ interface FlushedSpanState {
   errorMessage?: string
   metadata: Record<string, unknown>
   metadataKeyCount: number
+  metadataJson: string
   thoughtBlocks: string[]
   thoughtBlockCount: number
+  thoughtBlocksJson: string
 }
 
 /**
@@ -104,6 +106,7 @@ export class SQLiteAdapter implements ExportAdapter {
     warnIfTraceHasActiveSpans(trace, 'SQLiteAdapter')
     const upsertTrace = this.db.prepare(UPSERT_TRACE)
     const upsertSpan = this.db.prepare(UPSERT_SPAN)
+    const flushedInTransaction: Span[] = []
 
     const transaction = this.db.transaction((t: Trace) => {
       upsertTrace.run({
@@ -129,11 +132,14 @@ export class SQLiteAdapter implements ExportAdapter {
           metadata: JSON.stringify(span.metadata),
           thoughtBlocks: JSON.stringify(span.thoughtBlocks),
         })
-        this.rememberFlushedSpan(span)
+        flushedInTransaction.push(span)
       }
     })
 
     transaction(trace)
+    for (const span of flushedInTransaction) {
+      this.rememberFlushedSpan(span)
+    }
   }
 
   private shouldFlushSpan(span: Span): boolean {
@@ -142,21 +148,35 @@ export class SQLiteAdapter implements ExportAdapter {
     if (previous === undefined) return true
 
     // Active spans are still mutable: metadata/thought blocks can grow and the
-    // eventual endSpan() call changes status/timing. Re-flush them while active,
-    // but once completed/error spans have been persisted, skip them unless the
-    // small scalar dirty check below detects a state change.
+    // eventual endSpan() call changes status/timing. Re-flush them while active.
     if (span.status === 'active') return true
 
-    return (
+    if (
       previous.status !== span.status ||
       previous.endedAt !== span.endedAt ||
       previous.durationMs !== span.durationMs ||
-      previous.errorMessage !== span.errorMessage ||
-      previous.metadata !== span.metadata ||
-      previous.metadataKeyCount !== Object.keys(span.metadata).length ||
-      previous.thoughtBlocks !== span.thoughtBlocks ||
-      previous.thoughtBlockCount !== span.thoughtBlocks.length
-    )
+      previous.errorMessage !== span.errorMessage
+    ) {
+      return true
+    }
+
+    return this.metadataChanged(previous, span) || this.thoughtBlocksChanged(previous, span)
+  }
+
+  private metadataChanged(previous: FlushedSpanState, span: Span): boolean {
+    const keyCount = Object.keys(span.metadata).length
+    if (previous.metadata === span.metadata && previous.metadataKeyCount === keyCount) return false
+    return previous.metadataJson !== JSON.stringify(span.metadata)
+  }
+
+  private thoughtBlocksChanged(previous: FlushedSpanState, span: Span): boolean {
+    if (
+      previous.thoughtBlocks === span.thoughtBlocks &&
+      previous.thoughtBlockCount === span.thoughtBlocks.length
+    ) {
+      return false
+    }
+    return previous.thoughtBlocksJson !== JSON.stringify(span.thoughtBlocks)
   }
 
   private rememberFlushedSpan(span: Span): void {
@@ -172,8 +192,10 @@ export class SQLiteAdapter implements ExportAdapter {
       errorMessage: span.errorMessage,
       metadata: span.metadata,
       metadataKeyCount: Object.keys(span.metadata).length,
+      metadataJson: JSON.stringify(span.metadata),
       thoughtBlocks: span.thoughtBlocks,
       thoughtBlockCount: span.thoughtBlocks.length,
+      thoughtBlocksJson: JSON.stringify(span.thoughtBlocks),
     })
   }
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -42,6 +42,17 @@ interface TraceSummaryRow {
   spanCount: number
 }
 
+interface FlushedSpanState {
+  status: Span['status']
+  endedAt?: number
+  durationMs?: number
+  errorMessage?: string
+  metadata: Record<string, unknown>
+  metadataKeyCount: number
+  thoughtBlocks: string[]
+  thoughtBlockCount: number
+}
+
 /**
  * Parse a JSON column, returning a fallback instead of throwing when the
  * stored value is corrupt. A single bad row must not poison the whole trace
@@ -79,6 +90,7 @@ function rowToSpan(row: SpanRow): Span {
  */
 export class SQLiteAdapter implements ExportAdapter {
   private readonly db: Database.Database
+  private readonly flushedSpans = new Map<string, Map<string, FlushedSpanState>>()
 
   constructor(filePath: string) {
     this.db = new Database(filePath)
@@ -102,6 +114,8 @@ export class SQLiteAdapter implements ExportAdapter {
         endedAt: t.endedAt ?? null,
       })
       for (const span of t.spans) {
+        if (!this.shouldFlushSpan(span)) continue
+
         upsertSpan.run({
           id: span.id,
           traceId: span.traceId,
@@ -115,10 +129,52 @@ export class SQLiteAdapter implements ExportAdapter {
           metadata: JSON.stringify(span.metadata),
           thoughtBlocks: JSON.stringify(span.thoughtBlocks),
         })
+        this.rememberFlushedSpan(span)
       }
     })
 
     transaction(trace)
+  }
+
+  private shouldFlushSpan(span: Span): boolean {
+    const byTrace = this.flushedSpans.get(span.traceId)
+    const previous = byTrace?.get(span.id)
+    if (previous === undefined) return true
+
+    // Active spans are still mutable: metadata/thought blocks can grow and the
+    // eventual endSpan() call changes status/timing. Re-flush them while active,
+    // but once completed/error spans have been persisted, skip them unless the
+    // small scalar dirty check below detects a state change.
+    if (span.status === 'active') return true
+
+    return (
+      previous.status !== span.status ||
+      previous.endedAt !== span.endedAt ||
+      previous.durationMs !== span.durationMs ||
+      previous.errorMessage !== span.errorMessage ||
+      previous.metadata !== span.metadata ||
+      previous.metadataKeyCount !== Object.keys(span.metadata).length ||
+      previous.thoughtBlocks !== span.thoughtBlocks ||
+      previous.thoughtBlockCount !== span.thoughtBlocks.length
+    )
+  }
+
+  private rememberFlushedSpan(span: Span): void {
+    let byTrace = this.flushedSpans.get(span.traceId)
+    if (byTrace === undefined) {
+      byTrace = new Map<string, FlushedSpanState>()
+      this.flushedSpans.set(span.traceId, byTrace)
+    }
+    byTrace.set(span.id, {
+      status: span.status,
+      endedAt: span.endedAt,
+      durationMs: span.durationMs,
+      errorMessage: span.errorMessage,
+      metadata: span.metadata,
+      metadataKeyCount: Object.keys(span.metadata).length,
+      thoughtBlocks: span.thoughtBlocks,
+      thoughtBlockCount: span.thoughtBlocks.length,
+    })
   }
 
   async queryByTraceId(traceId: string): Promise<Trace | null> {


### PR DESCRIPTION
## Summary
- Persist only new or dirty SQLite spans during incremental flushes while still upserting trace metadata.
- Count each Prometheus span once and defer active spans until they are completed/error to avoid double-counting mutable spans.
- Add regression coverage for repeated flushes of the same trace.

## Test Plan
- npm --workspace @franken/observer test -- --run src/adapters/sqlite/SQLiteAdapter.test.ts src/adapters/prometheus/PrometheusAdapter.test.ts
- npm --workspace @franken/observer test -- --run src/adapters/sqlite/SQLiteAdapter.integration.test.ts src/adapters/prometheus/PrometheusAdapter.test.ts
- npm run build --workspace @franken/types && npm --workspace @franken/observer run typecheck
- npm --workspace @franken/observer test
- npm --workspace @franken/observer run build
- npx turbo run test typecheck build --filter=@franken/observer

Closes #1110