### PR TITLE
fix(observer): sanitize non-finite OTEL numeric attributes

### DIFF
--- a/packages/franken-observer/src/export/OTELSerializer.test.ts
+++ b/packages/franken-observer/src/export/OTELSerializer.test.ts
@@ -61,13 +61,37 @@ describe('OTELSerializer', () => {
       const trace = TraceContext.createTrace('goal')
       const span = TraceContext.startSpan(trace, { name: 'llm' })
       SpanLifecycle.recordTokenUsage(span, { promptTokens: 100, completionTokens: 50 })
+      SpanLifecycle.setMetadata(span, { latencyMs: 12.5 })
       TraceContext.endSpan(span)
       TraceContext.endTrace(trace)
 
       const result = OTELSerializer.serializeTrace(trace)
       const attrs = result.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
       const promptAttr = attrs.find(a => a.key === 'promptTokens')
+      const latencyAttr = attrs.find(a => a.key === 'latencyMs')
       expect(promptAttr?.value).toEqual({ intValue: 100 })
+      expect(latencyAttr?.value).toEqual({ doubleValue: 12.5 })
+    })
+
+    it('serialises non-finite numeric metadata as strings', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'llm' })
+      SpanLifecycle.setMetadata(span, {
+        latencyMs: Number.NaN,
+        positiveInfinity: Infinity,
+        negativeInfinity: -Infinity,
+      })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+
+      const result = OTELSerializer.serializeTrace(trace)
+      const attrs = result.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+      const attrValues = Object.fromEntries(attrs.map(attr => [attr.key, attr.value]))
+
+      expect(attrValues.latencyMs).toEqual({ stringValue: 'NaN' })
+      expect(attrValues.positiveInfinity).toEqual({ stringValue: 'Infinity' })
+      expect(attrValues.negativeInfinity).toEqual({ stringValue: '-Infinity' })
+      expect(JSON.stringify(result)).not.toContain('null')
     })
 
     it('serialises thought blocks as a joined string attribute', () => {

--- a/packages/franken-observer/src/export/OTELSerializer.ts
+++ b/packages/franken-observer/src/export/OTELSerializer.ts
@@ -51,6 +51,7 @@ function toAttributeValue(v: unknown): OTELAttributeValue {
   if (typeof v === 'string') return { stringValue: v }
   if (typeof v === 'boolean') return { boolValue: v }
   if (typeof v === 'number') {
+    if (!Number.isFinite(v)) return { stringValue: String(v) }
     return Number.isInteger(v) ? { intValue: v } : { doubleValue: v }
   }
   return { stringValue: String(v) }


### PR DESCRIPTION
## Summary
- Convert non-finite numeric OTEL metadata attributes to string attributes before serialization.
- Preserve finite integer and double metadata serialization.
- Add regression coverage for NaN, Infinity, -Infinity, and JSON serialization not producing null attributes.

## Test Plan
- npm run test --workspace @franken/observer -- src/export/OTELSerializer.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint:any -- --scope @franken/observer
- npm run test --workspace @franken/observer

Closes #1225
