### PR TITLE
fix(observer): report ADR rule exceptions by rule

### DIFF
--- a/packages/franken-observer/src/evals/deterministic/ArchitecturalAdherence.test.ts
+++ b/packages/franken-observer/src/evals/deterministic/ArchitecturalAdherence.test.ts
@@ -72,6 +72,42 @@ describe('ArchitecturalAdherenceEval', () => {
       })
       expect(result.reason).toContain('TypeScript output must not use the `any` type')
     })
+
+    it('reports throwing rules by rule and continues evaluating remaining rules', async () => {
+      const evaluatedRules: string[] = []
+      const throwingRule: ADRRule = {
+        name: 'parse-adr-links',
+        description: 'ADR references must be parseable',
+        check: () => {
+          evaluatedRules.push('parse-adr-links')
+          throw new Error('ADR parser failed')
+        },
+      }
+      const passingRule: ADRRule = {
+        name: 'passing-rule',
+        description: 'A passing rule should still run after an earlier exception',
+        check: () => {
+          evaluatedRules.push('passing-rule')
+          return true
+        },
+      }
+
+      const result = await runner.run(ev, {
+        output: `const x: any = 1`,
+        rules: [throwingRule, noAnyRule, passingRule],
+      })
+
+      expect(result.status).toBe('fail')
+      expect(result.reason).toContain('[parse-adr-links] ADR references must be parseable')
+      expect(result.reason).toContain('ADR parser failed')
+      expect(result.reason).toContain('[no-any] TypeScript output must not use the `any` type')
+      expect(result.reason).not.toContain('passing-rule')
+      expect(result.details?.['violatedRules']).toEqual(['parse-adr-links', 'no-any'])
+      expect(result.details?.['ruleErrors']).toEqual([
+        { rule: 'parse-adr-links', error: 'ADR parser failed' },
+      ])
+      expect(evaluatedRules).toEqual(['parse-adr-links', 'passing-rule'])
+    })
   })
 
   describe('score', () => {

--- a/packages/franken-observer/src/evals/deterministic/ArchitecturalAdherence.ts
+++ b/packages/franken-observer/src/evals/deterministic/ArchitecturalAdherence.ts
@@ -28,15 +28,35 @@ export class ArchitecturalAdherenceEval implements Eval<ArchitecturalAdherenceIn
       return { evalName: this.name, status: 'pass', score: 1.0 }
     }
 
-    const violated = rules.filter(r => !r.check(output))
+    const violated: ADRRule[] = []
+    const ruleErrors: Array<{ rule: string; error: string }> = []
+
+    for (const rule of rules) {
+      try {
+        if (!rule.check(output)) {
+          violated.push(rule)
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        violated.push(rule)
+        ruleErrors.push({ rule: rule.name, error: message })
+      }
+    }
+
     const score = (rules.length - violated.length) / rules.length
 
     if (violated.length === 0) {
       return { evalName: this.name, status: 'pass', score: 1.0 }
     }
 
+    const errorsByRule = new Map(ruleErrors.map(({ rule, error }) => [rule, error]))
     const reason = violated
-      .map(r => `[${r.name}] ${r.description}`)
+      .map(r => {
+        const error = errorsByRule.get(r.name)
+        return error
+          ? `[${r.name}] ${r.description} (rule threw: ${error})`
+          : `[${r.name}] ${r.description}`
+      })
       .join('; ')
 
     return {
@@ -44,7 +64,10 @@ export class ArchitecturalAdherenceEval implements Eval<ArchitecturalAdherenceIn
       status: 'fail',
       score,
       reason,
-      details: { violatedRules: violated.map(r => r.name) },
+      details: {
+        violatedRules: violated.map(r => r.name),
+        ...(ruleErrors.length > 0 ? { ruleErrors } : {}),
+      },
     }
   }
 }


### PR DESCRIPTION
## Summary
- isolate ArchitecturalAdherence ADR rule checks so one thrown rule does not abort the eval
- report thrown rules as violated rules with per-rule diagnostic messages
- add regression coverage for one throwing rule plus normal failing and passing rules

## Test Plan
- npm test -- ArchitecturalAdherence.test.ts
- npm test -- --filter=@franken/observer
- npm run build
- npm run typecheck

Closes #1223