### PR TITLE
docs(web): clarify Vite proxy target for backend ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ npm --workspace @franken/web run dev:chat
 
 Open the Vite URL, usually `http://127.0.0.1:5173/`. By default the dashboard talks to the chat server through TLS-preferred API defaults and reads the same observer, governor, cost, and Beast data written by MCP mode in that project.
 
-If you run the backend on a different port, keep browser requests same-origin and point the Vite dev proxy at that backend:
+If you run the backend on a different port, keep browser requests same-origin and point the Vite dev proxy at that backend. Leave `VITE_API_URL` unset for local Vite development; setting a browser-facing backend URL can turn `/v1` and `/api` calls into cross-origin requests that fail CORS instead of flowing through the dev proxy.
 
 ```bash
 npm --workspace @franken/orchestrator run chat-server -- --base-dir /path/to/your-project --port 4242

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ npm --workspace @franken/web run dev:chat
 
 Open the Vite URL, usually `http://127.0.0.1:5173/`. By default the dashboard talks to the chat server through TLS-preferred API defaults and reads the same observer, governor, cost, and Beast data written by MCP mode in that project.
 
-If you run the backend on a different port, keep browser requests same-origin and point the Vite dev proxy at that backend. Leave `VITE_API_URL` unset for local Vite development; setting a browser-facing backend URL can turn `/v1` and `/api` calls into cross-origin requests that fail CORS instead of flowing through the dev proxy.
+If you run the backend on a different port, keep browser requests same-origin and point the Vite dev proxy at that backend. Leave `VITE_API_URL` unset for local Vite development; the current dashboard ignores that legacy value, so it will not change the backend port. Use `VITE_API_PROXY_TARGET` instead so `/v1` and `/api` continue flowing through the dev proxy.
 
 ```bash
 npm --workspace @franken/orchestrator run chat-server -- --base-dir /path/to/your-project --port 4242

--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -54,7 +54,7 @@ npm --workspace @franken/web run dev:chat
 
 That proxies same-origin browser requests to `http://127.0.0.1:3737`; production deployments should use TLS-terminated `https://` and `wss://` endpoints.
 
-If your backend is on a different port, keep browser requests same-origin and set the Vite proxy target:
+If your backend is on a different port, keep browser requests same-origin and set the Vite proxy target. Leave `VITE_API_URL` unset in local Vite development; use `VITE_API_PROXY_TARGET` instead so `/v1` and `/api` stay on the Vite origin and the dev server forwards them to the backend without browser CORS failures.
 
 ```bash
 VITE_API_PROXY_TARGET=http://127.0.0.1:4242 npm --workspace @franken/web run dev

--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -54,7 +54,7 @@ npm --workspace @franken/web run dev:chat
 
 That proxies same-origin browser requests to `http://127.0.0.1:3737`; production deployments should use TLS-terminated `https://` and `wss://` endpoints.
 
-If your backend is on a different port, keep browser requests same-origin and set the Vite proxy target. Leave `VITE_API_URL` unset in local Vite development; use `VITE_API_PROXY_TARGET` instead so `/v1` and `/api` stay on the Vite origin and the dev server forwards them to the backend without browser CORS failures.
+If your backend is on a different port, keep browser requests same-origin and set the Vite proxy target. Leave `VITE_API_URL` unset in local Vite development; the current dashboard ignores that legacy value, so it will not change the backend port. Use `VITE_API_PROXY_TARGET` instead so `/v1` and `/api` stay on the Vite origin while the dev server forwards them to the backend.
 
 ```bash
 VITE_API_PROXY_TARGET=http://127.0.0.1:4242 npm --workspace @franken/web run dev


### PR DESCRIPTION
## Summary
- clarify that local Vite dashboard runs should leave `VITE_API_URL` unset
- point custom backend ports at `VITE_API_PROXY_TARGET` so browser calls remain same-origin and avoid CORS failures

## Test Plan
- `git diff --check`
- `npm --workspace @franken/types run build`
- `npm --workspace @franken/web run typecheck`
- `npm --workspace @franken/web run build`

Closes #1002