### PR TITLE
fix(orchestrator): block chat input during approval

### DIFF
--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -19,9 +19,11 @@ const SLASH_COMMANDS = new Set([
 
 export interface ChatRuntimeState {
   sessionId: string;
+  approvalResolved?: boolean;
   pendingApproval: boolean;
   pendingApprovalContext?: PendingApprovalContext;
   pendingApprovalDescription?: string;
+  pendingApprovalRequestedAt?: string;
   projectId: string;
   transcript: TranscriptMessage[];
   beastContext?: ChatBeastContext | null | undefined;
@@ -42,6 +44,7 @@ export interface ChatRuntimeResult {
   pendingApproval: boolean;
   pendingApprovalContext?: PendingApprovalContext;
   pendingApprovalDescription?: string;
+  pendingApprovalRequestedAt?: string;
   providerContext?: {
     provider: string;
     model?: string;
@@ -78,9 +81,10 @@ export interface ChatRuntimeRunOptions {
 
 export function pendingApprovalRuntimeState(
   pendingApproval: PendingApproval | null | undefined,
-): Pick<ChatRuntimeState, 'pendingApproval' | 'pendingApprovalContext' | 'pendingApprovalDescription'> {
+  pendingApprovalState = false,
+): Pick<ChatRuntimeState, 'pendingApproval' | 'pendingApprovalContext' | 'pendingApprovalDescription' | 'pendingApprovalRequestedAt'> {
   if (!pendingApproval) {
-    return { pendingApproval: false };
+    return { pendingApproval: pendingApprovalState };
   }
 
   return {
@@ -93,6 +97,7 @@ export function pendingApprovalRuntimeState(
       ...(pendingApproval.sessionId ? { sessionId: pendingApproval.sessionId } : {}),
     },
     pendingApprovalDescription: pendingApproval.description,
+    pendingApprovalRequestedAt: pendingApproval.requestedAt,
   };
 }
 
@@ -111,7 +116,7 @@ export class ChatRuntime {
     const trimmed = input.trim();
     const command = trimmed.startsWith('/') ? trimmed.split(/\s+/)[0]?.toLowerCase() : undefined;
 
-    if (state.pendingApproval && command !== '/approve') {
+    if (state.pendingApproval && !state.approvalResolved && command !== '/approve') {
       if (trimmed.toLowerCase().startsWith('action rejected by user:')) {
         return this.result({ ...state, pendingApproval: false }, [
           { kind: 'approval', content: 'Rejected.' },
@@ -131,6 +136,9 @@ export class ChatRuntime {
           : {}),
         ...(state.pendingApprovalDescription !== undefined
           ? { pendingApprovalDescription: state.pendingApprovalDescription }
+          : {}),
+        ...(state.pendingApprovalRequestedAt !== undefined
+          ? { pendingApprovalRequestedAt: state.pendingApprovalRequestedAt }
           : {}),
         state: 'pending_approval',
       });
@@ -354,6 +362,7 @@ export class ChatRuntime {
       outcome?: TurnOutcome;
       pendingApprovalContext?: PendingApprovalContext;
       pendingApprovalDescription?: string;
+      pendingApprovalRequestedAt?: string;
       state?: string;
       tier?: string | null;
       providerContext?: ChatRuntimeResult['providerContext'];
@@ -370,6 +379,9 @@ export class ChatRuntime {
         : {}),
       ...(extra?.pendingApprovalDescription !== undefined
         ? { pendingApprovalDescription: extra.pendingApprovalDescription }
+        : {}),
+      ...(extra?.pendingApprovalRequestedAt !== undefined
+        ? { pendingApprovalRequestedAt: extra.pendingApprovalRequestedAt }
         : {}),
       ...(extra?.providerContext ? { providerContext: extra.providerContext } : {}),
       ...(extra?.phase ? { phase: extra.phase } : {}),

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -20,6 +20,8 @@ const SLASH_COMMANDS = new Set([
 export interface ChatRuntimeState {
   sessionId: string;
   pendingApproval: boolean;
+  pendingApprovalContext?: PendingApprovalContext;
+  pendingApprovalDescription?: string;
   projectId: string;
   transcript: TranscriptMessage[];
   beastContext?: ChatBeastContext | null | undefined;
@@ -74,6 +76,26 @@ export interface ChatRuntimeRunOptions {
   onEvent?: ((event: TurnEvent) => void) | undefined;
 }
 
+export function pendingApprovalRuntimeState(
+  pendingApproval: PendingApproval | null | undefined,
+): Pick<ChatRuntimeState, 'pendingApproval' | 'pendingApprovalContext' | 'pendingApprovalDescription'> {
+  if (!pendingApproval) {
+    return { pendingApproval: false };
+  }
+
+  return {
+    pendingApproval: true,
+    pendingApprovalContext: {
+      ...(pendingApproval.tool ? { tool: pendingApproval.tool } : {}),
+      ...(pendingApproval.command ? { command: pendingApproval.command } : {}),
+      ...(pendingApproval.risk ? { risk: pendingApproval.risk } : {}),
+      ...(pendingApproval.affectedFiles ? { affectedFiles: pendingApproval.affectedFiles } : {}),
+      ...(pendingApproval.sessionId ? { sessionId: pendingApproval.sessionId } : {}),
+    },
+    pendingApprovalDescription: pendingApproval.description,
+  };
+}
+
 export class ChatRuntime {
   private readonly engine: ConversationEngine;
   private readonly beastDispatchAdapter: BeastDispatchPort | undefined;
@@ -87,22 +109,35 @@ export class ChatRuntime {
 
   async run(input: string, state: ChatRuntimeState, options?: ChatRuntimeRunOptions): Promise<ChatRuntimeResult> {
     const trimmed = input.trim();
-    if (trimmed.startsWith('/')) {
-      const command = trimmed.split(/\s+/)[0]?.toLowerCase();
-      if (command && SLASH_COMMANDS.has(command)) {
-        return this.runSlashCommand(command, trimmed, state, options);
-      }
-    }
+    const command = trimmed.startsWith('/') ? trimmed.split(/\s+/)[0]?.toLowerCase() : undefined;
 
-    if (state.pendingApproval) {
+    if (state.pendingApproval && command !== '/approve') {
+      if (trimmed.toLowerCase().startsWith('action rejected by user:')) {
+        return this.result({ ...state, pendingApproval: false }, [
+          { kind: 'approval', content: 'Rejected.' },
+        ], {
+          state: 'rejected',
+        });
+      }
+
       return this.result(state, [
         {
           kind: 'approval',
           content: 'Approval is pending. Resolve the approval request before sending another message.',
         },
       ], {
+        ...(state.pendingApprovalContext !== undefined
+          ? { pendingApprovalContext: state.pendingApprovalContext }
+          : {}),
+        ...(state.pendingApprovalDescription !== undefined
+          ? { pendingApprovalDescription: state.pendingApprovalDescription }
+          : {}),
         state: 'pending_approval',
       });
+    }
+
+    if (command && SLASH_COMMANDS.has(command)) {
+      return this.runSlashCommand(command, trimmed, state, options);
     }
 
     return this.runTurn(trimmed, state, options);

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -59,10 +59,6 @@ export interface ChatRuntimeOptions {
   turnRunner: TurnRunner;
 }
 
-function nowIso(): string {
-  return new Date().toISOString();
-}
-
 function stateFromRunResult(runResult: TurnRunResult): string {
   switch (runResult.status) {
     case 'pending_approval':
@@ -96,6 +92,17 @@ export class ChatRuntime {
       if (command && SLASH_COMMANDS.has(command)) {
         return this.runSlashCommand(command, trimmed, state, options);
       }
+    }
+
+    if (state.pendingApproval) {
+      return this.result(state, [
+        {
+          kind: 'approval',
+          content: 'Approval is pending. Resolve the approval request before sending another message.',
+        },
+      ], {
+        state: 'pending_approval',
+      });
     }
 
     return this.runTurn(trimmed, state, options);

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -163,7 +163,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     return withChatMutationAdmission(c, session.id, async () => {
       const result = await runtime.run(content, {
         sessionId: session.id,
-        ...pendingApprovalRuntimeState(session.pendingApproval),
+        ...pendingApprovalRuntimeState(session.pendingApproval, session.state === 'pending_approval'),
         projectId: session.projectId,
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
@@ -175,7 +175,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       session.pendingApproval = result.pendingApproval && result.pendingApprovalDescription
         ? {
             description: result.pendingApprovalDescription,
-            requestedAt: new Date().toISOString(),
+            requestedAt: result.pendingApprovalRequestedAt ?? new Date().toISOString(),
             ...result.pendingApprovalContext,
           }
         : null;
@@ -238,6 +238,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
       if (approved) {
         const pendingApproval = session.pendingApproval ?? null;
+        const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
         const runtimeInput = approvalRuntimeInput(pendingApproval);
         const originalState = session.state;
         session.pendingApproval = null;
@@ -247,7 +248,8 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
         try {
           result = await runtime.run(runtimeInput, {
             sessionId: session.id,
-            pendingApproval: !pendingApproval?.command,
+            pendingApproval: wasPendingApproval,
+            approvalResolved: true,
             projectId: session.projectId,
             transcript: session.transcript,
             ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { approvalRuntimeInput } from '../../chat/approval-input.js';
 import type { ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
-import type { ChatRuntime } from '../../chat/runtime.js';
+import { ChatRuntime, pendingApprovalRuntimeState } from '../../chat/runtime.js';
 import type { TurnRunner } from '../../chat/turn-runner.js';
 import type {
   ApiDataEnvelope,
@@ -163,7 +163,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     return withChatMutationAdmission(c, session.id, async () => {
       const result = await runtime.run(content, {
         sessionId: session.id,
-        pendingApproval: Boolean(session.pendingApproval),
+        ...pendingApprovalRuntimeState(session.pendingApproval),
         projectId: session.projectId,
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
@@ -238,7 +238,6 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
       if (approved) {
         const pendingApproval = session.pendingApproval ?? null;
-        const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
         const runtimeInput = approvalRuntimeInput(pendingApproval);
         const originalState = session.state;
         session.pendingApproval = null;
@@ -248,7 +247,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
         try {
           result = await runtime.run(runtimeInput, {
             sessionId: session.id,
-            pendingApproval: wasPendingApproval,
+            pendingApproval: !pendingApproval?.command,
             projectId: session.projectId,
             transcript: session.transcript,
             ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -161,6 +161,15 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const session = getSessionOrThrow(sessionStore, id);
 
     return withChatMutationAdmission(c, session.id, async () => {
+      if (session.pendingApproval || session.state === 'pending_approval') {
+        return c.json({
+          error: {
+            code: 'APPROVAL_PENDING',
+            message: 'Approval is pending. Resolve the approval request before sending another message.',
+          },
+        }, 409);
+      }
+
       const result = await runtime.run(content, {
         sessionId: session.id,
         ...pendingApprovalRuntimeState(session.pendingApproval, session.state === 'pending_approval'),

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -253,6 +253,33 @@ export class ChatSocketController {
     content: string,
     executionMode?: 'process' | 'container',
   ): Promise<void> {
+    if (session.pendingApproval || session.state === 'pending_approval') {
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'APPROVAL_PENDING',
+        message: 'Approval is pending. Resolve the approval request before sending another message.',
+        timestamp: nowIso(),
+      });
+      return;
+    }
+
+    this.emit(peer, {
+      type: 'message.accepted',
+      clientMessageId,
+      sessionId: session.id,
+      timestamp: nowIso(),
+    });
+    this.emit(peer, {
+      type: 'message.delivered',
+      clientMessageId,
+      timestamp: nowIso(),
+    });
+    this.emit(peer, {
+      type: 'message.read',
+      clientMessageId,
+      timestamp: nowIso(),
+    });
+
     const result = await this.runtime.run(content, {
       sessionId: session.id,
       ...pendingApprovalRuntimeState(session.pendingApproval, session.state === 'pending_approval'),
@@ -261,33 +288,6 @@ export class ChatSocketController {
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
       ...(executionMode ? { executionMode } : {}),
     });
-
-    const turnAccepted = result.transcript !== session.transcript;
-    if (turnAccepted) {
-      this.emit(peer, {
-        type: 'message.accepted',
-        clientMessageId,
-        sessionId: session.id,
-        timestamp: nowIso(),
-      });
-      this.emit(peer, {
-        type: 'message.delivered',
-        clientMessageId,
-        timestamp: nowIso(),
-      });
-      this.emit(peer, {
-        type: 'message.read',
-        clientMessageId,
-        timestamp: nowIso(),
-      });
-    } else if (result.state === 'pending_approval' && result.pendingApproval) {
-      this.emit(peer, {
-        type: 'turn.error',
-        code: 'APPROVAL_PENDING',
-        message: 'Approval is pending. Resolve the approval request before sending another message.',
-        timestamp: nowIso(),
-      });
-    }
 
     session.transcript = result.transcript;
     session.state = result.state;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import type { Duplex } from 'node:stream';
 import { WebSocketServer, type WebSocket } from 'ws';
 import { approvalRuntimeInput } from '../chat/approval-input.js';
-import { ChatRuntime } from '../chat/runtime.js';
+import { ChatRuntime, pendingApprovalRuntimeState } from '../chat/runtime.js';
 import type { ISessionStore } from '../chat/session-store.js';
 import type { ChatSession } from '../chat/types.js';
 import type { TurnEvent } from '../chat/turn-runner.js';
@@ -272,7 +272,7 @@ export class ChatSocketController {
 
     const result = await this.runtime.run(content, {
       sessionId: session.id,
-      pendingApproval: Boolean(session.pendingApproval),
+      ...pendingApprovalRuntimeState(session.pendingApproval),
       projectId: session.projectId,
       transcript: session.transcript,
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
@@ -406,7 +406,7 @@ export class ChatSocketController {
     try {
       result = await this.runtime.run(runtimeInput, {
         sessionId: session.id,
-        pendingApproval: Boolean(pendingApproval) || originalState === 'pending_approval',
+        pendingApproval: !pendingApproval?.command,
         projectId: session.projectId,
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -253,23 +253,6 @@ export class ChatSocketController {
     content: string,
     executionMode?: 'process' | 'container',
   ): Promise<void> {
-    this.emit(peer, {
-      type: 'message.accepted',
-      clientMessageId,
-      sessionId: session.id,
-      timestamp: nowIso(),
-    });
-    this.emit(peer, {
-      type: 'message.delivered',
-      clientMessageId,
-      timestamp: nowIso(),
-    });
-    this.emit(peer, {
-      type: 'message.read',
-      clientMessageId,
-      timestamp: nowIso(),
-    });
-
     const result = await this.runtime.run(content, {
       sessionId: session.id,
       ...pendingApprovalRuntimeState(session.pendingApproval, session.state === 'pending_approval'),
@@ -278,6 +261,33 @@ export class ChatSocketController {
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
       ...(executionMode ? { executionMode } : {}),
     });
+
+    const turnAccepted = result.transcript !== session.transcript;
+    if (turnAccepted) {
+      this.emit(peer, {
+        type: 'message.accepted',
+        clientMessageId,
+        sessionId: session.id,
+        timestamp: nowIso(),
+      });
+      this.emit(peer, {
+        type: 'message.delivered',
+        clientMessageId,
+        timestamp: nowIso(),
+      });
+      this.emit(peer, {
+        type: 'message.read',
+        clientMessageId,
+        timestamp: nowIso(),
+      });
+    } else if (result.state === 'pending_approval' && result.pendingApproval) {
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'APPROVAL_PENDING',
+        message: 'Approval is pending. Resolve the approval request before sending another message.',
+        timestamp: nowIso(),
+      });
+    }
 
     session.transcript = result.transcript;
     session.state = result.state;

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -272,7 +272,7 @@ export class ChatSocketController {
 
     const result = await this.runtime.run(content, {
       sessionId: session.id,
-      ...pendingApprovalRuntimeState(session.pendingApproval),
+      ...pendingApprovalRuntimeState(session.pendingApproval, session.state === 'pending_approval'),
       projectId: session.projectId,
       transcript: session.transcript,
       ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
@@ -284,7 +284,7 @@ export class ChatSocketController {
     session.pendingApproval = result.pendingApproval && result.pendingApprovalDescription
       ? {
           description: result.pendingApprovalDescription,
-          requestedAt: nowIso(),
+          requestedAt: result.pendingApprovalRequestedAt ?? nowIso(),
           ...result.pendingApprovalContext,
         }
       : null;
@@ -406,7 +406,8 @@ export class ChatSocketController {
     try {
       result = await this.runtime.run(runtimeInput, {
         sessionId: session.id,
-        pendingApproval: !pendingApproval?.command,
+        pendingApproval: Boolean(pendingApproval) || originalState === 'pending_approval',
+        approvalResolved: true,
         projectId: session.projectId,
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -264,6 +264,39 @@ describe('Chat HTTP Routes', () => {
     expect(sessionBody.data.state).toBe('active');
   });
 
+  it('POST /v1/chat/sessions/:id/messages rejects sends while approval is pending', async () => {
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+
+    const firstRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'run deployment' }),
+    });
+    expect(firstRes.status).toBe(200);
+
+    const blockedRes = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'send stale draft' }),
+    });
+    expect(blockedRes.status).toBe(409);
+    const blockedBody = await blockedRes.json();
+    expect(blockedBody.error).toMatchObject({
+      code: 'APPROVAL_PENDING',
+      message: expect.stringContaining('Approval is pending'),
+    });
+
+    const sessionRes = await app.request(`/v1/chat/sessions/${created.id}`);
+    const sessionBody = await sessionRes.json();
+    expect(sessionBody.data.state).toBe('pending_approval');
+    expect(sessionBody.data.transcript).toHaveLength(1);
+  });
+
   it('runs a Beast interview in chat and dispatches a persisted Beast run', async () => {
     const repository = new SQLiteBeastRepository(join(TMP, 'beasts.db'));
     const logStore = new BeastLogStore(join(TMP, 'beast-logs'));

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -353,6 +353,66 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('acknowledges accepted websocket messages before the runtime turn completes', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    type RunResult = {
+      displayMessages: { kind: 'reply'; content: string }[];
+      events: unknown[];
+      pendingApproval: false;
+      state: 'active';
+      tier: 'cheap';
+      transcript: typeof session.transcript;
+    };
+    let resolveRun!: (value: RunResult) => void;
+    const runPromise = new Promise<RunResult>((resolve) => {
+      resolveRun = resolve;
+    });
+    const runtime = {
+      run: vi.fn(() => runPromise),
+    };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    const receivePromise = controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-long-turn',
+      content: 'run a long task',
+    }));
+
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect(sent.map((raw) => JSON.parse(raw) as { type: string })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'message.accepted' }),
+      expect.objectContaining({ type: 'message.delivered' }),
+      expect.objectContaining({ type: 'message.read' }),
+    ]));
+
+    resolveRun({
+      displayMessages: [{ kind: 'reply', content: 'ok' }],
+      events: [],
+      pendingApproval: false,
+      state: 'active',
+      tier: 'cheap',
+      transcript: session.transcript,
+    });
+    await receivePromise;
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('emits execution events after an approved action runs', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -299,6 +299,60 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('does not acknowledge websocket messages rejected by pending approval', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute: vi.fn() }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-stale',
+      content: 'start another task',
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events.map((event) => event.type)).not.toContain('message.accepted');
+    expect(events.map((event) => event.type)).not.toContain('message.delivered');
+    expect(events.map((event) => event.type)).not.toContain('message.read');
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'APPROVAL_PENDING',
+    }));
+    expect(store.get(session.id)?.transcript).toEqual([]);
+    expect(store.get(session.id)?.pendingApproval).toEqual(expect.objectContaining({
+      requestedAt: '2026-03-09T00:00:00Z',
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('emits execution events after an approved action runs', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { ConversationEngine } from '../../../src/chat/conversation-engine.js';
 import { createChatRuntime } from '../../../src/chat/chat-runtime-factory.js';
 import { ChatRuntime } from '../../../src/chat/runtime.js';
 import { TurnRunner } from '../../../src/chat/turn-runner.js';
@@ -78,7 +79,7 @@ describe('chat runtime parity', () => {
             approvalRequired: true,
           },
         }),
-      } as any,
+      } as unknown as ConversationEngine,
       turnRunner: new TurnRunner({ execute: vi.fn() }),
     });
 
@@ -97,5 +98,50 @@ describe('chat runtime parity', () => {
       risk: expect.stringContaining('Requires explicit approval'),
       sessionId: 'session-1',
     }));
+  });
+
+  it('blocks normal chat turns while approval is pending', async () => {
+    const engine = { processTurn: vi.fn() };
+    const runner = new TurnRunner({ execute: vi.fn() });
+    const runtime = new ChatRuntime({
+      engine: engine as unknown as ConversationEngine,
+      turnRunner: runner,
+    });
+    const transcript = [
+      { role: 'assistant' as const, content: 'approval required: deploy staging', timestamp: '2026-07-09T00:00:00.000Z' },
+    ];
+
+    const result = await runtime.run('please continue anyway', {
+      sessionId: 'session-1',
+      pendingApproval: true,
+      projectId: 'test-project',
+      transcript,
+    });
+
+    expect(result.state).toBe('pending_approval');
+    expect(result.pendingApproval).toBe(true);
+    expect(result.transcript).toBe(transcript);
+    expect(result.displayMessages[0]).toMatchObject({
+      kind: 'approval',
+      content: expect.stringContaining('Approval is pending'),
+    });
+    expect(engine.processTurn).not.toHaveBeenCalled();
+  });
+
+  it('still allows slash commands while approval is pending', async () => {
+    const runtime = createChatRuntime({
+      chatLlm: { complete: vi.fn().mockResolvedValue('ignored') },
+      projectName: 'test-project',
+    });
+
+    const result = await runtime.runtime.run('/status', {
+      sessionId: 'session-1',
+      pendingApproval: true,
+      projectId: 'test-project',
+      transcript: [],
+    });
+
+    expect(result.displayMessages[0]?.content).toContain('project=test-project');
+    expect(result.state).toBe('active');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
@@ -128,20 +128,46 @@ describe('chat runtime parity', () => {
     expect(engine.processTurn).not.toHaveBeenCalled();
   });
 
-  it('still allows slash commands while approval is pending', async () => {
+  it('blocks mutating slash commands while approval is pending', async () => {
     const runtime = createChatRuntime({
-      chatLlm: { complete: vi.fn().mockResolvedValue('ignored') },
+      chatLlm: { complete: vi.fn().mockResolvedValue('chat ignored') },
+      executionLlm: { complete: vi.fn().mockResolvedValue('execution ignored') },
       projectName: 'test-project',
     });
 
-    const result = await runtime.runtime.run('/status', {
+    const result = await runtime.runtime.run('/run deploy something else', {
       sessionId: 'session-1',
       pendingApproval: true,
+      pendingApprovalDescription: 'deploy staging',
+      pendingApprovalContext: { tool: 'execution', command: 'deploy staging', sessionId: 'session-1' },
       projectId: 'test-project',
       transcript: [],
     });
 
-    expect(result.displayMessages[0]?.content).toContain('project=test-project');
-    expect(result.state).toBe('active');
+    expect(result.state).toBe('pending_approval');
+    expect(result.pendingApproval).toBe(true);
+    expect(result.pendingApprovalDescription).toBe('deploy staging');
+    expect(result.pendingApprovalContext).toEqual(expect.objectContaining({ command: 'deploy staging' }));
+    expect(result.displayMessages[0]?.content).toContain('Approval is pending');
+  });
+
+  it('maps comms rejection action text to a rejected approval state', async () => {
+    const runtime = createChatRuntime({
+      chatLlm: { complete: vi.fn().mockResolvedValue('chat ignored') },
+      projectName: 'test-project',
+    });
+
+    const result = await runtime.runtime.run('Action rejected by user: reject', {
+      sessionId: 'session-1',
+      pendingApproval: true,
+      pendingApprovalDescription: 'deploy staging',
+      pendingApprovalContext: { tool: 'execution', command: 'deploy staging', sessionId: 'session-1' },
+      projectId: 'test-project',
+      transcript: [],
+    });
+
+    expect(result.state).toBe('rejected');
+    expect(result.pendingApproval).toBe(false);
+    expect(result.displayMessages[0]).toMatchObject({ kind: 'approval', content: 'Rejected.' });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -103,10 +103,36 @@ describe('chat approval route persistence', () => {
     expect(stored?.state).toBe('pending_approval');
     expect(stored?.pendingApproval).toEqual(expect.objectContaining({
       description: 'Deploy the generated fix',
+      requestedAt: '2026-07-07T15:23:06.000Z',
       tool: 'execution',
       command: 'deploy staging',
       risk: 'Requires approval.',
       sessionId: session.id,
     }));
+  });
+
+  it('blocks stale HTTP messages for legacy state-only pending approvals', async () => {
+    const llm = { complete: vi.fn().mockResolvedValue('should not run') };
+    const app = createChatApp({
+      sessionStore,
+      llm,
+      projectName: 'chat-approval-route-test',
+    });
+    const session = sessionStore.create('project-1');
+    session.state = 'pending_approval';
+    session.pendingApproval = null;
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'start something else' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(llm.complete).not.toHaveBeenCalled();
+    const stored = sessionStore.get(session.id);
+    expect(stored?.state).toBe('pending_approval');
+    expect(stored?.pendingApproval).toBeNull();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -75,4 +75,38 @@ describe('chat approval route persistence', () => {
     expect(stored?.state).toBe('rejected');
     expect(stored?.pendingApproval).toBeNull();
   });
+
+  it('preserves pending approval metadata when a stale HTTP message is blocked', async () => {
+    const app = createChatApp({
+      sessionStore,
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'chat-approval-route-test',
+    });
+    const session = pendingApprovalSession(sessionStore.create('project-1'));
+    session.pendingApproval = {
+      ...session.pendingApproval!,
+      tool: 'execution',
+      command: 'deploy staging',
+      risk: 'Requires approval.',
+      sessionId: session.id,
+    };
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'start something else' }),
+    });
+
+    expect(response.status).toBe(200);
+    const stored = sessionStore.get(session.id);
+    expect(stored?.state).toBe('pending_approval');
+    expect(stored?.pendingApproval).toEqual(expect.objectContaining({
+      description: 'Deploy the generated fix',
+      tool: 'execution',
+      command: 'deploy staging',
+      risk: 'Requires approval.',
+      sessionId: session.id,
+    }));
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -98,7 +98,12 @@ describe('chat approval route persistence', () => {
       body: JSON.stringify({ content: 'start something else' }),
     });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(409);
+    const body = await response.json() as { error: { code: string; message: string } };
+    expect(body.error).toMatchObject({
+      code: 'APPROVAL_PENDING',
+      message: expect.stringContaining('Approval is pending'),
+    });
     const stored = sessionStore.get(session.id);
     expect(stored?.state).toBe('pending_approval');
     expect(stored?.pendingApproval).toEqual(expect.objectContaining({
@@ -129,7 +134,7 @@ describe('chat approval route persistence', () => {
       body: JSON.stringify({ content: 'start something else' }),
     });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(409);
     expect(llm.complete).not.toHaveBeenCalled();
     const stored = sessionStore.get(session.id);
     expect(stored?.state).toBe('pending_approval');

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -308,6 +308,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     retryMessage,
     send,
     sessionId: activeSessionId,
+    sessionState,
     showTypingIndicator,
     status,
     tier,
@@ -711,11 +712,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     getSidebarFocusableElements(sidebar).at(-1)?.focus();
   }
 
+  const hasPendingApproval = Boolean(pendingApproval) || sessionState === 'pending_approval';
   const composerDisabled = status === 'connecting'
     || status === 'sending'
     || status === 'streaming'
-    || Boolean(pendingApproval);
-  const composerDisabledReason = pendingApproval
+    || hasPendingApproval;
+  const composerDisabledReason = hasPendingApproval
     ? 'Dispatch is disabled while an approval request is pending. Approve or reject it before sending another message.'
     : undefined;
 
@@ -927,7 +929,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                   }).catch(() => undefined);
                 }}
                 resetKey={`${activeProjectId}:${activeSessionId ?? selectedSessionId ?? 'new'}:${sessionSeed}`}
-                retryDisabled={Boolean(pendingApproval) || (status !== 'idle' && status !== 'error')}
+                retryDisabled={hasPendingApproval || (status !== 'idle' && status !== 'error')}
                 showTypingIndicator={showTypingIndicator}
               />
               <Composer

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -711,6 +711,14 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     getSidebarFocusableElements(sidebar).at(-1)?.focus();
   }
 
+  const composerDisabled = status === 'connecting'
+    || status === 'sending'
+    || status === 'streaming'
+    || Boolean(pendingApproval);
+  const composerDisabledReason = pendingApproval
+    ? 'Dispatch is disabled while an approval request is pending. Approve or reject it before sending another message.'
+    : undefined;
+
   return (
     <div className={`dashboard-shell ${isSidebarOpen ? 'dashboard-shell--nav-open' : ''}`}>
       <button
@@ -926,7 +934,8 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 key={composerSessionKey}
                 connectionStatus={connectionStatus}
                 clearedFailedDraft={clearedFailedDraft}
-                disabled={status === 'connecting' || status === 'sending' || status === 'streaming'}
+                disabled={composerDisabled}
+                disabledReasonText={composerDisabledReason}
                 onReconnect={reconnect}
                 onSend={send}
                 status={status}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -927,7 +927,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                   }).catch(() => undefined);
                 }}
                 resetKey={`${activeProjectId}:${activeSessionId ?? selectedSessionId ?? 'new'}:${sessionSeed}`}
-                retryDisabled={status !== 'idle' && status !== 'error'}
+                retryDisabled={Boolean(pendingApproval) || (status !== 'idle' && status !== 'error')}
                 showTypingIndicator={showTypingIndicator}
               />
               <Composer

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -948,9 +948,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               <CostBadge tier={tier ?? 'pending'} tokenTotals={tokenTotals} costUsd={costUsd} />
               <ActivityPane events={activity} resetKey={`${activeProjectId}:${activeSessionId ?? selectedSessionId ?? 'new'}:${sessionSeed}`} />
               <ApprovalCard
-                pending={Boolean(pendingApproval)}
+                pending={hasPendingApproval}
                 approval={pendingApproval}
-                description={pendingApproval?.description ?? ''}
+                description={pendingApproval?.description ?? (hasPendingApproval ? 'Approval is pending. Approve or reject it before sending another message.' : '')}
                 resolving={approvalResolving}
                 error={approvalError}
                 sessionId={activeSessionId}

--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -5,6 +5,7 @@ export interface ComposerProps {
   connectionStatus: ConnectionStatus;
   clearedFailedDraft?: { content: string; nonce: number };
   disabled: boolean;
+  disabledReasonText?: string;
   onReconnect?: () => void;
   onSend: (content: string) => Promise<void> | void;
   status: SessionStatus;
@@ -76,12 +77,13 @@ function canRetryConnection(connectionStatus: ConnectionStatus): boolean {
   return connectionStatus === 'disconnected' || connectionStatus === 'offline' || connectionStatus === 'error';
 }
 
-export function Composer({ connectionStatus, clearedFailedDraft, disabled, onReconnect, onSend, status }: ComposerProps) {
+export function Composer({ connectionStatus, clearedFailedDraft, disabled, disabledReasonText, onReconnect, onSend, status }: ComposerProps) {
   const [error, setError] = useState<{ content: string; message: string } | null>(null);
   const [isSending, setIsSending] = useState(false);
   const [value, setValue] = useState('');
   const lastClearedFailedDraftNonceRef = useRef<number | null>(null);
-  const helpText = disabledReason(status)
+  const helpText = disabledReasonText
+    ?? disabledReason(status)
     ?? connectionHelp(connectionStatus)
     ?? 'Type a message, then press Dispatch or Ctrl+Enter to send.';
   const liveStatus = `${connectionStatusLabel(connectionStatus)}. ${sessionStatusLabel(status)}.`;

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -66,6 +66,7 @@ export interface UseChatSessionResult {
   reconnect: () => void;
   send: (content: string) => Promise<void>;
   sessionId: string | null;
+  sessionState: string | null;
   showTypingIndicator: boolean;
   status: SessionStatus;
   tier: string | null;
@@ -373,6 +374,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const [pendingApproval, setPendingApproval] = useState<PendingApproval | null>(null);
   const [projectId, setProjectId] = useState(opts.projectId);
   const [sessionId, setSessionId] = useState<string | null>(opts.sessionId ?? null);
+  const [sessionState, setSessionState] = useState<string | null>(null);
   const [showTypingIndicator, setShowTypingIndicator] = useState(false);
   const [socketToken, setSocketToken] = useState<string | null>(null);
   const [socketGeneration, setSocketGeneration] = useState(0);
@@ -456,6 +458,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setSocketToken(refreshed.socketToken);
         setMessages((current) => reconcileRecoveryMessages(current, refreshed.transcript));
         setPendingApproval(refreshed.pendingApproval ?? null);
+        setSessionState(refreshed.state);
         setTokenTotals(refreshed.tokenTotals);
         setCostUsd(refreshed.costUsd);
         setStatus('idle');
@@ -502,6 +505,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     lastMessageRef.current = null;
     activeSessionIdRef.current = null;
     setSessionId(null);
+    setSessionState(null);
     setSocketToken(null);
     setPendingApproval(null);
     setShowTypingIndicator(false);
@@ -526,6 +530,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         activeSessionIdRef.current = session.id;
         setSocketToken(session.socketToken);
         setSessionId(session.id);
+        setSessionState(session.state);
         setProjectId(session.projectId);
         setMessages(applySessionSnapshot(session));
         setPendingApproval(session.pendingApproval ?? null);
@@ -609,6 +614,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
             readyRef.current = true;
             setMessages((current) => reconcileRecoveryMessages(current, payload.transcript));
             setPendingApproval(payload.pendingApproval ?? null);
+            setSessionState(payload.state);
             setProjectId(payload.projectId);
           }
           return;
@@ -994,6 +1000,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     retryMessage,
     send,
     sessionId,
+    sessionState,
     showTypingIndicator,
     status,
     tier,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -676,6 +676,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setActivity((current) => [...current, payload]);
           return;
         case 'turn.approval.requested':
+          setSessionState('pending_approval');
           setPendingApproval({
             description: payload.description,
             requestedAt: payload.timestamp,
@@ -705,6 +706,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           setStatus('idle');
           return;
         case 'turn.approval.resolved':
+          setSessionState(payload.approved ? 'approved' : 'rejected');
           setPendingApproval(null);
           setApprovalError(null);
           updateApprovalResolving(false);
@@ -718,6 +720,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           ]);
           return;
         case 'turn.error':
+          if (payload.code === 'APPROVAL_PENDING') {
+            void refreshSession();
+          }
           updateApprovalResolving(false);
           setApprovalError(payload.message);
           setActivity((current) => [
@@ -844,6 +849,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
             refreshed,
           ));
           setPendingApproval(refreshed.pendingApproval ?? null);
+          setSessionState(refreshed.state);
           setTokenTotals(refreshed.tokenTotals);
           setCostUsd(refreshed.costUsd);
           setStatus('idle');
@@ -867,6 +873,19 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       } catch (error) {
         if (!sessionStillCurrent(sessionId)) {
           return;
+        }
+        try {
+          const refreshed = await clientRef.current.getSession(sessionId);
+          if (sessionStillCurrent(sessionId)) {
+            readyRef.current = true;
+            setMessages((current) => mergeSessionSnapshot(current, refreshed));
+            setPendingApproval(refreshed.pendingApproval ?? null);
+            setSessionState(refreshed.state);
+            setTokenTotals(refreshed.tokenTotals);
+            setCostUsd(refreshed.costUsd);
+          }
+        } catch {
+          // Preserve the original send failure while keeping the draft retryable.
         }
         const sendError = error instanceof Error
           ? error
@@ -952,6 +971,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           }), withSnapshot);
         });
         setPendingApproval(refreshed.pendingApproval ?? null);
+        setSessionState(refreshed.state);
         setActivity((current) => [
           ...current,
           ...activityEventsFromApproveResult(approvalResult, approved),

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -202,6 +202,15 @@ vi.mock('../../src/hooks/use-chat-session.js', () => ({
         modelTier: 'cheap',
         streaming: false,
       },
+      {
+        id: 'user-failed',
+        role: 'user',
+        content: 'Retry this failed request',
+        timestamp: '2026-03-09T00:00:02Z',
+        receipt: 'failed',
+        error: 'network failed',
+        canRetry: true,
+      },
     ],
     status: 'idle' as const,
     connectionStatus: 'connected' as const,
@@ -492,6 +501,7 @@ describe('ChatShell', () => {
     const input = screen.getByRole('textbox');
     expect(input.getAttribute('aria-disabled')).toBe('true');
     expect(screen.getByRole('button', { name: 'Dispatch' })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('button', { name: 'Resend failed message' })).toHaveProperty('disabled', true);
     expect(screen.getByText('Dispatch is disabled while an approval request is pending. Approve or reject it before sending another message.')).toBeDefined();
   });
 

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -486,6 +486,15 @@ describe('ChatShell', () => {
     expect(screen.getByText('turn.execution.start')).toBeDefined();
   });
 
+  it('disables normal chat input while approval is pending', () => {
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    const input = screen.getByRole('textbox');
+    expect(input.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Dispatch' })).toHaveProperty('disabled', true);
+    expect(screen.getByText('Dispatch is disabled while an approval request is pending. Approve or reject it before sending another message.')).toBeDefined();
+  });
+
   it('labels conversations with preview, state, message count, updated time, and a shortened id', async () => {
     mockListSessions.mockResolvedValue([
       {

--- a/packages/franken-web/tests/components/composer.test.tsx
+++ b/packages/franken-web/tests/components/composer.test.tsx
@@ -44,6 +44,22 @@ describe('Composer', () => {
     expect(screen.getByText('Dispatch is disabled while Frankenbeast is responding.')).toBeTruthy();
   });
 
+  it('uses a pending-approval disabled reason when provided', () => {
+    render(
+      <Composer
+        onSend={vi.fn()}
+        disabled={true}
+        disabledReasonText="Dispatch is disabled while an approval request is pending."
+        connectionStatus="connected"
+        status="idle"
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.getByText('Dispatch is disabled while an approval request is pending.')).toBeTruthy();
+  });
+
   it('announces connection and session states in a live status region', () => {
     render(<Composer onSend={vi.fn()} disabled={false} connectionStatus="reconnecting" status="idle" />);
 

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -138,6 +138,7 @@ describe('useChatSession', () => {
       expect(result.current.sessionId).toBe('chat-1');
     });
 
+    expect(result.current.sessionState).toBe('active');
     expect(mockCreateSession).toHaveBeenCalledWith('test-proj');
     expect(mockSocketUrl).toHaveBeenCalledWith('chat-1', 'signed-token');
     expect(mockSocketProtocols).toHaveBeenCalledWith('signed-token');

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -266,6 +266,43 @@ describe('useChatSession', () => {
     expect(result.current.status).toBe('idle');
   });
 
+  it('refreshes approval metadata when an HTTP fallback send is blocked', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    mockSendMessage.mockRejectedValueOnce(new Error('Approval is pending. Resolve the approval request before sending another message.'));
+    mockGetSession.mockResolvedValueOnce({
+      id: 'chat-1',
+      projectId: 'test-proj',
+      transcript: [],
+      state: 'pending_approval',
+      pendingApproval: {
+        description: 'Deploy the generated fix',
+        requestedAt: '2026-03-09T00:00:06Z',
+      },
+      socketToken: 'signed-token',
+      tokenTotals: { cheap: 1, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0.01,
+      createdAt: '2026-03-09T00:00:00Z',
+      updatedAt: '2026-03-09T00:00:07Z',
+    });
+
+    await act(async () => {
+      await expect(result.current.send('blocked over HTTP')).rejects.toThrow('Approval is pending');
+    });
+
+    expect(result.current.sessionState).toBe('pending_approval');
+    expect(result.current.pendingApproval?.description).toBe('Deploy the generated fix');
+    expect(result.current.messages).toContainEqual(expect.objectContaining({
+      content: 'blocked over HTTP',
+      receipt: 'failed',
+      canRetry: true,
+    }));
+  });
+
   it('does not offer a retry when HTTP send succeeds but refresh fails', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 
@@ -784,6 +821,7 @@ describe('useChatSession', () => {
     });
 
     expect(result.current.pendingApproval?.description).toBe('Deploy the generated fix');
+    expect(result.current.sessionState).toBe('pending_approval');
 
     await act(async () => {
       await result.current.approve(true);
@@ -793,6 +831,17 @@ describe('useChatSession', () => {
       type: 'approval.respond',
       approved: true,
     });
+
+    act(() => {
+      socket.message({
+        type: 'turn.approval.resolved',
+        approved: true,
+        timestamp: '2026-03-09T00:00:07Z',
+      });
+    });
+
+    expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.sessionState).toBe('approved');
   });
 
   it('falls back to HTTP approval when the websocket is not ready', async () => {
@@ -822,6 +871,7 @@ describe('useChatSession', () => {
     expect(mockGetSession).toHaveBeenCalledWith('chat-1');
     expect(socket.sent).toHaveLength(0);
     expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.sessionState).toBe('active');
     expect(result.current.approvalResolving).toBe(false);
     expect(result.current.approvalError).toBeNull();
     expect(result.current.status).toBe('idle');


### PR DESCRIPTION
## Summary
- Block non-command chat turns in ChatRuntime while an approval is pending
- Disable the web composer during pending approval and explain the required approve/reject action
- Add runtime and web component coverage for pending-approval chat blocking

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/chat/runtime-parity.test.ts
- npm --prefix packages/franken-web test -- tests/components/composer.test.tsx tests/components/chat-shell.test.tsx
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-web run typecheck
- npm run build
- npm --prefix packages/franken-orchestrator run lint

Closes #1154