### PR TITLE
fix(governor): refresh approval signature verifier

### DIFF
--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -30,20 +30,21 @@ export class ApprovalGateway {
   private readonly channel: ApprovalChannel;
   private readonly auditRecorder: AuditRecorder;
   private readonly config: GovernorConfig;
-  private readonly signatureVerifier: SignatureVerifier | undefined;
+  private readonly configuredSignatureVerifier: SignatureVerifier | undefined;
+  private configSignatureVerifier: SignatureVerifier | undefined;
+  private configSignatureVerifierSecret: string | undefined;
   private readonly sessionTokenStore: SessionTokenStore | undefined;
 
   constructor(deps: ApprovalGatewayDeps) {
     this.channel = deps.channel;
     this.auditRecorder = deps.auditRecorder;
     this.config = deps.config;
-    this.signatureVerifier = deps.signatureVerifier
-      ?? (deps.config.signingSecret ? new SignatureVerifier(deps.config.signingSecret) : undefined);
+    this.configuredSignatureVerifier = deps.signatureVerifier;
     this.sessionTokenStore = deps.sessionTokenStore;
   }
 
   async requestApproval(request: ApprovalRequest): Promise<ApprovalOutcome> {
-    if (this.config.requireSignedApprovals && !this.signatureVerifier) {
+    if (this.config.requireSignedApprovals && !this.resolveSignatureVerifier()) {
       throw new ApprovalConfigurationError(
         'Signed approvals are required but no signature verifier is configured. Provide config.signingSecret or ApprovalGatewayDeps.signatureVerifier.',
       );
@@ -71,7 +72,7 @@ export class ApprovalGateway {
   }
 
   private verifySignature(response: ApprovalResponse): void {
-    const signatureVerifier = this.signatureVerifier;
+    const signatureVerifier = this.resolveSignatureVerifier();
     const payload = formatApprovalResponseSignaturePayload({
       requestId: response.requestId,
       decision: response.decision,
@@ -80,6 +81,26 @@ export class ApprovalGateway {
     if (!signatureVerifier || !response.signature || !signatureVerifier.verify(payload, response.signature)) {
       throw new SignatureVerificationError(response.requestId);
     }
+  }
+
+  private resolveSignatureVerifier(): SignatureVerifier | undefined {
+    if (this.configuredSignatureVerifier) {
+      return this.configuredSignatureVerifier;
+    }
+
+    const signingSecret = this.config.signingSecret;
+    if (!signingSecret) {
+      this.configSignatureVerifier = undefined;
+      this.configSignatureVerifierSecret = undefined;
+      return undefined;
+    }
+
+    if (this.configSignatureVerifierSecret !== signingSecret) {
+      this.configSignatureVerifier = new SignatureVerifier(signingSecret);
+      this.configSignatureVerifierSecret = signingSecret;
+    }
+
+    return this.configSignatureVerifier;
   }
 
   private async withTimeout(

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -182,6 +182,56 @@ describe('ApprovalGateway — security integration', () => {
     expect(outcome.decision).toBe('APPROVE');
   });
 
+  it('refreshes the config-derived verifier when config.signingSecret changes', async () => {
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: 'old-secret' };
+    const channel = makeFakeChannel();
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+    });
+
+    const sign = (secret: string, requestId: string) => new SignatureVerifier(secret).sign(
+      formatApprovalResponseSignaturePayload({ requestId, decision: 'APPROVE' }),
+    );
+
+    vi.mocked(channel.requestApproval)
+      .mockResolvedValueOnce({
+        requestId: 'req-old',
+        decision: 'APPROVE',
+        respondedBy: 'human',
+        respondedAt: new Date(),
+        signature: sign('old-secret', 'req-old'),
+      })
+      .mockResolvedValueOnce({
+        requestId: 'req-stale',
+        decision: 'APPROVE',
+        respondedBy: 'human',
+        respondedAt: new Date(),
+        signature: sign('old-secret', 'req-stale'),
+      })
+      .mockResolvedValueOnce({
+        requestId: 'req-new',
+        decision: 'APPROVE',
+        respondedBy: 'human',
+        respondedAt: new Date(),
+        signature: sign('new-secret', 'req-new'),
+      });
+
+    await expect(gateway.requestApproval(makeRequest({ requestId: 'req-old' }))).resolves.toMatchObject({
+      decision: 'APPROVE',
+    });
+
+    config.signingSecret = 'new-secret';
+
+    await expect(gateway.requestApproval(makeRequest({ requestId: 'req-stale' }))).rejects.toThrow(
+      SignatureVerificationError,
+    );
+    await expect(gateway.requestApproval(makeRequest({ requestId: 'req-new' }))).resolves.toMatchObject({
+      decision: 'APPROVE',
+    });
+  });
+
   it('rejects an unsigned response whose requestId does not match the active request', async () => {
     // Response is for a different (stale/misrouted) request than the one in flight.
     const channel = makeFakeChannel({ requestId: 'req-OTHER', decision: 'APPROVE' });


### PR DESCRIPTION
## Summary
- Rebuild ApprovalGateway's config-derived SignatureVerifier whenever the active signing secret changes
- Keep explicit SignatureVerifier injection behavior unchanged
- Add a rotation regression test that rejects stale old-secret responses and accepts the new secret

## Test Plan
- npm --workspace @franken/governor test -- --run tests/unit/gateway/approval-gateway-security.test.ts
- npm --workspace @franken/types run build
- npm --workspace @franken/governor run typecheck
- npm --workspace @franken/governor run build
- npm --workspace @franken/governor test

Closes #933