### PR TITLE
fix(web): refresh chat socket token after errors

### DIFF
--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -129,6 +129,41 @@ describe('useChatSession error banners', () => {
     ]);
   });
 
+  it('fetches a fresh socket token before reconnecting after a websocket error', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
+      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    expect(MockWebSocket.instances[0]!.protocols).toEqual([
+      'franken.chat.v1',
+      'franken.chat.token.socket-token-1',
+    ]);
+
+    act(() => {
+      MockWebSocket.instances[0]!.onerror?.();
+    });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+    expect(fetch).toHaveBeenLastCalledWith(
+      'http://localhost:3000/v1/chat/sessions/session-1',
+      { credentials: 'same-origin', method: 'GET' },
+    );
+    expect(MockWebSocket.instances[1]!.protocols).toEqual([
+      'franken.chat.v1',
+      'franken.chat.token.socket-token-2',
+    ]);
+  });
+
   it('turns socket turn errors into visible retry banners', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
     vi.stubGlobal('WebSocket', MockWebSocket);

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -580,8 +580,17 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     let shouldReconnect = true;
+    let reconnectRefreshInFlight = false;
     setConnectionStatus('connecting');
     readyRef.current = false;
+
+    function refreshBeforeReconnect() {
+      if (reconnectRefreshInFlight) {
+        return;
+      }
+      reconnectRefreshInFlight = true;
+      refreshSession();
+    }
 
     const socket = new WebSocket(
       clientRef.current.socketUrl(sessionId, socketToken),
@@ -749,6 +758,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       if (socketRef.current !== socket) {
         return;
       }
+      const hadPendingSends = pendingSendsRef.current.size > 0;
       failAllPendingSends(new Error('WebSocket send failed before the server acknowledged the message.'));
       if (approvalResolvingRef.current) {
         updateApprovalResolving(false);
@@ -763,6 +773,15 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         'Reconnect',
         'socket_error',
       ));
+      if (!shouldReconnect || hadPendingSends) {
+        return;
+      }
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        setConnectionStatus('offline');
+        return;
+      }
+      setConnectionStatus('reconnecting');
+      refreshBeforeReconnect();
     };
 
     socket.onclose = () => {
@@ -781,7 +800,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           return;
         }
         setConnectionStatus('reconnecting');
-        refreshSession();
+        refreshBeforeReconnect();
       } else {
         setConnectionStatus('disconnected');
       }


### PR DESCRIPTION
## Summary
- refresh the chat session snapshot before reconnecting after websocket errors, not just closes
- guard reconnect refreshes so error+close event pairs do not issue duplicate session refreshes
- add regression coverage for websocket error reconnects using a freshly returned socket token

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run test --workspace @franken/web -- use-chat-session.test.tsx tests/hooks/use-chat-session.test.ts
- npm run test --workspace @franken/web
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm run lint:any

Closes #1258