### PR TITLE
test(live-bench): restore live test target

### DIFF
--- a/docs/superpowers/plans/2026-05-23-live-cli-benchmark-pipeline.md
+++ b/docs/superpowers/plans/2026-05-23-live-cli-benchmark-pipeline.md
@@ -490,6 +490,8 @@ Each adapter should:
 
 `tests/live/*.live.test.ts` should skip unless `FBEAST_LIVE_BENCH_E2E=1` and the required binary exists. Live tests should run a tiny fixture with a short timeout and assert evidence files exist, not exact model output.
 
+The package-local `test:live` target currently discovers checked-in smoke coverage under `packages/live-bench/tests/live/`; keep that directory populated whenever the script remains published, and extend it with the Codex/Gemini adapter live tests as those adapters land.
+
 **Step 4: Verify default suite**
 
 ```bash

--- a/packages/live-bench/package.json
+++ b/packages/live-bench/package.json
@@ -20,7 +20,7 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:live": "FBEAST_LIVE_BENCH_E2E=1 vitest run tests/live",
+    "test:live": "npm run build && FBEAST_LIVE_BENCH_E2E=1 vitest run tests/live",
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "dependencies": {

--- a/packages/live-bench/tests/live/live-bench-cli.live.test.ts
+++ b/packages/live-bench/tests/live/live-bench-cli.live.test.ts
@@ -1,0 +1,25 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const cliEntrypoint = join(packageRoot, 'dist', 'cli', 'main.js');
+const corpusRoot = join(packageRoot, 'corpus');
+const runLiveBenchE2e = process.env.FBEAST_LIVE_BENCH_E2E === '1';
+
+describe.skipIf(!runLiveBenchE2e)('live-bench package live target', () => {
+  it('executes the built package CLI against the checked-in corpus', () => {
+    expect(existsSync(cliEntrypoint), `${cliEntrypoint} should exist; npm run test:live builds before running live tests`).toBe(true);
+
+    const result = spawnSync(process.execPath, [cliEntrypoint, 'list', corpusRoot], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.split(/\r?\n/)).toContain('write-readme');
+  });
+});

--- a/packages/live-bench/tests/package-script-target.test.ts
+++ b/packages/live-bench/tests/package-script-target.test.ts
@@ -1,0 +1,32 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function collectTestFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(root, entry.name);
+    if (entry.isDirectory()) {
+      return collectTestFiles(fullPath);
+    }
+    return /\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+describe('live test script target', () => {
+  it('points at an existing directory with a checked-in live test', () => {
+    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    const testLiveScript = packageJson.scripts?.['test:live'] ?? '';
+    const match = /vitest\s+run\s+(\S+)/.exec(testLiveScript);
+
+    expect(match?.[1]).toBe('tests/live');
+
+    const liveTarget = join(packageRoot, match?.[1] ?? '');
+    expect(existsSync(liveTarget)).toBe(true);
+    expect(collectTestFiles(liveTarget).some((file) => file.endsWith('.live.test.ts'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- restores a checked-in `packages/live-bench/tests/live` target for the package-local live suite
- makes `npm run test:live` build the CLI before the live smoke test executes it against the checked-in corpus
- adds a package-script regression test so `test:live` cannot point at a missing live-test directory again

## Test Plan
- `npm run test --workspace @franken/live-bench -- --run tests/package-script-target.test.ts`
- `npm run typecheck --workspace @franken/live-bench`
- `npm run build --workspace @franken/live-bench`
- `npm run test:live --workspace @franken/live-bench`
- `npm run test --workspace @franken/live-bench`

Closes #1239
