### PR TITLE
fix(orchestrator): clean up CLI provider child processes

### DIFF
--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -147,6 +147,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
     let totalOutputTokens = 0;
     let emittedText = false;
     let emittedToolUse = false;
+    let streamCompleted = false;
 
     try {
       for await (const line of rl) {
@@ -171,6 +172,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
           const isErrorResult = parsed['is_error'] === true || subtype === 'error' || subtype?.startsWith('error_') === true;
           if (isErrorResult) {
             const message = resultText.trim() || errorText.trim() || errors.join('\n').trim() || 'claude returned an error result frame';
+            streamCompleted = true;
             yield {
               type: 'error',
               error: message,
@@ -194,6 +196,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
             (parsed['total_output_tokens'] as number | undefined) ??
             totalOutputTokens;
           if (!emittedText && !emittedToolUse) {
+            streamCompleted = true;
             yield {
               type: 'error',
               error: 'claude result frame contained no text output',
@@ -201,6 +204,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
             };
             return;
           }
+          streamCompleted = true;
           yield {
             type: 'done',
             usage: {
@@ -298,6 +302,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
           continue;
         } else if (type === 'message_stop') {
           if (!emittedText && !emittedToolUse) {
+            streamCompleted = true;
             yield {
               type: 'error',
               error: 'claude stream completed without parseable text',
@@ -305,6 +310,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
             };
             return;
           }
+          streamCompleted = true;
           yield {
             type: 'done',
             usage: {
@@ -330,12 +336,14 @@ export class ClaudeCliAdapter implements ILlmProvider {
         proc.on('close', resolve);
       });
       if (exitCode !== 0) {
+        streamCompleted = true;
         yield {
           type: 'error',
           error: `claude process exited with code ${exitCode}`,
           retryable: false,
         };
       } else if (!emittedText) {
+        streamCompleted = true;
         yield {
           type: 'error',
           error: 'claude process exited without producing a result frame or text output',
@@ -344,7 +352,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
       }
     } finally {
       rl.close();
-      terminateRunningProcess(proc);
+      if (!streamCompleted) {
+        terminateRunningProcess(proc);
+      }
     }
   }
 }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -172,7 +172,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
           const isErrorResult = parsed['is_error'] === true || subtype === 'error' || subtype?.startsWith('error_') === true;
           if (isErrorResult) {
             const message = resultText.trim() || errorText.trim() || errors.join('\n').trim() || 'claude returned an error result frame';
-            streamCompleted = true;
             yield {
               type: 'error',
               error: message,
@@ -196,7 +195,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
             (parsed['total_output_tokens'] as number | undefined) ??
             totalOutputTokens;
           if (!emittedText && !emittedToolUse) {
-            streamCompleted = true;
             yield {
               type: 'error',
               error: 'claude result frame contained no text output',
@@ -302,7 +300,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
           continue;
         } else if (type === 'message_stop') {
           if (!emittedText && !emittedToolUse) {
-            streamCompleted = true;
             yield {
               type: 'error',
               error: 'claude stream completed without parseable text',
@@ -326,7 +323,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
             (error?.['message'] as string) ?? 'Unknown error';
           const retryable =
             message.includes('rate') || message.includes('overloaded');
-          streamCompleted = true;
           yield { type: 'error', error: message, retryable };
           return;
         }
@@ -337,14 +333,12 @@ export class ClaudeCliAdapter implements ILlmProvider {
         proc.on('close', resolve);
       });
       if (exitCode !== 0) {
-        streamCompleted = true;
         yield {
           type: 'error',
           error: `claude process exited with code ${exitCode}`,
           retryable: false,
         };
       } else if (!emittedText) {
-        streamCompleted = true;
         yield {
           type: 'error',
           error: 'claude process exited without producing a result frame or text output',

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -14,6 +14,12 @@ import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 import { tryExtractTextFromNode } from '../skills/providers/stream-json-utils.js';
 
+function terminateRunningProcess(proc: ChildProcess): void {
+  if (proc.exitCode === null && proc.signalCode === null) {
+    proc.kill();
+  }
+}
+
 export interface ClaudeCliOptions {
   binaryPath?: string;
   model?: string;
@@ -142,198 +148,203 @@ export class ClaudeCliAdapter implements ILlmProvider {
     let emittedText = false;
     let emittedToolUse = false;
 
-    for await (const line of rl) {
-      if (!line.trim()) continue;
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(line) as Record<string, unknown>;
-      } catch {
-        continue;
-      }
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
 
-      const type = parsed['type'] as string;
+        const type = parsed['type'] as string;
 
-      if (type === 'result') {
-        const resultText = typeof parsed['result'] === 'string' ? parsed['result'] : '';
-        const errorText =
-          typeof parsed['error'] === 'string'
-            ? parsed['error']
-            : ((parsed['error'] as Record<string, unknown> | undefined)?.['message'] as string | undefined) ?? '';
-        const errors = Array.isArray(parsed['errors']) ? parsed['errors'].filter((value): value is string => typeof value === 'string') : [];
-        const subtype = parsed['subtype'] as string | undefined;
-        const isErrorResult = parsed['is_error'] === true || subtype === 'error' || subtype?.startsWith('error_') === true;
-        if (isErrorResult) {
-          const message = resultText.trim() || errorText.trim() || errors.join('\n').trim() || 'claude returned an error result frame';
-          yield {
-            type: 'error',
-            error: message,
-            retryable: message.includes('rate') || message.includes('overloaded'),
-          };
-          return;
-        }
-        if (resultText.length > 0 && !emittedText) {
-          yield { type: 'text', content: resultText };
-          emittedText = true;
-        }
-        const usage = parsed['usage'] as Record<string, number> | undefined;
-        totalInputTokens =
-          usage?.['input_tokens'] ??
-          usage?.['inputTokens'] ??
-          (parsed['total_input_tokens'] as number | undefined) ??
-          totalInputTokens;
-        totalOutputTokens =
-          usage?.['output_tokens'] ??
-          usage?.['outputTokens'] ??
-          (parsed['total_output_tokens'] as number | undefined) ??
-          totalOutputTokens;
-        if (!emittedText && !emittedToolUse) {
-          yield {
-            type: 'error',
-            error: 'claude result frame contained no text output',
-            retryable: false,
-          };
-          return;
-        }
-        yield {
-          type: 'done',
-          usage: {
-            inputTokens: totalInputTokens,
-            outputTokens: totalOutputTokens,
-            totalTokens: totalInputTokens + totalOutputTokens,
-          },
-        };
-        return;
-      } else if (type === 'content_block_start') {
-        const block = parsed['content_block'] as Record<string, unknown>;
-        if (block?.['type'] === 'tool_use') {
-          currentToolUse = {
-            id: block['id'] as string,
-            name: block['name'] as string,
-            inputJson: '',
-          };
-        }
-      } else if (type === 'content_block_delta') {
-        const delta = parsed['delta'] as Record<string, unknown>;
-        if (delta?.['type'] === 'text_delta') {
-          yield { type: 'text', content: delta['text'] as string };
-          emittedText = true;
-        } else if (
-          delta?.['type'] === 'input_json_delta' &&
-          currentToolUse
-        ) {
-          currentToolUse.inputJson += delta['partial_json'] as string;
-        }
-      } else if (type === 'content_block_stop') {
-        if (currentToolUse) {
-          let input: unknown = {};
-          try {
-            input = JSON.parse(currentToolUse.inputJson);
-          } catch {
-            /* empty input */
+        if (type === 'result') {
+          const resultText = typeof parsed['result'] === 'string' ? parsed['result'] : '';
+          const errorText =
+            typeof parsed['error'] === 'string'
+              ? parsed['error']
+              : ((parsed['error'] as Record<string, unknown> | undefined)?.['message'] as string | undefined) ?? '';
+          const errors = Array.isArray(parsed['errors']) ? parsed['errors'].filter((value): value is string => typeof value === 'string') : [];
+          const subtype = parsed['subtype'] as string | undefined;
+          const isErrorResult = parsed['is_error'] === true || subtype === 'error' || subtype?.startsWith('error_') === true;
+          if (isErrorResult) {
+            const message = resultText.trim() || errorText.trim() || errors.join('\n').trim() || 'claude returned an error result frame';
+            yield {
+              type: 'error',
+              error: message,
+              retryable: message.includes('rate') || message.includes('overloaded'),
+            };
+            return;
           }
-          yield {
-            type: 'tool_use',
-            id: currentToolUse.id,
-            name: currentToolUse.name,
-            input,
-          };
-          emittedToolUse = true;
-          currentToolUse = null;
-        }
-      } else if (type === 'message_delta') {
-        const usage = parsed['usage'] as
-          | Record<string, number>
-          | undefined;
-        if (usage) {
-          totalOutputTokens = usage['output_tokens'] ?? totalOutputTokens;
-        }
-      } else if (type === 'message_start') {
-        const message = parsed['message'] as Record<string, unknown> | undefined;
-        const usage = message?.['usage'] as Record<string, number> | undefined;
-        if (usage) {
-          totalInputTokens = usage['input_tokens'] ?? 0;
-        }
-      } else if (type === 'assistant') {
-        const message = parsed['message'] as Record<string, unknown> | undefined;
-        const usage = message?.['usage'] as Record<string, number> | undefined;
-        if (usage) {
-          totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
-          totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
-        }
-        const content = (message?.['content'] ?? parsed['content']) as unknown;
-        if (Array.isArray(content)) {
-          for (const block of content) {
-            if (!block || typeof block !== 'object') continue;
-            const record = block as Record<string, unknown>;
-            if (record['type'] === 'text' && typeof record['text'] === 'string') {
-              yield { type: 'text', content: record['text'] };
-              emittedText = true;
-            } else if (record['type'] === 'tool_use') {
-              yield {
-                type: 'tool_use',
-                id: (record['id'] as string) ?? crypto.randomUUID(),
-                name: record['name'] as string,
-                input: record['input'] ?? {},
-              };
-              emittedToolUse = true;
-            }
-          }
-        } else {
-          const parts: string[] = [];
-          tryExtractTextFromNode(content ?? message ?? parsed, parts);
-          const text = parts.join('');
-          if (text.length > 0) {
-            yield { type: 'text', content: text };
+          if (resultText.length > 0 && !emittedText) {
+            yield { type: 'text', content: resultText };
             emittedText = true;
           }
-        }
-      } else if (type === 'user') {
-        continue;
-      } else if (type === 'message_stop') {
-        if (!emittedText && !emittedToolUse) {
+          const usage = parsed['usage'] as Record<string, number> | undefined;
+          totalInputTokens =
+            usage?.['input_tokens'] ??
+            usage?.['inputTokens'] ??
+            (parsed['total_input_tokens'] as number | undefined) ??
+            totalInputTokens;
+          totalOutputTokens =
+            usage?.['output_tokens'] ??
+            usage?.['outputTokens'] ??
+            (parsed['total_output_tokens'] as number | undefined) ??
+            totalOutputTokens;
+          if (!emittedText && !emittedToolUse) {
+            yield {
+              type: 'error',
+              error: 'claude result frame contained no text output',
+              retryable: false,
+            };
+            return;
+          }
           yield {
-            type: 'error',
-            error: 'claude stream completed without parseable text',
-            retryable: true,
+            type: 'done',
+            usage: {
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+              totalTokens: totalInputTokens + totalOutputTokens,
+            },
           };
           return;
+        } else if (type === 'content_block_start') {
+          const block = parsed['content_block'] as Record<string, unknown>;
+          if (block?.['type'] === 'tool_use') {
+            currentToolUse = {
+              id: block['id'] as string,
+              name: block['name'] as string,
+              inputJson: '',
+            };
+          }
+        } else if (type === 'content_block_delta') {
+          const delta = parsed['delta'] as Record<string, unknown>;
+          if (delta?.['type'] === 'text_delta') {
+            yield { type: 'text', content: delta['text'] as string };
+            emittedText = true;
+          } else if (
+            delta?.['type'] === 'input_json_delta' &&
+            currentToolUse
+          ) {
+            currentToolUse.inputJson += delta['partial_json'] as string;
+          }
+        } else if (type === 'content_block_stop') {
+          if (currentToolUse) {
+            let input: unknown = {};
+            try {
+              input = JSON.parse(currentToolUse.inputJson);
+            } catch {
+              /* empty input */
+            }
+            yield {
+              type: 'tool_use',
+              id: currentToolUse.id,
+              name: currentToolUse.name,
+              input,
+            };
+            emittedToolUse = true;
+            currentToolUse = null;
+          }
+        } else if (type === 'message_delta') {
+          const usage = parsed['usage'] as
+            | Record<string, number>
+            | undefined;
+          if (usage) {
+            totalOutputTokens = usage['output_tokens'] ?? totalOutputTokens;
+          }
+        } else if (type === 'message_start') {
+          const message = parsed['message'] as Record<string, unknown> | undefined;
+          const usage = message?.['usage'] as Record<string, number> | undefined;
+          if (usage) {
+            totalInputTokens = usage['input_tokens'] ?? 0;
+          }
+        } else if (type === 'assistant') {
+          const message = parsed['message'] as Record<string, unknown> | undefined;
+          const usage = message?.['usage'] as Record<string, number> | undefined;
+          if (usage) {
+            totalInputTokens = usage['input_tokens'] ?? usage['inputTokens'] ?? totalInputTokens;
+            totalOutputTokens = usage['output_tokens'] ?? usage['outputTokens'] ?? totalOutputTokens;
+          }
+          const content = (message?.['content'] ?? parsed['content']) as unknown;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (!block || typeof block !== 'object') continue;
+              const record = block as Record<string, unknown>;
+              if (record['type'] === 'text' && typeof record['text'] === 'string') {
+                yield { type: 'text', content: record['text'] };
+                emittedText = true;
+              } else if (record['type'] === 'tool_use') {
+                yield {
+                  type: 'tool_use',
+                  id: (record['id'] as string) ?? crypto.randomUUID(),
+                  name: record['name'] as string,
+                  input: record['input'] ?? {},
+                };
+                emittedToolUse = true;
+              }
+            }
+          } else {
+            const parts: string[] = [];
+            tryExtractTextFromNode(content ?? message ?? parsed, parts);
+            const text = parts.join('');
+            if (text.length > 0) {
+              yield { type: 'text', content: text };
+              emittedText = true;
+            }
+          }
+        } else if (type === 'user') {
+          continue;
+        } else if (type === 'message_stop') {
+          if (!emittedText && !emittedToolUse) {
+            yield {
+              type: 'error',
+              error: 'claude stream completed without parseable text',
+              retryable: true,
+            };
+            return;
+          }
+          yield {
+            type: 'done',
+            usage: {
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+              totalTokens: totalInputTokens + totalOutputTokens,
+            },
+          };
+          return;
+        } else if (type === 'error') {
+          const error = parsed['error'] as Record<string, unknown> | undefined;
+          const message =
+            (error?.['message'] as string) ?? 'Unknown error';
+          const retryable =
+            message.includes('rate') || message.includes('overloaded');
+          yield { type: 'error', error: message, retryable };
+          return;
         }
-        yield {
-          type: 'done',
-          usage: {
-            inputTokens: totalInputTokens,
-            outputTokens: totalOutputTokens,
-            totalTokens: totalInputTokens + totalOutputTokens,
-          },
-        };
-        return;
-      } else if (type === 'error') {
-        const error = parsed['error'] as Record<string, unknown> | undefined;
-        const message =
-          (error?.['message'] as string) ?? 'Unknown error';
-        const retryable =
-          message.includes('rate') || message.includes('overloaded');
-        yield { type: 'error', error: message, retryable };
-        return;
       }
-    }
 
-    // If process exited without message_stop, check exit code
-    const exitCode = await new Promise<number | null>((resolve) => {
-      proc.on('close', resolve);
-    });
-    if (exitCode !== 0) {
-      yield {
-        type: 'error',
-        error: `claude process exited with code ${exitCode}`,
-        retryable: false,
-      };
-    } else if (!emittedText) {
-      yield {
-        type: 'error',
-        error: 'claude process exited without producing a result frame or text output',
-        retryable: false,
-      };
+      // If process exited without message_stop, check exit code
+      const exitCode = await new Promise<number | null>((resolve) => {
+        proc.on('close', resolve);
+      });
+      if (exitCode !== 0) {
+        yield {
+          type: 'error',
+          error: `claude process exited with code ${exitCode}`,
+          retryable: false,
+        };
+      } else if (!emittedText) {
+        yield {
+          type: 'error',
+          error: 'claude process exited without producing a result frame or text output',
+          retryable: false,
+        };
+      }
+    } finally {
+      rl.close();
+      terminateRunningProcess(proc);
     }
   }
 }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -326,6 +326,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
             (error?.['message'] as string) ?? 'Unknown error';
           const retryable =
             message.includes('rate') || message.includes('overloaded');
+          streamCompleted = true;
           yield { type: 'error', error: message, retryable };
           return;
         }

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -130,6 +130,7 @@ export class CodexCliAdapter implements ILlmProvider {
     const rl = createInterface({ input: proc.stdout! });
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let streamCompleted = false;
 
     try {
       for await (const line of rl) {
@@ -162,6 +163,7 @@ export class CodexCliAdapter implements ILlmProvider {
           totalOutputTokens =
             (usage['output_tokens'] as number) ?? totalOutputTokens;
           if (type === 'done') {
+            streamCompleted = true;
             yield {
               type: 'done',
               usage: {
@@ -177,6 +179,7 @@ export class CodexCliAdapter implements ILlmProvider {
             (parsed['message'] as string) ?? 'Unknown error';
           const retryable =
             message.includes('rate') || message.includes('429');
+          streamCompleted = true;
           yield { type: 'error', error: message, retryable };
           return;
         }
@@ -187,12 +190,14 @@ export class CodexCliAdapter implements ILlmProvider {
         proc.on('close', resolve);
       });
       if (exitCode !== 0 && exitCode !== null) {
+        streamCompleted = true;
         yield {
           type: 'error',
           error: `codex process exited with code ${exitCode}`,
           retryable: false,
         };
       } else {
+        streamCompleted = true;
         yield {
           type: 'done',
           usage: {
@@ -204,7 +209,9 @@ export class CodexCliAdapter implements ILlmProvider {
       }
     } finally {
       rl.close();
-      terminateRunningProcess(proc);
+      if (!streamCompleted) {
+        terminateRunningProcess(proc);
+      }
     }
   }
 }

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -179,7 +179,6 @@ export class CodexCliAdapter implements ILlmProvider {
             (parsed['message'] as string) ?? 'Unknown error';
           const retryable =
             message.includes('rate') || message.includes('429');
-          streamCompleted = true;
           yield { type: 'error', error: message, retryable };
           return;
         }
@@ -190,7 +189,6 @@ export class CodexCliAdapter implements ILlmProvider {
         proc.on('close', resolve);
       });
       if (exitCode !== 0 && exitCode !== null) {
-        streamCompleted = true;
         yield {
           type: 'error',
           error: `codex process exited with code ${exitCode}`,

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -13,6 +13,12 @@ import type {
 import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 
+function terminateRunningProcess(proc: ChildProcess): void {
+  if (proc.exitCode === null && proc.signalCode === null) {
+    proc.kill();
+  }
+}
+
 export interface CodexCliOptions {
   binaryPath?: string;
   model?: string;
@@ -125,75 +131,80 @@ export class CodexCliAdapter implements ILlmProvider {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
 
-    for await (const line of rl) {
-      if (!line.trim()) continue;
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(line) as Record<string, unknown>;
-      } catch {
-        continue;
-      }
-
-      const type = parsed['type'] as string;
-
-      if (type === 'message' || type === 'content') {
-        const content = parsed['content'] as string | undefined;
-        if (content) {
-          yield { type: 'text', content };
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
         }
-      } else if (type === 'function_call' || type === 'tool_call') {
-        yield {
-          type: 'tool_use',
-          id: (parsed['id'] as string) ?? crypto.randomUUID(),
-          name: parsed['name'] as string,
-          input: parsed['arguments'] ?? parsed['input'] ?? {},
-        };
-      } else if (type === 'usage' || type === 'done') {
-        const usage = (parsed['usage'] as Record<string, number>) ?? parsed;
-        totalInputTokens =
-          (usage['input_tokens'] as number) ?? totalInputTokens;
-        totalOutputTokens =
-          (usage['output_tokens'] as number) ?? totalOutputTokens;
-        if (type === 'done') {
+
+        const type = parsed['type'] as string;
+
+        if (type === 'message' || type === 'content') {
+          const content = parsed['content'] as string | undefined;
+          if (content) {
+            yield { type: 'text', content };
+          }
+        } else if (type === 'function_call' || type === 'tool_call') {
           yield {
-            type: 'done',
-            usage: {
-              inputTokens: totalInputTokens,
-              outputTokens: totalOutputTokens,
-              totalTokens: totalInputTokens + totalOutputTokens,
-            },
+            type: 'tool_use',
+            id: (parsed['id'] as string) ?? crypto.randomUUID(),
+            name: parsed['name'] as string,
+            input: parsed['arguments'] ?? parsed['input'] ?? {},
           };
+        } else if (type === 'usage' || type === 'done') {
+          const usage = (parsed['usage'] as Record<string, number>) ?? parsed;
+          totalInputTokens =
+            (usage['input_tokens'] as number) ?? totalInputTokens;
+          totalOutputTokens =
+            (usage['output_tokens'] as number) ?? totalOutputTokens;
+          if (type === 'done') {
+            yield {
+              type: 'done',
+              usage: {
+                inputTokens: totalInputTokens,
+                outputTokens: totalOutputTokens,
+                totalTokens: totalInputTokens + totalOutputTokens,
+              },
+            };
+            return;
+          }
+        } else if (type === 'error') {
+          const message =
+            (parsed['message'] as string) ?? 'Unknown error';
+          const retryable =
+            message.includes('rate') || message.includes('429');
+          yield { type: 'error', error: message, retryable };
           return;
         }
-      } else if (type === 'error') {
-        const message =
-          (parsed['message'] as string) ?? 'Unknown error';
-        const retryable =
-          message.includes('rate') || message.includes('429');
-        yield { type: 'error', error: message, retryable };
-        return;
       }
-    }
 
-    // Stream ended without a done/error frame — check exit code
-    const exitCode = await new Promise<number | null>((resolve) => {
-      proc.on('close', resolve);
-    });
-    if (exitCode !== 0 && exitCode !== null) {
-      yield {
-        type: 'error',
-        error: `codex process exited with code ${exitCode}`,
-        retryable: false,
-      };
-    } else {
-      yield {
-        type: 'done',
-        usage: {
-          inputTokens: totalInputTokens,
-          outputTokens: totalOutputTokens,
-          totalTokens: totalInputTokens + totalOutputTokens,
-        },
-      };
+      // Stream ended without a done/error frame — check exit code
+      const exitCode = await new Promise<number | null>((resolve) => {
+        proc.on('close', resolve);
+      });
+      if (exitCode !== 0 && exitCode !== null) {
+        yield {
+          type: 'error',
+          error: `codex process exited with code ${exitCode}`,
+          retryable: false,
+        };
+      } else {
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            totalTokens: totalInputTokens + totalOutputTokens,
+          },
+        };
+      }
+    } finally {
+      rl.close();
+      terminateRunningProcess(proc);
     }
   }
 }

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -33,6 +33,12 @@ import { tryExtractTextFromNode } from '../skills/providers/stream-json-utils.js
 const MANAGED_START = '<!-- FRANKENBEAST MANAGED SECTION - DO NOT EDIT -->';
 const MANAGED_END = '<!-- END FRANKENBEAST SECTION -->';
 
+function terminateRunningProcess(proc: ChildProcess): void {
+  if (proc.exitCode === null && proc.signalCode === null) {
+    proc.kill();
+  }
+}
+
 export interface GeminiCliOptions {
   binaryPath?: string;
   model?: string;
@@ -494,149 +500,191 @@ export class GeminiCliAdapter implements ILlmProvider {
     let emittedToolUse = false;
     let sawTerminalFrame = false;
 
-    for await (const line of rl) {
-      if (!line.trim()) continue;
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(line) as Record<string, unknown>;
-      } catch {
-        continue;
-      }
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
 
-      const type = parsed['type'] as string;
+        const type = parsed['type'] as string;
 
-      if (type === 'result') {
-        const parts: string[] = [];
-        tryExtractTextFromNode(parsed['result'] ?? parsed, parts);
-        const text = parts.join('');
-        const error = parsed['error'] as Record<string, unknown> | string | undefined;
-        const errorText = typeof error === 'string' ? error : ((error?.['message'] as string | undefined) ?? '');
-        const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error' || parsed['status'] === 'error';
-        if (isErrorResult) {
-          const message = text || errorText || 'gemini returned an error result frame';
+        if (type === 'result') {
+          const parts: string[] = [];
+          tryExtractTextFromNode(parsed['result'] ?? parsed, parts);
+          const text = parts.join('');
+          const error = parsed['error'] as Record<string, unknown> | string | undefined;
+          const errorText = typeof error === 'string' ? error : ((error?.['message'] as string | undefined) ?? '');
+          const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error' || parsed['status'] === 'error';
+          if (isErrorResult) {
+            const message = text || errorText || 'gemini returned an error result frame';
+            yield {
+              type: 'error',
+              error: message,
+              retryable: message.includes('rate') || message.includes('RESOURCE_EXHAUSTED'),
+            };
+            return;
+          }
+          if (text.length > 0 && !emittedText) {
+            yield { type: 'text', content: text };
+            emittedText = true;
+          }
+          const usage = (parsed['usage'] ?? parsed['stats']) as Record<string, number> | undefined;
+          if (usage) {
+            totalInputTokens =
+              usage['input_tokens'] ??
+              usage['inputTokens'] ??
+              usage['prompt_tokens'] ??
+              usage['promptTokenCount'] ??
+              usage['totalInputTokens'] ??
+              totalInputTokens;
+            totalOutputTokens =
+              usage['output_tokens'] ??
+              usage['outputTokens'] ??
+              usage['completion_tokens'] ??
+              usage['candidatesTokenCount'] ??
+              usage['totalOutputTokens'] ??
+              totalOutputTokens;
+          }
+          if (!emittedText && !emittedToolUse) {
+            yield {
+              type: 'error',
+              error: 'gemini result frame contained no text output',
+              retryable: false,
+            };
+            return;
+          }
+          sawTerminalFrame = true;
+
+          yield {
+            type: 'done',
+            usage: {
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+              totalTokens: totalInputTokens + totalOutputTokens,
+
+            },
+          };
+          return;
+        } else if (type === 'content_block_delta') {
+          const delta = parsed['delta'] as Record<string, unknown>;
+          if (delta?.['type'] === 'text_delta') {
+            yield { type: 'text', content: delta['text'] as string };
+            emittedText = true;
+          }
+        } else if (type === 'content_block_start') {
+          const block = parsed['content_block'] as Record<string, unknown>;
+          if (block?.['type'] === 'tool_use') {
+            yield {
+              type: 'tool_use',
+              id: (block['id'] as string) ?? crypto.randomUUID(),
+              name: block['name'] as string,
+              input: block['input'] ?? {},
+            };
+            emittedToolUse = true;
+          }
+        } else if (type === 'tool_use') {
+          yield {
+            type: 'tool_use',
+            id: (parsed['tool_id'] as string) ?? (parsed['id'] as string) ?? crypto.randomUUID(),
+            name: (parsed['tool_name'] as string) ?? (parsed['name'] as string),
+            input: parsed['parameters'] ?? parsed['input'] ?? {},
+          };
+          emittedToolUse = true;
+        } else if (type === 'message_delta') {
+          const usage = parsed['usage'] as Record<string, number> | undefined;
+          if (usage) {
+            totalOutputTokens = usage['output_tokens'] ?? totalOutputTokens;
+          }
+        } else if (type === 'message_start') {
+          const message = parsed['message'] as Record<string, unknown> | undefined;
+          const usage = message?.['usage'] as Record<string, number> | undefined;
+          if (usage) {
+            totalInputTokens = usage['input_tokens'] ?? 0;
+          }
+        } else if (type === 'message') {
+          const message = parsed['message'] as Record<string, unknown> | undefined;
+          const role = (message?.['role'] ?? parsed['role']) as string | undefined;
+          if (role === 'assistant') {
+            const content = message?.['content'] ?? parsed['content'] ?? parsed['parts'];
+            if (Array.isArray(content)) {
+              const parts = content
+                .map((part) => (part && typeof part === 'object' ? (part as Record<string, unknown>)['text'] : part))
+                .filter((part): part is string => typeof part === 'string');
+              const text = parts.join('');
+              if (text.length > 0) {
+                yield { type: 'text', content: text };
+                emittedText = true;
+              }
+            } else if (typeof content === 'string') {
+              if (content.length > 0) {
+                yield { type: 'text', content };
+                emittedText = true;
+              }
+            } else {
+              const parts: string[] = [];
+              tryExtractTextFromNode(parsed, parts);
+              const text = parts.join('');
+              if (text.length > 0) {
+                yield { type: 'text', content: text };
+                emittedText = true;
+              }
+            }
+          }
+        } else if (type === 'message_stop') {
+          sawTerminalFrame = true;
+          if (!emittedText && !emittedToolUse) {
+            yield {
+              type: 'error',
+              error: 'gemini stream completed without parseable text',
+              retryable: true,
+            };
+            return;
+          }
+          yield {
+            type: 'done',
+            usage: {
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+              totalTokens: totalInputTokens + totalOutputTokens,
+            },
+          };
+          return;
+        } else if (type === 'error') {
+          const message = this.stringifyGeminiContent(parsed['message'] ?? parsed['error'] ?? 'Unknown error');
           yield {
             type: 'error',
             error: message,
             retryable: message.includes('rate') || message.includes('RESOURCE_EXHAUSTED'),
           };
           return;
-        }
-        if (text.length > 0 && !emittedText) {
-          yield { type: 'text', content: text };
-          emittedText = true;
-        }
-        const usage = (parsed['usage'] ?? parsed['stats']) as Record<string, number> | undefined;
-        if (usage) {
-          totalInputTokens =
-            usage['input_tokens'] ??
-            usage['inputTokens'] ??
-            usage['prompt_tokens'] ??
-            usage['promptTokenCount'] ??
-            usage['totalInputTokens'] ??
-            totalInputTokens;
-          totalOutputTokens =
-            usage['output_tokens'] ??
-            usage['outputTokens'] ??
-            usage['completion_tokens'] ??
-            usage['candidatesTokenCount'] ??
-            usage['totalOutputTokens'] ??
-            totalOutputTokens;
-        }
-        if (!emittedText && !emittedToolUse) {
-          yield {
-            type: 'error',
-            error: 'gemini result frame contained no text output',
-            retryable: false,
-          };
-          return;
-        }
-        sawTerminalFrame = true;
-
-        yield {
-          type: 'done',
-          usage: {
-            inputTokens: totalInputTokens,
-            outputTokens: totalOutputTokens,
-            totalTokens: totalInputTokens + totalOutputTokens,
-
-          },
-        };
-        return;
-      } else if (type === 'content_block_delta') {
-        const delta = parsed['delta'] as Record<string, unknown>;
-        if (delta?.['type'] === 'text_delta') {
-          yield { type: 'text', content: delta['text'] as string };
-          emittedText = true;
-        }
-      } else if (type === 'content_block_start') {
-        const block = parsed['content_block'] as Record<string, unknown>;
-        if (block?.['type'] === 'tool_use') {
-          yield {
-            type: 'tool_use',
-            id: (block['id'] as string) ?? crypto.randomUUID(),
-            name: block['name'] as string,
-            input: block['input'] ?? {},
-          };
-          emittedToolUse = true;
-        }
-      } else if (type === 'tool_use') {
-        yield {
-          type: 'tool_use',
-          id: (parsed['tool_id'] as string) ?? (parsed['id'] as string) ?? crypto.randomUUID(),
-          name: (parsed['tool_name'] as string) ?? (parsed['name'] as string),
-          input: parsed['parameters'] ?? parsed['input'] ?? {},
-        };
-        emittedToolUse = true;
-      } else if (type === 'message_delta') {
-        const usage = parsed['usage'] as Record<string, number> | undefined;
-        if (usage) {
-          totalOutputTokens = usage['output_tokens'] ?? totalOutputTokens;
-        }
-      } else if (type === 'message_start') {
-        const message = parsed['message'] as Record<string, unknown> | undefined;
-        const usage = message?.['usage'] as Record<string, number> | undefined;
-        if (usage) {
-          totalInputTokens = usage['input_tokens'] ?? 0;
-        }
-      } else if (type === 'message') {
-        const message = parsed['message'] as Record<string, unknown> | undefined;
-        const role = (message?.['role'] ?? parsed['role']) as string | undefined;
-        if (role === 'assistant') {
-          const content = message?.['content'] ?? parsed['content'] ?? parsed['parts'];
-          if (Array.isArray(content)) {
-            const parts = content
-              .map((part) => (part && typeof part === 'object' ? (part as Record<string, unknown>)['text'] : part))
-              .filter((part): part is string => typeof part === 'string');
-            const text = parts.join('');
-            if (text.length > 0) {
-              yield { type: 'text', content: text };
-              emittedText = true;
-            }
-          } else if (typeof content === 'string') {
-            if (content.length > 0) {
-              yield { type: 'text', content };
-              emittedText = true;
-            }
-          } else {
-            const parts: string[] = [];
-            tryExtractTextFromNode(parsed, parts);
-            const text = parts.join('');
-            if (text.length > 0) {
-              yield { type: 'text', content: text };
-              emittedText = true;
-            }
+        } else if (type === 'tool_result') {
+          continue;
+        } else if (!emittedText) {
+          const parts: string[] = [];
+          tryExtractTextFromNode(parsed, parts);
+          const text = parts.join('').trim();
+          if (text.length > 0) {
+            yield { type: 'text', content: text };
+            emittedText = true;
           }
         }
-      } else if (type === 'message_stop') {
-        sawTerminalFrame = true;
-        if (!emittedText && !emittedToolUse) {
-          yield {
-            type: 'error',
-            error: 'gemini stream completed without parseable text',
-            retryable: true,
-          };
-          return;
-        }
+      }
+
+      // Stream ended without message_stop/result/error — check exit code
+      const exitCode = await new Promise<number | null>((resolve) => {
+        proc.on('close', resolve);
+      });
+      if (exitCode !== 0 && exitCode !== null) {
+        yield {
+          type: 'error',
+          error: `gemini process exited with code ${exitCode}`,
+          retryable: false,
+        };
+      } else if (sawTerminalFrame && (emittedText || emittedToolUse)) {
         yield {
           type: 'done',
           usage: {
@@ -645,53 +693,16 @@ export class GeminiCliAdapter implements ILlmProvider {
             totalTokens: totalInputTokens + totalOutputTokens,
           },
         };
-        return;
-      } else if (type === 'error') {
-        const message = this.stringifyGeminiContent(parsed['message'] ?? parsed['error'] ?? 'Unknown error');
+      } else {
         yield {
           type: 'error',
-          error: message,
-          retryable: message.includes('rate') || message.includes('RESOURCE_EXHAUSTED'),
+          error: 'gemini process exited without producing a result frame or text output',
+          retryable: false,
         };
-        return;
-      } else if (type === 'tool_result') {
-        continue;
-      } else if (!emittedText) {
-        const parts: string[] = [];
-        tryExtractTextFromNode(parsed, parts);
-        const text = parts.join('').trim();
-        if (text.length > 0) {
-          yield { type: 'text', content: text };
-          emittedText = true;
-        }
       }
-    }
-
-    // Stream ended without message_stop/result/error — check exit code
-    const exitCode = await new Promise<number | null>((resolve) => {
-      proc.on('close', resolve);
-    });
-    if (exitCode !== 0 && exitCode !== null) {
-      yield {
-        type: 'error',
-        error: `gemini process exited with code ${exitCode}`,
-        retryable: false,
-      };
-    } else if (sawTerminalFrame && (emittedText || emittedToolUse)) {
-      yield {
-        type: 'done',
-        usage: {
-          inputTokens: totalInputTokens,
-          outputTokens: totalOutputTokens,
-          totalTokens: totalInputTokens + totalOutputTokens,
-        },
-      };
-    } else {
-      yield {
-        type: 'error',
-        error: 'gemini process exited without producing a result frame or text output',
-        retryable: false,
-      };
+    } finally {
+      rl.close();
+      terminateRunningProcess(proc);
     }
   }
 

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -522,7 +522,6 @@ export class GeminiCliAdapter implements ILlmProvider {
           const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error' || parsed['status'] === 'error';
           if (isErrorResult) {
             const message = text || errorText || 'gemini returned an error result frame';
-            streamCompleted = true;
             yield {
               type: 'error',
               error: message,
@@ -552,7 +551,6 @@ export class GeminiCliAdapter implements ILlmProvider {
               totalOutputTokens;
           }
           if (!emittedText && !emittedToolUse) {
-            streamCompleted = true;
             yield {
               type: 'error',
               error: 'gemini result frame contained no text output',
@@ -641,7 +639,6 @@ export class GeminiCliAdapter implements ILlmProvider {
         } else if (type === 'message_stop') {
           sawTerminalFrame = true;
           if (!emittedText && !emittedToolUse) {
-            streamCompleted = true;
             yield {
               type: 'error',
               error: 'gemini stream completed without parseable text',
@@ -661,7 +658,6 @@ export class GeminiCliAdapter implements ILlmProvider {
           return;
         } else if (type === 'error') {
           const message = this.stringifyGeminiContent(parsed['message'] ?? parsed['error'] ?? 'Unknown error');
-          streamCompleted = true;
           yield {
             type: 'error',
             error: message,
@@ -686,7 +682,6 @@ export class GeminiCliAdapter implements ILlmProvider {
         proc.on('close', resolve);
       });
       if (exitCode !== 0 && exitCode !== null) {
-        streamCompleted = true;
         yield {
           type: 'error',
           error: `gemini process exited with code ${exitCode}`,
@@ -703,7 +698,6 @@ export class GeminiCliAdapter implements ILlmProvider {
           },
         };
       } else {
-        streamCompleted = true;
         yield {
           type: 'error',
           error: 'gemini process exited without producing a result frame or text output',

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -499,6 +499,7 @@ export class GeminiCliAdapter implements ILlmProvider {
     let emittedText = false;
     let emittedToolUse = false;
     let sawTerminalFrame = false;
+    let streamCompleted = false;
 
     try {
       for await (const line of rl) {
@@ -521,6 +522,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           const isErrorResult = parsed['is_error'] === true || parsed['subtype'] === 'error' || parsed['status'] === 'error';
           if (isErrorResult) {
             const message = text || errorText || 'gemini returned an error result frame';
+            streamCompleted = true;
             yield {
               type: 'error',
               error: message,
@@ -550,6 +552,7 @@ export class GeminiCliAdapter implements ILlmProvider {
               totalOutputTokens;
           }
           if (!emittedText && !emittedToolUse) {
+            streamCompleted = true;
             yield {
               type: 'error',
               error: 'gemini result frame contained no text output',
@@ -559,6 +562,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           }
           sawTerminalFrame = true;
 
+          streamCompleted = true;
           yield {
             type: 'done',
             usage: {
@@ -637,6 +641,7 @@ export class GeminiCliAdapter implements ILlmProvider {
         } else if (type === 'message_stop') {
           sawTerminalFrame = true;
           if (!emittedText && !emittedToolUse) {
+            streamCompleted = true;
             yield {
               type: 'error',
               error: 'gemini stream completed without parseable text',
@@ -644,6 +649,7 @@ export class GeminiCliAdapter implements ILlmProvider {
             };
             return;
           }
+          streamCompleted = true;
           yield {
             type: 'done',
             usage: {
@@ -655,6 +661,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           return;
         } else if (type === 'error') {
           const message = this.stringifyGeminiContent(parsed['message'] ?? parsed['error'] ?? 'Unknown error');
+          streamCompleted = true;
           yield {
             type: 'error',
             error: message,
@@ -679,12 +686,14 @@ export class GeminiCliAdapter implements ILlmProvider {
         proc.on('close', resolve);
       });
       if (exitCode !== 0 && exitCode !== null) {
+        streamCompleted = true;
         yield {
           type: 'error',
           error: `gemini process exited with code ${exitCode}`,
           retryable: false,
         };
       } else if (sawTerminalFrame && (emittedText || emittedToolUse)) {
+        streamCompleted = true;
         yield {
           type: 'done',
           usage: {
@@ -694,6 +703,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           },
         };
       } else {
+        streamCompleted = true;
         yield {
           type: 'error',
           error: 'gemini process exited without producing a result frame or text output',
@@ -702,7 +712,9 @@ export class GeminiCliAdapter implements ILlmProvider {
       }
     } finally {
       rl.close();
-      terminateRunningProcess(proc);
+      if (!streamCompleted) {
+        terminateRunningProcess(proc);
+      }
     }
   }
 

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -162,11 +162,12 @@ describe('ClaudeCliAdapter', () => {
     });
 
     it('reads top-level Claude result token totals', async () => {
-      mockSpawn([
+      const proc = mockSpawn([
         JSON.stringify({ type: 'result', result: 'Final answer', usage: {}, total_input_tokens: 21, total_output_tokens: 8 }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 21, outputTokens: 8, totalTokens: 29 } });
+      expect(proc.kill).not.toHaveBeenCalled();
     });
 
     it('treats Claude error result subtypes as failures', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -17,7 +17,9 @@ function mockSpawn(stdoutLines: string[], exitCode = 0) {
     stdin,
     stderr: new PassThrough(),
     pid: 1234,
-    kill: vi.fn(),
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
   });
   (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
 
@@ -27,7 +29,10 @@ function mockSpawn(stdoutLines: string[], exitCode = 0) {
       stdout.write(line + '\n');
     }
     stdout.end();
-    setImmediate(() => proc.emit('close', exitCode));
+    setImmediate(() => {
+      proc.exitCode = exitCode;
+      proc.emit('close', exitCode);
+    });
   });
 
   return proc;
@@ -321,6 +326,18 @@ describe('ClaudeCliAdapter', () => {
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
       expect(events[0]).toEqual({ type: 'error', error: 'rate limit exceeded', retryable: true });
+    });
+
+    it('kills the spawned Claude process when stream iteration stops early', async () => {
+      const proc = mockSpawn([
+        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'partial' } }),
+      ]);
+      const iterator = adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] });
+
+      await expect(iterator.next()).resolves.toEqual({ value: { type: 'text', content: 'partial' }, done: false });
+      await iterator.return(undefined);
+
+      expect(proc.kill).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -327,7 +327,7 @@ describe('ClaudeCliAdapter', () => {
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
       expect(events[0]).toEqual({ type: 'error', error: 'rate limit exceeded', retryable: true });
-      expect(proc.kill).not.toHaveBeenCalled();
+      expect(proc.kill).toHaveBeenCalledTimes(1);
     });
 
     it('kills the spawned Claude process when stream iteration stops early', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -322,11 +322,12 @@ describe('ClaudeCliAdapter', () => {
     });
 
     it('emits retryable error on rate limit', async () => {
-      mockSpawn([
+      const proc = mockSpawn([
         JSON.stringify({ type: 'error', error: { message: 'rate limit exceeded' } }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
       expect(events[0]).toEqual({ type: 'error', error: 'rate limit exceeded', retryable: true });
+      expect(proc.kill).not.toHaveBeenCalled();
     });
 
     it('kills the spawned Claude process when stream iteration stops early', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -122,9 +122,10 @@ describe('CodexCliAdapter', () => {
     });
 
     it('emits retryable error on rate limit message', async () => {
-      mockSpawn([JSON.stringify({ type: 'error', message: 'rate limit 429' })]);
+      const proc = mockSpawn([JSON.stringify({ type: 'error', message: 'rate limit 429' })]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
       expect(events[0]).toEqual({ type: 'error', error: 'rate limit 429', retryable: true });
+      expect(proc.kill).toHaveBeenCalledTimes(1);
     });
 
     it('kills the spawned Codex process when stream iteration stops early', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -95,13 +95,14 @@ describe('CodexCliAdapter', () => {
 
   describe('execute()', () => {
     it('parses text content events', async () => {
-      mockSpawn([
+      const proc = mockSpawn([
         JSON.stringify({ type: 'message', content: 'Hello from Codex' }),
         JSON.stringify({ type: 'done', usage: { input_tokens: 80, output_tokens: 20 } }),
       ]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'text', content: 'Hello from Codex' });
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 80, outputTokens: 20, totalTokens: 100 } });
+      expect(proc.kill).not.toHaveBeenCalled();
     });
 
     it('parses tool call events', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -12,12 +12,23 @@ import { spawn } from 'node:child_process';
 function mockSpawn(stdoutLines: string[], exitCode = 0) {
   const stdout = new PassThrough();
   const stdin = new PassThrough();
-  const proc = Object.assign(new EventEmitter(), { stdout, stdin, stderr: new PassThrough(), pid: 1, kill: vi.fn() });
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
   (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
   setImmediate(() => {
     for (const line of stdoutLines) stdout.write(line + '\n');
     stdout.end();
-    setImmediate(() => proc.emit('close', exitCode));
+    setImmediate(() => {
+      proc.exitCode = exitCode;
+      proc.emit('close', exitCode);
+    });
   });
   return proc;
 }
@@ -113,6 +124,16 @@ describe('CodexCliAdapter', () => {
       mockSpawn([JSON.stringify({ type: 'error', message: 'rate limit 429' })]);
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'x' }] }));
       expect(events[0]).toEqual({ type: 'error', error: 'rate limit 429', retryable: true });
+    });
+
+    it('kills the spawned Codex process when stream iteration stops early', async () => {
+      const proc = mockSpawn([JSON.stringify({ type: 'message', content: 'partial' })]);
+      const iterator = adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] });
+
+      await expect(iterator.next()).resolves.toEqual({ value: { type: 'text', content: 'partial' }, done: false });
+      await iterator.return(undefined);
+
+      expect(proc.kill).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -314,7 +314,7 @@ describe('GeminiCliAdapter', () => {
     });
 
     it('parses Gemini CLI result wrapper frames', async () => {
-      mockSpawn([
+      const proc = mockSpawn([
         JSON.stringify({
           type: 'result',
           result: { response: { text: 'Gemini wrapper answer' } },
@@ -326,6 +326,7 @@ describe('GeminiCliAdapter', () => {
         { type: 'text', content: 'Gemini wrapper answer' },
         { type: 'done', usage: { inputTokens: 8, outputTokens: 3, totalTokens: 11 } },
       ]);
+      expect(proc.kill).not.toHaveBeenCalled();
     });
 
     it('preserves whitespace in Gemini result wrapper frames', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -14,12 +14,23 @@ import { spawn } from 'node:child_process';
 function mockSpawn(stdoutLines: string[], exitCode = 0) {
   const stdout = new PassThrough();
   const stdin = new PassThrough();
-  const proc = Object.assign(new EventEmitter(), { stdout, stdin, stderr: new PassThrough(), pid: 1, kill: vi.fn() });
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
   (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
   setImmediate(() => {
     for (const line of stdoutLines) stdout.write(line + '\n');
     stdout.end();
-    setImmediate(() => proc.emit('close', exitCode));
+    setImmediate(() => {
+      proc.exitCode = exitCode;
+      proc.emit('close', exitCode);
+    });
   });
   return proc;
 }
@@ -439,6 +450,18 @@ describe('GeminiCliAdapter', () => {
         type: 'error',
         error: expect.stringContaining('gemini process exited with code 2'),
       });
+    });
+
+    it('kills the spawned Gemini process when stream iteration stops early', async () => {
+      const proc = mockSpawn([
+        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'partial' } }),
+      ]);
+      const iterator = adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] });
+
+      await expect(iterator.next()).resolves.toEqual({ value: { type: 'text', content: 'partial' }, done: false });
+      await iterator.return(undefined);
+
+      expect(proc.kill).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add cleanup guards around Claude, Codex, and Gemini CLI stream parsing so abandoned async generators terminate still-running child processes.
- Add regression coverage for early-stopped provider streams in all three CLI adapters.

## Test Plan
- npm run test --workspace @franken/orchestrator -- --run tests/unit/providers/claude-cli-adapter.test.ts tests/unit/providers/codex-cli-adapter.test.ts tests/unit/providers/gemini-cli-adapter.test.ts
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #872