### PR TITLE
fix(orchestrator): tolerate corrupt LLM cache JSON

### DIFF
--- a/packages/franken-orchestrator/src/cache/llm-cache-store.ts
+++ b/packages/franken-orchestrator/src/cache/llm-cache-store.ts
@@ -64,7 +64,7 @@ export class LlmCacheStore {
       const raw = await readFile(filePath, 'utf8');
       return JSON.parse(raw) as StoredCacheEntry;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) {
         return undefined;
       }
       throw error;

--- a/packages/franken-orchestrator/src/cache/provider-session-store.ts
+++ b/packages/franken-orchestrator/src/cache/provider-session-store.ts
@@ -64,7 +64,7 @@ export class ProviderSessionStore {
       const raw = await readFile(filePath, 'utf8');
       return JSON.parse(raw) as StoredProviderSessionRecord;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) {
         return undefined;
       }
       throw error;

--- a/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CachedLlmClient } from '../../../src/cache/cached-llm-client.js';
 import { LlmCacheStore } from '../../../src/cache/llm-cache-store.js';
@@ -24,17 +24,30 @@ describe('CachedLlmClient', () => {
     const llm = new FakeLlmAdapter({ defaultResponse: 'LLM RESULT' });
     const metrics = new CacheMetrics();
 
+    const policy = new LlmCachePolicy();
+
     return {
       llm,
       metrics,
+      rootDir,
+      policy,
       client: new CachedLlmClient({
         llm,
         cacheStore: new LlmCacheStore(rootDir, { schemaVersion: 1 }),
-        policy: new LlmCachePolicy(),
+        policy,
         providerSessions: new ProviderSessionStore(rootDir, { schemaVersion: 1 }),
         metrics,
       }),
     };
+  }
+
+  async function writeCorruptJson(filePath: string): Promise<void> {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, '{"truncated":', 'utf8');
+  }
+
+  function encodeSegment(value: string): string {
+    return encodeURIComponent(value);
   }
 
   it('returns cached responses for repeated calls in the same work scope', async () => {
@@ -92,6 +105,107 @@ describe('CachedLlmClient', () => {
       projectStableHits: 1,
       managedResponseHits: 0,
       managedResponseMisses: 2,
+    });
+  });
+
+  it('treats corrupt project-stable cache JSON as a miss and calls the backing llm', async () => {
+    const { llm, client, metrics, rootDir, policy } = await createHarness();
+    const request = {
+      scope: {
+        projectId: 'frankenbeast',
+        workId: 'issue:99',
+      },
+      operation: 'issue-triage',
+      stablePrefix: 'skill injection',
+      workPrefix: 'issue 99 summary',
+      volatileSuffix: 'new comment text',
+    };
+    const computed = policy.buildRequest(request);
+    if (!computed.projectStableKey) {
+      throw new Error('test request must produce a project-stable key');
+    }
+    await writeCorruptJson(join(
+      rootDir,
+      'project',
+      encodeSegment(request.scope.projectId),
+      'stable',
+      `${encodeSegment(computed.projectStableKey)}.json`,
+    ));
+
+    await expect(client.complete(request)).resolves.toBe('LLM RESULT');
+
+    expect(llm.callCount).toBe(1);
+    expect(metrics.snapshot()).toMatchObject({
+      projectStableHits: 0,
+      managedResponseMisses: 1,
+      innerCalls: 1,
+    });
+  });
+
+  it('treats corrupt work response cache JSON as a miss and replaces it', async () => {
+    const { llm, client, rootDir, policy } = await createHarness();
+    const request = {
+      scope: {
+        projectId: 'frankenbeast',
+        workId: 'issue:99',
+      },
+      operation: 'issue-triage',
+      stablePrefix: 'skill injection',
+      workPrefix: 'issue 99 summary',
+      volatileSuffix: 'new comment text',
+    };
+    const computed = policy.buildRequest(request);
+    await writeCorruptJson(join(
+      rootDir,
+      'work',
+      encodeSegment(request.scope.projectId),
+      encodeSegment(request.scope.workId),
+      'entries',
+      `${encodeSegment(computed.responseKey)}.json`,
+    ));
+
+    await expect(client.complete(request)).resolves.toBe('LLM RESULT');
+    await expect(client.complete(request)).resolves.toBe('LLM RESULT');
+
+    expect(llm.callCount).toBe(1);
+  });
+
+  it('treats corrupt provider-session JSON as a miss before native-session fallback', async () => {
+    const { llm, client, rootDir, metrics } = await createHarness();
+    const resume = vi.fn<
+      (sessionId: string | undefined, prompt: string) => Promise<{ content: string; sessionId: string } | undefined>
+    >().mockResolvedValueOnce(undefined);
+    const request = {
+      scope: {
+        projectId: 'frankenbeast',
+        workId: 'issue:99',
+      },
+      operation: 'issue-triage',
+      stablePrefix: 'skill injection',
+      workPrefix: 'issue 99 summary',
+      volatileSuffix: 'new comment text',
+      nativeSession: {
+        provider: 'claude',
+        model: 'claude-sonnet-4-6',
+        resume,
+      },
+    };
+    await writeCorruptJson(join(
+      rootDir,
+      'work',
+      encodeSegment(request.scope.projectId),
+      encodeSegment(request.scope.workId),
+      'provider-session.json',
+    ));
+
+    await expect(client.complete(request)).resolves.toBe('LLM RESULT');
+
+    expect(resume).toHaveBeenCalledWith(undefined, expect.any(String));
+    expect(llm.callCount).toBe(1);
+    expect(metrics.snapshot()).toMatchObject({
+      nativeSessionAttempts: 1,
+      nativeSessionFallbacks: 1,
+      innerCalls: 1,
     });
   });
 


### PR DESCRIPTION
## Summary
- Treat truncated/corrupt LLM cache entry JSON as a cache miss instead of throwing.
- Treat corrupt provider-session JSON as a miss so native-session resume can fall back normally.
- Add CachedLlmClient regressions for corrupt project cache, work response cache, and provider-session JSON.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/cache/cached-llm-client.test.ts
- npm --prefix packages/franken-orchestrator test -- tests/unit/cache
- npm --prefix packages/franken-orchestrator run lint
- npm run build
- npm run typecheck
- npm --prefix packages/franken-orchestrator test

Closes #1219