### PR TITLE
perf(brain): batch SqliteBrain hydrate writes

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -415,14 +415,41 @@ export class SqliteBrain implements IBrain {
     workingMemoryLimits?: Partial<WorkingMemoryLimits>,
   ): SqliteBrain {
     const brain = new SqliteBrain(dbPath, workingMemoryLimits, { hydrateWorkingMemoryFromDb: false });
-    brain.working.restore(snapshot.working);
-    brain.flush();
-    for (const event of snapshot.episodic) {
-      brain.episodic.record(event);
+
+    try {
+      const insertEvent = brain.db.prepare(
+        `INSERT INTO episodic_events (type, step, summary, details, created_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      );
+      const insertCheckpoint = brain.db.prepare(
+        `INSERT INTO checkpoints (state, created_at) VALUES (?, ?)`,
+      );
+
+      const restoreSnapshot = brain.db.transaction(() => {
+        brain.working.restore(snapshot.working);
+        brain.working.flushToDb();
+
+        for (const event of snapshot.episodic) {
+          insertEvent.run(
+            event.type,
+            event.step ?? null,
+            event.summary,
+            event.details ? JSON.stringify(event.details) : null,
+            event.createdAt,
+          );
+        }
+
+        if (snapshot.checkpoint) {
+          insertCheckpoint.run(JSON.stringify(snapshot.checkpoint), snapshot.checkpoint.timestamp);
+        }
+      });
+
+      restoreSnapshot();
+    } catch (error) {
+      brain.close();
+      throw error;
     }
-    if (snapshot.checkpoint) {
-      brain.recovery.checkpoint(snapshot.checkpoint);
-    }
+
     return brain;
   }
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -408,6 +408,48 @@ describe('SqliteBrain', () => {
       brain2.close();
     });
 
+    it('hydrate() rolls back working memory, episodic replay, and checkpoint together on failure', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+      const snapshot: BrainSnapshot = {
+        version: 1,
+        timestamp: '2026-07-09T00:00:00Z',
+        working: { fresh: 'snapshot' },
+        episodic: [
+          {
+            type: 'success',
+            summary: 'first event should roll back',
+            createdAt: '2026-07-09T00:00:00Z',
+          },
+          {
+            type: 'failure',
+            summary: undefined,
+            createdAt: '2026-07-09T00:01:00Z',
+          } as unknown as EpisodicEvent,
+        ],
+        checkpoint: {
+          runId: 'run-rollback',
+          phase: 'execution',
+          step: 1,
+          context: {},
+          timestamp: '2026-07-09T00:02:00Z',
+        },
+        metadata: { lastProvider: '', switchReason: '', totalTokensUsed: 0 },
+      };
+
+      try {
+        expect(() => SqliteBrain.hydrate(snapshot, dbPath)).toThrow();
+
+        const reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.keys()).toEqual([]);
+        expect(reopened.episodic.count()).toBe(0);
+        expect(reopened.recovery.lastCheckpoint()).toBeNull();
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('hydrate creates independent brain instance', () => {
       brain.working.set('shared', 'original');
       const snapshot = brain.serialize();


### PR DESCRIPTION
## Summary
- Restore SqliteBrain snapshots inside a single SQLite transaction
- Replay episodic events and optional checkpoints with prepared statements in the same hydrate transaction
- Add rollback coverage proving working memory, episodic replay, and checkpoint restore are atomic on failure

## Test Plan
- npm --workspace @franken/types run build
- npm --workspace @franken/brain run typecheck
- npm --workspace @franken/brain run build
- npm --workspace @franken/brain run lint
- npm --workspace @franken/brain test

Closes #940