### PR TITLE
fix(critique): validate hardcoded IPv4 octets

### DIFF
--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -81,12 +81,25 @@ export class ScalabilityEvaluator implements Evaluator {
 
   private checkHardcodedIPs(content: string, findings: EvaluationFinding[]): void {
     for (const match of content.matchAll(HARDCODED_IP_PATTERN)) {
+      const ipAddress = match[1] ?? '';
+      if (!this.isValidIPv4Address(ipAddress)) {
+        continue;
+      }
+
       findings.push({
-        message: `Found hardcoded IP address: "${match[1]}". Use environment variables or config.`,
+        message: `Found hardcoded IP address: "${ipAddress}". Use environment variables or config.`,
         severity: 'warning',
         suggestion: 'Move IP address to environment variable or DNS hostname',
       });
     }
+  }
+
+  private isValidIPv4Address(ipAddress: string): boolean {
+    const octets = ipAddress.split('.');
+    return octets.length === 4 && octets.every((octet) => {
+      const value = Number(octet);
+      return Number.isInteger(value) && value >= 0 && value <= 255;
+    });
   }
 
   private checkHardcodedPorts(content: string, findings: EvaluationFinding[]): void {

--- a/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/scalability.test.ts
@@ -30,13 +30,24 @@ describe('ScalabilityEvaluator', () => {
     expect(result.findings.some((f) => f.message.includes('hardcoded'))).toBe(true);
   });
 
-  it('flags hardcoded IP addresses', async () => {
+  it.each(['127.0.0.1', '192.168.1.10'])('flags valid hardcoded IPv4 address %s', async (ipAddress) => {
     const evaluator = new ScalabilityEvaluator();
-    const content = `const host = "192.168.1.100";`;
+    const content = `const host = "${ipAddress}";`;
     const result = await evaluator.evaluate(createInput(content));
 
-    expect(result.findings.some((f) => f.message.includes('hardcoded'))).toBe(true);
+    expect(result.findings.some((f) => f.message.includes(`hardcoded IP address: "${ipAddress}"`))).toBe(true);
   });
+
+  it.each(['999.999.999.999', '300.1.2.3', '1.2.3.999'])(
+    'does not flag invalid dotted-quad %s as a hardcoded IPv4 address',
+    async (ipAddress) => {
+      const evaluator = new ScalabilityEvaluator();
+      const content = `const placeholder = "${ipAddress}";`;
+      const result = await evaluator.evaluate(createInput(content));
+
+      expect(result.findings.some((f) => f.message.includes('hardcoded IP address'))).toBe(false);
+    },
+  );
 
   it.each([
     ['bare declaration', 'const port = 8080;'],


### PR DESCRIPTION
## Summary
- validates dotted-quad hardcoded IP matches before reporting scalability findings
- keeps valid IPv4 literals reportable while suppressing invalid octet values
- adds regression coverage for valid and invalid IPv4 dotted-quads

## Test Plan
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-critique test -- tests/unit/evaluators/scalability.test.ts
- npm --prefix packages/franken-critique run lint
- npm --prefix packages/franken-critique run build
- npm --prefix packages/franken-critique test

Closes #1205