### PR TITLE
docs(ramp-up): link canonical workspace inventory

### DIFF
--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -4,7 +4,7 @@
 
 ## What Is This?
 
-A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`: the consolidated core packages, `franken-mcp-suite` (`@franken/mcp-suite`), and `live-bench` (`@franken/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-monorepo-migration.md) and ADR-031 for the earlier consolidation history; do not treat the deleted pre-consolidation MCP package as the current MCP suite.
+A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`, matching the canonical inventories in [README.md](../README.md#current-workspace-packages) and [docs/guides/quickstart.md](guides/quickstart.md#project-structure): the consolidated core packages, `franken-mcp-suite` (`@franken/mcp-suite`), and `live-bench` (`@franken/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-monorepo-migration.md) and ADR-031 for the earlier consolidation history; the historical `franken-mcp` package was removed, while the current `@franken/mcp-suite` workspace remains active.
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- link the ramp-up package count to the canonical README and quickstart inventories
- clarify that historical `franken-mcp` was removed while current `@franken/mcp-suite` remains active
- preserve current entries for `franken-mcp-suite` and `live-bench`

## Test Plan
- [x] python3 targeted acceptance check for docs/RAMP_UP.md
- [x] npm run test:root -- tests/docs-issue-511.test.ts tests/workspaces.test.ts

Closes #1156