### PR TITLE
test(docs): guard local ADR links

### DIFF
--- a/tests/docs-issue-1094.test.ts
+++ b/tests/docs-issue-1094.test.ts
@@ -1,0 +1,76 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+const MARKDOWN_LINK_PATTERN = /!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/gu;
+const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/iu;
+
+const collectMarkdownFiles = (directory: string): string[] => readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+  const entryPath = resolve(directory, entry.name);
+  if (entry.isDirectory()) {
+    return collectMarkdownFiles(entryPath);
+  }
+
+  return extname(entry.name) === '.md' ? [entryPath] : [];
+});
+
+const docsLinkCheckFiles = (): string[] => {
+  const rootDocs = readdirSync(ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === '.md')
+    .map((entry) => resolve(ROOT, entry.name));
+
+  const docsTree = collectMarkdownFiles(resolve(ROOT, 'docs'));
+
+  const packageReadmes = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => resolve(ROOT, 'packages', entry.name, 'README.md'))
+    .filter((path) => existsSync(path));
+
+  return [...rootDocs, ...docsTree, ...packageReadmes].sort();
+};
+
+const missingLocalLinks = (): string[] => docsLinkCheckFiles().flatMap((filePath) => {
+  const markdown = readFileSync(filePath, 'utf8');
+  const fileDir = dirname(filePath);
+  const relativeFile = filePath.slice(ROOT.length + 1);
+  const missing: string[] = [];
+
+  for (const [lineIndex, line] of markdown.split('\n').entries()) {
+    for (const match of line.matchAll(MARKDOWN_LINK_PATTERN)) {
+      const rawTarget = match[1]?.replace(/^<|>$/gu, '') ?? '';
+      const pathOnly = rawTarget.split('#', 1)[0];
+
+      if (!pathOnly || rawTarget.startsWith('#') || SCHEME_PATTERN.test(rawTarget)) {
+        continue;
+      }
+
+      const decodedTarget = decodeURIComponent(pathOnly);
+      const targetPath = resolve(fileDir, decodedTarget);
+      if (!existsSync(targetPath)) {
+        missing.push(`${relativeFile}:${lineIndex + 1} ${rawTarget}`);
+      }
+    }
+  }
+
+  return missing;
+});
+
+describe('issue #1094 local docs links', () => {
+  it('keeps root docs, docs/**, and package READMEs free of broken local Markdown links', () => {
+    expect(missingLocalLinks()).toEqual([]);
+  });
+
+  it('points renamed ADR and design references at existing retained documents', () => {
+    expect(readDoc('CLAUDE.md')).toContain('(docs/adr/011-real-monorepo-migration.md)');
+    expect(readDoc('docs/RAMP_UP.md')).toContain('(adr/011-real-monorepo-migration.md)');
+    expect(readDoc('docs/ARCHITECTURE.md')).toContain('(adr/011-real-monorepo-migration.md)');
+    expect(readDoc('docs/ARCHITECTURE.md')).toContain('(adr/016-chat-server-entrypoint-for-dashboard.md)');
+    expect(readDoc('docs/adr/008-approach-c-full-pipeline.md')).toContain('planning artifact has been retired');
+    expect(readDoc('packages/franken-governor/README.md')).toContain('(docs/adr/ADR-001-typescript-strict-nodenext.md)');
+    expect(readDoc('packages/franken-governor/README.md')).toContain('(docs/adr/ADR-007-session-token-activation.md)');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a root Vitest regression that checks local Markdown links across root docs, docs/**, and package READMEs
- Assert the renamed ADR/design references from issue #1094 point at retained documents

## Test Plan
- npm exec vitest -- run tests/docs-issue-1094.test.ts
- npm run test:root
- npm run typecheck
- npm run build

Closes #1094