### PR TITLE
fix(web): align Create Agent workflow configs

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-review.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-review.tsx
@@ -1,11 +1,25 @@
 import type { ReactNode } from 'react';
 import { useBeastStore } from '../../../stores/beast-store';
+import { validateWizardStep } from '../wizard-validation';
+
+type WorkflowReviewValues = {
+  workflowType?: string;
+  goal?: string;
+  topic?: string;
+  outputPath?: string;
+  docPath?: string;
+  outputDir?: string;
+  provider?: string;
+  objective?: string;
+  chunkDirectory?: string;
+  chunkDir?: string;
+};
 
 export function StepReview() {
   const { stepValues, setWizardStep } = useBeastStore();
 
   const identity = stepValues[0] as { name?: string; description?: string } | undefined;
-  const workflow = stepValues[1] as { workflowType?: string } | undefined;
+  const workflow = stepValues[1] as WorkflowReviewValues | undefined;
   const llm = stepValues[2] as { defaultProvider?: string; defaultModel?: string } | undefined;
   const modules = stepValues[3] as Record<string, boolean> | undefined;
   const skills = stepValues[4] as { selectedSkills?: string[] } | undefined;
@@ -20,7 +34,7 @@ export function StepReview() {
       </ReviewSection>
 
       <ReviewSection title="Workflow" stepIndex={1} onEdit={setWizardStep}>
-        <p className="text-sm text-beast-text">{workflow?.workflowType ?? '(not set)'}</p>
+        <WorkflowReview workflow={workflow} stepValues={stepValues} />
       </ReviewSection>
 
       <ReviewSection title="LLM Targets" stepIndex={2} onEdit={setWizardStep}>
@@ -72,6 +86,62 @@ export function StepReview() {
 
     </div>
   );
+}
+
+function WorkflowReview({ workflow, stepValues }: {
+  workflow: WorkflowReviewValues | undefined;
+  stepValues: Record<number, Record<string, unknown> | undefined>;
+}) {
+  const workflowErrors = validateWizardStep(1, stepValues);
+  const rows = buildWorkflowReviewRows(workflow);
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-beast-text">{workflow?.workflowType ?? '(not set)'}</p>
+      {rows.length > 0 && (
+        <dl className="grid gap-1 text-xs text-beast-muted sm:grid-cols-[max-content_1fr]">
+          {rows.map(({ label, value }) => (
+            <div key={label} className="contents">
+              <dt className="font-medium text-beast-subtle">{label}</dt>
+              <dd className="font-mono text-beast-text break-all">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {Object.keys(workflowErrors).length > 0 && (
+        <div className="rounded border border-red-700 bg-red-900/30 px-3 py-2 text-xs text-red-200">
+          <p className="font-medium">Required workflow fields are missing:</p>
+          <ul className="mt-1 list-disc pl-4">
+            {Object.values(workflowErrors).map((message) => <li key={message}>{message}</li>)}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildWorkflowReviewRows(workflow: WorkflowReviewValues | undefined): Array<{ label: string; value: string }> {
+  if (!workflow?.workflowType) return [];
+  if (workflow.workflowType === 'design-interview') {
+    return [
+      { label: 'Goal', value: workflow.goal ?? workflow.topic ?? '(missing)' },
+      { label: 'Output path', value: workflow.outputPath ?? '(missing)' },
+    ];
+  }
+  if (workflow.workflowType === 'chunk-plan') {
+    return [
+      { label: 'Design doc', value: workflow.docPath ?? '(missing)' },
+      { label: 'Output directory', value: workflow.outputDir ?? '(missing)' },
+    ];
+  }
+  if (workflow.workflowType === 'martin-loop') {
+    return [
+      { label: 'Provider', value: workflow.provider ?? '(missing)' },
+      { label: 'Objective', value: workflow.objective ?? '(missing)' },
+      { label: 'Chunk directory', value: workflow.chunkDirectory ?? workflow.chunkDir ?? '(missing)' },
+    ];
+  }
+  return [];
 }
 
 function ReviewSection({ title, stepIndex, onEdit, children }: {

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -96,11 +96,11 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
       {values.workflowType === 'design-interview' && (
         <div className="space-y-4">
           <div>
-            <label htmlFor="wf-topic" className="block text-sm font-medium text-beast-text mb-1.5">Goal</label>
+            <label htmlFor="wf-goal" className="block text-sm font-medium text-beast-text mb-1.5">Goal</label>
             <textarea
-              id="wf-topic"
-              value={(values.topic as string) ?? ''}
-              onChange={(e) => updateField('topic', e.target.value)}
+              id="wf-goal"
+              value={(values.goal as string) ?? (values.topic as string) ?? ''}
+              onChange={(e) => updateField('goal', e.target.value)}
               placeholder="Describe what the design interview should produce..."
               rows={3}
               className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent resize-y"
@@ -181,8 +181,8 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
             <input
               id="wf-dir"
               type="text"
-              value={(values.chunkDir as string) ?? ''}
-              onChange={(e) => updateField('chunkDir', e.target.value)}
+              value={(values.chunkDirectory as string) ?? (values.chunkDir as string) ?? ''}
+              onChange={(e) => updateField('chunkDirectory', e.target.value)}
               placeholder="/path/to/chunks/"
               className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
             />

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -4,9 +4,9 @@ import { buildWizardLaunchConfig } from './wizard-launch-config';
 describe('buildWizardLaunchConfig', () => {
   it('maps design interview fields to backend init config keys', () => {
     expect(buildWizardLaunchConfig({
-      1: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
+      1: { workflowType: 'design-interview', goal: 'Draft a billing design', outputPath: 'docs/billing.md' },
     })).toMatchObject({
-      workflow: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
+      workflow: { workflowType: 'design-interview', goal: 'Draft a billing design', outputPath: 'docs/billing.md' },
       executionMode: 'process',
       goal: 'Draft a billing design',
       outputPath: 'docs/billing.md',
@@ -15,7 +15,7 @@ describe('buildWizardLaunchConfig', () => {
 
   it('frontloads prompt text and attached files into run config promptConfig', () => {
     const config = buildWizardLaunchConfig({
-      1: { workflowType: 'design-interview', topic: 'Draft a billing design', outputPath: 'docs/billing.md' },
+      1: { workflowType: 'design-interview', goal: 'Draft a billing design', outputPath: 'docs/billing.md' },
       5: {
         promptText: 'Consider enterprise billing.',
         files: [{ name: 'notes.md', content: 'Existing constraints.' }],
@@ -31,9 +31,9 @@ describe('buildWizardLaunchConfig', () => {
 
   it('maps martin loop fields to backend init config keys', () => {
     expect(buildWizardLaunchConfig({
-      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
+      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDirectory: 'tasks/chunks' },
     })).toMatchObject({
-      workflow: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
+      workflow: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDirectory: 'tasks/chunks' },
       executionMode: 'process',
       provider: 'codex',
       objective: 'Implement chunks',
@@ -43,11 +43,32 @@ describe('buildWizardLaunchConfig', () => {
 
   it('leaves martin objective as a CLI-safe scalar and carries attached files in promptConfig', () => {
     expect(buildWizardLaunchConfig({
-      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDir: 'tasks/chunks' },
+      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDirectory: 'tasks/chunks' },
       5: { files: [{ name: 'context.txt', content: 'Use this context.' }] },
     })).toMatchObject({
       objective: 'Implement chunks',
       promptConfig: { text: 'Attached file: context.txt\n\nUse this context.' },
+    });
+  });
+
+  it('keeps legacy wizard aliases compatible while preferring backend field names', () => {
+    expect(buildWizardLaunchConfig({
+      1: {
+        workflowType: 'martin-loop',
+        provider: 'codex',
+        objective: 'Implement chunks',
+        chunkDir: 'legacy/chunks',
+        chunkDirectory: 'tasks/chunks',
+      },
+    })).toMatchObject({
+      chunkDirectory: 'tasks/chunks',
+    });
+
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'design-interview', topic: 'Legacy topic', outputPath: 'docs/design.md' },
+    })).toMatchObject({
+      goal: 'Legacy topic',
+      outputPath: 'docs/design.md',
     });
   });
 });

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -48,8 +48,9 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
   }
 
   if (workflow?.workflowType === 'design-interview') {
-    if (typeof workflow.topic === 'string') {
-      config.goal = workflow.topic;
+    const goal = typeof workflow.goal === 'string' ? workflow.goal : workflow.topic;
+    if (typeof goal === 'string') {
+      config.goal = goal;
     }
     if (typeof workflow.outputPath === 'string') {
       config.outputPath = workflow.outputPath;
@@ -71,8 +72,9 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
     if (typeof workflow.objective === 'string') {
       config.objective = workflow.objective;
     }
-    if (typeof workflow.chunkDir === 'string') {
-      config.chunkDirectory = workflow.chunkDir;
+    const chunkDirectory = typeof workflow.chunkDirectory === 'string' ? workflow.chunkDirectory : workflow.chunkDir;
+    if (typeof chunkDirectory === 'string') {
+      config.chunkDirectory = chunkDirectory;
     }
   }
 

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -5,12 +5,14 @@ type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
 
 type WorkflowValues = {
   workflowType?: unknown;
+  goal?: unknown;
   topic?: unknown;
   outputPath?: unknown;
   docPath?: unknown;
   outputDir?: unknown;
   provider?: unknown;
   objective?: unknown;
+  chunkDirectory?: unknown;
   chunkDir?: unknown;
 };
 
@@ -42,7 +44,7 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
     }
 
     if (values.workflowType === 'design-interview') {
-      if (isBlank(values.topic)) {
+      if (isBlank(values.goal ?? values.topic)) {
         errors.topic = 'Design interview goal is required.';
       }
       if (isBlank(values.outputPath)) {
@@ -69,7 +71,7 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
       if (isBlank(values.objective)) {
         errors.objective = 'Objective is required.';
       }
-      if (isBlank(values.chunkDir)) {
+      if (isBlank(values.chunkDirectory ?? values.chunkDir)) {
         errors.chunkDir = 'Chunk directory path is required.';
       }
     }

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 
-afterEach(cleanup);
 import { StepReview } from '../../../../src/components/beasts/steps/step-review';
 import { useBeastStore } from '../../../../src/stores/beast-store';
+
+afterEach(cleanup);
 
 describe('StepReview', () => {
   beforeEach(() => {
@@ -16,6 +17,35 @@ describe('StepReview', () => {
     render(<StepReview />);
     expect(screen.getByText('Test Agent')).toBeTruthy();
     expect(screen.getByText(/design-interview/i)).toBeTruthy();
+  });
+
+  it('shows backend-required workflow details before launch', () => {
+    useBeastStore.getState().setStepValues(1, {
+      workflowType: 'martin-loop',
+      provider: 'codex',
+      objective: 'Implement chunks',
+      chunkDirectory: 'tasks/chunks',
+    });
+
+    render(<StepReview />);
+
+    expect(screen.getByText('Provider')).toBeTruthy();
+    expect(screen.getByText('codex')).toBeTruthy();
+    expect(screen.getByText('Objective')).toBeTruthy();
+    expect(screen.getByText('Implement chunks')).toBeTruthy();
+    expect(screen.getByText('Chunk directory')).toBeTruthy();
+    expect(screen.getByText('tasks/chunks')).toBeTruthy();
+    expect(screen.queryByText('Required workflow fields are missing:')).toBeNull();
+  });
+
+  it('surfaces missing required workflow fields on the review step', () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview', goal: '' });
+
+    render(<StepReview />);
+
+    expect(screen.getByText('Required workflow fields are missing:')).toBeTruthy();
+    expect(screen.getByText('Design interview goal is required.')).toBeTruthy();
+    expect(screen.getByText('Design interview output path is required.')).toBeTruthy();
   });
 
   it('has edit links that call setWizardStep', () => {

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -31,6 +31,20 @@ describe('StepWorkflow', () => {
     expect(screen.getByLabelText('Output Path')).toBeTruthy();
   });
 
+  it('collects backend design-interview fields', () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
+    render(<StepWorkflow />);
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Draft billing design' } });
+    fireEvent.change(screen.getByLabelText('Output Path'), { target: { value: 'docs/billing.md' } });
+
+    expect(useBeastStore.getState().stepValues[1]).toEqual({
+      workflowType: 'design-interview',
+      goal: 'Draft billing design',
+      outputPath: 'docs/billing.md',
+    });
+  });
+
   it('collects both required chunk-plan launch fields', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan' });
     render(<StepWorkflow />);
@@ -42,6 +56,22 @@ describe('StepWorkflow', () => {
       workflowType: 'chunk-plan',
       docPath: 'docs/design.md',
       outputDir: 'tasks/chunks',
+    });
+  });
+
+  it('collects backend martin-loop fields', () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'martin-loop' });
+    render(<StepWorkflow />);
+
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'codex' } });
+    fireEvent.change(screen.getByLabelText('Objective'), { target: { value: 'Implement chunks' } });
+    fireEvent.change(screen.getByLabelText('Chunk Directory Path'), { target: { value: 'tasks/chunks' } });
+
+    expect(useBeastStore.getState().stepValues[1]).toEqual({
+      workflowType: 'martin-loop',
+      provider: 'codex',
+      objective: 'Implement chunks',
+      chunkDirectory: 'tasks/chunks',
     });
   });
 

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -30,10 +30,15 @@ describe('WizardDialog', () => {
     expect(toggle).toBeTruthy();
   });
 
-  it('footer launch uses the shared config shape for non-default workflows', () => {
+  it('footer launch uses backend-aligned config shape for non-default workflows', () => {
     const onLaunch = vi.fn();
     useBeastStore.getState().setStepValues(0, { name: 'Footer Agent' });
-    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' });
+    useBeastStore.getState().setStepValues(1, {
+      workflowType: 'martin-loop',
+      provider: 'codex',
+      objective: 'Implement chunks',
+      chunkDirectory: 'tasks/chunks',
+    });
     useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
 
     render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={onLaunch} />);
@@ -43,11 +48,31 @@ describe('WizardDialog', () => {
 
     expect(onLaunch).toHaveBeenCalledWith({
       identity: { name: 'Footer Agent' },
-      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
+      workflow: {
+        workflowType: 'martin-loop',
+        provider: 'codex',
+        objective: 'Implement chunks',
+        chunkDirectory: 'tasks/chunks',
+      },
       executionMode: 'process',
-      designDocPath: 'docs/design.md',
-      outputDir: 'tasks/chunks',
+      provider: 'codex',
+      objective: 'Implement chunks',
+      chunkDirectory: 'tasks/chunks',
     });
+  });
+
+  it('blocks launch on review when backend-required workflow fields are missing', () => {
+    const onLaunch = vi.fn();
+    useBeastStore.getState().setStepValues(0, { name: 'Footer Agent' });
+    useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview', goal: 'Draft design' });
+    useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
+
+    render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={onLaunch} />);
+
+    expect(screen.getByRole('button', { name: /launch/i })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('alert').textContent).toContain('Design interview output path is required.');
+    fireEvent.click(screen.getByText('Launch Agent'));
+    expect(onLaunch).not.toHaveBeenCalled();
   });
 
   it('keeps the launch progress status region mounted before launching', () => {

--- a/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { validateWizardStep } from '../../../src/components/beasts/wizard-validation';
 
 describe('wizard validation', () => {
+  it('accepts backend-aligned design-interview fields', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'design-interview', goal: 'Draft billing design', outputPath: 'docs/billing.md' },
+    });
+
+    expect(errors).toEqual({});
+  });
+
+  it('rejects design-interview when backend-required fields are missing', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'design-interview', goal: '   ' },
+    });
+
+    expect(errors).toEqual({
+      topic: 'Design interview goal is required.',
+      outputPath: 'Design interview output path is required.',
+    });
+  });
+
   it('accepts repo-relative Markdown chunk-plan design docs', () => {
     const errors = validateWizardStep(1, {
       1: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
@@ -23,5 +42,25 @@ describe('wizard validation', () => {
     });
 
     expect(errors.docPath).toBe('Design doc path must be a repo-relative Markdown file without traversal.');
+  });
+
+  it('accepts backend-aligned martin-loop fields', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDirectory: 'tasks/chunks' },
+    });
+
+    expect(errors).toEqual({});
+  });
+
+  it('rejects martin-loop when backend-required fields are missing', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'martin-loop', provider: '', objective: '   ' },
+    });
+
+    expect(errors).toEqual({
+      provider: 'Provider is required.',
+      objective: 'Objective is required.',
+      chunkDir: 'Chunk directory path is required.',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- map Design Interview and Martin Loop wizard values to backend-required config keys
- collect backend-aligned goal and chunkDirectory fields while preserving legacy topic/chunkDir fallbacks
- expand Review/launch validation and tests so missing workflow fields block before dispatch

## Test Plan
- npm test --workspace @franken/web
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm run lint:any

Closes #1179