### PR TITLE
fix(orchestrator): resolve run config hardening follow-ups

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -50,6 +50,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
       onRunStatusChange: (runId: string) => runService.notifyRunStatusChange(runId),
       eventBus,
       runConfigDir,
+      runConfigRoot: projectRoot,
       worktreeIsolation: {
         enabled: true,
         projectRoot,

--- a/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
@@ -75,7 +75,7 @@ export class ContainerBeastExecutor implements BeastExecutor {
     if (deps.eventBus) {
       options.eventBus = deps.eventBus;
     }
-    options.runConfigOwner = parseRunConfigOwner(writableWorkspaceUser(policy));
+    options.runConfigOwner = () => parseRunConfigOwner(writableWorkspaceUser(policy));
     const nextAttemptNumber = (run: BeastRun): number => deps.repository.listAttempts(run.id).length + 1;
     options.transformSpec = (run, _originalSpec, mergedSpec) => toDockerSpec(mergedSpec, policy, {
       containerName: containerNameForRunAttempt(run, nextAttemptNumber(run)),

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -24,6 +24,8 @@ export interface RunConfigSnapshotOwner {
   readonly gid: number;
 }
 
+type RunConfigSnapshotOwnerProvider = () => RunConfigSnapshotOwner | undefined;
+
 const SENSITIVE_CONFIG_KEY_PATTERN = /(?:password|passwd|pwd|secret|clientsecret|token|apikey|accesskey|privatekey|auth|credential|webhook)/i;
 
 function escapeRegExp(value: string): string {
@@ -209,7 +211,8 @@ export interface ProcessBeastExecutorOptions {
   eventBus?: BeastEventBus;
   defaultStopTimeoutMs?: number;
   runConfigDir?: string;
-  runConfigOwner?: RunConfigSnapshotOwner;
+  runConfigRoot?: string;
+  runConfigOwner?: RunConfigSnapshotOwner | RunConfigSnapshotOwnerProvider;
   transformSpec?: (
     run: BeastRun,
     originalSpec: BeastProcessSpec,
@@ -233,6 +236,12 @@ function applyRunConfigOwnership(path: string, owner: RunConfigSnapshotOwner | u
     return;
   }
   chownSync(path, owner.uid, owner.gid);
+}
+
+function resolveRunConfigOwner(
+  owner: RunConfigSnapshotOwner | RunConfigSnapshotOwnerProvider | undefined,
+): RunConfigSnapshotOwner | undefined {
+  return typeof owner === 'function' ? owner() : owner;
 }
 
 function ensureSecureRunConfigDirectory(configDir: string, owner: RunConfigSnapshotOwner | undefined, rootDir: string): void {
@@ -329,13 +338,18 @@ export class ProcessBeastExecutor implements BeastExecutor {
       : processSpec;
 
     // Write configSnapshot to a JSON file for the spawned process to load
-    const runConfigRoot = resolve(isolatedSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd());
+    const runConfigRoot = resolve(this.options.runConfigRoot ?? isolatedSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd());
     const configDir = resolve(this.options.runConfigDir ?? join(runConfigRoot, '.fbeast', '.build', 'run-configs'));
-    const runConfigOwner = this.options.runConfigOwner;
+    const runConfigOwner = resolveRunConfigOwner(this.options.runConfigOwner);
     ensureSecureRunConfigDirectory(configDir, runConfigOwner, runConfigRoot);
     const configFilePath = join(configDir, `${run.id}.json`);
-    if (existsSync(configFilePath)) {
+    try {
+      lstatSync(configFilePath);
       unlinkSync(configFilePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
     }
     this.pendingConfigFilePaths.set(run.id, configFilePath);
 

--- a/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { statSync } from 'node:fs';
+import { mkdirSync, statSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -8,7 +8,7 @@ import { DEFAULT_SANDBOX_POLICY } from '../../../src/beasts/execution/sandbox-po
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
-import type { BeastProcessSpec } from '../../../src/beasts/types.js';
+import type { BeastDefinition, BeastProcessSpec } from '../../../src/beasts/types.js';
 import type { ProcessCallbacks, ProcessSupervisorLike } from '../../../src/beasts/execution/process-supervisor.js';
 
 describe('ContainerBeastExecutor', () => {
@@ -95,6 +95,64 @@ describe('ContainerBeastExecutor', () => {
       expect(statSync(dir).gid).toBe(expectedGid);
     }
     expect(statSync(configPath).mode & 0o777).toBe(0o600);
+    expect(statSync(configPath).uid).toBe(expectedUid);
+    expect(statSync(configPath).gid).toBe(expectedGid);
+  });
+
+  it('uses the current Docker user for run-config ownership when the workspace appears after construction', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-container-executor-'));
+    const workspaceHostPath = join(workDir, 'late-workspace');
+    const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logStore = new BeastLogStore(join(workDir, 'logs'));
+    const spawned: BeastProcessSpec[] = [];
+    const fakeSupervisor: ProcessSupervisorLike = {
+      spawn: vi.fn(async (spec: BeastProcessSpec, _callbacks: ProcessCallbacks) => {
+        spawned.push(spec);
+        return { pid: 4242 };
+      }),
+      stop: vi.fn(async () => undefined),
+      kill: vi.fn(async () => undefined),
+    };
+    const executor = new ContainerBeastExecutor({
+      repository,
+      logStore,
+      supervisorFactory: () => fakeSupervisor,
+      policy: {
+        ...DEFAULT_SANDBOX_POLICY,
+        user: '12345:12345',
+        image: 'fbeast/sandbox:test',
+        workspaceHostPath,
+      },
+    });
+    mkdirSync(workspaceHostPath, { recursive: true });
+    const run = repository.createRun({
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'container',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const definition: BeastDefinition = {
+      id: 'test-beast',
+      version: 1,
+      label: 'Test Beast',
+      description: 'Test beast',
+      executionModeDefault: 'container',
+      configSchema: { parse: (value: unknown) => value },
+      interviewPrompts: [],
+      telemetryLabels: {},
+      buildProcessSpec: () => ({ command: 'node', args: ['agent.js'], cwd: workspaceHostPath, env: {} }),
+    };
+
+    await executor.start(run, definition);
+
+    const userFlag = spawned[0].args.indexOf('--user');
+    const containerUser = spawned[0].args[userFlag + 1]!;
+    const [expectedUid, expectedGid] = containerUser.split(':').map((part) => Number.parseInt(part, 10));
+    expect(containerUser).not.toBe('12345:12345');
+    const configPath = join(workspaceHostPath, '.fbeast', '.build', 'run-configs', `${run.id}.json`);
     expect(statSync(configPath).uid).toBe(expectedUid);
     expect(statSync(configPath).gid).toBe(expectedGid);
   });

--- a/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, statSync } from 'node:fs';
+import { chownSync, mkdirSync, statSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -57,7 +57,7 @@ describe('ContainerBeastExecutor', () => {
       label: 'Test Beast',
       description: 'Test beast',
       executionModeDefault: 'container' as const,
-      configSchema: { parse: (value: unknown) => value },
+      configSchema: { parse: (value: unknown) => value as Readonly<Record<string, unknown>> },
       interviewPrompts: [],
       telemetryLabels: {},
       buildProcessSpec: () => ({ command: 'node', args: ['agent.js'], cwd: workDir, env: { FRANKENBEAST_RUN_CONFIG: '/workspace/config.json' } }),
@@ -113,18 +113,28 @@ describe('ContainerBeastExecutor', () => {
       stop: vi.fn(async () => undefined),
       kill: vi.fn(async () => undefined),
     };
+    const eventualWorkspaceUid = typeof process.getuid === 'function' && process.getuid() === 0
+      ? 10001
+      : (typeof process.getuid === 'function' ? process.getuid() : 1000);
+    const eventualWorkspaceGid = typeof process.getgid === 'function' && process.getuid?.() !== 0
+      ? process.getgid()
+      : 10001;
+    const fallbackUser = eventualWorkspaceUid === 12345 ? '23456:23456' : '12345:12345';
     const executor = new ContainerBeastExecutor({
       repository,
       logStore,
       supervisorFactory: () => fakeSupervisor,
       policy: {
         ...DEFAULT_SANDBOX_POLICY,
-        user: '12345:12345',
+        user: fallbackUser,
         image: 'fbeast/sandbox:test',
         workspaceHostPath,
       },
     });
     mkdirSync(workspaceHostPath, { recursive: true });
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      chownSync(workspaceHostPath, eventualWorkspaceUid, eventualWorkspaceGid);
+    }
     const run = repository.createRun({
       definitionId: 'test-beast',
       definitionVersion: 1,
@@ -140,7 +150,7 @@ describe('ContainerBeastExecutor', () => {
       label: 'Test Beast',
       description: 'Test beast',
       executionModeDefault: 'container',
-      configSchema: { parse: (value: unknown) => value },
+      configSchema: { parse: (value: unknown) => value as Readonly<Record<string, unknown>> },
       interviewPrompts: [],
       telemetryLabels: {},
       buildProcessSpec: () => ({ command: 'node', args: ['agent.js'], cwd: workspaceHostPath, env: {} }),
@@ -151,7 +161,7 @@ describe('ContainerBeastExecutor', () => {
     const userFlag = spawned[0].args.indexOf('--user');
     const containerUser = spawned[0].args[userFlag + 1]!;
     const [expectedUid, expectedGid] = containerUser.split(':').map((part) => Number.parseInt(part, 10));
-    expect(containerUser).not.toBe('12345:12345');
+    expect(containerUser).not.toBe(fallbackUser);
     const configPath = join(workspaceHostPath, '.fbeast', '.build', 'run-configs', `${run.id}.json`);
     expect(statSync(configPath).uid).toBe(expectedUid);
     expect(statSync(configPath).gid).toBe(expectedGid);
@@ -193,7 +203,7 @@ describe('ContainerBeastExecutor', () => {
       label: 'Test Beast',
       description: 'Test beast',
       executionModeDefault: 'container' as const,
-      configSchema: { parse: (value: unknown) => value },
+      configSchema: { parse: (value: unknown) => value as Readonly<Record<string, unknown>> },
       interviewPrompts: [],
       telemetryLabels: {},
       buildProcessSpec: () => ({ command: 'node', args: ['agent.js'], cwd: workDir, env: {} }),

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -52,7 +52,7 @@ describe('createBeastServices', () => {
       )?.runConfigDir === expectedRunConfigDir);
       expect(matchingCall).toBeDefined();
       const [, , supervisor, options] = matchingCall!;
-      expect(options).toMatchObject({ runConfigDir: expectedRunConfigDir });
+      expect(options).toMatchObject({ runConfigDir: expectedRunConfigDir, runConfigRoot: resolve(projectRoot) });
       expect(supervisor).toMatchObject({ options: { projectRoot: resolve(projectRoot) } });
 
       services.dispose();

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -892,6 +892,48 @@ describe('ProcessBeastExecutor', () => {
       expect(serializedPersisted).not.toContain(sensitiveTokenValue);
       expect(serializedPersisted).not.toContain(sensitiveWebhookUrl);
       expect(serializedPersisted).not.toContain(sensitivePrivateCredential);
+    });
+
+    it('creates configured run-config dirs relative to the configured secure root', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const supervisor = createSupervisorMock();
+      const projectRoot = join(workDir, 'project-root');
+      const agentWorktree = join(workDir, 'agent-worktree');
+      const runConfigDir = join(projectRoot, '.fbeast', '.build', 'run-configs');
+      mkdirSync(agentWorktree, { recursive: true });
+      mkdirSync(projectRoot, { recursive: true });
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { runConfigDir, runConfigRoot: projectRoot });
+      const run = createTestRun(repo);
+
+      await executor.start(run, createDefinitionWithCwd(agentWorktree));
+
+      const configPath = join(runConfigDir, `${run.id}.json`);
+      expect(existsSync(configPath)).toBe(true);
+      for (const dir of [join(projectRoot, '.fbeast'), join(projectRoot, '.fbeast', '.build'), runConfigDir]) {
+        expect(statSync(dir).mode & 0o777).toBe(0o700);
+      }
+    });
+
+    it('replaces dangling run-config snapshot symlinks before writing', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const supervisor = createSupervisorMock();
+      const projectRoot = join(workDir, 'project-root');
+      const runConfigDir = join(projectRoot, '.fbeast', '.build', 'run-configs');
+      mkdirSync(runConfigDir, { recursive: true });
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor, { runConfigDir, runConfigRoot: projectRoot });
+      const run = createTestRun(repo);
+      const configPath = join(runConfigDir, `${run.id}.json`);
+      symlinkSync(join(workDir, 'missing-target.json'), configPath);
+
+      await executor.start(run, createDefinitionWithCwd(projectRoot));
+
+      expect(lstatSync(configPath).isSymbolicLink()).toBe(false);
+      expect(readFileSync(configPath, 'utf8')).toContain('Test objective');
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
     });
 
     it('refuses symlinked run-config directories before applying secure modes', async () => {


### PR DESCRIPTION
## Summary
- addresses late Codex findings from merged PR #895 for issue #602
- keeps explicit run-config dirs anchored to the project root during worktree-isolated runs
- recomputes container run-config ownership at start time so it matches the Docker user
- replaces stale/dangling snapshot symlinks before writing the sensitive run config file

## Test Plan
- npm run test --workspace @franken/orchestrator -- process-beast-executor.test.ts container-beast-executor.test.ts create-beast-services.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint:security
- git diff --check

Follow-up to #895 / closes remaining Codex feedback for #602.