### PR TITLE
fix(observer): close cache follow-up findings

### DIFF
--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -24,6 +24,21 @@ function makeTraceNoModel() {
   return trace
 }
 
+function makeMultiSpanTrace(tokenCounts: number[]) {
+  const trace = TraceContext.createTrace('multi')
+  for (const [index, promptTokens] of tokenCounts.entries()) {
+    const span = TraceContext.startSpan(trace, { name: `llm-call-${index}` })
+    SpanLifecycle.recordTokenUsage(span, {
+      promptTokens,
+      completionTokens: 0,
+      model: 'claude-sonnet-4-6',
+    })
+    TraceContext.endSpan(span)
+  }
+  TraceContext.endTrace(trace)
+  return trace
+}
+
 describe('PrometheusAdapter', () => {
   describe('scrape() — token metrics', () => {
     it('returns a non-empty string after a flush', async () => {
@@ -100,6 +115,19 @@ describe('PrometheusAdapter', () => {
       const out = adapter.scrape()
       expect(out).toMatch(
         /franken_observer_tokens_total\{model="claude-sonnet-4-6",type="prompt"\}\s+300/,
+      )
+    })
+
+    it('does not evict the next cached span while retrying a large trace', async () => {
+      const adapter = new PrometheusAdapter({ maxDedupeSpans: 2 })
+      const trace = makeMultiSpanTrace([100, 200, 300])
+
+      await adapter.flush(trace)
+      await adapter.flush(trace)
+
+      const out = adapter.scrape()
+      expect(out).toMatch(
+        /franken_observer_tokens_total\{model="claude-sonnet-4-6",type="prompt"\}\s+600/,
       )
     })
 

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -131,6 +131,40 @@ describe('PrometheusAdapter', () => {
       )
     })
 
+    it('prunes oldest span ids without dropping newly flushed spans from the same trace', async () => {
+      const adapter = new PrometheusAdapter({ maxDedupeSpans: 3 })
+      const first = TraceContext.createTrace('first')
+      const firstSpan = TraceContext.startSpan(first, { name: 'llm-call' })
+      SpanLifecycle.recordTokenUsage(firstSpan, {
+        promptTokens: 100,
+        completionTokens: 0,
+        model: 'claude-sonnet-4-6',
+      })
+      TraceContext.endSpan(firstSpan)
+      const second = makeTrace('claude-sonnet-4-6', 200, 0)
+      const third = makeTrace('claude-sonnet-4-6', 300, 0)
+
+      await adapter.flush(first)
+      await adapter.flush(second)
+
+      const appended = TraceContext.startSpan(first, { name: 'llm-call-appended' })
+      SpanLifecycle.recordTokenUsage(appended, {
+        promptTokens: 400,
+        completionTokens: 0,
+        model: 'claude-sonnet-4-6',
+      })
+      TraceContext.endSpan(appended)
+      TraceContext.endTrace(first)
+      await adapter.flush(first)
+      await adapter.flush(third)
+      await adapter.flush(first)
+
+      const out = adapter.scrape()
+      expect(out).toMatch(
+        /franken_observer_tokens_total\{model="claude-sonnet-4-6",type="prompt"\}\s+1100/,
+      )
+    })
+
     it('tracks multiple models independently', async () => {
       const adapter = new PrometheusAdapter()
       await adapter.flush(makeTrace('claude-sonnet-4-6', 100, 50))

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -15,6 +15,11 @@ interface TokenCounts {
   completion: number
 }
 
+interface FlushedSpanEntry {
+  traceId: string
+  spanId: string
+}
+
 function escapePrometheusLabelValue(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"')
 }
@@ -35,6 +40,7 @@ export class PrometheusAdapter implements ExportAdapter {
   private spanCounters = new Map<string, number>()
   private costCounters = new Map<string, number>()
   private flushedSpanIdsByTrace = new Map<string, Set<string>>()
+  private flushedSpanInsertionOrder = new Map<string, FlushedSpanEntry>()
   private flushedSpanIdCount = 0
 
   constructor(options: PrometheusAdapterOptions = {}) {
@@ -99,7 +105,9 @@ export class PrometheusAdapter implements ExportAdapter {
 
     for (const spanId of spanIds) {
       if (flushedSpanIds.has(spanId)) continue
+      const spanKey = `${traceId}\u0000${spanId}`
       flushedSpanIds.add(spanId)
+      this.flushedSpanInsertionOrder.set(spanKey, { traceId, spanId })
       this.flushedSpanIdCount += 1
     }
 
@@ -108,25 +116,28 @@ export class PrometheusAdapter implements ExportAdapter {
 
   private pruneFlushedSpans(currentTraceId: string): void {
     while (this.flushedSpanIdCount > this.maxDedupeSpans) {
-      const oldestTraceId = this.flushedSpanIdsByTrace.keys().next().value as string | undefined
-      if (oldestTraceId === undefined) break
+      let pruned = false
 
-      // Keep the trace currently being flushed intact so a retry of a large
-      // trace does not evict the next span immediately before it is checked and
-      // double-count the trace. Older traces are pruned first; a single large
-      // trace may temporarily exceed the configured cap until another trace is
-      // flushed.
-      if (oldestTraceId === currentTraceId) {
-        if (this.flushedSpanIdsByTrace.size === 1) break
-        const current = this.flushedSpanIdsByTrace.get(oldestTraceId)
-        this.flushedSpanIdsByTrace.delete(oldestTraceId)
-        this.flushedSpanIdsByTrace.set(oldestTraceId, current ?? new Set<string>())
-        continue
+      for (const [spanKey, entry] of this.flushedSpanInsertionOrder) {
+        // Keep the trace currently being flushed intact so a retry of a large
+        // trace does not evict the next span immediately before it is checked and
+        // double-count the trace. Older individual span ids from other traces are
+        // pruned first; a single large current trace may temporarily exceed the
+        // configured cap until another trace is flushed.
+        if (entry.traceId === currentTraceId) continue
+
+        this.flushedSpanInsertionOrder.delete(spanKey)
+        const traceSpanIds = this.flushedSpanIdsByTrace.get(entry.traceId)
+        traceSpanIds?.delete(entry.spanId)
+        if (traceSpanIds?.size === 0) {
+          this.flushedSpanIdsByTrace.delete(entry.traceId)
+        }
+        this.flushedSpanIdCount -= 1
+        pruned = true
+        break
       }
 
-      const pruned = this.flushedSpanIdsByTrace.get(oldestTraceId)
-      this.flushedSpanIdCount -= pruned?.size ?? 0
-      this.flushedSpanIdsByTrace.delete(oldestTraceId)
+      if (!pruned) break
     }
   }
 
@@ -178,6 +189,7 @@ export class PrometheusAdapter implements ExportAdapter {
     this.spanCounters.clear()
     this.costCounters.clear()
     this.flushedSpanIdsByTrace.clear()
+    this.flushedSpanInsertionOrder.clear()
     this.flushedSpanIdCount = 0
   }
 

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -34,7 +34,8 @@ export class PrometheusAdapter implements ExportAdapter {
   private tokenCounters = new Map<string, TokenCounts>()
   private spanCounters = new Map<string, number>()
   private costCounters = new Map<string, number>()
-  private flushedSpanIds = new Map<string, undefined>()
+  private flushedSpanIdsByTrace = new Map<string, Set<string>>()
+  private flushedSpanIdCount = 0
 
   constructor(options: PrometheusAdapterOptions = {}) {
     this.pricingTable = options.pricingTable
@@ -43,9 +44,11 @@ export class PrometheusAdapter implements ExportAdapter {
 
   async flush(trace: Trace): Promise<void> {
     warnIfTraceHasActiveSpans(trace, 'PrometheusAdapter')
+    const flushedSpanIds = this.flushedSpanIdsByTrace.get(trace.id)
+    const newlyFlushedSpanIds: string[] = []
+
     for (const span of trace.spans) {
-      const spanKey = `${trace.id}\u0000${span.id}`
-      if (this.flushedSpanIds.has(spanKey) || span.status === 'active') continue
+      if (flushedSpanIds?.has(span.id) || span.status === 'active') continue
 
       // Span status counter
       this.spanCounters.set(span.status, (this.spanCounters.get(span.status) ?? 0) + 1)
@@ -79,17 +82,51 @@ export class PrometheusAdapter implements ExportAdapter {
         }
       }
 
-      this.rememberFlushedSpan(spanKey)
+      newlyFlushedSpanIds.push(span.id)
     }
+
+    this.rememberFlushedSpans(trace.id, newlyFlushedSpanIds)
   }
 
-  private rememberFlushedSpan(spanKey: string): void {
-    if (this.maxDedupeSpans === 0) return
-    this.flushedSpanIds.set(spanKey, undefined)
-    while (this.flushedSpanIds.size > this.maxDedupeSpans) {
-      const oldest = this.flushedSpanIds.keys().next().value as string | undefined
-      if (oldest === undefined) break
-      this.flushedSpanIds.delete(oldest)
+  private rememberFlushedSpans(traceId: string, spanIds: string[]): void {
+    if (this.maxDedupeSpans === 0 || spanIds.length === 0) return
+
+    let flushedSpanIds = this.flushedSpanIdsByTrace.get(traceId)
+    if (flushedSpanIds === undefined) {
+      flushedSpanIds = new Set<string>()
+      this.flushedSpanIdsByTrace.set(traceId, flushedSpanIds)
+    }
+
+    for (const spanId of spanIds) {
+      if (flushedSpanIds.has(spanId)) continue
+      flushedSpanIds.add(spanId)
+      this.flushedSpanIdCount += 1
+    }
+
+    this.pruneFlushedSpans(traceId)
+  }
+
+  private pruneFlushedSpans(currentTraceId: string): void {
+    while (this.flushedSpanIdCount > this.maxDedupeSpans) {
+      const oldestTraceId = this.flushedSpanIdsByTrace.keys().next().value as string | undefined
+      if (oldestTraceId === undefined) break
+
+      // Keep the trace currently being flushed intact so a retry of a large
+      // trace does not evict the next span immediately before it is checked and
+      // double-count the trace. Older traces are pruned first; a single large
+      // trace may temporarily exceed the configured cap until another trace is
+      // flushed.
+      if (oldestTraceId === currentTraceId) {
+        if (this.flushedSpanIdsByTrace.size === 1) break
+        const current = this.flushedSpanIdsByTrace.get(oldestTraceId)
+        this.flushedSpanIdsByTrace.delete(oldestTraceId)
+        this.flushedSpanIdsByTrace.set(oldestTraceId, current ?? new Set<string>())
+        continue
+      }
+
+      const pruned = this.flushedSpanIdsByTrace.get(oldestTraceId)
+      this.flushedSpanIdCount -= pruned?.size ?? 0
+      this.flushedSpanIdsByTrace.delete(oldestTraceId)
     }
   }
 
@@ -140,7 +177,8 @@ export class PrometheusAdapter implements ExportAdapter {
     this.tokenCounters.clear()
     this.spanCounters.clear()
     this.costCounters.clear()
-    this.flushedSpanIds.clear()
+    this.flushedSpanIdsByTrace.clear()
+    this.flushedSpanIdCount = 0
   }
 
   async queryByTraceId(_traceId: string): Promise<Trace | null> {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -51,6 +51,8 @@ describe('SQLiteAdapter', () => {
       .mockReturnValueOnce({ run: upsertSpanRun })
       .mockReturnValueOnce({ run: upsertTraceRun })
       .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
     transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
 
     const adapter = new SQLiteAdapter('/tmp/traces.db')
@@ -76,12 +78,19 @@ describe('SQLiteAdapter', () => {
     await adapter.flush(clonedTrace)
     expect(upsertSpanRun).toHaveBeenCalledTimes(1)
 
+    first.metadata.step = 3
+    await adapter.flush(trace)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(2)
+    expect(upsertSpanRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: first.id, metadata: JSON.stringify({ step: 3 }) }),
+    )
+
     const second = TraceContext.startSpan(trace, { name: 'second' })
     SpanLifecycle.setMetadata(second, { step: 2 })
     TraceContext.endSpan(second)
     await adapter.flush(trace)
 
-    expect(upsertSpanRun).toHaveBeenCalledTimes(2)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(3)
     expect(upsertSpanRun).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: second.id, metadata: JSON.stringify({ step: 2 }) }),
     )
@@ -116,5 +125,33 @@ describe('SQLiteAdapter', () => {
     expect(upsertSpanRun).toHaveBeenCalledTimes(4)
     expect(upsertSpanRun.mock.calls[2]?.[0]).toEqual(expect.objectContaining({ id: first.id }))
     expect(upsertSpanRun.mock.calls[3]?.[0]).toEqual(expect.objectContaining({ id: second.id }))
+  })
+
+  it('bounds flushed-span snapshots by evicting older trace groups', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', { maxFlushedSpanSnapshots: 1 })
+    const firstTrace = TraceContext.createTrace('first')
+    const firstSpan = TraceContext.startSpan(firstTrace, { name: 'first' })
+    TraceContext.endSpan(firstSpan)
+    const secondTrace = TraceContext.createTrace('second')
+    const secondSpan = TraceContext.startSpan(secondTrace, { name: 'second' })
+    TraceContext.endSpan(secondSpan)
+
+    await adapter.flush(firstTrace)
+    await adapter.flush(secondTrace)
+    await adapter.flush(firstTrace)
+
+    expect(upsertSpanRun).toHaveBeenCalledTimes(3)
+    expect(upsertSpanRun.mock.calls[2]?.[0]).toEqual(expect.objectContaining({ id: firstSpan.id }))
   })
 })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -55,6 +55,11 @@ interface FlushedSpanState {
   thoughtBlocksJson: string
 }
 
+export interface SQLiteAdapterOptions {
+  /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
+  maxFlushedSpanSnapshots?: number
+}
+
 /**
  * Parse a JSON column, returning a fallback instead of throwing when the
  * stored value is corrupt. A single bad row must not poison the whole trace
@@ -92,10 +97,16 @@ function rowToSpan(row: SpanRow): Span {
  */
 export class SQLiteAdapter implements ExportAdapter {
   private readonly db: Database.Database
+  private readonly maxFlushedSpanSnapshots: number
   private readonly flushedSpans = new Map<string, Map<string, FlushedSpanState>>()
+  private flushedSpanSnapshotCount = 0
 
-  constructor(filePath: string) {
+  constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
     this.db = new Database(filePath)
+    this.maxFlushedSpanSnapshots = Math.max(
+      0,
+      Math.floor(options.maxFlushedSpanSnapshots ?? 10_000),
+    )
     this.db.pragma('busy_timeout = 5000')
     this.db.pragma('journal_mode = WAL')
     this.db.pragma('foreign_keys = ON')
@@ -164,26 +175,23 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   private metadataChanged(previous: FlushedSpanState, span: Span): boolean {
-    const keyCount = Object.keys(span.metadata).length
-    if (previous.metadata === span.metadata && previous.metadataKeyCount === keyCount) return false
     return previous.metadataJson !== JSON.stringify(span.metadata)
   }
 
   private thoughtBlocksChanged(previous: FlushedSpanState, span: Span): boolean {
-    if (
-      previous.thoughtBlocks === span.thoughtBlocks &&
-      previous.thoughtBlockCount === span.thoughtBlocks.length
-    ) {
-      return false
-    }
     return previous.thoughtBlocksJson !== JSON.stringify(span.thoughtBlocks)
   }
 
   private rememberFlushedSpan(span: Span): void {
+    if (this.maxFlushedSpanSnapshots === 0) return
+
     let byTrace = this.flushedSpans.get(span.traceId)
     if (byTrace === undefined) {
       byTrace = new Map<string, FlushedSpanState>()
       this.flushedSpans.set(span.traceId, byTrace)
+    }
+    if (!byTrace.has(span.id)) {
+      this.flushedSpanSnapshotCount += 1
     }
     byTrace.set(span.id, {
       status: span.status,
@@ -197,6 +205,30 @@ export class SQLiteAdapter implements ExportAdapter {
       thoughtBlockCount: span.thoughtBlocks.length,
       thoughtBlocksJson: JSON.stringify(span.thoughtBlocks),
     })
+    this.pruneFlushedSpanSnapshots(span.traceId)
+  }
+
+  private pruneFlushedSpanSnapshots(currentTraceId: string): void {
+    while (this.flushedSpanSnapshotCount > this.maxFlushedSpanSnapshots) {
+      const oldestTraceId = this.flushedSpans.keys().next().value as string | undefined
+      if (oldestTraceId === undefined) break
+
+      // Do not evict snapshots for the trace currently being flushed: doing so
+      // would make a large retry walk miss the next span and re-upsert the trace.
+      // Prune older trace groups first; a single large current trace may exceed
+      // the cap until the adapter sees another trace.
+      if (oldestTraceId === currentTraceId) {
+        if (this.flushedSpans.size === 1) break
+        const current = this.flushedSpans.get(oldestTraceId)
+        this.flushedSpans.delete(oldestTraceId)
+        this.flushedSpans.set(oldestTraceId, current ?? new Map<string, FlushedSpanState>())
+        continue
+      }
+
+      const pruned = this.flushedSpans.get(oldestTraceId)
+      this.flushedSpanSnapshotCount -= pruned?.size ?? 0
+      this.flushedSpans.delete(oldestTraceId)
+    }
   }
 
   async queryByTraceId(traceId: string): Promise<Trace | null> {

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -47,6 +47,7 @@ export type { LoopDetectionResult, LoopDetectorOptions } from './incident/LoopDe
 export type { InterruptSignal } from './incident/InterruptEmitter.js'
 export type { PostMortemOptions } from './incident/PostMortemGenerator.js'
 export type { LangfuseAdapterOptions, FetchFn } from './adapters/langfuse/LangfuseAdapter.js'
+export type { SQLiteAdapterOptions } from './adapters/sqlite/SQLiteAdapter.js'
 export type { PrometheusAdapterOptions } from './adapters/prometheus/PrometheusAdapter.js'
 export type { TempoAdapterOptions, TempoBasicAuth } from './adapters/tempo/TempoAdapter.js'
 export type { WebhookNotifierOptions, WebhookRetryOptions } from './notify/WebhookNotifier.js'


### PR DESCRIPTION
## Summary
- Fixes late Codex findings from merged PR #1297 by making Prometheus dedupe pruning trace-group aware so large repeated flushes do not evict the next span while retrying.
- Adds a bounded SQLite flushed-span snapshot cache and removes same-object fast paths so in-place metadata/thoughtBlocks edits are compared against stored JSON snapshots.
- Adds targeted regression tests for the large-trace Prometheus retry case, SQLite in-place payload edits, and SQLite snapshot eviction.

## Test Plan
- `npm --workspace @franken/observer test -- --run src/adapters/sqlite/SQLiteAdapter.test.ts src/adapters/prometheus/PrometheusAdapter.test.ts`
- `npm --workspace @franken/observer run typecheck`
- `npm --workspace @franken/observer run build`

Follow-up to #1297. Keeps issue #1110 closed.
