### PR TITLE
fix(observer): reject invalid Prometheus token metadata

### DIFF
--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -24,6 +24,32 @@ function makeTraceNoModel() {
   return trace
 }
 
+function makeTraceWithMetadata(metadata: Record<string, unknown>) {
+  const trace = TraceContext.createTrace('metadata')
+  const span = TraceContext.startSpan(trace, { name: 'llm-call' })
+  SpanLifecycle.setMetadata(span, metadata)
+  TraceContext.endSpan(span)
+  TraceContext.endTrace(trace)
+  return trace
+}
+
+function makeTraceWithTwoMetadataSpans(...metadataEntries: Record<string, unknown>[]) {
+  const trace = TraceContext.createTrace('metadata-batch')
+  for (const metadata of metadataEntries) {
+    const span = TraceContext.startSpan(trace, { name: 'llm-call' })
+    SpanLifecycle.setMetadata(span, metadata)
+    TraceContext.endSpan(span)
+  }
+  TraceContext.endTrace(trace)
+  return trace
+}
+
+function expectNoInvalidPrometheusNumbers(out: string) {
+  expect(out).not.toMatch(/\s(?:NaN|Infinity|-Infinity)(?:\n|$)/)
+  expect(out).not.toMatch(/franken_observer_tokens_total\{[^}]+\}\s+-/)
+  expect(out).not.toMatch(/franken_observer_cost_usd_total\{[^}]+\}\s+-/)
+}
+
 function makeMultiSpanTrace(tokenCounts: number[]) {
   const trace = TraceContext.createTrace('multi')
   for (const [index, promptTokens] of tokenCounts.entries()) {
@@ -188,6 +214,60 @@ describe('PrometheusAdapter', () => {
       const out = adapter.scrape()
       // Token section should be absent when no token data recorded
       expect(out).not.toContain('franken_observer_tokens_total')
+    })
+
+    it.each([
+      ['promptTokens', Number.NaN],
+      ['promptTokens', Number.POSITIVE_INFINITY],
+      ['promptTokens', Number.NEGATIVE_INFINITY],
+      ['promptTokens', -1],
+      ['promptTokens', 1.5],
+      ['promptTokens', Number.MAX_SAFE_INTEGER + 1],
+      ['completionTokens', Number.NaN],
+      ['completionTokens', Number.POSITIVE_INFINITY],
+      ['completionTokens', Number.NEGATIVE_INFINITY],
+      ['completionTokens', -1],
+      ['completionTokens', 1.5],
+      ['completionTokens', Number.MAX_SAFE_INTEGER + 1],
+    ])('rejects invalid %s metadata value %s without mutating counters', async (field, value) => {
+      const adapter = new PrometheusAdapter({
+        pricingTable: { 'claude-sonnet-4-6': { promptPerMillion: 3, completionPerMillion: 15 } },
+      })
+      await adapter.flush(makeTrace('claude-sonnet-4-6', 10, 5))
+      const before = adapter.scrape()
+
+      await expect(
+        adapter.flush(
+          makeTraceWithMetadata({
+            model: 'claude-sonnet-4-6',
+            promptTokens: field === 'promptTokens' ? value : 1,
+            completionTokens: field === 'completionTokens' ? value : 1,
+          }),
+        ),
+      ).rejects.toThrow(RangeError)
+
+      const after = adapter.scrape()
+      expect(after).toBe(before)
+      expectNoInvalidPrometheusNumbers(after)
+    })
+
+    it('rejects a batch atomically when later token metadata would overflow totals', async () => {
+      const adapter = new PrometheusAdapter()
+
+      await expect(
+        adapter.flush(
+          makeTraceWithTwoMetadataSpans(
+            {
+              model: 'claude-sonnet-4-6',
+              promptTokens: Number.MAX_SAFE_INTEGER,
+              completionTokens: 0,
+            },
+            { model: 'claude-sonnet-4-6', promptTokens: 1, completionTokens: 0 },
+          ),
+        ),
+      ).rejects.toThrow(RangeError)
+
+      expect(adapter.scrape()).toBe('')
     })
   })
 

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -24,6 +24,24 @@ function escapePrometheusLabelValue(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"')
 }
 
+function assertValidTokenDelta(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(
+      `PrometheusAdapter: ${label} must be a non-negative safe integer, received ${value}`,
+    )
+  }
+}
+
+function safeAddTokenCounter(current: number, delta: number, label: string): number {
+  const next = current + delta
+  if (!Number.isSafeInteger(next)) {
+    throw new RangeError(
+      `PrometheusAdapter: ${label} total ${next} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+    )
+  }
+  return next
+}
+
 /**
  * Write-only ExportAdapter that accumulates token, span, and (optionally)
  * cost counters from flushed traces and exposes them in Prometheus text
@@ -51,11 +69,48 @@ export class PrometheusAdapter implements ExportAdapter {
   async flush(trace: Trace): Promise<void> {
     warnIfTraceHasActiveSpans(trace, 'PrometheusAdapter')
     const flushedSpanIds = this.flushedSpanIdsByTrace.get(trace.id)
+    const flushableSpans = trace.spans.filter(
+      span => !(flushedSpanIds?.has(span.id) ?? false) && span.status !== 'active',
+    )
+
+    // Validate token metadata before mutating any counters. A malformed span in
+    // a batch must not partially advance span/token/cost counters or poison the
+    // repeated-flush dedupe cache.
+    const pendingTokenCounters = new Map<string, TokenCounts>()
+    for (const [model, counts] of this.tokenCounters) {
+      pendingTokenCounters.set(model, { ...counts })
+    }
+
+    for (const span of flushableSpans) {
+      const model = span.metadata['model']
+      if (typeof model !== 'string') continue
+
+      const promptTokens = span.metadata['promptTokens']
+      const completionTokens = span.metadata['completionTokens']
+      if (typeof promptTokens === 'number') {
+        assertValidTokenDelta(promptTokens, 'promptTokens')
+      }
+      if (typeof completionTokens === 'number') {
+        assertValidTokenDelta(completionTokens, 'completionTokens')
+      }
+      if (typeof promptTokens !== 'number' && typeof completionTokens !== 'number') continue
+
+      const prompt = typeof promptTokens === 'number' ? promptTokens : 0
+      const completion = typeof completionTokens === 'number' ? completionTokens : 0
+      const existing = pendingTokenCounters.get(model) ?? { prompt: 0, completion: 0 }
+      const nextPrompt = safeAddTokenCounter(existing.prompt, prompt, `${model} prompt`)
+      const nextCompletion = safeAddTokenCounter(
+        existing.completion,
+        completion,
+        `${model} completion`,
+      )
+      safeAddTokenCounter(nextPrompt, nextCompletion, `${model} token`)
+      pendingTokenCounters.set(model, { prompt: nextPrompt, completion: nextCompletion })
+    }
+
     const newlyFlushedSpanIds: string[] = []
 
-    for (const span of trace.spans) {
-      if (flushedSpanIds?.has(span.id) || span.status === 'active') continue
-
+    for (const span of flushableSpans) {
       // Span status counter
       this.spanCounters.set(span.status, (this.spanCounters.get(span.status) ?? 0) + 1)
 
@@ -74,8 +129,8 @@ export class PrometheusAdapter implements ExportAdapter {
 
         const existing = this.tokenCounters.get(model) ?? { prompt: 0, completion: 0 }
         this.tokenCounters.set(model, {
-          prompt: existing.prompt + prompt,
-          completion: existing.completion + completion,
+          prompt: safeAddTokenCounter(existing.prompt, prompt, `${model} prompt`),
+          completion: safeAddTokenCounter(existing.completion, completion, `${model} completion`),
         })
 
         // Cost counter — only when pricing table covers this model


### PR DESCRIPTION
## Summary
- validate Prometheus token metadata before mutating span/token/cost counters
- reject non-finite, negative, fractional, unsafe, or overflowing token totals atomically
- add regression tests for invalid prompt/completion metadata and overflow batches

## Test Plan
- corepack npm test -- src/adapters/prometheus/PrometheusAdapter.test.ts (in packages/franken-observer)
- corepack npm test (in packages/franken-observer)
- corepack npm run build --workspace @franken/types
- corepack npm run typecheck --workspace @franken/observer
- corepack npm run build --workspace @franken/observer
- corepack npm run lint:any
- git diff --check

Closes #1224