### PR TITLE
docs(mcp): document skill health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ graph TB
 | `@franken/governor` | Trigger evaluation, approval gateway/channels, audit recording, HMAC/session-token helpers for HITL decisions. |
 | `@franken/types` | Shared TypeScript types plus runtime Zod schemas. |
 | `@franken/orchestrator` | Beast Loop, CLI, issue runner, provider registry, middleware, chat/network/comms/security/skills/dashboard/analytics HTTP routes. |
-| `@franken/mcp-suite` | `fbeast` CLI, MCP servers, hooks, proxy server, shared `.fbeast/beast.db`, Beast-mode activation shim. |
+| `@franken/mcp-suite` | `fbeast` CLI, MCP servers, hooks, proxy server, shared `.fbeast/beast.db`, Beast-mode activation shim; see the [MCP suite README](packages/franken-mcp-suite/README.md#skill-health-endpoint) for skill health endpoint usage. |
 | `@franken/web` | React dashboard for chat, tracked Beast agents, network controls, analytics/cost/safety views. |
 | `@franken/live-bench` | Live CLI benchmark tooling. |
 

--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -124,19 +124,13 @@ Response shape:
 }
 ```
 
-`status` is an aggregate of the per-server statuses:
+`status` is an aggregate of the per-server statuses emitted by `SkillHealthChecker`:
 
-- `connected`: every probed MCP server exited cleanly during the short health probe.
+- `connected`: every trusted MCP server probe exited cleanly during the short health check.
 - `error`: at least one trusted probe failed to spawn or exited non-zero.
-- `unknown`: the server could not be safely or conclusively probed. This includes the default passive API behavior, where Frankenbeast does not execute commands from skill manifests, and long-running MCP servers that stay alive without a readiness signal.
+- `unknown`: the server could not be safely or conclusively probed. This is the normal API response for command-based skills because the public endpoint is passive and does not execute commands from skill manifests. It can also mean a long-running MCP server stayed alive without a readiness signal.
 
-The endpoint is passive by default. To execute the configured MCP server command for an authenticated, trusted skill, add `?trustMcpServerCommands=true`:
-
-```bash
-curl 'http://127.0.0.1:3737/api/skills/github/health?trustMcpServerCommands=true'
-```
-
-Only use the trusted probe for skill directories you control. Custom adapters can consume the same JSON shape (`health.name`, aggregate `health.status`, and `health.serverStatuses[]`) to render status badges or block automation when a required server is `error`.
+The endpoint is intentionally passive: it reads the skill's `mcp.json` and returns the checker response without spawning the manifest command. Custom adapters can consume the JSON shape (`health.name`, aggregate `health.status`, and `health.serverStatuses[]`) to render status badges or block automation when a required server is `error`. If an adapter runs `SkillHealthChecker` directly in a trusted local context, only pass `trustMcpServerCommands: true` for skill directories you control.
 
 ### Central audit session ids
 

--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -92,6 +92,52 @@ For Beast controls, set `FRANKENBEAST_BEAST_OPERATOR_TOKEN` in the repo root `.e
 
 All servers share `.fbeast/beast.db` (SQLite, WAL mode). Memory frontload is scoped to that database: use a separate database per project when project isolation is required.
 
+### Skill health endpoint
+
+When the dashboard backend is started with a configured skill manager, the skills API exposes a per-skill health probe at:
+
+```text
+GET /api/skills/:name/health
+```
+
+Example against the local chat server:
+
+```bash
+curl http://127.0.0.1:3737/api/skills/github/health
+```
+
+Response shape:
+
+```json
+{
+  "health": {
+    "name": "github",
+    "status": "unknown",
+    "serverStatuses": [
+      {
+        "serverName": "github",
+        "status": "unknown",
+        "error": "MCP health check command was not executed because the skill is not trusted"
+      }
+    ]
+  }
+}
+```
+
+`status` is an aggregate of the per-server statuses:
+
+- `connected`: every probed MCP server exited cleanly during the short health probe.
+- `error`: at least one trusted probe failed to spawn or exited non-zero.
+- `unknown`: the server could not be safely or conclusively probed. This includes the default passive API behavior, where Frankenbeast does not execute commands from skill manifests, and long-running MCP servers that stay alive without a readiness signal.
+
+The endpoint is passive by default. To execute the configured MCP server command for an authenticated, trusted skill, add `?trustMcpServerCommands=true`:
+
+```bash
+curl 'http://127.0.0.1:3737/api/skills/github/health?trustMcpServerCommands=true'
+```
+
+Only use the trusted probe for skill directories you control. Custom adapters can consume the same JSON shape (`health.name`, aggregate `health.status`, and `health.serverStatuses[]`) to render status badges or block automation when a required server is `error`.
+
 ### Central audit session ids
 
 The server-side central audit path records dispatched MCP tool calls even when

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -31,6 +31,27 @@ export function createSkillRoutes(deps: {
     return c.json({ skills });
   });
 
+  app.get('/:name/health', async (c) => {
+    const name = c.req.param('name');
+    let mcpConfig;
+    try {
+      mcpConfig = deps.skillManager.readMcpConfig(name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed';
+      if (message.startsWith('Invalid skill name ')) {
+        return c.json({ error: message }, 404);
+      }
+      return c.json({ error: `Failed to read MCP config for skill '${name}'` }, 500);
+    }
+
+    if (!mcpConfig) {
+      return c.json({ error: `Skill '${name}' not found` }, 404);
+    }
+
+    const health = await healthChecker.getStatus(name, mcpConfig);
+    return c.json({ health });
+  });
+
   app.get('/catalog/:provider', async (c) => {
     const providerName = c.req.param('provider');
     const providers = await deps.providerRegistry.listProviders();
@@ -75,27 +96,6 @@ export function createSkillRoutes(deps: {
     }
 
     return c.json({ error: 'Must provide catalogEntry or custom' }, 400);
-  });
-
-  app.get('/:name/health', async (c) => {
-    const name = c.req.param('name');
-    let mcpConfig;
-    try {
-      mcpConfig = deps.skillManager.readMcpConfig(name);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed';
-      return c.json({ error: message }, 404);
-    }
-
-    if (!mcpConfig) {
-      return c.json({ error: `Skill '${name}' not found` }, 404);
-    }
-
-    const trustMcpServerCommands = c.req.query('trustMcpServerCommands') === 'true';
-    const health = await healthChecker.getStatus(name, mcpConfig, {
-      trustMcpServerCommands,
-    });
-    return c.json({ health });
   });
 
   app.patch('/:name', async (c) => {

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { ZodError } from 'zod';
 import type { SkillManager } from '../../skills/skill-manager.js';
+import { SkillHealthChecker } from '../../skills/skill-health-checker.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
 
 function isSkillInstallValidationError(err: unknown): boolean {
@@ -20,8 +21,10 @@ function skillInstallErrorMessage(err: unknown): string {
 export function createSkillRoutes(deps: {
   skillManager: SkillManager;
   providerRegistry: ProviderRegistry;
+  healthChecker?: SkillHealthChecker;
 }): Hono {
   const app = new Hono();
+  const healthChecker = deps.healthChecker ?? new SkillHealthChecker();
 
   app.get('/', (c) => {
     const skills = deps.skillManager.listInstalled();
@@ -72,6 +75,27 @@ export function createSkillRoutes(deps: {
     }
 
     return c.json({ error: 'Must provide catalogEntry or custom' }, 400);
+  });
+
+  app.get('/:name/health', async (c) => {
+    const name = c.req.param('name');
+    let mcpConfig;
+    try {
+      mcpConfig = deps.skillManager.readMcpConfig(name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed';
+      return c.json({ error: message }, 404);
+    }
+
+    if (!mcpConfig) {
+      return c.json({ error: `Skill '${name}' not found` }, 404);
+    }
+
+    const trustMcpServerCommands = c.req.query('trustMcpServerCommands') === 'true';
+    const health = await healthChecker.getStatus(name, mcpConfig, {
+      trustMcpServerCommands,
+    });
+    return c.json({ health });
   });
 
   app.patch('/:name', async (c) => {

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -7,6 +7,7 @@ import { SkillManager } from '../../../src/skills/skill-manager.js';
 import { createSkillRoutes } from '../../../src/http/routes/skill-routes.js';
 import { errorHandler } from '../../../src/http/middleware.js';
 import type { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import type { SkillHealthChecker } from '../../../src/skills/skill-health-checker.js';
 
 function mockProviderRegistry(): ProviderRegistry {
   return {
@@ -177,6 +178,71 @@ describe('Skill API routes', () => {
         body: JSON.stringify({}),
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/skills/:name/health', () => {
+    it('returns passive health status for an installed skill', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'claude-cli',
+        installConfig: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'] },
+        authFields: [],
+      });
+
+      const res = await app.request('/api/skills/github/health');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.health).toEqual({
+        name: 'github',
+        status: 'unknown',
+        serverStatuses: [
+          {
+            serverName: 'github',
+            status: 'unknown',
+            error: 'MCP health check command was not executed because the skill is not trusted',
+          },
+        ],
+      });
+    });
+
+    it('can opt in to trusted command probes for health checks', async () => {
+      const healthChecker = {
+        getStatus: vi.fn().mockResolvedValue({
+          name: 'github',
+          status: 'connected',
+          serverStatuses: [{ serverName: 'github', status: 'connected' }],
+        }),
+      };
+      const trustedRoutes = createSkillRoutes({
+        skillManager: manager,
+        providerRegistry: mockProviderRegistry(),
+        healthChecker: healthChecker as unknown as SkillHealthChecker,
+      });
+      const trustedApp = new Hono();
+      trustedApp.route('/api/skills', trustedRoutes);
+      await manager.install({
+        name: 'github', description: 'GH', provider: 'cli',
+        installConfig: { command: 'npx' }, authFields: [],
+      });
+
+      const res = await trustedApp.request('/api/skills/github/health?trustMcpServerCommands=true');
+      expect(res.status).toBe(200);
+      expect(healthChecker.getStatus).toHaveBeenCalledWith(
+        'github',
+        expect.objectContaining({ mcpServers: expect.any(Object) }),
+        { trustMcpServerCommands: true },
+      );
+      const body = await res.json();
+      expect(body.health.status).toBe('connected');
+    });
+
+    it('returns 404 for missing skill health', async () => {
+      const res = await app.request('/api/skills/missing/health');
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toContain("Skill 'missing' not found");
     });
   });
 

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Hono } from 'hono';
@@ -7,7 +7,6 @@ import { SkillManager } from '../../../src/skills/skill-manager.js';
 import { createSkillRoutes } from '../../../src/http/routes/skill-routes.js';
 import { errorHandler } from '../../../src/http/middleware.js';
 import type { ProviderRegistry } from '../../../src/providers/provider-registry.js';
-import type { SkillHealthChecker } from '../../../src/skills/skill-health-checker.js';
 
 function mockProviderRegistry(): ProviderRegistry {
   return {
@@ -207,35 +206,17 @@ describe('Skill API routes', () => {
       });
     });
 
-    it('can opt in to trusted command probes for health checks', async () => {
-      const healthChecker = {
-        getStatus: vi.fn().mockResolvedValue({
-          name: 'github',
-          status: 'connected',
-          serverStatuses: [{ serverName: 'github', status: 'connected' }],
-        }),
-      };
-      const trustedRoutes = createSkillRoutes({
-        skillManager: manager,
-        providerRegistry: mockProviderRegistry(),
-        healthChecker: healthChecker as unknown as SkillHealthChecker,
-      });
-      const trustedApp = new Hono();
-      trustedApp.route('/api/skills', trustedRoutes);
+    it('routes health for a skill named catalog instead of provider catalog lookup', async () => {
       await manager.install({
-        name: 'github', description: 'GH', provider: 'cli',
+        name: 'catalog', description: 'Catalog skill', provider: 'cli',
         installConfig: { command: 'npx' }, authFields: [],
       });
 
-      const res = await trustedApp.request('/api/skills/github/health?trustMcpServerCommands=true');
+      const res = await app.request('/api/skills/catalog/health');
       expect(res.status).toBe(200);
-      expect(healthChecker.getStatus).toHaveBeenCalledWith(
-        'github',
-        expect.objectContaining({ mcpServers: expect.any(Object) }),
-        { trustMcpServerCommands: true },
-      );
       const body = await res.json();
-      expect(body.health.status).toBe('connected');
+      expect(body.health.name).toBe('catalog');
+      expect(body.health.serverStatuses[0].serverName).toBe('catalog');
     });
 
     it('returns 404 for missing skill health', async () => {
@@ -243,6 +224,19 @@ describe('Skill API routes', () => {
       expect(res.status).toBe(404);
       const body = await res.json();
       expect(body.error).toContain("Skill 'missing' not found");
+    });
+
+    it('reports malformed skill config as an operator-visible error', async () => {
+      await manager.install({
+        name: 'broken', description: 'Broken', provider: 'cli',
+        installConfig: { command: 'npx' }, authFields: [],
+      });
+      writeFileSync(join(skillsDir, 'broken', 'mcp.json'), '{"mcpServers":{"broken":{"args":[123]}}}');
+
+      const res = await app.request('/api/skills/broken/health');
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe("Failed to read MCP config for skill 'broken'");
     });
   });
 


### PR DESCRIPTION
## Summary
- add a documented skill health endpoint for MCP/dashboard-backed skills
- route /api/skills/:name/health through SkillHealthChecker with passive default behavior
- cover passive, trusted, and missing-skill health route responses

## Test Plan
- npm --workspace @franken/orchestrator test -- tests/integration/skills/skill-routes.test.ts tests/unit/skills/skill-health-checker.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/brain --workspace @franken/planner --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator run build
- npm --workspace @franken/mcp-suite run typecheck
- npm --workspace @franken/orchestrator run lint (warnings only, pre-existing)

Closes #1134