### PR TITLE
docs(run-cli-beast): clarify supported beast providers

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -13,7 +13,7 @@ The beast harness is split across two CLIs. This guide covers both.
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26`
 - For API-backed `frankenbeast` provider registry runs, an API key for at least one supported provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`
-- For `fbeast mcp beast` preset activation, a supported Beast provider path: `anthropic-api` with `ANTHROPIC_API_KEY`, or an installed/logged-in `claude` / `codex` CLI for `claude-cli` / `codex-cli`
+- For `fbeast mcp beast` preset activation, one of the supported Beast provider paths: `anthropic-api` with `ANTHROPIC_API_KEY`, or an installed/logged-in `claude` / `codex` CLI for `claude-cli` / `codex-cli`
 
 ```bash
 cp .env.example .env
@@ -70,6 +70,8 @@ fbeast mcp beast --provider=claude-cli             # Claude CLI binary (prompts 
 ```
 
 This writes `.fbeast/config.json` with `mode: "beast"` and prints the beast catalog. The `claude-cli` provider spawns subprocesses outside the API billing path and asks for one-time confirmation.
+
+The `fbeast mcp beast` activation shim currently accepts only the provider values shown above. Provider registry entries such as `openai-api`, `gemini-api`, or `gemini-cli` can still be used by `frankenbeast` runs, but they are not `fbeast mcp beast --provider` presets unless the shim adds explicit support for them.
 
 ---
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -164,4 +164,24 @@ describe('local setup scripts', () => {
       expect(readme).toContain(frankenOverride);
     }
   });
+
+  it('keeps the CLI Beast guide aligned with supported Beast activation providers', () => {
+    const runCliBeastGuide = read('docs/guides/run-cli-beast.md');
+    const beastModeSource = read('packages/franken-mcp-suite/src/cli/beast-mode.ts');
+
+    expect(runCliBeastGuide).not.toContain('OLLAMA_BASE_URL');
+    expect(runCliBeastGuide).not.toMatch(/local\s+Ollama/i);
+    expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=anthropic-api');
+    expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=codex-cli');
+    expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=claude-cli');
+
+    const providersMatch = beastModeSource.match(/SUPPORTED_BEAST_PROVIDERS = new Set\(\[([^\]]+)\]\)/);
+    expect(providersMatch).not.toBeNull();
+    const supportedProviders = providersMatch?.[1] ?? '';
+    for (const provider of ['anthropic-api', 'codex-cli', 'claude-cli']) {
+      expect(supportedProviders).toContain(provider);
+      expect(runCliBeastGuide).toContain(`--provider=${provider}`);
+    }
+    expect(supportedProviders).not.toContain('ollama');
+  });
 });


### PR DESCRIPTION
## Summary
- Clarify that `fbeast mcp beast` accepts only its documented preset provider paths.
- Keep `OLLAMA_BASE_URL` / local Ollama out of the CLI Beast guide and add regression coverage against reintroducing it as a prerequisite.

## Test Plan
- [x] `npm run test:root -- tests/local-setup-scripts.test.ts`
- [x] `npm run typecheck -- --filter=@franken/mcp-suite`

Closes #1152
