### PR TITLE
docs(env): clarify Beast operator token example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ FRANKEN_MIN_CRITIQUE_SCORE=0.7
 
 # Shared local Beast operator token used by chat-server and dashboard Beast routes.
 # Preferred location for local development; package-local franken-web .env.local remains fallback-only.
+# Do not use VITE_BEAST_OPERATOR_TOKEN; VITE_* values are exposed to browser code.
 # FRANKENBEAST_BEAST_OPERATOR_TOKEN=replace-with-random-token
 
 # Optional: proxy chat-server Beast routes to an already-running Beast daemon.

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -134,6 +134,8 @@ describe('local setup scripts', () => {
     expect(envExample).not.toMatch(/^GRAFANA_PASSWORD=admin$/m);
     expect(envExample).toContain('Grafana\'s built-in admin/admin default is insecure');
     expect(envExample).toContain('Generate a unique local password before uncommenting');
+    expect(envExample).toContain('Do not use VITE_BEAST_OPERATOR_TOKEN');
+    expect(envExample).not.toMatch(/^#?\s*VITE_BEAST_OPERATOR_TOKEN=/m);
 
     for (const doc of [readme, quickstart, runCliBeastGuide]) {
       expect(doc).toContain('ANTHROPIC_API_KEY');


### PR DESCRIPTION
## Summary
- Clarifies the root `.env.example` Beast operator token entry uses the server-side `FRANKENBEAST_BEAST_OPERATOR_TOKEN`.
- Explicitly warns not to set `VITE_BEAST_OPERATOR_TOKEN`, because `VITE_*` values are browser-exposed.
- Adds root setup coverage so the unsafe VITE token entry cannot be reintroduced.

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run typecheck
- npm run lint:security
- npm run build
- npm run lint:any

Closes #1331
