### PR TITLE
fix(observer): enforce GoldenTraceEval span order

### DIFF
--- a/packages/franken-observer/src/evals/regression/GoldenTraceEval.test.ts
+++ b/packages/franken-observer/src/evals/regression/GoldenTraceEval.test.ts
@@ -66,6 +66,20 @@ describe('GoldenTraceEval', () => {
       expect(result.details?.['extraSpans']).toContain('lookup')
     })
 
+    it('fails when the actual trace has the same span names in a different order', async () => {
+      const trace = makeActualTrace(['summarise', 'search', 'plan'])
+      const result = await runner.run(ev, { actual: trace, golden })
+      expect(result.status).toBe('fail')
+      expect(result.reason).toContain('Span order mismatch at index 0')
+      expect(result.details?.['spanOrderMismatch']).toEqual({
+        index: 0,
+        expected: 'plan',
+        actual: 'summarise',
+        expectedSequence: ['plan', 'search', 'summarise'],
+        actualSequence: ['summarise', 'search', 'plan'],
+      })
+    })
+
     it('fails when the actual trace is empty but golden has spans', async () => {
       const trace = makeActualTrace([])
       const result = await runner.run(ev, { actual: trace, golden })

--- a/packages/franken-observer/src/evals/regression/GoldenTraceEval.ts
+++ b/packages/franken-observer/src/evals/regression/GoldenTraceEval.ts
@@ -31,22 +31,58 @@ export class GoldenTraceEval implements Eval<GoldenTraceInput> {
     const actualNames = input.actual.spans.map(s => s.name)
     const goldenNames = input.golden.spans.map(s => s.name)
 
-    const goldenSet = new Set(goldenNames)
-    const actualSet = new Set(actualNames)
+    const remainingActualCounts = new Map<string, number>()
+    for (const name of actualNames) {
+      remainingActualCounts.set(name, (remainingActualCounts.get(name) ?? 0) + 1)
+    }
 
-    const missingSpans = goldenNames.filter(n => !actualSet.has(n))
-    const extraSpans = actualNames.filter(n => !goldenSet.has(n))
+    const missingSpans: string[] = []
+    for (const name of goldenNames) {
+      const count = remainingActualCounts.get(name) ?? 0
+      if (count > 0) {
+        remainingActualCounts.set(name, count - 1)
+      } else {
+        missingSpans.push(name)
+      }
+    }
 
-    const matchCount = goldenNames.filter(n => actualSet.has(n)).length
-    const score = goldenNames.length === 0 ? 1.0 : matchCount / goldenNames.length
+    const extraSpans: string[] = []
+    for (const name of actualNames) {
+      if (goldenNames.includes(name)) continue
+      extraSpans.push(name)
+    }
+    for (const [name, count] of remainingActualCounts.entries()) {
+      if (goldenNames.includes(name)) {
+        for (let i = 0; i < count; i += 1) extraSpans.push(name)
+      }
+    }
 
-    if (missingSpans.length === 0 && extraSpans.length === 0) {
+    const orderedMatchCount = goldenNames.filter((name, index) => actualNames[index] === name).length
+    const score = goldenNames.length === 0 ? 1.0 : orderedMatchCount / goldenNames.length
+    const firstMismatchIndex = goldenNames.findIndex((name, index) => actualNames[index] !== name)
+    const spanOrderMismatch =
+      missingSpans.length === 0 && extraSpans.length === 0 && firstMismatchIndex !== -1
+        ? {
+            index: firstMismatchIndex,
+            expected: goldenNames[firstMismatchIndex],
+            actual: actualNames[firstMismatchIndex],
+            expectedSequence: goldenNames,
+            actualSequence: actualNames,
+          }
+        : undefined
+
+    if (missingSpans.length === 0 && extraSpans.length === 0 && spanOrderMismatch === undefined) {
       return { evalName: this.name, status: 'pass', score: 1.0 }
     }
 
     const parts: string[] = []
     if (missingSpans.length > 0) parts.push(`Missing spans: ${missingSpans.join(', ')}.`)
     if (extraSpans.length > 0) parts.push(`Extra spans: ${extraSpans.join(', ')}.`)
+    if (spanOrderMismatch) {
+      parts.push(
+        `Span order mismatch at index ${spanOrderMismatch.index}: expected ${spanOrderMismatch.expected}, got ${spanOrderMismatch.actual}.`,
+      )
+    }
 
     return {
       evalName: this.name,
@@ -56,6 +92,7 @@ export class GoldenTraceEval implements Eval<GoldenTraceInput> {
       details: {
         ...(missingSpans.length > 0 ? { missingSpans } : {}),
         ...(extraSpans.length > 0 ? { extraSpans } : {}),
+        ...(spanOrderMismatch ? { spanOrderMismatch } : {}),
       },
     }
   }


### PR DESCRIPTION
## Summary
- make GoldenTraceEval compare golden and actual spans by ordered position, not just set membership
- add diagnostics for the first ordered mismatch and preserve missing/extra span details
- add a regression test for same span names in reversed order

## Test Plan
- npm run test --workspace @franken/observer -- GoldenTraceEval.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run test --workspace @franken/observer

Closes #1220