### PR TITLE
fix(observer): validate http retry bounds

### DIFF
--- a/packages/franken-observer/src/export/httpRetry.test.ts
+++ b/packages/franken-observer/src/export/httpRetry.test.ts
@@ -83,4 +83,36 @@ describe('fetchWithRetry (issue #68)', () => {
       expect(delay).toBeLessThanOrEqual(250)
     }
   })
+
+  it('clamps invalid retry counts to preserve the initial attempt', async () => {
+    for (const maxRetries of [-1, Number.NaN, Number.POSITIVE_INFINITY, 1.9]) {
+      const sleep = noSleep()
+      const attempt = vi.fn().mockResolvedValue(serverError)
+      const res = await fetchWithRetry(attempt, { maxRetries, sleep })
+      expect(res).toEqual(serverError)
+      expect(attempt).toHaveBeenCalledTimes(maxRetries === 1.9 ? 2 : 1)
+      expect(sleep).toHaveBeenCalledTimes(maxRetries === 1.9 ? 1 : 0)
+    }
+  })
+
+  it('rejects invalid backoff bounds with clear errors before retry sleep', async () => {
+    const invalidOptions = [
+      { baseDelayMs: -1 },
+      { baseDelayMs: Number.NaN },
+      { baseDelayMs: Number.POSITIVE_INFINITY },
+      { maxDelayMs: -1 },
+      { maxDelayMs: Number.NaN },
+      { maxDelayMs: Number.POSITIVE_INFINITY },
+    ]
+
+    for (const options of invalidOptions) {
+      const sleep = noSleep()
+      const attempt = vi.fn().mockResolvedValue(serverError)
+      await expect(fetchWithRetry(attempt, { maxRetries: 1, ...options, sleep })).rejects.toThrow(
+        /baseDelayMs|maxDelayMs/,
+      )
+      expect(attempt).not.toHaveBeenCalled()
+      expect(sleep).not.toHaveBeenCalled()
+    }
+  })
 })

--- a/packages/franken-observer/src/export/httpRetry.test.ts
+++ b/packages/franken-observer/src/export/httpRetry.test.ts
@@ -111,8 +111,19 @@ describe('fetchWithRetry (issue #68)', () => {
       await expect(fetchWithRetry(attempt, { maxRetries: 1, ...options, sleep })).rejects.toThrow(
         /baseDelayMs|maxDelayMs/,
       )
-      expect(attempt).not.toHaveBeenCalled()
+      expect(attempt).toHaveBeenCalledTimes(1)
       expect(sleep).not.toHaveBeenCalled()
     }
+  })
+
+  it('preserves the initial attempt when invalid backoff bounds are unused', async () => {
+    const sleep = noSleep()
+    const attempt = vi.fn().mockResolvedValue(ok)
+
+    const res = await fetchWithRetry(attempt, { maxRetries: 0, baseDelayMs: -1, maxDelayMs: Number.NaN, sleep })
+
+    expect(res).toEqual(ok)
+    expect(attempt).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
   })
 })

--- a/packages/franken-observer/src/export/httpRetry.ts
+++ b/packages/franken-observer/src/export/httpRetry.ts
@@ -3,7 +3,11 @@ import type { FetchFn } from '../adapters/langfuse/LangfuseAdapter.js'
 type FetchResponse = Awaited<ReturnType<FetchFn>>
 
 export interface HttpRetryOptions {
-  /** Max retry attempts after the initial try. Default: 0 (no retry). */
+  /**
+   * Max retry attempts after the initial try. Default: 0 (no retry).
+   * Invalid, negative, or non-finite values are clamped to 0; fractional
+   * values are floored so the initial attempt is never skipped.
+   */
   maxRetries?: number
   /** Base delay in ms before the first retry. Default: 200. */
   baseDelayMs?: number
@@ -24,6 +28,20 @@ function isTransientStatus(status: number): boolean {
   return status === 429 || (status >= 500 && status <= 599)
 }
 
+function normalizeMaxRetries(maxRetries: number | undefined): number {
+  if (maxRetries === undefined) return 0
+  if (!Number.isFinite(maxRetries) || maxRetries < 0) return 0
+  return Math.floor(maxRetries)
+}
+
+function requireFiniteNonNegative(name: 'baseDelayMs' | 'maxDelayMs', value: number | undefined, defaultValue: number): number {
+  const normalized = value ?? defaultValue
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    throw new Error(`${name} must be a finite non-negative number`)
+  }
+  return normalized
+}
+
 /**
  * Invoke `attempt` with bounded exponential backoff. Retries only transient
  * failures: thrown errors (network), 5xx responses, and 429 rate-limit
@@ -36,9 +54,9 @@ export async function fetchWithRetry(
   attempt: () => Promise<FetchResponse>,
   options: HttpRetryOptions = {},
 ): Promise<FetchResponse> {
-  const maxRetries = options.maxRetries ?? 0
-  const baseDelayMs = options.baseDelayMs ?? 200
-  const maxDelayMs = options.maxDelayMs ?? 30_000
+  const maxRetries = normalizeMaxRetries(options.maxRetries)
+  const baseDelayMs = requireFiniteNonNegative('baseDelayMs', options.baseDelayMs, 200)
+  const maxDelayMs = requireFiniteNonNegative('maxDelayMs', options.maxDelayMs, 30_000)
   const jitter = options.jitter ?? true
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
 

--- a/packages/franken-observer/src/export/httpRetry.ts
+++ b/packages/franken-observer/src/export/httpRetry.ts
@@ -55,8 +55,6 @@ export async function fetchWithRetry(
   options: HttpRetryOptions = {},
 ): Promise<FetchResponse> {
   const maxRetries = normalizeMaxRetries(options.maxRetries)
-  const baseDelayMs = requireFiniteNonNegative('baseDelayMs', options.baseDelayMs, 200)
-  const maxDelayMs = requireFiniteNonNegative('maxDelayMs', options.maxDelayMs, 30_000)
   const jitter = options.jitter ?? true
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
 
@@ -65,6 +63,8 @@ export async function fetchWithRetry(
 
   for (let i = 0; i < maxAttempts; i++) {
     if (i > 0) {
+      const baseDelayMs = requireFiniteNonNegative('baseDelayMs', options.baseDelayMs, 200)
+      const maxDelayMs = requireFiniteNonNegative('maxDelayMs', options.maxDelayMs, 30_000)
       const base = Math.min(baseDelayMs * 2 ** (i - 1), maxDelayMs)
       // Clamp AFTER jitter so maxDelayMs is a true upper bound (callers rely on
       // it to cap shutdown-sensitive export latency).


### PR DESCRIPTION
## Summary
- Normalize invalid retry counts so fetchWithRetry always performs the initial attempt
- Validate backoff bounds before retrying to prevent negative or non-finite sleeps
- Add regression coverage for invalid retry and delay options

## Test Plan
- npm --prefix packages/franken-observer test -- src/export/httpRetry.test.ts
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run build

Closes #1148