### PR TITLE
fix(orchestrator): tolerate corrupt replay manifests

### DIFF
--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -767,6 +767,18 @@ function createIssueDeps(
   };
 }
 
+function readExistingReplayManifest(replayManifestPath: string): unknown[] {
+  if (!existsSync(replayManifestPath)) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(replayManifestPath, 'utf8')) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 function appendAuditFinalize(
   finalize: () => Promise<void>,
   observer: ObserverDepsBundle,
@@ -787,13 +799,7 @@ function appendAuditFinalize(
         }
         for (const [manifestRunId, records] of manifestsByRunId) {
           const replayManifestPath = join(observer.replayAuditRoot, `${manifestRunId}.replay.json`);
-          let existingManifest: unknown[] = [];
-          if (existsSync(replayManifestPath)) {
-            const parsed = JSON.parse(readFileSync(replayManifestPath, 'utf8')) as unknown;
-            if (Array.isArray(parsed)) {
-              existingManifest = parsed;
-            }
-          }
+          const existingManifest = readExistingReplayManifest(replayManifestPath);
           writeFileSync(
             replayManifestPath,
             JSON.stringify([...existingManifest, ...records], null, 2),

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -578,6 +578,27 @@ describe('dep-factory provider wiring', () => {
     expect(sessionManifest[0]?.runId).toBe('cli-session-1');
   });
 
+  it('does not let a corrupt existing replay manifest abort other finalize writes', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    const opts = makeOpts({ runSessionId: 'cli-session-1' });
+    const result = await createCliDeps(opts);
+    const auditDir = resolve(opts.paths.root, '.fbeast', 'audit');
+    mkdirSync(auditDir, { recursive: true });
+    writeFileSync(resolve(auditDir, 'issue-89.replay.json'), '{not valid json', 'utf8');
+    mockBridgeReplayManifest.push(
+      { version: 1, kind: 'llm.request', runId: 'issue-89', timestamp: '2026-05-25T00:00:00.000Z', contentRef: 'a'.repeat(64) },
+      { version: 1, kind: 'tool.result', runId: 'cli-session-1', timestamp: '2026-05-25T00:00:01.000Z', contentRef: 'b'.repeat(64) },
+    );
+
+    await result.finalize();
+
+    const issueManifest = JSON.parse(readFileSync(resolve(auditDir, 'issue-89.replay.json'), 'utf8')) as Array<{ runId: string }>;
+    const sessionManifest = JSON.parse(readFileSync(resolve(auditDir, 'cli-session-1.replay.json'), 'utf8')) as Array<{ runId: string }>;
+
+    expect(issueManifest).toEqual([expect.objectContaining({ runId: 'issue-89' })]);
+    expect(sessionManifest).toEqual([expect.objectContaining({ runId: 'cli-session-1' })]);
+  });
+
   it('clears issue-scoped runtime artifacts when reset is requested', async () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({


### PR DESCRIPTION
## Summary
- Ignore malformed existing replay manifest JSON when merging bridge replay records during finalize
- Keep writing replay manifests for every active run id even if one prior manifest is corrupt
- Add a regression covering a corrupt issue replay manifest plus another run manifest write

## Test Plan
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- --run tests/unit/cli/dep-factory-providers.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1153