### PR TITLE
docs: refresh assistant rule regeneration guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,4 +139,5 @@ Common patterns that MUST be ignored:
 
 - Create new `.mdc` files in `.cursor/rules/` for project-specific rules
 - Edit existing files directly; changes take effect immediately
-- Re-run to update: `npx @djm204/agent-skills javascript-expert qa-engineering testing web-backend ml-ai`
+- The checked-in root assistant rules are maintained from this repository. When workflow guidance changes, update the supported source in [`djm204/agent-workflow-skills`](https://github.com/djm204/agent-workflow-skills), then copy the relevant Claude/Cursor guidance into `.cursor/rules/` with a focused reviewable diff.
+- Do not regenerate the root `.cursor/rules/*.mdc` files with the legacy `@djm204/agent-skills` package; package-level `project-outline.md` cleanup is tracked separately from this root assistant-guide maintenance path.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,4 +38,5 @@ All rules are in `.cursor/rules/`. The AI assistant reads these automatically.
 
 - Create new `.mdc` files in `.cursor/rules/` for project-specific rules
 - Edit existing files directly; changes take effect immediately
-- Re-run to update: `npx @djm204/agent-skills web-frontend`
+- The checked-in root assistant rules are maintained from this repository. When workflow guidance changes, update the supported source in [`djm204/agent-workflow-skills`](https://github.com/djm204/agent-workflow-skills), then copy the relevant Gemini/Cursor guidance into `.cursor/rules/` with a focused reviewable diff.
+- Do not regenerate the root `.cursor/rules/*.mdc` files with the legacy `@djm204/agent-skills` package; package-level `project-outline.md` cleanup is tracked separately from this root assistant-guide maintenance path.

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -197,4 +197,16 @@ describe('local setup scripts', () => {
       'add CLI execution providers through `ICliProvider` or API-backed clients through the provider registry',
     );
   });
+
+  it('keeps root AI assistant rule regeneration guidance on the supported workflow source', () => {
+    for (const docPath of ['CLAUDE.md', 'GEMINI.md']) {
+      const doc = read(docPath);
+
+      expect(doc).toContain('djm204/agent-workflow-skills');
+      expect(doc).toContain('package-level `project-outline.md` cleanup is tracked separately');
+      expect(doc).toContain('Do not regenerate the root `.cursor/rules/*.mdc` files');
+      expect(doc).not.toContain('npx @djm204/agent-skills');
+      expect(doc).not.toMatch(/Re-run to update:/i);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Replace legacy root assistant rule regeneration commands with the supported agent-workflow-skills maintenance path
- Clarify that package-level project-outline cleanup is separate from root assistant-guide maintenance
- Add regression coverage for CLAUDE.md and GEMINI.md guidance

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run typecheck
- npm run build
- npm run lint:any
- npm run lint:security

Closes #1147