### PR TITLE
fix(governor): persist approval session tokens

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -469,9 +469,17 @@ When `requireSignedApprovals` is `true`, the gateway throws `SignatureVerificati
 On APPROVE, the gateway can issue a scoped, time-limited `SessionToken` — the agent must present this token to invoke the approved skill:
 
 ```typescript
-import { SessionTokenStore, createSessionToken } from '@franken/governor';
+import {
+  ApprovalGateway,
+  SessionTokenStore,
+  createGovernorApp,
+  defaultConfig,
+} from '@franken/governor';
 
-const store = new SessionTokenStore();
+const store = new SessionTokenStore({
+  // Optional: share tokens across short-lived governor/hook processes.
+  persistenceFile: '.frankenbeast/governor-session-tokens.json',
+});
 
 // Tokens are created automatically by ApprovalGateway when sessionTokenStore is provided
 const gateway = new ApprovalGateway({
@@ -491,6 +499,14 @@ if (outcome.decision === 'APPROVE' && outcome.token) {
   // Revoke when done
   store.revoke(outcome.token.tokenId);
 }
+
+const app = createGovernorApp({
+  signingSecret: process.env.FRANKEN_GOVERNOR_SIGNING_SECRET,
+  sessionTokenStore: store,
+});
+
+// External callers can validate through POST /v1/approval/session/validate
+// with a signed body: { "tokenId": "...", "scope": "deploy-prod" }.
 ```
 
 `SessionToken` fields:
@@ -504,7 +520,7 @@ if (outcome.decision === 'APPROVE' && outcome.token) {
 | `grantedAt` | `Date` | When the token was issued |
 | `expiresAt` | `Date` | When the token expires |
 
-Expired tokens are automatically cleaned up on access.
+Expired tokens are automatically cleaned up on access and during persisted-store loading.
 
 ## Configuration
 

--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -500,8 +500,9 @@ if (outcome.decision === 'APPROVE' && outcome.token) {
   store.revoke(outcome.token.tokenId);
 }
 
+const signingSecret = process.env.FRANKEN_GOVERNOR_SIGNING_SECRET;
 const app = createGovernorApp({
-  signingSecret: process.env.FRANKEN_GOVERNOR_SIGNING_SECRET,
+  ...(signingSecret ? { signingSecret } : {}),
   sessionTokenStore: store,
 });
 

--- a/packages/franken-governor/docs/adr/ADR-007-session-token-activation.md
+++ b/packages/franken-governor/docs/adr/ADR-007-session-token-activation.md
@@ -10,7 +10,9 @@ The requirements state "the agent only holds session tokens activated by human a
 
 ## Decision
 
-Define a `SessionToken` value object with `scope`, `expiresAt`, `grantedBy`, and `approvalId` fields. The `ApprovalGateway` creates and stores a `SessionToken` upon successful APPROVE response (when a `SessionTokenStore` is provided). The `SessionTokenStore` holds active tokens in memory and auto-expires them on access.
+Define a `SessionToken` value object with `scope`, `expiresAt`, `grantedBy`, and `approvalId` fields. The `ApprovalGateway` creates and stores a `SessionToken` upon successful APPROVE response (when a `SessionTokenStore` is provided). The `SessionTokenStore` can remain in-memory for single-process use or persist active tokens to a JSON file shared by short-lived governor processes. It auto-expires tokens on access and when a persisted store is loaded.
+
+The standalone governor HTTP app exposes `POST /v1/approval/session/validate` so external callers can validate a token against the same shared store. Validation requests require the governor signing secret in production and fail closed with `503` when no session token store is configured.
 
 Token IDs are generated via `randomUUID()` from `node:crypto`.
 
@@ -19,4 +21,5 @@ Token IDs are generated via `randomUUID()` from `node:crypto`.
 - **Positive:** Provides an audit chain from approval to execution.
 - **Positive:** Tokens auto-expire, preventing stale approvals from being reused.
 - **Positive:** Revocation is immediate via `store.revoke(tokenId)`.
-- **Negative:** Only meaningful within a single process; cross-process scenarios require additional infrastructure (deferred).
+- **Positive:** Short-lived governor processes can share approval tokens through an explicit persisted store and a signed validation endpoint.
+- **Negative:** Deployments that need cross-process validation must configure a shared `SessionTokenStore` or `sessionTokenStorePath`; otherwise validation fails closed.

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -61,7 +61,7 @@ export { GovernorAuditRecorder } from './audit/index.js';
 export { formatApprovalResponseSignaturePayload, SignatureVerifier } from './security/index.js';
 export type { ApprovalResponseSignaturePayloadFields } from './security/index.js';
 export { createSessionToken, SessionTokenStore } from './security/index.js';
-export type { CreateSessionTokenParams } from './security/index.js';
+export type { CreateSessionTokenParams, SessionTokenStoreOptions } from './security/index.js';
 
 export { CliChannel } from './channels/index.js';
 export type { ReadlineAdapter, CliChannelDeps } from './channels/index.js';

--- a/packages/franken-governor/src/security/index.ts
+++ b/packages/franken-governor/src/security/index.ts
@@ -6,3 +6,4 @@ export type { ApprovalResponseSignaturePayloadFields } from './signature-verifie
 export { createSessionToken } from './session-token.js';
 export type { CreateSessionTokenParams } from './session-token.js';
 export { SessionTokenStore } from './session-token-store.js';
+export type { SessionTokenStoreOptions } from './session-token-store.js';

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -1,6 +1,17 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname } from 'node:path';
 import type { SessionToken } from '../core/types.js';
+
+const LOCK_RETRY_MS = 10;
+const LOCK_TIMEOUT_MS = 5_000;
 
 export interface SessionTokenStoreOptions {
   /**
@@ -29,9 +40,16 @@ export class SessionTokenStore {
   }
 
   store(token: SessionToken): void {
-    this.loadPersistedTokens();
-    this.tokens.set(token.tokenId, token);
-    this.persist();
+    if (!this.persistenceFile) {
+      this.tokens.set(token.tokenId, token);
+      return;
+    }
+
+    this.withFileLock(() => {
+      this.loadPersistedTokens();
+      this.tokens.set(token.tokenId, token);
+      this.persist();
+    });
   }
 
   get(tokenId: string): SessionToken | undefined {
@@ -48,9 +66,16 @@ export class SessionTokenStore {
   }
 
   revoke(tokenId: string): void {
-    this.loadPersistedTokens();
-    this.tokens.delete(tokenId);
-    this.persist();
+    if (!this.persistenceFile) {
+      this.tokens.delete(tokenId);
+      return;
+    }
+
+    this.withFileLock(() => {
+      this.loadPersistedTokens();
+      this.tokens.delete(tokenId);
+      this.persist();
+    });
   }
 
   isValid(tokenId: string, scope?: string): boolean {
@@ -124,6 +149,39 @@ export class SessionTokenStore {
       grantedAt,
       expiresAt,
     };
+  }
+
+  private withFileLock<T>(operation: () => T): T {
+    if (!this.persistenceFile) return operation();
+
+    mkdirSync(dirname(this.persistenceFile), { recursive: true, mode: 0o700 });
+    const lockPath = `${this.persistenceFile}.lock`;
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    let lockFd: number | undefined;
+
+    while (lockFd === undefined) {
+      try {
+        lockFd = openSync(lockPath, 'wx', 0o600);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== 'EEXIST' || Date.now() >= deadline) {
+          throw err;
+        }
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, LOCK_RETRY_MS);
+      }
+    }
+
+    try {
+      return operation();
+    } finally {
+      closeSync(lockFd);
+      try {
+        unlinkSync(lockPath);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT') throw err;
+      }
+    }
   }
 
   private persist(): void {

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -1,18 +1,47 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import type { SessionToken } from '../core/types.js';
+
+export interface SessionTokenStoreOptions {
+  /**
+   * Optional JSON persistence file shared by short-lived governor processes.
+   * When omitted, the store remains in-memory only.
+   */
+  readonly persistenceFile?: string;
+}
+
+interface SerializedSessionToken {
+  readonly tokenId: string;
+  readonly approvalId: string;
+  readonly scope: string;
+  readonly grantedBy: string;
+  readonly grantedAt: string;
+  readonly expiresAt: string;
+}
 
 export class SessionTokenStore {
   private readonly tokens = new Map<string, SessionToken>();
+  private readonly persistenceFile: string | undefined;
+
+  constructor(options: SessionTokenStoreOptions = {}) {
+    this.persistenceFile = options.persistenceFile;
+    this.loadPersistedTokens();
+  }
 
   store(token: SessionToken): void {
+    this.loadPersistedTokens();
     this.tokens.set(token.tokenId, token);
+    this.persist();
   }
 
   get(tokenId: string): SessionToken | undefined {
+    this.loadPersistedTokens();
     const token = this.tokens.get(tokenId);
     if (token === undefined) return undefined;
 
     if (this.isExpired(token)) {
       this.tokens.delete(tokenId);
+      this.persist();
       return undefined;
     }
 
@@ -20,11 +49,100 @@ export class SessionTokenStore {
   }
 
   revoke(tokenId: string): void {
+    this.loadPersistedTokens();
     this.tokens.delete(tokenId);
+    this.persist();
   }
 
-  isValid(tokenId: string): boolean {
-    return this.get(tokenId) !== undefined;
+  isValid(tokenId: string, scope?: string): boolean {
+    const token = this.get(tokenId);
+    if (!token) return false;
+    return scope === undefined || token.scope === scope;
+  }
+
+  private loadPersistedTokens(): void {
+    if (!this.persistenceFile) return;
+
+    let raw: string;
+    try {
+      raw = readFileSync(this.persistenceFile, 'utf8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return;
+      throw err;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`Unable to read session token store: ${(err as Error).message}`);
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error('Unable to read session token store: expected an array');
+    }
+
+    this.tokens.clear();
+    for (const value of parsed) {
+      const token = this.deserialize(value);
+      if (token && !this.isExpired(token)) {
+        this.tokens.set(token.tokenId, token);
+      }
+    }
+
+    // Drop expired tokens as soon as a new process observes them.
+    this.persist();
+  }
+
+  private deserialize(value: unknown): SessionToken | null {
+    if (!value || typeof value !== 'object') return null;
+    const token = value as Partial<SerializedSessionToken>;
+    if (
+      typeof token.tokenId !== 'string'
+      || typeof token.approvalId !== 'string'
+      || typeof token.scope !== 'string'
+      || typeof token.grantedBy !== 'string'
+      || typeof token.grantedAt !== 'string'
+      || typeof token.expiresAt !== 'string'
+    ) {
+      return null;
+    }
+
+    const grantedAt = new Date(token.grantedAt);
+    const expiresAt = new Date(token.expiresAt);
+    if (Number.isNaN(grantedAt.getTime()) || Number.isNaN(expiresAt.getTime())) {
+      return null;
+    }
+
+    return {
+      tokenId: token.tokenId,
+      approvalId: token.approvalId,
+      scope: token.scope,
+      grantedBy: token.grantedBy,
+      grantedAt,
+      expiresAt,
+    };
+  }
+
+  private persist(): void {
+    if (!this.persistenceFile) return;
+
+    const payload: SerializedSessionToken[] = [...this.tokens.values()]
+      .filter((token) => !this.isExpired(token))
+      .map((token) => ({
+        tokenId: token.tokenId,
+        approvalId: token.approvalId,
+        scope: token.scope,
+        grantedBy: token.grantedBy,
+        grantedAt: token.grantedAt.toISOString(),
+        expiresAt: token.expiresAt.toISOString(),
+      }));
+
+    mkdirSync(dirname(this.persistenceFile), { recursive: true, mode: 0o700 });
+    const tmpPath = `${this.persistenceFile}.${process.pid}.tmp`;
+    writeFileSync(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmpPath, this.persistenceFile);
   }
 
   private isExpired(token: SessionToken): boolean {

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -158,12 +158,14 @@ export class SessionTokenStore {
 
     mkdirSync(dirname(this.persistenceFile), { recursive: true, mode: 0o700 });
     const lockPath = `${this.persistenceFile}.lock`;
+    const lockToken = `${process.pid}:${Date.now()}:${Math.random()}`;
     const deadline = Date.now() + LOCK_TIMEOUT_MS;
     let lockFd: number | undefined;
 
     while (lockFd === undefined) {
       try {
         lockFd = openSync(lockPath, 'wx', 0o600);
+        writeFileSync(lockFd, lockToken);
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
         if (code === 'EEXIST' && this.reclaimStaleLock(lockPath)) {
@@ -180,19 +182,27 @@ export class SessionTokenStore {
       return operation();
     } finally {
       closeSync(lockFd);
-      try {
+      this.releaseFileLock(lockPath, lockToken);
+    }
+  }
+
+  private releaseFileLock(lockPath: string, lockToken: string): void {
+    try {
+      if (readFileSync(lockPath, 'utf8') === lockToken) {
         unlinkSync(lockPath);
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code !== 'ENOENT') throw err;
       }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw err;
     }
   }
 
   private reclaimStaleLock(lockPath: string): boolean {
     try {
+      const observedToken = readFileSync(lockPath, 'utf8');
       const lockAgeMs = Date.now() - statSync(lockPath).mtimeMs;
       if (lockAgeMs < LOCK_STALE_MS) return false;
+      if (readFileSync(lockPath, 'utf8') !== observedToken) return false;
       unlinkSync(lockPath);
       return true;
     } catch (err) {

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -41,7 +41,6 @@ export class SessionTokenStore {
 
     if (this.isExpired(token)) {
       this.tokens.delete(tokenId);
-      this.persist();
       return undefined;
     }
 
@@ -68,7 +67,10 @@ export class SessionTokenStore {
       raw = readFileSync(this.persistenceFile, 'utf8');
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT') return;
+      if (code === 'ENOENT') {
+        this.tokens.clear();
+        return;
+      }
       throw err;
     }
 
@@ -91,8 +93,7 @@ export class SessionTokenStore {
       }
     }
 
-    // Drop expired tokens as soon as a new process observes them.
-    this.persist();
+    // Expired entries are ignored on read and pruned on the next write.
   }
 
   private deserialize(value: unknown): SessionToken | null {

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -4,6 +4,7 @@ import {
   openSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -12,6 +13,7 @@ import type { SessionToken } from '../core/types.js';
 
 const LOCK_RETRY_MS = 10;
 const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_STALE_MS = 30_000;
 
 export interface SessionTokenStoreOptions {
   /**
@@ -164,6 +166,9 @@ export class SessionTokenStore {
         lockFd = openSync(lockPath, 'wx', 0o600);
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'EEXIST' && this.reclaimStaleLock(lockPath)) {
+          continue;
+        }
         if (code !== 'EEXIST' || Date.now() >= deadline) {
           throw err;
         }
@@ -181,6 +186,19 @@ export class SessionTokenStore {
         const code = (err as NodeJS.ErrnoException).code;
         if (code !== 'ENOENT') throw err;
       }
+    }
+  }
+
+  private reclaimStaleLock(lockPath: string): boolean {
+    try {
+      const lockAgeMs = Date.now() - statSync(lockPath).mtimeMs;
+      if (lockAgeMs < LOCK_STALE_MS) return false;
+      unlinkSync(lockPath);
+      return true;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return true;
+      throw err;
     }
   }
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -151,10 +151,14 @@ function normalizeSlackDecision(actionId: unknown): ResponseCode | null {
 export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   const app = new Hono();
   const registry = options.registry ?? new ApprovalWaiterRegistry();
-  const sessionTokenStore = options.sessionTokenStore
-    ?? (options.sessionTokenStorePath
-      ? new SessionTokenStore({ persistenceFile: options.sessionTokenStorePath })
-      : undefined);
+  let sessionTokenStore: SessionTokenStore | undefined = options.sessionTokenStore;
+  if (!sessionTokenStore && options.sessionTokenStorePath) {
+    try {
+      sessionTokenStore = new SessionTokenStore({ persistenceFile: options.sessionTokenStorePath });
+    } catch {
+      sessionTokenStore = undefined;
+    }
+  }
 
   // Health check
   app.get('/health', (c) => {

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -6,6 +6,7 @@ import {
   formatApprovalResponseSignaturePayload,
   SignatureVerifier,
 } from '../security/signature-verifier.js';
+import { SessionTokenStore } from '../security/session-token-store.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
 
@@ -24,6 +25,10 @@ export interface GovernorAppOptions {
    * `GET /health`) is available — no in-process caller can be waiting on it.
    */
   registry?: ApprovalWaiterRegistry;
+  /** Shared session token store used by the validation endpoint. */
+  sessionTokenStore?: SessionTokenStore;
+  /** JSON file used to share session tokens across governor processes. */
+  sessionTokenStorePath?: string;
 }
 
 /** Maximum age (seconds) for a Slack request timestamp before it is rejected as a replay. */
@@ -146,6 +151,10 @@ function normalizeSlackDecision(actionId: unknown): ResponseCode | null {
 export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   const app = new Hono();
   const registry = options.registry ?? new ApprovalWaiterRegistry();
+  const sessionTokenStore = options.sessionTokenStore
+    ?? (options.sessionTokenStorePath
+      ? new SessionTokenStore({ persistenceFile: options.sessionTokenStorePath })
+      : undefined);
 
   // Health check
   app.get('/health', (c) => {
@@ -289,6 +298,66 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
       requestId: body.requestId,
       decision: body.decision,
       status: 'resolved',
+    });
+  });
+
+  // POST /v1/approval/session/validate — validate a session token for
+  // external callers. The endpoint fails closed when no shared token store is
+  // configured, so deployments cannot accidentally treat an unavailable
+  // validation path as success.
+  app.post('/v1/approval/session/validate', async (c) => {
+    const rawBody = Buffer.from(await c.req.arrayBuffer());
+    const body = parseJsonBody(rawBody);
+    if (!body) {
+      return c.json({ error: { message: 'Malformed JSON body' } }, 400);
+    }
+
+    if (!options.signingSecret) {
+      if (!options.allowUnsignedApprovalsForTests) {
+        return c.json({ error: { message: 'Signing secret required for session token validation' } }, 401);
+      }
+    } else {
+      const verification = verifyGovernorSignature(
+        c.req.header('x-governor-signature'),
+        rawBody,
+        options.signingSecret,
+      );
+      if (!verification.ok && verification.reason === 'missing') {
+        return c.json({ error: { message: 'Missing signature' } }, 401);
+      }
+      if (!verification.ok && verification.reason === 'malformed') {
+        return c.json({ error: { message: 'Malformed signature' } }, 401);
+      }
+      if (!verification.ok) {
+        return c.json({ error: { message: 'Invalid signature' } }, 401);
+      }
+    }
+
+    if (!sessionTokenStore) {
+      return c.json({ error: { message: 'Session token validation unavailable' } }, 503);
+    }
+
+    if (typeof body.tokenId !== 'string' || body.tokenId.length === 0) {
+      return c.json({ error: { message: 'Missing required field: tokenId' } }, 400);
+    }
+    if (body.scope !== undefined && typeof body.scope !== 'string') {
+      return c.json({ error: { message: 'Invalid field: scope must be a string' } }, 400);
+    }
+
+    const token = sessionTokenStore.get(body.tokenId);
+    if (!token || (body.scope !== undefined && token.scope !== body.scope)) {
+      return c.json({ valid: false }, 401);
+    }
+
+    return c.json({
+      valid: true,
+      token: {
+        approvalId: token.approvalId,
+        scope: token.scope,
+        grantedBy: token.grantedBy,
+        grantedAt: token.grantedAt.toISOString(),
+        expiresAt: token.expiresAt.toISOString(),
+      },
     });
   });
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { RESPONSE_CODES, type ResponseCode } from '../core/types.js';
+import { RESPONSE_CODES, type ResponseCode, type SessionToken } from '../core/types.js';
 import { ApprovalWaiterRegistry } from '../gateway/approval-waiter-registry.js';
 import {
   formatApprovalResponseSignaturePayload,
@@ -344,7 +344,12 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
       return c.json({ error: { message: 'Invalid field: scope must be a string' } }, 400);
     }
 
-    const token = sessionTokenStore.get(body.tokenId);
+    let token: SessionToken | undefined;
+    try {
+      token = sessionTokenStore.get(body.tokenId);
+    } catch {
+      return c.json({ error: { message: 'Session token validation unavailable' } }, 503);
+    }
     if (!token || (body.scope !== undefined && token.scope !== body.scope)) {
       return c.json({ valid: false }, 401);
     }

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionTokenStore } from '../../../src/security/session-token-store.js';
 import { createSessionToken } from '../../../src/security/session-token.js';
@@ -76,5 +79,77 @@ describe('SessionTokenStore', () => {
   it('isValid() returns false for unknown tokenId', () => {
     const store = new SessionTokenStore();
     expect(store.isValid('unknown')).toBe(false);
+  });
+
+  it('persists tokens so a new store instance can validate them', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const firstStore = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(10_000);
+
+      firstStore.store(token);
+
+      const secondStore = new SessionTokenStore({ persistenceFile });
+      expect(secondStore.get(token.tokenId)).toEqual(token);
+      expect(secondStore.isValid(token.tokenId, 'deploy')).toBe(true);
+      expect(secondStore.isValid(token.tokenId, 'other-scope')).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reloads persisted tokens on access for already-running validator processes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const validatorStore = new SessionTokenStore({ persistenceFile });
+      const issuingStore = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(10_000);
+
+      expect(validatorStore.isValid(token.tokenId)).toBe(false);
+      issuingStore.store(token);
+
+      expect(validatorStore.get(token.tokenId)).toEqual(token);
+      expect(validatorStore.isValid(token.tokenId, 'deploy')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('observes cross-process revocations before validating', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const validatorStore = new SessionTokenStore({ persistenceFile });
+      const issuingStore = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(10_000);
+
+      issuingStore.store(token);
+      expect(validatorStore.isValid(token.tokenId)).toBe(true);
+
+      issuingStore.revoke(token.tokenId);
+      expect(validatorStore.isValid(token.tokenId)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes persisted tokens after expiry', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const store = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(1000);
+      store.store(token);
+
+      vi.advanceTimersByTime(2000);
+
+      expect(store.get(token.tokenId)).toBeUndefined();
+      const persisted = JSON.parse(readFileSync(persistenceFile, 'utf8'));
+      expect(persisted).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -135,7 +135,25 @@ describe('SessionTokenStore', () => {
     }
   });
 
-  it('removes persisted tokens after expiry', () => {
+  it('clears cached tokens when the backing file disappears', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const validatorStore = new SessionTokenStore({ persistenceFile });
+      const issuingStore = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(10_000);
+
+      issuingStore.store(token);
+      expect(validatorStore.isValid(token.tokenId)).toBe(true);
+
+      unlinkSync(persistenceFile);
+      expect(validatorStore.isValid(token.tokenId)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores expired tokens on read and prunes them on the next write', () => {
     const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
     const persistenceFile = join(dir, 'tokens.json');
     try {
@@ -146,8 +164,15 @@ describe('SessionTokenStore', () => {
       vi.advanceTimersByTime(2000);
 
       expect(store.get(token.tokenId)).toBeUndefined();
+      const beforeWrite = JSON.parse(readFileSync(persistenceFile, 'utf8'));
+      expect(beforeWrite).toHaveLength(1);
+
+      const fresh = makeToken(10_000);
+      store.store(fresh);
+
       const persisted = JSON.parse(readFileSync(persistenceFile, 'utf8'));
-      expect(persisted).toEqual([]);
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].tokenId).toBe(fresh.tokenId);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, unlinkSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, unlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -148,6 +148,27 @@ describe('SessionTokenStore', () => {
 
       unlinkSync(persistenceFile);
       expect(validatorStore.isValid(token.tokenId)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers stale lock files before writing persisted tokens', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const staleLockPath = `${persistenceFile}.lock`;
+      writeFileSync(staleLockPath, 'stale');
+      const staleTime = new Date(Date.now() - 60_000);
+      utimesSync(staleLockPath, staleTime, staleTime);
+
+      const store = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(10_000);
+
+      store.store(token);
+
+      expect(store.isValid(token.tokenId)).toBe(true);
+      expect(() => readFileSync(staleLockPath, 'utf8')).toThrow();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createHmac } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createGovernorApp } from '../../../src/server/app.js';
@@ -426,6 +426,32 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(503);
       const body = await res.json();
       expect(body.error.message).toBe('Session token validation unavailable');
+    });
+
+    it('fails closed when persisted token storage becomes unreadable', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'governor-app-session-store-'));
+      const persistenceFile = join(dir, 'tokens.json');
+      try {
+        const issuingStore = new SessionTokenStore({ persistenceFile });
+        const token = makeStoredToken(issuingStore);
+        const app = createGovernorApp({
+          sessionTokenStorePath: persistenceFile,
+          allowUnsignedApprovalsForTests: true,
+        });
+        writeFileSync(persistenceFile, '{not-json');
+
+        const res = await app.request('/v1/approval/session/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tokenId: token.tokenId }),
+        });
+
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.error.message).toBe('Session token validation unavailable');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('requires signed validation requests in production mode', async () => {

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { createHmac } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createGovernorApp } from '../../../src/server/app.js';
+import { createSessionToken } from '../../../src/security/session-token.js';
+import { SessionTokenStore } from '../../../src/security/session-token-store.js';
 
 const SIGNING_FIXTURE = ['test', 'signing', 'fixture'].join('-');
 
@@ -109,8 +114,6 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/approval/respond', () => {
-    const signingFixture = SIGNING_FIXTURE;
-
     async function seedResponseApproval(
       app: ReturnType<typeof createGovernorApp>,
       requestId: string,
@@ -207,7 +210,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('verifies HMAC signature when signing secret configured', async () => {
-      const secret = signingFixture;
+      const secret = SIGNING_FIXTURE;
       const app = createGovernorApp({ signingSecret: secret });
 
       await seedResponseApproval(app, 'req-2', secret);
@@ -228,7 +231,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('verifies approval HMAC over raw body bytes including whitespace', async () => {
-      const secret = signingFixture;
+      const secret = SIGNING_FIXTURE;
       const app = createGovernorApp({ signingSecret: secret });
       await seedResponseApproval(app, 'req-raw-spacing', secret);
 
@@ -249,7 +252,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('requires signatures to match the exact raw body instead of parsed key ordering', async () => {
-      const secret = signingFixture;
+      const secret = SIGNING_FIXTURE;
       const app = createGovernorApp({ signingSecret: secret });
       await seedResponseApproval(app, 'req-key-order', secret);
 
@@ -271,7 +274,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('accepts normalized sha256 hex signatures through the timing-safe compare path', async () => {
-      const secret = signingFixture;
+      const secret = SIGNING_FIXTURE;
       const app = createGovernorApp({ signingSecret: secret });
       await seedResponseApproval(app, 'req-upper-hex', secret);
 
@@ -291,9 +294,9 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects invalid signature using timing-safe hex comparison', async () => {
-      const app = createGovernorApp({ signingSecret: signingFixture });
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
 
-      await seedResponseApproval(app, 'req-3', signingFixture);
+      await seedResponseApproval(app, 'req-3', SIGNING_FIXTURE);
 
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
@@ -310,7 +313,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('returns a clear 401 for a malformed signature', async () => {
-      const app = createGovernorApp({ signingSecret: signingFixture });
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
         headers: {
@@ -335,7 +338,7 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects missing signature when secret configured', async () => {
-      const app = createGovernorApp({ signingSecret: signingFixture });
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
 
       const res = await app.request('/v1/approval/respond', {
         method: 'POST',
@@ -346,6 +349,132 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(401);
       const body = await res.json();
       expect(body.error.message).toBe('Missing signature');
+    });
+  });
+
+  describe('POST /v1/approval/session/validate', () => {
+    function makeStoredToken(store: SessionTokenStore) {
+      const token = createSessionToken({
+        approvalId: 'req-token',
+        scope: 'deploy-prod',
+        grantedBy: 'human',
+        ttlMs: 3_600_000,
+      });
+      store.store(token);
+      return token;
+    }
+
+    it('validates a stored session token', async () => {
+      const store = new SessionTokenStore();
+      const token = makeStoredToken(store);
+      const app = createGovernorApp({
+        sessionTokenStore: store,
+        allowUnsignedApprovalsForTests: true,
+      });
+
+      const res = await app.request('/v1/approval/session/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tokenId: token.tokenId, scope: 'deploy-prod' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.valid).toBe(true);
+      expect(body.token).toMatchObject({
+        approvalId: 'req-token',
+        scope: 'deploy-prod',
+        grantedBy: 'human',
+      });
+      expect(body.token.tokenId).toBeUndefined();
+    });
+
+    it('validates tokens persisted by a separate store instance', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'governor-app-session-store-'));
+      const persistenceFile = join(dir, 'tokens.json');
+      try {
+        const issuingStore = new SessionTokenStore({ persistenceFile });
+        const token = makeStoredToken(issuingStore);
+        const app = createGovernorApp({
+          sessionTokenStorePath: persistenceFile,
+          allowUnsignedApprovalsForTests: true,
+        });
+
+        const res = await app.request('/v1/approval/session/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tokenId: token.tokenId }),
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.valid).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('fails closed when token validation storage is unavailable', async () => {
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+
+      const res = await app.request('/v1/approval/session/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tokenId: 'missing-store' }),
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error.message).toBe('Session token validation unavailable');
+    });
+
+    it('requires signed validation requests in production mode', async () => {
+      const store = new SessionTokenStore();
+      const token = makeStoredToken(store);
+      const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE, sessionTokenStore: store });
+      const payload = JSON.stringify({ tokenId: token.tokenId });
+
+      const missing = await app.request('/v1/approval/session/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+      });
+      expect(missing.status).toBe(401);
+
+      const valid = await app.request('/v1/approval/session/validate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-governor-signature': governorSignature(payload, SIGNING_FIXTURE),
+        },
+        body: payload,
+      });
+      expect(valid.status).toBe(200);
+    });
+
+    it('rejects unknown tokens and scope mismatches', async () => {
+      const store = new SessionTokenStore();
+      const token = makeStoredToken(store);
+      const app = createGovernorApp({
+        sessionTokenStore: store,
+        allowUnsignedApprovalsForTests: true,
+      });
+
+      const wrongScope = await app.request('/v1/approval/session/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tokenId: token.tokenId, scope: 'other-scope' }),
+      });
+      expect(wrongScope.status).toBe(401);
+      expect(await wrongScope.json()).toEqual({ valid: false });
+
+      const unknown = await app.request('/v1/approval/session/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tokenId: 'missing-token' }),
+      });
+      expect(unknown.status).toBe(401);
+      expect(await unknown.json()).toEqual({ valid: false });
     });
   });
 

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -428,7 +428,34 @@ describe('Governor Hono Server', () => {
       expect(body.error.message).toBe('Session token validation unavailable');
     });
 
-    it('fails closed when persisted token storage becomes unreadable', async () => {
+    it('fails closed when persisted token storage is malformed before app startup', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'governor-app-session-store-'));
+      const persistenceFile = join(dir, 'tokens.json');
+      try {
+        writeFileSync(persistenceFile, '{not-json');
+        const app = createGovernorApp({
+          sessionTokenStorePath: persistenceFile,
+          allowUnsignedApprovalsForTests: true,
+        });
+
+        const health = await app.request('/health');
+        expect(health.status).toBe(200);
+
+        const res = await app.request('/v1/approval/session/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tokenId: 'token-from-bad-store' }),
+        });
+
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.error.message).toBe('Session token validation unavailable');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('fails closed when persisted token storage becomes unreadable after app startup', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'governor-app-session-store-'));
       const persistenceFile = join(dir, 'tokens.json');
       try {


### PR DESCRIPTION
## Summary
- add optional persisted SessionTokenStore storage for short-lived governor processes
- add signed /v1/approval/session/validate endpoint that fails closed when storage is unavailable
- document the cross-process token validation model and cover persistence, reload, revocation, and HTTP validation tests

## Test Plan
- npm install
- npm --prefix packages/franken-governor test -- --run tests/unit/security/session-token-store.test.ts tests/unit/server/app.test.ts tests/unit/gateway/approval-gateway-security.test.ts
- npm --prefix packages/franken-governor run typecheck
- npm --prefix packages/franken-governor test
- npm --prefix packages/franken-governor run build
- npm run lint:any
- npm run lint:security

Closes #932