### PR TITLE
fix(observer): validate LLMJudgeEval scores

### DIFF
--- a/packages/franken-observer/src/evals/llm-judge/LLMJudgeEval.test.ts
+++ b/packages/franken-observer/src/evals/llm-judge/LLMJudgeEval.test.ts
@@ -54,6 +54,47 @@ describe('LLMJudgeEval', () => {
       const result = await runner.run(ev, 'borderline')
       expect(result.status).toBe('pass')
     })
+
+    it.each([
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['negative', -0.1],
+      ['greater than 1', 1.1],
+    ])('throws RangeError for invalid passThreshold %s', (_label, passThreshold) => {
+      expect(
+        () =>
+          new LLMJudgeEval({
+            name: 'invalid-threshold',
+            buildPrompt: (input) => input,
+            judge: mockJudge(0.8),
+            passThreshold,
+          }),
+      ).toThrow(RangeError)
+    })
+  })
+
+  describe('judge score validation', () => {
+    it.each([
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['negative', -0.1],
+      ['greater than 1', 1.1],
+    ])('returns an explicit failure for invalid judge score %s', async (_label, score) => {
+      const ev = new LLMJudgeEval({
+        name: 'invalid-score',
+        buildPrompt: (input) => input,
+        judge: mockJudge(score),
+      })
+
+      const result = await runner.run(ev, 'input')
+
+      expect(result).toMatchObject({
+        evalName: 'invalid-score',
+        status: 'fail',
+        reason: 'Judge returned invalid score: expected a finite number between 0 and 1',
+      })
+      expect(result.score).toBeUndefined()
+    })
   })
 
   describe('prompt building', () => {

--- a/packages/franken-observer/src/evals/llm-judge/LLMJudgeEval.ts
+++ b/packages/franken-observer/src/evals/llm-judge/LLMJudgeEval.ts
@@ -13,6 +13,10 @@ export interface JudgeResponse {
  */
 export type JudgeFunction = (prompt: string) => Promise<JudgeResponse>
 
+function isValidScore(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value <= 1
+}
+
 export interface LLMJudgeEvalOptions<TInput> {
   name: string
   /** Converts the raw eval input into the prompt sent to the judge LLM. */
@@ -39,6 +43,12 @@ export class LLMJudgeEval<TInput = string> implements Eval<TInput> {
     this.buildPrompt = options.buildPrompt
     this.judge = options.judge
     this.passThreshold = options.passThreshold ?? 0.7
+
+    if (!isValidScore(this.passThreshold)) {
+      throw new RangeError(
+        'passThreshold must be a finite number between 0 and 1',
+      )
+    }
   }
 
   async run(input: TInput): Promise<EvalResult> {
@@ -52,6 +62,14 @@ export class LLMJudgeEval<TInput = string> implements Eval<TInput> {
         evalName: this.name,
         status: 'fail',
         reason: `Judge function failed: ${message}`,
+      }
+    }
+
+    if (!isValidScore(response.score)) {
+      return {
+        evalName: this.name,
+        status: 'fail',
+        reason: 'Judge returned invalid score: expected a finite number between 0 and 1',
       }
     }
 


### PR DESCRIPTION
## Summary
- reject invalid LLMJudgeEval passThreshold values at construction
- fail explicitly when a judge returns a non-finite or out-of-range score
- add regression coverage for NaN, Infinity, negative, and >1 threshold/score values

## Test Plan
- npm run test --workspace @franken/observer -- --run src/evals/llm-judge/LLMJudgeEval.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/observer && npm run build --workspace @franken/observer
- npm run test --workspace @franken/observer

Closes #1221