### PR TITLE
fix(governor): sign approval responder metadata

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -439,14 +439,19 @@ const verifier = new SignatureVerifier(secret);
 
 // Sign the deterministic approval-response payload. Do not use JSON.stringify:
 // object key order can differ across runtimes and break verification.
-const payload = formatApprovalResponseSignaturePayload({ requestId: 'abc', decision: 'APPROVE' });
+const payload = formatApprovalResponseSignaturePayload({
+  requestId: 'abc',
+  decision: 'APPROVE',
+  respondedBy: 'alice@example.com',
+  feedback: 'Looks safe to deploy',
+});
 const signature = verifier.sign(payload);
 
 // Verify (timing-safe comparison)
 const isValid = verifier.verify(payload, signature);
 ```
 
-The canonical signed approval-response payload is `requestId:<url-encoded-id>|decision:<url-encoded-decision>` (for example `requestId:abc|decision:APPROVE`). Custom approval UIs and non-TypeScript clients must sign those exact bytes rather than serialized JSON.
+The canonical signed approval-response payload is `requestId:<url-encoded-id>|decision:<url-encoded-decision>|respondedBy:<url-encoded-responder>|feedback:<feedback-state>` (for example `requestId:abc|decision:APPROVE|respondedBy:alice%40example.com|feedback:s:Looks%20safe%20to%20deploy`). `feedback:<feedback-state>` is `feedback:u` when feedback is omitted and `feedback:s:<url-encoded-feedback>` when feedback is present. Custom approval UIs and non-TypeScript clients must sign those exact bytes rather than serialized JSON.
 
 To enable in the gateway:
 

--- a/packages/franken-governor/docs/adr/ADR-005-signed-approvals-hmac.md
+++ b/packages/franken-governor/docs/adr/ADR-005-signed-approvals-hmac.md
@@ -12,7 +12,7 @@ Production tasks require cryptographic proof that a specific human approved the 
 
 Use HMAC-SHA256 signatures via Node.js `node:crypto`. The `ApprovalResponse` includes an optional `signature` field. A `SignatureVerifier` validates signatures against a shared secret using timing-safe comparison. For non-production environments, signature verification is skipped (configurable via `config.requireSignedApprovals`).
 
-The signature payload is `JSON.stringify({ requestId, decision })` — the minimum data needed to prove the decision is authentic.
+The signature payload is a deterministic, non-JSON approval-response byte string formatted as `requestId:<url-encoded-id>|decision:<url-encoded-decision>|respondedBy:<url-encoded-responder>|feedback:<feedback-state>`. `feedback:<feedback-state>` is `feedback:u` when feedback is omitted and `feedback:s:<url-encoded-feedback>` when feedback is present. Signing `respondedBy` and `feedback` ensures the recorded responder identity and optional rationale cannot be tampered with after the decision is signed.
 
 ## Consequences
 

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -99,6 +99,8 @@ export class ApprovalGateway {
     const payload = formatApprovalResponseSignaturePayload({
       requestId: response.requestId,
       decision: response.decision,
+      respondedBy: response.respondedBy,
+      feedback: response.feedback,
     });
 
     if (!signatureVerifier || !response.signature || !signatureVerifier.verify(payload, response.signature)) {

--- a/packages/franken-governor/src/security/signature-verifier.ts
+++ b/packages/franken-governor/src/security/signature-verifier.ts
@@ -3,6 +3,12 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 export interface ApprovalResponseSignaturePayloadFields {
   readonly requestId: string;
   readonly decision: string;
+  readonly respondedBy: string;
+  readonly feedback?: string | undefined;
+}
+
+function formatOptionalField(value: string | undefined): string {
+  return value === undefined ? 'u' : `s:${encodeURIComponent(value)}`;
 }
 
 /**
@@ -14,7 +20,12 @@ export interface ApprovalResponseSignaturePayloadFields {
 export function formatApprovalResponseSignaturePayload(
   fields: ApprovalResponseSignaturePayloadFields,
 ): string {
-  return `requestId:${encodeURIComponent(fields.requestId)}|decision:${encodeURIComponent(fields.decision)}`;
+  return [
+    `requestId:${encodeURIComponent(fields.requestId)}`,
+    `decision:${encodeURIComponent(fields.decision)}`,
+    `respondedBy:${encodeURIComponent(fields.respondedBy)}`,
+    `feedback:${formatOptionalField(fields.feedback)}`,
+  ].join('|');
 }
 
 export class SignatureVerifier {

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -103,7 +103,7 @@ function parseJsonBody(rawBody: Buffer): ParsedJsonBody | null {
 /**
  * Produce a signature for a resolved `ApprovalResponse` matching the format
  * `ApprovalGateway.verifySignature` expects (HMAC-SHA256 hex digest of
- * `requestId:<id>|decision:<decision>`, via `SignatureVerifier`).
+ * `requestId:<id>|decision:<decision>|respondedBy:<operator>|feedback:<tagged-feedback>`, via `SignatureVerifier`).
  *
  * Without this, a caller awaiting the approval through `ApprovalGateway`
  * with `config.requireSignedApprovals: true` would always unblock only to
@@ -111,17 +111,19 @@ function parseJsonBody(rawBody: Buffer): ParsedJsonBody | null {
  * handed to the registry never carried a `signature` (see issue #411 review
  * follow-up). The HTTP handlers below have already authenticated the
  * caller (via `x-governor-signature` or the Slack signature scheme) before
- * calling this, so re-signing the canonical `{requestId, decision}` payload
+ * calling this, so re-signing the canonical approval response payload
  * with the same governor `signingSecret` is safe and lets the two
  * signature schemes compose.
  */
 function signApprovalResponse(
   requestId: string,
   decision: ResponseCode,
+  respondedBy: string,
+  feedback: string | undefined,
   signingSecret: string,
 ): string {
   return new SignatureVerifier(signingSecret).sign(
-    formatApprovalResponseSignaturePayload({ requestId, decision }),
+    formatApprovalResponseSignaturePayload({ requestId, decision, respondedBy, feedback }),
   );
 }
 
@@ -282,7 +284,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     // (a valid x-governor-signature, or explicitly allowed unsigned for
     // tests); see `signApprovalResponse` for why this is safe to attach.
     const signature = options.signingSecret
-      ? signApprovalResponse(body.requestId, decision, options.signingSecret)
+      ? signApprovalResponse(body.requestId, decision, respondedBy, feedback, options.signingSecret)
       : undefined;
 
     // Wake the real waiter (if any) registered via `HttpApprovalChannel`, so
@@ -457,7 +459,13 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     // `ApprovalGateway.requireSignedApprovals` accepts it too (see
     // `signApprovalResponse`).
     const slackSignature = options.signingSecret
-      ? signApprovalResponse(requestId, decision, options.signingSecret)
+      ? signApprovalResponse(
+        requestId,
+        decision,
+        payload.user?.id ?? payload.user?.username ?? 'slack',
+        undefined,
+        options.signingSecret,
+      )
       : undefined;
 
     registry.resolve(requestId, {

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -126,6 +126,7 @@ describe('ApprovalGateway — security integration', () => {
     const responsePayload = formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
+      respondedBy: 'human',
     });
     const validSig = verifier.sign(responsePayload);
     const channel = makeFakeChannel({ signature: validSig });
@@ -141,12 +142,62 @@ describe('ApprovalGateway — security integration', () => {
     expect(outcome.decision).toBe('APPROVE');
   });
 
+  it('rejects a signed approval when respondedBy is tampered after signing', async () => {
+    const verifier = new SignatureVerifier(signingFixture);
+    const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+    }));
+    const channel = makeFakeChannel({ signature: validSig, respondedBy: 'admin' });
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+      signatureVerifier: verifier,
+      sessionTokenStore: new SessionTokenStore(),
+    });
+
+    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(SignatureVerificationError);
+  });
+
+  it('rejects a signed approval when feedback is tampered after signing', async () => {
+    const verifier = new SignatureVerifier(signingFixture);
+    const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'REGEN',
+      respondedBy: 'human',
+      feedback: 'try again',
+    }));
+    const channel = makeFakeChannel({
+      decision: 'REGEN',
+      signature: validSig,
+      feedback: 'exfiltrate credentials',
+    });
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+      signatureVerifier: verifier,
+    });
+
+    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(SignatureVerificationError);
+  });
+
   it('uses a deterministic signature payload that is independent of JSON key order', async () => {
     const verifier = new SignatureVerifier(signingFixture);
-    const jsonPayloadWithDifferentOrder = JSON.stringify({ decision: 'APPROVE', requestId: 'req-001' });
+    const jsonPayloadWithDifferentOrder = JSON.stringify({
+      decision: 'APPROVE',
+      feedback: undefined,
+      requestId: 'req-001',
+      respondedBy: 'human',
+    });
     const deterministicPayload = formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
+      respondedBy: 'human',
     });
     const channel = makeFakeChannel({ signature: verifier.sign(deterministicPayload) });
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
@@ -214,6 +265,7 @@ describe('ApprovalGateway — security integration', () => {
     const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
+      respondedBy: 'human',
     }));
     const channel = makeFakeChannel({ signature: validSig });
     const wiredGateway = new ApprovalGateway({
@@ -236,7 +288,7 @@ describe('ApprovalGateway — security integration', () => {
     });
 
     const sign = (secret: string, requestId: string) => new SignatureVerifier(secret).sign(
-      formatApprovalResponseSignaturePayload({ requestId, decision: 'APPROVE' }),
+      formatApprovalResponseSignaturePayload({ requestId, decision: 'APPROVE', respondedBy: 'human' }),
     );
 
     vi.mocked(channel.requestApproval)
@@ -297,7 +349,7 @@ describe('ApprovalGateway — security integration', () => {
     // Attacker replays a genuinely-signed approval for request A against active request B.
     const verifier = new SignatureVerifier(signingFixture);
     const signedForOther = verifier.sign(
-      formatApprovalResponseSignaturePayload({ requestId: 'req-OTHER', decision: 'APPROVE' }),
+      formatApprovalResponseSignaturePayload({ requestId: 'req-OTHER', decision: 'APPROVE', respondedBy: 'human' }),
     );
     const channel = makeFakeChannel({ requestId: 'req-OTHER', signature: signedForOther });
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };

--- a/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
+++ b/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
@@ -36,14 +36,39 @@ describe('SignatureVerifier', () => {
   });
 
   it('sign + verify round-trip succeeds for approval response payloads', () => {
-    const payload = formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' });
+    const payload = formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+    });
     const sig = verifier.sign(payload);
     expect(verifier.verify(payload, sig)).toBe(true);
   });
 
   it('formats approval response payloads without relying on JSON key order', () => {
-    expect(formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' }))
-      .toBe('requestId:req-001|decision:APPROVE');
+    expect(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human@example.com',
+      feedback: 'ship it',
+    }))
+      .toBe('requestId:req-001|decision:APPROVE|respondedBy:human%40example.com|feedback:s:ship%20it');
+  });
+
+  it('distinguishes absent feedback from literal feedback values', () => {
+    expect(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+    }))
+      .toBe('requestId:req-001|decision:APPROVE|respondedBy:human|feedback:u');
+    expect(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+      feedback: '',
+    }))
+      .toBe('requestId:req-001|decision:APPROVE|respondedBy:human|feedback:s:');
   });
 
   it('produces deterministic signatures for same input', () => {


### PR DESCRIPTION
## Summary
- include respondedBy and feedback in the canonical ApprovalGateway response signature payload
- update HTTP/Slack approval response signing to cover the same metadata that the gateway verifies
- add regression coverage for respondedBy and feedback tampering

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/governor
- npm run typecheck --workspace @franken/governor
- npm run build --workspace @franken/governor

Closes #915