### PR TITLE
fix(orchestrator): cap websocket chat message size

### DIFF
--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, Server as HttpServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import type { Duplex } from 'node:stream';
-import { WebSocketServer, type WebSocket } from 'ws';
+import { WebSocketServer, type RawData, type WebSocket } from 'ws';
 import { approvalRuntimeInput } from '../chat/approval-input.js';
 import { ChatRuntime, pendingApprovalRuntimeState } from '../chat/runtime.js';
 import type { ISessionStore } from '../chat/session-store.js';
@@ -38,6 +38,7 @@ export interface ChatSocketControllerOptions {
   operatorToken?: string | undefined;
   chatRateLimit?: ChatRateLimitOptions;
   chatRateLimiter?: InMemoryRateLimiter;
+  maxMessageBytes?: number;
 }
 
 export interface ChatSocketConnectRequest {
@@ -54,6 +55,7 @@ export interface AttachChatWebSocketServerOptions extends ChatSocketControllerOp
 
 export const CHAT_SOCKET_PROTOCOL = 'franken.chat.v1';
 export const CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX = 'franken.chat.token.';
+export const DEFAULT_CHAT_SOCKET_MAX_MESSAGE_BYTES = 64 * 1024;
 
 interface ChatSocketProtocolAuth {
   hasChatProtocol: boolean;
@@ -109,6 +111,7 @@ export class ChatSocketController {
   private readonly tokenSecret: string;
   private readonly operatorToken: string | undefined;
   private readonly chatRateLimiter: InMemoryRateLimiter;
+  private readonly maxMessageBytes: number;
 
   constructor(options: ChatSocketControllerOptions) {
     this.allowedOrigins = options.allowedOrigins ?? [];
@@ -118,6 +121,7 @@ export class ChatSocketController {
     this.tokenSecret = options.tokenSecret;
     this.operatorToken = options.operatorToken;
     this.chatRateLimiter = options.chatRateLimiter ?? createChatRateLimiter(options.chatRateLimit ?? DEFAULT_CHAT_RATE_LIMIT);
+    this.maxMessageBytes = options.maxMessageBytes ?? DEFAULT_CHAT_SOCKET_MAX_MESSAGE_BYTES;
   }
 
   authorize(request: ChatSocketConnectRequest): { ok: true } | { ok: false; status: number } {
@@ -190,6 +194,17 @@ export class ChatSocketController {
         message: 'Socket is not bound to a chat session.',
         timestamp: nowIso(),
       });
+      return;
+    }
+
+    if (Buffer.byteLength(raw, 'utf8') > this.maxMessageBytes) {
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'MESSAGE_TOO_LARGE',
+        message: `Websocket chat event exceeds the ${this.maxMessageBytes} byte limit.`,
+        timestamp: nowIso(),
+      });
+      peer.close(1009, 'Message too large');
       return;
     }
 
@@ -521,10 +536,28 @@ function closeUnauthorized(
   socket.destroy();
 }
 
+function rawPayloadByteLength(payload: RawData): number {
+  if (Array.isArray(payload)) {
+    return payload.reduce((total, chunk) => total + chunk.byteLength, 0);
+  }
+  return payload.byteLength;
+}
+
+function rawPayloadToString(payload: RawData): string {
+  if (Array.isArray(payload)) {
+    return Buffer.concat(payload).toString('utf8');
+  }
+  if (Buffer.isBuffer(payload)) {
+    return payload.toString('utf8');
+  }
+  return Buffer.from(payload).toString('utf8');
+}
+
 export function attachChatWebSocketServer(options: AttachChatWebSocketServerOptions) {
   const path = options.path ?? '/v1/chat/ws';
+  const maxMessageBytes = options.maxMessageBytes ?? DEFAULT_CHAT_SOCKET_MAX_MESSAGE_BYTES;
   const controller = new ChatSocketController(options);
-  const server = new WebSocketServer({ noServer: true });
+  const server = new WebSocketServer({ noServer: true, maxPayload: maxMessageBytes });
 
   const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer): void => {
     const url = new URL(request.url ?? '', 'http://localhost');
@@ -565,9 +598,14 @@ export function attachChatWebSocketServer(options: AttachChatWebSocketServerOpti
         return;
       }
 
-      ws.on('message', async (payload: Buffer | ArrayBuffer | Buffer[]) => {
-        await controller.receive(peer, payload.toString());
+      ws.on('message', async (payload: RawData) => {
+        if (rawPayloadByteLength(payload) > maxMessageBytes) {
+          peer.close(1009, 'Message too large');
+          return;
+        }
+        await controller.receive(peer, rawPayloadToString(payload));
       });
+      ws.on('error', () => controller.disconnect(peer));
       ws.on('close', () => controller.disconnect(peer));
     });
   };

--- a/packages/franken-orchestrator/src/ws.d.ts
+++ b/packages/franken-orchestrator/src/ws.d.ts
@@ -7,13 +7,14 @@ declare module 'ws' {
   export interface WebSocket {
     close(code?: number, reason?: string): void;
     on(event: 'message', listener: (data: RawData) => void): this;
+    on(event: 'error', listener: (error: Error) => void): this;
     on(event: 'close', listener: () => void): this;
     send(data: string): void;
     terminate(): void;
   }
 
   export class WebSocketServer {
-    constructor(options: { noServer?: boolean });
+    constructor(options: { noServer?: boolean; maxPayload?: number });
     clients: Set<WebSocket>;
     close(callback?: (err?: Error) => void): void;
     handleUpgrade(

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -12,6 +12,7 @@ import {
   CHAT_SOCKET_PROTOCOL,
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
   ChatSocketController,
+  DEFAULT_CHAT_SOCKET_MAX_MESSAGE_BYTES,
   attachChatWebSocketServer,
 } from '../../../src/http/ws-chat-server.js';
 import {
@@ -235,6 +236,76 @@ describe('ws chat server', () => {
     expect(events.map((event) => event.type)).toContain('assistant.message.delta');
     expect(events.map((event) => event.type)).toContain('assistant.message.complete');
 
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('rejects websocket events that exceed the configured byte limit before parsing', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = { run: vi.fn() };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+      maxMessageBytes: 64,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-too-large',
+      content: 'x'.repeat(DEFAULT_CHAT_SOCKET_MAX_MESSAGE_BYTES),
+    }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as { type: string; code?: string });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'MESSAGE_TOO_LARGE',
+    }));
+    expect(peer.close).toHaveBeenCalledWith(1009, 'Message too large');
+    expect(runtime.run).not.toHaveBeenCalled();
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('configures the WebSocket server to close oversized frames', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = { run: vi.fn() };
+    const httpServer = createServer();
+    attachChatWebSocketServer({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+      server: httpServer,
+      maxMessageBytes: 64,
+    });
+    const port = await listen(httpServer);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}`,
+      [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${token}`],
+    );
+
+    await expect(onceSocket(socket, 'open')).resolves.toEqual([]);
+    socket.send(JSON.stringify({ type: 'ping', padding: 'x'.repeat(128) }));
+    const closeArgs = await onceSocket(socket, 'close');
+
+    expect(closeArgs[0]).toBe(1009);
+    expect(runtime.run).not.toHaveBeenCalled();
+
+    httpServer.close();
     rmSync(TMP, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary
- Adds a default 64 KiB inbound WebSocket chat frame/event limit.
- Configures ws maxPayload and closes oversize frames with code 1009.
- Rejects oversize controller events before JSON parsing and covers both paths with regression tests.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- --run tests/integration/chat/ws-chat-server.test.ts
- npm run build
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint
- npm run typecheck
- npm --prefix packages/franken-orchestrator test

Closes #1093