### PR TITLE
fix(critique): cover plural port scanner codex findings

### DIFF
--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -488,6 +488,11 @@ export class ScalabilityEvaluator implements Evaluator {
         continue;
       }
 
+      if (current === "'" && /[A-Za-z]/.test(content[index - 1] ?? '') && /[A-Za-z]/.test(content[index + 1] ?? '')) {
+        index += 1;
+        continue;
+      }
+
       if (current === '"' || current === "'") {
         const quote = current;
         let stop = index + 1;

--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -5,7 +5,7 @@ const HARDCODED_IP_PATTERN = /["'](\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})["']/g;
 const NON_PORT_IDENTIFIER_EXCLUSIONS = String.raw`(?:[Dd]efault)?[Vv]iew_?[Pp]orts?\w*|(?:DEFAULT_)?VIEW_PORTS?\w*|\w*(?:ViewPorts?|VIEW_PORTS?|view_ports?|view_?ports?|View_?Ports?|[Ss]upport_[Pp]ortal|[Tt]ransports?\b|[Ss]upports?\b|[Pp]ortal(?:s|Id)?\b|[Pp]ortfolios?\b|[Rr]eports?(?![Pp]ort)\w*|[Ii]mports?(?![Pp]ort)\w*|[Ee]xports?(?![Pp]ort)\w*|[Ii]mportant(?![Pp]ort)\w*|REPORT(?!_?PORT)\w*|IMPORT(?!_?PORT)\w*|EXPORT(?!_?PORT)\w*|IMPORTANT(?!_?PORT)\w*)|[Aa]irports?\w*|[Pp]assports?\w*|[Ss]ports?\w*`;
 const PORT_IDENTIFIER_PATTERN = String.raw`(?<![\w$])(?!(?:${NON_PORT_IDENTIFIER_EXCLUSIONS})(?![\w$]))\w*[Pp][Oo][Rr][Tt][Ss]?(?=$|[^a-z0-9_$]|[A-Z0-9_])\w*(?![\w$])`;
 const PORT_CONFIG_KEY_PATTERN = PORT_IDENTIFIER_PATTERN;
-const QUOTED_PORT_KEY_PATTERN = String.raw`["'](?!(?:[Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?|[^"']*[-.][Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?)[^"']*["'])(?:[A-Za-z0-9_]+[-.])*[Pp][Oo][Rr][Tt][Ss]?(?:[-.][A-Za-z0-9_]+)*["']`;
+const QUOTED_PORT_KEY_PATTERN = String.raw`["'](?!(?:[Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?|[^"']*[-._][Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?)[^"']*["'])(?:[A-Za-z0-9_]+[-.])*[Pp][Oo][Rr][Tt][Ss]?(?:[-.][A-Za-z0-9_]+)*["']`;
 const PORT_NUMBER_PATTERN = String.raw`(\d[\d_]{1,6})`;
 const PORT_PROPERTY_GAP_PATTERN = String.raw`(?:\s|/\*[\s\S]*?\*/|//[^\n]*(?:\n|$))*`;
 const PORT_TYPE_ANNOTATION_PATTERN = String.raw`(?:\s*:\s*(?:[^=;,\n<>]+|[^=;\n<>]*<[^=;]*>[^=;\n]*))?`;
@@ -157,10 +157,13 @@ export class ScalabilityEvaluator implements Evaluator {
       if (this.isInTypeOnlyRange(ignoredRanges, containerStart)) {
         continue;
       }
-      if (/(?:^|[^a-z0-9])(?:[Tt]ransports|[Ss]upports)(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+      if (/(?:^|[^a-z0-9])(?:[Aa]irports?|[Cc]arports?|[Pp]assports?|[Ss]ports?)(?:$|[^a-z0-9]|[A-Z_])/.test(normalizedContainerKey)) {
         continue;
       }
-      if (!/(?:^|[^a-z0-9]|[a-z](?=[A-Z]))[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+      if (/(?:^|[^a-z0-9])(?:[Tt]ransports|[Ss]upports)(?![-._]?[Pp][Oo][Rr][Tt][Ss])(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+        continue;
+      }
+      if (!/[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
         continue;
       }
       if (this.isInTypeOnlyRange(typeOnlyRanges, matchIndex) ||

--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -157,10 +157,10 @@ export class ScalabilityEvaluator implements Evaluator {
       if (this.isInTypeOnlyRange(ignoredRanges, containerStart)) {
         continue;
       }
-      if (/(?:^|[^a-z0-9])(?:[Aa]irports?|[Cc]arports?|[Pp]assports?|[Ss]ports?)(?:$|[^a-z0-9]|[A-Z_])/.test(normalizedContainerKey)) {
+      if (/^(?:[Aa]irports?|[Cc]arports?|[Pp]assports?|[Ss]ports?)(?![-._]?[Pp][Oo][Rr][Tt][Ss])(?:$|[^a-z0-9]|[A-Z_])/.test(normalizedContainerKey)) {
         continue;
       }
-      if (/(?:^|[^a-z0-9])(?:[Tt]ransports|[Ss]upports)(?![-._]?[Pp][Oo][Rr][Tt][Ss])(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+      if (/^(?:[Tt]ransports|[Ss]upports)(?![-._]?[Pp][Oo][Rr][Tt][Ss])(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
         continue;
       }
       if (!/[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {

--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -5,7 +5,7 @@ const HARDCODED_IP_PATTERN = /["'](\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})["']/g;
 const NON_PORT_IDENTIFIER_EXCLUSIONS = String.raw`(?:[Dd]efault)?[Vv]iew_?[Pp]orts?\w*|(?:DEFAULT_)?VIEW_PORTS?\w*|\w*(?:ViewPorts?|VIEW_PORTS?|view_ports?|view_?ports?|View_?Ports?|[Ss]upport_[Pp]ortal|[Tt]ransports?\b|[Ss]upports?\b|[Pp]ortal(?:s|Id)?\b|[Pp]ortfolios?\b|[Rr]eports?(?![Pp]ort)\w*|[Ii]mports?(?![Pp]ort)\w*|[Ee]xports?(?![Pp]ort)\w*|[Ii]mportant(?![Pp]ort)\w*|REPORT(?!_?PORT)\w*|IMPORT(?!_?PORT)\w*|EXPORT(?!_?PORT)\w*|IMPORTANT(?!_?PORT)\w*)|[Aa]irports?\w*|[Pp]assports?\w*|[Ss]ports?\w*`;
 const PORT_IDENTIFIER_PATTERN = String.raw`(?<![\w$])(?!(?:${NON_PORT_IDENTIFIER_EXCLUSIONS})(?![\w$]))\w*[Pp][Oo][Rr][Tt][Ss]?(?=$|[^a-z0-9_$]|[A-Z0-9_])\w*(?![\w$])`;
 const PORT_CONFIG_KEY_PATTERN = PORT_IDENTIFIER_PATTERN;
-const QUOTED_PORT_KEY_PATTERN = String.raw`["'](?!(?:[^"']*(?:[Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?)[^"']*))(?:[A-Za-z0-9_]+[-.])*[Pp][Oo][Rr][Tt][Ss]?(?:[-.][A-Za-z0-9_]+)*["']`;
+const QUOTED_PORT_KEY_PATTERN = String.raw`["'](?!(?:[Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?|[^"']*[-.][Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?)[^"']*["'])(?:[A-Za-z0-9_]+[-.])*[Pp][Oo][Rr][Tt][Ss]?(?:[-.][A-Za-z0-9_]+)*["']`;
 const PORT_NUMBER_PATTERN = String.raw`(\d[\d_]{1,6})`;
 const PORT_PROPERTY_GAP_PATTERN = String.raw`(?:\s|/\*[\s\S]*?\*/|//[^\n]*(?:\n|$))*`;
 const PORT_TYPE_ANNOTATION_PATTERN = String.raw`(?:\s*:\s*(?:[^=;,\n<>]+|[^=;\n<>]*<[^=;]*>[^=;\n]*))?`;
@@ -157,10 +157,10 @@ export class ScalabilityEvaluator implements Evaluator {
       if (this.isInTypeOnlyRange(ignoredRanges, containerStart)) {
         continue;
       }
-      if (/(?:^|[^a-z0-9])(?:[Tt]ransports?|[Ss]upports?)(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+      if (/(?:^|[^a-z0-9])(?:[Tt]ransports|[Ss]upports)(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
         continue;
       }
-      if (!/[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+      if (!/(?:^|[^a-z0-9]|[a-z](?=[A-Z]))[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
         continue;
       }
       if (this.isInTypeOnlyRange(typeOnlyRanges, matchIndex) ||

--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -157,6 +157,9 @@ export class ScalabilityEvaluator implements Evaluator {
       if (this.isInTypeOnlyRange(ignoredRanges, containerStart)) {
         continue;
       }
+      if (/(?:^|[^a-z0-9])(?:[Tt]ransports?|[Ss]upports?)(?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
+        continue;
+      }
       if (!/[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
         continue;
       }

--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -5,7 +5,7 @@ const HARDCODED_IP_PATTERN = /["'](\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})["']/g;
 const NON_PORT_IDENTIFIER_EXCLUSIONS = String.raw`(?:[Dd]efault)?[Vv]iew_?[Pp]orts?\w*|(?:DEFAULT_)?VIEW_PORTS?\w*|\w*(?:ViewPorts?|VIEW_PORTS?|view_ports?|view_?ports?|View_?Ports?|[Ss]upport_[Pp]ortal|[Tt]ransports?\b|[Ss]upports?\b|[Pp]ortal(?:s|Id)?\b|[Pp]ortfolios?\b|[Rr]eports?(?![Pp]ort)\w*|[Ii]mports?(?![Pp]ort)\w*|[Ee]xports?(?![Pp]ort)\w*|[Ii]mportant(?![Pp]ort)\w*|REPORT(?!_?PORT)\w*|IMPORT(?!_?PORT)\w*|EXPORT(?!_?PORT)\w*|IMPORTANT(?!_?PORT)\w*)|[Aa]irports?\w*|[Pp]assports?\w*|[Ss]ports?\w*`;
 const PORT_IDENTIFIER_PATTERN = String.raw`(?<![\w$])(?!(?:${NON_PORT_IDENTIFIER_EXCLUSIONS})(?![\w$]))\w*[Pp][Oo][Rr][Tt][Ss]?(?=$|[^a-z0-9_$]|[A-Z0-9_])\w*(?![\w$])`;
 const PORT_CONFIG_KEY_PATTERN = PORT_IDENTIFIER_PATTERN;
-const QUOTED_PORT_KEY_PATTERN = String.raw`["'](?!(?:[^"']*(?:[Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt])[^"']*))(?:[A-Za-z0-9_]+[-.])*[Pp][Oo][Rr][Tt](?:[-.][A-Za-z0-9_]+)*["']`;
+const QUOTED_PORT_KEY_PATTERN = String.raw`["'](?!(?:[^"']*(?:[Vv][Ii][Ee][Ww][-.][Pp][Oo][Rr][Tt][Ss]?)[^"']*))(?:[A-Za-z0-9_]+[-.])*[Pp][Oo][Rr][Tt][Ss]?(?:[-.][A-Za-z0-9_]+)*["']`;
 const PORT_NUMBER_PATTERN = String.raw`(\d[\d_]{1,6})`;
 const PORT_PROPERTY_GAP_PATTERN = String.raw`(?:\s|/\*[\s\S]*?\*/|//[^\n]*(?:\n|$))*`;
 const PORT_TYPE_ANNOTATION_PATTERN = String.raw`(?:\s*:\s*(?:[^=;,\n<>]+|[^=;\n<>]*<[^=;]*>[^=;\n]*))?`;
@@ -157,7 +157,7 @@ export class ScalabilityEvaluator implements Evaluator {
       if (this.isInTypeOnlyRange(ignoredRanges, containerStart)) {
         continue;
       }
-      if (!/[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9_]|[A-Z])/.test(normalizedContainerKey)) {
+      if (!/[Pp][Oo][Rr][Tt][Ss](?:$|[^a-z0-9]|[A-Z])/.test(normalizedContainerKey)) {
         continue;
       }
       if (this.isInTypeOnlyRange(typeOnlyRanges, matchIndex) ||
@@ -464,6 +464,15 @@ export class ScalabilityEvaluator implements Evaluator {
       if (current === '/' && this.startsRegexLiteral(content, index)) {
         const stop = this.findRegexLiteralEnd(content, index);
         ranges.push([index, stop - 1]);
+        index = stop;
+        continue;
+      }
+
+      if (current === '`' && content[index + 1] === '`' && content[index + 2] === '`') {
+        let stop = index + 3;
+        while (content[stop] === '`') {
+          stop += 1;
+        }
         index = stop;
         continue;
       }

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -571,6 +571,10 @@ const port: Brand<
 
   it('covers follow-up Codex plural and markdown fence cases', async () => {
     const evaluator = new ScalabilityEvaluator();
+    const cleanResult = await evaluator.evaluate(createInput('const cfg = { transports_by_mode: { bus: 8080 }, supports_by_mode: { retries: 8443 } };'));
+
+    expect(cleanResult.findings.some((f) => f.message.includes('hardcoded port number'))).toBe(false);
+
     const content = `Here is the problematic config:
 \`\`\`ts
 const markdownPort = 8080;

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -571,7 +571,7 @@ const port: Brand<
 
   it('covers follow-up Codex plural and markdown fence cases', async () => {
     const evaluator = new ScalabilityEvaluator();
-    const cleanResult = await evaluator.evaluate(createInput('const cfg = { transports_by_mode: { bus: 8080 }, supports_by_mode: { retries: 8443 } };'));
+    const cleanResult = await evaluator.evaluate(createInput('const cfg = { transports_by_mode: { bus: 8080 }, supports_by_mode: { retries: 8443 }, carports_by_site: { count: 5000 } };'));
 
     expect(cleanResult.findings.some((f) => f.message.includes('hardcoded port number'))).toBe(false);
 
@@ -580,7 +580,8 @@ const port: Brand<
 const markdownPort = 8080;
 \`\`\`
 const cfg = { ports_by_protocol: { https: 8443 }, server_ports_by_name: { admin: 9000 } };
-const quoted = { "server-ports": 3000, "server.ports": 5000 };
+const serviceMaps = { transport_ports: { http: 8081 }, support_ports: { health: 8082 } };
+const quoted = { "server-ports": 3000, "server.ports": 5000, "preview-ports": 6000 };
 config["server-ports"] = 7000;`;
     const result = await evaluator.evaluate(createInput(content));
 
@@ -588,9 +589,12 @@ config["server-ports"] = 7000;`;
       'Found hardcoded port number: 8080. Use environment variables or config.',
       'Found hardcoded port number: 3000. Use environment variables or config.',
       'Found hardcoded port number: 5000. Use environment variables or config.',
+      'Found hardcoded port number: 6000. Use environment variables or config.',
       'Found hardcoded port number: 7000. Use environment variables or config.',
       'Found hardcoded port number: 8443. Use environment variables or config.',
       'Found hardcoded port number: 9000. Use environment variables or config.',
+      'Found hardcoded port number: 8081. Use environment variables or config.',
+      'Found hardcoded port number: 8082. Use environment variables or config.',
     ]);
   });
 

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -569,6 +569,27 @@ const port: Brand<
     ]);
   });
 
+  it('covers follow-up Codex plural and markdown fence cases', async () => {
+    const evaluator = new ScalabilityEvaluator();
+    const content = `Here is the problematic config:
+\`\`\`ts
+const markdownPort = 8080;
+\`\`\`
+const cfg = { ports_by_protocol: { https: 8443 }, server_ports_by_name: { admin: 9000 } };
+const quoted = { "server-ports": 3000, "server.ports": 5000 };
+config["server-ports"] = 7000;`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.map((f) => f.message)).toEqual([
+      'Found hardcoded port number: 8080. Use environment variables or config.',
+      'Found hardcoded port number: 3000. Use environment variables or config.',
+      'Found hardcoded port number: 5000. Use environment variables or config.',
+      'Found hardcoded port number: 7000. Use environment variables or config.',
+      'Found hardcoded port number: 8443. Use environment variables or config.',
+      'Found hardcoded port number: 9000. Use environment variables or config.',
+    ]);
+  });
+
   it('preserves long interface declarations as type-only', async () => {
     const evaluator = new ScalabilityEvaluator();
     const longExtends = Array.from({ length: 260 }, (_, index) => `Base${index}`).join(' & ');

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -582,7 +582,7 @@ const markdownPort = 8080;
 const cfg = { ports_by_protocol: { https: 8443 }, server_ports_by_name: { admin: 9000 } };
 const serviceMaps = { transport_ports: { http: 8081 }, support_ports: { health: 8082 }, transports_ports: { http: 8083 }, supports_ports: { health: 8084 } };
 const lowercaseMaps = { serverports: { http: 8085 }, apiports: { grpc: 8086 } };
-const quoted = { "server-ports": 3000, "server.ports": 5000, "preview-ports": 6000 };
+const quoted = { "server-ports": 3000, "server.ports": 5000, "preview-ports": 6000, "sports-ports": 9443 };
 config["server-ports"] = 7000;`;
     const result = await evaluator.evaluate(createInput(content));
 
@@ -591,6 +591,7 @@ config["server-ports"] = 7000;`;
       'Found hardcoded port number: 3000. Use environment variables or config.',
       'Found hardcoded port number: 5000. Use environment variables or config.',
       'Found hardcoded port number: 6000. Use environment variables or config.',
+      'Found hardcoded port number: 9443. Use environment variables or config.',
       'Found hardcoded port number: 7000. Use environment variables or config.',
       'Found hardcoded port number: 8443. Use environment variables or config.',
       'Found hardcoded port number: 9000. Use environment variables or config.',

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -579,6 +579,10 @@ const port: Brand<
 \`\`\`ts
 const markdownPort = 8080;
 \`\`\`
+Here's another config:
+\`\`\`ts
+const contractionFencePort = 8087;
+\`\`\`
 const cfg = { ports_by_protocol: { https: 8443 }, server_ports_by_name: { admin: 9000 } };
 const serviceMaps = { transport_ports: { http: 8081 }, support_ports: { health: 8082 }, transports_ports: { http: 8083 }, supports_ports: { health: 8084 } };
 const lowercaseMaps = { serverports: { http: 8085 }, apiports: { grpc: 8086 } };
@@ -588,6 +592,7 @@ config["server-ports"] = 7000;`;
 
     expect(result.findings.map((f) => f.message)).toEqual([
       'Found hardcoded port number: 8080. Use environment variables or config.',
+      'Found hardcoded port number: 8087. Use environment variables or config.',
       'Found hardcoded port number: 3000. Use environment variables or config.',
       'Found hardcoded port number: 5000. Use environment variables or config.',
       'Found hardcoded port number: 6000. Use environment variables or config.',

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -571,7 +571,7 @@ const port: Brand<
 
   it('covers follow-up Codex plural and markdown fence cases', async () => {
     const evaluator = new ScalabilityEvaluator();
-    const cleanResult = await evaluator.evaluate(createInput('const cfg = { transports_by_mode: { bus: 8080 }, supports_by_mode: { retries: 8443 }, carports_by_site: { count: 5000 } };'));
+    const cleanResult = await evaluator.evaluate(createInput('const cfg = { transports_by_mode: { bus: 8080 }, supports_by_mode: { retries: 8443 }, carports_by_site: { count: 5000 }, "server_view-port": 1024 };'));
 
     expect(cleanResult.findings.some((f) => f.message.includes('hardcoded port number'))).toBe(false);
 
@@ -580,7 +580,8 @@ const port: Brand<
 const markdownPort = 8080;
 \`\`\`
 const cfg = { ports_by_protocol: { https: 8443 }, server_ports_by_name: { admin: 9000 } };
-const serviceMaps = { transport_ports: { http: 8081 }, support_ports: { health: 8082 } };
+const serviceMaps = { transport_ports: { http: 8081 }, support_ports: { health: 8082 }, transports_ports: { http: 8083 }, supports_ports: { health: 8084 } };
+const lowercaseMaps = { serverports: { http: 8085 }, apiports: { grpc: 8086 } };
 const quoted = { "server-ports": 3000, "server.ports": 5000, "preview-ports": 6000 };
 config["server-ports"] = 7000;`;
     const result = await evaluator.evaluate(createInput(content));
@@ -595,6 +596,10 @@ config["server-ports"] = 7000;`;
       'Found hardcoded port number: 9000. Use environment variables or config.',
       'Found hardcoded port number: 8081. Use environment variables or config.',
       'Found hardcoded port number: 8082. Use environment variables or config.',
+      'Found hardcoded port number: 8083. Use environment variables or config.',
+      'Found hardcoded port number: 8084. Use environment variables or config.',
+      'Found hardcoded port number: 8085. Use environment variables or config.',
+      'Found hardcoded port number: 8086. Use environment variables or config.',
     ]);
   });
 


### PR DESCRIPTION
## Summary
- allow plural quoted port keys such as "server-ports" and "server.ports"
- scan snake_case plural port containers such as ports_by_protocol
- avoid treating Markdown code fences as JavaScript template literals so fenced plan/code snippets are still scanned

## Test Plan
- npm --workspace @franken/critique test -- scalability.test.ts
- npm --workspace @franken/critique test
- npm --workspace @franken/critique run build

Follow-up to #1290 for late Codex findings.