### PR TITLE
fix(observer): validate span lifecycle token counts

### DIFF
--- a/packages/franken-observer/src/core/SpanLifecycle.test.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.test.ts
@@ -101,6 +101,27 @@ describe('SpanLifecycle', () => {
       ).not.toThrow()
     })
 
+    it.each([
+      ['negative prompt tokens', { promptTokens: -1, completionTokens: 0 }],
+      ['negative completion tokens', { promptTokens: 0, completionTokens: -1 }],
+      ['fractional prompt tokens', { promptTokens: 1.5, completionTokens: 0 }],
+      ['fractional completion tokens', { promptTokens: 0, completionTokens: 1.5 }],
+      ['NaN prompt tokens', { promptTokens: Number.NaN, completionTokens: 0 }],
+      ['NaN completion tokens', { promptTokens: 0, completionTokens: Number.NaN }],
+      ['infinite prompt tokens', { promptTokens: Number.POSITIVE_INFINITY, completionTokens: 0 }],
+      ['infinite completion tokens', { promptTokens: 0, completionTokens: Number.NEGATIVE_INFINITY }],
+      ['unsafe prompt tokens', { promptTokens: Number.MAX_SAFE_INTEGER + 1, completionTokens: 0 }],
+      ['unsafe completion tokens', { promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER + 1 }],
+      ['overflowing total tokens', { promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 1 }],
+    ])('rejects no-counter %s without mutating span metadata', (_name, usage) => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'llm-call' })
+      SpanLifecycle.setMetadata(span, { existing: 'kept' })
+
+      expect(() => SpanLifecycle.recordTokenUsage(span, usage)).toThrow(RangeError)
+      expect(span.metadata).toEqual({ existing: 'kept' })
+    })
+
     it('rejects an ended span before touching the counter (no poisoned totals)', () => {
       const trace = TraceContext.createTrace('goal')
       const span = TraceContext.startSpan(trace, { name: 'llm-call' })

--- a/packages/franken-observer/src/core/SpanLifecycle.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.ts
@@ -7,6 +7,24 @@ export interface TokenUsage {
   model?: string
 }
 
+function assertValidTokenDelta(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(
+      `SpanLifecycle: ${label} must be a non-negative safe integer, received ${value}`,
+    )
+  }
+}
+
+function safeAddTokenCounts(a: number, b: number): number {
+  const sum = a + b
+  if (!Number.isSafeInteger(sum)) {
+    throw new RangeError(
+      `SpanLifecycle: token total ${sum} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+    )
+  }
+  return sum
+}
+
 export const SpanLifecycle = {
   setMetadata(span: Span, data: Record<string, unknown>): void {
     if (span.status !== 'active') {
@@ -29,9 +47,13 @@ export const SpanLifecycle = {
     if (span.status !== 'active') {
       throw new Error(`Cannot record token usage on a ${span.status} span (id: ${span.id})`)
     }
-    // Record to the counter next: it validates the token counts and may throw
-    // on bad/overflowing input. Doing it before mutating the span keeps the
-    // rejection atomic — a rejected record leaves the span untouched.
+    assertValidTokenDelta(usage.promptTokens, 'promptTokens')
+    assertValidTokenDelta(usage.completionTokens, 'completionTokens')
+    const totalTokens = safeAddTokenCounts(usage.promptTokens, usage.completionTokens)
+
+    // Record to the counter next: it may throw if the new model/global totals
+    // would overflow. Doing it before mutating the span keeps the rejection
+    // atomic — a rejected record leaves the span untouched.
     if (counter !== undefined && usage.model !== undefined) {
       counter.record({
         model: usage.model,
@@ -42,7 +64,7 @@ export const SpanLifecycle = {
     const data: Record<string, unknown> = {
       promptTokens: usage.promptTokens,
       completionTokens: usage.completionTokens,
-      totalTokens: usage.promptTokens + usage.completionTokens,
+      totalTokens,
     }
     if (usage.model !== undefined) {
       data['model'] = usage.model


### PR DESCRIPTION
## Summary
- validate SpanLifecycle token deltas before writing span metadata
- reject non-safe, negative, non-finite, fractional, and overflowing no-counter token usage atomically
- add targeted regression coverage for no-counter invalid token metadata

## Test Plan
- npm --prefix packages/franken-observer test -- SpanLifecycle.test.ts
- npm --prefix packages/franken-observer test
- npm --prefix packages/franken-types run build && npm --prefix packages/franken-observer run typecheck && npm --prefix packages/franken-observer run build
- npm run lint:any

Closes #1151