### PR TITLE
docs(issues): archive stale pre-consolidation issue docs

### DIFF
--- a/docs/issues/001-cli-config-surface-not-applied.md
+++ b/docs/issues/001-cli-config-surface-not-applied.md
@@ -1,5 +1,7 @@
 # Issue: CLI Config Surface Is Not Applied End-to-End
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `@franken/orchestrator` CLI
 

--- a/docs/issues/002-plan-mode-drops-chunk-metadata.md
+++ b/docs/issues/002-plan-mode-drops-chunk-metadata.md
@@ -1,5 +1,7 @@
 # Issue: Plan Mode Drops Chunk Metadata When Writing Files
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `@franken/orchestrator` planning UX
 

--- a/docs/issues/003-cli-safety-pipeline-still-stubbed.md
+++ b/docs/issues/003-cli-safety-pipeline-still-stubbed.md
@@ -1,5 +1,7 @@
 # Issue: Local CLI Still Bypasses Core Safety Modules
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `@franken/orchestrator` CLI architecture
 

--- a/docs/issues/004-cli-uses-synthetic-skill-registry-and-no-mcp.md
+++ b/docs/issues/004-cli-uses-synthetic-skill-registry-and-no-mcp.md
@@ -1,5 +1,7 @@
 # Issue: CLI Uses A Synthetic Skill List And Cannot Reach Real Skills Or MCP
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `@franken/orchestrator` execution
 

--- a/docs/issues/005-resume-flag-is-unwired.md
+++ b/docs/issues/005-resume-flag-is-unwired.md
@@ -1,5 +1,7 @@
 # Issue: `--resume` Is Parsed And Documented But Has No Behavior
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: medium
 Area: `@franken/orchestrator` CLI
 

--- a/docs/issues/006-interview-and-plan-leak-trace-viewer-resources.md
+++ b/docs/issues/006-interview-and-plan-leak-trace-viewer-resources.md
@@ -1,5 +1,7 @@
 # Issue: Interview And Plan Phases Leak Trace Viewer Resources
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: medium
 Area: `@franken/orchestrator` CLI resource management
 

--- a/docs/issues/007-heartbeat-cli-is-stub-backed.md
+++ b/docs/issues/007-heartbeat-cli-is-stub-backed.md
@@ -1,5 +1,7 @@
 # Issue: `franken-heartbeat` CLI Is Stub-Backed Rather Than Real
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `franken-heartbeat`
 

--- a/docs/issues/008-franken-mcp-public-api-and-registry-are-incomplete.md
+++ b/docs/issues/008-franken-mcp-public-api-and-registry-are-incomplete.md
@@ -1,5 +1,7 @@
 # Issue: `franken-mcp` Public API And Registry Story Are Incomplete
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `franken-mcp`
 

--- a/docs/issues/009-root-build-and-test-scripts-skip-mcp-and-break-on-failure.md
+++ b/docs/issues/009-root-build-and-test-scripts-skip-mcp-and-break-on-failure.md
@@ -1,5 +1,7 @@
 # Issue: Root Build/Test Scripts Skip `franken-mcp` And Break After Failures
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: medium
 Area: repo automation
 

--- a/docs/issues/010-root-typecheck-is-red-and-docs-claim-green.md
+++ b/docs/issues/010-root-typecheck-is-red-and-docs-claim-green.md
@@ -1,5 +1,7 @@
 # Issue: Root Typecheck Is Red While Progress Docs Still Claim A Green Repo
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: repo health
 

--- a/docs/issues/011-firewall-exports-unimplemented-adapters.md
+++ b/docs/issues/011-firewall-exports-unimplemented-adapters.md
@@ -1,5 +1,7 @@
 # Issue: `frankenfirewall` Publicly Exports Adapters That Only Throw
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: medium
 Area: `frankenfirewall`
 

--- a/docs/issues/012-observer-trace-server-tests-require-real-socket-binding.md
+++ b/docs/issues/012-observer-trace-server-tests-require-real-socket-binding.md
@@ -1,5 +1,7 @@
 # Issue: `franken-observer` TraceServer Tests Require Real Socket Binding
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: medium
 Area: `franken-observer` test reliability
 

--- a/docs/issues/013-frankenfirewall-build-script-fails.md
+++ b/docs/issues/013-frankenfirewall-build-script-fails.md
@@ -1,5 +1,7 @@
 # Issue: `frankenfirewall` Build Script Currently Fails
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `frankenfirewall`
 

--- a/docs/issues/014-franken-mcp-build-script-fails.md
+++ b/docs/issues/014-franken-mcp-build-script-fails.md
@@ -1,5 +1,7 @@
 # Issue: `franken-mcp` Build Script Currently Fails
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 Severity: high
 Area: `franken-mcp`
 

--- a/docs/issues/AUDIT-2026-03-08.md
+++ b/docs/issues/AUDIT-2026-03-08.md
@@ -1,5 +1,7 @@
 # Codebase Audit — 2026-03-08
 
+> **Historical archive notice (2026-07-09):** This document is preserved from the pre-consolidation 2026-03 audit. It may mention removed packages such as `franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`, or legacy root scripts such as `test:all`. Use the status annotations in `docs/issues/INDEX.md` and the live `package.json`/`packages/*` workspaces as the source of truth for current contributor work.
+
 > Deep-dive audit across all 11 modules. 58 issues filed on GitHub (#18–#89).
 
 ## Audit Scope

--- a/docs/issues/INDEX.md
+++ b/docs/issues/INDEX.md
@@ -2,6 +2,8 @@
 
 Generated from the 2026-03-08 codebase audit.
 
+> **Historical archive notice (2026-07-09):** This index points at issue writeups generated from the pre-consolidation 2026-03 audit. They are retained as historical evidence, not as the active backlog. Several entries intentionally mention removed package names (`franken-mcp`, `frankenfirewall`, `franken-comms`, `franken-heartbeat`) or obsolete root automation (`test:all`, directory-changing shell loops); rely on each status annotation, current GitHub issues, and the live root Turbo scripts for current work.
+
 > **Status annotations added 2026-07-04** after re-verifying each issue against the live code.
 
 1. `001-cli-config-surface-not-applied.md` — **PARTIALLY FIXED** (config flows into BeastLoop; budgets enforced; provider default honored; provider-override `extraArgs` are still dropped in the main execution path — `CliLlmAdapter.execute()` calls `buildArgs()` without them)


### PR DESCRIPTION
## Summary
- Adds a historical archive notice to the generated 2026-03 issue index.
- Adds matching archive notices to every archived `docs/issues/*.md` writeup so stale package names/root script details are explicitly historical.

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm run lint:any`
- `npm run lint:security`
- `npm test`
- `python - <<'PY' ...` confirmed all 16 `docs/issues/*.md` files include the archive banner.

Closes #929
