### PR TITLE
fix(critique): ignore bare Node built-ins in ghost dependency checks

### DIFF
--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -1,3 +1,5 @@
+import { builtinModules } from 'node:module';
+
 import type {
   Evaluator,
   EvaluationInput,
@@ -7,6 +9,9 @@ import type {
 
 const IDENTIFIER_PATTERN = /[A-Za-z0-9_$]/;
 const QUOTE_CHARS = new Set(["'", '"', '`']);
+const NODE_BUILTIN_MODULES = new Set(
+  builtinModules.map((moduleName) => moduleName.replace(/^node:/, '')),
+);
 
 interface StringLiteralRead {
   value: string;
@@ -36,8 +41,8 @@ export class GhostDependencyEvaluator implements Evaluator {
       // Skip relative imports
       if (specifier.startsWith('.')) continue;
 
-      // Skip node: built-ins
-      if (specifier.startsWith('node:')) continue;
+      // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
+      if (isNodeBuiltinSpecifier(specifier)) continue;
 
       // Extract package name (handle scoped packages and subpath imports)
       const packageName = specifier.startsWith('@')
@@ -65,6 +70,13 @@ export class GhostDependencyEvaluator implements Evaluator {
       findings,
     };
   }
+}
+
+function isNodeBuiltinSpecifier(specifier: string): boolean {
+  const normalized = specifier.replace(/^node:/, '');
+  const packageName = normalized.split('/')[0]!;
+
+  return NODE_BUILTIN_MODULES.has(normalized) || NODE_BUILTIN_MODULES.has(packageName);
 }
 
 function extractDependencySpecifiers(content: string): string[] {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -1,4 +1,4 @@
-import { builtinModules } from 'node:module';
+import { isBuiltin } from 'node:module';
 
 import type {
   Evaluator,
@@ -9,9 +9,6 @@ import type {
 
 const IDENTIFIER_PATTERN = /[A-Za-z0-9_$]/;
 const QUOTE_CHARS = new Set(["'", '"', '`']);
-const NODE_BUILTIN_MODULES = new Set(
-  builtinModules.map((moduleName) => moduleName.replace(/^node:/, '')),
-);
 
 interface StringLiteralRead {
   value: string;
@@ -73,10 +70,7 @@ export class GhostDependencyEvaluator implements Evaluator {
 }
 
 function isNodeBuiltinSpecifier(specifier: string): boolean {
-  const normalized = specifier.replace(/^node:/, '');
-  const packageName = normalized.split('/')[0]!;
-
-  return NODE_BUILTIN_MODULES.has(normalized) || NODE_BUILTIN_MODULES.has(packageName);
+  return isBuiltin(specifier);
 }
 
 function extractDependencySpecifiers(content: string): string[] {

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -245,12 +245,22 @@ describe('GhostDependencyEvaluator', () => {
 
   it('still detects packages with names similar to Node built-ins', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
-    const content = `import fsExtra from 'fs-extra';`;
+    const content = `
+      import fsExtra from 'fs-extra';
+      import test from 'test';
+      import customFsTool from 'fs/foo';
+    `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(1);
-    expect(result.findings[0]!.message).toContain('fs-extra');
+    expect(result.findings).toHaveLength(3);
+    expect(result.findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('fs-extra'),
+        expect.stringContaining('test'),
+        expect.stringContaining('fs'),
+      ]),
+    );
   });
 
   it('detects require() calls with unknown packages', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -229,6 +229,30 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
+  it('ignores bare Node built-ins and built-in subpath imports', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `
+      import fs from 'fs';
+      import { join } from 'path';
+      import { readFile } from 'fs/promises';
+      const platform = require('os').platform();
+    `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('still detects packages with names similar to Node built-ins', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `import fsExtra from 'fs-extra';`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('fs-extra');
+  });
+
   it('detects require() calls with unknown packages', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const x = require('unknown-lib');`;


### PR DESCRIPTION
## Summary
- Skip bare Node.js built-in imports and built-in subpaths in `GhostDependencyEvaluator`
- Preserve existing `node:` built-in handling while still flagging similarly named third-party packages
- Add regression coverage for ESM imports and CommonJS `require()` of bare built-ins

## Test Plan
- [x] `npm test --workspace @franken/critique -- --run tests/unit/evaluators/ghost-dependency.test.ts -t "ignores bare Node built-ins"` (fails before fix, passes after)
- [x] `npm test --workspace @franken/critique -- --run tests/unit/evaluators/ghost-dependency.test.ts`
- [x] `npm test --workspace @franken/critique`
- [x] `npm run lint --workspace @franken/critique`
- [x] `npm run build --workspace @franken/types && npm run build --workspace @franken/critique`
- [x] `git diff --check`

Closes #1208
