### PR TITLE
docs(readme): clarify init backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,12 +600,15 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 Set this in `.fbeast/config.json`, then run `frankenbeast init` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
 
 **1Password / Bitwarden:**
-```bash
-frankenbeast init --backend 1password
-# or
-frankenbeast init --backend bitwarden
+```json
+{ "network": { "secureBackend": "1password" } }
 ```
-You can also set the backend in `.fbeast/config.json` with `{ "network": { "secureBackend": "1password" } }` before running `frankenbeast init`. For 1Password, create or use a vault literally named `frankenbeast`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, run `bw login`/`bw unlock` and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+```json
+{ "network": { "secureBackend": "bitwarden" } }
+```
+Set one of those values in `.fbeast/config.json`, then run `frankenbeast init`. You can also use the current CLI shortcut `frankenbeast init --backend 1password` or `frankenbeast init --backend bitwarden`; it applies the same `network.secureBackend` choice before the wizard writes `.fbeast/config.json`.
+
+For 1Password, create or use a vault literally named `frankenbeast`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, run `bw login`/`bw unlock` and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
 
 ### Operator token setup
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -168,6 +168,9 @@ describe('local setup scripts', () => {
     expect(readme).toContain('frankenbeast init --non-interactive');
     expect(readme).toContain('Choose the secret backend before the first init run');
     expect(readme).toContain('{ "network": { "secureBackend": "os-keychain" } }');
+    expect(readme).toContain('{ "network": { "secureBackend": "1password" } }');
+    expect(readme).toContain('{ "network": { "secureBackend": "bitwarden" } }');
+    expect(readme).toContain('it applies the same `network.secureBackend` choice');
     expect(readme).toContain('Chat, Dashboard, and Comms modules');
     expect(readme).toContain('export FRANKENBEAST_PASSPHRASE=<passphrase>');
     expect(readme).toContain('frankenbeast run --config .fbeast/config.json');


### PR DESCRIPTION
## Summary
- Clarifies README secret backend setup examples for 1Password and Bitwarden via `network.secureBackend` in `.fbeast/config.json`
- Notes the current `frankenbeast init --backend ...` shortcut applies the same backend choice before writing config
- Adds root README guard assertions for the documented backend config snippets

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run check:package-manager
- npm run typecheck -- --filter=@franken/orchestrator
- npm run build -- --filter=@franken/orchestrator

Closes #1084