### PR TITLE
fix(orchestrator): surface BeastEventBus listener failures

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
@@ -6,14 +6,39 @@ export interface BeastSseEvent {
 
 type EventListener = (event: BeastSseEvent) => void | Promise<void>;
 
+export interface BeastEventBusListenerError {
+  event: BeastSseEvent;
+  error: unknown;
+  listener: EventListener;
+}
+
+export interface BeastEventBusOptions {
+  maxBufferSize?: number;
+  onListenerError?: (failure: BeastEventBusListenerError) => void;
+}
+
+function reportDefaultListenerError({ event, error }: BeastEventBusListenerError): void {
+  console.error('[BeastEventBus] Listener failed', {
+    eventId: event.id,
+    eventType: event.type,
+    error,
+  });
+}
+
 export class BeastEventBus {
   private sequence = 0;
   private readonly listeners = new Set<EventListener>();
   private readonly buffer: BeastSseEvent[] = [];
   private readonly maxBufferSize: number;
+  private readonly onListenerError: (failure: BeastEventBusListenerError) => void;
 
-  constructor(maxBufferSize = 1000) {
-    this.maxBufferSize = maxBufferSize;
+  constructor(maxBufferSizeOrOptions: number | BeastEventBusOptions = 1000) {
+    const options = typeof maxBufferSizeOrOptions === 'number'
+      ? { maxBufferSize: maxBufferSizeOrOptions }
+      : maxBufferSizeOrOptions;
+
+    this.maxBufferSize = options.maxBufferSize ?? 1000;
+    this.onListenerError = options.onListenerError ?? reportDefaultListenerError;
   }
 
   publish(event: Omit<BeastSseEvent, 'id'>): void {
@@ -29,10 +54,10 @@ export class BeastEventBus {
       try {
         const result = listener(stamped);
         if (result && typeof result.catch === 'function') {
-          result.catch(() => {});
+          result.catch((error: unknown) => this.reportListenerError(stamped, error, listener));
         }
-      } catch {
-        // Don't let a failing sync listener break others
+      } catch (error) {
+        this.reportListenerError(stamped, error, listener);
       }
     }
   }
@@ -46,5 +71,13 @@ export class BeastEventBus {
 
   replaySince(lastEventId: number): BeastSseEvent[] {
     return this.buffer.filter((e) => e.id !== undefined && e.id > lastEventId);
+  }
+
+  private reportListenerError(event: BeastSseEvent, error: unknown, listener: EventListener): void {
+    try {
+      this.onListenerError({ event, error, listener });
+    } catch (handlerError) {
+      reportDefaultListenerError({ event, error: handlerError, listener });
+    }
   }
 }

--- a/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
@@ -14,7 +14,7 @@ export interface BeastEventBusListenerError {
 
 export interface BeastEventBusOptions {
   maxBufferSize?: number;
-  onListenerError?: (failure: BeastEventBusListenerError) => void;
+  onListenerError?: (failure: BeastEventBusListenerError) => void | Promise<void>;
 }
 
 function reportDefaultListenerError({ event, error }: BeastEventBusListenerError): void {
@@ -30,7 +30,7 @@ export class BeastEventBus {
   private readonly listeners = new Set<EventListener>();
   private readonly buffer: BeastSseEvent[] = [];
   private readonly maxBufferSize: number;
-  private readonly onListenerError: (failure: BeastEventBusListenerError) => void;
+  private readonly onListenerError: (failure: BeastEventBusListenerError) => void | Promise<void>;
 
   constructor(maxBufferSizeOrOptions: number | BeastEventBusOptions = 1000) {
     const options = typeof maxBufferSizeOrOptions === 'number'
@@ -75,7 +75,12 @@ export class BeastEventBus {
 
   private reportListenerError(event: BeastSseEvent, error: unknown, listener: EventListener): void {
     try {
-      this.onListenerError({ event, error, listener });
+      const result = this.onListenerError({ event, error, listener });
+      if (result && typeof result.catch === 'function') {
+        result.catch((handlerError: unknown) => {
+          reportDefaultListenerError({ event, error: handlerError, listener });
+        });
+      }
     } catch (handlerError) {
       reportDefaultListenerError({ event, error: handlerError, listener });
     }

--- a/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { BeastEventBus, type BeastSseEvent } from '../../../../src/beasts/events/beast-event-bus.js';
+import {
+  BeastEventBus,
+  type BeastEventBusListenerError,
+  type BeastSseEvent,
+} from '../../../../src/beasts/events/beast-event-bus.js';
 
 describe('BeastEventBus', () => {
   it('delivers events to subscribers', () => {
@@ -38,6 +42,45 @@ describe('BeastEventBus', () => {
     bus.publish({ type: 'agent.status', data: { agentId: 'a2', status: 'running', updatedAt: '' } });
 
     expect(received).toHaveLength(1);
+  });
+
+  it('reports sync listener errors without stopping later listeners', () => {
+    const errors: BeastEventBusListenerError[] = [];
+    const bus = new BeastEventBus({ onListenerError: (failure) => errors.push(failure) });
+    const received: BeastSseEvent[] = [];
+    const thrown = new Error('listener exploded');
+    const failingListener = () => {
+      throw thrown;
+    };
+
+    bus.subscribe(failingListener);
+    bus.subscribe((event) => received.push(event));
+
+    bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running', updatedAt: '' } });
+
+    expect(received).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ event: received[0], error: thrown, listener: failingListener });
+  });
+
+  it('reports async listener rejections without stopping later listeners', async () => {
+    const errors: BeastEventBusListenerError[] = [];
+    const bus = new BeastEventBus({ onListenerError: (failure) => errors.push(failure) });
+    const received: BeastSseEvent[] = [];
+    const rejected = new Error('stream write failed');
+    const failingListener = async () => {
+      throw rejected;
+    };
+
+    bus.subscribe(failingListener);
+    bus.subscribe((event) => received.push(event));
+
+    bus.publish({ type: 'run.log', data: { runId: 'r1', line: 'hello' } });
+    await Promise.resolve();
+
+    expect(received).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ event: received[0], error: rejected, listener: failingListener });
   });
 
   it('replays events from a given sequence ID', () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   BeastEventBus,
   type BeastEventBusListenerError,
@@ -81,6 +81,35 @@ describe('BeastEventBus', () => {
     expect(received).toHaveLength(1);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({ event: received[0], error: rejected, listener: failingListener });
+  });
+
+  it('handles async listener error reporter rejections', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const listenerError = new Error('listener failed');
+    const reporterError = new Error('reporter failed');
+    const bus = new BeastEventBus({
+      onListenerError: async () => {
+        throw reporterError;
+      },
+    });
+
+    try {
+      bus.subscribe(async () => {
+        throw listenerError;
+      });
+
+      bus.publish({ type: 'run.log', data: { runId: 'r1', line: 'hello' } });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(consoleError).toHaveBeenCalledWith('[BeastEventBus] Listener failed', {
+        eventId: 1,
+        eventType: 'run.log',
+        error: reporterError,
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('replays events from a given sequence ID', () => {


### PR DESCRIPTION
## Summary
- add a BeastEventBus listener-error diagnostic hook with a default console error reporter
- report both synchronous listener exceptions and asynchronous listener rejections without interrupting sibling listeners
- cover sync and async failure isolation in BeastEventBus unit tests

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/beasts/events/beast-event-bus.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm test --workspace @franken/orchestrator -- tests/unit/beasts tests/integration/beasts

Closes #1252