### PR TITLE
docs: fix broken internal markdown links

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## System Overview
 
-Frankenbeast is a deterministic guardrails framework for AI agents, organized as an npm workspaces monorepo with Turborepo. The current repo has 10 package manifests under `packages/*`. See [ADR-011](adr/011-monorepo-migration.md) for the monorepo migration and [ADR-031](adr/031-architecture-consolidation-provider-agnostic.md) for the package consolidation that absorbed several earlier standalone packages.
+Frankenbeast is a deterministic guardrails framework for AI agents, organized as an npm workspaces monorepo with Turborepo. The current repo has 10 package manifests under `packages/*`. See [ADR-011](adr/011-real-monorepo-migration.md) for the monorepo migration and [ADR-031](adr/031-architecture-consolidation-provider-agnostic.md) for the package consolidation that absorbed several earlier standalone packages.
 
 This document mixes two views:
 
@@ -354,7 +354,7 @@ Chunk-session recovery complements file checkpoints:
 - compaction writes rollback snapshots before transcript surgery
 - `ChunkSessionGc` prunes expired sessions and orphaned snapshots during CLI startup
 
-**Design reference:** See [Approach C Full Pipeline Design](plans/2026-03-05-approach-c-full-pipeline-design.md) and [ADR-008](adr/008-approach-c-full-pipeline.md).
+**Design reference:** See [ADR-008](adr/008-approach-c-full-pipeline.md) for the Approach C full-pipeline design history.
 
 ## CLI Pipeline
 
@@ -381,7 +381,7 @@ All project state lives in `.fbeast/` at the project root.
 
 **Provider selection:** `--provider <name>` sets the primary CLI agent (default: `claude`). `--providers <list>` sets a comma-separated fallback chain for rate-limit cascading (e.g., `claude,gemini,aider`). The config file `providers` section supports `default`, `fallbackChain`, and per-provider `overrides` (command path, model, extra args). CLI args take precedence over config file values.
 
-**Design reference:** See [CLI E2E Design](plans/2026-03-06-cli-e2e-design.md), [ADR-009](adr/009-global-cli-design.md), and [ADR-010](adr/010-pluggable-cli-providers.md).
+**Design reference:** See [ADR-009](adr/009-global-cli-design.md) and [ADR-010](adr/010-pluggable-cli-providers.md) for the CLI design history.
 
 ## Issues Pipeline
 
@@ -900,7 +900,7 @@ The `frankenbeast chat-server` subcommand exposes the ChatRuntime over HTTP and 
 | `ChatSocketController` | `src/http/ws-chat-server.ts` | WebSocket connection management, chunk-based content delivery, turn event streaming |
 | `chat-app.ts` | `src/http/chat-app.ts` | Hono HTTP routes for REST-based chat interactions |
 
-**Design reference:** See [ADR-014](adr/014-chat-two-tier-dispatch.md), [ADR-016](adr/016-chat-server-entrypoint.md), and [ADR-018](adr/018-tracked-agent-init-workflow.md).
+**Design reference:** See [ADR-014](adr/014-chat-two-tier-dispatch.md), [ADR-016](adr/016-chat-server-entrypoint-for-dashboard.md), and [ADR-018](adr/018-tracked-agent-init-workflow.md).
 
 ### Beast Control and Tracked Agents
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,7 +1,7 @@
 # Frankenbeast Implementation Progress
 
 > This document tracks PR-by-PR progress for Phases 2–7. Updated as each PR is completed.
-> Reference: [Implementation Plan](/home/pfk/.claude/plans/graceful-gathering-owl.md)
+> Reference: original local implementation plan (retired; not stored in this repository)
 
 ## Current State (2026-07-04)
 

--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -4,7 +4,7 @@
 
 ## What Is This?
 
-A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`, matching the canonical inventories in [README.md](../README.md#current-workspace-packages) and [docs/guides/quickstart.md](guides/quickstart.md#project-structure): the consolidated core packages, `franken-mcp-suite` (`@franken/mcp-suite`), and `live-bench` (`@franken/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-monorepo-migration.md) and ADR-031 for the earlier consolidation history; the historical `franken-mcp` package was removed, while the current `@franken/mcp-suite` workspace remains active.
+A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`, matching the canonical inventories in [README.md](../README.md#current-workspace-packages) and [docs/guides/quickstart.md](guides/quickstart.md#project-structure): the consolidated core packages, `franken-mcp-suite` (`@franken/mcp-suite`), and `live-bench` (`@franken/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-real-monorepo-migration.md) and ADR-031 for the earlier consolidation history; the historical `franken-mcp` package was removed, while the current `@franken/mcp-suite` workspace remains active.
 
 ## Modules
 

--- a/docs/adr/008-approach-c-full-pipeline.md
+++ b/docs/adr/008-approach-c-full-pipeline.md
@@ -8,7 +8,7 @@ Approach A ([ADR-007](007-cli-skill-execution-type.md)) provided CLI skill primi
 
 We needed the orchestrator to own the full pipeline: accept an idea in any form, decompose it into executable chunks, run them through the existing CLI skill pipeline, checkpoint progress for crash recovery, and create a PR at the end.
 
-Design reference: [`docs/plans/2026-03-05-approach-c-full-pipeline-design.md`](../plans/2026-03-05-approach-c-full-pipeline-design.md)
+Design reference: the original `docs/plans/2026-03-05-approach-c-full-pipeline-design.md` planning artifact has been retired; this ADR is the canonical retained design record for the Approach C full pipeline.
 
 ## Decision
 Three input modes converge to a single `PlanGraph` that executes through the existing Approach A pipeline:

--- a/docs/plans/consolidation/index.md
+++ b/docs/plans/consolidation/index.md
@@ -1,7 +1,7 @@
 # Architecture Consolidation — Design Specs
 
 **ADR:** [031-architecture-consolidation-provider-agnostic](../../adr/031-architecture-consolidation-provider-agnostic.md)
-**Implementation Plan:** [2026-03-18-architecture-consolidation-plan.md](../2026-03-18-architecture-consolidation-plan.md)
+**Implementation Plan:** See the phase index below and the [residuals master plan](residuals-master-plan.md) for the retained consolidation plan artifacts.
 **Date:** 2026-03-19
 **Status:** Design
 

--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -736,13 +736,13 @@ All I/O is injected — tests use fakes/mocks, no real network or terminal requi
 
 | ADR | Title |
 |-----|-------|
-| [ADR-001](docs/adr/001-typescript-strict-nodenext.md) | TypeScript Strict + NodeNext Resolution |
-| [ADR-002](docs/adr/002-approval-channel-strategy.md) | Approval Channel Strategy Pattern |
-| [ADR-003](docs/adr/003-composable-trigger-evaluators.md) | Composable Trigger Evaluators |
-| [ADR-004](docs/adr/004-audit-trail-episodic-trace.md) | Audit Trail via EpisodicTrace to MOD-03 |
-| [ADR-005](docs/adr/005-signed-approvals-hmac.md) | Signed Approvals with HMAC-SHA256 |
-| [ADR-006](docs/adr/006-custom-error-hierarchy.md) | Custom Error Hierarchy |
-| [ADR-007](docs/adr/007-session-token-activation.md) | Session Token Activation Model |
+| [ADR-001](docs/adr/ADR-001-typescript-strict-nodenext.md) | TypeScript Strict + NodeNext Resolution |
+| [ADR-002](docs/adr/ADR-002-approval-channel-strategy.md) | Approval Channel Strategy Pattern |
+| [ADR-003](docs/adr/ADR-003-composable-trigger-evaluators.md) | Composable Trigger Evaluators |
+| [ADR-004](docs/adr/ADR-004-audit-trail-episodic-trace.md) | Audit Trail via EpisodicTrace to MOD-03 |
+| [ADR-005](docs/adr/ADR-005-signed-approvals-hmac.md) | Signed Approvals with HMAC-SHA256 |
+| [ADR-006](docs/adr/ADR-006-custom-error-hierarchy.md) | Custom Error Hierarchy |
+| [ADR-007](docs/adr/ADR-007-session-token-activation.md) | Session Token Activation Model |
 
 ## License
 


### PR DESCRIPTION
## Summary
- update renamed ADR links in ramp-up and architecture docs
- replace links to retired local/planning artifacts with retained canonical docs or plain historical references
- fix package README ADR links to match the package-local ADR filenames

## Test Plan
- python3 /home/pfkagent/.hermes/kanban/workspaces/t_2a0da41c/md_link_check.py /home/pfkagent/dev/resolve-wt/issue-1197
- npm run typecheck
- npm run build
- npm test

Closes #1197
