### PR TITLE
fix(types): validate provider token usage counts

### DIFF
--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -168,11 +168,38 @@ export const ToolDefinitionSchema = z.object({
   requiresHitl: z.boolean().optional(),
 });
 
-export const TokenUsageSchema = z.object({
-  inputTokens: z.number().nonnegative(),
-  outputTokens: z.number().nonnegative(),
-  totalTokens: z.number().nonnegative(),
-});
+const TokenCountSchema = z
+  .number()
+  .finite()
+  .int()
+  .nonnegative()
+  .refine(Number.isSafeInteger, 'Token counts must be safe integers');
+
+export const TokenUsageSchema = z
+  .object({
+    inputTokens: TokenCountSchema,
+    outputTokens: TokenCountSchema,
+    totalTokens: TokenCountSchema,
+  })
+  .superRefine((usage, ctx) => {
+    const expectedTotal = usage.inputTokens + usage.outputTokens;
+    if (!Number.isSafeInteger(expectedTotal)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['totalTokens'],
+        message: `inputTokens + outputTokens must not exceed Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+      });
+      return;
+    }
+
+    if (usage.totalTokens !== expectedTotal) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['totalTokens'],
+        message: 'totalTokens must equal inputTokens + outputTokens',
+      });
+    }
+  });
 
 export const McpServerConfigSchema = z.object({
   command: z.string().min(1),

--- a/packages/franken-types/tests/provider.test.ts
+++ b/packages/franken-types/tests/provider.test.ts
@@ -46,6 +46,64 @@ describe('TokenUsageSchema', () => {
       TokenUsageSchema.parse({ inputTokens: 0, outputTokens: 0, totalTokens: -1 }),
     ).toThrow();
   });
+
+  it('rejects fractional token counts', () => {
+    expect(() =>
+      TokenUsageSchema.parse({ inputTokens: 1.5, outputTokens: 0, totalTokens: 1.5 }),
+    ).toThrow();
+    expect(() =>
+      TokenUsageSchema.parse({ inputTokens: 1, outputTokens: 0.5, totalTokens: 1.5 }),
+    ).toThrow();
+    expect(() =>
+      TokenUsageSchema.parse({ inputTokens: 1, outputTokens: 1, totalTokens: 2.5 }),
+    ).toThrow();
+  });
+
+  it('rejects non-finite token counts', () => {
+    expect(() =>
+      TokenUsageSchema.parse({ inputTokens: Number.NaN, outputTokens: 0, totalTokens: 0 }),
+    ).toThrow();
+    expect(() =>
+      TokenUsageSchema.parse({
+        inputTokens: Number.POSITIVE_INFINITY,
+        outputTokens: 0,
+        totalTokens: Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow();
+    expect(() =>
+      TokenUsageSchema.parse({
+        inputTokens: 0,
+        outputTokens: Number.POSITIVE_INFINITY,
+        totalTokens: Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow();
+    expect(() =>
+      TokenUsageSchema.parse({ inputTokens: 0, outputTokens: 0, totalTokens: Number.POSITIVE_INFINITY }),
+    ).toThrow();
+  });
+
+  it('rejects unsafe token counts and overflow totals', () => {
+    expect(() =>
+      TokenUsageSchema.parse({
+        inputTokens: Number.MAX_SAFE_INTEGER + 1,
+        outputTokens: 0,
+        totalTokens: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ).toThrow();
+    expect(() =>
+      TokenUsageSchema.parse({
+        inputTokens: Number.MAX_SAFE_INTEGER,
+        outputTokens: 1,
+        totalTokens: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects token usage records with inconsistent totals', () => {
+    expect(() =>
+      TokenUsageSchema.parse({ inputTokens: 10, outputTokens: 5, totalTokens: 999 }),
+    ).toThrow();
+  });
 });
 
 describe('ToolDefinitionSchema', () => {


### PR DESCRIPTION
## Summary
- hardens `TokenUsageSchema` to require finite non-negative safe integer token counts
- enforces `totalTokens === inputTokens + outputTokens` and rejects overflow totals
- adds provider schema regression coverage for fractional, non-finite, unsafe, overflow, and inconsistent token usage

## Test Plan
- npm test --workspace @franken/types
- npm run typecheck --workspace @franken/types
- npm run build --workspace @franken/types
- npm run lint:any

Closes #1246
