### PR TITLE
docs(env): document Ollama base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The shipped Hono HTTP surface is integrated in `@franken/orchestrator`'s chat se
 ### Optional
 
 - **ChromaDB** — required for semantic memory (MOD-03). Not needed for unit/integration tests.
-- **LLM API key** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY` for runtime use. Not needed for tests (mocked).
+- **LLM provider credentials** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY` for API-backed providers. Ollama-compatible provider registry entries use `OLLAMA_BASE_URL` instead of an API key; the local default is `http://localhost:11434`.
 - **Docker** — for running the local dev stack (ChromaDB, Grafana, Tempo).
 
 ### Beast project-root override
@@ -636,6 +636,7 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 | `OPENAI_API_KEY` | MOD-01 | Runtime only | OpenAI adapter API key |
 | `GOOGLE_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (Google AI Studio name) |
 | `GEMINI_API_KEY` | MOD-01 | Runtime only | Gemini adapter API key (alternative name) |
+| `OLLAMA_BASE_URL` | Provider registry | Only when using an Ollama-compatible provider entry | Ollama daemon base URL, usually `http://localhost:11434`; set a different HTTP(S) endpoint for remote or non-default daemons. It is intentionally absent from `.env.example` because the default local setup and current `fbeast mcp beast` presets do not consume it. |
 | `CHROMA_URL` | MOD-03 | If using semantic memory | ChromaDB base URL used by `scripts/seed.ts` and `scripts/verify-setup.ts` (default: `http://localhost:8000`) |
 | `SLACK_WEBHOOK_URL` | MOD-07 | If using Slack approvals | Slack webhook for HITL notifications |
 | `FRANKENBEAST_MODULE_MEMORY` | MOD-03 | Optional | Memory module config fallback and Beast child-env toggle. Only the literal value `false` records it as disabled when the `memory` config key is unset; current local CLI wiring still constructs the real memory adapter. |

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -22,6 +22,30 @@ cp .env.example .env
 # For fbeast mcp beast --provider=anthropic-api, set ANTHROPIC_API_KEY.
 ```
 
+### Ollama endpoints
+
+`OLLAMA_BASE_URL` is the optional base URL for Ollama-compatible provider registry entries. Set it only when the run configuration or provider registry entry you are using selects an Ollama-backed provider; the `fbeast mcp beast --provider=...` activation shim does not currently include an Ollama preset, so `OLLAMA_BASE_URL` is not required for the supported `anthropic-api`, `codex-cli`, or `claude-cli` Beast activation paths above.
+
+For a local Ollama daemon that listens on the default port, use:
+
+```bash
+export OLLAMA_BASE_URL=http://localhost:11434
+```
+
+For a non-default daemon, point the variable at that endpoint instead, for example:
+
+```bash
+export OLLAMA_BASE_URL=http://ollama.internal:11434
+```
+
+The root `.env.example` intentionally leaves `OLLAMA_BASE_URL` out because the default local setup and current `fbeast mcp beast` presets do not consume it. Add it to your private `.env` only when your selected provider configuration needs an Ollama-compatible endpoint.
+
+Quick verification, without exposing API keys:
+
+```bash
+curl "$OLLAMA_BASE_URL/api/tags"
+```
+
 ---
 
 ## 1. Install and link the CLIs

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -150,6 +150,9 @@ describe('local setup scripts', () => {
     expect(readme).toContain('CHROMA_URL');
     expect(readme).toContain('http://localhost:8000');
     expect(readme).toContain('Override it only when ChromaDB runs at a different local port/host or a remote');
+    expect(readme).toContain('OLLAMA_BASE_URL');
+    expect(readme).toContain('http://localhost:11434');
+    expect(readme).toContain('intentionally absent from `.env.example`');
     expect(readme).toContain('CLI flags > `FRANKEN_*` env vars > config file > built-in defaults');
     expect(readme).toContain('maxCritiqueIterations * 10000');
     for (const frankenOverride of [
@@ -169,8 +172,10 @@ describe('local setup scripts', () => {
     const runCliBeastGuide = read('docs/guides/run-cli-beast.md');
     const beastModeSource = read('packages/franken-mcp-suite/src/cli/beast-mode.ts');
 
-    expect(runCliBeastGuide).not.toContain('OLLAMA_BASE_URL');
-    expect(runCliBeastGuide).not.toMatch(/local\s+Ollama/i);
+    expect(runCliBeastGuide).toContain('`OLLAMA_BASE_URL` is the optional base URL');
+    expect(runCliBeastGuide).toContain('http://localhost:11434');
+    expect(runCliBeastGuide).toContain('intentionally leaves `OLLAMA_BASE_URL` out');
+    expect(runCliBeastGuide).toContain('`fbeast mcp beast --provider=...` activation shim does not currently include an Ollama preset');
     expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=anthropic-api');
     expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=codex-cli');
     expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=claude-cli');


### PR DESCRIPTION
## Summary
- document when `OLLAMA_BASE_URL` applies to Ollama-compatible provider registry entries
- clarify local/default and non-default Ollama endpoint values in the CLI Beast guide
- keep `.env.example` intentionally free of `OLLAMA_BASE_URL` while adding README/test coverage for that choice

## Test Plan
- [x] npm run test:root -- --run tests/local-setup-scripts.test.ts
- [x] npm run typecheck
- [x] git diff --check

Closes #1170
