### PR TITLE
fix(mcp-suite): preserve Windows shim trailing backslashes

### DIFF
--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -225,7 +225,7 @@ describe('fbeast main CLI', () => {
       // process.exit throws in test
     }
 
-    const commandLine = `"${shimPath}" "network" "up" "name&whoami" "100^%literal^%" "C:\\tmp\\" "with space" "--set=a"" b" "(group)|pipe"`;
+    const commandLine = `"${shimPath}" "network" "up" "name&whoami" "100^%literal^%" "C:\\tmp\\\\" "with space" "--set=a"" b" "(group)|pipe"`;
     expect(mockSpawnSync).toHaveBeenCalledWith(
       'C:\\Windows\\System32\\cmd.exe',
       ['/d', '/s', '/c', `"${commandLine}"`],

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -67,7 +67,13 @@ function quoteCmdArg(arg: string): string {
   // This string is parsed first by cmd.exe and then forwarded by the npm .cmd shim
   // via %*. Keep metacharacters literal by grouping every argv entry in quotes,
   // not by caret-escaping characters that would then leak into the child argv.
-  return `"${arg.replace(/"/g, '""').replace(/%/g, '^%')}"`;
+  // Backslashes immediately before quotes must be doubled so the downstream
+  // Windows argv parser preserves them instead of treating them as quote escapes.
+  const escaped = arg
+    .replace(/(\\*)"/g, (_match, backslashes: string) => `${backslashes}${backslashes}""`)
+    .replace(/(\\+)$/g, '$1$1')
+    .replace(/%/g, '^%');
+  return `"${escaped}"`;
 }
 
 function isWindowsShellShim(command: string): boolean {


### PR DESCRIPTION
## Summary
- Follow-up to #1063 / issue #591 for late Codex feedback on Windows shim argv quoting
- Double trailing backslashes when building the explicit cmd.exe command string so Windows argv parsing preserves paths ending in `\\`
- Update the MCP suite CLI regression expectation for trailing Windows paths

## Test Plan
- [x] `TMPDIR=$PWD/.tmp NODE_COMPILE_CACHE=$PWD/.node-compile-cache npm run test --workspace @franken/mcp-suite -- src/cli/main.test.ts`
- [x] `TMPDIR=$PWD/.tmp NODE_COMPILE_CACHE=$PWD/.node-compile-cache npm run typecheck --workspace @franken/mcp-suite` (after building workspace deps)
- [x] `TMPDIR=$PWD/.tmp NODE_COMPILE_CACHE=$PWD/.node-compile-cache npm run build --workspace @franken/mcp-suite` (after building workspace deps)
- [x] `TMPDIR=/tmp NODE_COMPILE_CACHE=$PWD/.node-compile-cache npm run test --workspace @franken/mcp-suite`

Follow-up to #591 and #1063.