### PR TITLE
fix(governor): audit failed signature verification

### DIFF
--- a/packages/franken-governor/src/audit/audit-recorder.ts
+++ b/packages/franken-governor/src/audit/audit-recorder.ts
@@ -1,16 +1,21 @@
 import type { ApprovalRequest, ApprovalResponse, ResponseCode } from '../core/types.js';
 import type { GovernorMemoryPort, EpisodicTraceRecord } from './governor-memory-port.js';
-import type { AuditRecorder } from '../gateway/approval-gateway.js';
+import type { AuditRecorder, AuditRecordOptions } from '../gateway/approval-gateway.js';
 
 export class GovernorAuditRecorder implements AuditRecorder {
   constructor(private readonly memoryPort: GovernorMemoryPort) {}
 
-  async record(request: ApprovalRequest, response: ApprovalResponse): Promise<void> {
+  async record(
+    request: ApprovalRequest,
+    response: ApprovalResponse,
+    options: AuditRecordOptions = {},
+  ): Promise<void> {
+    const signatureVerificationFailed = options.securityFailure === 'signature-verification';
     const trace: EpisodicTraceRecord = {
       id: request.requestId,
       type: 'episodic',
       projectId: request.projectId,
-      status: this.toStatus(response.decision),
+      status: signatureVerificationFailed ? 'failure' : this.toStatus(response.decision),
       createdAt: Date.now(),
       taskId: request.taskId,
       toolName: 'hitl-gateway',
@@ -24,8 +29,9 @@ export class GovernorAuditRecorder implements AuditRecorder {
         decision: response.decision,
         respondedBy: response.respondedBy,
         feedback: response.feedback,
+        securityFailure: options.securityFailure,
       },
-      tags: this.buildTags(response),
+      tags: this.buildTags(response, options),
     };
 
     await this.memoryPort.recordDecision(trace);
@@ -42,8 +48,13 @@ export class GovernorAuditRecorder implements AuditRecorder {
     }
   }
 
-  private buildTags(response: ApprovalResponse): string[] {
+  private buildTags(response: ApprovalResponse, options: AuditRecordOptions = {}): string[] {
     const tags: string[] = ['hitl'];
+
+    if (options.securityFailure === 'signature-verification') {
+      tags.push('hitl:signature-verification-failed', 'hitl:security-failure');
+      return tags;
+    }
 
     switch (response.decision) {
       case 'APPROVE':

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -15,7 +15,15 @@ import {
 } from '../errors/index.js';
 
 export interface AuditRecorder {
-  record(request: ApprovalRequest, response: ApprovalResponse): Promise<void>;
+  record(
+    request: ApprovalRequest,
+    response: ApprovalResponse,
+    options?: AuditRecordOptions,
+  ): Promise<void>;
+}
+
+export interface AuditRecordOptions {
+  readonly securityFailure?: 'signature-verification';
 }
 
 export interface ApprovalGatewayDeps {
@@ -63,7 +71,16 @@ export class ApprovalGateway {
     }
 
     if (this.config.requireSignedApprovals) {
-      this.verifySignature(response);
+      try {
+        this.verifySignature(response);
+      } catch (error) {
+        if (error instanceof SignatureVerificationError) {
+          await this.auditRecorder.record(request, response, {
+            securityFailure: 'signature-verification',
+          });
+        }
+        throw error;
+      }
     }
 
     await this.auditRecorder.record(request, response);

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -75,9 +75,15 @@ export class ApprovalGateway {
         this.verifySignature(response);
       } catch (error) {
         if (error instanceof SignatureVerificationError) {
-          await this.auditRecorder.record(request, response, {
-            securityFailure: 'signature-verification',
-          });
+          try {
+            await this.auditRecorder.record(request, response, {
+              securityFailure: 'signature-verification',
+            });
+          } catch {
+            // Preserve the signature verification contract for callers even if
+            // the audit backend is unavailable. The original verification
+            // failure remains the security-relevant result of this request.
+          }
         }
         throw error;
       }

--- a/packages/franken-governor/src/gateway/index.ts
+++ b/packages/franken-governor/src/gateway/index.ts
@@ -1,6 +1,6 @@
 export type { ApprovalChannel } from './approval-channel.js';
 export { ApprovalGateway } from './approval-gateway.js';
-export type { AuditRecorder, ApprovalGatewayDeps } from './approval-gateway.js';
+export type { AuditRecorder, AuditRecordOptions, ApprovalGatewayDeps } from './approval-gateway.js';
 export { GovernorCritiqueAdapter } from './governor-critique-adapter.js';
 export type {
   BudgetStateSource,

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -40,7 +40,7 @@ export type {
 
 export type { ApprovalChannel } from './gateway/index.js';
 export { ApprovalGateway } from './gateway/index.js';
-export type { AuditRecorder, ApprovalGatewayDeps } from './gateway/index.js';
+export type { AuditRecorder, AuditRecordOptions, ApprovalGatewayDeps } from './gateway/index.js';
 export { GovernorCritiqueAdapter } from './gateway/index.js';
 export type {
   BudgetStateSource,

--- a/packages/franken-governor/tests/unit/audit/audit-recorder.test.ts
+++ b/packages/franken-governor/tests/unit/audit/audit-recorder.test.ts
@@ -54,6 +54,25 @@ describe('GovernorAuditRecorder', () => {
     expect(trace.tags).toContain('hitl:approved');
   });
 
+  it('records signature verification failures as security failures even for attempted APPROVE responses', async () => {
+    const port = makeFakeMemoryPort();
+    const recorder = new GovernorAuditRecorder(port);
+
+    await recorder.record(
+      makeRequest(),
+      makeResponse({ decision: 'APPROVE', signature: 'invalid-sig' }),
+      { securityFailure: 'signature-verification' },
+    );
+
+    const trace = port.calls[0]!;
+    const output = trace.output as { decision: string; securityFailure: string };
+    expect(trace.status).toBe('failure');
+    expect(trace.tags).toContain('hitl:signature-verification-failed');
+    expect(trace.tags).toContain('hitl:security-failure');
+    expect(output.decision).toBe('APPROVE');
+    expect(output.securityFailure).toBe('signature-verification');
+  });
+
   it('records REGEN with status failure and tag hitl:rejected', async () => {
     const port = makeFakeMemoryPort();
     const recorder = new GovernorAuditRecorder(port);

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -66,15 +66,43 @@ describe('ApprovalGateway — security integration', () => {
   it('throws SignatureVerificationError when requireSignedApprovals is true and signature is invalid', async () => {
     const verifier = new SignatureVerifier(signingFixture);
     const channel = makeFakeChannel({ signature: 'invalid-sig' });
+    const auditRecorder = makeFakeAuditRecorder();
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
     const gateway = new ApprovalGateway({
       channel,
-      auditRecorder: makeFakeAuditRecorder(),
+      auditRecorder,
       config,
       signatureVerifier: verifier,
     });
+    const request = makeRequest();
 
-    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(SignatureVerificationError);
+    await expect(gateway.requestApproval(request)).rejects.toThrow(SignatureVerificationError);
+    expect(auditRecorder.record).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ requestId: request.requestId, signature: 'invalid-sig' }),
+      { securityFailure: 'signature-verification' },
+    );
+  });
+
+  it('audits missing signatures before rejecting signed approval flows', async () => {
+    const verifier = new SignatureVerifier(signingFixture);
+    const channel = makeFakeChannel({ signature: undefined });
+    const auditRecorder = makeFakeAuditRecorder();
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder,
+      config,
+      signatureVerifier: verifier,
+    });
+    const request = makeRequest();
+
+    await expect(gateway.requestApproval(request)).rejects.toThrow(SignatureVerificationError);
+    expect(auditRecorder.record).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ requestId: request.requestId }),
+      { securityFailure: 'signature-verification' },
+    );
   });
 
   it('passes when requireSignedApprovals is true and signature is valid', async () => {

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -105,6 +105,22 @@ describe('ApprovalGateway — security integration', () => {
     );
   });
 
+  it('preserves SignatureVerificationError when audit logging a failed signature also fails', async () => {
+    const verifier = new SignatureVerifier(signingFixture);
+    const channel = makeFakeChannel({ signature: 'invalid-sig' });
+    const auditRecorder = { record: vi.fn().mockRejectedValue(new Error('audit unavailable')) };
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder,
+      config,
+      signatureVerifier: verifier,
+    });
+
+    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(SignatureVerificationError);
+    expect(auditRecorder.record).toHaveBeenCalledOnce();
+  });
+
   it('passes when requireSignedApprovals is true and signature is valid', async () => {
     const verifier = new SignatureVerifier(signingFixture);
     const responsePayload = formatApprovalResponseSignaturePayload({


### PR DESCRIPTION
## Summary
- audit invalid or missing approval signatures before rethrowing SignatureVerificationError
- mark signature verification audit entries as security failures instead of approved HITL decisions
- add gateway and audit-recorder regressions for invalid/missing signatures

## Test Plan
- npm --workspace @franken/types run build
- npm --workspace @franken/governor run typecheck
- npm --workspace @franken/governor run build
- npx turbo run test --filter=@franken/governor

Closes #1108