### PR TITLE
docs(run-cli-beast): clarify local CLI link flow

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -33,6 +33,8 @@ npm install
 npm run local:link
 ```
 
+`local:link` is the supported local-checkout path. It builds the repo and links the package-name workspaces declared in `package.json`, so you do not need to run path-style `npm link --workspace=packages/...` commands manually.
+
 Verify:
 ```bash
 npm run local:verify-cli
@@ -267,12 +269,16 @@ The matrix covers parser/config truthfulness, `run` and `run --resume`, required
 ## Troubleshooting
 
 **`frankenbeast: command not found`**
+
+From the repo root, refresh the supported local links and verify both CLIs:
 ```bash
 npm run local:link
 npm run local:verify-cli
 ```
 
 **`fbeast-proxy` / `fbeast-memory` not found after `fbeast mcp init`**
+
+Use the same repo-root repair path; `local:link` links the workspace that owns the `fbeast-*` binaries before `local:verify-cli` checks them:
 ```bash
 npm run local:link
 npm run local:verify-cli

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -278,10 +278,11 @@ npm run local:verify-cli
 
 **`fbeast-proxy` / `fbeast-memory` not found after `fbeast mcp init`**
 
-Use the same repo-root repair path; `local:link` links the workspace that owns the `fbeast-*` binaries before `local:verify-cli` checks them:
+Use the same repo-root repair path; `local:link` links the workspace that owns the `fbeast-*` binaries, and `local:verify-cli` checks the primary `fbeast` / `frankenbeast` entrypoints:
 ```bash
 npm run local:link
 npm run local:verify-cli
+command -v fbeast-proxy fbeast-memory
 ```
 
 **Beast fails to start with "binary not found"**


### PR DESCRIPTION
## Summary
- Clarifies that `npm run local:link` is the supported local-checkout link path for the CLI Beast guide
- Explains that the script links package-name workspaces instead of path-style workspace selectors
- Aligns troubleshooting repair snippets for `frankenbeast` and `fbeast-*` binaries with `local:link` / `local:verify-cli`

## Test Plan
- Verified `docs/guides/run-cli-beast.md` contains no stale `--workspace=packages/...` selectors
- `npm run check:package-manager`

Closes #1203