### PR TITLE
docs(web): fix Vite environment table

### DIFF
--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -86,6 +86,13 @@ VITE_BEAST_API_PROXY_TARGET=http://127.0.0.1:4050
 VITE_PROJECT_ID=my-project
 ```
 
+| Variable | Purpose |
+| --- | --- |
+| `VITE_API_URL` | API base URL. Leave unset or empty for local Vite dev so requests stay same-origin and use the Vite dev proxy. Set it only when serving the built app or intentionally calling a remote backend directly. |
+| `VITE_API_PROXY_TARGET` | Backend target for the same-origin Vite dev proxy. Defaults to `http://127.0.0.1:3737`; set this when the backend runs on another port, for example `VITE_API_PROXY_TARGET=http://127.0.0.1:4242 npm run dev:chat`. |
+| `VITE_BEAST_API_PROXY_TARGET` | Beast daemon target when it differs from `VITE_API_PROXY_TARGET`, for example when Beast controls use a separate local orchestrator port. |
+| `VITE_PROJECT_ID` | Optional project identifier for scoping chat sessions. Defaults to `default`. |
+
 ### Operator token handling
 
 `FRANKENBEAST_BEAST_OPERATOR_TOKEN` is the shared secret that authenticates Beast control API requests (`/v1/beasts/*` routes). The orchestrator server validates this token on protected API requests.

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -88,8 +88,8 @@ VITE_PROJECT_ID=my-project
 
 | Variable | Purpose |
 | --- | --- |
-| `VITE_API_URL` | API base URL. Leave unset or empty for local Vite dev so requests stay same-origin and use the Vite dev proxy. Set it only when serving the built app or intentionally calling a remote backend directly. |
-| `VITE_API_PROXY_TARGET` | Backend target for the same-origin Vite dev proxy. Defaults to `http://127.0.0.1:3737`; set this when the backend runs on another port, for example `VITE_API_PROXY_TARGET=http://127.0.0.1:4242 npm run dev:chat`. |
+| `VITE_API_URL` | Legacy/reserved API base URL. Leave unset; the current web client intentionally ignores this value and always calls same-origin paths so browser requests stay behind the server-side proxy/BFF. |
+| `VITE_API_PROXY_TARGET` | Backend target for the same-origin Vite dev proxy. Defaults to `http://127.0.0.1:3737`; set this when the backend runs on another port, for example `VITE_API_PROXY_TARGET=http://127.0.0.1:4242 npm run dev`. |
 | `VITE_BEAST_API_PROXY_TARGET` | Beast daemon target when it differs from `VITE_API_PROXY_TARGET`, for example when Beast controls use a separate local orchestrator port. |
 | `VITE_PROJECT_ID` | Optional project identifier for scoping chat sessions. Defaults to `default`. |
 


### PR DESCRIPTION
## Summary
- Adds a well-formed two-column Vite environment variable table in the web README.
- Documents VITE_API_URL, VITE_API_PROXY_TARGET, VITE_BEAST_API_PROXY_TARGET, and VITE_PROJECT_ID without the malformed stray table fragment.

## Test Plan
- python3 inline Markdown table validation for packages/franken-web/README.md
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/web

Closes #1198