### PR TITLE
chore(types): disambiguate critique contracts

### DIFF
--- a/packages/franken-critique/docs/implementation-plan.md
+++ b/packages/franken-critique/docs/implementation-plan.md
@@ -165,7 +165,7 @@ Define all core types and port interfaces. No implementation code.
 
 ### Files
 - `src/types/common.ts` — `Severity`, `Verdict`, `Score`
-- `src/types/evaluation.ts` — `EvaluationInput`, `EvaluationResult`, `CritiqueResult`, `Evaluator` interface
+- `src/types/evaluation.ts` — `EvaluationInput`, `EvaluationResult`, `CritiquePipelineResult`, deprecated compatibility alias `CritiqueResult`, `Evaluator` interface
 - `src/types/contracts.ts` — `GuardrailsPort`, `MemoryPort`, `ObservabilityPort`, `EscalationPort`
 - `src/types/loop.ts` — `LoopState`, `LoopConfig`, `CritiqueLoopResult`, `CorrectionRequest`, `CritiqueIteration`, `CircuitBreaker` interface
 

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -9,6 +9,7 @@ export type {
   EvaluationInput,
   EvaluationFinding,
   EvaluationResult,
+  CritiquePipelineResult,
   CritiqueResult,
   Evaluator,
 } from './types/evaluation.js';

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -1,4 +1,4 @@
-import type { Evaluator, EvaluationInput, EvaluationResult, CritiqueResult } from '../types/evaluation.js';
+import type { Evaluator, EvaluationInput, EvaluationResult, CritiquePipelineResult } from '../types/evaluation.js';
 
 const SAFETY_EVALUATOR_NAME = 'safety';
 
@@ -17,7 +17,7 @@ export class CritiquePipeline {
     });
   }
 
-  async run(input: EvaluationInput): Promise<CritiqueResult> {
+  async run(input: EvaluationInput): Promise<CritiquePipelineResult> {
     if (this.evaluators.length === 0) {
       return { verdict: 'pass', overallScore: 1, results: [], shortCircuited: false };
     }

--- a/packages/franken-critique/src/types/common.ts
+++ b/packages/franken-critique/src/types/common.ts
@@ -1,6 +1,6 @@
 // Shared types re-exported from @franken/types
-export type { TaskId } from '@franken/types';
-export { createTaskId } from '@franken/types';
+export type { SessionId, TaskId } from '@franken/types';
+export { createSessionId, createTaskId } from '@franken/types';
 export type { Verdict } from '@franken/types';
 export type { CritiqueSeverity as Severity } from '@franken/types';
 
@@ -10,5 +10,4 @@ export type { CritiqueSeverity as Severity } from '@franken/types';
  */
 export type Score = number;
 
-/** Unique identifier for a critique session. */
-export type SessionId = string;
+// SessionId is intentionally the branded @franken/types SessionId.

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -1,4 +1,4 @@
-import type { TaskId } from './common.js';
+import type { SessionId, TaskId } from './common.js';
 import type { TokenSpend } from '@franken/types';
 
 export type { TokenSpend };
@@ -50,7 +50,7 @@ export interface EscalationRequest {
   readonly iterationCount: number;
   readonly lastCritiqueResults: readonly string[];
   readonly taskId: TaskId;
-  readonly sessionId: string;
+  readonly sessionId: SessionId;
 }
 
 // --- Port Interfaces (Hexagonal Architecture) ---
@@ -70,7 +70,7 @@ export interface MemoryPort {
 
 /** What MOD-06 needs from MOD-05 (Observer). */
 export interface ObservabilityPort {
-  getTokenSpend(sessionId: string): Promise<TokenSpend>;
+  getTokenSpend(sessionId: SessionId): Promise<TokenSpend>;
 }
 
 /** What MOD-06 emits to MOD-07 (Governor). */

--- a/packages/franken-critique/src/types/evaluation.ts
+++ b/packages/franken-critique/src/types/evaluation.ts
@@ -35,7 +35,7 @@ export interface EvaluationResult {
 }
 
 /** Aggregated result from all evaluators in the pipeline. */
-export interface CritiqueResult {
+export interface CritiquePipelineResult {
   /** Overall verdict (fail if any evaluator fails, warn if only warnings exist). */
   readonly verdict: Verdict;
   /** Average score across all evaluators. */
@@ -45,6 +45,13 @@ export interface CritiqueResult {
   /** Whether evaluation was short-circuited (e.g., safety failure). */
   readonly shortCircuited: boolean;
 }
+
+/**
+ * @deprecated Use CritiquePipelineResult for aggregate pipeline outcomes.
+ * @franken/types exports ProviderCritiqueFinding for individual provider
+ * critique findings.
+ */
+export type CritiqueResult = CritiquePipelineResult;
 
 /** An evaluator that can assess code or plans. */
 export interface Evaluator {

--- a/packages/franken-critique/src/types/loop.ts
+++ b/packages/franken-critique/src/types/loop.ts
@@ -1,5 +1,5 @@
 import type { Score, SessionId, TaskId } from './common.js';
-import type { CritiqueResult, EvaluationFinding, EvaluationInput } from './evaluation.js';
+import type { CritiquePipelineResult, EvaluationFinding, EvaluationInput } from './evaluation.js';
 import type { EscalationRequest } from './contracts.js';
 
 /** Configuration for the critique loop. */
@@ -28,8 +28,8 @@ export interface CritiqueIteration {
   readonly index: number;
   /** The input that was evaluated in this iteration. */
   readonly input: EvaluationInput;
-  /** The critique result for this iteration. */
-  readonly result: CritiqueResult;
+  /** The aggregate critique pipeline result for this iteration. */
+  readonly result: CritiquePipelineResult;
   /** Timestamp when the iteration completed. */
   readonly completedAt: string;
 }

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { createSessionId } from '@franken/types';
+import type { ProviderCritiqueFinding } from '@franken/types';
+import type {
+  CritiquePipelineResult,
+  CritiqueResult as DeprecatedCritiqueResult,
+  SessionId,
+} from '@franken/critique';
+
+describe('public critique type contracts', () => {
+  it('imports provider findings and critique pipeline results without alias confusion', () => {
+    const providerFinding: ProviderCritiqueFinding = {
+      evaluator: 'reflection',
+      severity: 7,
+      message: 'Missing error handling',
+    };
+
+    const pipelineResult: CritiquePipelineResult = {
+      verdict: 'warn',
+      overallScore: 0.75,
+      results: [
+        {
+          evaluatorName: providerFinding.evaluator,
+          verdict: 'warn',
+          score: 0.75,
+          findings: [
+            {
+              message: providerFinding.message,
+              severity: 'warning',
+            },
+          ],
+        },
+      ],
+      shortCircuited: false,
+    };
+    const compatibilityAlias: DeprecatedCritiqueResult = pipelineResult;
+
+    expect(compatibilityAlias.results[0]?.findings[0]?.message).toBe(providerFinding.message);
+  });
+
+  it('uses the branded @franken/types SessionId contract for critique sessions', () => {
+    const sessionId = createSessionId('critique-session-1');
+
+    expectTypeOf(sessionId).toMatchTypeOf<SessionId>();
+    expect(sessionId).toBe('critique-session-1');
+  });
+});

--- a/packages/franken-types/docs/RAMP_UP.md
+++ b/packages/franken-types/docs/RAMP_UP.md
@@ -9,6 +9,7 @@ The package ensures architectural consistency across the monorepo by enforcing a
 - **Branded IDs**: Prevents ID confusion at compile time (e.g., you cannot pass a `SessionId` where a `ProjectId` is expected).
 - **Result Monad**: Standardized error handling without throwing exceptions in core logic.
 - **Severity Enums**: Unified severity levels used by Firewall, Critique, and Heartbeat.
+- **Provider Critique Findings**: `ProviderCritiqueFinding` is the primary provider/evaluator finding shape; the older `CritiqueResult` export remains as a deprecated compatibility alias and should not be confused with `@franken/critique` pipeline results.
 - **LLM Interfaces**: Defines `ILlmClient` and `IResultLlmClient` to ensure interchangeable provider adapters.
 
 ## Key Exports

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -83,6 +83,7 @@ export type {
   McpServerConfig,
   AuthField,
   CritiqueContext,
+  ProviderCritiqueFinding,
   CritiqueResult,
   ProviderSkillConfig,
 } from './provider.js';

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -142,12 +142,19 @@ export interface CritiqueContext {
   objective?: string;
 }
 
-export interface CritiqueResult {
+export interface ProviderCritiqueFinding {
   evaluator: string;
   severity: number;
   message: string;
   suggestion?: string;
 }
+
+/**
+ * @deprecated Use ProviderCritiqueFinding for provider/evaluator findings.
+ * The @franken/critique package uses CritiquePipelineResult for aggregate
+ * pipeline outcomes.
+ */
+export type CritiqueResult = ProviderCritiqueFinding;
 
 // --- Skill Loading Types (used by Phase 5 SkillManager + Phase 8 Beast Loop) ---
 

--- a/packages/franken-types/tests/provider.test.ts
+++ b/packages/franken-types/tests/provider.test.ts
@@ -19,6 +19,7 @@ import {
   type ToolDefinition,
   type ImageSource,
   type CritiqueContext,
+  type ProviderCritiqueFinding,
   type CritiqueResult,
   type ProviderSkillConfig,
 } from '../src/index.js';
@@ -286,21 +287,22 @@ describe('Provider interfaces (type-level)', () => {
     expect(provider.discoverSkills).toBeDefined();
   });
 
-  it('CritiqueContext and CritiqueResult have required shape', () => {
+  it('CritiqueContext and ProviderCritiqueFinding have required shape', () => {
     const ctx: CritiqueContext = {
       phase: 'execution',
       stepsCompleted: 3,
       workSummary: 'Implemented auth',
       objective: 'Add user login',
     };
-    const result: CritiqueResult = {
+    const result: ProviderCritiqueFinding = {
       evaluator: 'reflection',
       severity: 7,
       message: 'Missing error handling',
       suggestion: 'Add try/catch around API calls',
     };
+    const deprecatedAlias: CritiqueResult = result;
     expect(ctx.phase).toBe('execution');
-    expect(result.severity).toBe(7);
+    expect(deprecatedAlias.severity).toBe(7);
   });
 
   it('ProviderSkillConfig has required shape', () => {


### PR DESCRIPTION
## Summary
- adds clearer primary type names for provider critique findings and aggregate critique pipeline results
- re-exports critique `SessionId` from the branded `@franken/types` contract and uses it in critique ports
- adds public contract coverage importing both packages without `CritiqueResult` alias confusion

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/types -- provider.test.ts
- npm run build --workspace @franken/critique
- npm run test --workspace @franken/critique -- tests/unit/types/public-contracts.test.ts
- npm run lint --workspace @franken/critique
- npm run typecheck --workspace @franken/types
- npm run test --workspace @franken/critique

Closes #958
