### PR TITLE
test(env): guard against stale firewall example

### DIFF
--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -129,6 +129,9 @@ describe('local setup scripts', () => {
     for (const removed of ['OLLAMA_BASE_URL', 'TEMPO_ENDPOINT', 'FIREWALL_PORT']) {
       expect(envExample).not.toContain(removed);
     }
+    expect(envExample).not.toMatch(/^# ── Firewall Server ──$/m);
+    expect(envExample).not.toMatch(/^#?\s*FIREWALL_PORT\s*=/m);
+    expect(envExample).not.toMatch(/frankenfirewall|firewall proxy|port 9090/i);
 
     expect(envExample).not.toMatch(/^GRAFANA_USER=admin$/m);
     expect(envExample).not.toMatch(/^GRAFANA_PASSWORD=admin$/m);


### PR DESCRIPTION
## Summary
- adds regression coverage that the root .env.example does not reintroduce the historical Firewall Server section
- verifies FIREWALL_PORT assignments and active frankenfirewall/port-9090 proxy guidance stay out of the env template

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run lint:security

Closes #1158