### PR TITLE
fix(orchestrator): harden generic comms gateway

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -291,6 +291,8 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     const commsRoutesOpts: Parameters<typeof commsRoutes>[0] = {
       config: opts.commsConfig,
       runtime: opts.commsRuntime,
+      security: operatorSecurity,
+      ...(effectiveOperatorToken ? { operatorToken: effectiveOperatorToken } : {}),
     };
     if (opts.securityConfig) {
       commsRoutesOpts.getWebhookSignaturePolicy = () => opts.securityConfig!.getSecurityConfig().webhookSignaturePolicy;

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -1,4 +1,6 @@
 import { Hono, type Context } from 'hono';
+import { createMiddleware } from 'hono/factory';
+import { z } from 'zod';
 import { ChatGateway } from '../../comms/gateway/chat-gateway.js';
 import { SessionMapper } from '../../comms/core/session-mapper.js';
 import { slackRouter } from '../../comms/channels/slack/slack-router.js';
@@ -11,7 +13,10 @@ import { TelegramAdapter } from '../../comms/channels/telegram/telegram-adapter.
 import { WhatsAppAdapter } from '../../comms/channels/whatsapp/whatsapp-adapter.js';
 import type { CommsConfig } from '../../comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../../comms/core/comms-runtime-port.js';
-import { requestSizeLimit } from '../middleware.js';
+import type { ChannelInboundMessage } from '../../comms/core/types.js';
+import { errorHandler, HttpError, parseJsonBody, requestSizeLimit, validateBody } from '../middleware.js';
+import { requireOperatorAuth } from '../operator-auth.js';
+import { TransportSecurityService } from '../security/transport-security.js';
 
 import type { WebhookSignaturePolicy } from '../../middleware/security-profiles.js';
 
@@ -21,9 +26,30 @@ const DEFAULT_GENERIC_COMMS_BODY_SIZE = 16 * 1024;
 export interface CommsRoutesOptions {
   config: CommsConfig;
   runtime?: CommsRuntimePort;
+  operatorToken?: string | undefined;
+  security?: TransportSecurityService | undefined;
   webhookSignaturePolicy?: WebhookSignaturePolicy;
   getWebhookSignaturePolicy?: () => WebhookSignaturePolicy;
 }
+
+const ChannelTypeSchema = z.enum(['slack', 'discord', 'telegram', 'whatsapp']);
+
+const GenericCommsInboundBody = z.object({
+  channelType: ChannelTypeSchema,
+  externalUserId: z.string().min(1),
+  externalChannelId: z.string().min(1),
+  externalThreadId: z.string().min(1).optional(),
+  externalMessageId: z.string().min(1),
+  text: z.string().min(1),
+  rawEvent: z.custom<unknown>((value) => value !== undefined, { message: 'Required' }),
+  receivedAt: z.string().datetime({ offset: true }),
+}).strict();
+
+const GenericCommsActionBody = z.object({
+  channelType: ChannelTypeSchema,
+  sessionId: z.string().min(1),
+  actionId: z.string().min(1),
+}).strict();
 
 export function commsRoutes(options: CommsRoutesOptions): Hono {
   const { config, runtime } = options;
@@ -49,8 +75,12 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   }
 
   const app = new Hono();
+  app.onError(errorHandler);
 
   app.get('/comms/health', (c) => c.json({ status: 'ok' }));
+  const genericCommsAuth = createGenericCommsAuth(options);
+  app.use('/v1/comms', genericCommsAuth);
+  app.use('/v1/comms/*', genericCommsAuth);
   app.use('/v1/comms', requestSizeLimit(DEFAULT_GENERIC_COMMS_BODY_SIZE));
   app.use('/v1/comms/*', requestSizeLimit(DEFAULT_GENERIC_COMMS_BODY_SIZE));
   app.use('/webhooks/*', requestSizeLimit(DEFAULT_GENERIC_COMMS_BODY_SIZE));
@@ -108,18 +138,38 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   }
 
   app.post('/v1/comms/inbound', async (c) => {
-    const body = await c.req.json();
+    const body = validateBody(GenericCommsInboundBody, await parseJsonBody(c)) as unknown as ChannelInboundMessage;
     await gateway.handleInbound(body);
     return c.json({ accepted: true });
   });
 
   app.post('/v1/comms/action', async (c) => {
-    const { channelType, sessionId, actionId } = await c.req.json();
+    const { channelType, sessionId, actionId } = validateBody(GenericCommsActionBody, await parseJsonBody(c));
     await gateway.handleAction(channelType, sessionId, actionId);
     return c.json({ accepted: true });
   });
 
   return app;
+}
+
+function createGenericCommsAuth(options: CommsRoutesOptions) {
+  if (options.operatorToken) {
+    return requireOperatorAuth({
+      operatorToken: options.operatorToken,
+      security: options.security ?? new TransportSecurityService(),
+    });
+  }
+
+  return createMiddleware(async (c, next) => {
+    if (!isLoopbackWebhookRequest(c.req.raw)) {
+      throw new HttpError(
+        403,
+        'FORBIDDEN',
+        'Generic comms gateway requires operator authentication or a loopback-only request',
+      );
+    }
+    await next();
+  });
 }
 
 function isLoopbackWebhookRequest(request: Request): boolean {

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../../src/comms/channels/whatsapp/whatsapp-adapter.js', () => ({
 import { commsRoutes } from '../../../src/http/routes/comms-routes.js';
 import type { CommsConfig } from '../../../src/comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../../../src/comms/core/comms-runtime-port.js';
+import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { testCredential } from '../../support/test-credentials.js';
 
 const TEST_SLACK_BOT_TOKEN = testCredential('TEST_SLACK_BOT_TOKEN');
@@ -25,6 +26,7 @@ const TEST_WHATSAPP_ACCESS_TOKEN = testCredential('TEST_WHATSAPP_ACCESS_TOKEN');
 const TEST_WHATSAPP_VERIFY_TOKEN = testCredential('TEST_WHATSAPP_VERIFY_TOKEN');
 const TEST_TELEGRAM_BOT_TOKEN = ['123456', testCredential('TEST_TELEGRAM_BOT_TOKEN_SECRET')].join(':');
 const TEST_TELEGRAM_WEBHOOK_SECRET_TOKEN = testCredential('TEST_TELEGRAM_WEBHOOK_SECRET_TOKEN');
+const TEST_OPERATOR_TOKEN = testCredential('TEST_COMMS_OPERATOR_TOKEN');
 
 function minimalConfig(overrides?: Partial<CommsConfig>): CommsConfig {
   return {
@@ -112,6 +114,76 @@ describe('commsRoutes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ accepted: true });
+  });
+
+  it('requires operator authentication for generic comms routes when an operator token is configured', async () => {
+    const app = commsRoutes({
+      config: minimalConfig(),
+      runtime: mockRuntime(),
+      operatorToken: TEST_OPERATOR_TOKEN,
+      security: new TransportSecurityService(),
+    });
+
+    const missing = await app.request('/v1/comms/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ channelType: 'slack', sessionId: 's1', actionId: 'approve' }),
+    });
+    expect(missing.status).toBe(401);
+    await expect(missing.json()).resolves.toMatchObject({ error: { code: 'UNAUTHORIZED' } });
+
+    const authenticated = await app.request('/v1/comms/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TEST_OPERATOR_TOKEN}` },
+      body: JSON.stringify({ channelType: 'slack', sessionId: 's1', actionId: 'approve' }),
+    });
+    expect(authenticated.status).toBe(200);
+    await expect(authenticated.json()).resolves.toEqual({ accepted: true });
+  });
+
+  it('rejects generic comms routes from non-loopback peers when no operator token is configured', async () => {
+    const app = commsRoutes({ config: minimalConfig(), runtime: mockRuntime() });
+
+    const external = await app.request('https://example.com/v1/comms/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        channelType: 'slack',
+        externalUserId: 'U1',
+        externalChannelId: 'C1',
+        externalMessageId: 'M1',
+        text: 'hello',
+        receivedAt: new Date().toISOString(),
+        rawEvent: {},
+      }),
+    });
+
+    expect(external.status).toBe(403);
+    await expect(external.json()).resolves.toMatchObject({ error: { code: 'FORBIDDEN' } });
+  });
+
+  it('rejects malformed generic comms inbound payloads before invoking the runtime', async () => {
+    const runtime = mockRuntime();
+    const app = commsRoutes({ config: minimalConfig(), runtime });
+
+    const res = await app.request('/v1/comms/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        channelType: 'slack',
+        externalUserId: 'U1',
+        externalChannelId: 'C1',
+        externalMessageId: 'M1',
+        text: '',
+        receivedAt: new Date().toISOString(),
+        rawEvent: {},
+        unexpected: true,
+      }),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({ error: { code: 'VALIDATION_ERROR' } });
+    expect(runtime.processInbound).not.toHaveBeenCalled();
   });
 
   it('rejects oversized generic comms inbound JSON before parsing', async () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -28,3 +28,6 @@
 - When a proxy/shared adapter needs active project config, pass both explicit `root` and `configPath` through every factory/init path; resolve relative config paths from the project root rather than `cwd`, and add nested-cwd regressions.
 - Treat explicit config paths (`--config`/env) as fail-closed: missing explicit security config must throw instead of silently falling back to a default scan tier. Keep only implicit legacy defaults optional.
 - User-configured regex filters need positive and negative ReDoS regressions before each Codex round: safe unquantified alternation (`(password|token)`) must still work, while nested quantifiers, quantified alternation, repeated quantified atoms, and bounded nested quantifiers must be rejected before scan evaluation.
+
+## 2026-07-09 — Generic comms gateway hardening
+- For generic comms routes, keep authentication before body parsing/size buffering, preserve local-dev by allowing only verified loopback requests when no operator token is configured, and add strict Zod regressions for both auth and malformed payloads. In Zod v3, `z.unknown()` can infer an optional object property; use a required custom schema or explicit post-parse cast when validating required unknown fields such as `rawEvent`.


### PR DESCRIPTION
## Summary
- Adds strict Zod schemas for generic `/v1/comms/inbound` and `/v1/comms/action` payloads before gateway dispatch.
- Requires operator authentication when an operator token is configured, and fails closed to loopback-only requests when no token is configured.
- Passes the chat app's effective operator token/security into comms routes and adds regression coverage.

## Test Plan
- npm exec -- vitest run tests/unit/http/comms-routes.test.ts
- npm exec -- vitest run tests/integration/chat/chat-server.test.ts
- npm run build
- npm run typecheck
- npm run lint:any
- npm run lint:security

Closes #679