### PR TITLE
fix(planner): convert strategy domain exceptions

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -48,7 +48,7 @@ export class PlanGraph {
     for (const task of tasks) {
       for (const depId of task.dependsOn) {
         if (!nodes.has(depId)) {
-          throw new Error(`Dependency '${depId}' not found in graph`);
+          throw new TaskNotFoundError(depId);
         }
       }
       edges.set(task.id, new Set(task.dependsOn));

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -2,8 +2,12 @@ import { applyModifications } from './hitl/plan-modifier.js';
 import { PlanExporter } from './hitl/plan-exporter.js';
 import { buildCoTExecutor } from './cot/cot-gate.js';
 import {
+  CyclicDependencyError,
+  DuplicateTaskError,
   RationaleRejectedError,
   MaxRecoveryAttemptsError,
+  RecursionDepthExceededError,
+  TaskNotFoundError,
   UnknownErrorEscalatedError,
 } from './core/errors.js';
 import { createTaskId } from './core/types.js';
@@ -77,6 +81,9 @@ export class Planner {
         if (err instanceof RationaleRejectedError) {
           return { status: 'rationale_rejected', taskId: createTaskId(err.taskId) };
         }
+        if (Planner.isStrategyDomainError(err)) {
+          return Planner.toStrategyDomainFailure(err);
+        }
         throw err;
       }
 
@@ -104,6 +111,27 @@ export class Planner {
         throw recoveryErr;
       }
     }
+  }
+
+  private static readonly STRATEGY_DOMAIN_FAILURE_TASK_ID = createTaskId('planner-domain-error');
+
+  private static isStrategyDomainError(err: unknown): err is Error {
+    return (
+      err instanceof CyclicDependencyError ||
+      err instanceof DuplicateTaskError ||
+      err instanceof RecursionDepthExceededError ||
+      err instanceof TaskNotFoundError
+    );
+  }
+
+  private static toStrategyDomainFailure(error: Error): PlanResult {
+    const failedTaskId = Planner.STRATEGY_DOMAIN_FAILURE_TASK_ID;
+    return {
+      status: 'failed',
+      taskResults: [{ status: 'failure', taskId: failedTaskId, error }],
+      failedTaskId,
+      error,
+    };
   }
 
   /**

--- a/packages/franken-planner/src/planners/linear.ts
+++ b/packages/franken-planner/src/planners/linear.ts
@@ -1,5 +1,5 @@
 import { PlanGraph } from '../core/dag.js';
-import { RecursionDepthExceededError } from '../core/errors.js';
+import { RationaleRejectedError, RecursionDepthExceededError } from '../core/errors.js';
 import type { PlanResult, PlanningStrategyName, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
 
@@ -26,7 +26,19 @@ export class LinearPlanner implements PlanningStrategy {
     const taskResults: TaskResult[] = [];
 
     for (const task of tasks) {
-      const result = await context.executor(task);
+      let result: TaskResult;
+      try {
+        result = await context.executor(task);
+      } catch (err) {
+        if (err instanceof RationaleRejectedError) {
+          throw err;
+        }
+        result = {
+          status: 'failure',
+          taskId: task.id,
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
       taskResults.push(result);
 
       if (result.status === 'failure') {

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -1,4 +1,9 @@
-import { DuplicateTaskError, RecursionDepthExceededError } from '../core/errors.js';
+import {
+  DuplicateTaskError,
+  RationaleRejectedError,
+  RecursionDepthExceededError,
+  TaskNotFoundError,
+} from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, Task, TaskId, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy } from './types.js';
@@ -33,7 +38,19 @@ export class RecursivePlanner implements PlanningStrategy {
     const allResults: TaskResult[] = [];
 
     for (const task of tasks) {
-      const result = await context.executor(task);
+      let result: TaskResult;
+      try {
+        result = await context.executor(task);
+      } catch (err) {
+        if (err instanceof RationaleRejectedError) {
+          throw err;
+        }
+        result = {
+          status: 'failure',
+          taskId: task.id,
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
 
       if (result.status === 'failure') {
         allResults.push(result);
@@ -84,9 +101,7 @@ export class RecursivePlanner implements PlanningStrategy {
           continue;
         }
         if (!completedTaskIds.has(dependencyId)) {
-          throw new Error(
-            `Recursive task '${task.id}' depends on unresolved external dependency '${dependencyId}'`
-          );
+          throw new TaskNotFoundError(dependencyId);
         }
       }
       edges.set(task.id, new Set(internalDependencies));

--- a/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
@@ -190,7 +190,7 @@ describe('Integration — RecursivePlanner', () => {
     ]);
   });
 
-  it('rejects expanded tasks that depend on external tasks not completed yet', async () => {
+  it('returns a failed result when expanded tasks depend on external tasks not completed yet', async () => {
     const parent = makeTask('parent');
     const laterSibling = makeTask('later-sibling');
     const sub = makeTask('sub', { dependsOn: [createTaskId('later-sibling')] });
@@ -201,8 +201,10 @@ describe('Integration — RecursivePlanner', () => {
       return Promise.resolve(ok(t.id));
     });
 
-    await expect(buildRecursivePlanner(graph, executor).plan('...')).rejects.toThrow(
-      /unresolved external dependency 'later-sibling'/
-    );
+    const result = await buildRecursivePlanner(graph, executor).plan('...');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
   });
 });

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -243,10 +243,10 @@ describe('PlanGraph — fromTasks', () => {
     );
   });
 
-  it('throws when a task references an unknown dependency', () => {
+  it('throws TaskNotFoundError when a task references an unknown dependency', () => {
     const task = makeTask('a', { dependsOn: [createTaskId('missing')] });
 
-    expect(() => PlanGraph.fromTasks([task])).toThrow(/Dependency 'missing' not found/);
+    expect(() => PlanGraph.fromTasks([task])).toThrowError(TaskNotFoundError);
   });
 
   it('throws CyclicDependencyError when tasks form a cycle', () => {

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -8,6 +8,8 @@ import {
   CyclicDependencyError,
   MaxRecoveryAttemptsError,
   RecursionDepthExceededError,
+  TaskNotFoundError,
+  UnknownErrorEscalatedError,
 } from '../../src/core/errors';
 import { createTaskId } from '../../src/core/types';
 import type { Task, TaskResult, Intent, KnownError, TaskId } from '../../src/core/types';
@@ -36,6 +38,10 @@ function success(id: string): TaskResult {
 
 function failure(id: string, message = 'task failed'): TaskResult {
   return { status: 'failure', taskId: createTaskId(id), error: new Error(message) };
+}
+
+function expand(id: string, newTasks: Task[]): TaskResult {
+  return { status: 'success', taskId: createTaskId(id), expand: true, newTasks };
 }
 
 function makeGuardrails(goal = 'test goal'): GuardrailsModule {
@@ -354,6 +360,39 @@ describe('Planner — strategy domain exceptions', () => {
     if (result.status !== 'failed') throw new Error('unexpected');
     expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
     expect(result.error).toBe(error);
+  });
+
+  it('keeps executor rejections associated with the task that failed', async () => {
+    const graph = PlanGraph.empty().addTask(makeTask('t-1'));
+    const error = new TaskNotFoundError('dependency');
+    const executor = vi.fn().mockRejectedValue(error);
+    const recovery = { recover: vi.fn().mockRejectedValue(new UnknownErrorEscalatedError('t-1', error)) };
+
+    const { planner } = buildPlanner({ graph, executor, recovery });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('t-1'));
+    expect(result.error).toBe(error);
+    expect(recovery.recover).toHaveBeenCalledWith(createTaskId('t-1'), error, graph, 1);
+  });
+
+  it('converts dangling expansion dependencies into failed plan results', async () => {
+    const parent = makeTask('parent');
+    const child: Task = { ...makeTask('child'), dependsOn: [createTaskId('missing')] };
+    const graph = PlanGraph.empty().addTask(parent);
+    const executor = vi.fn().mockResolvedValue(expand('parent', [child]));
+    const recovery = { recover: vi.fn() };
+
+    const { planner } = buildPlanner({ graph, executor, recovery });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
+    expect(result.error).toBeInstanceOf(TaskNotFoundError);
+    expect(recovery.recover).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -4,12 +4,16 @@ import { LinearPlanner } from '../../src/planners/linear';
 import { StubHITLGate } from '../../src/hitl/stub-hitl-gate';
 import { RecoveryController } from '../../src/recovery/recovery-controller';
 import { PlanGraph } from '../../src/core/dag';
-import { MaxRecoveryAttemptsError } from '../../src/core/errors';
+import {
+  CyclicDependencyError,
+  MaxRecoveryAttemptsError,
+  RecursionDepthExceededError,
+} from '../../src/core/errors';
 import { createTaskId } from '../../src/core/types';
 import type { Task, TaskResult, Intent, KnownError, TaskId } from '../../src/core/types';
 import type { GuardrailsModule } from '../../src/modules/mod01';
 import type { SelfCritiqueModule } from '../../src/modules/mod07';
-import type { GraphBuilder, TaskExecutor } from '../../src/planners/types';
+import type { GraphBuilder, PlanningStrategy, TaskExecutor } from '../../src/planners/types';
 import type { HITLGate } from '../../src/hitl/types';
 import type { MemoryModule } from '../../src/modules/mod03';
 import type { TaskModification } from '../../src/hitl/types';
@@ -58,6 +62,7 @@ interface PlannerOptions {
   memory?: MemoryModule;
   selfCritique?: SelfCritiqueModule;
   maxRecoveryAttempts?: number;
+  strategy?: PlanningStrategy;
   recovery?: {
     recover(failedTaskId: TaskId, error: Error, graph: PlanGraph, attempt: number): Promise<PlanGraph>;
   };
@@ -83,7 +88,7 @@ function buildPlanner(opts: PlannerOptions = {}): {
     graphBuilder,
     executor,
     hitlGate,
-    new LinearPlanner(),
+    opts.strategy ?? new LinearPlanner(),
     recovery,
     opts.selfCritique
   );
@@ -304,6 +309,51 @@ describe('Planner — self-correction loop', () => {
     const result = await planner.plan('do something');
 
     expect(result.status).toBe('failed');
+  });
+});
+
+describe('Planner — strategy domain exceptions', () => {
+  it('converts cyclic dependency errors from strategies into failed plan results', async () => {
+    const graph = PlanGraph.empty().addTask(makeTask('t-1'));
+    const error = new CyclicDependencyError('Graph contains a cycle');
+    const strategy: PlanningStrategy = {
+      name: 'linear',
+      execute: vi.fn().mockRejectedValue(error),
+    };
+    const recovery = { recover: vi.fn() };
+
+    const { planner } = buildPlanner({ graph, strategy, recovery });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
+    expect(result.error).toBe(error);
+    expect(result.taskResults).toEqual([
+      {
+        status: 'failure',
+        taskId: createTaskId('planner-domain-error'),
+        error,
+      },
+    ]);
+    expect(recovery.recover).not.toHaveBeenCalled();
+  });
+
+  it('converts recursion depth errors from strategies into failed plan results', async () => {
+    const graph = PlanGraph.empty().addTask(makeTask('t-1'));
+    const error = new RecursionDepthExceededError(11);
+    const strategy: PlanningStrategy = {
+      name: 'linear',
+      execute: vi.fn().mockRejectedValue(error),
+    };
+
+    const { planner } = buildPlanner({ graph, strategy });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
+    expect(result.error).toBe(error);
   });
 });
 


### PR DESCRIPTION
## Summary
- convert known planner-domain strategy exceptions into structured failed PlanResult responses
- add top-level Planner regressions for cycle and recursion-depth domain failures

## Test Plan
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-planner test -- tests/unit/planner.test.ts
- npm --prefix packages/franken-planner test
- npm --prefix packages/franken-planner run typecheck
- npm --prefix packages/franken-planner run build
- npm --prefix packages/franken-planner run lint

Closes #936