### PR TITLE
fix(orchestrator): reject invalid analytics time windows

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
 import type { AnalyticsFilters, AnalyticsOutcome, AnalyticsPageRequest, AnalyticsService } from '../../analytics/types.js';
 
 export interface AnalyticsRouteDeps {
@@ -13,20 +14,31 @@ const OUTCOMES = new Set<AnalyticsOutcome>([
   'error',
   'detected',
 ]);
+const TIME_WINDOWS = ['24h', '7d', '30d', 'all'] as const;
+const TIME_WINDOW_SET = new Set<string>(TIME_WINDOWS);
+
+type FiltersResult = { ok: true; filters: AnalyticsFilters } | { ok: false };
+type PageRequestResult = { ok: true; request: AnalyticsPageRequest } | { ok: false };
 
 export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
   const app = new Hono();
 
   app.get('/summary', async (c) => {
-    return c.json(await deps.analytics.getSummary(readFilters(c.req.query())));
+    const result = readFilters(c.req.query());
+    if (!result.ok) return invalidTimeWindow(c);
+    return c.json(await deps.analytics.getSummary(result.filters));
   });
 
   app.get('/sessions', async (c) => {
-    return c.json({ sessions: await deps.analytics.listSessions(readFilters(c.req.query())) });
+    const result = readFilters(c.req.query());
+    if (!result.ok) return invalidTimeWindow(c);
+    return c.json({ sessions: await deps.analytics.listSessions(result.filters) });
   });
 
   app.get('/events', async (c) => {
-    return c.json(await deps.analytics.listEvents(readPageRequest(c.req.query())));
+    const result = readPageRequest(c.req.query());
+    if (!result.ok) return invalidTimeWindow(c);
+    return c.json(await deps.analytics.listEvents(result.request));
   });
 
   app.get('/events/:id', async (c) => {
@@ -40,26 +52,49 @@ export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
   return app;
 }
 
-function readPageRequest(query: Record<string, string>): AnalyticsPageRequest {
+function readPageRequest(query: Record<string, string>): PageRequestResult {
   const filters = readFilters(query);
+  if (!filters.ok) {
+    return filters;
+  }
   const page = readPositiveInteger(query['page']);
   const pageSize = readPositiveInteger(query['pageSize']);
 
   return {
-    ...filters,
-    ...(page ? { page } : {}),
-    ...(pageSize ? { pageSize } : {}),
+    ok: true,
+    request: {
+      ...filters.filters,
+      ...(page ? { page } : {}),
+      ...(pageSize ? { pageSize } : {}),
+    },
   };
 }
 
-function readFilters(query: Record<string, string>): AnalyticsFilters {
+function readFilters(query: Record<string, string>): FiltersResult {
   const outcome = query['outcome'];
+  const timeWindow = query['timeWindow'];
+  if (timeWindow && !TIME_WINDOW_SET.has(timeWindow)) {
+    return { ok: false };
+  }
   return {
-    ...(query['sessionId'] ? { sessionId: query['sessionId'] } : {}),
-    ...(query['toolQuery'] ? { toolQuery: query['toolQuery'] } : {}),
-    ...(outcome && OUTCOMES.has(outcome as AnalyticsOutcome) ? { outcome: outcome as AnalyticsOutcome } : {}),
-    ...(query['timeWindow'] ? { timeWindow: query['timeWindow'] } : {}),
+    ok: true,
+    filters: {
+      ...(query['sessionId'] ? { sessionId: query['sessionId'] } : {}),
+      ...(query['toolQuery'] ? { toolQuery: query['toolQuery'] } : {}),
+      ...(outcome && OUTCOMES.has(outcome as AnalyticsOutcome) ? { outcome: outcome as AnalyticsOutcome } : {}),
+      ...(timeWindow ? { timeWindow } : {}),
+    },
   };
+}
+
+function invalidTimeWindow(c: Context) {
+  return c.json({
+    error: {
+      message: 'Unsupported Analytics timeWindow filter',
+      code: 'invalid_time_window',
+      allowedValues: TIME_WINDOWS,
+    },
+  }, 400);
 }
 
 function readPositiveInteger(value: string | undefined): number | undefined {

--- a/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
@@ -81,6 +81,23 @@ describe('analytics routes', () => {
     expect(service.listEvents).toHaveBeenCalledWith({ page: 2, pageSize: 25 });
   });
 
+  it('rejects unsupported timeWindow query values before reading analytics data', async () => {
+    const service = mockAnalyticsService();
+    const app = createAnalyticsRoutes({ analytics: service });
+
+    const res = await app.request('/events?timeWindow=30days');
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: {
+        message: 'Unsupported Analytics timeWindow filter',
+        code: 'invalid_time_window',
+        allowedValues: ['24h', '7d', '30d', 'all'],
+      },
+    });
+    expect(service.listEvents).not.toHaveBeenCalled();
+  });
+
   it('returns event details or a 404', async () => {
     const service = mockAnalyticsService();
     const app = createAnalyticsRoutes({ analytics: service });


### PR DESCRIPTION
## Summary
- Validate Analytics `timeWindow` filters at the HTTP route boundary.
- Return a structured 400 `invalid_time_window` error for unsupported values.
- Add unit coverage proving invalid values do not call the analytics service or silently expand to all-time results.

## Test Plan
- [x] `cd packages/franken-orchestrator && npm test -- tests/unit/http/analytics-routes.test.ts`
- [x] `npm run typecheck --workspace @franken/orchestrator`
- [x] `npm run build --workspace @franken/orchestrator`
- [x] `npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)
- [x] `git diff --check`

Closes #1217
