### PR TITLE
fix(planner): fail parallel planner on dangling dependencies

### DIFF
--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -60,6 +60,21 @@ export class ParallelPlanner implements PlanningStrategy {
       throw new RecursionDepthExceededError(depth);
     }
 
+    // Validate dangling dependency references before sorting/executing so a
+    // malformed plan cannot run a partial independent subset and be reported as
+    // success. Cycles remain a structural graph error from topoSort below.
+    const danglingDependency = findDanglingDependency(graph);
+    if (danglingDependency) {
+      return {
+        status: 'failed',
+        taskResults: [],
+        failedTaskId: danglingDependency.taskId,
+        error: new Error(
+          `Task '${danglingDependency.taskId}' depends on unknown dependency node '${danglingDependency.dependencyId}'`
+        ),
+      };
+    }
+
     // Validate the DAG up front so cyclic plans fail loudly instead of
     // deadlocking the wave scheduler and returning partial success.
     const tasks = graph.topoSort();
@@ -202,6 +217,22 @@ function normalizeMaxWaveConcurrency(value: number | undefined): number {
   }
 
   return value;
+}
+
+function findDanglingDependency(
+  graph: PlanGraph
+): { taskId: TaskId; dependencyId: TaskId } | undefined {
+  const taskIds = new Set(graph.getTasks().map((task) => task.id));
+
+  for (const task of graph.getTasks()) {
+    for (const dependencyId of graph.getDependencies(task.id)) {
+      if (!taskIds.has(dependencyId)) {
+        return { taskId: task.id, dependencyId };
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function createLimitedExecutor(executor: TaskExecutor, maxConcurrency: number): TaskExecutor {

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -46,6 +46,22 @@ function cyclicGraph(): PlanGraph {
   return PlanGraph.createWithRawEdges(nodes, edges);
 }
 
+function danglingDependencyGraph(): PlanGraph {
+  const ready = makeTask('ready');
+  const blocked = makeTask('blocked');
+  const missing = createTaskId('missing');
+  const nodes = new Map<TaskId, Task>([
+    [ready.id, ready],
+    [blocked.id, blocked],
+  ]);
+  const edges = new Map<TaskId, Set<TaskId>>([
+    [ready.id, new Set<TaskId>()],
+    [blocked.id, new Set<TaskId>([missing])],
+  ]);
+
+  return PlanGraph.createWithRawEdges(nodes, edges);
+}
+
 // ─── Happy path ───────────────────────────────────────────────────────────────
 
 describe('ParallelPlanner — happy path', () => {
@@ -351,6 +367,23 @@ describe('ParallelPlanner — cycle handling', () => {
     await expect(new ParallelPlanner().execute(cyclicGraph(), { executor })).rejects.toBeInstanceOf(
       CyclicDependencyError
     );
+    expect(executor).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Dangling dependency handling ─────────────────────────────────────────────
+
+describe('ParallelPlanner — dangling dependency handling', () => {
+  it('returns failed before executing tasks when a task depends on a missing task', async () => {
+    const executor = vi.fn().mockResolvedValue(success('ready'));
+
+    const result = await new ParallelPlanner().execute(danglingDependencyGraph(), { executor });
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('blocked'));
+    expect(result.error.message).toContain("depends on unknown dependency node 'missing'");
+    expect(result.taskResults).toEqual([]);
     expect(executor).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- fail `ParallelPlanner` with a structured failed result when a task depends on a missing task
- add a regression that proves dangling dependencies do not execute partial plans or report success

## Test Plan
- npm --prefix packages/franken-planner test -- tests/unit/planners/parallel.test.ts
- npm run build --workspace @franken/types
- npm --prefix packages/franken-planner run typecheck
- npm --prefix packages/franken-planner run build
- npm --prefix packages/franken-planner run lint
- npm --prefix packages/franken-planner test

Closes #937