### PR TITLE
docs(network): clarify secureBackend default

### DIFF
--- a/docs/guides/run-network-operator.md
+++ b/docs/guides/run-network-operator.md
@@ -111,11 +111,21 @@ Supported mode values:
 - `secure`
 - `insecure`
 
-Current secure backend preference order:
+Current default secure backend: `local-encrypted`.
 
-1. `1Password`
-2. `Bitwarden`
-3. OS secure store
-4. local encrypted store
+Supported `network.secureBackend` values:
 
-The local encrypted store is allowed, but it is not the optimal solution.
+- `1password`
+- `bitwarden`
+- `os-keychain`
+- `local-encrypted`
+
+`frankenbeast network` and `frankenbeast init` use the configured `network.secureBackend` value. If the key is unset, the config schema defaults to `local-encrypted`, and interactive init may prompt for `FRANKENBEAST_PASSPHRASE` to create or open the local encrypted vault.
+
+For production operators, prefer a managed secret backend when available, such as `1password`, `bitwarden`, or `os-keychain`. Select one explicitly in project config instead of relying on automatic backend discovery:
+
+```bash
+node packages/franken-orchestrator/dist/cli/run.js network config --set network.secureBackend=1password
+```
+
+Use `local-encrypted` for offline, CI/CD, or minimal deployments where a managed secret backend is not available.

--- a/docs/guides/run-network-operator.md
+++ b/docs/guides/run-network-operator.md
@@ -128,4 +128,6 @@ For production operators, prefer a managed secret backend when available, such a
 node packages/franken-orchestrator/dist/cli/run.js network config --set network.secureBackend=1password
 ```
 
+Choose the backend before running `frankenbeast init` when possible. Changing `network.secureBackend` later does not migrate existing secret refs or secret values; re-store or migrate referenced secrets such as `network.operatorTokenRef` into the newly selected backend before the next boot.
+
 Use `local-encrypted` for offline, CI/CD, or minimal deployments where a managed secret backend is not available.


### PR DESCRIPTION
## Summary
- Clarifies that `local-encrypted` is the current default secure backend.
- Lists supported `network.secureBackend` values.
- Shows how operators explicitly select a non-default backend.

## Test Plan
- `npm run check:package-manager`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)

Closes #1204
