### PR TITLE
fix(planner): skip completed recovery tasks

### DIFF
--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -11,7 +11,7 @@ import {
   UnknownErrorEscalatedError,
 } from './core/errors.js';
 import { createTaskId } from './core/types.js';
-import type { PlanResult, TaskId } from './core/types.js';
+import type { PlanResult, TaskId, TaskResult } from './core/types.js';
 import type { PlanGraph } from './core/dag.js';
 import type { GuardrailsModule } from './modules/mod01.js';
 import type { SelfCritiqueModule } from './modules/mod07.js';
@@ -72,11 +72,13 @@ export class Planner {
     // 5. Execute with self-correction loop (ADR-007)
     let currentGraph = graph;
     const recoveryAttemptsByTask = new Map<TaskId, number>();
+    const completedTaskIds = new Set<TaskId>();
+    const completedTaskResults = new Map<TaskId, TaskResult>();
 
     for (;;) {
       let result: PlanResult;
       try {
-        result = await this.strategy.execute(currentGraph, { executor });
+        result = await this.strategy.execute(currentGraph, { executor, completedTaskIds });
       } catch (err) {
         if (err instanceof RationaleRejectedError) {
           return { status: 'rationale_rejected', taskId: createTaskId(err.taskId) };
@@ -87,8 +89,13 @@ export class Planner {
         throw err;
       }
 
-      if (result.status === 'completed') return result;
+      if (result.status === 'completed') {
+        Planner.recordCompletedTasks(result.taskResults, completedTaskIds, completedTaskResults);
+        return { status: 'completed', taskResults: Array.from(completedTaskResults.values()) };
+      }
       if (result.status !== 'failed') return result; // defensive: unexpected status
+
+      Planner.recordCompletedTasks(result.taskResults, completedTaskIds, completedTaskResults);
 
       // result.status === 'failed' — attempt recovery
       const failedTaskLineage = Planner.getRecoveryLineageRoot(result.failedTaskId);
@@ -106,7 +113,7 @@ export class Planner {
           recoveryErr instanceof MaxRecoveryAttemptsError ||
           recoveryErr instanceof UnknownErrorEscalatedError
         ) {
-          return result;
+          return Planner.mergeCompletedIntoFailedResult(result, completedTaskResults);
         }
         throw recoveryErr;
       }
@@ -153,5 +160,28 @@ export class Planner {
     }
 
     return current;
+  }
+
+  private static recordCompletedTasks(
+    taskResults: TaskResult[],
+    completedTaskIds: Set<TaskId>,
+    completedTaskResults: Map<TaskId, TaskResult>
+  ): void {
+    for (const taskResult of taskResults) {
+      if (taskResult.status !== 'success') continue;
+      completedTaskIds.add(taskResult.taskId);
+      completedTaskResults.set(taskResult.taskId, taskResult);
+    }
+  }
+
+  private static mergeCompletedIntoFailedResult(
+    result: Extract<PlanResult, { status: 'failed' }>,
+    completedTaskResults: Map<TaskId, TaskResult>
+  ): Extract<PlanResult, { status: 'failed' }> {
+    const taskResultsById = new Map<TaskId, TaskResult>(completedTaskResults);
+    for (const taskResult of result.taskResults) {
+      taskResultsById.set(taskResult.taskId, taskResult);
+    }
+    return { ...result, taskResults: Array.from(taskResultsById.values()) };
   }
 }

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -7,7 +7,7 @@ import {
   UnknownErrorEscalatedError,
 } from './core/errors.js';
 import { createTaskId } from './core/types.js';
-import type { PlanResult, TaskId } from './core/types.js';
+import type { PlanResult, TaskId, TaskResult } from './core/types.js';
 import type { PlanGraph } from './core/dag.js';
 import type { GuardrailsModule } from './modules/mod01.js';
 import type { SelfCritiqueModule } from './modules/mod07.js';
@@ -68,11 +68,13 @@ export class Planner {
     // 5. Execute with self-correction loop (ADR-007)
     let currentGraph = graph;
     const recoveryAttemptsByTask = new Map<TaskId, number>();
+    const completedTaskIds = new Set<TaskId>();
+    const completedTaskResults = new Map<TaskId, TaskResult>();
 
     for (;;) {
       let result: PlanResult;
       try {
-        result = await this.strategy.execute(currentGraph, { executor });
+        result = await this.strategy.execute(currentGraph, { executor, completedTaskIds });
       } catch (err) {
         if (err instanceof RationaleRejectedError) {
           return { status: 'rationale_rejected', taskId: createTaskId(err.taskId) };
@@ -80,8 +82,13 @@ export class Planner {
         throw err;
       }
 
-      if (result.status === 'completed') return result;
+      if (result.status === 'completed') {
+        Planner.recordCompletedTasks(result.taskResults, completedTaskIds, completedTaskResults);
+        return { status: 'completed', taskResults: Array.from(completedTaskResults.values()) };
+      }
       if (result.status !== 'failed') return result; // defensive: unexpected status
+
+      Planner.recordCompletedTasks(result.taskResults, completedTaskIds, completedTaskResults);
 
       // result.status === 'failed' — attempt recovery
       const failedTaskLineage = Planner.getRecoveryLineageRoot(result.failedTaskId);
@@ -99,7 +106,7 @@ export class Planner {
           recoveryErr instanceof MaxRecoveryAttemptsError ||
           recoveryErr instanceof UnknownErrorEscalatedError
         ) {
-          return result;
+          return Planner.mergeCompletedIntoFailedResult(result, completedTaskResults);
         }
         throw recoveryErr;
       }
@@ -125,5 +132,28 @@ export class Planner {
     }
 
     return current;
+  }
+
+  private static recordCompletedTasks(
+    taskResults: TaskResult[],
+    completedTaskIds: Set<TaskId>,
+    completedTaskResults: Map<TaskId, TaskResult>
+  ): void {
+    for (const taskResult of taskResults) {
+      if (taskResult.status !== 'success') continue;
+      completedTaskIds.add(taskResult.taskId);
+      completedTaskResults.set(taskResult.taskId, taskResult);
+    }
+  }
+
+  private static mergeCompletedIntoFailedResult(
+    result: Extract<PlanResult, { status: 'failed' }>,
+    completedTaskResults: Map<TaskId, TaskResult>
+  ): Extract<PlanResult, { status: 'failed' }> {
+    const taskResultsById = new Map<TaskId, TaskResult>(completedTaskResults);
+    for (const taskResult of result.taskResults) {
+      taskResultsById.set(taskResult.taskId, taskResult);
+    }
+    return { ...result, taskResults: Array.from(taskResultsById.values()) };
   }
 }

--- a/packages/franken-planner/src/planners/linear.ts
+++ b/packages/franken-planner/src/planners/linear.ts
@@ -26,6 +26,10 @@ export class LinearPlanner implements PlanningStrategy {
     const taskResults: TaskResult[] = [];
 
     for (const task of tasks) {
+      if (context.completedTaskIds?.has(task.id)) {
+        continue;
+      }
+
       let result: TaskResult;
       try {
         result = await context.executor(task);
@@ -39,9 +43,9 @@ export class LinearPlanner implements PlanningStrategy {
           error: err instanceof Error ? err : new Error(String(err)),
         };
       }
-      taskResults.push(result);
 
       if (result.status === 'failure') {
+        taskResults.push(result);
         return {
           status: 'failed',
           taskResults,
@@ -64,8 +68,11 @@ export class LinearPlanner implements PlanningStrategy {
         if (subResult.status !== 'completed') {
           return subResult;
         }
-        taskResults.push(...subResult.taskResults);
+        taskResults.push(result, ...subResult.taskResults);
+        continue;
       }
+
+      taskResults.push(result);
     }
 
     return { status: 'completed', taskResults };

--- a/packages/franken-planner/src/planners/linear.ts
+++ b/packages/franken-planner/src/planners/linear.ts
@@ -26,10 +26,14 @@ export class LinearPlanner implements PlanningStrategy {
     const taskResults: TaskResult[] = [];
 
     for (const task of tasks) {
+      if (context.completedTaskIds?.has(task.id)) {
+        continue;
+      }
+
       const result = await context.executor(task);
-      taskResults.push(result);
 
       if (result.status === 'failure') {
+        taskResults.push(result);
         return {
           status: 'failed',
           taskResults,
@@ -52,8 +56,11 @@ export class LinearPlanner implements PlanningStrategy {
         if (subResult.status !== 'completed') {
           return subResult;
         }
-        taskResults.push(...subResult.taskResults);
+        taskResults.push(result, ...subResult.taskResults);
+        continue;
       }
+
+      taskResults.push(result);
     }
 
     return { status: 'completed', taskResults };

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -134,7 +134,9 @@ export class ParallelPlanner implements PlanningStrategy {
 
       const failures = waveResults.filter((r) => r.status === 'failure');
       if (failures.length > 0) {
-        allResults.push(...waveResults);
+        allResults.push(
+          ...waveResults.filter((r) => r.status === 'failure' || r.expand !== true)
+        );
         const first = failures[0]!;
         if (first.status === 'failure') {
           return {

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -78,7 +78,10 @@ export class ParallelPlanner implements PlanningStrategy {
     // Validate the DAG up front so cyclic plans fail loudly instead of
     // deadlocking the wave scheduler and returning partial success.
     const tasks = graph.topoSort();
-    const completedIds = new Set<TaskId>();
+    const taskIds = new Set(tasks.map((task) => task.id));
+    const completedIds = new Set<TaskId>(
+      Array.from(context.completedTaskIds ?? []).filter((taskId) => taskIds.has(taskId))
+    );
     const allResults: TaskResult[] = [];
 
     while (completedIds.size < tasks.length) {
@@ -129,10 +132,9 @@ export class ParallelPlanner implements PlanningStrategy {
         throw result.reason;
       });
 
-      allResults.push(...waveResults);
-
       const failures = waveResults.filter((r) => r.status === 'failure');
       if (failures.length > 0) {
+        allResults.push(...waveResults);
         const first = failures[0]!;
         if (first.status === 'failure') {
           return {
@@ -143,6 +145,8 @@ export class ParallelPlanner implements PlanningStrategy {
           };
         }
       }
+
+      allResults.push(...waveResults.filter((r) => r.status === 'success' && r.expand !== true));
 
       const settledExpansionResults = await Promise.allSettled(
         waveResults
@@ -176,6 +180,11 @@ export class ParallelPlanner implements PlanningStrategy {
         throw result.reason;
       });
 
+      const expandingResultsByTaskId = new Map(
+        waveResults
+          .filter((result) => result.status === 'success' && result.expand === true)
+          .map((result) => [result.taskId, result])
+      );
       let firstExpansionFailure: { taskId: TaskId; error: Error } | undefined;
       for (const { parentTaskId, subResult } of expansionResults) {
         if (subResult.status === 'failed') {
@@ -185,6 +194,10 @@ export class ParallelPlanner implements PlanningStrategy {
         }
         if (subResult.status !== 'completed') {
           return subResult;
+        }
+        const parentResult = expandingResultsByTaskId.get(parentTaskId);
+        if (parentResult) {
+          allResults.push(parentResult);
         }
         allResults.push(...subResult.taskResults);
       }

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -16,7 +16,7 @@ export class RecursivePlanner implements PlanningStrategy {
   constructor(private readonly maxDepth = 10) {}
 
   execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
-    return this._exec(graph, context, 0, new Set());
+    return this._exec(graph, context, 0, context.completedTaskIds ?? new Set());
   }
 
   private async _exec(
@@ -33,6 +33,10 @@ export class RecursivePlanner implements PlanningStrategy {
     const allResults: TaskResult[] = [];
 
     for (const task of tasks) {
+      if (completedTaskIds.has(task.id)) {
+        continue;
+      }
+
       const result = await context.executor(task);
 
       if (result.status === 'failure') {

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -21,7 +21,7 @@ export class RecursivePlanner implements PlanningStrategy {
   constructor(private readonly maxDepth = 10) {}
 
   execute(graph: PlanGraph, context: PlanContext): Promise<PlanResult> {
-    return this._exec(graph, context, 0, new Set());
+    return this._exec(graph, context, 0, context.completedTaskIds ?? new Set());
   }
 
   private async _exec(
@@ -38,6 +38,10 @@ export class RecursivePlanner implements PlanningStrategy {
     const allResults: TaskResult[] = [];
 
     for (const task of tasks) {
+      if (completedTaskIds.has(task.id)) {
+        continue;
+      }
+
       let result: TaskResult;
       try {
         result = await context.executor(task);

--- a/packages/franken-planner/src/planners/types.ts
+++ b/packages/franken-planner/src/planners/types.ts
@@ -1,4 +1,4 @@
-import type { Task, TaskResult, PlanResult, PlanningStrategyName, Intent } from '../core/types.js';
+import type { Task, TaskId, TaskResult, PlanResult, PlanningStrategyName, Intent } from '../core/types.js';
 import type { PlanGraph } from '../core/dag.js';
 
 /**
@@ -13,6 +13,13 @@ export type TaskExecutor = (task: Task) => Promise<TaskResult>;
  */
 export interface PlanContext {
   executor: TaskExecutor;
+
+  /**
+   * Tasks already completed by an earlier strategy execution in the same
+   * Planner self-correction loop. Strategies must treat these ids as satisfied
+   * dependencies and skip re-executing them on recovery retries.
+   */
+  completedTaskIds?: ReadonlySet<TaskId>;
 }
 
 /**

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -206,6 +206,33 @@ describe('Planner — self-correction loop', () => {
     expect(result.status).toBe('completed');
   });
 
+  it('does not replay completed predecessor tasks during self-correction retries', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
+    const memory = makeMemory([ke]);
+    const executedTaskIds: TaskId[] = [];
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      executedTaskIds.push(task.id);
+      if (task.id === createTaskId('t-2') && !executedTaskIds.includes(createTaskId('fix-t-2-attempt-1'))) {
+        return Promise.resolve(failure('t-2', 'disk full'));
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const { planner } = buildPlanner({ graph, executor, memory });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('completed');
+    expect(executedTaskIds).toEqual([
+      createTaskId('t-1'),
+      createTaskId('t-2'),
+      createTaskId('fix-t-2-attempt-1'),
+      createTaskId('t-2'),
+    ]);
+  });
+
   it('returns failed when max recovery attempts exceeded', async () => {
     const graph = PlanGraph.empty().addTask(makeTask('t-1'));
     const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
@@ -220,6 +247,29 @@ describe('Planner — self-correction loop', () => {
     const result = await planner.plan('do something');
 
     expect(result.status).toBe('failed');
+  });
+
+  it('preserves completed predecessors in terminal failed recovery results', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
+    const memory = makeMemory([ke]);
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('t-2')) return Promise.resolve(failure('t-2', 'disk full'));
+      return Promise.resolve(success(task.id));
+    });
+
+    const { planner } = buildPlanner({ graph, executor, memory, maxRecoveryAttempts: 1 });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('t-1'),
+      createTaskId('fix-t-2-attempt-1'),
+      createTaskId('t-2'),
+    ]);
   });
 
   it('tracks recovery attempts independently for each failed task', async () => {

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -217,6 +217,33 @@ describe('Planner — self-correction loop', () => {
     expect(result.status).toBe('completed');
   });
 
+  it('does not replay completed predecessor tasks during self-correction retries', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
+    const memory = makeMemory([ke]);
+    const executedTaskIds: TaskId[] = [];
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      executedTaskIds.push(task.id);
+      if (task.id === createTaskId('t-2') && !executedTaskIds.includes(createTaskId('fix-t-2-attempt-1'))) {
+        return Promise.resolve(failure('t-2', 'disk full'));
+      }
+      return Promise.resolve(success(task.id));
+    });
+
+    const { planner } = buildPlanner({ graph, executor, memory });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('completed');
+    expect(executedTaskIds).toEqual([
+      createTaskId('t-1'),
+      createTaskId('t-2'),
+      createTaskId('fix-t-2-attempt-1'),
+      createTaskId('t-2'),
+    ]);
+  });
+
   it('returns failed when max recovery attempts exceeded', async () => {
     const graph = PlanGraph.empty().addTask(makeTask('t-1'));
     const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
@@ -231,6 +258,29 @@ describe('Planner — self-correction loop', () => {
     const result = await planner.plan('do something');
 
     expect(result.status).toBe('failed');
+  });
+
+  it('preserves completed predecessors in terminal failed recovery results', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const ke: KnownError = { pattern: 'disk full', description: '', fixSuggestion: 'free space' };
+    const memory = makeMemory([ke]);
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('t-2')) return Promise.resolve(failure('t-2', 'disk full'));
+      return Promise.resolve(success(task.id));
+    });
+
+    const { planner } = buildPlanner({ graph, executor, memory, maxRecoveryAttempts: 1 });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('t-1'),
+      createTaskId('fix-t-2-attempt-1'),
+      createTaskId('t-2'),
+    ]);
   });
 
   it('tracks recovery attempts independently for each failed task', async () => {

--- a/packages/franken-planner/tests/unit/planners/linear.test.ts
+++ b/packages/franken-planner/tests/unit/planners/linear.test.ts
@@ -85,6 +85,24 @@ describe('LinearPlanner — happy path', () => {
     expect(result.taskResults).toHaveLength(2);
   });
 
+  it('skips tasks already completed by an earlier recovery iteration', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const executor = vi.fn().mockImplementation((task: Task) => Promise.resolve(success(task.id)));
+
+    const result = await new LinearPlanner().execute(graph, {
+      executor,
+      completedTaskIds: new Set([createTaskId('t-1')]),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledOnce();
+    expect(executor).toHaveBeenCalledWith(expect.objectContaining({ id: createTaskId('t-2') }));
+    if (result.status !== 'completed') throw new Error('unexpected status');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([createTaskId('t-2')]);
+  });
+
   it('executes expanded sub-tasks before continuing the linear plan', async () => {
     const parent = makeTask('parent');
     const sibling = makeTask('sibling');
@@ -177,7 +195,6 @@ describe('LinearPlanner — failure handling', () => {
     expect(result.failedTaskId).toBe(createTaskId('parent'));
     expect(result.error.message).toBe('sub exploded');
     expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
-      createTaskId('parent'),
       createTaskId('sub'),
     ]);
   });

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -468,6 +468,28 @@ describe('ParallelPlanner — failure handling', () => {
     expect(result.taskResults[1]?.status).toBe('failure');
   });
 
+  it('does not mark an unexpanded parent complete when a same-wave sibling fails', async () => {
+    const parent = makeTask('parent');
+    const sibling = makeTask('sibling');
+    const child = makeTask('child');
+    const graph = PlanGraph.empty().addTask(parent).addTask(sibling);
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      if (task.id === createTaskId('parent')) return Promise.resolve(expand('parent', [child]));
+      if (task.id === createTaskId('sibling')) return Promise.resolve(failure('sibling', 'boom'));
+      return Promise.resolve(success(task.id));
+    });
+
+    const result = await new ParallelPlanner().execute(graph, { executor });
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('sibling'));
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('sibling'),
+    ]);
+    expect(executor).not.toHaveBeenCalledWith(child);
+  });
+
   it('returns the expanding parent as failed when an expanded sub-task fails', async () => {
     const parent = makeTask('parent');
     const sub = makeTask('sub');

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -224,6 +224,37 @@ describe('ParallelPlanner — happy path', () => {
     expect(result.taskResults).toHaveLength(2);
   });
 
+  it('skips tasks already completed by an earlier recovery iteration', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const executor = vi.fn().mockImplementation((task: Task) => Promise.resolve(success(task.id)));
+
+    const result = await new ParallelPlanner().execute(graph, {
+      executor,
+      completedTaskIds: new Set([createTaskId('t-1')]),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledOnce();
+    expect(executor).toHaveBeenCalledWith(expect.objectContaining({ id: createTaskId('t-2') }));
+    if (result.status !== 'completed') throw new Error('unexpected status');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([createTaskId('t-2')]);
+  });
+
+  it('ignores completed ids that do not belong to the current graph', async () => {
+    const graph = PlanGraph.empty().addTask(makeTask('t-1'));
+    const executor = vi.fn().mockImplementation((task: Task) => Promise.resolve(success(task.id)));
+
+    const result = await new ParallelPlanner().execute(graph, {
+      executor,
+      completedTaskIds: new Set([createTaskId('unrelated')]),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledOnce();
+  });
+
   it('executes expanded sub-tasks before starting dependent waves', async () => {
     const parent = makeTask('parent');
     const dependent = makeTask('dependent');
@@ -453,7 +484,6 @@ describe('ParallelPlanner — failure handling', () => {
     expect(result.failedTaskId).toBe(createTaskId('parent'));
     expect(result.error.message).toBe('sub exploded');
     expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
-      createTaskId('parent'),
       createTaskId('sub'),
     ]);
   });
@@ -478,9 +508,8 @@ describe('ParallelPlanner — failure handling', () => {
     if (result.status !== 'failed') throw new Error('unexpected');
     expect(result.failedTaskId).toBe(createTaskId('parent-1'));
     expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
-      createTaskId('parent-1'),
-      createTaskId('parent-2'),
       createTaskId('sub-1'),
+      createTaskId('parent-2'),
       createTaskId('sub-2'),
     ]);
   });

--- a/packages/franken-planner/tests/unit/planners/recursive.test.ts
+++ b/packages/franken-planner/tests/unit/planners/recursive.test.ts
@@ -110,6 +110,24 @@ describe('RecursivePlanner — happy path', () => {
     expect(result.taskResults).toHaveLength(2);
   });
 
+  it('skips tasks already completed by an earlier recovery iteration', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('t-1'))
+      .addTask(makeTask('t-2'), [createTaskId('t-1')]);
+    const executor = vi.fn().mockImplementation((task: Task) => Promise.resolve(success(task.id)));
+
+    const result = await new RecursivePlanner().execute(graph, {
+      executor,
+      completedTaskIds: new Set([createTaskId('t-1')]),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledOnce();
+    expect(executor).toHaveBeenCalledWith(expect.objectContaining({ id: createTaskId('t-2') }));
+    if (result.status !== 'completed') throw new Error('unexpected');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([createTaskId('t-2')]);
+  });
+
   it('sub-tasks respect their own dependency order', async () => {
     const sub1 = makeTask('sub-1');
     const sub2: Task = {


### PR DESCRIPTION
## Summary
- Track task successes across Planner self-correction iterations
- Pass completed task ids into linear and parallel strategies so recovery retries skip already-completed work while treating those dependencies as satisfied
- Add regression coverage for Planner recovery replay plus direct linear/parallel skip behavior

## Test Plan
- npm --workspace @franken/planner test -- tests/unit/planner.test.ts -t "does not replay completed predecessor"
- npm --workspace @franken/planner test -- tests/unit/planner.test.ts tests/unit/planners/linear.test.ts tests/unit/planners/parallel.test.ts
- npm --workspace @franken/planner test
- npx turbo run build --filter=@franken/planner
- npm --workspace @franken/planner run typecheck
- npm --workspace @franken/planner run lint
- npx turbo run test --filter=@franken/planner

Note: the issue text suggests `npx turbo run test --filter=franken-planner`, but the live workspace package is named `@franken/planner`; that exact command fails with “No package found with name 'franken-planner' in workspace.”\n\nCloses #917