### PR TITLE
test(types): fail when no tests are discovered

### DIFF
--- a/packages/franken-types/vitest.config.ts
+++ b/packages/franken-types/vitest.config.ts
@@ -9,6 +9,5 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
-    passWithNoTests: true,
   },
 });


### PR DESCRIPTION
## Summary
- removes `passWithNoTests` from the franken-types Vitest config
- ensures `npm test` fails if the package's test glob stops matching files

## Test Plan
- `npm --prefix packages/franken-types test`
- `npm --prefix packages/franken-types run typecheck`
- `npm --prefix packages/franken-types run build`
- Temporarily moved `packages/franken-types/tests` aside and verified `npm test` exits 1 with `No test files found`

Closes #970