### PR TITLE
fix(brain): make checkpoints atomic with working-memory flush

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -307,11 +307,15 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
   ) {}
 
   checkpoint(state: ExecutionState): { id: string } {
-    this.flushWorkingMemory?.();
-    const result = this.db
-      .prepare(`INSERT INTO checkpoints (state, created_at) VALUES (?, ?)`)
-      .run(JSON.stringify(state), state.timestamp);
-    return { id: String(result.lastInsertRowid) };
+    const tx = this.db.transaction(() => {
+      this.flushWorkingMemory?.();
+      const result = this.db
+        .prepare(`INSERT INTO checkpoints (state, created_at) VALUES (?, ?)`)
+        .run(JSON.stringify(state), state.timestamp);
+      return { id: String(result.lastInsertRowid) };
+    });
+
+    return tx() as { id: string };
   }
 
   lastCheckpoint(): ExecutionState | null {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -287,6 +287,31 @@ describe('SqliteBrain', () => {
       expect(row?.value).toBe('"value1"');
     });
 
+    it('checkpoint() rolls back working memory flush when checkpoint insert fails', () => {
+      const db = (brain as unknown as {
+        db: {
+          exec: (sql: string) => void;
+          prepare: (sql: string) => { get: (key: string) => { value: string } | undefined };
+        };
+      }).db;
+
+      brain.working.set('key1', 'value1');
+      db.exec(`
+        CREATE TRIGGER fail_checkpoint_insert
+        BEFORE INSERT ON checkpoints
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated checkpoint insert failure');
+        END;
+      `);
+
+      expect(() => brain.recovery.checkpoint(makeState())).toThrow(
+        'simulated checkpoint insert failure',
+      );
+
+      const row = db.prepare('SELECT value FROM working_memory WHERE key = ?').get('key1');
+      expect(row).toBeUndefined();
+    });
+
     it('lastCheckpoint() returns most recent', () => {
       brain.recovery.checkpoint(makeState({ step: 1 }));
       brain.recovery.checkpoint(makeState({ step: 2 }));


### PR DESCRIPTION
## Summary
- Wrap recovery checkpoint creation and working-memory flush in one SQLite transaction.
- Add a failure-injection regression test proving a failed checkpoint insert rolls back the working-memory flush.

## Test Plan
- npm test -- tests/unit/sqlite-brain.test.ts (from packages/franken-brain; initial retry after Vitest rejected unsupported --runInBand)
- npm --workspace @franken/types run build
- npm --workspace @franken/brain run typecheck
- npm --workspace @franken/brain run lint
- npm --workspace @franken/brain test
- npm --workspace @franken/brain run build

Closes #939
