### PR TITLE
fix(web): enforce auth for dashboard SSE tickets

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -1,11 +1,14 @@
-import { Hono } from 'hono';
+import { timingSafeEqual } from 'node:crypto';
+import { Hono, type Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 import type { SkillManager } from '../../skills/skill-manager.js';
 import type { SecurityConfig } from '../../middleware/security-profiles.js';
+import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthAllowed } from '../operator-auth.js';
 
 const DASHBOARD_SNAPSHOT_POLL_MS = 1_000;
 const DASHBOARD_HEARTBEAT_MS = 30_000;
+const DASHBOARD_SSE_TICKET_SCOPE = 'dashboard';
 
 export interface DashboardRouteDeps {
   skillManager: SkillManager;
@@ -31,6 +34,36 @@ function buildSnapshot(deps: DashboardRouteDeps) {
   };
 }
 
+function safeTokenCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+function authenticateTicketRequest(c: Context, operatorToken: string): Response | undefined {
+  const headerToken = extractOperatorToken(c.req.header('Authorization'))
+    ?? c.req.header('x-frankenbeast-operator-token')
+    ?? undefined;
+  const cookieToken = extractOperatorTokenCookie(c.req.header('cookie'));
+  const provided = headerToken ?? cookieToken;
+
+  if (!headerToken && cookieToken && !isCookieOperatorAuthAllowed({
+    method: c.req.method,
+    origin: c.req.header('origin'),
+    requestUrl: c.req.url,
+    secFetchSite: c.req.header('sec-fetch-site'),
+  })) {
+    return c.json({ error: { code: 'FORBIDDEN', message: 'Cookie operator authentication requires a same-origin request' } }, 403);
+  }
+
+  if (!provided || !safeTokenCompare(provided, operatorToken)) {
+    return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid bearer token' } }, 401);
+  }
+
+  return undefined;
+}
+
 export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   const app = new Hono();
   const ticketStore = deps.ticketStore;
@@ -48,11 +81,13 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
     if (!operatorToken) {
       return c.json({ ticket: null });
     }
+    const authError = authenticateTicketRequest(c, operatorToken);
+    if (authError) return authError;
     if (!ticketStore) {
       return c.json({ error: { code: 'UNAVAILABLE', message: 'Dashboard SSE tickets are not configured' } }, 503);
     }
 
-    return c.json({ ticket: ticketStore.issue(operatorToken) });
+    return c.json({ ticket: ticketStore.issue(operatorToken, DASHBOARD_SSE_TICKET_SCOPE) });
   });
 
   // GET /api/dashboard/events — ticket-authenticated SSE stream for real-time dashboard updates
@@ -62,7 +97,7 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
       if (!ticketStore || !ticket) {
         return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
       }
-      const ticketStatus = ticketStore.consume(ticket, operatorToken);
+      const ticketStatus = ticketStore.consume(ticket, operatorToken, DASHBOARD_SSE_TICKET_SCOPE);
       if (ticketStatus === 'reused') {
         return c.body(null, 204);
       }

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -43,6 +43,16 @@ function createMockDeps(): DashboardRouteDeps {
   };
 }
 
+async function issueDashboardTicket(app: ReturnType<typeof createDashboardRoutes>): Promise<string> {
+  const ticketRes = await app.request('/events/ticket', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${TEST_DASHBOARD_TOKEN}` },
+  });
+  expect(ticketRes.status).toBe(200);
+  const { ticket } = await ticketRes.json() as { ticket: string };
+  return ticket;
+}
+
 describe('dashboard routes', () => {
   afterEach(() => {
     ticketStore?.destroy();
@@ -99,11 +109,35 @@ describe('dashboard routes', () => {
   });
 
   describe('GET /events', () => {
-    it('POST /events/ticket returns a short-lived stream ticket', async () => {
+    it('POST /events/ticket rejects requests without operator auth', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
 
       const res = await app.request('/events/ticket', { method: 'POST' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /events/ticket rejects invalid operator auth', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+
+      const res = await app.request('/events/ticket', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${TEST_DASHBOARD_TOKEN}-invalid` },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /events/ticket returns a short-lived stream ticket for bearer-authenticated callers', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+
+      const res = await app.request('/events/ticket', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${TEST_DASHBOARD_TOKEN}` },
+      });
 
       expect(res.status).toBe(200);
       const body = await res.json() as { ticket?: string };
@@ -137,8 +171,7 @@ describe('dashboard routes', () => {
     it('returns SSE content-type with a valid ticket', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
-      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
-      const { ticket } = await ticketRes.json() as { ticket: string };
+      const ticket = await issueDashboardTicket(app);
 
       const res = await app.request(`/events?ticket=${ticket}`);
       expect(res.headers.get('content-type')).toContain('text/event-stream');
@@ -148,8 +181,7 @@ describe('dashboard routes', () => {
     it('rejects a reused stream ticket so EventSource stops retries', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
-      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
-      const { ticket } = await ticketRes.json() as { ticket: string };
+      const ticket = await issueDashboardTicket(app);
 
       const first = await app.request(`/events?ticket=${ticket}`);
       expect(first.status).toBe(200);
@@ -174,8 +206,7 @@ describe('dashboard routes', () => {
     it('sends initial snapshot event in the stream', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
-      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
-      const { ticket } = await ticketRes.json() as { ticket: string };
+      const ticket = await issueDashboardTicket(app);
       const res = await app.request(`/events?ticket=${ticket}`);
 
       // Read partial stream — the SSE connection stays open, so we read
@@ -212,8 +243,7 @@ describe('dashboard routes', () => {
         const deps = createMockDeps();
         const providers = deps.getProviders as ReturnType<typeof vi.fn>;
         const app = createDashboardRoutes(deps);
-        const ticketRes = await app.request('/events/ticket', { method: 'POST' });
-        const { ticket } = await ticketRes.json() as { ticket: string };
+        const ticket = await issueDashboardTicket(app);
         const res = await app.request(`/events?ticket=${ticket}`);
 
         const reader = res.body!.getReader();
@@ -248,8 +278,7 @@ describe('dashboard routes', () => {
         const deps = createMockDeps();
         const providers = deps.getProviders as ReturnType<typeof vi.fn>;
         const app = createDashboardRoutes(deps);
-        const ticketRes = await app.request('/events/ticket', { method: 'POST' });
-        const { ticket } = await ticketRes.json() as { ticket: string };
+        const ticket = await issueDashboardTicket(app);
         const res = await app.request(`/events?ticket=${ticket}`);
         const reader = res.body!.getReader();
 


### PR DESCRIPTION
## Summary
- Require operator auth before minting dashboard SSE connection tickets
- Scope dashboard SSE tickets before consuming them on `/api/dashboard/events`
- Add dashboard route regressions for missing, invalid, and valid ticket-mint auth

## Test Plan
- npm run test -- tests/unit/http/dashboard-routes.test.ts
- npm run test -- tests/integration/http/control-plane-auth.test.ts tests/unit/http/beast-sse-routes.test.ts
- npm run test -- src/lib/dashboard-api.test.ts (in packages/franken-web)
- npm run build
- npm run typecheck
- npm run lint (packages/franken-orchestrator; warnings only, pre-existing)

Closes #688