### PR TITLE
docs(security): warn about Grafana default credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@
 CHROMA_URL=http://localhost:8000
 
 # ── Grafana ──
+# Grafana's built-in admin/admin default is insecure and must not be used.
 # Local docker-compose requires an explicit non-default password before Grafana starts.
 # Generate a unique local password before uncommenting; never copy admin/admin into deployments.
 # The compose startup guard resets the persisted admin password for existing local Grafana volumes.

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -132,6 +132,7 @@ describe('local setup scripts', () => {
 
     expect(envExample).not.toMatch(/^GRAFANA_USER=admin$/m);
     expect(envExample).not.toMatch(/^GRAFANA_PASSWORD=admin$/m);
+    expect(envExample).toContain('Grafana\'s built-in admin/admin default is insecure');
     expect(envExample).toContain('Generate a unique local password before uncommenting');
 
     for (const doc of [readme, quickstart, runCliBeastGuide]) {


### PR DESCRIPTION
## Summary
- Adds an explicit .env.example warning that Grafana's built-in admin/admin default is insecure.
- Extends local setup coverage to keep the warning from regressing.

## Test Plan
- npm exec vitest -- run tests/local-setup-scripts.test.ts -t '.env.example documents current local env vars without removed service knobs'
- npm exec vitest -- run tests/local-setup-scripts.test.ts
- npm run lint:security
- npm run typecheck

Closes #1168