### PR TITLE
docs(env): clarify local Tempo endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,11 @@ $EDITOR .env  # uncomment GRAFANA_USER=admin, set a unique GRAFANA_PASSWORD, and
 # image versions and mounts ./tempo.yaml so local tracing starts deterministically.
 docker compose up -d
 
+# Local Tempo exposes OTLP/HTTP writes on http://localhost:4318 for TempoAdapter
+# and readiness on http://localhost:3200/ready for verify-setup. The root
+# .env.example intentionally does not define a TEMPO_ENDPOINT override; pass
+# custom Tempo endpoints through TempoAdapter options instead.
+
 # Seed ChromaDB with initial collections. This uses CHROMA_URL from the environment.
 npx tsx scripts/seed.ts
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -150,6 +150,10 @@ describe('local setup scripts', () => {
     expect(readme).toContain('CHROMA_URL');
     expect(readme).toContain('http://localhost:8000');
     expect(readme).toContain('Override it only when ChromaDB runs at a different local port/host or a remote');
+    expect(readme).toContain('Local Tempo exposes OTLP/HTTP writes on http://localhost:4318');
+    expect(readme).toContain('readiness on http://localhost:3200/ready');
+    expect(readme).toContain('does not define a TEMPO_ENDPOINT override');
+    expect(readme).toContain('TempoAdapter options');
     expect(readme).toContain('CLI flags > `FRANKEN_*` env vars > config file > built-in defaults');
     expect(readme).toContain('maxCritiqueIterations * 10000');
     for (const frankenOverride of [


### PR DESCRIPTION
## Summary
- Clarifies root local setup docs for Tempo's fixed local compose endpoints.
- Notes that the root `.env.example` intentionally does not expose a `TEMPO_ENDPOINT` override and points custom writers to `TempoAdapter` options.
- Adds root README coverage to the local setup docs regression test.

## Test Plan
- `npm exec vitest run tests/local-setup-scripts.test.ts`
- `npm run check:package-manager`
- `npm run test:root`

Closes #1169