### PR TITLE
docs(observer): document ESM-only build outputs

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -767,15 +767,17 @@ The package ships an extensive unit test suite. All adapters and integrations ar
 ## Building
 
 ```bash
-npm run build       # tsc → dist/ (ESM + DTS)
+npm run build       # tsc → dist/ (ESM, declarations, and maps)
 npm run typecheck   # tsc --noEmit
 ```
 
 Output:
 
 ```
-dist/index.js      # ESM
-dist/index.d.ts    # TypeScript declarations
+dist/index.js       # ESM entrypoint
+dist/index.js.map   # ESM source map
+dist/index.d.ts     # TypeScript declarations
+dist/index.d.ts.map # TypeScript declaration map
 ```
 
 The build is plain `tsc` and the output is **ESM-only** (`"type": "module"`). The `exports` map has `types` and `import` conditions but no `require` entry, so the package cannot be `require()`d from CommonJS — consumers must use `import` (or a dynamic `import()` from CJS).


### PR DESCRIPTION
## Summary
- update the observer README build section to describe the actual ESM-only TypeScript output
- list the generated index.js, declaration, and source-map files instead of stale CJS artifacts

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm test --workspace @franken/observer

Closes #1080