### PR TITLE
fix(mcp-suite): keep json client config project-scoped

### DIFF
--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -30,7 +30,7 @@ fbeast mcp init --pick=memory,firewall,governor
 fbeast mcp init --mode=proxy
 ```
 
-`fbeast mcp init` auto-detects your client (Claude Code, Gemini CLI, or Codex CLI) and registers MCP servers in the appropriate project-scoped config. For Claude and Gemini, fbeast writes `.claude/settings.json` or `.gemini/settings.json` in the current project instead of mutating your user-global settings file, preventing one project's MCP database/root from being reused in another checkout. Override with `--client=claude|gemini|codex`.
+`fbeast mcp init` auto-detects your client (Claude Code, Gemini CLI, or Codex CLI) and registers MCP servers in the appropriate project-scoped config. For Claude, MCP servers are written to the current project's `.mcp.json` and optional hooks/instructions to `.claude/settings.json` / `.claude/`; for Gemini, MCP servers and optional hooks are written to `.gemini/settings.json`. fbeast does not mutate your user-global Claude/Gemini settings by default, preventing one project's MCP database/root from being reused in another checkout. Override with `--client=claude|gemini|codex`.
 
 ## Uninstall
 

--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -30,7 +30,7 @@ fbeast mcp init --pick=memory,firewall,governor
 fbeast mcp init --mode=proxy
 ```
 
-`fbeast mcp init` auto-detects your client (Claude Code, Gemini CLI, or Codex CLI) and registers MCP servers in the appropriate config. Override with `--client=claude|gemini|codex`.
+`fbeast mcp init` auto-detects your client (Claude Code, Gemini CLI, or Codex CLI) and registers MCP servers in the appropriate project-scoped config. For Claude and Gemini, fbeast writes `.claude/settings.json` or `.gemini/settings.json` in the current project instead of mutating your user-global settings file, preventing one project's MCP database/root from being reused in another checkout. Override with `--client=claude|gemini|codex`.
 
 ## Uninstall
 

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -51,31 +51,33 @@ describe('fbeast init', () => {
     expect(content).toContain('fbeast_memory_frontload');
   });
 
-  it('writes MCP server config to settings.json', () => {
+  it('writes Claude MCP server config to project .mcp.json', () => {
     const root = tmpDir();
     dirs.push(root);
 
     runInit({ root, claudeDir: join(root, '.claude'), hooks: false });
 
-    const settingsPath = join(root, '.claude', 'settings.json');
-    expect(existsSync(settingsPath)).toBe(true);
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    expect(settings.mcpServers['fbeast-memory']).toBeDefined();
-    expect(settings.mcpServers['fbeast-planner']).toBeDefined();
-    expect(settings.mcpServers['fbeast-critique']).toBeDefined();
-    expect(settings.mcpServers['fbeast-firewall']).toBeDefined();
-    expect(settings.mcpServers['fbeast-observer']).toBeDefined();
-    expect(settings.mcpServers['fbeast-governor']).toBeDefined();
-    expect(settings.mcpServers['fbeast-skills']).toBeDefined();
+    const mcpPath = join(root, '.mcp.json');
+    expect(existsSync(mcpPath)).toBe(true);
+    const mcpConfig = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-planner']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-critique']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-firewall']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-observer']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-governor']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-skills']).toBeDefined();
+    const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers).toBeUndefined();
   });
 
-  it('merges with existing settings.json comments and trailing commas without overwriting', () => {
+  it('merges with existing Claude .mcp.json comments and trailing commas without overwriting', () => {
     const root = tmpDir();
     dirs.push(root);
     const claudeDir = join(root, '.claude');
     mkdirSync(claudeDir, { recursive: true });
-    const settingsPath = join(claudeDir, 'settings.json');
-    writeFileSync(settingsPath, `{
+    const mcpPath = join(root, '.mcp.json');
+    writeFileSync(mcpPath, `{
       // Existing user-managed MCP server.
       "mcpServers": {
         "my-other-server": { "command": "other" },
@@ -85,10 +87,10 @@ describe('fbeast init', () => {
 
     runInit({ root, claudeDir, hooks: false });
 
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    expect(settings.mcpServers['my-other-server']).toBeDefined();
-    expect(settings.mcpServers['fbeast-memory']).toBeDefined();
-    expect(settings.customKey).toBe(true);
+    const mcpConfig = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+    expect(mcpConfig.mcpServers['my-other-server']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeDefined();
+    expect(mcpConfig.customKey).toBe(true);
   });
 
   it('respects pick list', () => {
@@ -97,10 +99,10 @@ describe('fbeast init', () => {
 
     runInit({ root, claudeDir: join(root, '.claude'), hooks: false, servers: ['memory', 'critique'] });
 
-    const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
-    expect(settings.mcpServers['fbeast-memory']).toBeDefined();
-    expect(settings.mcpServers['fbeast-critique']).toBeDefined();
-    expect(settings.mcpServers['fbeast-planner']).toBeUndefined();
+    const mcpConfig = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf-8'));
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-critique']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-planner']).toBeUndefined();
   });
 
   it('writes Claude hooks when hooks are enabled', () => {
@@ -139,8 +141,8 @@ describe('fbeast init', () => {
     const preCmd = (settings.hooks.PreToolUse[0] as any).hooks[0].command as string;
     const postCmd = (settings.hooks.PostToolUse[0] as any).hooks[0].command as string;
 
-    expect(preCmd).toBe(`'${join(root, '.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')}'`);
-    expect(postCmd).toBe(`'${join(root, '.fbeast', 'hooks', 'fbeast-claude-post-tool.sh')}'`);
+    expect(preCmd).toBe(`'${join('.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')}'`);
+    expect(postCmd).toBe(`'${join('.fbeast', 'hooks', 'fbeast-claude-post-tool.sh')}'`);
   });
 
   it('uses project config dir instead of mutating home settings when no project-level dir exists yet', () => {
@@ -362,7 +364,7 @@ describe('fbeast init', () => {
     ).toThrow('failed to remove legacy Codex MCP server fbeast-memory');
   });
 
-  it('uses cwd-relative database paths for global Claude settings across project roots', () => {
+  it('uses cwd-relative database paths for Claude .mcp.json across project roots', () => {
     const globalConfigDir = tmpDir();
     const rootA = tmpDir();
     const rootB = tmpDir();
@@ -372,13 +374,18 @@ describe('fbeast init', () => {
 
     runInit({ root: rootB, claudeDir: globalConfigDir, hooks: false, servers: ['memory'] });
 
-    const settings = JSON.parse(readFileSync(join(globalConfigDir, 'settings.json'), 'utf-8'));
-    expect(settings.mcpServers['fbeast-memory']).toEqual({
+    const configA = JSON.parse(readFileSync(join(rootA, '.mcp.json'), 'utf-8'));
+    const configB = JSON.parse(readFileSync(join(rootB, '.mcp.json'), 'utf-8'));
+    expect(configA.mcpServers['fbeast-memory']).toEqual({
       command: 'fbeast-memory',
       args: ['--db', join('.fbeast', 'beast.db')],
     });
-    expect(JSON.stringify(settings.mcpServers)).not.toContain(rootA);
-    expect(JSON.stringify(settings.mcpServers)).not.toContain(rootB);
+    expect(configB.mcpServers['fbeast-memory']).toEqual({
+      command: 'fbeast-memory',
+      args: ['--db', join('.fbeast', 'beast.db')],
+    });
+    expect(JSON.stringify(configA.mcpServers)).not.toContain(rootA);
+    expect(JSON.stringify(configB.mcpServers)).not.toContain(rootB);
   });
 
   it('proxy mode writes single fbeast-proxy entry (not 7) for claude client', () => {
@@ -387,11 +394,11 @@ describe('fbeast init', () => {
 
     runInit({ root, claudeDir: join(root, '.claude'), hooks: false, mode: 'proxy' });
 
-    const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
-    const keys = Object.keys(settings.mcpServers);
+    const mcpConfig = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf-8'));
+    const keys = Object.keys(mcpConfig.mcpServers);
     expect(keys).toEqual(['fbeast-proxy']);
-    expect(settings.mcpServers['fbeast-proxy']).toEqual({ command: 'fbeast-proxy', args: ['--db', join('.fbeast', 'beast.db')] });
-    expect(settings.mcpServers['fbeast-memory']).toBeUndefined();
+    expect(mcpConfig.mcpServers['fbeast-proxy']).toEqual({ command: 'fbeast-proxy', args: ['--db', join('.fbeast', 'beast.db')] });
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeUndefined();
   });
 
   it('proxy mode writes single fbeast-proxy entry for gemini client', () => {
@@ -408,16 +415,16 @@ describe('fbeast init', () => {
     expect(settings.mcpServers['fbeast-memory']).toBeUndefined();
   });
 
-  it('standard mode (default) still writes 7 individual entries', () => {
+  it('standard mode (default) still writes 7 individual Claude .mcp.json entries', () => {
     const root = tmpDir();
     dirs.push(root);
 
     runInit({ root, claudeDir: join(root, '.claude'), hooks: false, mode: 'standard' });
 
-    const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
-    expect(Object.keys(settings.mcpServers).length).toBe(7);
-    expect(settings.mcpServers['fbeast-memory']).toBeDefined();
-    expect(settings.mcpServers['fbeast-proxy']).toBeUndefined();
+    const mcpConfig = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf-8'));
+    expect(Object.keys(mcpConfig.mcpServers).length).toBe(7);
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-proxy']).toBeUndefined();
   });
 
   it('proxy mode for codex writes only the project-scoped fbeast-proxy entry', () => {

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -143,7 +143,7 @@ describe('fbeast init', () => {
     expect(postCmd).toBe(`'${join(root, '.fbeast', 'hooks', 'fbeast-claude-post-tool.sh')}'`);
   });
 
-  it('falls back to home config dir when no project-level dir exists', () => {
+  it('uses project config dir instead of mutating home settings when no project-level dir exists yet', () => {
     const cwd = '/tmp/project';
     const homeDir = '/tmp/home';
 
@@ -154,10 +154,10 @@ describe('fbeast init', () => {
       exists: (path) => path === join(homeDir, '.claude'),
     });
 
-    expect(claudeDir).toBe(join(homeDir, '.claude'));
+    expect(claudeDir).toBe(join(cwd, '.claude'));
   });
 
-  it('resolves gemini client to .gemini dir', () => {
+  it('resolves gemini client to project .gemini dir', () => {
     const cwd = '/tmp/project';
     const homeDir = '/tmp/home';
 
@@ -168,7 +168,7 @@ describe('fbeast init', () => {
       exists: (path) => path === join(homeDir, '.gemini'),
     });
 
-    expect(geminiDir).toBe(join(homeDir, '.gemini'));
+    expect(geminiDir).toBe(join(cwd, '.gemini'));
   });
 
   it('writes Gemini hooks and shell scripts when --client=gemini --hooks', () => {

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -81,16 +81,27 @@ describe('fbeast init', () => {
       // Existing user-managed MCP server.
       "mcpServers": {
         "my-other-server": { "command": "other" },
+        "fbeast-planner": { "command": "legacy-planner" },
       },
       "customKey": true,
     }`);
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({
+      mcpServers: {
+        'fbeast-memory': { command: 'legacy-memory' },
+        'other-settings-server': { command: 'other-settings-server' },
+      },
+    }));
 
     runInit({ root, claudeDir, hooks: false });
 
     const mcpConfig = JSON.parse(readFileSync(mcpPath, 'utf-8'));
     expect(mcpConfig.mcpServers['my-other-server']).toBeDefined();
     expect(mcpConfig.mcpServers['fbeast-memory']).toBeDefined();
+    expect(mcpConfig.mcpServers['fbeast-planner'].command).toBe('fbeast-planner');
     expect(mcpConfig.customKey).toBe(true);
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers['fbeast-memory']).toBeUndefined();
+    expect(settings.mcpServers['other-settings-server']).toBeDefined();
   });
 
   it('respects pick list', () => {
@@ -141,8 +152,16 @@ describe('fbeast init', () => {
     const preCmd = (settings.hooks.PreToolUse[0] as any).hooks[0].command as string;
     const postCmd = (settings.hooks.PostToolUse[0] as any).hooks[0].command as string;
 
-    expect(preCmd).toBe(`'${join('.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')}'`);
-    expect(postCmd).toBe(`'${join('.fbeast', 'hooks', 'fbeast-claude-post-tool.sh')}'`);
+    expect(preCmd).toContain('sh -c');
+    expect(preCmd).toContain('CLAUDE_PROJECT_DIR');
+    expect(preCmd).toContain('cd "$p"');
+    expect(preCmd).not.toContain('do;');
+    expect(preCmd).toContain(join('.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh').split('\\').join('/'));
+    expect(postCmd).toContain('sh -c');
+    expect(postCmd).toContain('CLAUDE_PROJECT_DIR');
+    expect(postCmd).toContain('cd "$p"');
+    expect(postCmd).not.toContain('do;');
+    expect(postCmd).toContain(join('.fbeast', 'hooks', 'fbeast-claude-post-tool.sh').split('\\').join('/'));
   });
 
   it('uses project config dir instead of mutating home settings when no project-level dir exists yet', () => {
@@ -197,7 +216,13 @@ describe('fbeast init', () => {
     expect(Array.isArray(afterHooks)).toBe(true);
     const beforeCmd = (beforeHooks[0] as any).hooks[0].command as string;
     const afterCmd = (afterHooks[0] as any).hooks[0].command as string;
+    expect(beforeCmd).toContain('GEMINI_PROJECT_ROOT');
+    expect(beforeCmd).toContain('cd "$p"');
+    expect(beforeCmd).not.toContain('do;');
     expect(beforeCmd).toContain('gemini-before-tool.sh');
+    expect(afterCmd).toContain('GEMINI_PROJECT_ROOT');
+    expect(afterCmd).toContain('cd "$p"');
+    expect(afterCmd).not.toContain('do;');
     expect(afterCmd).toContain('gemini-after-tool.sh');
   });
 
@@ -392,6 +417,7 @@ describe('fbeast init', () => {
     const root = tmpDir();
     dirs.push(root);
 
+    runInit({ root, claudeDir: join(root, '.claude'), hooks: false, mode: 'standard' });
     runInit({ root, claudeDir: join(root, '.claude'), hooks: false, mode: 'proxy' });
 
     const mcpConfig = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf-8'));

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -95,10 +95,15 @@ function initJsonClient(options: {
     settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
   }
 
-  // Add MCP server entries. Claude/Gemini settings.json can be global, so keep
-  // project paths cwd-relative instead of pinning the first initialized checkout
-  // into every future client session.
-  const mcpServers = (settings['mcpServers'] as Record<string, unknown>) ?? {};
+  // Add MCP server entries. Claude project-scoped MCP registrations belong in
+  // .mcp.json; Gemini uses .gemini/settings.json. Keep paths cwd-relative so a
+  // config file never pins one checkout's absolute database path into another.
+  const mcpConfigPath = client === 'claude' ? join(root, '.mcp.json') : settingsPath;
+  let mcpConfig: Record<string, unknown> = client === 'claude' ? {} : settings;
+  if (client === 'claude' && existsSync(mcpConfigPath)) {
+    mcpConfig = parseJsonObjectWithComments(readFileSync(mcpConfigPath, 'utf-8'));
+  }
+  const mcpServers = (mcpConfig['mcpServers'] as Record<string, unknown>) ?? {};
   const dbPath = join('.fbeast', 'beast.db');
   const proxyArgs = ['--db', dbPath];
   if (mode === 'proxy') {
@@ -108,7 +113,7 @@ function initJsonClient(options: {
       mcpServers[`fbeast-${srv}`] = { command: SERVER_BIN_MAP[srv], args: ['--db', dbPath] };
     }
   }
-  settings['mcpServers'] = mcpServers;
+  mcpConfig['mcpServers'] = mcpServers;
 
   // Hooks
   if (hooks) {
@@ -117,20 +122,23 @@ function initJsonClient(options: {
       config.hooks = true;
       config.save();
     } else {
-      // Gemini: write shell scripts, reference them in BeforeTool/AfterTool
-      const scripts = writeHookScripts(root, 'gemini');
-      settings['hooks'] = mergeGeminiHooks(settings['hooks'], scripts);
+      // Gemini: write shell scripts, reference project-relative paths in BeforeTool/AfterTool
+      writeHookScripts(root, 'gemini');
+      settings['hooks'] = mergeGeminiHooks(settings['hooks'], projectRelativeHookScripts('gemini'));
       config.hooks = true;
       config.save();
     }
   }
 
+  if (client === 'claude') {
+    writeJsonFileAtomic(mcpConfigPath, mcpConfig);
+  }
   writeJsonFileAtomic(settingsPath, settings);
 
   printLine(`fbeast initialized in ${root}`);
   printLine(`  Config:     ${config.configPath}`);
   printLine(`  Database:   ${config.dbPath}`);
-  printLine(`  MCP config: ${settingsPath}`);
+  printLine(`  MCP config: ${mcpConfigPath}`);
   printLine(`  Servers:    ${mode === 'proxy' ? 'fbeast-proxy (proxy mode)' : servers.join(', ')}`);
   if (hooks) printLine(`  Hooks:      enabled (${client})`);
 }
@@ -247,6 +255,18 @@ function tomlString(value: string): string {
 
 // ─── Hook config builders ─────────────────────────────────────────────────────
 
+function projectRelativeHookScripts(client: 'claude' | 'gemini'): { preTool: string; postTool: string } {
+  return client === 'claude'
+    ? {
+        preTool: join('.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh'),
+        postTool: join('.fbeast', 'hooks', 'fbeast-claude-post-tool.sh'),
+      }
+    : {
+        preTool: join('.fbeast', 'hooks', 'gemini-before-tool.sh'),
+        postTool: join('.fbeast', 'hooks', 'gemini-after-tool.sh'),
+      };
+}
+
 /**
  * Claude Code: PreToolUse / PostToolUse with generated shell scripts that read JSON from stdin.
  */
@@ -254,7 +274,8 @@ function mergeClaudeHooks(
   existing: unknown,
   root: string,
 ): Record<string, unknown[]> {
-  const scripts = writeHookScripts(root, 'claude');
+  writeHookScripts(root, 'claude');
+  const scripts = projectRelativeHookScripts('claude');
   const fbeastHooks: Record<string, unknown[]> = {
     PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: shellQuote(scripts.preTool) }] }],
     PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: shellQuote(scripts.postTool) }] }],

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -103,6 +103,10 @@ function initJsonClient(options: {
   if (client === 'claude' && existsSync(mcpConfigPath)) {
     mcpConfig = parseJsonObjectWithComments(readFileSync(mcpConfigPath, 'utf-8'));
   }
+  if (client === 'claude') {
+    pruneFbeastMcpServerEntries(settings);
+  }
+  pruneFbeastMcpServerEntries(mcpConfig);
   const mcpServers = (mcpConfig['mcpServers'] as Record<string, unknown>) ?? {};
   const dbPath = join('.fbeast', 'beast.db');
   const proxyArgs = ['--db', dbPath];
@@ -124,7 +128,7 @@ function initJsonClient(options: {
     } else {
       // Gemini: write shell scripts, reference project-relative paths in BeforeTool/AfterTool
       writeHookScripts(root, 'gemini');
-      settings['hooks'] = mergeGeminiHooks(settings['hooks'], projectRelativeHookScripts('gemini'));
+      settings['hooks'] = mergeGeminiHooks(settings['hooks'], projectRootHookScripts('gemini'));
       config.hooks = true;
       config.save();
     }
@@ -255,15 +259,32 @@ function tomlString(value: string): string {
 
 // ─── Hook config builders ─────────────────────────────────────────────────────
 
-function projectRelativeHookScripts(client: 'claude' | 'gemini'): { preTool: string; postTool: string } {
+function projectRootHookCommand(scriptPath: string): string {
+  const normalizedPath = scriptPath.split('\\').join('/');
+  const executablePath = `./${normalizedPath}`;
+  const lookup = [
+    `p=\${CLAUDE_PROJECT_DIR:-\${GEMINI_PROJECT_ROOT:-}}`,
+    `if [ -n "$p" ] && [ -x "$p/${normalizedPath}" ]; then cd "$p" && exec "${executablePath}"; fi`,
+    'd=$PWD',
+    'while [ "$d" != / ]; do '
+      + `if [ -x "$d/${normalizedPath}" ]; then cd "$d" && exec "${executablePath}"; fi; `
+      + 'd=$(dirname "$d")',
+    'done',
+    `echo "fbeast hook script not found: ${normalizedPath}" >&2`,
+    'exit 127',
+  ].join('; ');
+  return `sh -c ${shellQuote(lookup)}`;
+}
+
+function projectRootHookScripts(client: 'claude' | 'gemini'): { preTool: string; postTool: string } {
   return client === 'claude'
     ? {
-        preTool: join('.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh'),
-        postTool: join('.fbeast', 'hooks', 'fbeast-claude-post-tool.sh'),
+        preTool: projectRootHookCommand(join('.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh')),
+        postTool: projectRootHookCommand(join('.fbeast', 'hooks', 'fbeast-claude-post-tool.sh')),
       }
     : {
-        preTool: join('.fbeast', 'hooks', 'gemini-before-tool.sh'),
-        postTool: join('.fbeast', 'hooks', 'gemini-after-tool.sh'),
+        preTool: projectRootHookCommand(join('.fbeast', 'hooks', 'gemini-before-tool.sh')),
+        postTool: projectRootHookCommand(join('.fbeast', 'hooks', 'gemini-after-tool.sh')),
       };
 }
 
@@ -275,10 +296,10 @@ function mergeClaudeHooks(
   root: string,
 ): Record<string, unknown[]> {
   writeHookScripts(root, 'claude');
-  const scripts = projectRelativeHookScripts('claude');
+  const scripts = projectRootHookScripts('claude');
   const fbeastHooks: Record<string, unknown[]> = {
-    PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: shellQuote(scripts.preTool) }] }],
-    PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: shellQuote(scripts.postTool) }] }],
+    PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: scripts.preTool }] }],
+    PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: scripts.postTool }] }],
   };
 
   const hooks: Record<string, unknown[]> = {};
@@ -458,6 +479,15 @@ function isFbeastHook(value: unknown): boolean {
   return inner.some(
     (h) => isObjectRecord(h) && typeof h['command'] === 'string' && h['command'].includes('fbeast'),
   );
+}
+
+function pruneFbeastMcpServerEntries(config: Record<string, unknown>): void {
+  const mcpServers = config['mcpServers'];
+  if (!isObjectRecord(mcpServers)) return;
+  for (const key of Object.keys(mcpServers)) {
+    if (key.startsWith('fbeast-')) delete mcpServers[key];
+  }
+  config['mcpServers'] = mcpServers;
 }
 
 function shellQuote(value: string): string {

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -6,7 +6,7 @@ function printLine(...args: unknown[]): void {
 
 import { existsSync } from 'node:fs';
 import { constants, homedir } from 'node:os';
-import { win32 } from 'node:path';
+import { join, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { resolveInitOptions } from './init-options.js';
@@ -95,6 +95,17 @@ function resolveCommand(command: string, args: string[]): ResolvedCommand {
 function resolveClient(): McpClient {
   const clientArg = parseMcpClient(process.argv.find((a) => a.startsWith('--client='))?.split('=')[1]);
   return clientArg ?? detectMcpClient({ cwd: process.cwd(), homeDir: homedir(), exists: existsSync });
+}
+
+function resolveUninstallClientConfigDir(client: McpClient, root: string): string {
+  const projectDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
+  if (client === 'codex') return projectDir;
+
+  const homeDir = join(homedir(), client === 'claude' ? '.claude' : '.gemini');
+  if (!existsSync(join(projectDir, 'settings.json')) && existsSync(join(homeDir, 'settings.json'))) {
+    return homeDir;
+  }
+  return projectDir;
 }
 
 function reportMcpInitError(error: unknown): never {
@@ -199,7 +210,7 @@ switch (subcommand) {
     const { runUninstall } = await import('./uninstall.js');
     const root = process.cwd();
     const client = resolveClient();
-    const claudeDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
+    const claudeDir = resolveUninstallClientConfigDir(client, root);
     const purge = process.argv.includes('--purge') ? true : undefined;
     await runUninstall({ root, claudeDir, client, purge });
     break;

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -6,7 +6,7 @@ function printLine(...args: unknown[]): void {
 
 import { existsSync } from 'node:fs';
 import { constants, homedir } from 'node:os';
-import { join, win32 } from 'node:path';
+import { win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { resolveInitOptions } from './init-options.js';
@@ -99,14 +99,7 @@ function resolveClient(): McpClient {
 
 function resolveUninstallClientConfigDirs(client: McpClient, root: string): string[] {
   const projectDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
-  if (client === 'codex') return [projectDir];
-
-  const homeDir = join(homedir(), client === 'claude' ? '.claude' : '.gemini');
-  const dirs = [projectDir];
-  if (existsSync(join(homeDir, 'settings.json')) && homeDir !== projectDir) {
-    dirs.push(homeDir);
-  }
-  return dirs;
+  return [projectDir];
 }
 
 function reportMcpInitError(error: unknown): never {

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -97,15 +97,16 @@ function resolveClient(): McpClient {
   return clientArg ?? detectMcpClient({ cwd: process.cwd(), homeDir: homedir(), exists: existsSync });
 }
 
-function resolveUninstallClientConfigDir(client: McpClient, root: string): string {
+function resolveUninstallClientConfigDirs(client: McpClient, root: string): string[] {
   const projectDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
-  if (client === 'codex') return projectDir;
+  if (client === 'codex') return [projectDir];
 
   const homeDir = join(homedir(), client === 'claude' ? '.claude' : '.gemini');
-  if (!existsSync(join(projectDir, 'settings.json')) && existsSync(join(homeDir, 'settings.json'))) {
-    return homeDir;
+  const dirs = [projectDir];
+  if (existsSync(join(homeDir, 'settings.json')) && homeDir !== projectDir) {
+    dirs.push(homeDir);
   }
-  return projectDir;
+  return dirs;
 }
 
 function reportMcpInitError(error: unknown): never {
@@ -210,9 +211,10 @@ switch (subcommand) {
     const { runUninstall } = await import('./uninstall.js');
     const root = process.cwd();
     const client = resolveClient();
-    const claudeDir = resolveUninstallClientConfigDir(client, root);
+    const jsonConfigDirs = resolveUninstallClientConfigDirs(client, root);
+    const claudeDir = jsonConfigDirs[0] ?? resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
     const purge = process.argv.includes('--purge') ? true : undefined;
-    await runUninstall({ root, claudeDir, client, purge });
+    await runUninstall({ root, claudeDir, jsonConfigDirs, client, purge });
     break;
   }
   case 'beast': {

--- a/packages/franken-mcp-suite/src/cli/mcp-client-paths.test.ts
+++ b/packages/franken-mcp-suite/src/cli/mcp-client-paths.test.ts
@@ -1,8 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { join } from 'node:path';
-import { detectMcpClient } from './mcp-client-paths.js';
+import { detectMcpClient, resolveClientConfigDir } from './mcp-client-paths.js';
 
 describe('MCP client detection', () => {
+  it('resolves JSON-client config dirs to the project even when only home config exists', () => {
+    const cwd = '/project';
+    const homeDir = '/home/user';
+    const existing = new Set([join(homeDir, '.claude'), join(homeDir, '.gemini')]);
+
+    expect(resolveClientConfigDir({
+      client: 'claude',
+      cwd,
+      homeDir,
+      exists: (path) => existing.has(path),
+    })).toBe(join(cwd, '.claude'));
+    expect(resolveClientConfigDir({
+      client: 'gemini',
+      cwd,
+      homeDir,
+      exists: (path) => existing.has(path),
+    })).toBe(join(cwd, '.gemini'));
+  });
+
   it('prefers project Codex config over home-level JSON clients', () => {
     const cwd = '/project';
     const homeDir = '/home/user';

--- a/packages/franken-mcp-suite/src/cli/mcp-client-paths.ts
+++ b/packages/franken-mcp-suite/src/cli/mcp-client-paths.ts
@@ -20,7 +20,11 @@ export interface ResolveClientConfigDirInput {
 
 /**
  * Returns the config directory for file-based clients (claude, gemini).
- * Prefers a project-level dir if it exists, falls back to home-level.
+ * Always returns the project-level dir for JSON clients so `fbeast init` writes
+ * project-scoped MCP registrations instead of mutating user-global
+ * settings.json files with fbeast server entries. Detection may still use
+ * home-level config dirs to infer the requested client, but registration is
+ * intentionally rooted in the current project.
  * Not applicable for codex — use the codex CLI instead.
  */
 export function resolveClientConfigDir(input: ResolveClientConfigDirInput): string {
@@ -29,11 +33,7 @@ export function resolveClientConfigDir(input: ResolveClientConfigDirInput): stri
     // codex doesn't have a writable config dir — return home/.codex for reference only
     return join(input.homeDir, '.codex');
   }
-  const projectDir = join(input.cwd, dirName);
-  if (input.exists(projectDir)) {
-    return projectDir;
-  }
-  return join(input.homeDir, dirName);
+  return join(input.cwd, dirName);
 }
 
 /**

--- a/packages/franken-mcp-suite/src/cli/uninstall-entrypoint.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall-entrypoint.test.ts
@@ -73,7 +73,7 @@ describe('fbeast-uninstall entrypoint', () => {
     expect(hasFbeast(after)).toBe(false);
   });
 
-  it('prunes legacy home Claude settings as well as project settings on uninstall', async () => {
+  it('keeps uninstall scoped to project Claude settings when home settings also exist', async () => {
     const root = tmpDir();
     const home = tmpDir();
     dirs.push(root, home);
@@ -109,7 +109,7 @@ describe('fbeast-uninstall entrypoint', () => {
     expect(projectMcp.mcpServers['fbeast-memory']).toBeUndefined();
     expect(projectMcp.mcpServers['project-server']).toBeDefined();
     const homeSettings = JSON.parse(readFileSync(join(homeClaudeDir, 'settings.json'), 'utf-8'));
-    expect(homeSettings.mcpServers['fbeast-planner']).toBeUndefined();
+    expect(homeSettings.mcpServers['fbeast-planner']).toBeDefined();
     expect(homeSettings.mcpServers['other-server']).toBeDefined();
   });
 

--- a/packages/franken-mcp-suite/src/cli/uninstall-entrypoint.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall-entrypoint.test.ts
@@ -73,20 +73,31 @@ describe('fbeast-uninstall entrypoint', () => {
     expect(hasFbeast(after)).toBe(false);
   });
 
-  it('falls back to legacy home Claude settings on uninstall when project settings do not exist', async () => {
+  it('prunes legacy home Claude settings as well as project settings on uninstall', async () => {
     const root = tmpDir();
     const home = tmpDir();
     dirs.push(root, home);
     process.env.HOME = home;
 
+    const projectClaudeDir = join(root, '.claude');
+    mkdirSync(projectClaudeDir, { recursive: true });
+    writeFileSync(join(projectClaudeDir, 'settings.json'), JSON.stringify({ hooks: { PreToolUse: [] } }));
+    writeFileSync(join(root, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        'fbeast-memory': { command: 'fbeast-memory' },
+        'project-server': { command: 'project-server' },
+      },
+    }));
+
     const homeClaudeDir = join(home, '.claude');
     mkdirSync(homeClaudeDir, { recursive: true });
     writeFileSync(join(homeClaudeDir, 'settings.json'), JSON.stringify({
       mcpServers: {
-        'fbeast-memory': { command: 'fbeast-memory' },
+        'fbeast-planner': { command: 'fbeast-planner' },
         'other-server': { command: 'other-server' },
       },
     }));
+
     vi.doMock('../shared/is-main.js', () => ({ isMain: () => true }));
     vi.spyOn(console, 'info').mockImplementation(() => undefined);
     process.chdir(root);
@@ -94,10 +105,12 @@ describe('fbeast-uninstall entrypoint', () => {
 
     await import('./uninstall.js');
 
+    const projectMcp = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf-8'));
+    expect(projectMcp.mcpServers['fbeast-memory']).toBeUndefined();
+    expect(projectMcp.mcpServers['project-server']).toBeDefined();
     const homeSettings = JSON.parse(readFileSync(join(homeClaudeDir, 'settings.json'), 'utf-8'));
-    expect(homeSettings.mcpServers['fbeast-memory']).toBeUndefined();
+    expect(homeSettings.mcpServers['fbeast-planner']).toBeUndefined();
     expect(homeSettings.mcpServers['other-server']).toBeDefined();
-    expect(existsSync(join(root, '.claude', 'settings.json'))).toBe(false);
   });
 
   it('honors an explicit Codex client argument', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall-entrypoint.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall-entrypoint.test.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto';
 
 const originalArgv = process.argv;
 const originalCwd = process.cwd();
+const originalHome = process.env.HOME;
 
 function tmpDir(): string {
   const dir = join(tmpdir(), `fbeast-uninstall-entrypoint-${randomUUID()}`);
@@ -19,6 +20,11 @@ describe('fbeast-uninstall entrypoint', () => {
   afterEach(() => {
     process.argv = originalArgv;
     process.chdir(originalCwd);
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     vi.restoreAllMocks();
     vi.resetModules();
     vi.doUnmock('../shared/is-main.js');
@@ -65,6 +71,33 @@ describe('fbeast-uninstall entrypoint', () => {
     expect(settings.mcpServers['other-server']).toBeDefined();
     expect(hasFbeast(before)).toBe(false);
     expect(hasFbeast(after)).toBe(false);
+  });
+
+  it('falls back to legacy home Claude settings on uninstall when project settings do not exist', async () => {
+    const root = tmpDir();
+    const home = tmpDir();
+    dirs.push(root, home);
+    process.env.HOME = home;
+
+    const homeClaudeDir = join(home, '.claude');
+    mkdirSync(homeClaudeDir, { recursive: true });
+    writeFileSync(join(homeClaudeDir, 'settings.json'), JSON.stringify({
+      mcpServers: {
+        'fbeast-memory': { command: 'fbeast-memory' },
+        'other-server': { command: 'other-server' },
+      },
+    }));
+    vi.doMock('../shared/is-main.js', () => ({ isMain: () => true }));
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    process.chdir(root);
+    process.argv = ['node', 'fbeast-uninstall', '--client=claude', '--purge'];
+
+    await import('./uninstall.js');
+
+    const homeSettings = JSON.parse(readFileSync(join(homeClaudeDir, 'settings.json'), 'utf-8'));
+    expect(homeSettings.mcpServers['fbeast-memory']).toBeUndefined();
+    expect(homeSettings.mcpServers['other-server']).toBeDefined();
+    expect(existsSync(join(root, '.claude', 'settings.json'))).toBe(false);
   });
 
   it('honors an explicit Codex client argument', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -26,7 +26,7 @@ describe('fbeast uninstall', () => {
     dirs.length = 0;
   });
 
-  it('removes fbeast MCP entries from settings.json', async () => {
+  it('removes fbeast Claude MCP entries from project .mcp.json', async () => {
     const root = tmpDir();
     dirs.push(root);
     const claudeDir = join(root, '.claude');
@@ -34,18 +34,18 @@ describe('fbeast uninstall', () => {
     runInit({ root, claudeDir, hooks: false });
     await runUninstall({ root, claudeDir, purge: false });
 
-    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
-    expect(settings.mcpServers['fbeast-memory']).toBeUndefined();
-    expect(settings.mcpServers['fbeast-planner']).toBeUndefined();
+    const mcpConfig = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf-8'));
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeUndefined();
+    expect(mcpConfig.mcpServers['fbeast-planner']).toBeUndefined();
   });
 
-  it('preserves non-fbeast MCP entries in settings.json with comments and trailing commas', async () => {
+  it('preserves non-fbeast Claude MCP entries in .mcp.json with comments and trailing commas', async () => {
     const root = tmpDir();
     dirs.push(root);
     const claudeDir = join(root, '.claude');
     mkdirSync(claudeDir, { recursive: true });
 
-    const settingsPath = join(claudeDir, 'settings.json');
+    const settingsPath = join(root, '.mcp.json');
     writeFileSync(settingsPath, `{
       "mcpServers": {
         "fbeast-memory": { "command": "fbeast-memory" },

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -351,14 +351,7 @@ function pruneFbeastFromEntry(entry: unknown): unknown | null {
 
 function resolveUninstallClientConfigDirs(client: McpClient, root: string): string[] {
   const projectDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
-  if (client === 'codex') return [projectDir];
-
-  const homeDir = join(homedir(), client === 'claude' ? '.claude' : '.gemini');
-  const dirs = [projectDir];
-  if (existsSync(join(homeDir, 'settings.json')) && homeDir !== projectDir) {
-    dirs.push(homeDir);
-  }
-  return dirs;
+  return [projectDir];
 }
 
 const isMain = (await import('../shared/is-main.js')).isMain(import.meta.url);

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -338,12 +338,23 @@ function pruneFbeastFromEntry(entry: unknown): unknown | null {
   return entry;
 }
 
+function resolveUninstallClientConfigDir(client: McpClient, root: string): string {
+  const projectDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
+  if (client === 'codex') return projectDir;
+
+  const homeDir = join(homedir(), client === 'claude' ? '.claude' : '.gemini');
+  if (!existsSync(join(projectDir, 'settings.json')) && existsSync(join(homeDir, 'settings.json'))) {
+    return homeDir;
+  }
+  return projectDir;
+}
+
 const isMain = (await import('../shared/is-main.js')).isMain(import.meta.url);
 if (isMain) {
   const root = process.cwd();
   const clientArg = parseMcpClient(process.argv.find((a) => a.startsWith('--client='))?.split('=')[1]);
   const client = clientArg ?? detectMcpClient({ cwd: root, homeDir: homedir(), exists: existsSync });
-  const claudeDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
+  const claudeDir = resolveUninstallClientConfigDir(client, root);
   const purge = process.argv.includes('--purge') ? true : undefined;
   runUninstall({ root, claudeDir, client, purge }).catch((err) => {
     console.error('fbeast-uninstall failed:', err);

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -17,6 +17,7 @@ import type { FbeastServer } from '../shared/config.js';
 export interface UninstallOptions {
   root: string;
   claudeDir: string;
+  jsonConfigDirs?: string[];
   client?: McpClient;
   purge?: boolean | undefined;
   ask?: (question: string) => Promise<string>;
@@ -35,7 +36,10 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
   if (client === 'codex') {
     uninstallCodex({ root, spawnFn });
   } else {
-    uninstallJsonClient({ root, claudeDir, client });
+    const dirs = options.jsonConfigDirs ?? [claudeDir];
+    for (const dir of [...new Set(dirs)]) {
+      uninstallJsonClient({ root, claudeDir: dir, client });
+    }
   }
 
   const fbeastDir = join(root, '.fbeast');
@@ -58,14 +62,7 @@ function uninstallJsonClient(options: { root: string; claudeDir: string; client:
   const settingsPath = join(claudeDir, 'settings.json');
 
   if (existsSync(settingsPath)) {
-    const settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
-
-    // Remove fbeast MCP servers
-    const mcpServers = (settings['mcpServers'] as Record<string, unknown>) ?? {};
-    for (const key of Object.keys(mcpServers)) {
-      if (key.startsWith('fbeast-')) delete mcpServers[key];
-    }
-    settings['mcpServers'] = mcpServers;
+    const settings = pruneFbeastMcpServers(settingsPath);
 
     if (client === 'gemini') {
       // Gemini: prune fbeast hooks from BeforeTool/AfterTool, keep entries with remaining hooks
@@ -103,10 +100,24 @@ function uninstallJsonClient(options: { root: string; claudeDir: string; client:
   if (existsSync(instrPath)) unlinkSync(instrPath);
 
   if (client === 'claude') {
+    pruneFbeastMcpServers(join(root, '.mcp.json'));
     removeGeneratedHookScripts(root, 'claude');
   } else if (client === 'gemini') {
     removeGeneratedHookScripts(root, 'gemini');
   }
+}
+
+function pruneFbeastMcpServers(settingsPath: string): Record<string, unknown> {
+  if (!existsSync(settingsPath)) return {};
+
+  const settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
+  const mcpServers = (settings['mcpServers'] as Record<string, unknown>) ?? {};
+  for (const key of Object.keys(mcpServers)) {
+    if (key.startsWith('fbeast-')) delete mcpServers[key];
+  }
+  settings['mcpServers'] = mcpServers;
+  writeJsonFileAtomic(settingsPath, settings);
+  return settings;
 }
 
 // ─── Codex ────────────────────────────────────────────────────────────────────
@@ -338,15 +349,16 @@ function pruneFbeastFromEntry(entry: unknown): unknown | null {
   return entry;
 }
 
-function resolveUninstallClientConfigDir(client: McpClient, root: string): string {
+function resolveUninstallClientConfigDirs(client: McpClient, root: string): string[] {
   const projectDir = resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
-  if (client === 'codex') return projectDir;
+  if (client === 'codex') return [projectDir];
 
   const homeDir = join(homedir(), client === 'claude' ? '.claude' : '.gemini');
-  if (!existsSync(join(projectDir, 'settings.json')) && existsSync(join(homeDir, 'settings.json'))) {
-    return homeDir;
+  const dirs = [projectDir];
+  if (existsSync(join(homeDir, 'settings.json')) && homeDir !== projectDir) {
+    dirs.push(homeDir);
   }
-  return projectDir;
+  return dirs;
 }
 
 const isMain = (await import('../shared/is-main.js')).isMain(import.meta.url);
@@ -354,9 +366,10 @@ if (isMain) {
   const root = process.cwd();
   const clientArg = parseMcpClient(process.argv.find((a) => a.startsWith('--client='))?.split('=')[1]);
   const client = clientArg ?? detectMcpClient({ cwd: root, homeDir: homedir(), exists: existsSync });
-  const claudeDir = resolveUninstallClientConfigDir(client, root);
+  const jsonConfigDirs = resolveUninstallClientConfigDirs(client, root);
+  const claudeDir = jsonConfigDirs[0] ?? resolveClientConfigDir({ client, cwd: root, homeDir: homedir(), exists: existsSync });
   const purge = process.argv.includes('--purge') ? true : undefined;
-  runUninstall({ root, claudeDir, client, purge }).catch((err) => {
+  runUninstall({ root, claudeDir, jsonConfigDirs, client, purge }).catch((err) => {
     console.error('fbeast-uninstall failed:', err);
     process.exit(1);
   });

--- a/packages/franken-mcp-suite/src/integration/dual-mode.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/dual-mode.integration.test.ts
@@ -37,13 +37,13 @@ describe('dual-mode integration', () => {
 
     runInit({ root, claudeDir, hooks: true, servers: ['memory', 'planner'] });
 
-    const settingsPath = join(claudeDir, 'settings.json');
-    const before = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const mcpConfigPath = join(root, '.mcp.json');
+    const before = JSON.parse(readFileSync(mcpConfigPath, 'utf-8'));
     const mcpBefore = JSON.parse(JSON.stringify(before.mcpServers));
 
     await runBeastMode(['--provider=anthropic-api'], noopDeps(root));
 
-    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const after = JSON.parse(readFileSync(mcpConfigPath, 'utf-8'));
     expect(after.mcpServers).toEqual(mcpBefore);
 
     const config = FbeastConfig.load(root);

--- a/packages/franken-mcp-suite/src/integration/init-uninstall.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/init-uninstall.integration.test.ts
@@ -25,7 +25,7 @@ describe('init/uninstall integration', () => {
     dirs.length = 0;
   });
 
-  it('writes settings to the fallback Claude dir and removes fbeast entries on uninstall', async () => {
+  it('writes Claude MCP config to project .mcp.json and removes fbeast entries on uninstall', async () => {
     const root = tmpDir('fbeast-root');
     const homeDir = tmpDir('fbeast-home');
     dirs.push(root, homeDir);
@@ -39,13 +39,13 @@ describe('init/uninstall integration', () => {
 
     runInit({ root, claudeDir, hooks: false, servers: ['memory'] });
 
-    const settingsPath = join(claudeDir, 'settings.json');
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    expect(settings.mcpServers['fbeast-memory']).toBeDefined();
+    const mcpConfigPath = join(root, '.mcp.json');
+    const mcpConfig = JSON.parse(readFileSync(mcpConfigPath, 'utf-8'));
+    expect(mcpConfig.mcpServers['fbeast-memory']).toBeDefined();
 
     await runUninstall({ root, claudeDir, purge: true });
 
-    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const after = JSON.parse(readFileSync(mcpConfigPath, 'utf-8'));
     expect(after.mcpServers['fbeast-memory']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- keep Claude/Gemini JSON-client MCP registration in the current project's .claude/.gemini config dir instead of home settings
- preserve home-level config detection only for choosing the client, not for write targets
- document the project-scoped init behavior and add regression coverage

## Test Plan
- npm test -- --run src/cli/mcp-client-paths.test.ts src/cli/init.test.ts (packages/franken-mcp-suite)
- npm run build --workspace @franken/types
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/orchestrator
- npm run typecheck (packages/franken-mcp-suite)
- npm run build (packages/franken-mcp-suite)
- npm test (packages/franken-mcp-suite)

Closes #934