### PR TITLE
fix(web): drive beast wizard from catalog definitions

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-review.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-review.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
+import type { BeastCatalogEntry } from '../../../lib/beast-api';
 import { useBeastStore } from '../../../stores/beast-store';
+import { findCatalogEntry, getPromptLabel, getPromptValue } from '../wizard-catalog';
 import { validateWizardStep } from '../wizard-validation';
 
 type WorkflowReviewValues = {
@@ -7,6 +9,7 @@ type WorkflowReviewValues = {
   goal?: string;
   topic?: string;
   outputPath?: string;
+  designDocPath?: string;
   docPath?: string;
   outputDir?: string;
   provider?: string;
@@ -15,7 +18,7 @@ type WorkflowReviewValues = {
   chunkDir?: string;
 };
 
-export function StepReview() {
+export function StepReview({ catalog }: { catalog?: readonly BeastCatalogEntry[] }) {
   const { stepValues, setWizardStep } = useBeastStore();
 
   const identity = stepValues[0] as { name?: string; description?: string } | undefined;
@@ -34,7 +37,7 @@ export function StepReview() {
       </ReviewSection>
 
       <ReviewSection title="Workflow" stepIndex={1} onEdit={setWizardStep}>
-        <WorkflowReview workflow={workflow} stepValues={stepValues} />
+        <WorkflowReview workflow={workflow} stepValues={stepValues} catalog={catalog} />
       </ReviewSection>
 
       <ReviewSection title="LLM Targets" stepIndex={2} onEdit={setWizardStep}>
@@ -88,16 +91,18 @@ export function StepReview() {
   );
 }
 
-function WorkflowReview({ workflow, stepValues }: {
+function WorkflowReview({ workflow, stepValues, catalog }: {
   workflow: WorkflowReviewValues | undefined;
   stepValues: Record<number, Record<string, unknown> | undefined>;
+  catalog?: readonly BeastCatalogEntry[];
 }) {
-  const workflowErrors = validateWizardStep(1, stepValues);
-  const rows = buildWorkflowReviewRows(workflow);
+  const workflowErrors = validateWizardStep(1, stepValues, catalog);
+  const rows = buildWorkflowReviewRows(workflow, catalog);
+  const selectedDefinition = findCatalogEntry(catalog, workflow?.workflowType);
 
   return (
     <div className="space-y-2">
-      <p className="text-sm text-beast-text">{workflow?.workflowType ?? '(not set)'}</p>
+      <p className="text-sm text-beast-text">{selectedDefinition?.label ?? workflow?.workflowType ?? '(not set)'}</p>
       {rows.length > 0 && (
         <dl className="grid gap-1 text-xs text-beast-muted sm:grid-cols-[max-content_1fr]">
           {rows.map(({ label, value }) => (
@@ -120,28 +125,16 @@ function WorkflowReview({ workflow, stepValues }: {
   );
 }
 
-function buildWorkflowReviewRows(workflow: WorkflowReviewValues | undefined): Array<{ label: string; value: string }> {
+function buildWorkflowReviewRows(
+  workflow: WorkflowReviewValues | undefined,
+  catalog?: readonly BeastCatalogEntry[],
+): Array<{ label: string; value: string }> {
   if (!workflow?.workflowType) return [];
-  if (workflow.workflowType === 'design-interview') {
-    return [
-      { label: 'Goal', value: workflow.goal ?? workflow.topic ?? '(missing)' },
-      { label: 'Output path', value: workflow.outputPath ?? '(missing)' },
-    ];
-  }
-  if (workflow.workflowType === 'chunk-plan') {
-    return [
-      { label: 'Design doc', value: workflow.docPath ?? '(missing)' },
-      { label: 'Output directory', value: workflow.outputDir ?? '(missing)' },
-    ];
-  }
-  if (workflow.workflowType === 'martin-loop') {
-    return [
-      { label: 'Provider', value: workflow.provider ?? '(missing)' },
-      { label: 'Objective', value: workflow.objective ?? '(missing)' },
-      { label: 'Chunk directory', value: workflow.chunkDirectory ?? workflow.chunkDir ?? '(missing)' },
-    ];
-  }
-  return [];
+  const definition = findCatalogEntry(catalog, workflow.workflowType);
+  return (definition?.interviewPrompts ?? []).map((prompt) => ({
+    label: getPromptLabel(prompt),
+    value: String(getPromptValue(workflow as Record<string, unknown>, prompt) ?? '(missing)'),
+  }));
 }
 
 function ReviewSection({ title, stepIndex, onEdit, children }: {

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -1,27 +1,26 @@
 import { useEffect } from 'react';
 import { useBeastStore } from '../../../stores/beast-store';
 import { PresetCardGroup } from '../shared/preset-card';
-import type { BeastContainerRuntimeStatus, BeastExecutionMode } from '../../../lib/beast-api';
-
-const WORKFLOWS = [
-  { id: 'design-interview', title: 'Design Interview', description: 'Launch interactive design session' },
-  { id: 'chunk-plan', title: 'Chunk Design Doc', description: 'Break a design doc into implementation chunks' },
-  { id: 'martin-loop', title: 'Run Chunked Project', description: 'Execute an already-chunked plan' },
-];
+import type { BeastCatalogEntry, BeastContainerRuntimeStatus, BeastExecutionMode, BeastInterviewPrompt } from '../../../lib/beast-api';
+import { getEffectiveCatalog, getPromptLabel, getPromptValue } from '../wizard-catalog';
 
 interface StepWorkflowProps {
+  catalog?: readonly BeastCatalogEntry[];
   containerRuntime?: BeastContainerRuntimeStatus;
 }
 
 const DEFAULT_CONTAINER_UNAVAILABLE_REASON = 'Container runtime availability has not been reported by the backend.';
 
-export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
+export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
   const { stepValues, setStepValues } = useBeastStore();
   const values = (stepValues[1] ?? {}) as { workflowType?: string; executionMode?: BeastExecutionMode; [key: string]: unknown };
-  const selectedExecutionMode = values.executionMode ?? 'process';
-  const containerUnavailableReason = containerRuntime?.available === true
+  const workflows = getEffectiveCatalog(catalog);
+  const selectedWorkflow = workflows.find((entry) => entry.id === values.workflowType);
+  const selectedExecutionMode = values.executionMode ?? selectedWorkflow?.executionModeDefault ?? 'process';
+  const containerStatus = selectedWorkflow?.containerRuntime ?? containerRuntime;
+  const containerUnavailableReason = containerStatus?.available === true
     ? null
-    : (containerRuntime?.reason ?? DEFAULT_CONTAINER_UNAVAILABLE_REASON);
+    : (containerStatus?.reason ?? DEFAULT_CONTAINER_UNAVAILABLE_REASON);
   const effectiveExecutionMode = selectedExecutionMode === 'container' && containerUnavailableReason
     ? 'process'
     : selectedExecutionMode;
@@ -33,10 +32,17 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
   }, [containerUnavailableReason, selectedExecutionMode, setStepValues, values]);
 
   function handleSelect(id: string) {
-    setStepValues(1, { ...values, workflowType: id });
+    if (id === values.workflowType) {
+      setStepValues(1, { ...values, workflowType: id });
+      return;
+    }
+
+    const nextWorkflow = workflows.find((entry) => entry.id === id);
+    const executionMode = values.executionMode ?? nextWorkflow?.executionModeDefault;
+    setStepValues(1, { workflowType: id, ...(executionMode ? { executionMode } : {}) });
   }
 
-  function updateField(field: string, value: string) {
+  function updateField(field: string, value: string | boolean) {
     setStepValues(1, { ...values, [field]: value });
   }
 
@@ -49,7 +55,11 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
 
   return (
     <div className="p-8 space-y-6">
-      <PresetCardGroup presets={WORKFLOWS} selected={values.workflowType ?? ''} onSelect={handleSelect} />
+      <PresetCardGroup
+        presets={workflows.map((entry) => ({ id: entry.id, title: entry.label, description: entry.description }))}
+        selected={values.workflowType ?? ''}
+        onSelect={handleSelect}
+      />
 
       <fieldset className="space-y-3 rounded-xl border border-beast-border bg-beast-panel p-4">
         <legend className="px-1 text-sm font-medium text-beast-text">Execution mode</legend>
@@ -93,102 +103,109 @@ export function StepWorkflow({ containerRuntime }: StepWorkflowProps) {
         )}
       </fieldset>
 
-      {values.workflowType === 'design-interview' && (
+      {selectedWorkflow && (
         <div className="space-y-4">
-          <div>
-            <label htmlFor="wf-goal" className="block text-sm font-medium text-beast-text mb-1.5">Goal</label>
-            <textarea
-              id="wf-goal"
-              value={(values.goal as string) ?? (values.topic as string) ?? ''}
-              onChange={(e) => updateField('goal', e.target.value)}
-              placeholder="Describe what the design interview should produce..."
-              rows={3}
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent resize-y"
+          {selectedWorkflow.interviewPrompts.map((prompt) => (
+            <CatalogPromptField
+              key={prompt.key}
+              prompt={prompt}
+              value={getPromptValue(values, prompt)}
+              onChange={(value) => updateField(prompt.key, value)}
             />
-          </div>
-          <div>
-            <label htmlFor="wf-output-path" className="block text-sm font-medium text-beast-text mb-1.5">Output Path</label>
-            <input
-              id="wf-output-path"
-              type="text"
-              value={(values.outputPath as string) ?? ''}
-              onChange={(e) => updateField('outputPath', e.target.value)}
-              placeholder="docs/design.md"
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-            />
-          </div>
-        </div>
-      )}
-
-      {values.workflowType === 'chunk-plan' && (
-        <div className="space-y-4">
-          <div>
-            <label htmlFor="wf-file" className="block text-sm font-medium text-beast-text mb-1.5">Design Doc Path</label>
-            <input
-              id="wf-file"
-              type="text"
-              value={(values.docPath as string) ?? ''}
-              onChange={(e) => updateField('docPath', e.target.value)}
-              placeholder="docs/design-doc.md"
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-            />
-            <p className="mt-1 text-xs text-beast-muted">Use a repo-relative Markdown path; absolute paths and ../ traversal are rejected.</p>
-          </div>
-          <div>
-            <label htmlFor="wf-output-dir" className="block text-sm font-medium text-beast-text mb-1.5">Output Directory</label>
-            <input
-              id="wf-output-dir"
-              type="text"
-              value={(values.outputDir as string) ?? ''}
-              onChange={(e) => updateField('outputDir', e.target.value)}
-              placeholder="/path/to/chunks"
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-            />
-          </div>
-        </div>
-      )}
-
-      {values.workflowType === 'martin-loop' && (
-        <div className="space-y-4">
-          <div>
-            <label htmlFor="wf-provider" className="block text-sm font-medium text-beast-text mb-1.5">Provider</label>
-            <select
-              id="wf-provider"
-              value={(values.provider as string) ?? ''}
-              onChange={(e) => updateField('provider', e.target.value)}
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-            >
-              <option value="">Select provider...</option>
-              <option value="claude">Claude</option>
-              <option value="codex">Codex</option>
-              <option value="gemini">Gemini</option>
-              <option value="aider">Aider</option>
-            </select>
-          </div>
-          <div>
-            <label htmlFor="wf-objective" className="block text-sm font-medium text-beast-text mb-1.5">Objective</label>
-            <input
-              id="wf-objective"
-              type="text"
-              value={(values.objective as string) ?? ''}
-              onChange={(e) => updateField('objective', e.target.value)}
-              placeholder="Describe what the Martin Loop should accomplish..."
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-            />
-          </div>
-          <div>
-            <label htmlFor="wf-dir" className="block text-sm font-medium text-beast-text mb-1.5">Chunk Directory Path</label>
-            <input
-              id="wf-dir"
-              type="text"
-              value={(values.chunkDirectory as string) ?? (values.chunkDir as string) ?? ''}
-              onChange={(e) => updateField('chunkDirectory', e.target.value)}
-              placeholder="/path/to/chunks/"
-              className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-            />
-          </div>
+          ))}
         </div>
       )}
     </div>
   );
+}
+
+function CatalogPromptField({
+  prompt,
+  value,
+  onChange,
+}: {
+  prompt: BeastInterviewPrompt;
+  value: unknown;
+  onChange: (value: string | boolean) => void;
+}) {
+  const label = getPromptLabel(prompt);
+  const id = `wf-${prompt.key}`;
+
+  if (prompt.kind === 'boolean') {
+    return (
+      <label className="flex items-center gap-3 rounded-lg border border-beast-border bg-beast-control px-4 py-3 text-sm text-beast-text">
+        <input
+          id={id}
+          type="checkbox"
+          checked={value === true}
+          onChange={(event) => onChange(event.target.checked)}
+          className="h-4 w-4 rounded border-beast-border bg-beast-panel text-beast-accent focus:ring-beast-accent"
+        />
+        <span>{label}{prompt.required ? ' *' : ''}</span>
+      </label>
+    );
+  }
+
+  if (prompt.options?.length) {
+    return (
+      <div>
+        <label htmlFor={id} className="block text-sm font-medium text-beast-text mb-1.5">{label}{prompt.required ? ' *' : ''}</label>
+        <select
+          id={id}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(event) => onChange(event.target.value)}
+          className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
+        >
+          <option value="">Select...</option>
+          {prompt.options.map((option) => <option key={option} value={option}>{option}</option>)}
+        </select>
+      </div>
+    );
+  }
+
+  const placeholder = buildPlaceholder(prompt);
+  const inputType = prompt.kind === 'file' || prompt.kind === 'directory' ? 'text' : undefined;
+  const rows = prompt.kind === 'string' && !isSingleLinePathPrompt(prompt) ? 3 : undefined;
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-beast-text mb-1.5">{label}{prompt.required ? ' *' : ''}</label>
+      {rows ? (
+        <textarea
+          id={id}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={placeholder}
+          rows={rows}
+          className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent resize-y"
+        />
+      ) : (
+        <input
+          id={id}
+          type={inputType ?? 'text'}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={placeholder}
+          className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
+        />
+      )}
+      {prompt.kind === 'file' && (
+        <p className="mt-1 text-xs text-beast-muted">Use a repo-relative Markdown path when required by the selected Beast.</p>
+      )}
+    </div>
+  );
+}
+
+function isSingleLinePathPrompt(prompt: BeastInterviewPrompt): boolean {
+  const key = prompt.key.toLowerCase();
+  return prompt.kind === 'file' || prompt.kind === 'directory' || key.includes('path') || key.includes('dir') || key.includes('directory');
+}
+
+function buildPlaceholder(prompt: BeastInterviewPrompt): string {
+  if (prompt.key === 'goal') return 'Describe what the design interview should produce...';
+  if (prompt.key === 'outputPath') return 'docs/design.md';
+  if (prompt.key === 'designDocPath') return 'docs/design-doc.md';
+  if (prompt.key === 'outputDir') return 'tasks/chunks';
+  if (prompt.key === 'chunkDirectory') return 'tasks/chunks/';
+  return prompt.prompt;
 }

--- a/packages/franken-web/src/components/beasts/wizard-catalog.ts
+++ b/packages/franken-web/src/components/beasts/wizard-catalog.ts
@@ -1,0 +1,76 @@
+import type { BeastCatalogEntry, BeastInterviewPrompt } from '../../lib/beast-api';
+
+export const FALLBACK_BEAST_CATALOG: readonly BeastCatalogEntry[] = [
+  {
+    id: 'design-interview',
+    version: 1,
+    label: 'Design Interview',
+    description: 'Create a tracked agent that drives an interactive design interview and writes a design document artifact.',
+    executionModeDefault: 'process',
+    interviewPrompts: [
+      { key: 'goal', prompt: 'What should the design interview produce?', kind: 'string', required: true },
+      { key: 'outputPath', prompt: 'Where should the design document be written?', kind: 'string', required: true },
+    ],
+  },
+  {
+    id: 'chunk-plan',
+    version: 1,
+    label: 'Design Doc -> Chunk Creation',
+    description: 'Turn a design document into chunked implementation artifacts through the tracked init workflow.',
+    executionModeDefault: 'process',
+    interviewPrompts: [
+      { key: 'designDocPath', prompt: 'Which design document should be chunked?', kind: 'file', required: true },
+      { key: 'outputDir', prompt: 'Where should the chunk plan be written?', kind: 'string', required: true },
+    ],
+  },
+  {
+    id: 'martin-loop',
+    version: 1,
+    label: 'Martin Loop',
+    description: 'Create a tracked agent for MartinLoop, validate the chunk directory, then dispatch execution.',
+    executionModeDefault: 'process',
+    interviewPrompts: [
+      { key: 'provider', prompt: 'Which provider should run the martin loop?', kind: 'string', required: true, options: ['claude', 'codex', 'gemini', 'aider'] },
+      { key: 'objective', prompt: 'What should the martin loop accomplish?', kind: 'string', required: true },
+      { key: 'chunkDirectory', prompt: 'Which chunk directory should MartinLoop execute from?', kind: 'directory', required: true },
+    ],
+  },
+] as const;
+
+export function getEffectiveCatalog(catalog: readonly BeastCatalogEntry[] | undefined): readonly BeastCatalogEntry[] {
+  return catalog && catalog.length > 0 ? catalog : FALLBACK_BEAST_CATALOG;
+}
+
+export function findCatalogEntry(
+  catalog: readonly BeastCatalogEntry[] | undefined,
+  id: string | undefined,
+): BeastCatalogEntry | undefined {
+  if (!id) return undefined;
+  return getEffectiveCatalog(catalog).find((entry) => entry.id === id);
+}
+
+export function getPromptLabel(prompt: BeastInterviewPrompt): string {
+  return prompt.prompt.replace(/[?.!]+$/g, '');
+}
+
+export function getPromptValue(
+  values: Record<string, unknown> | undefined,
+  prompt: BeastInterviewPrompt,
+): unknown {
+  if (!values) return undefined;
+  if (prompt.key === 'goal') {
+    return values.goal ?? values.topic;
+  }
+  if (prompt.key === 'designDocPath') {
+    return values.designDocPath ?? values.docPath;
+  }
+  if (prompt.key === 'chunkDirectory') {
+    return values.chunkDirectory ?? values.chunkDir;
+  }
+  return values[prompt.key];
+}
+
+export function isBlankCatalogValue(value: unknown): boolean {
+  if (typeof value === 'boolean') return false;
+  return typeof value !== 'string' || value.trim().length === 0;
+}

--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -49,12 +49,12 @@ describe('WizardDialog validation', () => {
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
     expect(screen.getByRole('alert').textContent).toContain('Workflow type is required');
 
-    fireEvent.click(screen.getByRole('button', { name: /Chunk Design Doc/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Design Doc -> Chunk Creation/ }));
     expect(screen.getByRole('alert').textContent).toContain('Design doc path is required');
     expect(screen.getByRole('alert').textContent).toContain('Output directory is required');
 
-    fireEvent.change(screen.getByLabelText('Design Doc Path'), { target: { value: 'docs/design.md' } });
-    fireEvent.change(screen.getByLabelText('Output Directory'), { target: { value: 'tasks/chunks' } });
+    fireEvent.change(screen.getByLabelText(/design document should be chunked/i), { target: { value: 'docs/design.md' } });
+    fireEvent.change(screen.getByLabelText(/chunk plan be written/i), { target: { value: 'tasks/chunks' } });
 
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', false);
   });
@@ -91,6 +91,6 @@ describe('WizardDialog validation', () => {
 
     expect(reviewHeading.compareDocumentPosition(launchButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByText('Reviewable Agent')).toBeTruthy();
-    expect(screen.getByText('design-interview')).toBeTruthy();
+    expect(screen.getAllByText('Design Interview').length).toBeGreaterThan(0);
   });
 });

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -17,7 +17,7 @@ import {
   validateWizardStep,
   type WizardValidationErrors,
 } from './wizard-validation';
-import type { BeastContainerRuntimeStatus } from '../../lib/beast-api';
+import type { BeastCatalogEntry, BeastContainerRuntimeStatus } from '../../lib/beast-api';
 
 const STEP_LABELS = [...WIZARD_SECTION_LABELS];
 
@@ -25,12 +25,13 @@ interface WizardDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onLaunch: (config: Record<string, unknown>) => void;
+  catalog?: readonly BeastCatalogEntry[];
   containerRuntime?: BeastContainerRuntimeStatus;
   launching?: boolean;
   launchError?: string | null;
 }
 
-export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, launching, launchError }: WizardDialogProps) {
+export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRuntime, launching, launchError }: WizardDialogProps) {
   const {
     wizardStep,
     highestCompleted,
@@ -46,12 +47,12 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
 
   const isLastStep = wizardStep === STEP_LABELS.length - 1;
   const isFirstStep = wizardStep === 0;
-  const currentValidationErrors = validateWizardStep(wizardStep, stepValues);
+  const currentValidationErrors = validateWizardStep(wizardStep, stepValues, catalog);
   const currentStepIsValid = Object.keys(currentValidationErrors).length === 0;
-  const formValidationErrors = validateWizardStep(STEP_LABELS.length - 1, stepValues);
+  const formValidationErrors = validateWizardStep(STEP_LABELS.length - 1, stepValues, catalog);
   const formIsValid = Object.keys(formValidationErrors).length === 0;
   const promptFilesLoading = Boolean(stepValues[5]?.filesLoading);
-  const stepStatuses = buildStepStatuses(wizardStep, highestCompleted, stepValues);
+  const stepStatuses = buildStepStatuses(wizardStep, highestCompleted, stepValues, catalog);
 
   function syncValidationErrors(step: number, errors: WizardValidationErrors) {
     if (Object.keys(errors).length > 0) {
@@ -70,10 +71,10 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
       return;
     }
 
-    const firstInvalidStep = getFirstInvalidWizardStep(stepValues);
+    const firstInvalidStep = getFirstInvalidWizardStep(stepValues, catalog);
     if (firstInvalidStep !== null) {
       for (let i = 0; i < STEP_LABELS.length - 1; i += 1) {
-        syncValidationErrors(i, validateWizardStep(i, stepValues));
+        syncValidationErrors(i, validateWizardStep(i, stepValues, catalog));
       }
       if (wizardMode === 'wizard') {
         setWizardStep(firstInvalidStep);
@@ -82,7 +83,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
     }
 
     clearValidationErrors(wizardStep);
-    onLaunch(buildWizardLaunchConfig(stepValues));
+    onLaunch(buildWizardLaunchConfig(stepValues, catalog));
   }
 
   function handleNext() {
@@ -101,13 +102,13 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
   function renderStep() {
     switch (wizardStep) {
       case 0: return <StepIdentity />;
-      case 1: return <StepWorkflow containerRuntime={containerRuntime} />;
+      case 1: return <StepWorkflow catalog={catalog} containerRuntime={containerRuntime} />;
       case 2: return <StepLlmTargets />;
       case 3: return <StepModules />;
       case 4: return <StepSkills />;
       case 5: return <StepPrompts />;
       case 6: return <StepGit />;
-      case 7: return <StepReview />;
+      case 7: return <StepReview catalog={catalog} />;
       default: return null;
     }
   }
@@ -168,13 +169,13 @@ export function WizardDialog({ isOpen, onClose, onLaunch, containerRuntime, laun
             {wizardMode === 'wizard' ? renderStep() : (
               <div className="space-y-8 p-8">
                 <FormSection title="Identity"><StepIdentity /></FormSection>
-                <FormSection title="Workflow"><StepWorkflow containerRuntime={containerRuntime} /></FormSection>
+                <FormSection title="Workflow"><StepWorkflow catalog={catalog} containerRuntime={containerRuntime} /></FormSection>
                 <FormSection title="LLM Targets"><StepLlmTargets /></FormSection>
                 <FormSection title="Modules"><StepModules /></FormSection>
                 <FormSection title="Skills"><StepSkills /></FormSection>
                 <FormSection title="Prompts"><StepPrompts /></FormSection>
                 <FormSection title="Git"><StepGit /></FormSection>
-                <FormSection title="Review"><StepReview /></FormSection>
+                <FormSection title="Review"><StepReview catalog={catalog} /></FormSection>
               </div>
             )}
           </div>
@@ -273,6 +274,7 @@ function buildStepStatuses(
   wizardStep: number,
   highestCompleted: number,
   stepValues: Record<number, Record<string, unknown> | undefined>,
+  catalog?: readonly BeastCatalogEntry[],
 ): Record<number, 'complete' | 'error' | 'current' | 'locked'> {
   const statuses: Record<number, 'complete' | 'error' | 'current' | 'locked'> = {};
 
@@ -283,7 +285,7 @@ function buildStepStatuses(
       continue;
     }
 
-    statuses[i] = Object.keys(validateWizardStep(i, stepValues)).length > 0
+    statuses[i] = Object.keys(validateWizardStep(i, stepValues, catalog)).length > 0
       ? 'error'
       : i === wizardStep
         ? 'current'

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { BeastCatalogEntry } from '../../lib/beast-api';
 import { buildWizardLaunchConfig } from './wizard-launch-config';
 
 describe('buildWizardLaunchConfig', () => {
@@ -51,7 +52,40 @@ describe('buildWizardLaunchConfig', () => {
     });
   });
 
+  it('flattens backend catalog prompt keys into launch config for custom definitions', () => {
+    const catalog: BeastCatalogEntry[] = [{
+      id: 'custom-beast',
+      label: 'Custom Backend Beast',
+      description: 'Served by backend catalog',
+      executionModeDefault: 'process',
+      interviewPrompts: [
+        { key: 'objective', prompt: 'What should it do?', kind: 'string', required: true },
+        { key: 'provider', prompt: 'Which provider?', kind: 'string', required: true },
+      ],
+    }];
+
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'custom-beast', objective: 'Ship catalog UX', provider: 'codex' },
+    }, catalog)).toMatchObject({
+      workflow: { workflowType: 'custom-beast', objective: 'Ship catalog UX', provider: 'codex' },
+      objective: 'Ship catalog UX',
+      provider: 'codex',
+    });
+  });
+
   it('keeps legacy wizard aliases compatible while preferring backend field names', () => {
+    expect(buildWizardLaunchConfig({
+      1: {
+        workflowType: 'chunk-plan',
+        docPath: 'legacy/design.md',
+        designDocPath: 'docs/design.md',
+        outputDir: 'tasks/chunks',
+      },
+    })).toMatchObject({
+      designDocPath: 'docs/design.md',
+      outputDir: 'tasks/chunks',
+    });
+
     expect(buildWizardLaunchConfig({
       1: {
         workflowType: 'martin-loop',

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -1,3 +1,6 @@
+import type { BeastCatalogEntry } from '../../lib/beast-api';
+import { findCatalogEntry, getPromptValue, isBlankCatalogValue } from './wizard-catalog';
+
 export const WIZARD_SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 'skills', 'prompts', 'git'] as const;
 
 type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
@@ -26,7 +29,10 @@ function buildPromptFrontload(prompts: Record<string, unknown> | undefined): str
   return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
 }
 
-export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<string, unknown> {
+export function buildWizardLaunchConfig(
+  stepValues: WizardStepValues,
+  catalog?: readonly BeastCatalogEntry[],
+): Record<string, unknown> {
   const config: Record<string, unknown> = {};
 
   for (let i = 0; i < WIZARD_SECTION_KEYS.length; i += 1) {
@@ -36,6 +42,9 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
   }
 
   const workflow = config.workflow as Record<string, unknown> | undefined;
+  const selectedWorkflow = typeof workflow?.workflowType === 'string'
+    ? findCatalogEntry(catalog, workflow.workflowType)
+    : undefined;
   const promptFrontload = buildPromptFrontload(config.prompts as Record<string, unknown> | undefined);
   if (promptFrontload) {
     config.promptConfig = { text: promptFrontload };
@@ -45,6 +54,15 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
     config.executionMode = workflow.executionMode;
   } else {
     config.executionMode = 'process';
+  }
+
+  if (selectedWorkflow && workflow) {
+    for (const prompt of selectedWorkflow.interviewPrompts) {
+      const value = getPromptValue(workflow, prompt);
+      if (!isBlankCatalogValue(value)) {
+        config[prompt.key] = value;
+      }
+    }
   }
 
   if (workflow?.workflowType === 'design-interview') {
@@ -57,12 +75,14 @@ export function buildWizardLaunchConfig(stepValues: WizardStepValues): Record<st
     }
   }
 
-  if (workflow?.workflowType === 'chunk-plan' && typeof workflow.docPath === 'string') {
-    config.designDocPath = workflow.docPath;
-  }
-
-  if (workflow?.workflowType === 'chunk-plan' && typeof workflow.outputDir === 'string') {
-    config.outputDir = workflow.outputDir;
+  if (workflow?.workflowType === 'chunk-plan') {
+    const designDocPath = typeof workflow.designDocPath === 'string' ? workflow.designDocPath : workflow.docPath;
+    if (typeof designDocPath === 'string') {
+      config.designDocPath = designDocPath;
+    }
+    if (typeof workflow.outputDir === 'string') {
+      config.outputDir = workflow.outputDir;
+    }
   }
 
   if (workflow?.workflowType === 'martin-loop') {

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -1,3 +1,6 @@
+import type { BeastCatalogEntry, BeastInterviewPrompt } from '../../lib/beast-api';
+import { findCatalogEntry, getPromptValue, isBlankCatalogValue } from './wizard-catalog';
+
 export const WIZARD_SECTION_LABELS = ['Identity', 'Workflow', 'LLM Targets', 'Modules', 'Skills', 'Prompts', 'Git', 'Review'] as const;
 
 export type WizardValidationErrors = Record<string, string>;
@@ -8,6 +11,7 @@ type WorkflowValues = {
   goal?: unknown;
   topic?: unknown;
   outputPath?: unknown;
+  designDocPath?: unknown;
   docPath?: unknown;
   outputDir?: unknown;
   provider?: unknown;
@@ -27,7 +31,38 @@ function isRepoRelativeMarkdownDesignDocPath(value: string): boolean {
   return /\.(?:md|mdx|markdown)$/i.test(value);
 }
 
-export function validateWizardStep(step: number, stepValues: WizardStepValues): WizardValidationErrors {
+function requiredMessage(prompt: BeastInterviewPrompt): string {
+  if (prompt.key === 'goal') return 'Design interview goal is required.';
+  if (prompt.key === 'outputPath') return 'Design interview output path is required.';
+  if (prompt.key === 'designDocPath') return 'Design doc path is required.';
+  if (prompt.key === 'outputDir') return 'Output directory is required.';
+  if (prompt.key === 'provider') return 'Provider is required.';
+  if (prompt.key === 'objective') return 'Objective is required.';
+  if (prompt.key === 'chunkDirectory') return 'Chunk directory path is required.';
+  return `${prompt.prompt.replace(/[?.!]+$/g, '')} is required.`;
+}
+
+function validateCatalogPrompt(
+  errors: WizardValidationErrors,
+  values: WorkflowValues,
+  prompt: BeastInterviewPrompt,
+): void {
+  const value = getPromptValue(values as Record<string, unknown>, prompt);
+  const errorKey = prompt.key === 'chunkDirectory' ? 'chunkDir' : prompt.key;
+  if (prompt.required && isBlankCatalogValue(value)) {
+    errors[errorKey] = requiredMessage(prompt);
+    return;
+  }
+  if (prompt.key === 'designDocPath' && typeof value === 'string' && !isRepoRelativeMarkdownDesignDocPath(value)) {
+    errors.designDocPath = 'Design doc path must be a repo-relative Markdown file without traversal.';
+  }
+}
+
+export function validateWizardStep(
+  step: number,
+  stepValues: WizardStepValues,
+  catalog?: readonly BeastCatalogEntry[],
+): WizardValidationErrors {
   const errors: WizardValidationErrors = {};
 
   if (step === 0) {
@@ -43,52 +78,20 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
       errors.workflowType = 'Workflow type is required.';
     }
 
-    if (values.workflowType === 'design-interview') {
-      if (isBlank(values.goal ?? values.topic)) {
-        errors.topic = 'Design interview goal is required.';
-      }
-      if (isBlank(values.outputPath)) {
-        errors.outputPath = 'Design interview output path is required.';
-      }
-    }
-
-    if (values.workflowType === 'chunk-plan') {
-      const docPath = values.docPath;
-      if (isBlank(docPath)) {
-        errors.docPath = 'Design doc path is required.';
-      } else if (typeof docPath !== 'string' || !isRepoRelativeMarkdownDesignDocPath(docPath)) {
-        errors.docPath = 'Design doc path must be a repo-relative Markdown file without traversal.';
-      }
-      if (isBlank(values.outputDir)) {
-        errors.outputDir = 'Output directory is required.';
-      }
-    }
-
-    if (values.workflowType === 'martin-loop') {
-      if (isBlank(values.provider)) {
-        errors.provider = 'Provider is required.';
-      }
-      if (isBlank(values.objective)) {
-        errors.objective = 'Objective is required.';
-      }
-      if (isBlank(values.chunkDirectory ?? values.chunkDir)) {
-        errors.chunkDir = 'Chunk directory path is required.';
-      }
-    }
-
-    if (
-      !isBlank(values.workflowType) &&
-      values.workflowType !== 'design-interview' &&
-      values.workflowType !== 'chunk-plan' &&
-      values.workflowType !== 'martin-loop'
-    ) {
+    const workflowType = typeof values.workflowType === 'string' ? values.workflowType : undefined;
+    const selectedDefinition = findCatalogEntry(catalog, workflowType);
+    if (workflowType && !selectedDefinition) {
       errors.workflowType = 'Choose a supported launch workflow.';
+    }
+
+    for (const prompt of selectedDefinition?.interviewPrompts ?? []) {
+      validateCatalogPrompt(errors, values, prompt);
     }
   }
 
   if (step === 7) {
     for (let i = 0; i < WIZARD_SECTION_LABELS.length - 1; i += 1) {
-      const stepErrors = validateWizardStep(i, stepValues);
+      const stepErrors = validateWizardStep(i, stepValues, catalog);
       for (const [field, message] of Object.entries(stepErrors)) {
         errors[`${i}.${field}`] = `${WIZARD_SECTION_LABELS[i]}: ${message}`;
       }
@@ -98,15 +101,22 @@ export function validateWizardStep(step: number, stepValues: WizardStepValues): 
   return errors;
 }
 
-export function getFirstInvalidWizardStep(stepValues: WizardStepValues): number | null {
+export function getFirstInvalidWizardStep(
+  stepValues: WizardStepValues,
+  catalog?: readonly BeastCatalogEntry[],
+): number | null {
   for (let i = 0; i < WIZARD_SECTION_LABELS.length - 1; i += 1) {
-    if (Object.keys(validateWizardStep(i, stepValues)).length > 0) {
+    if (Object.keys(validateWizardStep(i, stepValues, catalog)).length > 0) {
       return i;
     }
   }
   return null;
 }
 
-export function isWizardStepValid(step: number, stepValues: WizardStepValues): boolean {
-  return Object.keys(validateWizardStep(step, stepValues)).length === 0;
+export function isWizardStepValid(
+  step: number,
+  stepValues: WizardStepValues,
+  catalog?: readonly BeastCatalogEntry[],
+): boolean {
+  return Object.keys(validateWizardStep(step, stepValues, catalog)).length === 0;
 }

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -237,9 +237,11 @@ export function buildInitAction(
     const workflow = config.workflow as Record<string, unknown> | undefined;
     const designDocPath = typeof config.designDocPath === 'string'
       ? config.designDocPath
-      : typeof workflow?.docPath === 'string'
-        ? workflow.docPath
-        : '';
+      : typeof workflow?.designDocPath === 'string'
+        ? workflow.designDocPath
+        : typeof workflow?.docPath === 'string'
+          ? workflow.docPath
+          : '';
 
     return {
       kind: 'chunk-plan',

--- a/packages/franken-web/src/pages/beasts-page.tsx
+++ b/packages/franken-web/src/pages/beasts-page.tsx
@@ -36,6 +36,7 @@ interface BeastsPageProps {
 export function BeastsPage({
   agents,
   agentDetail,
+  catalog,
   runs,
   containerRuntime,
   disabled,
@@ -127,6 +128,7 @@ export function BeastsPage({
         onClose={() => setShowWizard(false)}
         onLaunch={handleLaunch}
         containerRuntime={containerRuntime}
+        catalog={catalog}
         launching={launching}
         launchError={launchError}
       />

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -16,7 +16,7 @@ describe('StepReview', () => {
   it('renders summary sections from Zustand state', () => {
     render(<StepReview />);
     expect(screen.getByText('Test Agent')).toBeTruthy();
-    expect(screen.getByText(/design-interview/i)).toBeTruthy();
+    expect(screen.getByText('Design Interview')).toBeTruthy();
   });
 
   it('shows backend-required workflow details before launch', () => {
@@ -29,11 +29,11 @@ describe('StepReview', () => {
 
     render(<StepReview />);
 
-    expect(screen.getByText('Provider')).toBeTruthy();
+    expect(screen.getByText('Which provider should run the martin loop')).toBeTruthy();
     expect(screen.getByText('codex')).toBeTruthy();
-    expect(screen.getByText('Objective')).toBeTruthy();
+    expect(screen.getByText('What should the martin loop accomplish')).toBeTruthy();
     expect(screen.getByText('Implement chunks')).toBeTruthy();
-    expect(screen.getByText('Chunk directory')).toBeTruthy();
+    expect(screen.getByText('Which chunk directory should MartinLoop execute from')).toBeTruthy();
     expect(screen.getByText('tasks/chunks')).toBeTruthy();
     expect(screen.queryByText('Required workflow fields are missing:')).toBeNull();
   });
@@ -58,12 +58,12 @@ describe('StepReview', () => {
   });
 
   it('does not render a launch action inside the review step', () => {
-    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' });
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan', designDocPath: 'docs/design.md', outputDir: 'tasks/chunks' });
     useBeastStore.getState().setStepValues(2, { defaultProvider: 'codex', defaultModel: 'gpt-5.1' });
     render(<StepReview />);
 
     expect(screen.queryByRole('button', { name: /launch/i })).toBeNull();
-    expect(screen.getByText('chunk-plan')).toBeTruthy();
+    expect(screen.getByText('Design Doc -> Chunk Creation')).toBeTruthy();
     expect(screen.getByText('codex / gpt-5.1')).toBeTruthy();
   });
 });

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -2,6 +2,20 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { StepWorkflow } from '../../../../src/components/beasts/steps/step-workflow';
 import { useBeastStore } from '../../../../src/stores/beast-store';
+import type { BeastCatalogEntry } from '../../../../src/lib/beast-api';
+
+const backendCatalog: BeastCatalogEntry[] = [
+  {
+    id: 'custom-beast',
+    label: 'Custom Backend Beast',
+    description: 'Definition served by the backend catalog',
+    executionModeDefault: 'process',
+    interviewPrompts: [
+      { key: 'objective', prompt: 'What should the custom beast do?', kind: 'string', required: true },
+      { key: 'provider', prompt: 'Which backend provider should run?', kind: 'string', required: true, options: ['codex', 'claude'] },
+    ],
+  },
+];
 
 afterEach(cleanup);
 
@@ -13,9 +27,29 @@ describe('StepWorkflow', () => {
   it('renders supported workflow cards', () => {
     render(<StepWorkflow />);
     expect(screen.getByText('Design Interview')).toBeTruthy();
-    expect(screen.getByText('Chunk Design Doc')).toBeTruthy();
+    expect(screen.getByText('Design Doc -> Chunk Creation')).toBeTruthy();
     expect(screen.queryByText('Issues Agent')).toBeNull();
-    expect(screen.getByText('Run Chunked Project')).toBeTruthy();
+    expect(screen.getByText('Martin Loop')).toBeTruthy();
+  });
+
+  it('renders backend catalog definitions instead of static workflow cards when provided', () => {
+    render(<StepWorkflow catalog={backendCatalog} />);
+    expect(screen.getByText('Custom Backend Beast')).toBeTruthy();
+    expect(screen.queryByText('Design Interview')).toBeNull();
+  });
+
+  it('renders backend interview prompts for the selected catalog definition', () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'custom-beast' });
+    render(<StepWorkflow catalog={backendCatalog} />);
+
+    fireEvent.change(screen.getByLabelText(/custom beast do/i), { target: { value: 'Ship catalog UX' } });
+    fireEvent.change(screen.getByLabelText(/backend provider/i), { target: { value: 'codex' } });
+
+    expect(useBeastStore.getState().stepValues[1]).toMatchObject({
+      workflowType: 'custom-beast',
+      objective: 'Ship catalog UX',
+      provider: 'codex',
+    });
   });
 
   it('selecting a card highlights it and stores in Zustand', () => {
@@ -24,19 +58,38 @@ describe('StepWorkflow', () => {
     expect(useBeastStore.getState().stepValues[1]?.workflowType).toBe('design-interview');
   });
 
+  it('does not wipe answers when reselecting the selected workflow card', () => {
+    useBeastStore.getState().setStepValues(1, {
+      workflowType: 'design-interview',
+      executionMode: 'container',
+      goal: 'Draft billing design',
+      outputPath: 'docs/billing.md',
+    });
+    render(<StepWorkflow containerRuntime={{ available: true }} />);
+
+    fireEvent.click(screen.getByText('Design Interview'));
+
+    expect(useBeastStore.getState().stepValues[1]).toEqual({
+      workflowType: 'design-interview',
+      executionMode: 'container',
+      goal: 'Draft billing design',
+      outputPath: 'docs/billing.md',
+    });
+  });
+
   it('shows workflow-specific fields after selection', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
     render(<StepWorkflow />);
     expect(screen.getByPlaceholderText(/design interview should produce/i)).toBeTruthy();
-    expect(screen.getByLabelText('Output Path')).toBeTruthy();
+    expect(screen.getByLabelText(/design document be written/i)).toBeTruthy();
   });
 
   it('collects backend design-interview fields', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
     render(<StepWorkflow />);
 
-    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Draft billing design' } });
-    fireEvent.change(screen.getByLabelText('Output Path'), { target: { value: 'docs/billing.md' } });
+    fireEvent.change(screen.getByLabelText(/design interview produce/i), { target: { value: 'Draft billing design' } });
+    fireEvent.change(screen.getByLabelText(/design document be written/i), { target: { value: 'docs/billing.md' } });
 
     expect(useBeastStore.getState().stepValues[1]).toEqual({
       workflowType: 'design-interview',
@@ -49,12 +102,13 @@ describe('StepWorkflow', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan' });
     render(<StepWorkflow />);
 
-    fireEvent.change(screen.getByLabelText('Design Doc Path'), { target: { value: 'docs/design.md' } });
-    fireEvent.change(screen.getByLabelText('Output Directory'), { target: { value: 'tasks/chunks' } });
+    fireEvent.change(screen.getByLabelText(/design document should be chunked/i), { target: { value: 'docs/design.md' } });
+    fireEvent.change(screen.getByLabelText(/chunk plan be written/i), { target: { value: 'tasks/chunks' } });
 
+    expect(screen.getByLabelText(/chunk plan be written/i).tagName).toBe('INPUT');
     expect(useBeastStore.getState().stepValues[1]).toEqual({
       workflowType: 'chunk-plan',
-      docPath: 'docs/design.md',
+      designDocPath: 'docs/design.md',
       outputDir: 'tasks/chunks',
     });
   });
@@ -63,9 +117,9 @@ describe('StepWorkflow', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'martin-loop' });
     render(<StepWorkflow />);
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'codex' } });
-    fireEvent.change(screen.getByLabelText('Objective'), { target: { value: 'Implement chunks' } });
-    fireEvent.change(screen.getByLabelText('Chunk Directory Path'), { target: { value: 'tasks/chunks' } });
+    fireEvent.change(screen.getByLabelText(/provider should run the martin loop/i), { target: { value: 'codex' } });
+    fireEvent.change(screen.getByLabelText(/martin loop accomplish/i), { target: { value: 'Implement chunks' } });
+    fireEvent.change(screen.getByLabelText(/chunk directory should MartinLoop execute/i), { target: { value: 'tasks/chunks' } });
 
     expect(useBeastStore.getState().stepValues[1]).toEqual({
       workflowType: 'martin-loop',

--- a/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
@@ -16,14 +16,22 @@ describe('wizard validation', () => {
     });
 
     expect(errors).toEqual({
-      topic: 'Design interview goal is required.',
+      goal: 'Design interview goal is required.',
       outputPath: 'Design interview output path is required.',
     });
   });
 
   it('accepts repo-relative Markdown chunk-plan design docs', () => {
     const errors = validateWizardStep(1, {
-      1: { workflowType: 'chunk-plan', docPath: 'docs/design.md', outputDir: 'tasks/chunks' },
+      1: { workflowType: 'chunk-plan', designDocPath: 'docs/design.md', outputDir: 'tasks/chunks' },
+    });
+
+    expect(errors).toEqual({});
+  });
+
+  it('accepts legacy design-interview topic alias from restored wizard state', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'design-interview', topic: 'Legacy goal', outputPath: 'docs/design.md' },
     });
 
     expect(errors).toEqual({});
@@ -38,10 +46,10 @@ describe('wizard validation', () => {
     'docs/design.md\0',
   ])('rejects unsafe chunk-plan design doc path %s', (docPath) => {
     const errors = validateWizardStep(1, {
-      1: { workflowType: 'chunk-plan', docPath, outputDir: 'tasks/chunks' },
+      1: { workflowType: 'chunk-plan', designDocPath: docPath, outputDir: 'tasks/chunks' },
     });
 
-    expect(errors.docPath).toBe('Design doc path must be a repo-relative Markdown file without traversal.');
+    expect(errors.designDocPath).toBe('Design doc path must be a repo-relative Markdown file without traversal.');
   });
 
   it('accepts backend-aligned martin-loop fields', () => {

--- a/packages/franken-web/tests/pages/beasts-page.test.tsx
+++ b/packages/franken-web/tests/pages/beasts-page.test.tsx
@@ -56,6 +56,25 @@ describe('BeastsPage', () => {
     expect(screen.getByText('Identity')).toBeTruthy();
   });
 
+  it('drives wizard workflow choices from backend catalog prop', () => {
+    render(<BeastsPage {...baseProps} catalog={[{
+      id: 'custom-beast',
+      label: 'Custom Backend Beast',
+      description: 'Served from backend catalog',
+      executionModeDefault: 'process',
+      interviewPrompts: [
+        { key: 'objective', prompt: 'What should the custom beast do?', kind: 'string', required: true },
+      ],
+    }]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }));
+    fireEvent.change(screen.getByLabelText(/agent name/i), { target: { value: 'Catalog Agent' } });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByText('Custom Backend Beast')).toBeTruthy();
+    expect(screen.queryByText('Design Interview')).toBeNull();
+  });
+
   it('shows error banner when error prop is set', () => {
     render(<BeastsPage {...baseProps} error="Something went wrong" />);
     expect(screen.getByText('Something went wrong')).toBeTruthy();

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-09 — Franken-web beast wizard catalog data
+- When backend beast definitions expose interview prompts, drive cards, labels, validation, review rows, and launch config from the catalog instead of adding one-off hardcoded UI branches. Preserve old aliases (`docPath`, `chunkDir`, `topic`) only as compatibility fallbacks while preferring backend field names (`designDocPath`, `chunkDirectory`, `goal`).
+
 ## 2026-07-06 — Critique scanner edge cases
 - Dependency/comment/string scanners that manually skip regex literals must cover keyword-prefixed regexes (including await), postfix-operator division, JSX closing tags, template interpolations, and import trivia comments. Add regression tests for each Codex-reported lexical edge case before re-triggering review.
 


### PR DESCRIPTION
## Summary
- Thread backend beast catalog data into the creation wizard and use catalog prompt definitions for workflow cards, fields, validation, and review output.
- Preserve legacy wizard field aliases while preferring backend field names like designDocPath, chunkDirectory, and goal.
- Update launch/init config handling and regression coverage for catalog-driven wizard behavior.

## Test Plan
- npm run test --workspace @franken/web
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm run lint:security

Closes #408