### PR TITLE
docs(deploy-beasts): refresh dashboard workflow guidance

### DIFF
--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -144,7 +144,11 @@ Use the dashboard wizard to create a tracked agent, choose the supported executi
 2. Click **Create Agent**.
 3. Fill the wizard:
    - **Identity**: name/description for the tracked agent.
-   - **Workflow**: choose `chunk-plan` for a dashboard-launched tracked run on current main. The catalog may also list `design-interview` and `martin-loop`, but launch those through CLI/API until the dashboard supplies their strict config fields. The wizard may also show UI-only presets such as `issues-agent`; those are not deployable Beast catalog entries until their backend definition exists.
+   - **Workflow**: choose a deployable Beast workflow and provide the required fields the dashboard renders for that definition:
+     - `design-interview`: **Goal** (`goal`) and **Output Path** (`outputPath`).
+     - `chunk-plan`: **Design Doc Path** (`designDocPath`) and **Output Directory** (`outputDir`). The design doc path must be repo-relative, must not contain `..` traversal, and must point to a Markdown file.
+     - `martin-loop`: **Provider** (`provider`), **Objective** (`objective`), and **Chunk Directory Path** (`chunkDirectory`).
+     - UI-only presets such as `issues-agent` are not deployable Beast catalog entries until their backend definition exists.
    - **LLM Targets**: select provider/model routing.
    - **Modules**: keep guardrail modules enabled unless you intentionally need a narrower run.
    - **Skills** and **Prompts**: attach context and prompt material.
@@ -152,7 +156,7 @@ Use the dashboard wizard to create a tracked agent, choose the supported executi
 4. Review the generated launch config.
 5. Click **Launch**.
 
-The dashboard creates a tracked agent first. For supported tracked-agent workflows, starting the agent dispatches the linked Beast run. If the agent does not start immediately, select it in the list and click **Start** from the detail panel. If validation fails because required definition fields are missing, use the raw CLI/API run path for that definition instead.
+The dashboard creates a tracked agent first. For supported tracked-agent workflows, starting the agent dispatches the linked Beast run. If the agent does not start immediately, select it in the list and click **Start** from the detail panel. If validation fails, correct the highlighted workflow field values or use the raw CLI/API run path when you need to submit a config shape the wizard does not expose.
 
 ## 5. Monitor status, events, and logs
 
@@ -214,9 +218,11 @@ frankenbeast beasts delete <agent-id>
 
 - The backend token and server-side proxy token differ. Use or update the configured operator token, then make the backend and Vite proxy resolve that same token for chat, network, dashboard, and Beast routes; do not assume a dummy browser env value overrides a stored backend token.
 
-`A dashboard launch fails validation for design-interview or martin-loop`
+`A dashboard launch fails validation`
 
-- Expected on current main. The tracked-agent wizard does not yet populate the strict definition fields for those runs. Launch them through the CLI/API with their required config fields instead.
+- Check the highlighted workflow fields before launching. `design-interview` requires `goal` and `outputPath`; `chunk-plan` requires a repo-relative Markdown `designDocPath` plus `outputDir`; `martin-loop` requires `provider`, `objective`, and `chunkDirectory`.
+- For file and directory fields, browsers may expose fake paths from pickers. Enter the path the backend should resolve, such as a repo-relative design document path or the real chunk directory path, instead of relying on a browser-only fake path.
+- If you need optional or advanced config fields that the wizard does not render, use the raw CLI/API run path and submit the complete config explicitly.
 
 `Container mode fails to start`
 


### PR DESCRIPTION
## Summary
- Removes the stale dashboard `chunk-plan`-only workflow warning from the deploy guide.
- Documents the current dashboard workflow fields for `design-interview`, `chunk-plan`, and `martin-loop`.
- Updates validation troubleshooting to focus on missing/invalid values, browser fake paths, and advanced config fallbacks.

## Test Plan
- `grep -RIn "chunk-plan.*current main\|design-interview.*martin-loop.*CLI/API\|does not yet populate the strict definition fields\|Expected on current main" docs/guides/deploy-beasts.md` (expected no matches)
- `git diff --check`
- `npm run check:package-manager`

Closes #1202