### PR TITLE
fix(web): mint chat websocket tickets before connect

### DIFF
--- a/packages/franken-critique/tests/integration/critique-loop-full.test.ts
+++ b/packages/franken-critique/tests/integration/critique-loop-full.test.ts
@@ -4,16 +4,16 @@ import type { GuardrailsPort, MemoryPort, ObservabilityPort } from '../../src/ty
 import type { EvaluationInput } from '../../src/types/evaluation.js';
 import type { LoopConfig } from '../../src/types/loop.js';
 
-const forbiddenInvocationName = 'unsafeCall';
-const forbiddenInvocationPattern = `${forbiddenInvocationName}\\(`;
+const unsafeDynamicCallName = 'executeUntrustedCode';
+const unsafeDynamicCallPattern = `${unsafeDynamicCallName}\\(`;
 
 function createMockGuardrailsPort(): GuardrailsPort {
   return {
     getSafetyRules: vi.fn().mockResolvedValue([
       {
-        id: `no-${forbiddenInvocationName}`,
-        description: `no ${forbiddenInvocationName}`,
-        pattern: forbiddenInvocationPattern,
+        id: `no-${unsafeDynamicCallName}`,
+        description: `no ${unsafeDynamicCallName}`,
+        pattern: unsafeDynamicCallPattern,
         severity: 'block',
       },
     ]),
@@ -87,7 +87,7 @@ describe('Full Critique Loop Integration', () => {
     });
 
     const result = await reviewer.review(
-      createInput(`${forbiddenInvocationName}("malicious code")`),
+      createInput(`${unsafeDynamicCallName}("malicious code")`),
       createLoopConfig({ maxIterations: 1 }),
     );
 

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -23,10 +23,10 @@ function createInput(content: string): EvaluationInput {
   return { content, metadata: {} };
 }
 
-const forbiddenInvocationName = 'unsafeCall';
-const forbiddenInvocationPattern = `${forbiddenInvocationName}\\(`;
-function forbiddenInvocation(argument: string): string {
-  return `${forbiddenInvocationName}(${argument})`;
+const unsafeDynamicCallName = 'executeUntrustedCode';
+const unsafeDynamicCallPattern = `${unsafeDynamicCallName}\\(`;
+function unsafeDynamicCall(argument: string): string {
+  return `${unsafeDynamicCallName}(${argument})`;
 }
 
 describe('SafetyEvaluator', () => {
@@ -42,8 +42,8 @@ describe('SafetyEvaluator', () => {
     const port = createMockGuardrailsPort([
       {
         id: 'r1',
-        description: `no ${forbiddenInvocationName}`,
-        pattern: forbiddenInvocationPattern,
+        description: `no ${unsafeDynamicCallName}`,
+        pattern: unsafeDynamicCallPattern,
         severity: 'block',
       },
     ]);
@@ -60,20 +60,20 @@ describe('SafetyEvaluator', () => {
     const port = createMockGuardrailsPort([
       {
         id: 'r1',
-        description: `no ${forbiddenInvocationName}`,
-        pattern: forbiddenInvocationPattern,
+        description: `no ${unsafeDynamicCallName}`,
+        pattern: unsafeDynamicCallPattern,
         severity: 'block',
       },
     ]);
     const evaluator = new SafetyEvaluator(port);
 
-    const result = await evaluator.evaluate(createInput(forbiddenInvocation('"code"')));
+    const result = await evaluator.evaluate(createInput(unsafeDynamicCall('"code"')));
 
     expect(result.verdict).toBe('fail');
     expect(result.score).toBe(0);
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]!.severity).toBe('critical');
-    expect(result.findings[0]!.message).toContain(`no ${forbiddenInvocationName}`);
+    expect(result.findings[0]!.message).toContain(`no ${unsafeDynamicCallName}`);
   });
 
   it('warns but passes on warning-severity rules', async () => {
@@ -243,8 +243,8 @@ describe('SafetyEvaluator', () => {
     const port = createMockGuardrailsPort([
       {
         id: 'r1',
-        description: `no ${forbiddenInvocationName}`,
-        pattern: forbiddenInvocationPattern,
+        description: `no ${unsafeDynamicCallName}`,
+        pattern: unsafeDynamicCallPattern,
         severity: 'block',
       },
       {
@@ -257,7 +257,7 @@ describe('SafetyEvaluator', () => {
     const evaluator = new SafetyEvaluator(port);
 
     const result = await evaluator.evaluate(
-      createInput(`${forbiddenInvocation('"code"')}; exec("y")`),
+      createInput(`${unsafeDynamicCall('"code"')}; exec("y")`),
     );
 
     expect(result.verdict).toBe('fail');
@@ -280,7 +280,7 @@ describe('SafetyEvaluator', () => {
       {
         id: 'bad-regex',
         description: 'bad regex',
-        pattern: `${forbiddenInvocationName}(`,
+        pattern: `${unsafeDynamicCallName}(`,
         severity: 'block',
       },
     ]);

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -55,7 +55,7 @@ describe('LessonRecorder', () => {
   });
 
   it('records a lesson when multi-iteration pass occurs (fail then pass)', async () => {
-    const forbiddenInvocationName = 'unsafeCall';
+    const unsafeDynamicCallName = 'executeUntrustedCode';
 
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);
@@ -63,7 +63,7 @@ describe('LessonRecorder', () => {
     const result: CritiqueLoopResult = {
       verdict: 'pass',
       iterations: [
-        createIteration(0, 'fail', 'safety', [{ message: `${forbiddenInvocationName}() detected`, severity: 'critical' }]),
+        createIteration(0, 'fail', 'safety', [{ message: `${unsafeDynamicCallName}() detected`, severity: 'critical' }]),
         createIteration(1, 'pass'),
       ],
     };
@@ -74,7 +74,7 @@ describe('LessonRecorder', () => {
     expect(port.recordLesson).toHaveBeenCalledWith(
       expect.objectContaining({
         evaluatorName: 'safety',
-        failureDescription: expect.stringContaining(`${forbiddenInvocationName}()`),
+        failureDescription: expect.stringContaining(`${unsafeDynamicCallName}()`),
         taskId: 'test-task',
       }),
     );

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -129,7 +129,7 @@ describe('CritiquePipeline', () => {
   });
 
   it('short-circuits on safety evaluator failure', async () => {
-    const forbiddenInvocationName = 'unsafeCall';
+    const unsafeDynamicCallName = 'executeUntrustedCode';
 
     const safety = createMockEvaluator('safety', 'deterministic', {
       verdict: 'fail',
@@ -139,7 +139,7 @@ describe('CritiquePipeline', () => {
     const other = createMockEvaluator('other', 'heuristic');
 
     const pipeline = new CritiquePipeline([safety, other]);
-    const result = await pipeline.run(createInput(`${forbiddenInvocationName}("hack")`));
+    const result = await pipeline.run(createInput(`${unsafeDynamicCallName}("hack")`));
 
     expect(result.verdict).toBe('fail');
     expect(result.shortCircuited).toBe(true);

--- a/packages/franken-critique/tests/unit/reviewer.test.ts
+++ b/packages/franken-critique/tests/unit/reviewer.test.ts
@@ -118,14 +118,14 @@ describe('createReviewer', () => {
   });
 
   it('handles safety failure with short-circuit', async () => {
-    const forbiddenInvocationName = 'unsafeCall';
+    const unsafeDynamicCallName = 'executeUntrustedCode';
 
     const guardrails: GuardrailsPort = {
       getSafetyRules: vi.fn().mockResolvedValue([
         {
-          id: `no-${forbiddenInvocationName}`,
-          description: `no ${forbiddenInvocationName}`,
-          pattern: `${forbiddenInvocationName}\\(`,
+          id: `no-${unsafeDynamicCallName}`,
+          description: `no ${unsafeDynamicCallName}`,
+          pattern: `${unsafeDynamicCallName}\\(`,
           severity: 'block' as const,
         },
       ]),
@@ -134,7 +134,7 @@ describe('createReviewer', () => {
       }),
     };
     const reviewer = createReviewer(makeConfig({ guardrails }));
-    const input = makeInput(`${forbiddenInvocationName}("dangerous")`);
+    const input = makeInput(`${unsafeDynamicCallName}("dangerous")`);
     const result = await reviewer.review(input, makeLoopConfig());
     expect(result.verdict).toBe('fail');
   });

--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -439,14 +439,19 @@ const verifier = new SignatureVerifier(secret);
 
 // Sign the deterministic approval-response payload. Do not use JSON.stringify:
 // object key order can differ across runtimes and break verification.
-const payload = formatApprovalResponseSignaturePayload({ requestId: 'abc', decision: 'APPROVE' });
+const payload = formatApprovalResponseSignaturePayload({
+  requestId: 'abc',
+  decision: 'APPROVE',
+  respondedBy: 'alice@example.com',
+  feedback: 'Looks safe to deploy',
+});
 const signature = verifier.sign(payload);
 
 // Verify (timing-safe comparison)
 const isValid = verifier.verify(payload, signature);
 ```
 
-The canonical signed approval-response payload is `requestId:<url-encoded-id>|decision:<url-encoded-decision>` (for example `requestId:abc|decision:APPROVE`). Custom approval UIs and non-TypeScript clients must sign those exact bytes rather than serialized JSON.
+The canonical signed approval-response payload is `requestId:<url-encoded-id>|decision:<url-encoded-decision>|respondedBy:<url-encoded-responder>|feedback:<feedback-state>` (for example `requestId:abc|decision:APPROVE|respondedBy:alice%40example.com|feedback:s:Looks%20safe%20to%20deploy`). `feedback:<feedback-state>` is `feedback:u` when feedback is omitted and `feedback:s:<url-encoded-feedback>` when feedback is present. Custom approval UIs and non-TypeScript clients must sign those exact bytes rather than serialized JSON.
 
 To enable in the gateway:
 

--- a/packages/franken-governor/docs/adr/ADR-005-signed-approvals-hmac.md
+++ b/packages/franken-governor/docs/adr/ADR-005-signed-approvals-hmac.md
@@ -12,7 +12,7 @@ Production tasks require cryptographic proof that a specific human approved the 
 
 Use HMAC-SHA256 signatures via Node.js `node:crypto`. The `ApprovalResponse` includes an optional `signature` field. A `SignatureVerifier` validates signatures against a shared secret using timing-safe comparison. For non-production environments, signature verification is skipped (configurable via `config.requireSignedApprovals`).
 
-The signature payload is `JSON.stringify({ requestId, decision })` — the minimum data needed to prove the decision is authentic.
+The signature payload is a deterministic, non-JSON approval-response byte string formatted as `requestId:<url-encoded-id>|decision:<url-encoded-decision>|respondedBy:<url-encoded-responder>|feedback:<feedback-state>`. `feedback:<feedback-state>` is `feedback:u` when feedback is omitted and `feedback:s:<url-encoded-feedback>` when feedback is present. Signing `respondedBy` and `feedback` ensures the recorded responder identity and optional rationale cannot be tampered with after the decision is signed.
 
 ## Consequences
 

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -99,6 +99,8 @@ export class ApprovalGateway {
     const payload = formatApprovalResponseSignaturePayload({
       requestId: response.requestId,
       decision: response.decision,
+      respondedBy: response.respondedBy,
+      feedback: response.feedback,
     });
 
     if (!signatureVerifier || !response.signature || !signatureVerifier.verify(payload, response.signature)) {

--- a/packages/franken-governor/src/security/signature-verifier.ts
+++ b/packages/franken-governor/src/security/signature-verifier.ts
@@ -3,6 +3,12 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 export interface ApprovalResponseSignaturePayloadFields {
   readonly requestId: string;
   readonly decision: string;
+  readonly respondedBy: string;
+  readonly feedback?: string | undefined;
+}
+
+function formatOptionalField(value: string | undefined): string {
+  return value === undefined ? 'u' : `s:${encodeURIComponent(value)}`;
 }
 
 /**
@@ -14,7 +20,12 @@ export interface ApprovalResponseSignaturePayloadFields {
 export function formatApprovalResponseSignaturePayload(
   fields: ApprovalResponseSignaturePayloadFields,
 ): string {
-  return `requestId:${encodeURIComponent(fields.requestId)}|decision:${encodeURIComponent(fields.decision)}`;
+  return [
+    `requestId:${encodeURIComponent(fields.requestId)}`,
+    `decision:${encodeURIComponent(fields.decision)}`,
+    `respondedBy:${encodeURIComponent(fields.respondedBy)}`,
+    `feedback:${formatOptionalField(fields.feedback)}`,
+  ].join('|');
 }
 
 export class SignatureVerifier {

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -103,7 +103,7 @@ function parseJsonBody(rawBody: Buffer): ParsedJsonBody | null {
 /**
  * Produce a signature for a resolved `ApprovalResponse` matching the format
  * `ApprovalGateway.verifySignature` expects (HMAC-SHA256 hex digest of
- * `requestId:<id>|decision:<decision>`, via `SignatureVerifier`).
+ * `requestId:<id>|decision:<decision>|respondedBy:<operator>|feedback:<tagged-feedback>`, via `SignatureVerifier`).
  *
  * Without this, a caller awaiting the approval through `ApprovalGateway`
  * with `config.requireSignedApprovals: true` would always unblock only to
@@ -111,17 +111,19 @@ function parseJsonBody(rawBody: Buffer): ParsedJsonBody | null {
  * handed to the registry never carried a `signature` (see issue #411 review
  * follow-up). The HTTP handlers below have already authenticated the
  * caller (via `x-governor-signature` or the Slack signature scheme) before
- * calling this, so re-signing the canonical `{requestId, decision}` payload
+ * calling this, so re-signing the canonical approval response payload
  * with the same governor `signingSecret` is safe and lets the two
  * signature schemes compose.
  */
 function signApprovalResponse(
   requestId: string,
   decision: ResponseCode,
+  respondedBy: string,
+  feedback: string | undefined,
   signingSecret: string,
 ): string {
   return new SignatureVerifier(signingSecret).sign(
-    formatApprovalResponseSignaturePayload({ requestId, decision }),
+    formatApprovalResponseSignaturePayload({ requestId, decision, respondedBy, feedback }),
   );
 }
 
@@ -282,7 +284,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     // (a valid x-governor-signature, or explicitly allowed unsigned for
     // tests); see `signApprovalResponse` for why this is safe to attach.
     const signature = options.signingSecret
-      ? signApprovalResponse(body.requestId, decision, options.signingSecret)
+      ? signApprovalResponse(body.requestId, decision, respondedBy, feedback, options.signingSecret)
       : undefined;
 
     // Wake the real waiter (if any) registered via `HttpApprovalChannel`, so
@@ -457,7 +459,13 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     // `ApprovalGateway.requireSignedApprovals` accepts it too (see
     // `signApprovalResponse`).
     const slackSignature = options.signingSecret
-      ? signApprovalResponse(requestId, decision, options.signingSecret)
+      ? signApprovalResponse(
+        requestId,
+        decision,
+        payload.user?.id ?? payload.user?.username ?? 'slack',
+        undefined,
+        options.signingSecret,
+      )
       : undefined;
 
     registry.resolve(requestId, {

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -126,6 +126,7 @@ describe('ApprovalGateway — security integration', () => {
     const responsePayload = formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
+      respondedBy: 'human',
     });
     const validSig = verifier.sign(responsePayload);
     const channel = makeFakeChannel({ signature: validSig });
@@ -141,12 +142,62 @@ describe('ApprovalGateway — security integration', () => {
     expect(outcome.decision).toBe('APPROVE');
   });
 
+  it('rejects a signed approval when respondedBy is tampered after signing', async () => {
+    const verifier = new SignatureVerifier(signingFixture);
+    const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+    }));
+    const channel = makeFakeChannel({ signature: validSig, respondedBy: 'admin' });
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+      signatureVerifier: verifier,
+      sessionTokenStore: new SessionTokenStore(),
+    });
+
+    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(SignatureVerificationError);
+  });
+
+  it('rejects a signed approval when feedback is tampered after signing', async () => {
+    const verifier = new SignatureVerifier(signingFixture);
+    const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'REGEN',
+      respondedBy: 'human',
+      feedback: 'try again',
+    }));
+    const channel = makeFakeChannel({
+      decision: 'REGEN',
+      signature: validSig,
+      feedback: 'exfiltrate credentials',
+    });
+    const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
+    const gateway = new ApprovalGateway({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      config,
+      signatureVerifier: verifier,
+    });
+
+    await expect(gateway.requestApproval(makeRequest())).rejects.toThrow(SignatureVerificationError);
+  });
+
   it('uses a deterministic signature payload that is independent of JSON key order', async () => {
     const verifier = new SignatureVerifier(signingFixture);
-    const jsonPayloadWithDifferentOrder = JSON.stringify({ decision: 'APPROVE', requestId: 'req-001' });
+    const jsonPayloadWithDifferentOrder = JSON.stringify({
+      decision: 'APPROVE',
+      feedback: undefined,
+      requestId: 'req-001',
+      respondedBy: 'human',
+    });
     const deterministicPayload = formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
+      respondedBy: 'human',
     });
     const channel = makeFakeChannel({ signature: verifier.sign(deterministicPayload) });
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };
@@ -214,6 +265,7 @@ describe('ApprovalGateway — security integration', () => {
     const validSig = verifier.sign(formatApprovalResponseSignaturePayload({
       requestId: 'req-001',
       decision: 'APPROVE',
+      respondedBy: 'human',
     }));
     const channel = makeFakeChannel({ signature: validSig });
     const wiredGateway = new ApprovalGateway({
@@ -236,7 +288,7 @@ describe('ApprovalGateway — security integration', () => {
     });
 
     const sign = (secret: string, requestId: string) => new SignatureVerifier(secret).sign(
-      formatApprovalResponseSignaturePayload({ requestId, decision: 'APPROVE' }),
+      formatApprovalResponseSignaturePayload({ requestId, decision: 'APPROVE', respondedBy: 'human' }),
     );
 
     vi.mocked(channel.requestApproval)
@@ -297,7 +349,7 @@ describe('ApprovalGateway — security integration', () => {
     // Attacker replays a genuinely-signed approval for request A against active request B.
     const verifier = new SignatureVerifier(signingFixture);
     const signedForOther = verifier.sign(
-      formatApprovalResponseSignaturePayload({ requestId: 'req-OTHER', decision: 'APPROVE' }),
+      formatApprovalResponseSignaturePayload({ requestId: 'req-OTHER', decision: 'APPROVE', respondedBy: 'human' }),
     );
     const channel = makeFakeChannel({ requestId: 'req-OTHER', signature: signedForOther });
     const config = { ...defaultConfig(), requireSignedApprovals: true, signingSecret: signingFixture };

--- a/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
+++ b/packages/franken-governor/tests/unit/security/signature-verifier.test.ts
@@ -36,14 +36,39 @@ describe('SignatureVerifier', () => {
   });
 
   it('sign + verify round-trip succeeds for approval response payloads', () => {
-    const payload = formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' });
+    const payload = formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+    });
     const sig = verifier.sign(payload);
     expect(verifier.verify(payload, sig)).toBe(true);
   });
 
   it('formats approval response payloads without relying on JSON key order', () => {
-    expect(formatApprovalResponseSignaturePayload({ requestId: 'req-001', decision: 'APPROVE' }))
-      .toBe('requestId:req-001|decision:APPROVE');
+    expect(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human@example.com',
+      feedback: 'ship it',
+    }))
+      .toBe('requestId:req-001|decision:APPROVE|respondedBy:human%40example.com|feedback:s:ship%20it');
+  });
+
+  it('distinguishes absent feedback from literal feedback values', () => {
+    expect(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+    }))
+      .toBe('requestId:req-001|decision:APPROVE|respondedBy:human|feedback:u');
+    expect(formatApprovalResponseSignaturePayload({
+      requestId: 'req-001',
+      decision: 'APPROVE',
+      respondedBy: 'human',
+      feedback: '',
+    }))
+      .toBe('requestId:req-001|decision:APPROVE|respondedBy:human|feedback:s:');
   });
 
   it('produces deterministic signatures for same input', () => {

--- a/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
+++ b/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
@@ -17,6 +17,9 @@ export class InMemoryRateLimiter {
   constructor(private readonly options: BeastRateLimitOptions) {}
 
   take(key: string): { allowed: boolean; remaining: number } {
+    if (this.options.max <= 0) {
+      return { allowed: false, remaining: 0 };
+    }
     const now = Date.now();
     const current = this.counters.get(key);
     if (!current || current.resetAt <= now) {

--- a/packages/franken-orchestrator/src/chat/types.ts
+++ b/packages/franken-orchestrator/src/chat/types.ts
@@ -41,5 +41,5 @@ export type { ChatBeastContext, TranscriptMessage, TurnOutcome };
 
 export { ChatBeastContextSchema, TranscriptMessageSchema, TokenTotalsSchema };
 
-export const ChatSessionSchema = ChatSessionResponseSchema.omit({ socketToken: true });
-export type ChatSession = Omit<ChatSessionResponse, 'socketToken'>;
+export const ChatSessionSchema = ChatSessionResponseSchema;
+export type ChatSession = ChatSessionResponse;

--- a/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/core/chat-runtime-comms-adapter.ts
@@ -5,6 +5,8 @@ import type {
 } from './comms-runtime-port.js';
 import type { OutboundMessageStatus } from './types.js';
 import type { ChatRuntime, ChatRuntimeState } from '../../chat/runtime.js';
+import type { InMemoryRateLimiter } from '../../beasts/http/beast-rate-limit.js';
+import { chatClientKey } from '../../http/chat-rate-limit.js';
 
 export interface CommsSessionStore {
   load(id: string): Promise<CommsSession | null>;
@@ -20,6 +22,10 @@ export interface CommsSession {
   beastContext?: unknown;
   routingMetadata?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+export interface ChatRuntimeCommsAdapterOptions {
+  chatRateLimiter?: InMemoryRateLimiter;
 }
 
 function normalizeRoutingMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
@@ -43,13 +49,29 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
   constructor(
     private readonly runtime: ChatRuntime,
     private readonly sessionStore: CommsSessionStore,
+    private readonly options: ChatRuntimeCommsAdapterOptions = {},
   ) {}
 
   async processInbound(
     input: CommsInboundInput,
   ): Promise<CommsInboundResult> {
-    // Load or create session
     let session = await this.sessionStore.load(input.sessionId);
+    const routingMetadata = normalizeRoutingMetadata(input.metadata ?? session?.routingMetadata);
+    const principal = input.externalUserId === 'system'
+      ? `${input.channelType}:session:${input.sessionId}`
+      : `${input.channelType}:user:${input.externalUserId}`;
+
+    if (this.options.chatRateLimiter && !this.options.chatRateLimiter.take(chatClientKey({
+      action: 'message',
+      principal,
+    })).allowed) {
+      return {
+        text: 'Rate limit exceeded. Please wait before sending another chat message.',
+        status: 'reply',
+        ...(routingMetadata ? { metadata: routingMetadata } : {}),
+      };
+    }
+
     if (!session) {
       session = await this.sessionStore.create(input.sessionId, {
         channelType: input.channelType,
@@ -67,7 +89,6 @@ export class ChatRuntimeCommsAdapter implements CommsRuntimePort {
 
     // Run through ChatRuntime
     const result = await this.runtime.run(input.text, state);
-    const routingMetadata = normalizeRoutingMetadata(input.metadata ?? session.routingMetadata);
     const pendingApproval = result.pendingApproval
       ? result.pendingApprovalDescription
         ? {

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -246,7 +246,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     operatorToken: effectiveOperatorToken,
     streamTicketStore: chatStreamTicketStore,
     chatRateLimiter,
-    issueSocketToken: (sessionId) => issueSessionToken({
+    issueSocketTicket: (sessionId) => issueSessionToken({
       expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS,
       secret: sessionTokenSecret,
       sessionId,

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -243,7 +243,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     operatorToken: effectiveOperatorToken,
     streamTicketStore: chatStreamTicketStore,
     chatRateLimit: opts.chatRateLimit ?? opts.beastControl?.rateLimit ?? DEFAULT_CHAT_RATE_LIMIT,
-    issueSocketToken: (sessionId) => issueSessionToken({
+    issueSocketTicket: (sessionId) => issueSessionToken({
       expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS,
       secret: sessionTokenSecret,
       sessionId,

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -11,7 +11,6 @@ import { agentRoutes } from './routes/agent-routes.js';
 import { AgentInitService } from '../beasts/services/agent-init-service.js';
 import { createBeastSseRoutes } from './routes/beast-sse-routes.js';
 import { beastRoutes, type BeastRoutesDeps } from './routes/beast-routes.js';
-import type { BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
 import { chatRoutes } from './routes/chat-routes.js';
 import { networkRoutes } from './routes/network-routes.js';
 import { commsRoutes } from './routes/comms-routes.js';
@@ -37,7 +36,8 @@ import { createSkillRoutes } from './routes/skill-routes.js';
 import { createDashboardRoutes, type DashboardRouteDeps } from './routes/dashboard-routes.js';
 import { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
 import { createAnalyticsRoutes, type AnalyticsRouteDeps } from './routes/analytics-routes.js';
-import { DEFAULT_CHAT_RATE_LIMIT } from './chat-rate-limit.js';
+import { createChatRateLimiter, DEFAULT_CHAT_RATE_LIMIT, type ChatRateLimitOptions } from './chat-rate-limit.js';
+import type { InMemoryRateLimiter } from '../beasts/http/beast-rate-limit.js';
 
 export interface ChatAppOptions {
   sessionStoreDir?: string;
@@ -75,8 +75,9 @@ export interface ChatAppOptions {
   analyticsDeps?: AnalyticsRouteDeps;
   /** Optional owner-managed ticket store for browser EventSource chat streams. */
   chatStreamTicketStore?: SseConnectionTicketStore;
-  /** Rate/concurrency guard for chat message and approval REST mutations. */
-  chatRateLimit?: BeastRateLimitOptions;
+  /** Rate/concurrency guard shared by chat REST, websocket, and comms mutations. */
+  chatRateLimit?: ChatRateLimitOptions;
+  chatRateLimiter?: InMemoryRateLimiter;
   /** Optional gateway compatibility proxy for /v1/beasts/* now owned by beasts-daemon. */
   beastDaemon?: { baseUrl: string; operatorToken?: string | undefined };
 }
@@ -148,6 +149,8 @@ export function createChatApp(opts: ChatAppOptions): Hono {
   const transportSecurity = opts.transportSecurity ?? new TransportSecurityService();
   const effectiveOperatorToken = opts.operatorToken ?? opts.beastControl?.operatorToken ?? opts.beastDaemon?.operatorToken;
   const chatStreamTicketStore = opts.chatStreamTicketStore ?? (effectiveOperatorToken ? new SseConnectionTicketStore() : undefined);
+  const chatRateLimiter = opts.chatRateLimiter
+    ?? createChatRateLimiter(opts.chatRateLimit ?? opts.beastControl?.rateLimit ?? DEFAULT_CHAT_RATE_LIMIT);
 
   const app = new Hono();
   app.use('*', requestId);
@@ -242,7 +245,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     turnRunner: runtimeBundle.turnRunner,
     operatorToken: effectiveOperatorToken,
     streamTicketStore: chatStreamTicketStore,
-    chatRateLimit: opts.chatRateLimit ?? opts.beastControl?.rateLimit ?? DEFAULT_CHAT_RATE_LIMIT,
+    chatRateLimiter,
     issueSocketToken: (sessionId) => issueSessionToken({
       expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS,
       secret: sessionTokenSecret,

--- a/packages/franken-orchestrator/src/http/chat-rate-limit.ts
+++ b/packages/franken-orchestrator/src/http/chat-rate-limit.ts
@@ -1,7 +1,13 @@
 import { createHash } from 'node:crypto';
-import type { BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
+import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
 
-export const DEFAULT_CHAT_RATE_LIMIT: BeastRateLimitOptions = { windowMs: 60_000, max: 20 };
+export type ChatRateLimitOptions = BeastRateLimitOptions;
+
+export const DEFAULT_CHAT_RATE_LIMIT: ChatRateLimitOptions = { windowMs: 60_000, max: 20 };
+
+export function createChatRateLimiter(options: ChatRateLimitOptions = DEFAULT_CHAT_RATE_LIMIT): InMemoryRateLimiter {
+  return new InMemoryRateLimiter(options);
+}
 
 export function hashChatRateLimitPrincipal(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 24);
@@ -10,4 +16,32 @@ export function hashChatRateLimitPrincipal(value: string): string {
 export function chatRateLimitPrincipalFromAddress(address: string | undefined): string {
   const normalized = address?.trim();
   return normalized ? `ip:${hashChatRateLimitPrincipal(normalized)}` : 'anonymous';
+}
+
+export function chatRateLimitPrincipal(parts: {
+  readonly operatorToken?: string | undefined;
+  readonly remoteAddress?: string | undefined;
+  readonly principal?: string | undefined;
+}): string {
+  const explicitPrincipal = parts.principal?.trim();
+  if (explicitPrincipal) {
+    return `principal:${hashChatRateLimitPrincipal(explicitPrincipal)}`;
+  }
+
+  const operatorToken = parts.operatorToken?.trim();
+  if (operatorToken) {
+    return `operator:${hashChatRateLimitPrincipal(operatorToken)}`;
+  }
+
+  return chatRateLimitPrincipalFromAddress(parts.remoteAddress);
+}
+
+export function chatClientKey(parts: {
+  readonly action: 'message' | 'approval';
+  readonly sessionId?: string | undefined;
+  readonly operatorToken?: string | undefined;
+  readonly remoteAddress?: string | undefined;
+  readonly principal?: string | undefined;
+}): string {
+  return `chat:${parts.action}:${chatRateLimitPrincipal(parts)}`;
 }

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -27,6 +27,8 @@ import { localPlaintextOrSecureEndpoint, localPlaintextOrSecureWebSocketUrl } fr
 import { closeHttpServer, handleHonoHttpRequest } from './http-server-utils.js';
 import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
 import { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
+import { createChatRateLimiter, DEFAULT_CHAT_RATE_LIMIT, type ChatRateLimitOptions } from './chat-rate-limit.js';
+import type { InMemoryRateLimiter } from '../beasts/http/beast-rate-limit.js';
 
 export interface StartChatServerOptions {
   host?: string;
@@ -60,6 +62,7 @@ export interface StartChatServerOptions {
   dashboardDeps?: DashboardRouteDeps;
   analyticsDeps?: AnalyticsRouteDeps;
   beastDaemon?: { baseUrl: string; operatorToken?: string | undefined };
+  chatRateLimit?: ChatRateLimitOptions;
 }
 
 export interface ChatServerHandle {
@@ -101,6 +104,7 @@ function createCommsRuntimeAdapter(
   sessionStore: ISessionStore,
   sessionStoreDir: string,
   projectName: string,
+  chatRateLimiter?: InMemoryRateLimiter,
 ): CommsRuntimePort {
   const toStoredSessionId = (id: string): string => encodeURIComponent(id);
   return new ChatRuntimeCommsAdapter(runtime, {
@@ -183,7 +187,7 @@ function createCommsRuntimeAdapter(
       };
       sessionStore.save(session);
     },
-  });
+  }, { ...(chatRateLimiter ? { chatRateLimiter } : {}) });
 }
 
 function enabledSignedExternalWebhookChannels(commsConfig: CommsConfig | undefined): string[] {
@@ -269,6 +273,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
   }
   const tokenSecret = createSessionTokenSecret();
   const sessionStore = resolveChatServerSessionStore(options);
+  const chatRateLimiter = createChatRateLimiter(options.chatRateLimit ?? options.beastControl?.rateLimit ?? DEFAULT_CHAT_RATE_LIMIT);
   const runtime = createChatRuntime({
     chatLlm: options.llm,
     projectName: options.projectName,
@@ -294,7 +299,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
   });
   const commsRuntime = options.commsRuntime
     ?? (options.commsConfig
-      ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName)
+      ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName, chatRateLimiter)
       : undefined);
   const chatStreamTicketStore = effectiveOperatorToken ? new SseConnectionTicketStore() : undefined;
   const app = createChatApp({
@@ -316,6 +321,8 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ...(options.analyticsDeps ? { analyticsDeps: options.analyticsDeps } : {}),
     ...(chatStreamTicketStore ? { chatStreamTicketStore } : {}),
     ...(options.beastDaemon ? { beastDaemon: options.beastDaemon } : {}),
+    ...(options.chatRateLimit ? { chatRateLimit: options.chatRateLimit } : {}),
+    chatRateLimiter,
   });
   const server = createServer((request, response) => {
     void handleHonoHttpRequest(app, request, response);
@@ -328,7 +335,9 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     sessionStore,
     tokenSecret,
     ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
-    ...(options.beastControl?.rateLimit ? { chatRateLimit: options.beastControl.rateLimit } : {}),
+    ...(options.chatRateLimit ? { chatRateLimit: options.chatRateLimit } : {}),
+    ...(effectiveOperatorToken ? { operatorToken: effectiveOperatorToken } : {}),
+    chatRateLimiter,
   });
 
   await new Promise<void>((resolve, reject) => {

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -25,9 +25,29 @@ const MIME_TYPES: Record<string, string> = {
   '.webp': 'image/webp',
 };
 
+const VALID_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
+type DashboardBuildStatus =
+  | { state: 'ready' }
+  | { state: 'building' }
+  | { state: 'failed'; message: string };
+
+const HOP_BY_HOP_HEADERS = [
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+] as const;
+
 export interface DashboardStaticResponseOptions {
   apiTarget?: string | undefined;
   operatorToken?: string | undefined;
+  signal?: AbortSignal | undefined;
+  buildStatus?: DashboardBuildStatus | undefined;
 }
 
 export interface DashboardStaticServerOptions extends DashboardStaticResponseOptions {
@@ -56,6 +76,17 @@ function normalizeBaseUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   return trimmed.replace(/\/+$/, '');
+}
+
+
+function removeHopByHopHeaders(headers: Headers): void {
+  const connectionTokens = headers.get('connection')
+    ?.split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token && VALID_HEADER_NAME.test(token)) ?? [];
+  for (const header of [...HOP_BY_HOP_HEADERS, 'host', ...connectionTokens]) {
+    headers.delete(header);
+  }
 }
 
 function isSameOriginProxyRequest(request: Request): boolean {
@@ -96,7 +127,7 @@ async function createProxyResponse(
 
   const targetUrl = resolveProxyTargetUrl(apiTarget, sourceUrl);
   const headers = new Headers(request.headers);
-  headers.delete('host');
+  removeHopByHopHeaders(headers);
   if (options.operatorToken) {
     headers.set('authorization', `Bearer ${options.operatorToken}`);
   }
@@ -105,11 +136,19 @@ async function createProxyResponse(
     method: request.method,
     headers,
     redirect: 'manual',
+    ...(options.signal ? { signal: options.signal } : {}),
   };
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     init.body = await request.arrayBuffer();
   }
-  return fetch(targetUrl, init);
+  const upstreamResponse = await fetch(targetUrl, init);
+  const responseHeaders = new Headers(upstreamResponse.headers);
+  removeHopByHopHeaders(responseHeaders);
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
 }
 
 function sanitizeWebhookPathForProxy(pathname: string): string {
@@ -159,6 +198,22 @@ async function readStaticFile(filePath: string): Promise<Response | undefined> {
   }
 }
 
+function dashboardBuildUnavailableResponse(buildStatus: DashboardBuildStatus): Response | undefined {
+  if (buildStatus.state === 'building') {
+    return response('Dashboard build in progress', {
+      status: 503,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    });
+  }
+  if (buildStatus.state === 'failed') {
+    return response(`Dashboard build failed: ${buildStatus.message}`, {
+      status: 503,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    });
+  }
+  return undefined;
+}
+
 export async function createDashboardStaticResponse(
   request: Request,
   staticDir: string,
@@ -166,6 +221,23 @@ export async function createDashboardStaticResponse(
 ): Promise<Response> {
   const url = new URL(request.url);
   if (url.pathname === '/health') {
+    if (options.buildStatus?.state === 'building') {
+      return response(JSON.stringify({ service: SERVICE_IDENTITY, ok: false, reason: 'dashboard-build-building' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+      });
+    }
+    if (options.buildStatus?.state === 'failed') {
+      return response(JSON.stringify({
+        service: SERVICE_IDENTITY,
+        ok: false,
+        reason: 'dashboard-build-failed',
+        message: options.buildStatus.message,
+      }), {
+        status: 503,
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+      });
+    }
     const indexPath = resolveSafeAssetPath(staticDir, '/index.html');
     const index = indexPath ? await readStaticFile(indexPath) : undefined;
     if (!index) {
@@ -183,6 +255,11 @@ export async function createDashboardStaticResponse(
   if (isReservedBackendPath(url.pathname)) {
     return await createProxyResponse(request, options)
       ?? response('Not Found', { status: 404, headers: { 'content-type': 'text/plain; charset=utf-8' } });
+  }
+
+  const unavailable = options.buildStatus ? dashboardBuildUnavailableResponse(options.buildStatus) : undefined;
+  if (unavailable) {
+    return unavailable;
   }
 
   if (request.method !== 'GET' && request.method !== 'HEAD') {
@@ -325,25 +402,44 @@ function attachBackendUpgradeProxy(server: HttpServer, options: DashboardStaticS
   });
 }
 
-function startOptionalBuild(options: DashboardStaticServerOptions): void {
+function startOptionalBuild(options: DashboardStaticServerOptions): DashboardBuildStatus {
   if (!options.buildCommand) {
-    return;
+    return { state: 'ready' };
   }
+  const status: DashboardBuildStatus = { state: 'building' };
   const child = spawn(options.buildCommand, options.buildArgs ?? [], {
     cwd: process.cwd(),
     env: process.env,
     stdio: 'inherit',
   });
-  child.once('exit', (code) => {
-    if (code && code !== 0) {
-      console.error(`Dashboard build command exited with status ${code}`);
-    }
+  child.once('error', (error) => {
+    Object.assign(status, { state: 'failed', message: error.message });
   });
+  child.once('exit', (code, signal) => {
+    if (code === 0) {
+      Object.assign(status, { state: 'ready' });
+      return;
+    }
+    const message = signal
+      ? `Dashboard build command terminated by signal ${signal}`
+      : `Dashboard build command exited with status ${code ?? 'unknown'}`;
+    Object.assign(status, { state: 'failed', message });
+    console.error(message);
+  });
+  return status;
 }
 
 export async function startDashboardStaticServer(options: DashboardStaticServerOptions): Promise<HttpServer> {
+  let buildStatus: DashboardBuildStatus = options.buildCommand ? { state: 'building' } : { state: 'ready' };
   const server = createServer((req, res) => {
     const host = req.headers.host ?? `${options.host}:${options.port}`;
+    const abortController = new AbortController();
+    const abortRequest = () => abortController.abort();
+    req.once('aborted', abortRequest);
+    req.once('error', abortRequest);
+    res.once('close', () => {
+      if (!res.writableEnded) abortRequest();
+    });
     void readIncomingBody(req)
       .then(async (body) => {
         const requestInit: RequestInit = { headers: headersFromIncoming(req.headers) };
@@ -355,7 +451,11 @@ export async function startDashboardStaticServer(options: DashboardStaticServerO
         }
         const requestUrl = new URL(req.url ?? '/', requestBaseUrlFromIncoming(req.headers, host));
         const request = new Request(requestUrl, requestInit);
-        const staticResponse = await createDashboardStaticResponse(request, options.staticDir, options);
+        const staticResponse = await createDashboardStaticResponse(request, options.staticDir, {
+          ...options,
+          buildStatus,
+          signal: abortController.signal,
+        });
         await writeWebResponse(staticResponse, req.method, res);
       })
       .catch((error) => {
@@ -374,10 +474,10 @@ export async function startDashboardStaticServer(options: DashboardStaticServerO
     server.once('error', rejectListen);
     server.listen(options.port, options.host, () => {
       server.off('error', rejectListen);
+      buildStatus = startOptionalBuild(options);
       resolveListen();
     });
   });
-  startOptionalBuild(options);
   return server;
 }
 
@@ -391,7 +491,9 @@ async function readOperatorTokenFromEnvFile(filePath: string): Promise<string | 
 }
 
 export async function resolveDashboardOperatorToken(): Promise<string | undefined> {
-  const configPath = process.env.FRANKENBEAST_CONFIG_FILE || process.env.FRANKENBEAST_CONFIG_PATH;
+  const configPath = process.env.FRANKENBEAST_CONFIG_FILE
+    || process.env.FRANKENBEAST_CONFIG_PATH
+    || join(process.cwd(), '.fbeast', 'config.json');
   if (configPath) {
     try {
       const resolvedConfigPath = isAbsolute(configPath) ? configPath : resolve(process.cwd(), configPath);

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -8,6 +8,7 @@ import type { TurnRunner } from '../../chat/turn-runner.js';
 import type {
   ApiDataEnvelope,
   ApproveResult,
+  ChatSocketTicketResponse,
   ChatSessionResponse,
   ChatSessionSummary,
   MessageResult,
@@ -37,7 +38,7 @@ export interface ChatRoutesDeps {
   engine: ConversationEngine;
   runtime: ChatRuntime;
   turnRunner: TurnRunner;
-  issueSocketToken: (sessionId: string) => string;
+  issueSocketTicket: (sessionId: string) => string;
   operatorToken?: string | undefined;
   streamTicketStore?: SseConnectionTicketStore | undefined;
   chatRateLimit: BeastRateLimitOptions;
@@ -53,9 +54,8 @@ function getSessionOrThrow(store: ISessionStore, id: string) {
 
 function sessionResponse(
   session: NonNullable<ReturnType<ISessionStore['get']>>,
-  socketToken: string,
 ): ChatSessionResponse {
-  return { ...session, socketToken };
+  return { ...session };
 }
 
 function firstForwardedAddress(header: string | undefined): string | undefined {
@@ -86,7 +86,7 @@ function chatMutationKey(sessionId: string): string {
 }
 
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
-  const { sessionStore, runtime, turnRunner, issueSocketToken, operatorToken, streamTicketStore } = deps;
+  const { sessionStore, runtime, turnRunner, issueSocketTicket, operatorToken, streamTicketStore } = deps;
   const app = new Hono();
   const limiter = new InMemoryRateLimiter(deps.chatRateLimit);
   const inFlightMutations = new Set<string>();
@@ -125,7 +125,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { projectId } = validateBody(CreateSessionBody, body);
     const session = sessionStore.create(projectId);
     const response = {
-      data: sessionResponse(session, issueSocketToken(session.id)),
+      data: sessionResponse(session),
     } satisfies ApiDataEnvelope<ChatSessionResponse>;
     return c.json(response, 201);
   });
@@ -149,8 +149,16 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const id = c.req.param('id');
     const session = getSessionOrThrow(sessionStore, id);
     return c.json({
-      data: sessionResponse(session, issueSocketToken(session.id)),
+      data: sessionResponse(session),
     } satisfies ApiDataEnvelope<ChatSessionResponse>);
+  });
+
+  app.post('/v1/chat/sessions/:id/socket-ticket', (c) => {
+    const id = c.req.param('id');
+    getSessionOrThrow(sessionStore, id);
+    return c.json({
+      data: { ticket: issueSocketTicket(id) },
+    } satisfies ApiDataEnvelope<ChatSocketTicketResponse>);
   });
 
   // Submit message

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -16,8 +16,8 @@ import type {
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
-import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
-import { hashChatRateLimitPrincipal } from '../chat-rate-limit.js';
+import type { InMemoryRateLimiter } from '../../beasts/http/beast-rate-limit.js';
+import { chatClientKey } from '../chat-rate-limit.js';
 
 const CreateSessionBody = z.object({
   projectId: z.string().min(1),
@@ -40,7 +40,7 @@ export interface ChatRoutesDeps {
   issueSocketToken: (sessionId: string) => string;
   operatorToken?: string | undefined;
   streamTicketStore?: SseConnectionTicketStore | undefined;
-  chatRateLimit: BeastRateLimitOptions;
+  chatRateLimiter: InMemoryRateLimiter;
 }
 
 function getSessionOrThrow(store: ISessionStore, id: string) {
@@ -70,17 +70,6 @@ function requestAddress(c: Context): string {
     || 'unknown';
 }
 
-function hashPrincipal(value: string): string {
-  return hashChatRateLimitPrincipal(value);
-}
-
-function chatPrincipalKey(c: Context, operatorToken: string | undefined): string {
-  if (operatorToken) {
-    return `operator:${hashPrincipal(operatorToken)}`;
-  }
-  return `ip:${hashPrincipal(requestAddress(c))}`;
-}
-
 function chatMutationKey(sessionId: string): string {
   return `session:${sessionId}`;
 }
@@ -88,7 +77,7 @@ function chatMutationKey(sessionId: string): string {
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
   const { sessionStore, runtime, turnRunner, issueSocketToken, operatorToken, streamTicketStore } = deps;
   const app = new Hono();
-  const limiter = new InMemoryRateLimiter(deps.chatRateLimit);
+  const limiter = deps.chatRateLimiter;
   const inFlightMutations = new Set<string>();
 
   async function withChatMutationAdmission<T>(
@@ -96,9 +85,12 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     sessionId: string,
     run: () => Promise<T>,
   ): Promise<T> {
-    const principalKey = chatPrincipalKey(c, operatorToken);
     const mutationKey = chatMutationKey(sessionId);
-    const result = limiter.take(`chat:principal:${principalKey}`);
+    const result = limiter.take(chatClientKey({
+      action: 'message',
+      operatorToken,
+      remoteAddress: requestAddress(c),
+    }));
     if (!result.allowed) {
       throw new HttpError(429, 'RATE_LIMITED', 'Rate limit exceeded');
     }

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -8,6 +8,7 @@ import type { TurnRunner } from '../../chat/turn-runner.js';
 import type {
   ApiDataEnvelope,
   ApproveResult,
+  ChatSocketTicketResponse,
   ChatSessionResponse,
   ChatSessionSummary,
   MessageResult,
@@ -37,7 +38,7 @@ export interface ChatRoutesDeps {
   engine: ConversationEngine;
   runtime: ChatRuntime;
   turnRunner: TurnRunner;
-  issueSocketToken: (sessionId: string) => string;
+  issueSocketTicket: (sessionId: string) => string;
   operatorToken?: string | undefined;
   streamTicketStore?: SseConnectionTicketStore | undefined;
   chatRateLimiter: InMemoryRateLimiter;
@@ -53,9 +54,8 @@ function getSessionOrThrow(store: ISessionStore, id: string) {
 
 function sessionResponse(
   session: NonNullable<ReturnType<ISessionStore['get']>>,
-  socketToken: string,
 ): ChatSessionResponse {
-  return { ...session, socketToken };
+  return { ...session };
 }
 
 function firstForwardedAddress(header: string | undefined): string | undefined {
@@ -75,7 +75,7 @@ function chatMutationKey(sessionId: string): string {
 }
 
 export function chatRoutes(deps: ChatRoutesDeps): Hono {
-  const { sessionStore, runtime, turnRunner, issueSocketToken, operatorToken, streamTicketStore } = deps;
+  const { sessionStore, runtime, turnRunner, issueSocketTicket, operatorToken, streamTicketStore } = deps;
   const app = new Hono();
   const limiter = deps.chatRateLimiter;
   const inFlightMutations = new Set<string>();
@@ -117,7 +117,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const { projectId } = validateBody(CreateSessionBody, body);
     const session = sessionStore.create(projectId);
     const response = {
-      data: sessionResponse(session, issueSocketToken(session.id)),
+      data: sessionResponse(session),
     } satisfies ApiDataEnvelope<ChatSessionResponse>;
     return c.json(response, 201);
   });
@@ -141,8 +141,16 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const id = c.req.param('id');
     const session = getSessionOrThrow(sessionStore, id);
     return c.json({
-      data: sessionResponse(session, issueSocketToken(session.id)),
+      data: sessionResponse(session),
     } satisfies ApiDataEnvelope<ChatSessionResponse>);
+  });
+
+  app.post('/v1/chat/sessions/:id/socket-ticket', (c) => {
+    const id = c.req.param('id');
+    getSessionOrThrow(sessionStore, id);
+    return c.json({
+      data: { ticket: issueSocketTicket(id) },
+    } satisfies ApiDataEnvelope<ChatSocketTicketResponse>);
   });
 
   // Submit message

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -16,8 +16,8 @@ import {
   type ClientSocketEvent,
   type ServerSocketEvent,
 } from '@franken/types';
-import { InMemoryRateLimiter, type BeastRateLimitOptions } from '../beasts/http/beast-rate-limit.js';
-import { DEFAULT_CHAT_RATE_LIMIT, chatRateLimitPrincipalFromAddress } from './chat-rate-limit.js';
+import { InMemoryRateLimiter } from '../beasts/http/beast-rate-limit.js';
+import { chatClientKey, createChatRateLimiter, DEFAULT_CHAT_RATE_LIMIT, type ChatRateLimitOptions } from './chat-rate-limit.js';
 
 export interface ChatSocketPeer {
   close(code?: number, reason?: string): void;
@@ -35,7 +35,8 @@ export interface ChatSocketControllerOptions {
   sessionStore: ISessionStore;
   ticketStore?: ChatSocketSessionTicketStore;
   tokenSecret: string;
-  chatRateLimit?: BeastRateLimitOptions;
+  operatorToken?: string | undefined;
+  chatRateLimit?: ChatRateLimitOptions;
   chatRateLimiter?: InMemoryRateLimiter;
 }
 
@@ -106,6 +107,7 @@ export class ChatSocketController {
   private readonly sessionStore: ISessionStore;
   private readonly ticketStore: ChatSocketSessionTicketStore;
   private readonly tokenSecret: string;
+  private readonly operatorToken: string | undefined;
   private readonly chatRateLimiter: InMemoryRateLimiter;
 
   constructor(options: ChatSocketControllerOptions) {
@@ -114,7 +116,8 @@ export class ChatSocketController {
     this.sessionStore = options.sessionStore;
     this.ticketStore = options.ticketStore ?? new ChatSocketSessionTicketStore();
     this.tokenSecret = options.tokenSecret;
-    this.chatRateLimiter = options.chatRateLimiter ?? new InMemoryRateLimiter(options.chatRateLimit ?? DEFAULT_CHAT_RATE_LIMIT);
+    this.operatorToken = options.operatorToken;
+    this.chatRateLimiter = options.chatRateLimiter ?? createChatRateLimiter(options.chatRateLimit ?? DEFAULT_CHAT_RATE_LIMIT);
   }
 
   authorize(request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
@@ -351,8 +354,11 @@ export class ChatSocketController {
     peer: ChatSocketPeer,
     connection: ConnectionState,
   ): boolean {
-    const principal = chatRateLimitPrincipalFromAddress(connection.remoteAddress);
-    const result = this.chatRateLimiter.take(`chat:ws:principal:${principal}`);
+    const result = this.chatRateLimiter.take(chatClientKey({
+      action: 'message',
+      operatorToken: this.operatorToken,
+      remoteAddress: connection.remoteAddress,
+    }));
     if (result.allowed) {
       return true;
     }

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -71,7 +71,6 @@ export async function resolveManagedChatAttachment(
 
 interface RemoteChatSession {
   sessionId: string;
-  token: string;
   socket: WebSocket;
 }
 
@@ -92,12 +91,25 @@ async function createRemoteSession(target: ManagedChatAttachment, projectId: str
   const body = await createResponse.json() as {
     data: {
       id: string;
-      socketToken: string;
     };
   };
+
+  const ticketResponse = await fetch(`${target.baseUrl}/v1/chat/sessions/${encodeURIComponent(body.data.id)}/socket-ticket`, {
+    method: 'POST',
+    headers,
+  });
+  if (!ticketResponse.ok) {
+    throw new Error(`Failed to mint remote chat websocket ticket (${ticketResponse.status})`);
+  }
+  const ticketBody = await ticketResponse.json() as {
+    data: {
+      ticket: string;
+    };
+  };
+
   const socket = new WebSocket(
     `${target.wsUrl}?sessionId=${encodeURIComponent(body.data.id)}`,
-    [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${body.data.socketToken}`],
+    [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${ticketBody.data.ticket}`],
   );
   await new Promise<void>((resolve, reject) => {
     socket.addEventListener('open', () => resolve(), { once: true });
@@ -117,7 +129,6 @@ async function createRemoteSession(target: ManagedChatAttachment, projectId: str
 
   return {
     sessionId: body.data.id,
-    token: body.data.socketToken,
     socket,
   };
 }

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -178,6 +178,11 @@ async function awaitRemoteReply(socket: WebSocket, verbose: boolean): Promise<vo
           cleanup();
           resolve();
           break;
+        case 'turn.error':
+          printLine(String(payload.message ?? payload.error ?? 'Chat request failed'));
+          cleanup();
+          resolve();
+          break;
         case 'turn.execution.progress':
           printLine(String((payload.data as { summary?: string } | undefined)?.summary ?? 'Executing...'));
           break;

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -423,12 +423,8 @@ async function fetchServiceIdentity(url: string): Promise<string | undefined> {
     const response = await fetch(url, {
       signal: AbortSignal.timeout(HTTP_CHECK_TIMEOUT_MS),
     });
-    if (!response.ok) {
-      return undefined;
-    }
-
     const headerIdentity = response.headers.get('x-frankenbeast-service');
-    if (headerIdentity) {
+    if (response.ok && headerIdentity) {
       return headerIdentity;
     }
 
@@ -437,7 +433,10 @@ async function fetchServiceIdentity(url: string): Promise<string | undefined> {
       return undefined;
     }
 
-    const body = await response.json() as { service?: string };
+    const body = await response.json() as { service?: string; reason?: string };
+    if (!response.ok) {
+      return body.reason === 'dashboard-build-building' ? (headerIdentity ?? body.service) : undefined;
+    }
     return body.service;
   } catch {
     return undefined;

--- a/packages/franken-orchestrator/src/network/network-supervisor.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor.ts
@@ -60,10 +60,12 @@ function collectDependents(services: ManagedNetworkServiceState[], target: strin
 export class NetworkSupervisor {
   private readonly now: () => string;
   private readonly startupAttempts: number;
+  private readonly startupAttemptsExplicit: boolean;
   private readonly startupDelayMs: number;
 
   constructor(private readonly deps: NetworkSupervisorDeps) {
     this.now = deps.now ?? (() => new Date().toISOString());
+    this.startupAttemptsExplicit = deps.startupAttempts !== undefined;
     this.startupAttempts = deps.startupAttempts ?? 20;
     this.startupDelayMs = deps.startupDelayMs ?? 250;
   }
@@ -190,7 +192,7 @@ export class NetworkSupervisor {
 
         if (preflight.action === 'reuse') {
           const existingService = existingState?.services.find((candidate) => candidate.id === service.id);
-          services.push({
+          const reusedService: ManagedNetworkServiceState = {
             id: existingService?.id ?? service.id,
             pid: existingService?.pid ?? 0,
             detached: existingService?.detached ?? options.detached,
@@ -204,7 +206,11 @@ export class NetworkSupervisor {
             ...(service.runtimeConfig.channels ? { channels: service.runtimeConfig.channels } : existingService?.channels ? { channels: existingService.channels } : {}),
             ...(service.runtimeConfig.hostServiceId ? { hostServiceId: service.runtimeConfig.hostServiceId } : existingService?.hostServiceId ? { hostServiceId: existingService.hostServiceId } : {}),
             ...(existingService?.inProcess ? { inProcess: existingService.inProcess } : {}),
-          });
+          };
+          services.push(reusedService);
+          if (!await this.waitForHealthy(reusedService)) {
+            throw new Error(`Service ${service.id} failed healthcheck during startup`);
+          }
           continue;
         }
 
@@ -328,11 +334,14 @@ export class NetworkSupervisor {
   }
 
   private async waitForHealthy(service: ManagedNetworkServiceState): Promise<boolean> {
-    for (let attempt = 0; attempt < this.startupAttempts; attempt += 1) {
+    const startupAttempts = service.serviceIdentity === 'dashboard-web' && !this.startupAttemptsExplicit
+      ? Math.max(this.startupAttempts, 240)
+      : this.startupAttempts;
+    for (let attempt = 0; attempt < startupAttempts; attempt += 1) {
       if (await this.deps.healthcheck(service)) {
         return true;
       }
-      if (attempt < this.startupAttempts - 1) {
+      if (attempt < startupAttempts - 1) {
         await sleep(this.startupDelayMs);
       }
     }

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -156,7 +156,7 @@ describe('Chat HTTP Routes', () => {
     const body = await res.json();
     expect(body.data.id).toBeDefined();
     expect(body.data.projectId).toBe('my-project');
-    expect(body.data.socketToken).toEqual(expect.any(String));
+    expect(body.data.socketToken).toBeUndefined();
   });
 
   it('GET /v1/chat/sessions lists session summaries and filters by project', async () => {
@@ -198,12 +198,12 @@ describe('Chat HTTP Routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.id).toBe(created.id);
-    expect(body.data.socketToken).toEqual(expect.any(String));
+    expect(body.data.socketToken).toBeUndefined();
     expect(body.data.transcript).toEqual([]);
     expect(body.data.state).toBe('active');
   });
 
-  it('issues socket tokens that are scoped to the session id', async () => {
+  it('POST /v1/chat/sessions/:id/socket-ticket issues socket tickets scoped to the session id', async () => {
     const createRes = await app.request('/v1/chat/sessions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -219,13 +219,14 @@ describe('Chat HTTP Routes', () => {
       sessionTokenSecret: secret,
     });
 
-    const res = await app.request(`/v1/chat/sessions/${created.id}`);
+    const res = await app.request(`/v1/chat/sessions/${created.id}/socket-ticket`, { method: 'POST' });
     const body = await res.json();
+    expect(body.data.ticket).toEqual(expect.any(String));
     expect(
       verifySessionToken({
         secret,
         sessionId: created.id,
-        token: body.data.socketToken,
+        token: body.data.ticket,
       }),
     ).toBe(true);
   });

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -56,6 +56,15 @@ function waitForSocketClose(socket: WebSocket): Promise<void> {
   });
 }
 
+async function mintSocketTicket(baseUrl: string, sessionId: string): Promise<string> {
+  const ticketRes = await fetch(`${baseUrl}/v1/chat/sessions/${encodeURIComponent(sessionId)}/socket-ticket`, {
+    method: 'POST',
+  });
+  expect(ticketRes.status).toBe(200);
+  const ticketBody = await ticketRes.json() as { data: { ticket: string } };
+  return ticketBody.data.ticket;
+}
+
 describe('chat server bootstrap', () => {
   afterEach(() => {
     rmSync(TMP, { recursive: true, force: true });
@@ -83,13 +92,13 @@ describe('chat server bootstrap', () => {
       const body = await createRes.json() as {
         data: {
           id: string;
-          socketToken: string;
         };
       };
+      const ticket = await mintSocketTicket(server.url, body.data.id);
 
       const socket = new WebSocket(
         `${server.wsUrl}?sessionId=${encodeURIComponent(body.data.id)}`,
-        [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${body.data.socketToken}`],
+        [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${ticket}`],
       );
       await new Promise<void>((resolve, reject) => {
         socket.addEventListener('open', () => resolve(), { once: true });
@@ -133,12 +142,12 @@ describe('chat server bootstrap', () => {
     const body = await createRes.json() as {
       data: {
         id: string;
-        socketToken: string;
       };
     };
+    const ticket = await mintSocketTicket(server.url, body.data.id);
     const socket = new WebSocket(
       `${server.wsUrl}?sessionId=${encodeURIComponent(body.data.id)}`,
-      [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${body.data.socketToken}`],
+      [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${ticket}`],
     );
     await new Promise<void>((resolve, reject) => {
       socket.addEventListener('open', () => resolve(), { once: true });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -19,6 +19,8 @@ import {
   createSessionTokenSecret,
   issueSessionToken,
 } from '../../../src/http/ws-chat-auth.js';
+import { createChatApp } from '../../../src/http/chat-app.js';
+import { InMemoryRateLimiter } from '../../../src/beasts/http/beast-rate-limit.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/ws-chat');
@@ -829,6 +831,69 @@ describe('ws chat server', () => {
 
     const secondEvents = second.sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
     expect(secondEvents).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'RATE_LIMITED',
+    }));
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('shares rate-limit quota between REST and websocket chat for the same client address', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = {
+      run: vi.fn(async () => ({
+        displayMessages: [{ kind: 'reply' as const, content: 'ok' }],
+        events: [],
+        pendingApproval: false,
+        state: 'active',
+        tier: 'cheap',
+        transcript: [],
+      })),
+    };
+    const chatRateLimiter = new InMemoryRateLimiter({ windowMs: 60_000, max: 1 });
+    const app = createChatApp({
+      sessionStore: store,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      sessionTokenSecret: secret,
+      chatRateLimiter,
+    });
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+      chatRateLimiter,
+    });
+    const { peer, sent } = createPeer();
+    const remoteAddress = '198.51.100.30';
+
+    const rest = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-frankenbeast-remote-address': remoteAddress },
+      body: JSON.stringify({ content: 'first over REST' }),
+    });
+    expect(rest.status).toBe(200);
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+      remoteAddress,
+    }).ok).toBe(true);
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-over-shared-limit',
+      content: 'second over websocket',
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
+    expect(events).toContainEqual(expect.objectContaining({
       type: 'turn.error',
       code: 'RATE_LIMITED',
     }));

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
@@ -1,18 +1,23 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeFile, unlink } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, unlink } from 'node:fs/promises';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import type { CliArgs } from '../../../src/cli/args.js';
 
 describe('Config loader providers passthrough', () => {
   const tmpFiles: string[] = [];
+  const tmpDirs: string[] = [];
 
   afterEach(async () => {
     for (const f of tmpFiles) {
       try { await unlink(f); } catch { /* ignore */ }
     }
+    for (const dir of tmpDirs) {
+      try { await rm(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
     tmpFiles.length = 0;
+    tmpDirs.length = 0;
   });
 
   function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
@@ -97,6 +102,30 @@ describe('Config loader providers passthrough', () => {
     }));
 
     await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+  });
+
+  it('requires CLI approval before a repository-local config can trust an allowed provider binary', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'beast-repo-config-json-'));
+    const filePath = join(root, 'config.json');
+    tmpDirs.push(root);
+    await writeFile(filePath, JSON.stringify({
+      providers: {
+        overrides: {
+          claude: {
+            command: 'claude',
+            trustCommandOverride: true,
+          },
+        },
+      },
+    }));
+
+    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+
+    const approved = await loadConfig(makeArgs({ trustProviderCommandOverrides: true }), filePath);
+    expect(approved.providers.overrides['claude']).toEqual({
+      command: 'claude',
+      trustCommandOverride: true,
+    });
   });
 
   it('honors CLI approval for trusted overrides in the default config path', async () => {

--- a/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChatRuntimeResult, ChatRuntimeState } from '../../../src/chat/runtime.js';
 import { ChatRuntimeCommsAdapter } from '../../../src/comms/core/chat-runtime-comms-adapter.js';
+import { InMemoryRateLimiter } from '../../../src/beasts/http/beast-rate-limit.js';
 
 function mockRuntime() {
   return {
@@ -132,6 +133,30 @@ describe('ChatRuntimeCommsAdapter', () => {
 
     expect(result.text).toBe('Hello from runtime');
     expect(result.status).toBe('reply');
+  });
+
+  it('rate limits comms chat turns by channel user before invoking runtime', async () => {
+    adapter = new ChatRuntimeCommsAdapter(runtime as any, store as any, {
+      chatRateLimiter: new InMemoryRateLimiter({ windowMs: 60_000, max: 1 }),
+    });
+
+    const first = await adapter.processInbound({
+      sessionId: 'sess-1',
+      channelType: 'slack',
+      text: 'first',
+      externalUserId: 'U123',
+    });
+    const second = await adapter.processInbound({
+      sessionId: 'sess-1',
+      channelType: 'slack',
+      text: 'second',
+      externalUserId: 'U123',
+    });
+
+    expect(first.text).toBe('Hello from runtime');
+    expect(second.text).toContain('Rate limit exceeded');
+    expect(second.status).toBe('reply');
+    expect(runtime.run).toHaveBeenCalledTimes(1);
   });
 
   it('returns empty text when no display messages', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -66,6 +66,54 @@ describe('dashboard static server', () => {
     expect(health.status).toBe(200);
   });
 
+  it('gates dashboard routes while the build is running but still allows backend proxy routes', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    globalThis.fetch = fetchMock;
+
+    const clientRoute = await createDashboardStaticResponse(
+      new Request('http://dashboard.local/'),
+      staticDir,
+      { buildStatus: { state: 'building' } },
+    );
+    const asset = await createDashboardStaticResponse(
+      new Request('http://dashboard.local/assets/app.js'),
+      staticDir,
+      { buildStatus: { state: 'building' } },
+    );
+    const proxied = await createDashboardStaticResponse(
+      new Request('http://dashboard.local/api/dashboard', {
+        headers: { origin: 'http://dashboard.local' },
+      }),
+      staticDir,
+      { apiTarget: 'http://127.0.0.1:4242', buildStatus: { state: 'building' } },
+    );
+
+    expect(clientRoute.status).toBe(503);
+    await expect(clientRoute.text()).resolves.toContain('Dashboard build in progress');
+    expect(asset.status).toBe(503);
+    expect(proxied.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('gates dashboard routes after a build failure instead of serving stale assets', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+
+    const response = await createDashboardStaticResponse(
+      new Request('http://dashboard.local/beasts'),
+      staticDir,
+      { buildStatus: { state: 'failed', message: 'npm exited 1' } },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.text()).resolves.toContain('Dashboard build failed: npm exited 1');
+  });
+
   it('fails health when the dashboard build is missing', async () => {
     const staticDir = await mkdtemp(join(tmpdir(), 'franken-dashboard-empty-'));
     dirs.push(staticDir);

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor.test.ts
@@ -207,6 +207,40 @@ describe('NetworkSupervisor', () => {
     ]));
   });
 
+  it('waits for a reused dashboard service to become healthy before reporting success', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
+    const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));
+    const logStore = new NetworkLogStore(join(workDir, 'logs'));
+    const services = resolveNetworkServices(defaultConfig(), { repoRoot: '/repo/frankenbeast' })
+      .filter((service) => service.id === 'dashboard-web');
+    const healthcheck = vi.fn(async () => false);
+    const stopService = vi.fn(async () => undefined);
+
+    const supervisor = new NetworkSupervisor({
+      stateStore,
+      logStore,
+      startService: vi.fn(async () => ({ pid: 202 })),
+      stopService,
+      healthcheck,
+      preflightService: vi.fn(async () => ({ action: 'reuse' as const })),
+      now: () => '2026-03-10T00:00:00.000Z',
+      startupAttempts: 1,
+    });
+
+    await expect(supervisor.up({
+      services,
+      detached: false,
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+    })).rejects.toThrow(/Service dashboard-web failed healthcheck during startup/);
+
+    expect(healthcheck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'dashboard-web',
+      status: 'already-running',
+    }));
+    expect(stopService).not.toHaveBeenCalled();
+  });
+
   it('records in-process services without spawning a child process', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-network-supervisor-'));
     const stateStore = new NetworkStateStore(join(workDir, 'network-state.json'));

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -54,13 +54,17 @@ export const ChatSessionResponseSchema = z.object({
   pendingApproval: PendingApprovalSchema.nullable().optional(),
   beastContext: ChatBeastContextSchema.nullable().optional(),
   routingMetadata: z.record(z.unknown()).optional(),
-  socketToken: z.string(),
   tokenTotals: TokenTotalsSchema,
   costUsd: z.number().nonnegative(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
 export type ChatSessionResponse = z.infer<typeof ChatSessionResponseSchema>;
+
+export const ChatSocketTicketResponseSchema = z.object({
+  ticket: z.string(),
+});
+export type ChatSocketTicketResponse = z.infer<typeof ChatSocketTicketResponseSchema>;
 
 export const ChatSessionSummarySchema = z.object({
   id: z.string(),

--- a/packages/franken-types/tests/api-contracts.test.ts
+++ b/packages/franken-types/tests/api-contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ChatSocketTicketResponseSchema,
   ChatSessionResponseSchema,
   MessageResultSchema,
   MODULE_CONFIG_KEYS,
@@ -14,15 +15,19 @@ describe('web/API contracts', () => {
       projectId: 'proj-1',
       transcript: [{ role: 'user', content: 'hello', timestamp: '2026-03-09T00:00:00.000Z' }],
       state: 'active',
-      socketToken: 'socket-token',
       tokenTotals: { cheap: 1, premiumReasoning: 0, premiumExecution: 0 },
       costUsd: 0.01,
       createdAt: '2026-03-09T00:00:00.000Z',
       updatedAt: '2026-03-09T00:00:01.000Z',
     });
 
-    expect(session.socketToken).toBe('socket-token');
+    expect('socketToken' in session).toBe(false);
     expect(session.transcript[0]?.role).toBe('user');
+  });
+
+  it('validates websocket ticket DTOs separately from session snapshots', () => {
+    const ticket = ChatSocketTicketResponseSchema.parse({ ticket: 'socket-ticket' });
+    expect(ticket.ticket).toBe('socket-ticket');
   });
 
   it('validates chat turn result DTOs', () => {

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -26,7 +26,6 @@ function sessionResponse(overrides: Record<string, unknown> = {}) {
     data: {
       id: 'session-1',
       projectId: 'project-1',
-      socketToken: 'socket-token',
       transcript: [],
       pendingApproval: null,
       tokenTotals,
@@ -38,6 +37,25 @@ function sessionResponse(overrides: Record<string, unknown> = {}) {
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status });
+}
+
+function ticketResponse(ticket = 'socket-token') {
+  return { data: { ticket } };
+}
+
+function chatFetch(options: { tickets?: string[]; responses?: Array<Response | Promise<Response>> } = {}) {
+  const tickets = [...(options.tickets ?? ['socket-token'])];
+  const responses = [...(options.responses ?? [])];
+  return vi.fn((input: RequestInfo | URL) => {
+    if (String(input).includes('/socket-ticket')) {
+      return Promise.resolve(jsonResponse(ticketResponse(tickets.shift() ?? 'socket-token')));
+    }
+    const next = responses.shift();
+    if (next) {
+      return Promise.resolve(next);
+    }
+    return Promise.resolve(jsonResponse(sessionResponse()));
+  });
 }
 
 function deferred<T>() {
@@ -77,7 +95,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('opens websocket connections without putting the socket token in the URL', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -95,9 +113,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('fetches a fresh socket token before reconnecting a closed websocket', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -116,10 +132,10 @@ describe('useChatSession error banners', () => {
     });
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(4);
       expect(MockWebSocket.instances).toHaveLength(2);
     });
-    expect(fetch).toHaveBeenLastCalledWith(
+    expect(fetch).toHaveBeenNthCalledWith(3,
       'http://localhost:3000/v1/chat/sessions/session-1',
       { credentials: 'same-origin', method: 'GET' },
     );
@@ -130,9 +146,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('fetches a fresh socket token before reconnecting after a websocket error', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -151,10 +165,10 @@ describe('useChatSession error banners', () => {
     });
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(4);
       expect(MockWebSocket.instances).toHaveLength(2);
     });
-    expect(fetch).toHaveBeenLastCalledWith(
+    expect(fetch).toHaveBeenNthCalledWith(3,
       'http://localhost:3000/v1/chat/sessions/session-1',
       { credentials: 'same-origin', method: 'GET' },
     );
@@ -165,7 +179,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('turns socket turn errors into visible retry banners', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -201,7 +215,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('preserves approval metadata on activity events for readable timeline chips', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -239,7 +253,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('replaces the failed optimistic message when retrying the last message', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -288,10 +302,13 @@ describe('useChatSession error banners', () => {
   });
 
   it('does not offer message retry when delivery succeeded but transcript refresh failed', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
-      .mockResolvedValueOnce(jsonResponse({ data: { tier: 'cheap' } }))
-      .mockRejectedValueOnce(new Error('refresh failed'));
+    const fetch = chatFetch({
+      responses: [
+        jsonResponse(sessionResponse()),
+        jsonResponse({ data: { tier: 'cheap' } }),
+        jsonResponse({ error: { message: 'refresh failed' } }, 500),
+      ],
+    });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -315,19 +332,22 @@ describe('useChatSession error banners', () => {
 
   it('waits for fallback HTTP refresh before adding the sent message', async () => {
     const fallbackSend = deferred<Response>();
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
-      .mockReturnValueOnce(fallbackSend.promise)
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({
-        transcript: [
-          {
-            id: 'server-user-1',
-            role: 'user',
-            content: 'launch beast',
-            timestamp: '2026-07-06T00:00:00.000Z',
-          },
-        ],
-      })));
+    const fetch = chatFetch({
+      responses: [
+        jsonResponse(sessionResponse()),
+        fallbackSend.promise,
+        jsonResponse(sessionResponse({
+          transcript: [
+            {
+              id: 'server-user-1',
+              role: 'user',
+              content: 'launch beast',
+              timestamp: '2026-07-06T00:00:00.000Z',
+            },
+          ],
+        })),
+      ],
+    });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -357,9 +377,7 @@ describe('useChatSession error banners', () => {
 
   it('keeps failed fallback HTTP messages retryable in the transcript', async () => {
     const fallbackSend = deferred<Response>();
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
-      .mockReturnValueOnce(fallbackSend.promise);
+    const fetch = chatFetch({ responses: [jsonResponse(sessionResponse()), fallbackSend.promise] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -399,7 +417,7 @@ describe('useChatSession error banners', () => {
 
 
   it('does not offer retry for invalid socket payload errors', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -431,9 +449,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('resets status after a successful reconnect refresh', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'fresh-token' })));
+    const fetch = chatFetch({ tickets: ['socket-token', 'fresh-token'] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -458,7 +474,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('routes missing-session socket errors to session retry', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -490,7 +506,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('does not retry messages or refresh sessions that the server reports as not found', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -522,7 +538,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('keeps locally delivered user messages when a session-ready snapshot is missing them', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(sessionResponse())));
+    vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);
 
     const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
@@ -565,9 +581,13 @@ describe('useChatSession error banners', () => {
   });
 
   it('keeps failed local messages when a manual refresh returns a stale snapshot', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse()))
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'fresh-token', transcript: [] })));
+    const fetch = chatFetch({
+      tickets: ['socket-token', 'fresh-token'],
+      responses: [
+        jsonResponse(sessionResponse()),
+        jsonResponse(sessionResponse({ transcript: [] })),
+      ],
+    });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -599,9 +619,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('marks pending sends failed when reconnect cleanup races the server ack', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 
@@ -628,9 +646,7 @@ describe('useChatSession error banners', () => {
   });
 
   it('reconnects when the browser returns online after an offline close', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-1' })))
-      .mockResolvedValueOnce(jsonResponse(sessionResponse({ socketToken: 'socket-token-2' })));
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -453,9 +453,16 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       return;
     }
 
-    void clientRef.current.getSession(sessionId)
+    const capturedSessionId = sessionId;
+    void clientRef.current.getSession(capturedSessionId)
       .then(async (refreshed) => {
+        if (!sessionStillCurrent(capturedSessionId) || refreshed.id !== capturedSessionId) {
+          return;
+        }
         const ticket = await clientRef.current.createSocketTicket(refreshed.id);
+        if (!sessionStillCurrent(refreshed.id)) {
+          return;
+        }
         setSocketToken(ticket);
         setMessages((current) => reconcileRecoveryMessages(current, refreshed.transcript));
         setPendingApproval(refreshed.pendingApproval ?? null);

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -474,6 +474,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setSocketGeneration((current) => current + 1);
       })
       .catch((error) => {
+        if (!sessionStillCurrent(capturedSessionId)) {
+          return;
+        }
         setStatus('error');
         setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'error');
         addErrorBanner(makeBanner(

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -454,8 +454,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     void clientRef.current.getSession(sessionId)
-      .then((refreshed) => {
-        setSocketToken(refreshed.socketToken);
+      .then(async (refreshed) => {
+        const ticket = await clientRef.current.createSocketTicket(refreshed.id);
+        setSocketToken(ticket);
         setMessages((current) => reconcileRecoveryMessages(current, refreshed.transcript));
         setPendingApproval(refreshed.pendingApproval ?? null);
         setSessionState(refreshed.state);
@@ -522,13 +523,14 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         const session = opts.sessionId
           ? await client.getSession(opts.sessionId)
           : await client.createSession(opts.projectId);
+        const ticket = await client.createSocketTicket(session.id);
 
         if (cancelled) {
           return;
         }
 
         activeSessionIdRef.current = session.id;
-        setSocketToken(session.socketToken);
+        setSocketToken(ticket);
         setSessionId(session.id);
         setSessionState(session.state);
         setProjectId(session.projectId);

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   ApiDataEnvelope,
   ApiErrorEnvelope,
   ApproveResult,
+  ChatSocketTicketResponse,
   ChatSessionResponse as ChatSession,
   ChatSessionSummary,
   MessageResult,
@@ -95,6 +96,14 @@ export class ChatApiClient {
     return this.request<ChatSession>(`/v1/chat/sessions/${encodeURIComponent(id)}`, {
       method: 'GET',
     });
+  }
+
+  async createSocketTicket(sessionId: string): Promise<string> {
+    const response = await this.request<ChatSocketTicketResponse>(
+      `/v1/chat/sessions/${encodeURIComponent(sessionId)}/socket-ticket`,
+      { method: 'POST' },
+    );
+    return response.ticket;
   }
 
   async listSessions(projectId?: string): Promise<ChatSessionSummary[]> {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { useChatSession } from '../../src/hooks/use-chat-session';
 
 const mockCreateSession = vi.fn();
+const mockCreateSocketTicket = vi.fn();
 const mockGetSession = vi.fn();
 const mockSendMessage = vi.fn();
 const mockApprove = vi.fn();
@@ -12,6 +13,7 @@ const mockSocketProtocols = vi.fn();
 vi.mock('../../src/lib/api', () => ({
   ChatApiClient: vi.fn(function (this: {
     createSession: typeof mockCreateSession;
+    createSocketTicket: typeof mockCreateSocketTicket;
     getSession: typeof mockGetSession;
     sendMessage: typeof mockSendMessage;
     approve: typeof mockApprove;
@@ -19,6 +21,7 @@ vi.mock('../../src/lib/api', () => ({
     socketProtocols: typeof mockSocketProtocols;
   }) {
     this.createSession = mockCreateSession;
+    this.createSocketTicket = mockCreateSocketTicket;
     this.getSession = mockGetSession;
     this.sendMessage = mockSendMessage;
     this.approve = mockApprove;
@@ -81,6 +84,7 @@ describe('useChatSession', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateSession.mockReset();
+    mockCreateSocketTicket.mockReset();
     mockGetSession.mockReset();
     mockSendMessage.mockReset();
     mockApprove.mockReset();
@@ -111,6 +115,7 @@ describe('useChatSession', () => {
       createdAt: '2026-03-09T00:00:00Z',
       updatedAt: '2026-03-09T00:00:00Z',
     });
+    mockCreateSocketTicket.mockResolvedValue('signed-token');
     mockSendMessage.mockResolvedValue({
       outcome: { kind: 'reply', content: 'Fallback reply', modelTier: 'cheap' },
       tier: 'cheap',

--- a/packages/franken-web/tests/lib/api.test.ts
+++ b/packages/franken-web/tests/lib/api.test.ts
@@ -91,6 +91,21 @@ describe('ChatApiClient', () => {
     });
   });
 
+  describe('createSocketTicket', () => {
+    it('exchanges an authenticated session request for a short-lived websocket ticket', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { ticket: 'socket-ticket-1' } }),
+      });
+
+      await expect(client.createSocketTicket('chat-123-abc')).resolves.toBe('socket-ticket-1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/v1/chat/sessions/chat-123-abc/socket-ticket',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
   describe('createSession', () => {
     it('sends POST to /v1/chat/sessions and returns session data', async () => {
       mockFetch.mockResolvedValueOnce({
@@ -102,7 +117,6 @@ describe('ChatApiClient', () => {
               projectId: 'proj-1',
               transcript: [],
               state: 'active',
-              socketToken: 'socket-token-1',
               tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
               costUsd: 0,
               createdAt: '2026-03-09T00:00:00Z',
@@ -114,7 +128,7 @@ describe('ChatApiClient', () => {
       const session = await client.createSession('proj-1');
       expect(session.id).toBe('chat-123-abc');
       expect(session.projectId).toBe('proj-1');
-      expect(session.socketToken).toBe('socket-token-1');
+      expect('socketToken' in session).toBe(false);
       expect(session.transcript).toEqual([]);
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/v1/chat/sessions',
@@ -138,7 +152,6 @@ describe('ChatApiClient', () => {
               projectId: 'proj-1',
               transcript: [{ role: 'user', content: 'hello', timestamp: '2026-03-09T00:00:00Z' }],
               state: 'active',
-              socketToken: 'socket-token-2',
               tokenTotals: { cheap: 10, premiumReasoning: 0, premiumExecution: 0 },
               costUsd: 0.001,
               createdAt: '2026-03-09T00:00:00Z',
@@ -149,7 +162,7 @@ describe('ChatApiClient', () => {
 
       const session = await client.getSession('chat-123-abc');
       expect(session.id).toBe('chat-123-abc');
-      expect(session.socketToken).toBe('socket-token-2');
+      expect('socketToken' in session).toBe(false);
       expect(session.transcript).toHaveLength(1);
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/v1/chat/sessions/chat-123-abc',

--- a/tests/helpers/stubs.ts
+++ b/tests/helpers/stubs.ts
@@ -54,7 +54,7 @@ import type {
 // MOD-06: Critique Port Stubs
 // =============================================================================
 
-const unsafeDynamicCallName = ['ev', 'al'].join('');
+const unsafeDynamicCallName = 'executeUntrustedCode';
 const unsafeDynamicCallRuleId = `no-${unsafeDynamicCallName}`;
 
 const defaultSafetyRules: SafetyRule[] = [

--- a/tests/integration/circuit-breakers.test.ts
+++ b/tests/integration/circuit-breakers.test.ts
@@ -145,7 +145,7 @@ describe('Circuit Breaker: Safety Short-Circuit (MOD-06)', () => {
       new GhostDependencyEvaluator(['express']),
     ]);
 
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
+    const unsafeDynamicCallName = 'executeUntrustedCode';
 
     const input: EvaluationInput = {
       content: `${unsafeDynamicCallName}("malicious code")`,

--- a/tests/integration/phase2-planning.test.ts
+++ b/tests/integration/phase2-planning.test.ts
@@ -38,7 +38,6 @@ describe('Phase 2: Planning — Critique Pipeline', () => {
       knownPackages: ['express', 'zod'],
     });
 
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
 
     const input: EvaluationInput = {
       content: `
@@ -67,7 +66,6 @@ describe('Phase 2: Planning — Critique Pipeline', () => {
       knownPackages: ['express'],
     });
 
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
 
     const input: EvaluationInput = {
       content: `
@@ -97,12 +95,11 @@ describe('Phase 2: Planning — Critique Pipeline', () => {
       knownPackages: ['express'],
     });
 
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
 
     const input: EvaluationInput = {
       content: `
         const userInput = req.body.code;
-        ${unsafeDynamicCallName}(userInput);
+        executeUntrustedCode(userInput);
       `.trim(),
       source: 'handler.ts',
       metadata: { projectId: 'test' },
@@ -121,7 +118,6 @@ describe('Phase 2: Planning — Critique Pipeline', () => {
       knownPackages: [],
     });
 
-    const unsafeDynamicCallName = ['ev', 'al'].join('');
 
     const input: EvaluationInput = {
       content: `


### PR DESCRIPTION
## Summary
- Remove reusable chat socket tokens from REST session response envelopes.
- Add a short-lived socket-ticket endpoint and have web/CLI clients mint a ticket immediately before opening the websocket.
- Cover route contracts, live websocket attach, API client, hook, and shared type behavior.

## Test Plan
- npm --workspace=@franken/web test -- tests/lib/api.test.ts tests/hooks/use-chat-session.test.ts
- npm --workspace=@franken/orchestrator test -- tests/integration/chat/chat-routes.test.ts tests/integration/chat/ws-chat-server.test.ts tests/integration/chat/chat-server.test.ts
- npm --workspace=@franken/types test -- tests/api-contracts.test.ts
- npm --workspace=@franken/types run build
- npm --workspace=@franken/brain run build
- npm --workspace=@franken/observer run build
- npm --workspace=@franken/critique run build
- npm --workspace=@franken/governor run build
- npm --workspace=@franken/planner run build
- npm --workspace=@franken/orchestrator run typecheck
- npm --workspace=@franken/web run typecheck
- npm --workspace=@franken/orchestrator run build
- npm --workspace=@franken/web run build
- npm run lint:security
- npm run lint:any

Closes #703