### PR TITLE
fix(critique): preserve loop warning verdicts

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -37,6 +37,7 @@ export type {
   CorrectionRequest,
   CritiqueLoopResult,
   CritiqueLoopPass,
+  CritiqueLoopWarn,
   CritiqueLoopFail,
   CritiqueLoopHalted,
   CritiqueLoopEscalated,

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -57,7 +57,7 @@ export class CritiqueLoop {
       // Pass/warn: warnings are non-critical findings that should surface in
       // results without forcing correction iterations.
       if (critiqueResult.verdict === 'pass' || critiqueResult.verdict === 'warn') {
-        return { verdict: 'pass', iterations: state.iterations };
+        return { verdict: critiqueResult.verdict, iterations: state.iterations };
       }
 
       // Fail: update failure history

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -11,8 +11,8 @@ export class LessonRecorder {
   }
 
   async record(result: CritiqueLoopResult, taskId: TaskId): Promise<void> {
-    // Only record lessons from multi-iteration passes
-    if (result.verdict !== 'pass' || result.iterations.length <= 1) {
+    // Only record lessons from multi-iteration pass/warn successes.
+    if ((result.verdict !== 'pass' && result.verdict !== 'warn') || result.iterations.length <= 1) {
       return;
     }
 

--- a/packages/franken-critique/src/types/loop.ts
+++ b/packages/franken-critique/src/types/loop.ts
@@ -46,9 +46,15 @@ export interface CorrectionRequest {
   readonly iterationCount: number;
 }
 
-/** Result when the critique loop passes. */
+/** Result when the critique loop passes without warning-bearing findings. */
 export interface CritiqueLoopPass {
   readonly verdict: 'pass';
+  readonly iterations: readonly CritiqueIteration[];
+}
+
+/** Result when the critique loop passes but warning-bearing findings are present. */
+export interface CritiqueLoopWarn {
+  readonly verdict: 'warn';
   readonly iterations: readonly CritiqueIteration[];
 }
 
@@ -76,6 +82,7 @@ export interface CritiqueLoopEscalated {
 /** Discriminated union of all possible loop outcomes. */
 export type CritiqueLoopResult =
   | CritiqueLoopPass
+  | CritiqueLoopWarn
   | CritiqueLoopFail
   | CritiqueLoopHalted
   | CritiqueLoopEscalated;

--- a/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
+++ b/packages/franken-critique/tests/unit/loop/critique-loop.test.ts
@@ -34,6 +34,20 @@ function createPassingPipeline(): CritiquePipeline {
   return new CritiquePipeline([evaluator]);
 }
 
+function createWarningPipeline(): CritiquePipeline {
+  const evaluator: Evaluator = {
+    name: 'warning-rule',
+    category: 'deterministic',
+    evaluate: vi.fn().mockResolvedValue({
+      evaluatorName: 'warning-rule',
+      verdict: 'warn',
+      score: 0.7,
+      findings: [{ message: 'review before shipping', severity: 'warning' }],
+    }),
+  };
+  return new CritiquePipeline([evaluator]);
+}
+
 interface FailingPipelineOptions {
   readonly evaluatorName?: string;
   readonly findings?: readonly EvaluationFinding[];
@@ -72,6 +86,15 @@ describe('CritiqueLoop', () => {
 
     expect(result.verdict).toBe('pass');
     expect(result.iterations).toHaveLength(1);
+  });
+
+  it('returns warn on first iteration when pipeline passes with warnings', async () => {
+    const loop = new CritiqueLoop(createWarningPipeline(), []);
+    const result = await loop.run(createInput('warning-bearing code'), createConfig());
+
+    expect(result.verdict).toBe('warn');
+    expect(result.iterations).toHaveLength(1);
+    expect(result.iterations[0]!.result.verdict).toBe('warn');
   });
 
   it('returns fail with correction when pipeline fails', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -103,12 +103,12 @@ describe('LessonRecorder', () => {
     expect(call.timestamp).toBeTruthy();
   });
 
-  it('uses a warning-only terminal iteration as the applied correction', async () => {
+  it('records a lesson when multi-iteration recovery ends with warnings', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);
 
     const result: CritiqueLoopResult = {
-      verdict: 'pass',
+      verdict: 'warn',
       iterations: [
         createIteration(0, 'fail', 'complexity', [{ message: 'too many params', severity: 'warning' }]),
         createIteration(1, 'warn', 'adr-compliance', [{ message: 'review ADR', severity: 'warning' }]),
@@ -120,6 +120,7 @@ describe('LessonRecorder', () => {
     const call = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
       correctionApplied: string;
     };
+    expect(port.recordLesson).toHaveBeenCalledTimes(1);
     expect(call.correctionApplied).toBe('Corrected in iteration 1');
   });
 

--- a/packages/franken-orchestrator/src/adapters/critique-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/critique-adapter.ts
@@ -48,6 +48,7 @@ export interface EscalationRequest {
 
 export type CritiqueLoopResult =
   | { readonly verdict: 'pass'; readonly iterations: readonly CritiqueIteration[] }
+  | { readonly verdict: 'warn'; readonly iterations: readonly CritiqueIteration[] }
   | { readonly verdict: 'fail'; readonly iterations: readonly CritiqueIteration[]; readonly correction: CorrectionRequest }
   | { readonly verdict: 'halted'; readonly iterations: readonly CritiqueIteration[]; readonly reason: string }
   | { readonly verdict: 'escalated'; readonly iterations: readonly CritiqueIteration[]; readonly escalation: EscalationRequest };
@@ -102,9 +103,9 @@ export class CritiquePortAdapter implements ICritiqueModule {
     const lastResult = lastIteration?.result;
     const findings = lastResult ? this.mapFindings(lastResult.results) : [];
 
-    if (loopResult.verdict === 'pass') {
+    if (loopResult.verdict === 'pass' || loopResult.verdict === 'warn') {
       return {
-        verdict: 'pass',
+        verdict: loopResult.verdict,
         findings,
         score: lastResult?.overallScore ?? 0,
       };

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -134,7 +134,7 @@ export interface ICritiqueModule {
 }
 
 export interface CritiqueResult {
-  readonly verdict: 'pass' | 'fail';
+  readonly verdict: 'pass' | 'warn' | 'fail';
   readonly findings: readonly CritiqueFinding[];
   readonly score: number;
   /**

--- a/packages/franken-orchestrator/src/phases/planning.ts
+++ b/packages/franken-orchestrator/src/phases/planning.ts
@@ -107,7 +107,10 @@ export async function runPlanning(
       throw new CritiqueBudgetHaltError(1, reason);
     }
 
-    if (critiqueResult.verdict === 'pass' && critiqueResult.score >= config.minCritiqueScore) {
+    if (
+      (critiqueResult.verdict === 'pass' || critiqueResult.verdict === 'warn') &&
+      critiqueResult.score >= config.minCritiqueScore
+    ) {
       return; // Plan approved
     }
 
@@ -178,7 +181,10 @@ export async function runPlanning(
       throw new CritiqueBudgetHaltError(i + 1, reason);
     }
 
-    if (critiqueResult.verdict === 'pass' && critiqueResult.score >= config.minCritiqueScore) {
+    if (
+      (critiqueResult.verdict === 'pass' || critiqueResult.verdict === 'warn') &&
+      critiqueResult.score >= config.minCritiqueScore
+    ) {
       return; // Plan approved
     }
   }

--- a/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/critique-adapter.test.ts
@@ -50,6 +50,53 @@ describe('CritiquePortAdapter', () => {
     );
   });
 
+  it('maps critique warning results without collapsing them to pass', async () => {
+    const loop = {
+      run: vi.fn().mockResolvedValue({
+        verdict: 'warn',
+        iterations: [
+          {
+            index: 0,
+            input: { content: 'plan', metadata: {} },
+            result: {
+              verdict: 'warn',
+              overallScore: 0.8,
+              results: [
+                {
+                  evaluatorName: 'ADR',
+                  verdict: 'warn',
+                  score: 0.8,
+                  findings: [{ message: 'ADR coverage is thin', severity: 'warning' }],
+                },
+              ],
+              shortCircuited: false,
+            },
+            completedAt: '2026-03-05T00:00:00.000Z',
+          },
+        ],
+      }),
+    };
+
+    const adapter = new CritiquePortAdapter({
+      loop,
+      config: {
+        maxIterations: 1,
+        tokenBudget: 1000,
+        consensusThreshold: 2,
+        sessionId: 'sess-1',
+        taskId: 'plan-review',
+      },
+    });
+
+    const result = await adapter.reviewPlan(plan);
+
+    expect(result).toEqual({
+      verdict: 'warn',
+      findings: [{ evaluator: 'ADR', severity: 'warning', message: 'ADR coverage is thin' }],
+      score: 0.8,
+    });
+  });
+
   it('maps critique failures with findings', async () => {
     const loop = {
       run: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- Preserve `CritiqueLoop` warning-bearing success as a top-level `verdict: 'warn'` instead of collapsing it to `pass`.
- Export the new `CritiqueLoopWarn` type and propagate warning verdicts through the orchestrator critique adapter.
- Treat warning-bearing critique success as terminal approval in planning when score thresholds pass while keeping findings visible.

## Test Plan
- `npm --prefix packages/franken-critique test -- tests/unit/loop/critique-loop.test.ts`
- `npm --prefix packages/franken-orchestrator test -- tests/unit/adapters/critique-adapter.test.ts`
- `npm --prefix packages/franken-critique run build`
- `npm --prefix packages/franken-orchestrator run build`
- `npm --prefix packages/franken-critique run lint`
- `npm --prefix packages/franken-orchestrator run lint` (passes with existing warnings)
- `npm run build`
- `npm --prefix packages/franken-critique test`
- `npm --prefix packages/franken-orchestrator test -- tests/unit/phases/planning.test.ts tests/unit/cli/dep-factory-providers.test.ts`

Closes #1160
