### PR TITLE
fix(critique): isolate evaluator exceptions

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -5,6 +5,7 @@
 export type { Severity, Verdict, Score, SessionId, TaskId } from './types/common.js';
 
 // Types — evaluation
+export { EVALUATOR_EXCEPTION_LOCATION } from './types/evaluation.js';
 export type {
   EvaluationInput,
   EvaluationFinding,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1,6 +1,7 @@
 import type { MemoryPort, CritiqueLesson } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
+import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
 
 export class LessonRecorder {
   private readonly memory: MemoryPort;
@@ -42,10 +43,14 @@ export class LessonRecorder {
     );
 
     for (const evalResult of failingIteration.result.results) {
-      if (evalResult.verdict === 'fail' && evalResult.findings.length > 0) {
+      const critiqueFindings = evalResult.findings.filter(
+        (finding) => finding.location !== EVALUATOR_EXCEPTION_LOCATION,
+      );
+
+      if (evalResult.verdict === 'fail' && critiqueFindings.length > 0) {
         lessons.push({
           evaluatorName: evalResult.evaluatorName,
-          failureDescription: evalResult.findings.map((f) => f.message).join('; '),
+          failureDescription: critiqueFindings.map((f) => f.message).join('; '),
           correctionApplied: passingIteration
             ? `Corrected in iteration ${passingIteration.index}`
             : 'Unknown correction',

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -7,6 +7,13 @@ function hasWarningFinding(result: EvaluationResult): boolean {
   return result.findings.some((finding) => finding.severity !== 'info');
 }
 
+function logEvaluatorException(evaluator: Evaluator, error: unknown): void {
+  console.warn('Critique evaluator threw during evaluation', {
+    evaluatorName: evaluator.name,
+    error,
+  });
+}
+
 function createEvaluatorExceptionResult(evaluator: Evaluator): EvaluationResult {
   return {
     evaluatorName: evaluator.name,
@@ -47,7 +54,8 @@ export class CritiquePipeline {
 
       try {
         result = await evaluator.evaluate(input);
-      } catch {
+      } catch (error) {
+        logEvaluatorException(evaluator, error);
         results.push(createEvaluatorExceptionResult(evaluator));
         if (evaluator.name === SAFETY_EVALUATOR_NAME) {
           shortCircuited = true;

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -65,6 +65,10 @@ export class CritiquePipeline {
         result = await evaluator.evaluate(input);
       } catch (error) {
         results.push(createEvaluatorExceptionResult(evaluator, error));
+        if (evaluator.name === SAFETY_EVALUATOR_NAME) {
+          shortCircuited = true;
+          break;
+        }
         continue;
       }
 

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -1,3 +1,4 @@
+import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
 import type { Evaluator, EvaluationInput, EvaluationResult, CritiquePipelineResult } from '../types/evaluation.js';
 
 const SAFETY_EVALUATOR_NAME = 'safety';
@@ -6,34 +7,17 @@ function hasWarningFinding(result: EvaluationResult): boolean {
   return result.findings.some((finding) => finding.severity !== 'info');
 }
 
-function summarizeEvaluatorError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message || error.name;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-}
-
-function createEvaluatorExceptionResult(evaluator: Evaluator, error: unknown): EvaluationResult {
-  const summary = summarizeEvaluatorError(error) || 'Unknown evaluator error';
-
+function createEvaluatorExceptionResult(evaluator: Evaluator): EvaluationResult {
   return {
     evaluatorName: evaluator.name,
     verdict: 'fail',
     score: 0,
     findings: [
       {
-        message: `Evaluator "${evaluator.name}" failed with an exception: ${summary}`,
+        message: `Evaluator "${evaluator.name}" failed because an internal evaluator error occurred.`,
         severity: 'critical',
-        suggestion: 'Inspect the evaluator dependency or implementation and retry the critique run.',
+        location: EVALUATOR_EXCEPTION_LOCATION,
+        suggestion: 'Inspect trusted evaluator logs or dependencies before retrying the critique run.',
       },
     ],
   };
@@ -63,8 +47,8 @@ export class CritiquePipeline {
 
       try {
         result = await evaluator.evaluate(input);
-      } catch (error) {
-        results.push(createEvaluatorExceptionResult(evaluator, error));
+      } catch {
+        results.push(createEvaluatorExceptionResult(evaluator));
         if (evaluator.name === SAFETY_EVALUATOR_NAME) {
           shortCircuited = true;
           break;

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -6,6 +6,39 @@ function hasWarningFinding(result: EvaluationResult): boolean {
   return result.findings.some((finding) => finding.severity !== 'info');
 }
 
+function summarizeEvaluatorError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function createEvaluatorExceptionResult(evaluator: Evaluator, error: unknown): EvaluationResult {
+  const summary = summarizeEvaluatorError(error) || 'Unknown evaluator error';
+
+  return {
+    evaluatorName: evaluator.name,
+    verdict: 'fail',
+    score: 0,
+    findings: [
+      {
+        message: `Evaluator "${evaluator.name}" failed with an exception: ${summary}`,
+        severity: 'critical',
+        suggestion: 'Inspect the evaluator dependency or implementation and retry the critique run.',
+      },
+    ],
+  };
+}
+
 export class CritiquePipeline {
   private readonly evaluators: readonly Evaluator[];
 
@@ -26,7 +59,15 @@ export class CritiquePipeline {
     let shortCircuited = false;
 
     for (const evaluator of this.evaluators) {
-      const result = await evaluator.evaluate(input);
+      let result: EvaluationResult;
+
+      try {
+        result = await evaluator.evaluate(input);
+      } catch (error) {
+        results.push(createEvaluatorExceptionResult(evaluator, error));
+        continue;
+      }
+
       results.push(result);
 
       // Short-circuit on safety failure

--- a/packages/franken-critique/src/types/evaluation.ts
+++ b/packages/franken-critique/src/types/evaluation.ts
@@ -10,6 +10,8 @@ export interface EvaluationInput {
   readonly metadata: Readonly<Record<string, unknown>>;
 }
 
+export const EVALUATOR_EXCEPTION_LOCATION = 'internal:evaluator-exception';
+
 /** A single finding from an evaluator. */
 export interface EvaluationFinding {
   /** Human-readable description of the issue. */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { LessonRecorder } from '../../../src/memory/lesson-recorder.js';
+import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
 import type { MemoryPort } from '../../../src/types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../../../src/types/loop.js';
-import type { CritiqueResult } from '../../../src/types/evaluation.js';
+import type { CritiqueResult, EvaluationFinding } from '../../../src/types/evaluation.js';
 
 function createMockMemoryPort(): MemoryPort {
   return {
@@ -16,7 +17,7 @@ function createIteration(
   index: number,
   verdict: 'pass' | 'warn' | 'fail',
   evaluatorName = 'mock',
-  findings: { message: string; severity: 'critical' | 'warning' | 'info' }[] = [],
+  findings: EvaluationFinding[] = [],
 ): CritiqueIteration {
   const result: CritiqueResult = {
     verdict,
@@ -120,6 +121,29 @@ describe('LessonRecorder', () => {
       correctionApplied: string;
     };
     expect(call.correctionApplied).toBe('Corrected in iteration 1');
+  });
+
+  it('does not record evaluator infrastructure exceptions as learned critique lessons', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'adr-compliance', [
+          {
+            message: 'Evaluator "adr-compliance" failed because an internal evaluator error occurred.',
+            severity: 'critical',
+            location: EVALUATOR_EXCEPTION_LOCATION,
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-123');
+
+    expect(port.recordLesson).not.toHaveBeenCalled();
   });
 
   it('does not record on fail verdict', async () => {

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -24,6 +24,18 @@ function createMockEvaluator(
   };
 }
 
+function createThrowingEvaluator(
+  name: string,
+  category: 'deterministic' | 'heuristic',
+  error: unknown,
+): Evaluator {
+  return {
+    name,
+    category,
+    evaluate: vi.fn().mockRejectedValue(error),
+  };
+}
+
 describe('CritiquePipeline', () => {
   it('returns pass with empty evaluator list', async () => {
     const pipeline = new CritiquePipeline([]);
@@ -161,6 +173,40 @@ describe('CritiquePipeline', () => {
     expect(result.shortCircuited).toBe(false);
     expect(result.results).toHaveLength(2);
     expect(other.evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates evaluator exceptions as structured failures and continues later evaluators', async () => {
+    const passing = createMockEvaluator('passing', 'deterministic', { score: 0.8 });
+    const throwing = createThrowingEvaluator(
+      'flaky-adr-check',
+      'heuristic',
+      new Error('memory backend unavailable'),
+    );
+    const later = createMockEvaluator('later', 'heuristic', { score: 0.6 });
+
+    const pipeline = new CritiquePipeline([passing, throwing, later]);
+    const result = await pipeline.run(createInput('code'));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.shortCircuited).toBe(false);
+    expect(result.overallScore).toBeCloseTo((0.8 + 0 + 0.6) / 3);
+    expect(result.results).toHaveLength(3);
+    expect(result.results[0]).toMatchObject({ evaluatorName: 'passing', verdict: 'pass' });
+    expect(result.results[1]).toMatchObject({
+      evaluatorName: 'flaky-adr-check',
+      verdict: 'fail',
+      score: 0,
+      findings: [
+        {
+          severity: 'critical',
+          message: expect.stringContaining('flaky-adr-check'),
+          suggestion: expect.stringContaining('evaluator'),
+        },
+      ],
+    });
+    expect(result.results[1]?.findings[0]?.message).toContain('memory backend unavailable');
+    expect(result.results[2]).toMatchObject({ evaluatorName: 'later', verdict: 'pass' });
+    expect(later.evaluate).toHaveBeenCalledTimes(1);
   });
 
   it('calculates average score across all evaluators', async () => {

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { CritiquePipeline } from '../../../src/pipeline/critique-pipeline.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
 import type { Evaluator, EvaluationInput, EvaluationResult } from '../../../src/types/evaluation.js';
@@ -38,6 +38,10 @@ function createThrowingEvaluator(
 }
 
 describe('CritiquePipeline', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns pass with empty evaluator list', async () => {
     const pipeline = new CritiquePipeline([]);
     const result = await pipeline.run(createInput('code'));
@@ -177,12 +181,10 @@ describe('CritiquePipeline', () => {
   });
 
   it('isolates evaluator exceptions as structured failures and continues later evaluators', async () => {
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const backendError = new Error('memory backend unavailable');
     const passing = createMockEvaluator('passing', 'deterministic', { score: 0.8 });
-    const throwing = createThrowingEvaluator(
-      'flaky-adr-check',
-      'heuristic',
-      new Error('memory backend unavailable'),
-    );
+    const throwing = createThrowingEvaluator('flaky-adr-check', 'heuristic', backendError);
     const later = createMockEvaluator('later', 'heuristic', { score: 0.6 });
 
     const pipeline = new CritiquePipeline([passing, throwing, later]);
@@ -209,9 +211,14 @@ describe('CritiquePipeline', () => {
     expect(result.results[1]?.findings[0]?.message).not.toContain('memory backend unavailable');
     expect(result.results[2]).toMatchObject({ evaluatorName: 'later', verdict: 'pass' });
     expect(later.evaluate).toHaveBeenCalledTimes(1);
+    expect(logged).toHaveBeenCalledWith('Critique evaluator threw during evaluation', {
+      evaluatorName: 'flaky-adr-check',
+      error: backendError,
+    });
   });
 
   it('short-circuits after converting a safety evaluator exception into a structured failure', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const safety = createThrowingEvaluator('safety', 'deterministic', new Error('guardrails unavailable'));
     const other = createMockEvaluator('other', 'heuristic');
 

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -209,6 +209,30 @@ describe('CritiquePipeline', () => {
     expect(later.evaluate).toHaveBeenCalledTimes(1);
   });
 
+  it('short-circuits after converting a safety evaluator exception into a structured failure', async () => {
+    const safety = createThrowingEvaluator('safety', 'deterministic', new Error('guardrails unavailable'));
+    const other = createMockEvaluator('other', 'heuristic');
+
+    const pipeline = new CritiquePipeline([safety, other]);
+    const result = await pipeline.run(createInput('code'));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.shortCircuited).toBe(true);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      evaluatorName: 'safety',
+      verdict: 'fail',
+      score: 0,
+      findings: [
+        {
+          severity: 'critical',
+          message: expect.stringContaining('guardrails unavailable'),
+        },
+      ],
+    });
+    expect(other.evaluate).not.toHaveBeenCalled();
+  });
+
   it('calculates average score across all evaluators', async () => {
     const a = createMockEvaluator('a', 'deterministic', { score: 0.8 });
     const b = createMockEvaluator('b', 'heuristic', { score: 0.6 });

--- a/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
+++ b/packages/franken-critique/tests/unit/pipeline/critique-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CritiquePipeline } from '../../../src/pipeline/critique-pipeline.js';
+import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
 import type { Evaluator, EvaluationInput, EvaluationResult } from '../../../src/types/evaluation.js';
 
 function createInput(content: string): EvaluationInput {
@@ -199,12 +200,13 @@ describe('CritiquePipeline', () => {
       findings: [
         {
           severity: 'critical',
+          location: EVALUATOR_EXCEPTION_LOCATION,
           message: expect.stringContaining('flaky-adr-check'),
-          suggestion: expect.stringContaining('evaluator'),
+          suggestion: expect.stringContaining('trusted evaluator logs'),
         },
       ],
     });
-    expect(result.results[1]?.findings[0]?.message).toContain('memory backend unavailable');
+    expect(result.results[1]?.findings[0]?.message).not.toContain('memory backend unavailable');
     expect(result.results[2]).toMatchObject({ evaluatorName: 'later', verdict: 'pass' });
     expect(later.evaluate).toHaveBeenCalledTimes(1);
   });
@@ -226,7 +228,8 @@ describe('CritiquePipeline', () => {
       findings: [
         {
           severity: 'critical',
-          message: expect.stringContaining('guardrails unavailable'),
+          location: EVALUATOR_EXCEPTION_LOCATION,
+          message: expect.stringContaining('internal evaluator error'),
         },
       ],
     });

--- a/packages/franken-orchestrator/src/adapters/critique-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/critique-adapter.ts
@@ -1,5 +1,7 @@
 import type { ICritiqueModule, CritiqueFinding, CritiqueResult, PlanGraph } from '../deps.js';
 
+const EVALUATOR_EXCEPTION_LOCATION = 'internal:evaluator-exception';
+
 export interface EvaluationInput {
   readonly content: string;
   readonly source?: string | undefined;
@@ -9,6 +11,7 @@ export interface EvaluationInput {
 export interface EvaluationFinding {
   readonly message: string;
   readonly severity: string;
+  readonly location?: string | undefined;
 }
 
 export interface EvaluationResult {
@@ -108,16 +111,29 @@ export class CritiquePortAdapter implements ICritiqueModule {
     }
 
     if (loopResult.verdict === 'fail') {
+      const infrastructureFailure = this.hasEvaluatorExceptionFinding(lastResult?.results ?? []);
       const correctionFindings = loopResult.correction.findings.map(finding => ({
         evaluator: 'critique-loop',
         severity: finding.severity,
         message: finding.message,
+        ...(finding.location ? { location: finding.location } : {}),
       }));
       const normalizedFindings = findings.length > 0
         ? findings
         : correctionFindings.length > 0
           ? correctionFindings
           : [{ evaluator: 'critique-loop', severity: 'high', message: loopResult.correction.summary }];
+
+      if (infrastructureFailure) {
+        return {
+          verdict: 'fail',
+          findings: normalizedFindings,
+          score: loopResult.correction.score ?? lastResult?.overallScore ?? 0,
+          halted: true,
+          haltReason: 'Critique evaluator infrastructure failure',
+        };
+      }
+
       return {
         verdict: 'fail',
         findings: normalizedFindings,
@@ -150,7 +166,14 @@ export class CritiquePortAdapter implements ICritiqueModule {
         evaluator: result.evaluatorName,
         severity: finding.severity,
         message: finding.message,
+        ...(finding.location ? { location: finding.location } : {}),
       })),
+    );
+  }
+
+  private hasEvaluatorExceptionFinding(results: readonly EvaluationResult[]): boolean {
+    return results.some(result =>
+      result.findings.some(finding => finding.location === EVALUATOR_EXCEPTION_LOCATION),
     );
   }
 }

--- a/packages/franken-orchestrator/src/adapters/critique-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/critique-adapter.ts
@@ -153,6 +153,16 @@ export class CritiquePortAdapter implements ICritiqueModule {
       };
     }
 
+    if (this.hasEvaluatorExceptionFinding(lastResult?.results ?? [])) {
+      return {
+        verdict: 'fail',
+        findings,
+        score: lastResult?.overallScore ?? 0,
+        halted: true,
+        haltReason: 'Critique evaluator infrastructure failure',
+      };
+    }
+
     return {
       verdict: 'fail',
       findings: [{ evaluator: 'critique-loop', severity: 'high', message: loopResult.escalation.reason }],

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -152,6 +152,7 @@ export interface CritiqueFinding {
   readonly evaluator: string;
   readonly severity: string;
   readonly message: string;
+  readonly location?: string | undefined;
 }
 
 /** What the orchestrator needs from MOD-07 (Governor). */

--- a/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
@@ -217,6 +217,69 @@ describe('CritiquePortAdapter', () => {
     });
   });
 
+  it('treats escalated evaluator infrastructure exceptions as terminal', async () => {
+    const loop = {
+      run: vi.fn().mockResolvedValue({
+        verdict: 'escalated',
+        iterations: [
+          {
+            index: 0,
+            input: { content: 'plan', metadata: {} },
+            result: {
+              verdict: 'fail',
+              overallScore: 0,
+              shortCircuited: false,
+              results: [
+                {
+                  evaluatorName: 'adr-compliance',
+                  verdict: 'fail',
+                  score: 0,
+                  findings: [
+                    {
+                      message: 'Evaluator "adr-compliance" failed because an internal evaluator error occurred.',
+                      severity: 'critical',
+                      location: EVALUATOR_EXCEPTION_LOCATION,
+                    },
+                  ],
+                },
+              ],
+            },
+            completedAt: '2026-03-05T00:00:00.000Z',
+          },
+        ],
+        escalation: { reason: 'Consensus failure' },
+      }),
+    };
+
+    const adapter = new CritiquePortAdapter({
+      loop,
+      config: {
+        maxIterations: 1,
+        tokenBudget: 1000,
+        consensusThreshold: 0.7,
+        sessionId: 'sess-1',
+        taskId: 'plan-review',
+      },
+    });
+
+    const result = await adapter.reviewPlan(plan);
+
+    expect(result).toEqual({
+      verdict: 'fail',
+      score: 0,
+      findings: [
+        {
+          evaluator: 'adr-compliance',
+          severity: 'critical',
+          message: 'Evaluator "adr-compliance" failed because an internal evaluator error occurred.',
+          location: EVALUATOR_EXCEPTION_LOCATION,
+        },
+      ],
+      halted: true,
+      haltReason: 'Critique evaluator infrastructure failure',
+    });
+  });
+
   it('flags halted loop results as terminal (regression: PR #343 P1)', async () => {
     const loop = {
       run: vi.fn().mockResolvedValue({

--- a/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
@@ -7,6 +7,8 @@ const plan = {
   ],
 };
 
+const EVALUATOR_EXCEPTION_LOCATION = 'internal:evaluator-exception';
+
 describe('CritiquePortAdapter', () => {
   it('maps critique pass results into CritiqueResult', async () => {
     const loop = {
@@ -144,6 +146,74 @@ describe('CritiquePortAdapter', () => {
       verdict: 'fail',
       score: 0.2,
       findings: [{ evaluator: 'critique-loop', severity: 'medium', message: 'Missing coverage' }],
+    });
+  });
+
+  it('treats evaluator infrastructure exceptions as terminal instead of replanning feedback', async () => {
+    const loop = {
+      run: vi.fn().mockResolvedValue({
+        verdict: 'fail',
+        iterations: [
+          {
+            index: 0,
+            input: { content: 'plan', metadata: {} },
+            result: {
+              verdict: 'fail',
+              overallScore: 0,
+              shortCircuited: false,
+              results: [
+                {
+                  evaluatorName: 'adr-compliance',
+                  verdict: 'fail',
+                  score: 0,
+                  findings: [
+                    {
+                      message: 'Evaluator "adr-compliance" failed because an internal evaluator error occurred.',
+                      severity: 'critical',
+                      location: EVALUATOR_EXCEPTION_LOCATION,
+                    },
+                  ],
+                },
+              ],
+            },
+            completedAt: '2026-03-05T00:00:00.000Z',
+          },
+        ],
+        correction: {
+          summary: 'Fix the plan',
+          findings: [],
+          score: 0,
+          iterationCount: 1,
+        },
+      }),
+    };
+
+    const adapter = new CritiquePortAdapter({
+      loop,
+      config: {
+        maxIterations: 1,
+        tokenBudget: 1000,
+        consensusThreshold: 2,
+        sessionId: 'sess-1',
+        taskId: 'plan-review',
+      },
+    });
+
+    const result = await adapter.reviewPlan(plan);
+
+    expect(result).toEqual({
+      verdict: 'fail',
+      score: 0,
+      findings: [
+        {
+          evaluator: 'adr-compliance',
+          severity: 'critical',
+          message: 'Evaluator "adr-compliance" failed because an internal evaluator error occurred.',
+          location: EVALUATOR_EXCEPTION_LOCATION,
+        },
+      ],
+      halted: true,
+      haltReason: 'Critique evaluator infrastructure failure',
     });
   });
 


### PR DESCRIPTION
## Summary
- convert CritiquePipeline evaluator exceptions into structured fail results
- preserve prior results and continue later evaluators after non-safety exceptions
- add regression coverage for a throwing evaluator

## Test Plan
- npm --prefix packages/franken-critique test -- tests/unit/pipeline/critique-pipeline.test.ts
- npm --prefix packages/franken-critique test
- npm --prefix packages/franken-critique run lint
- npm run build -- --filter=@franken/types --filter=@franken/critique
- npm run typecheck -- --filter=@franken/types --filter=@franken/critique

Closes #1210