### PR TITLE
fix(mcp): reject unknown critique evaluators

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/critique-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/critique-adapter.ts
@@ -86,15 +86,17 @@ export function createCritiqueAdapter(): CritiqueAdapter {
   };
 
   function resolveEvaluators(names?: string[]) {
-    const selected = (names && names.length > 0 ? names : defaultEvaluators())
-      .map((name) => evaluatorMap.get(name))
-      .filter((evaluator): evaluator is Evaluator => evaluator !== undefined);
+    const requestedNames = names && names.length > 0 ? names : defaultEvaluators();
+    const unknownNames = requestedNames.filter((name) => !evaluatorMap.has(name));
 
-    return selected.length > 0 ? selected : [
-      new LogicLoopEvaluator(),
-      new ComplexityEvaluator(),
-      new ConcisenessEvaluator(),
-    ];
+    if (unknownNames.length > 0) {
+      const noun = unknownNames.length === 1 ? 'evaluator' : 'evaluators';
+      throw new Error(
+        `Unknown critique ${noun}: ${unknownNames.join(', ')}. Expected one of: ${defaultEvaluators().join(', ')}`,
+      );
+    }
+
+    return requestedNames.map((name) => evaluatorMap.get(name)!);
   }
 }
 

--- a/packages/franken-mcp-suite/src/servers/critique.test.ts
+++ b/packages/franken-mcp-suite/src/servers/critique.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { createCritiqueAdapter } from '../adapters/critique-adapter.js';
 import { createCritiqueServer } from './critique.js';
 
 describe('Critique Server', () => {
@@ -50,6 +51,31 @@ describe('Critique Server', () => {
     const compareResult = await compareTool.handler({ original: 'var x = 1', revised: 'const x = 1' });
     expect(critique.compare).toHaveBeenCalledWith({ original: 'var x = 1', revised: 'const x = 1' });
     expect(compareResult.content[0]!.text).toContain('improved');
+  });
+
+  it('rejects unknown critique evaluators instead of falling back to defaults', async () => {
+    const server = createCritiqueServer({ critique: createCritiqueAdapter() });
+
+    const result = await server.callTool('fbeast_critique_evaluate', {
+      content: 'x',
+      evaluators: 'logicloop',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Unknown critique evaluator: logicloop');
+    expect(result.content[0]!.text).toContain('logic-loop, complexity, conciseness');
+  });
+
+  it('rejects partially unknown critique evaluator lists deterministically', async () => {
+    const server = createCritiqueServer({ critique: createCritiqueAdapter() });
+
+    const result = await server.callTool('fbeast_critique_evaluate', {
+      content: 'x',
+      evaluators: 'logic-loop,missing-one,complexity,stale-two',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Unknown critique evaluators: missing-one, stale-two');
   });
 
   it('serves critique tools when lazy audit DB setup fails', async () => {

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -216,7 +216,7 @@ const TOOLS: ToolFull[] = [
       properties: {
         content: { type: 'string', description: 'Code or text to evaluate' },
         criteria: { type: 'string', description: 'Comma-separated criteria: correctness, readability, security, complexity' },
-        evaluators: { type: 'string', description: 'Comma-separated evaluator names (e.g. logic-loop, complexity)' },
+        evaluators: { type: 'string', description: 'Comma-separated evaluator names. Supported values: logic-loop, complexity, conciseness. Unknown names are rejected.' },
       },
       required: ['content'],
     },


### PR DESCRIPTION
## Summary
- reject unknown fbeast_critique_evaluate evaluator names instead of falling back to defaults
- report all invalid evaluator names while documenting the supported values
- add regression coverage for unknown-only and partially unknown evaluator lists

## Test Plan
- npm --workspace @franken/mcp-suite test -- src/servers/critique.test.ts
- npm --workspace @franken/mcp-suite run typecheck
- npm run build
- npm run lint:any

Closes #1255