### PR TITLE
fix(web): surface network API structured errors

### DIFF
--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -1,6 +1,18 @@
-import type { ApiDataEnvelope, NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
+import type { ApiDataEnvelope, ApiErrorEnvelope, NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
 
 export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
+
+export class NetworkApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'NetworkApiError';
+  }
+}
 
 export class NetworkApiClient {
   constructor(private readonly baseUrl: string) {}
@@ -52,9 +64,30 @@ export class NetworkApiClient {
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const response = await fetch(`${this.baseUrl}${path}`, init);
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+      throw await this.toError(response);
     }
     const body = await response.json() as ApiDataEnvelope<T>;
     return body.data;
+  }
+
+  private async toError(response: Response): Promise<NetworkApiError> {
+    const fallbackMessage = `HTTP ${response.status}`;
+    try {
+      const body = await response.json() as ApiErrorEnvelope;
+      const serverMessage = body.error?.message;
+      if (serverMessage) {
+        const code = body.error.code;
+        const codeSuffix = code ? `, ${code}` : '';
+        return new NetworkApiError(
+          `${serverMessage} (HTTP ${response.status}${codeSuffix})`,
+          response.status,
+          code,
+          body.error.details,
+        );
+      }
+    } catch {
+      // Fall through with HTTP status message for empty, malformed, or non-JSON bodies.
+    }
+    return new NetworkApiError(fallbackMessage, response.status);
   }
 }

--- a/packages/franken-web/tests/lib/network-api.test.ts
+++ b/packages/franken-web/tests/lib/network-api.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { NetworkApiClient } from '../../src/lib/network-api';
+import { NetworkApiClient, NetworkApiError } from '../../src/lib/network-api';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -94,5 +94,40 @@ describe('NetworkApiClient', () => {
       'http://localhost:3000/v1/network/logs/chat-server',
       expect.objectContaining({ method: 'GET' }),
     );
+  });
+
+  it('surfaces structured network error envelopes with status and code context', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: () => Promise.resolve({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          details: [{ path: ['assignments'], message: 'Expected array' }],
+        },
+      }),
+    });
+
+    try {
+      await client.updateConfig(['network.mode=insecure']);
+      throw new Error('Expected updateConfig to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(NetworkApiError);
+      expect((error as Error).message).toBe('Request validation failed (HTTP 422, VALIDATION_ERROR)');
+      expect((error as NetworkApiError).status).toBe(422);
+      expect((error as NetworkApiError).code).toBe('VALIDATION_ERROR');
+      expect((error as NetworkApiError).details).toEqual([{ path: ['assignments'], message: 'Expected array' }]);
+    }
+  });
+
+  it('falls back to HTTP status for malformed network error bodies', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+    });
+
+    await expect(client.getStatus()).rejects.toThrow('HTTP 502');
   });
 });


### PR DESCRIPTION
## Summary
- Parse structured Network API error envelopes on non-OK responses.
- Throw a `NetworkApiError` that preserves HTTP status, backend error code, and details while surfacing the backend message.
- Add regressions for structured validation errors and malformed-body fallback handling.

## Test Plan
- `npm ci`
- `npm --prefix packages/franken-types run build`
- `npm --prefix packages/franken-web test -- --run tests/lib/network-api.test.ts src/lib/network-api.test.ts`
- `npm --prefix packages/franken-web run typecheck`
- `npm --prefix packages/franken-web run build`
- `npm --prefix packages/franken-web test`
- `git diff --check`

Closes #1244
