### PR TITLE
docs: refresh Claude workspace package map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,23 +4,23 @@ This project uses AI-assisted development. Rules in `.cursor/rules/` provide gui
 
 ## Monorepo Layout
 
-This is an npm workspaces monorepo with Turborepo for build orchestration. All 10 packages live under `packages/`:
+This is an npm workspaces monorepo with Turborepo for build orchestration. The root `package.json` declares `packages/*`, so the live workspace map is the direct `packages/<name>/package.json` set:
 
 ```
 packages/
-├── franken-types/           # Shared types + runtime Zod schemas (@franken/types)
+├── franken-types/           # @franken/types: Shared types + runtime Zod schemas
 ├── franken-brain/           # @franken/brain: MOD-03 SQLite-backed memory (working + episodic)
 ├── franken-planner/         # @franken/planner: MOD-04 DAG planning, strategies, recovery primitives
-├── franken-observer/        # MOD-05: Tracing, token/cost tracking, circuit breaker (@franken/observer)
-├── franken-critique/        # MOD-06: Self-critique evaluators + reviewer loop (@franken/critique)
-├── franken-governor/        # MOD-07: HITL governance, triggers, approval gateway (@franken/governor)
+├── franken-observer/        # @franken/observer: MOD-05 tracing, token/cost tracking, circuit breaker
+├── franken-critique/        # @franken/critique: MOD-06 self-critique evaluators + reviewer loop
+├── franken-governor/        # @franken/governor: MOD-07 HITL governance, triggers, approval gateway
 ├── franken-orchestrator/    # @franken/orchestrator: Beast Loop, CLI, chat/network servers
-├── franken-mcp-suite/       # fbeast CLI, MCP servers, hooks, proxy (@franken/mcp-suite)
-├── franken-web/             # React dashboard (@franken/web)
-└── live-bench/              # Live CLI benchmark tooling (@franken/live-bench)
+├── franken-mcp-suite/       # @franken/mcp-suite: fbeast CLI, MCP servers, hooks, proxy
+├── franken-web/             # @franken/web: React dashboard
+└── live-bench/              # @franken/live-bench: Live CLI benchmark tooling
 ```
 
-Former packages `frankenfirewall` (MOD-01), `franken-skills` (MOD-02), `franken-heartbeat` (MOD-08), `franken-mcp`, and `franken-comms` were consolidated into `@franken/orchestrator` and `franken-mcp-suite` per [ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md); their capabilities live on as internal adapters.
+Historical packages `frankenfirewall` (MOD-01), `franken-skills` (MOD-02), `franken-heartbeat` (MOD-08), `franken-mcp`, and `franken-comms` are not standalone workspaces anymore; they were consolidated into `@franken/orchestrator` and `@franken/mcp-suite` per [ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md), with their capabilities retained as internal adapters.
 
 **Build commands** (all via Turborepo):
 - `npm run build` — runs `turbo run build` (dependency-ordered)

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -239,4 +239,43 @@ describe('local setup scripts', () => {
       expect(doc).not.toMatch(/Re-run to update:/i);
     }
   });
+
+  it('keeps CLAUDE.md workspace package map aligned with live package manifests', () => {
+    const claudeGuide = read('CLAUDE.md');
+    const packageDirs = readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((dir) => existsSync(join(ROOT, 'packages', dir, 'package.json')))
+      .sort();
+
+    const packageScopes = packageDirs.map((dir) => {
+      const manifest = JSON.parse(read(`packages/${dir}/package.json`)) as { name: string };
+      return manifest.name;
+    });
+
+    expect(packageDirs).toEqual([
+      'franken-brain',
+      'franken-critique',
+      'franken-governor',
+      'franken-mcp-suite',
+      'franken-observer',
+      'franken-orchestrator',
+      'franken-planner',
+      'franken-types',
+      'franken-web',
+      'live-bench',
+    ]);
+
+    for (const dir of packageDirs) {
+      expect(claudeGuide).toContain(`${dir}/`);
+    }
+    for (const scope of packageScopes) {
+      expect(claudeGuide).toContain(scope);
+    }
+
+    expect(claudeGuide).toContain('The root `package.json` declares `packages/*`');
+    expect(claudeGuide).toContain('@franken/types');
+    expect(claudeGuide).not.toContain('@frankenbeast/types');
+    expect(claudeGuide).toContain('not standalone workspaces anymore');
+  });
 });


### PR DESCRIPTION
## Summary
- Refresh CLAUDE.md to describe the live packages/* workspace manifest set and current @franken/* package scopes.
- Mark consolidated legacy packages as historical/non-workspace entries.
- Add a root regression test that compares the CLAUDE.md package map against live package manifests and rejects @frankenbeast/types.

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run typecheck

Closes #1085