### PR TITLE
docs(mcp): update local link recovery advice

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -89,7 +89,7 @@ npx frankenbeast issues --repo owner/repo --dry-run
 The `fbeast` binary ships from the `@franken/mcp-suite` package (there is no package named `fbeast`). Install it persistently so both `fbeast` and the `fbeast-*` MCP server binaries stay on PATH — `mcp init` registers servers as bare `fbeast-memory`/`fbeast-proxy` commands the AI client spawns later, so a one-shot `npx` would leave those servers unable to start:
 
 ```bash
-# Install once (global), or link from the monorepo with: npm link --workspace=packages/franken-mcp-suite
+# Install once (global), or link both local CLIs from the monorepo with: npm run local:link
 npm install -g @franken/mcp-suite
 
 # Standard MCP registration

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -30,16 +30,12 @@ From the repo root:
 
 ```bash
 npm install
-npm run build
-npm link --workspace=packages/franken-mcp-suite
-npm link --workspace=packages/franken-orchestrator
+npm run local:link
 ```
 
 Verify:
-
 ```bash
-fbeast mcp              # MCP suite CLI
-frankenbeast --help    # Orchestrator CLI
+npm run local:verify-cli
 ```
 
 ---
@@ -272,12 +268,14 @@ The matrix covers parser/config truthfulness, `run` and `run --resume`, required
 
 **`frankenbeast: command not found`**
 ```bash
-npm link --workspace=packages/franken-orchestrator
+npm run local:link
+npm run local:verify-cli
 ```
 
 **`fbeast-proxy` / `fbeast-memory` not found after `fbeast mcp init`**
 ```bash
-npm link --workspace=packages/franken-mcp-suite
+npm run local:link
+npm run local:verify-cli
 ```
 
 **Beast fails to start with "binary not found"**

--- a/docs/guides/wrap-external-agent.md
+++ b/docs/guides/wrap-external-agent.md
@@ -7,7 +7,7 @@ The current repo does not ship a `firewall` Docker Compose service or a standalo
 Install the MCP suite in the project you want to govern. The `fbeast` binary ships from the `@franken/mcp-suite` package (there is no package named `fbeast`), and `mcp init` registers servers as bare `fbeast-memory`/`fbeast-proxy` commands that the AI client spawns later — so install the package persistently (global or `npm link`) rather than via a one-shot `npx`, otherwise the registered servers won't be on PATH at runtime:
 
 ```bash
-npm install -g @franken/mcp-suite      # or: npm link --workspace=packages/franken-mcp-suite
+npm install -g @franken/mcp-suite      # or, from this repo: npm run local:link
 fbeast mcp init
 fbeast mcp init --hooks                # optional: pre/post-tool governance and audit logs
 ```

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "lint:any": "node scripts/audit-explicit-any.mjs",
     "lint:security": "node scripts/check-plain-http.mjs && node scripts/check-hardcoded-secrets.mjs && node scripts/audit-todo-markers.mjs",
     "audit:todos": "node scripts/audit-todo-markers.mjs",
+    "local:link": "npm run build && npm link --workspace=@franken/mcp-suite --workspace=@franken/orchestrator",
+    "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "test": "turbo run test",
     "test:root": "vitest run",
     "test:root:watch": "vitest",

--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -14,7 +14,7 @@ would leave the registered servers unable to start.
 # Global install (publishes the fbeast + fbeast-* binaries onto PATH)
 npm install -g @franken/mcp-suite
 # …or, from a clone of this monorepo:
-#   npm install && npm link --workspace=packages/franken-mcp-suite
+#   npm install && npm run local:link && npm run local:verify-cli
 
 # Initialize for your project
 cd your-project

--- a/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
@@ -161,7 +161,7 @@ describe('runBeastMode', () => {
     const message = mockLog.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(message).toContain('npm run local:link');
     expect(message).toContain('npm run local:verify-cli');
-    expect(message).not.toContain('npm install -g @franken/orchestrator');
+    expect(message).toContain('npm install -g @franken/orchestrator');
     expect(message).toContain('frankenbeast beasts catalog');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');
     mockLog.mockRestore();

--- a/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.test.ts
@@ -159,7 +159,9 @@ describe('runBeastMode', () => {
     await runBeastMode([], deps);
 
     const message = mockLog.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(message).toContain('npm install -g @franken/orchestrator');
+    expect(message).toContain('npm run local:link');
+    expect(message).toContain('npm run local:verify-cli');
+    expect(message).not.toContain('npm install -g @franken/orchestrator');
     expect(message).toContain('frankenbeast beasts catalog');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');
     mockLog.mockRestore();

--- a/packages/franken-mcp-suite/src/cli/beast-mode.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.ts
@@ -6,7 +6,7 @@ import { FbeastConfig } from '../shared/config.js';
 function printLine(...args: unknown[]): void {
   console.info(...args);
 }
-const FRANKENBEAST_INSTALL_COMMAND = 'npm install -g @franken/orchestrator';
+const FRANKENBEAST_INSTALL_HELP = ['from the repo root, run: npm run local:link', 'then verify with: npm run local:verify-cli'];
 const SUPPORTED_BEAST_PROVIDERS = new Set(['anthropic-api', 'codex-cli', 'claude-cli']);
 
 function parseProvider(argv: string[]): string {
@@ -54,8 +54,10 @@ export async function runBeastMode(argv: string[], deps: BeastModeDeps): Promise
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('binary not found') || msg.includes('ENOENT')) {
-      printLine('\nTo launch the orchestrator, install the frankenbeast CLI:');
-      printLine(`  ${FRANKENBEAST_INSTALL_COMMAND}`);
+      printLine('\nTo launch the orchestrator from a local checkout:');
+      for (const line of FRANKENBEAST_INSTALL_HELP) {
+        printLine(`  ${line}`);
+      }
       printLine('  frankenbeast beasts catalog');
     } else {
       throw err;

--- a/packages/franken-mcp-suite/src/cli/beast-mode.ts
+++ b/packages/franken-mcp-suite/src/cli/beast-mode.ts
@@ -6,7 +6,11 @@ import { FbeastConfig } from '../shared/config.js';
 function printLine(...args: unknown[]): void {
   console.info(...args);
 }
-const FRANKENBEAST_INSTALL_HELP = ['from the repo root, run: npm run local:link', 'then verify with: npm run local:verify-cli'];
+const FRANKENBEAST_INSTALL_HELP = [
+  'for a local checkout, from the repo root run: npm run local:link',
+  'then verify with: npm run local:verify-cli',
+  'for a global install, run: npm install -g @franken/orchestrator',
+];
 const SUPPORTED_BEAST_PROVIDERS = new Set(['anthropic-api', 'codex-cli', 'claude-cli']);
 
 function parseProvider(argv: string[]): string {

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -254,7 +254,7 @@ describe('fbeast main CLI', () => {
     const message = mockError.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(message).toContain('npm run local:link');
     expect(message).toContain('npm run local:verify-cli');
-    expect(message).not.toContain('npm install -g @franken/orchestrator');
+    expect(message).toContain('npm install -g @franken/orchestrator');
     expect(message).not.toContain('@fbeast/orchestrator');
     expect(mockExit).toHaveBeenCalledWith(1);
     mockError.mockRestore();
@@ -295,7 +295,7 @@ describe('fbeast main CLI', () => {
     );
     expect(message).toContain('npm run local:link');
     expect(message).toContain('npm run local:verify-cli');
-    expect(message).not.toContain('npm install -g @franken/orchestrator');
+    expect(message).toContain('npm install -g @franken/orchestrator');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');
     mockLog.mockRestore();
     cwdSpy.mockRestore();

--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -252,7 +252,9 @@ describe('fbeast main CLI', () => {
     }
 
     const message = mockError.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(message).toContain('@franken/orchestrator');
+    expect(message).toContain('npm run local:link');
+    expect(message).toContain('npm run local:verify-cli');
+    expect(message).not.toContain('npm install -g @franken/orchestrator');
     expect(message).not.toContain('@fbeast/orchestrator');
     expect(mockExit).toHaveBeenCalledWith(1);
     mockError.mockRestore();
@@ -291,7 +293,9 @@ describe('fbeast main CLI', () => {
       ['/d', '/s', '/c', `"${commandLine}"`],
       expect.objectContaining({ stdio: 'pipe', shell: false, encoding: 'utf8', windowsVerbatimArguments: true }),
     );
-    expect(message).toContain('npm install -g @franken/orchestrator');
+    expect(message).toContain('npm run local:link');
+    expect(message).toContain('npm run local:verify-cli');
+    expect(message).not.toContain('npm install -g @franken/orchestrator');
     expect(message).not.toContain('npm link --workspace=franken-orchestrator');
     mockLog.mockRestore();
     cwdSpy.mockRestore();

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -12,7 +12,8 @@ import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient
 import { resolveInitOptions } from './init-options.js';
 
 const command = process.argv[2];
-const FRANKENBEAST_INSTALL_HELP = "install @franken/orchestrator with 'npm install -g @franken/orchestrator'";
+const FRANKENBEAST_INSTALL_HELP =
+  'from the repo root, run: npm run local:link\n' + 'then verify with: npm run local:verify-cli';
 const TOP_LEVEL_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
 const MCP_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
 

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -13,7 +13,9 @@ import { resolveInitOptions } from './init-options.js';
 
 const command = process.argv[2];
 const FRANKENBEAST_INSTALL_HELP =
-  'from the repo root, run: npm run local:link\n' + 'then verify with: npm run local:verify-cli';
+  'for a local checkout, from the repo root run: npm run local:link\n' +
+  'then verify with: npm run local:verify-cli\n' +
+  "for a global install, run: npm install -g @franken/orchestrator";
 const TOP_LEVEL_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
 const MCP_HELP_OPTIONS = new Set(['--help', '-h', 'help']);
 


### PR DESCRIPTION
## Summary
- point fbeast missing-frankenbeast recovery messages at the repo-local `npm run local:link` / `npm run local:verify-cli` flow
- add root local link/verify scripts using package-name workspace selectors for both local CLIs
- refresh local setup docs and regression expectations so stale path-style workspace selectors are not recommended

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/cli/main.test.ts src/cli/beast-mode.test.ts
- npm run build
- npm --prefix packages/franken-mcp-suite run typecheck
- npm --prefix packages/franken-mcp-suite run build
- npm run lint:any
- npm --prefix packages/franken-mcp-suite test
- npm run typecheck

Closes #1209