### PR TITLE
fix(web): read chunk-plan design docs from workflow config

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -219,7 +219,7 @@ function formatStreamedLogLine(event: { eventId?: string; stream?: string; line:
   return event.line;
 }
 
-function buildInitAction(
+export function buildInitAction(
   definitionId: string,
   config: Record<string, unknown>,
   chatSessionId: string | undefined,
@@ -234,9 +234,16 @@ function buildInitAction(
   }
 
   if (definitionId === 'chunk-plan') {
+    const workflow = config.workflow as Record<string, unknown> | undefined;
+    const designDocPath = typeof config.designDocPath === 'string'
+      ? config.designDocPath
+      : typeof workflow?.docPath === 'string'
+        ? workflow.docPath
+        : '';
+
     return {
       kind: 'chunk-plan',
-      command: `/plan --design-doc ${String(config.designDocPath ?? '')}`,
+      command: `/plan --design-doc ${designDocPath}`,
       config,
       ...(chatSessionId ? { chatSessionId } : {}),
     };

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { ChatShell } from '../../src/components/chat-shell.js';
+import { ChatShell, buildInitAction } from '../../src/components/chat-shell.js';
 import { useDashboardStore } from '../../src/stores/dashboard-store.js';
 
 const mockListSessions = vi.fn().mockResolvedValue([
@@ -436,6 +436,30 @@ afterEach(() => {
     },
     attempts: [],
     events: [],
+  });
+});
+
+describe('buildInitAction', () => {
+  it('reads chunk-plan design doc paths from the nested wizard workflow config', () => {
+    expect(buildInitAction('chunk-plan', {
+      workflow: { workflowType: 'chunk-plan', docPath: 'docs/design.md' },
+      outputDir: 'tasks/chunks',
+      executionMode: 'process',
+    }, 'sess-1')).toMatchObject({
+      kind: 'chunk-plan',
+      command: '/plan --design-doc docs/design.md',
+      chatSessionId: 'sess-1',
+    });
+  });
+
+  it('prefers normalized chunk-plan design doc paths when present', () => {
+    expect(buildInitAction('chunk-plan', {
+      workflow: { workflowType: 'chunk-plan', docPath: 'docs/from-workflow.md' },
+      designDocPath: 'docs/from-normalized.md',
+    }, undefined)).toMatchObject({
+      kind: 'chunk-plan',
+      command: '/plan --design-doc docs/from-normalized.md',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Read chunk-plan design doc paths from nested wizard workflow config when building dashboard launch actions
- Preserve normalized designDocPath precedence for existing callers
- Add regression coverage for nested workflow docPath launch commands

## Test Plan
- npm ci
- npm --prefix packages/franken-web test -- tests/components/chat-shell.test.tsx src/components/beasts/wizard-launch-config.test.ts
- npm run build --workspace @franken/types && npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build

Closes #354