### PR TITLE
test: make Docker sandbox smoke coverage explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run deterministic root Vitest suite
         run: npm run test:root
 
+      - name: Run Docker sandbox build smoke test
+        run: npm run test:docker:sandbox
+
       - run: npm run lint:security
 
       - name: Track code comment debt markers

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "test": "turbo run test",
     "test:root": "vitest run",
+    "test:docker:sandbox": "node scripts/run-docker-sandbox-smoke.mjs",
     "test:root:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },

--- a/scripts/run-docker-sandbox-smoke.mjs
+++ b/scripts/run-docker-sandbox-smoke.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const dockerVersion = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+  encoding: 'utf8',
+  stdio: 'pipe',
+});
+
+if (dockerVersion.error || dockerVersion.status !== 0) {
+  const reason = dockerVersion.error?.message
+    ?? dockerVersion.stderr?.trim()
+    ?? `docker version exited with status ${dockerVersion.status}`;
+  console.warn(`Docker sandbox build smoke test skipped: Docker daemon unavailable (${reason}).`);
+  process.exit(0);
+}
+
+const version = dockerVersion.stdout.trim() || 'unknown';
+console.log(`Docker sandbox build smoke test running: Docker daemon ${version} is available.`);
+
+const vitestArgs = [
+  'node_modules/vitest/vitest.mjs',
+  'run',
+  'tests/sandbox-dockerfile.test.ts',
+  '--reporter=verbose',
+];
+const result = spawnSync(process.execPath, vitestArgs, {
+  env: {
+    ...process.env,
+    DOCKER_BUILD: 'true',
+  },
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(`Docker sandbox build smoke test failed to start: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (result.status === 0) {
+  console.log('Docker sandbox build smoke test passed: fbeast/sandbox image builds from the repo Dockerfile.');
+}
+
+process.exit(result.status ?? 1);

--- a/tests/vitest-env.test.ts
+++ b/tests/vitest-env.test.ts
@@ -59,4 +59,19 @@ describe('Vitest environment flag helper', () => {
     expect(config).toContain('include,');
     expect(config).toContain('exclude,');
   });
+
+  it('declares an explicit Docker sandbox smoke path with pass and skip output', () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+      scripts?: Record<string, string>;
+    };
+    const ci = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf-8');
+    const smokeScript = readFileSync(resolve(ROOT, 'scripts/run-docker-sandbox-smoke.mjs'), 'utf-8');
+
+    expect(pkg.scripts?.['test:docker:sandbox']).toBe('node scripts/run-docker-sandbox-smoke.mjs');
+    expect(ci).toContain('Run Docker sandbox build smoke test');
+    expect(ci).toContain('npm run test:docker:sandbox');
+    expect(smokeScript).toContain('DOCKER_BUILD');
+    expect(smokeScript).toContain('Docker sandbox build smoke test skipped: Docker daemon unavailable');
+    expect(smokeScript).toContain('Docker sandbox build smoke test passed');
+  });
 });


### PR DESCRIPTION
## Summary
- add an explicit npm Docker sandbox smoke script that logs pass vs skip states
- run the Docker sandbox smoke script from CI after the deterministic root suite
- cover the script and CI wiring in root Vitest tests

## Test Plan
- npm run test:root -- --run tests/vitest-env.test.ts tests/sandbox-dockerfile.test.ts
- npm run test:docker:sandbox
- npm run typecheck
- npm run build
- npm run lint:security
- npm run check:package-manager

Closes #927