### PR TITLE
docs(readme): document Chroma URL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,9 @@ cd packages/franken-orchestrator && npm run test:e2e
 cp .env.example .env
 $EDITOR .env  # uncomment GRAFANA_USER=admin, set a unique GRAFANA_PASSWORD, and adjust CHROMA_URL if needed
 
-# If you changed CHROMA_URL in .env, export that same endpoint before seed/verify.
+# .env.example defaults CHROMA_URL to http://localhost:8000 for local compose.
+# Override it only when ChromaDB runs at a different local port/host or a remote
+# TLS-terminated endpoint, then export that same endpoint before seed/verify.
 # export CHROMA_URL=https://chromadb.example.com
 
 # Start supporting services (ChromaDB, Grafana, Tempo). The compose file pins

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -144,6 +144,9 @@ describe('local setup scripts', () => {
       expect(doc).toContain('GEMINI_API_KEY');
     }
 
+    expect(readme).toContain('CHROMA_URL');
+    expect(readme).toContain('http://localhost:8000');
+    expect(readme).toContain('Override it only when ChromaDB runs at a different local port/host or a remote');
     expect(readme).toContain('CLI flags > `FRANKEN_*` env vars > config file > built-in defaults');
     expect(readme).toContain('maxCritiqueIterations * 10000');
     for (const frankenOverride of [


### PR DESCRIPTION
## Summary
- documents the root README CHROMA_URL default for local compose
- clarifies when to override CHROMA_URL before seed/verify scripts
- adds a root setup-doc regression assertion for the README note

## Test Plan
- npm exec -- vitest run tests/local-setup-scripts.test.ts
- npm run check:package-manager
- npm run test:root (fails in pre-existing integration tests: TruncationStrategy constructor and HITL approval expectations)

Closes #1329