### PR TITLE
fix(critique): detect dynamic import ghost dependencies

### DIFF
--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -38,6 +38,9 @@ export class GhostDependencyEvaluator implements Evaluator {
       // Skip relative imports
       if (specifier.startsWith('.')) continue;
 
+      // Skip absolute local paths used by dynamic import() loaders.
+      if (specifier.startsWith('/')) continue;
+
       // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
       if (isNodeBuiltinSpecifier(specifier)) continue;
 
@@ -248,24 +251,48 @@ function canStartNativeDynamicImport(
   content: string,
   importIndex: number,
 ): boolean {
-  const previous = previousNonWhitespace(content, importIndex - 1);
-  if (previous === '.' || previous === '#') return false;
+  const previousIndex = previousNonWhitespaceIndex(content, importIndex - 1);
+  const previous = previousIndex === null ? null : content[previousIndex]!;
+  if (
+    previous === '#' ||
+    (previous === '.' &&
+      previousIndex !== null &&
+      !isSpreadOperand(content, previousIndex))
+  ) {
+    return false;
+  }
 
-  const statementStart = Math.max(
-    content.lastIndexOf(';', importIndex - 1),
-    content.lastIndexOf('{', importIndex - 1),
-    content.lastIndexOf('}', importIndex - 1),
-  );
+  const statementStart = content.lastIndexOf(';', importIndex - 1);
   const prefix = content.slice(statementStart + 1, importIndex);
-  const startsAfterObjectBrace = content[statementStart] === '{';
   const isTernaryBranch = prefix.includes('?');
+  const endsAfterTypeAnnotation = /:\s*$/.test(prefix);
 
   return !(
-    /\btype\s+[A-Za-z_$][\w$]*(?:\s*<[^;>{}]*>)?\s*=\s*$/.test(prefix) ||
-    (/\btype\b/.test(prefix) && /\btypeof\s*$/.test(prefix)) ||
-    (!startsAfterObjectBrace && !isTernaryBranch && /:\s*$/.test(prefix)) ||
-    /\b(?:interface|type)\b[^;{}]*\bextends\s*$/.test(prefix)
+    isInsideTypeDeclaration(prefix) ||
+    (endsAfterTypeAnnotation &&
+      !isTernaryBranch &&
+      !isLikelyObjectLiteralValue(content, importIndex))
   );
+}
+
+function isSpreadOperand(content: string, dotIndex: number): boolean {
+  return content.slice(dotIndex - 2, dotIndex + 1) === '...';
+}
+
+function isInsideTypeDeclaration(prefix: string): boolean {
+  return /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix);
+}
+
+function isLikelyObjectLiteralValue(content: string, importIndex: number): boolean {
+  const colonIndex = content.lastIndexOf(':', importIndex - 1);
+  if (colonIndex === -1) return false;
+
+  let i = colonIndex - 1;
+  while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
+  while (i >= 0 && isIdentifierCharacter(content[i]!)) i -= 1;
+  while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
+
+  return content[i] === '{' || content[i] === ',';
 }
 
 function readRequireSpecifier(
@@ -492,9 +519,17 @@ function isRegexLiteralStart(content: string, index: number): boolean {
 }
 
 function previousNonWhitespace(content: string, index: number): string | null {
+  const indexOfPrevious = previousNonWhitespaceIndex(content, index);
+  return indexOfPrevious === null ? null : content[indexOfPrevious]!;
+}
+
+function previousNonWhitespaceIndex(
+  content: string,
+  index: number,
+): number | null {
   for (let i = index; i >= 0; i--) {
     const ch = content[i]!;
-    if (!/\s/.test(ch)) return ch;
+    if (!/\s/.test(ch)) return i;
   }
 
   return null;

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -208,7 +208,7 @@ function startsWithKeyword(
 }
 
 function isInsideJsxText(content: string, index: number): boolean {
-  const previousOpen = content.lastIndexOf('<', index);
+  const previousOpen = findPreviousJsxOpeningTag(content, index);
   if (previousOpen === -1 || content[previousOpen + 1] === '/' || content[previousOpen + 1] === '!') return false;
   if (isIdentifierCharacter(content[previousOpen - 1] ?? '') || content[previousOpen - 1] === ')') return false;
 
@@ -221,9 +221,66 @@ function isInsideJsxText(content: string, index: number): boolean {
   const nextClosingTag = content.indexOf(`</${tagMatch[1]}>`, index);
   if (nextClosingTag === -1) return false;
 
-  const previousExpressionOpen = content.lastIndexOf('{', index);
-  const previousExpressionClose = content.lastIndexOf('}', index);
-  return previousExpressionOpen <= previousClose || previousExpressionClose > previousExpressionOpen;
+  return !hasUnclosedJsxExpression(content, previousClose + 1, index);
+}
+
+function findPreviousJsxOpeningTag(content: string, index: number): number {
+  let previousOpen = -1;
+  for (let i = 0; i < index; i += 1) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i = skipSingleLineComment(content, i + 2);
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i = skipMultiLineComment(content, i + 2);
+      continue;
+    }
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i);
+      continue;
+    }
+
+    if (
+      ch === '<' &&
+      next !== '/' &&
+      next !== '!' &&
+      !isIdentifierCharacter(content[i - 1] ?? '') &&
+      content[i - 1] !== ')'
+    ) {
+      previousOpen = i;
+    }
+  }
+
+  return previousOpen;
+}
+
+function hasUnclosedJsxExpression(content: string, startIndex: number, endIndex: number): boolean {
+  let depth = 0;
+  for (let i = startIndex; i < endIndex; i += 1) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i = skipSingleLineComment(content, i + 2);
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i = skipMultiLineComment(content, i + 2);
+      continue;
+    }
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i);
+      continue;
+    }
+
+    if (ch === '{') depth += 1;
+    else if (ch === '}' && depth > 0) depth -= 1;
+  }
+
+  return depth > 0;
 }
 
 function readStaticImportSpecifier(
@@ -509,6 +566,14 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   if (/(?:^|[;{}\n])\s*(?:const|let|var)\b[\s\S]*=\s*$/.test(prefix)) return false;
   if (/(?:^|[;{}\n])\s*(?:static\s+)?(?:accessor\s+)?[#A-Za-z_$][\w$]*\s*=\s*$/.test(prefix)) return false;
   if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
+  if (
+    /(?:^|[^.])\b(?:in|extends|keyof)\s*$/.test(prefixWithoutTrailingTrivia) &&
+    (endsInsideNestedTypeReference(prefix) ||
+      isInsideTypeDeclaration(prefix) ||
+      isInsideTypeAnnotation(prefix, content, templateIndex, isTernaryBranch))
+  ) {
+    return true;
+  }
   const previousIndex = skipTriviaBackward(content, templateIndex - 1);
   if (previousIndex >= 0 && /[\w$)\]]/.test(content[previousIndex] ?? '')) return false;
   return (
@@ -1328,7 +1393,11 @@ function decodeStringEscape(content: string, slashIndex: number): { value: strin
       const closeIndex = content.indexOf('}', slashIndex + 3);
       const hex = closeIndex === -1 ? '' : content.slice(slashIndex + 3, closeIndex);
       if (/^[0-9A-Fa-f]{1,6}$/.test(hex)) {
-        return { value: String.fromCodePoint(parseInt(hex, 16)), endIndex: closeIndex };
+        const codePoint = parseInt(hex, 16);
+        return {
+          value: codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : content.slice(slashIndex, closeIndex + 1),
+          endIndex: closeIndex,
+        };
       }
     }
     const hex = content.slice(slashIndex + 2, slashIndex + 6);

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -41,7 +41,9 @@ export class GhostDependencyEvaluator implements Evaluator {
       // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
       if (isNodeBuiltinSpecifier(specifier)) continue;
 
-      const packageSpecifier = normalizePackageUrlSpecifier(specifier);
+      const packageSpecifier = stripSpecifierResourceSuffix(
+        normalizePackageUrlSpecifier(specifier),
+      );
 
       // Extract package name (handle scoped packages and subpath imports)
       const packageName = packageSpecifier.startsWith('@')
@@ -82,6 +84,11 @@ function normalizePackageUrlSpecifier(specifier: string): string {
     .replace(/^(?:npm|jsr):/, '')
     .replace(/^(@[^/]+\/[^/@]+)@[^/]+/, '$1')
     .replace(/^([^/@]+)@[^/]+/, '$1');
+}
+
+function stripSpecifierResourceSuffix(specifier: string): string {
+  const queryIndex = specifier.search(/[?#]/);
+  return queryIndex === -1 ? specifier : specifier.slice(0, queryIndex);
 }
 
 function isLocalImportSpecifier(specifier: string): boolean {
@@ -469,7 +476,10 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   const statementStart = findDynamicImportStatementStart(content, templateIndex);
   const prefix = content.slice(statementStart + 1, templateIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
+  if (/(?:^|[^.])\b(?:as|satisfies)\s*$/.test(prefix.trimEnd())) return true;
   if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
+  const previousIndex = skipTriviaBackward(content, templateIndex - 1);
+  if (previousIndex >= 0 && /[\w$)\]]/.test(content[previousIndex] ?? '')) return false;
   return (
     endsInsideNestedTypeReference(prefix) ||
     isInsideTypeDeclaration(prefix) ||
@@ -794,10 +804,46 @@ function readDynamicImportSpecifierForTypeContext(
   i = skipImportTrivia(content, i + 1);
   const specifier = readDynamicImportArgumentSpecifier(content, i);
   if (!specifier) return null;
-  const nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  let nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  if (content[nextTokenIndex] === ',') {
+    nextTokenIndex = skipDynamicImportAttributeArgument(content, nextTokenIndex + 1);
+    if (nextTokenIndex === -1) return null;
+  }
   return content[nextTokenIndex] === ')'
     ? { value: specifier.value, endIndex: nextTokenIndex }
     : null;
+}
+
+function skipDynamicImportAttributeArgument(content: string, index: number): number {
+  let i = skipImportTrivia(content, index);
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  while (i < content.length) {
+    const ch = content[i]!;
+    if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0 && ch === ')') return i;
+    if (content[i] === '/' && content[i + 1] === '/') {
+      i = skipImportTrivia(content, skipSingleLineComment(content, i + 2));
+      continue;
+    }
+    if (content[i] === '/' && content[i + 1] === '*') {
+      i = skipImportTrivia(content, skipMultiLineComment(content, i + 2) + 1);
+      continue;
+    }
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i) + 1;
+      continue;
+    }
+    if (ch === '{') braceDepth += 1;
+    else if (ch === '}' && braceDepth > 0) braceDepth -= 1;
+    else if (ch === '[') bracketDepth += 1;
+    else if (ch === ']' && bracketDepth > 0) bracketDepth -= 1;
+    else if (ch === '(') parenDepth += 1;
+    else if (ch === ')' && parenDepth > 0) parenDepth -= 1;
+    i += 1;
+  }
+
+  return -1;
 }
 
 function stripTrailingTrivia(content: string): string {
@@ -836,7 +882,7 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   const suffix = prefix.slice(newlineIndex + 1);
   if (
     !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
-    !/^\s*(?:export\s+)?(?:default\b|[!~+\-\[(@]|using\b|abstract\s+class\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+    !/^\s*(?:export\s+)?(?:default\b|[!~+\-\[(@]|using\b|abstract\s+class\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*(?:\(|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
       suffix,
     )
   ) {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -77,6 +77,7 @@ function isLocalImportSpecifier(specifier: string): boolean {
   return (
     specifier.startsWith('.') ||
     specifier.startsWith('/') ||
+    specifier.startsWith('#') ||
     specifier.startsWith('file:') ||
     /^[A-Za-z][A-Za-z0-9+.-]*:/.test(specifier) ||
     /^[A-Za-z]:/.test(specifier)
@@ -289,6 +290,13 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   if (/(?:\bas\s*|\bsatisfies\s*)$/.test(prefix)) return true;
 
   const trimmed = prefix.trimEnd();
+  if (
+    /(?:,|\bextends\b|=)$/.test(trimmed) &&
+    trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>')
+  ) {
+    return true;
+  }
+
   const operator = trimmed.at(-1);
   if (operator === '<') return true;
 
@@ -303,7 +311,7 @@ function isInsideTypeDeclaration(prefix: string): boolean {
     !/\n\s*(?:const|let|var|await|return|throw|if|for|while|switch|try|function|class)\b/.test(
       prefix,
     ) &&
-    !/\}\s*\n\s*(?:void\s*$|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
+    !/\}\s*\n\s*(?:void\s*$|\(|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
       prefix,
     )
   );
@@ -315,12 +323,14 @@ function isInsideTypeAnnotation(
   importIndex: number,
   isTernaryBranch: boolean,
 ): boolean {
-  if (isTernaryBranch) return false;
+  if (isTernaryBranch && !isInsideConditionalType(prefix)) return false;
 
   const annotationIndex = prefix.lastIndexOf(':');
   if (annotationIndex === -1) return false;
 
   const beforeAnnotation = prefix.slice(0, annotationIndex);
+  if (/:\s*\{[^}]*$/.test(beforeAnnotation)) return true;
+
   const outerAnnotationIndex = beforeAnnotation.lastIndexOf(':');
   if (outerAnnotationIndex !== -1) {
     const outerAnnotationSuffix = beforeAnnotation.slice(outerAnnotationIndex + 1);
@@ -335,12 +345,19 @@ function isInsideTypeAnnotation(
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (/[=;]/.test(annotationSuffix)) return false;
-  if (/^\s*(?:return|throw|void)\b/.test(annotationSuffix)) return false;
-  if (/\{[\s\S]*\b(?:return|throw|void|case|default)\b/.test(annotationSuffix)) {
+  if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
+  if (/\{[\s\S]*\b(?:return|throw|void|await|case|default)\b/.test(annotationSuffix)) {
     return false;
   }
 
   return !isLikelyObjectLiteralValue(content, importIndex);
+}
+
+function isInsideConditionalType(prefix: string): boolean {
+  const questionIndex = prefix.lastIndexOf('?');
+  if (questionIndex === -1) return false;
+
+  return /\bextends\b/.test(prefix.slice(0, questionIndex));
 }
 
 function hasTernaryBranchMarker(prefix: string): boolean {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -219,19 +219,91 @@ function readDynamicImportSpecifier(
   content: string,
   index: number,
 ): StringLiteralRead | null {
-  let i = skipWhitespace(content, index);
+  if (!canStartNativeDynamicImport(content, index - 'import'.length)) {
+    return null;
+  }
+
+  let i = skipImportTrivia(content, index);
   if (content[i] !== '(') return null;
 
+  const openParenIndex = i;
   i = skipImportTrivia(content, i + 1);
-  if (content[i] !== "'" && content[i] !== '"') return null;
 
-  const specifier = readQuotedString(content, i);
+  const specifier =
+    content[i] === '`'
+      ? readNoSubstitutionTemplateString(content, i)
+      : content[i] === "'" || content[i] === '"'
+        ? readQuotedString(content, i)
+        : null;
   if (!specifier) return null;
 
-  const closeParenIndex = skipImportTrivia(content, specifier.endIndex + 1);
-  if (content[closeParenIndex] !== ')') return null;
+  const nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  if (content[nextTokenIndex] !== ')' && content[nextTokenIndex] !== ',') {
+    return null;
+  }
+
+  const closeParenIndex = findClosingParen(content, openParenIndex);
+  if (closeParenIndex === null) return null;
 
   return { value: specifier.value, endIndex: closeParenIndex };
+}
+
+function canStartNativeDynamicImport(
+  content: string,
+  importIndex: number,
+): boolean {
+  const previous = previousNonWhitespace(content, importIndex - 1);
+  if (previous === '.') return false;
+
+  const statementStart = Math.max(
+    content.lastIndexOf(';', importIndex - 1),
+    content.lastIndexOf('\n', importIndex - 1),
+    content.lastIndexOf('{', importIndex - 1),
+    content.lastIndexOf('}', importIndex - 1),
+  );
+  const prefix = content.slice(statementStart + 1, importIndex);
+
+  return !(
+    /\btype\s+[A-Za-z_$][\w$]*(?:\s*<[^;>{}]*>)?\s*=\s*$/.test(prefix) ||
+    /:\s*$/.test(prefix) ||
+    /\b(?:interface|type)\b[^;{}]*\bextends\s*$/.test(prefix)
+  );
+}
+
+function findClosingParen(content: string, openParenIndex: number): number | null {
+  let depth = 1;
+
+  for (let i = openParenIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i = skipSingleLineComment(content, i + 2);
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      i = skipMultiLineComment(content, i + 2);
+      continue;
+    }
+
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i);
+      continue;
+    }
+
+    if (ch === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+
+  return null;
 }
 
 function readRequireSpecifier(
@@ -251,6 +323,33 @@ function readRequireSpecifier(
   if (content[closeParenIndex] !== ')') return null;
 
   return specifier;
+}
+
+function readNoSubstitutionTemplateString(
+  content: string,
+  startIndex: number,
+): StringLiteralRead | null {
+  let value = '';
+
+  for (let i = startIndex + 1; i < content.length; i++) {
+    const ch = content[i]!;
+
+    if (ch === '\\') {
+      const escaped = content[i + 1];
+      if (escaped) {
+        value += escaped;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '$' && content[i + 1] === '{') return null;
+    if (ch === '`') return { value, endIndex: i };
+
+    value += ch;
+  }
+
+  return null;
 }
 
 function readQuotedString(

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -108,6 +108,16 @@ function extractDependencySpecifiers(content: string): string[] {
     }
 
     if (startsWithKeyword(content, i, 'import')) {
+      const dynamicallyImported = readDynamicImportSpecifier(
+        content,
+        i + 'import'.length,
+      );
+      if (dynamicallyImported) {
+        specifiers.push(dynamicallyImported.value);
+        i = dynamicallyImported.endIndex;
+        continue;
+      }
+
       const imported = readStaticImportSpecifier(content, i + 'import'.length);
       if (imported) {
         specifiers.push(imported.value);
@@ -203,6 +213,25 @@ function readStaticImportSpecifier(
   }
 
   return null;
+}
+
+function readDynamicImportSpecifier(
+  content: string,
+  index: number,
+): StringLiteralRead | null {
+  let i = skipWhitespace(content, index);
+  if (content[i] !== '(') return null;
+
+  i = skipImportTrivia(content, i + 1);
+  if (content[i] !== "'" && content[i] !== '"') return null;
+
+  const specifier = readQuotedString(content, i);
+  if (!specifier) return null;
+
+  const closeParenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  if (content[closeParenIndex] !== ')') return null;
+
+  return { value: specifier.value, endIndex: closeParenIndex };
 }
 
 function readRequireSpecifier(

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -542,6 +542,7 @@ function isTypeOnlyImportReferenceUse(
   }
 
   const trimmed = prefix.trimEnd();
+  if (hasCompletedStatementBeforeImport(prefix)) return false;
   if (/\{\s*(?:return|throw|void|await|yield|case|default)\b[\s\S]*$/.test(trimmed)) {
     return false;
   }
@@ -552,10 +553,16 @@ function isTypeOnlyImportReferenceUse(
   if (/\b(?:declare\s+)?namespace\b[\s\S]*\{\s*(?:export\s+)?type\b[\s\S]*$/.test(trimmed)) {
     return true;
   }
-  if (/(?:^|[^.])(?:\bimplements\b|\bkeyof\b|\btypeof\b)\s*(?:\([^)]*)?$/.test(trimmed)) {
+  if (/(?:^|[^.])(?:\bimplements\b|\bkeyof\b)\s*(?:\([^)]*)?$/.test(trimmed)) {
     return true;
   }
-  if (/(?:^|[^.])(?:\bas\b|\bsatisfies\b)\s+[\s\S]*$/.test(trimmed)) {
+  if (/(?:^|[^.])\bkeyof\s+typeof\s*(?:\([^)]*)?$/.test(trimmed)) {
+    return true;
+  }
+  if (/(?:^|[^.])\btypeof\s*(?:\([^)]*)?$/.test(trimmed)) {
+    return isInsideTypeDeclaration(prefix) || isInsideTypeAnnotation(prefix, content, importIndex, false);
+  }
+  if (isInsideOpenTypeAssertion(trimmed)) {
     return true;
   }
 
@@ -564,6 +571,33 @@ function isTypeOnlyImportReferenceUse(
   const openBraceIndex = trimmed.lastIndexOf('{');
   const semicolonIndex = trimmed.lastIndexOf(';');
   return colonIndex > semicolonIndex && !/\{\s*(?:return|throw|void|await|yield|case|default)\b[\s\S]*$/.test(trimmed.slice(openBraceIndex));
+}
+
+function hasCompletedStatementBeforeImport(prefix: string): boolean {
+  const newlineIndex = prefix.lastIndexOf('\n');
+  if (newlineIndex === -1) return false;
+
+  const suffix = prefix.slice(newlineIndex + 1);
+  if (!/^\s*$/.test(suffix)) return false;
+
+  const previousLine = prefix.slice(0, newlineIndex).trimEnd();
+  return !/[=?:,|&<{([]$/.test(previousLine) && !/\bextends\s*$/.test(previousLine);
+}
+
+function isInsideOpenTypeAssertion(trimmedPrefix: string): boolean {
+  const assertionMatch = /(?:^|[^.])\b(?:as|satisfies)\b/g;
+  let latestAssertionIndex = -1;
+  let match: RegExpExecArray | null;
+  while ((match = assertionMatch.exec(trimmedPrefix)) !== null) {
+    latestAssertionIndex = match.index;
+  }
+  if (latestAssertionIndex === -1) return false;
+
+  const suffix = trimmedPrefix.slice(latestAssertionIndex);
+  const lastComma = suffix.lastIndexOf(',');
+  const lastEquals = suffix.lastIndexOf('=');
+  const lastArrow = suffix.lastIndexOf('=>');
+  return lastComma === -1 && lastEquals === -1 && lastArrow === -1;
 }
 
 function readDynamicImportSpecifierForTypeContext(
@@ -636,13 +670,13 @@ function isInsideTypeAnnotation(
   if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
   if (
     /(?:\bas|\bsatisfies)\s*\{[^}]*$/.test(beforeAnnotation) &&
-    !hasRuntimeBlockAfterAnnotation(prefix, annotationIndex)
+    !hasRuntimeAfterAnnotation(prefix, annotationIndex)
   ) {
     return true;
   }
   if (
     /:\s*\{[^}]*$/.test(beforeAnnotation) &&
-    !hasRuntimeBlockAfterAnnotation(prefix, annotationIndex)
+    !hasRuntimeAfterAnnotation(prefix, annotationIndex)
   ) {
     return true;
   }
@@ -666,8 +700,10 @@ function isInsideTypeAnnotation(
   }
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
+  if (hasRuntimeAfterClosedTypeContext(annotationSuffix)) return false;
   if (/[=;]/.test(annotationSuffix)) return false;
   if (/=>/.test(annotationSuffix)) {
+    if (/\)\s*:\s*[^=]*=>\s*$/.test(prefix)) return false;
     return /^\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*(?:\[\])?)\s*=>\s*$/.test(
       annotationSuffix,
     );
@@ -686,9 +722,13 @@ function isInsideTypeAnnotation(
   return !isLikelyObjectLiteralValue(content, importIndex);
 }
 
-function hasRuntimeBlockAfterAnnotation(prefix: string, annotationIndex: number): boolean {
-  return /}\s*\{\s*(?:return|throw|void|await|yield|case|default)\b/.test(
-    prefix.slice(annotationIndex + 1),
+function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boolean {
+  return hasRuntimeAfterClosedTypeContext(prefix.slice(annotationIndex + 1));
+}
+
+function hasRuntimeAfterClosedTypeContext(annotationSuffix: string): boolean {
+  return /}\s*\)?(?:\s*\{\s*(?:return|throw|void|await|yield|case|default)\b|[^\S\n]*\n\s*(?:void\s*$|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
+    annotationSuffix,
   );
 }
 

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -108,7 +108,7 @@ function extractDependencySpecifiers(content: string): string[] {
 
     if (ch === '`') {
       if (isTypeOnlyTemplateString(content, i)) {
-        i = skipStringLiteral(content, i);
+        i = readTemplateString(content, i).endIndex;
         continue;
       }
       const template = readTemplateString(content, i);
@@ -344,6 +344,10 @@ function canStartNativeDynamicImport(
 
   const statementStart = findDynamicImportStatementStart(content, importIndex);
   const prefix = content.slice(statementStart + 1, importIndex);
+  const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix).trimEnd();
+  if (/\b(?:as|satisfies)$/.test(prefixWithoutTrailingTrivia)) {
+    return false;
+  }
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const isNestedTypeReference = endsInsideNestedTypeReference(prefix);
 
@@ -412,13 +416,13 @@ function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boo
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
-  if (/(?:^|[^.])(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
+  if (/(?:^|[^.])(?:\bas\s+|\bsatisfies\s+|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
-  if (/(?:\bas\s*|\bsatisfies\s*)\(\s*\)\s*=>\s*$/.test(prefixWithoutTrailingTrivia)) {
+  if (/(?:\bas\s+|\bsatisfies\s+)\(\s*\)\s*=>\s*$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
-  if (/(?:\bas\s*|\bsatisfies\s*)\s*(?:readonly\s*)?(?:\[\s*)?$/.test(prefixWithoutTrailingTrivia)) {
+  if (/(?:\bas\s+|\bsatisfies\s+)(?:readonly\s*)?(?:\[\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
 
@@ -435,6 +439,11 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   if (operator === '<') return /(?:[>\]])<$/.test(trimmed);
 
   if (operator !== '|' && operator !== '&') return false;
+
+  const colonIndex = trimmed.lastIndexOf(':');
+  if (colonIndex !== -1 && /[=;]/.test(trimmed.slice(colonIndex + 1))) {
+    return false;
+  }
 
   return (
     trimmed.at(-2) !== operator &&
@@ -470,7 +479,10 @@ function isInsideGenericTypeArgument(
     i = skipImportTrivia(content, i + 2);
   }
 
-  return content[i] === '>';
+  if (content[i] !== '>') return false;
+
+  const afterClose = skipImportTrivia(content, i + 1);
+  return !isIdentifierCharacter(content[afterClose] ?? '');
 }
 
 function isTypeOnlyImportReferenceUse(
@@ -501,13 +513,13 @@ function isTypeOnlyImportReferenceUse(
   if (/(?:^|[;\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(trimmed)) {
     return true;
   }
-  if (/\bdeclare\s+namespace\b[\s\S]*\{\s*type\b[\s\S]*$/.test(trimmed)) {
+  if (/\b(?:declare\s+)?namespace\b[\s\S]*\{\s*(?:export\s+)?type\b[\s\S]*$/.test(trimmed)) {
     return true;
   }
   if (/(?:^|[^.])(?:\bimplements\b|\bkeyof\b|\btypeof\b)\s*(?:\([^)]*)?$/.test(trimmed)) {
     return true;
   }
-  if (/(?:^|[^.])(?:\bas\b|\bsatisfies\b)[\s\S]*$/.test(trimmed)) {
+  if (/(?:^|[^.])(?:\bas\b|\bsatisfies\b)\s+[\s\S]*$/.test(trimmed)) {
     return true;
   }
 

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -402,16 +402,31 @@ function findTypeScriptAngleAssertionEnd(content: string, index: number): number
 }
 
 function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boolean {
-  const openBraceIndex = content.lastIndexOf('{', semicolonIndex);
+  const openBraceIndex = findContainingOpenBrace(content, semicolonIndex);
   if (openBraceIndex === -1) return false;
-  const closeBraceIndex = content.lastIndexOf('}', semicolonIndex);
-  if (closeBraceIndex > openBraceIndex) return false;
 
   const beforeBrace = content.slice(0, openBraceIndex);
   return (
     /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace) ||
     /(?:\bas\s*|\bsatisfies\s*|:)\s*$/.test(beforeBrace.trimEnd())
   );
+}
+
+function findContainingOpenBrace(content: string, index: number): number {
+  let depth = 0;
+
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const ch = content[i]!;
+    if (ch === '}') {
+      depth += 1;
+      continue;
+    }
+    if (ch !== '{') continue;
+    if (depth === 0) return i;
+    depth -= 1;
+  }
+
+  return -1;
 }
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
@@ -468,7 +483,7 @@ function isInsideGenericTypeArgument(
   if (!dynamicImport) return false;
 
   let i = skipImportTrivia(content, dynamicImport.endIndex + 1);
-  while (content[i] === '.' || (content[i] === '[' && content[i + 1] === ']')) {
+  while (content[i] === '.' || content[i] === '[') {
     if (content[i] === '.') {
       i = skipImportTrivia(content, i + 1);
       if (!/[A-Za-z_$]/.test(content[i] ?? '')) return false;
@@ -476,13 +491,34 @@ function isInsideGenericTypeArgument(
       i = skipImportTrivia(content, i);
       continue;
     }
-    i = skipImportTrivia(content, i + 2);
+    const indexedAccessEnd = findBalancedBracketEnd(content, i);
+    if (indexedAccessEnd === -1) return false;
+    i = skipImportTrivia(content, indexedAccessEnd + 1);
   }
 
   if (content[i] !== '>') return false;
 
   const afterClose = skipImportTrivia(content, i + 1);
   return !isIdentifierCharacter(content[afterClose] ?? '');
+}
+
+function findBalancedBracketEnd(content: string, openIndex: number): number {
+  let depth = 0;
+
+  for (let i = openIndex; i < content.length; i += 1) {
+    const ch = content[i]!;
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipStringLiteral(content, i);
+      continue;
+    }
+    if (ch === '[') depth += 1;
+    if (ch === ']') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
 }
 
 function isTypeOnlyImportReferenceUse(
@@ -574,7 +610,7 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   const suffix = prefix.slice(newlineIndex + 1);
   if (
     !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
-    !/^\s*(?:export\s+)?(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+    !/^\s*(?:export\s+)?(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
       suffix,
     )
   ) {
@@ -598,8 +634,18 @@ function isInsideTypeAnnotation(
 
   const beforeAnnotation = prefix.slice(0, annotationIndex);
   if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
-  if (/(?:\bas|\bsatisfies)\s*\{[^}]*$/.test(beforeAnnotation)) return true;
-  if (/:\s*\{[^}]*$/.test(beforeAnnotation)) return true;
+  if (
+    /(?:\bas|\bsatisfies)\s*\{[^}]*$/.test(beforeAnnotation) &&
+    !hasRuntimeBlockAfterAnnotation(prefix, annotationIndex)
+  ) {
+    return true;
+  }
+  if (
+    /:\s*\{[^}]*$/.test(beforeAnnotation) &&
+    !hasRuntimeBlockAfterAnnotation(prefix, annotationIndex)
+  ) {
+    return true;
+  }
   if (
     /(?:^|[;{}\n])\s*[A-Za-z_$][\w$]*$/.test(beforeAnnotation) &&
     !/\bclass\b[\s\S]*\{[^}]*$/.test(beforeAnnotation)
@@ -627,7 +673,7 @@ function isInsideTypeAnnotation(
     );
   }
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
-  if (/\n\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
+  if (/\n\s*(?:void\s*)?$|\n\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
     return false;
   }
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
@@ -638,6 +684,12 @@ function isInsideTypeAnnotation(
   }
 
   return !isLikelyObjectLiteralValue(content, importIndex);
+}
+
+function hasRuntimeBlockAfterAnnotation(prefix: string, annotationIndex: number): boolean {
+  return /}\s*\{\s*(?:return|throw|void|await|yield|case|default)\b/.test(
+    prefix.slice(annotationIndex + 1),
+  );
 }
 
 function isInsideConditionalType(prefix: string): boolean {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -357,7 +357,11 @@ function canStartNativeDynamicImport(
     return false;
   }
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
-  const isNestedTypeReference = endsInsideNestedTypeReference(prefix);
+  const isObjectLiteralValue = isLikelyObjectLiteralValue(content, importIndex);
+  const isNestedTypeReference = endsInsideNestedTypeReference(
+    prefix,
+    isObjectLiteralValue,
+  );
 
   return !(
     isNestedTypeReference ||
@@ -446,7 +450,10 @@ function findContainingOpenBrace(content: string, index: number): number {
   return -1;
 }
 
-function endsInsideNestedTypeReference(prefix: string): boolean {
+function endsInsideNestedTypeReference(
+  prefix: string,
+  isObjectLiteralValue = false,
+): boolean {
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
   if (/(?:^|[^.])(?:\bas\s+|\bsatisfies\s+|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
@@ -471,6 +478,7 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   if (operator === '<') return /(?:[>\]])<$/.test(trimmed);
 
   if (operator !== '|' && operator !== '&') return false;
+  if (isObjectLiteralValue) return false;
 
   const colonIndex = trimmed.lastIndexOf(':');
   if (colonIndex !== -1 && /[=;]/.test(trimmed.slice(colonIndex + 1))) {
@@ -583,7 +591,7 @@ function isTypeOnlyImportReferenceUse(
     return false;
   }
 
-  if (/(?:^|[;\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(trimmed)) {
+  if (/(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(trimmed)) {
     return true;
   }
   if (/\b(?:declare\s+)?namespace\b[\s\S]*\{\s*(?:export\s+)?type\b[\s\S]*$/.test(trimmed)) {
@@ -632,6 +640,9 @@ function isInsideOpenTypeAssertion(trimmedPrefix: string): boolean {
   if (latestAssertionIndex === -1) return false;
 
   const suffix = trimmedPrefix.slice(latestAssertionIndex);
+  if (/}\s*\)?\s*\n\s*(?:void\s+)?import\s*\($/.test(suffix)) {
+    return false;
+  }
   const lastComma = suffix.lastIndexOf(',');
   const lastEquals = suffix.lastIndexOf('=');
   const lastArrow = suffix.lastIndexOf('=>');
@@ -660,12 +671,12 @@ function stripTrailingTrivia(content: string): string {
 
 function isInsideTypeDeclaration(prefix: string): boolean {
   return (
-    /(?:^|[;\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
+    /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
-    !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
+    !/\n\s*(?:export\s+)?(?:default\b|const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
-    !/\}\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b[\s\S]*$/.test(
+    !/\}\s*(?:export\s+)?(?:default\b|const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b[\s\S]*$/.test(
       prefix,
     ) &&
     !/\}\s*(?:export\s+)?$/.test(prefix) &&
@@ -682,7 +693,7 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   const suffix = prefix.slice(newlineIndex + 1);
   if (
     !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
-    !/^\s*(?:export\s+)?(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+    !/^\s*(?:export\s+)?(?:default\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
       suffix,
     )
   ) {
@@ -703,6 +714,7 @@ function isInsideTypeAnnotation(
 
   const annotationIndex = prefix.lastIndexOf(':');
   if (annotationIndex === -1) return false;
+  if (hasCompletedStatementBeforeImport(prefix)) return false;
 
   const beforeAnnotation = prefix.slice(0, annotationIndex);
   if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
@@ -793,8 +805,7 @@ function isLikelyObjectLiteralValue(content: string, importIndex: number): boole
   const colonIndex = content.lastIndexOf(':', importIndex - 1);
   if (colonIndex === -1) return false;
 
-  let i = colonIndex - 1;
-  while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
+  let i = skipTriviaBackward(content, colonIndex - 1);
 
   if (content[i] === "'" || content[i] === '"') {
     i = skipQuotedKeyBackward(content, i);

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -35,15 +35,15 @@ export class GhostDependencyEvaluator implements Evaluator {
     const seen = new Set<string>();
 
     for (const specifier of extractDependencySpecifiers(input.content)) {
-      // Skip local imports, including absolute paths/URLs used by dynamic loaders.
-      if (isLocalImportSpecifier(specifier)) continue;
-
-      // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
-      if (isNodeBuiltinSpecifier(specifier)) continue;
-
       const packageSpecifier = stripSpecifierResourceSuffix(
         normalizePackageUrlSpecifier(specifier),
       );
+
+      // Skip local imports, including absolute paths/URLs used by dynamic loaders.
+      if (isLocalImportSpecifier(packageSpecifier)) continue;
+
+      // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
+      if (isNodeBuiltinSpecifier(packageSpecifier)) continue;
 
       // Extract package name (handle scoped packages and subpath imports)
       const packageName = packageSpecifier.startsWith('@')
@@ -87,8 +87,12 @@ function normalizePackageUrlSpecifier(specifier: string): string {
 }
 
 function stripSpecifierResourceSuffix(specifier: string): string {
-  const queryIndex = specifier.search(/[?#]/);
-  return queryIndex === -1 ? specifier : specifier.slice(0, queryIndex);
+  const queryIndex = specifier.indexOf('?');
+  const fragmentIndex = specifier.indexOf('#', 1);
+  const suffixIndex = [queryIndex, fragmentIndex]
+    .filter((index) => index !== -1)
+    .sort((left, right) => left - right)[0];
+  return suffixIndex === undefined ? specifier : specifier.slice(0, suffixIndex);
 }
 
 function isLocalImportSpecifier(specifier: string): boolean {
@@ -479,6 +483,7 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix).trimEnd();
   if (isOpenTemplateAssertionKeyword(prefixWithoutTrailingTrivia)) return true;
   if (/(?:^|[;{}\n])\s*(?:const|let|var)\b[\s\S]*=\s*$/.test(prefix)) return false;
+  if (/(?:^|[;{}\n])\s*(?:static\s+)?(?:accessor\s+)?[#A-Za-z_$][\w$]*\s*=\s*$/.test(prefix)) return false;
   if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
   const previousIndex = skipTriviaBackward(content, templateIndex - 1);
   if (previousIndex >= 0 && /[\w$)\]]/.test(content[previousIndex] ?? '')) return false;

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -793,10 +793,10 @@ function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
-    !/\n\s*(?:export\s+)?(?:default\b|const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
+    !/\n\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
-    !/\}\s*(?:export\s+)?(?:default\b|const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b[\s\S]*$/.test(
+    !/\}\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b[\s\S]*$/.test(
       prefix,
     ) &&
     !/\}\s*(?:export\s+)?$/.test(prefix) &&

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -412,7 +412,7 @@ function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boo
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
-  if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
+  if (/(?:^|[^.])(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
   if (/(?:\bas\s*|\bsatisfies\s*)\(\s*\)\s*=>\s*$/.test(prefixWithoutTrailingTrivia)) {
@@ -432,7 +432,7 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   }
 
   const operator = trimmed.at(-1);
-  if (operator === '<') return /(?:[A-Z_$][\w$]*|[>\]])<$/.test(trimmed);
+  if (operator === '<') return /(?:[>\]])<$/.test(trimmed);
 
   if (operator !== '|' && operator !== '&') return false;
 
@@ -498,7 +498,16 @@ function isTypeOnlyImportReferenceUse(
     return false;
   }
 
-  if (/(?:\btype\b|\binterface\b|\bimplements\b|\bkeyof\b|\btypeof\b|\bas\b|\bsatisfies\b)[\s\S]*$/.test(trimmed)) {
+  if (/(?:^|[;\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(trimmed)) {
+    return true;
+  }
+  if (/\bdeclare\s+namespace\b[\s\S]*\{\s*type\b[\s\S]*$/.test(trimmed)) {
+    return true;
+  }
+  if (/(?:^|[^.])(?:\bimplements\b|\bkeyof\b|\btypeof\b)\s*(?:\([^)]*)?$/.test(trimmed)) {
+    return true;
+  }
+  if (/(?:^|[^.])(?:\bas\b|\bsatisfies\b)[\s\S]*$/.test(trimmed)) {
     return true;
   }
 
@@ -531,7 +540,7 @@ function stripTrailingTrivia(content: string): string {
 
 function isInsideTypeDeclaration(prefix: string): boolean {
   return (
-    /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
+    /(?:^|[;\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
     !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
@@ -551,7 +560,14 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   if (newlineIndex === -1) return false;
 
   const suffix = prefix.slice(newlineIndex + 1);
-  if (!/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix)) return false;
+  if (
+    !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
+    !/^\s*(?:export\s+)?(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+      suffix,
+    )
+  ) {
+    return false;
+  }
 
   const previousLine = prefix.slice(0, newlineIndex).trimEnd();
   return !/[=?:,|&<{([]$/.test(previousLine) && !/\bextends\s*$/.test(previousLine);
@@ -599,6 +615,9 @@ function isInsideTypeAnnotation(
     );
   }
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
+  if (/\n\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
+    return false;
+  }
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
     return false;
   }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -296,6 +296,13 @@ function readDynamicImportArgumentSpecifier(
     return readQuotedString(content, index);
   }
 
+  if (content[index] === '<') {
+    const assertionEnd = content.indexOf('>', index + 1);
+    if (assertionEnd === -1) return null;
+    const assertedStart = skipImportTrivia(content, assertionEnd + 1);
+    return readDynamicImportArgumentSpecifier(content, assertedStart);
+  }
+
   if (content[index] !== '(') return null;
 
   const nestedStart = skipImportTrivia(content, index + 1);
@@ -323,7 +330,7 @@ function canStartNativeDynamicImport(
     return false;
   }
 
-  const statementStart = content.lastIndexOf(';', importIndex - 1);
+  const statementStart = findDynamicImportStatementStart(content, importIndex);
   const prefix = content.slice(statementStart + 1, importIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const isNestedTypeReference = endsInsideNestedTypeReference(prefix);
@@ -339,9 +346,28 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
   return content.slice(dotIndex - 2, dotIndex + 1) === '...';
 }
 
+function findDynamicImportStatementStart(content: string, importIndex: number): number {
+  let statementStart = content.lastIndexOf(';', importIndex - 1);
+  while (statementStart !== -1 && isSemicolonInsideTypeBody(content, statementStart)) {
+    statementStart = content.lastIndexOf(';', statementStart - 1);
+  }
+
+  return statementStart;
+}
+
+function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boolean {
+  const openBraceIndex = content.lastIndexOf('{', semicolonIndex);
+  if (openBraceIndex === -1) return false;
+  const closeBraceIndex = content.lastIndexOf('}', semicolonIndex);
+  if (closeBraceIndex > openBraceIndex) return false;
+
+  const beforeBrace = content.slice(0, openBraceIndex);
+  return /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace);
+}
+
 function endsInsideNestedTypeReference(prefix: string): boolean {
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
-  if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
+  if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
 
@@ -371,7 +397,7 @@ function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
-    !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|if|for|while|switch|try|function|async\s+function|class)\b/.test(
+    !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
     !/\}\s*\n\s*(?:export\s+)?$/.test(prefix) &&
@@ -427,6 +453,7 @@ function isInsideTypeAnnotation(
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (/[=;]/.test(annotationSuffix)) return false;
+  if (/=>/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
     return false;
@@ -442,7 +469,8 @@ function isInsideConditionalType(prefix: string): boolean {
   const questionIndex = prefix.lastIndexOf('?');
   if (questionIndex === -1) return false;
 
-  return /\bextends\b/.test(prefix.slice(0, questionIndex));
+  const condition = prefix.slice(0, questionIndex);
+  return /\bextends\b/.test(condition) && !/(?:={2,3}|!==?|[<>]=?)/.test(condition);
 }
 
 function hasTernaryBranchMarker(prefix: string): boolean {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -76,6 +76,8 @@ function isNodeBuiltinSpecifier(specifier: string): boolean {
 }
 
 function normalizePackageUrlSpecifier(specifier: string): string {
+  if (!/^(?:npm|jsr):/.test(specifier)) return specifier;
+
   return specifier
     .replace(/^(?:npm|jsr):/, '')
     .replace(/^(@[^/]+\/[^/@]+)@[^/]+/, '$1')
@@ -295,7 +297,15 @@ function skipTypeScriptImportArgumentAssertion(
   if (!keyword) return index;
 
   let i = skipImportTrivia(content, index + keyword.length);
-  while (i < content.length && content[i] !== ')' && content[i] !== ',') {
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  while (i < content.length) {
+    const ch = content[i]!;
+    if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0 && angleDepth === 0 && (ch === ')' || ch === ',')) {
+      break;
+    }
     if (content[i] === '/' && content[i + 1] === '/') {
       i = skipImportTrivia(content, skipSingleLineComment(content, i + 2));
       continue;
@@ -304,6 +314,18 @@ function skipTypeScriptImportArgumentAssertion(
       i = skipImportTrivia(content, skipMultiLineComment(content, i + 2) + 1);
       continue;
     }
+    if (QUOTE_CHARS.has(ch)) {
+      i = skipStringLiteral(content, i) + 1;
+      continue;
+    }
+    if (ch === '<') angleDepth += 1;
+    else if (ch === '>' && angleDepth > 0) angleDepth -= 1;
+    else if (ch === '{') braceDepth += 1;
+    else if (ch === '}' && braceDepth > 0) braceDepth -= 1;
+    else if (ch === '[') bracketDepth += 1;
+    else if (ch === ']' && bracketDepth > 0) bracketDepth -= 1;
+    else if (ch === '(') parenDepth += 1;
+    else if (ch === ')' && parenDepth > 0) parenDepth -= 1;
     i += 1;
   }
 
@@ -914,7 +936,7 @@ function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boo
 }
 
 function hasRuntimeAfterClosedTypeContext(annotationSuffix: string): boolean {
-  return /}\s*\)?(?:\s*\{\s*(?:return|throw|void|await|yield|case|default)\b|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|using\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
+  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|using\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
     annotationSuffix,
   );
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -78,6 +78,7 @@ function isLocalImportSpecifier(specifier: string): boolean {
     specifier.startsWith('.') ||
     specifier.startsWith('/') ||
     specifier.startsWith('file:') ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(specifier) ||
     /^[A-Za-z]:/.test(specifier)
   );
 }
@@ -272,8 +273,10 @@ function canStartNativeDynamicImport(
   const prefix = content.slice(statementStart + 1, importIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const endsAfterTypeAnnotation = /:\s*$/.test(prefix);
+  const isNestedTypeReference = /(?:\bas\s*|\bsatisfies\s*|<\s*)$/.test(prefix);
 
   return !(
+    isNestedTypeReference ||
     isInsideTypeDeclaration(prefix) ||
     (endsAfterTypeAnnotation &&
       !isTernaryBranch &&
@@ -289,6 +292,9 @@ function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !/\n\s*(?:const|let|var|await|return|throw|if|for|while|switch|try|function|class)\b/.test(
+      prefix,
+    ) &&
+    !/\}\s*\n\s*(?:[A-Za-z_$][\w$]*\s*\(|(?:await\s+)?import\s*\()/.test(
       prefix,
     )
   );
@@ -308,10 +314,52 @@ function isLikelyObjectLiteralValue(content: string, importIndex: number): boole
 
   let i = colonIndex - 1;
   while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
-  while (i >= 0 && isIdentifierCharacter(content[i]!)) i -= 1;
+
+  if (content[i] === "'" || content[i] === '"') {
+    i = skipQuotedKeyBackward(content, i);
+  } else if (content[i] === ']') {
+    i = skipBalancedKeyBackward(content, i);
+  } else if (/[0-9]/.test(content[i] ?? '')) {
+    while (i >= 0 && /[0-9._]/.test(content[i]!)) i -= 1;
+  } else {
+    while (i >= 0 && isIdentifierCharacter(content[i]!)) i -= 1;
+  }
+
   while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
 
   return content[i] === '{' || content[i] === ',';
+}
+
+function skipQuotedKeyBackward(content: string, quoteIndex: number): number {
+  const quote = content[quoteIndex]!;
+
+  for (let i = quoteIndex - 1; i >= 0; i -= 1) {
+    if (content[i] !== quote) continue;
+
+    let backslashCount = 0;
+    for (let j = i - 1; j >= 0 && content[j] === '\\'; j -= 1) {
+      backslashCount += 1;
+    }
+
+    if (backslashCount % 2 === 0) return i - 1;
+  }
+
+  return quoteIndex - 1;
+}
+
+function skipBalancedKeyBackward(content: string, closeIndex: number): number {
+  let depth = 0;
+
+  for (let i = closeIndex; i >= 0; i -= 1) {
+    const ch = content[i]!;
+    if (ch === ']') depth += 1;
+    if (ch === '[') {
+      depth -= 1;
+      if (depth === 0) return i - 1;
+    }
+  }
+
+  return closeIndex - 1;
 }
 
 function readRequireSpecifier(

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -478,6 +478,7 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix).trimEnd();
   if (isOpenTemplateAssertionKeyword(prefixWithoutTrailingTrivia)) return true;
+  if (/(?:^|[;{}\n])\s*(?:const|let|var)\b[\s\S]*=\s*$/.test(prefix)) return false;
   if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
   const previousIndex = skipTriviaBackward(content, templateIndex - 1);
   if (previousIndex >= 0 && /[\w$)\]]/.test(content[previousIndex] ?? '')) return false;
@@ -502,6 +503,10 @@ function findTypeScriptAngleAssertionEnd(content: string, index: number): number
   for (let i = index; i < content.length; i++) {
     const ch = content[i]!;
     if (ch === '<') depth += 1;
+    if (ch === '=' && content[i + 1] === '>') {
+      i += 1;
+      continue;
+    }
     if (ch === '>') {
       depth -= 1;
       if (depth === 0) return i;
@@ -883,6 +888,10 @@ function stripTrailingTrivia(content: string): string {
 }
 
 function isInsideTypeDeclaration(prefix: string): boolean {
+  if (/(?:^|[;{}\n])\s*(?:const|let|var)\b[\s\S]*=\s*$/.test(prefix)) {
+    return false;
+  }
+
   if (/(?:^|[;{}\n])\s*(?:type|interface)\s*[:=]\s*(?:await\b\s*)?$/.test(prefix)) {
     return false;
   }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -469,6 +469,7 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   const statementStart = findDynamicImportStatementStart(content, templateIndex);
   const prefix = content.slice(statementStart + 1, templateIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
+  if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
   return (
     endsInsideNestedTypeReference(prefix) ||
     isInsideTypeDeclaration(prefix) ||
@@ -535,7 +536,7 @@ function endsInsideNestedTypeReference(
   isObjectLiteralValue = false,
 ): boolean {
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
-  if (/(?:^|[^.])(?:\bas\s+|\bsatisfies\s+|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
+  if (/(?:^|[^.])(?:\bas(?:\s+|$)|\bsatisfies(?:\s+|$)|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
   if (/(?:\bas\s+|\bsatisfies\s+)\(\s*\)\s*=>\s*$/.test(prefixWithoutTrailingTrivia)) {
@@ -815,10 +816,10 @@ function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
-    !/\n\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
+    !/\n\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b/.test(
       prefix,
     ) &&
-    !/\}\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b[\s\S]*$/.test(
+    !/\}\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b[\s\S]*$/.test(
       prefix,
     ) &&
     !/\}\s*(?:export\s+)?$/.test(prefix) &&
@@ -835,7 +836,7 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   const suffix = prefix.slice(newlineIndex + 1);
   if (
     !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
-    !/^\s*(?:export\s+)?(?:default\b|[!~+\-\[(@]|using\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+    !/^\s*(?:export\s+)?(?:default\b|[!~+\-\[(@]|using\b|abstract\s+class\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
       suffix,
     )
   ) {
@@ -904,7 +905,7 @@ function isInsideTypeAnnotation(
   }
   if (/[=;]/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
-  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|using\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
+  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
     return false;
   }
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
@@ -936,7 +937,7 @@ function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boo
 }
 
 function hasRuntimeAfterClosedTypeContext(annotationSuffix: string): boolean {
-  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|using\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
+  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
     annotationSuffix,
   );
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -243,11 +243,48 @@ function readDynamicImportSpecifier(
   if (!specifier) return null;
 
   const nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  const assertedTokenIndex = skipTypeScriptImportArgumentAssertion(
+    content,
+    nextTokenIndex,
+  );
+  if (assertedTokenIndex !== nextTokenIndex) {
+    return content[assertedTokenIndex] === ')' || content[assertedTokenIndex] === ','
+      ? { value: specifier.value, endIndex: assertedTokenIndex - 1 }
+      : null;
+  }
+
   if (content[nextTokenIndex] !== ')' && content[nextTokenIndex] !== ',') {
     return null;
   }
 
   return specifier;
+}
+
+function skipTypeScriptImportArgumentAssertion(
+  content: string,
+  index: number,
+): number {
+  const keyword = startsWithKeyword(content, index, 'as')
+    ? 'as'
+    : startsWithKeyword(content, index, 'satisfies')
+      ? 'satisfies'
+      : null;
+  if (!keyword) return index;
+
+  let i = skipImportTrivia(content, index + keyword.length);
+  while (i < content.length && content[i] !== ')' && content[i] !== ',') {
+    if (content[i] === '/' && content[i + 1] === '/') {
+      i = skipImportTrivia(content, skipSingleLineComment(content, i + 2));
+      continue;
+    }
+    if (content[i] === '/' && content[i + 1] === '*') {
+      i = skipImportTrivia(content, skipMultiLineComment(content, i + 2) + 1);
+      continue;
+    }
+    i += 1;
+  }
+
+  return i;
 }
 
 function readDynamicImportArgumentSpecifier(
@@ -275,7 +312,7 @@ function canStartNativeDynamicImport(
   content: string,
   importIndex: number,
 ): boolean {
-  const previousIndex = previousNonWhitespaceIndex(content, importIndex - 1);
+  const previousIndex = previousNonTriviaIndex(content, importIndex - 1);
   const previous = previousIndex === null ? null : content[previousIndex]!;
   if (
     previous === '#' ||
@@ -303,7 +340,8 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
 }
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
-  if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)(?:(?:keyof|typeof)\s*)?$/.test(prefix)) {
+  const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
+  if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
 
@@ -317,16 +355,22 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   }
 
   const operator = trimmed.at(-1);
-  if (operator === '<') return true;
+  if (operator === '<') return !/\s<$/.test(trimmed);
 
   if (operator !== '|' && operator !== '&') return false;
 
-  return trimmed.at(-2) !== operator;
+  return trimmed.at(-2) !== operator && trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>');
+}
+
+function stripTrailingTrivia(content: string): string {
+  const i = skipTriviaBackward(content, content.length - 1);
+  return content.slice(0, i + 1);
 }
 
 function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
+    !hasCompletedTypeDeclarationBeforeImport(prefix) &&
     !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
@@ -335,6 +379,17 @@ function isInsideTypeDeclaration(prefix: string): boolean {
       prefix,
     )
   );
+}
+
+function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
+  const newlineIndex = prefix.lastIndexOf('\n');
+  if (newlineIndex === -1) return false;
+
+  const suffix = prefix.slice(newlineIndex + 1);
+  if (!/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix)) return false;
+
+  const previousLine = prefix.slice(0, newlineIndex).trimEnd();
+  return !/[=?:,|&<{([]$/.test(previousLine) && !/\bextends\s*$/.test(previousLine);
 }
 
 function isInsideTypeAnnotation(
@@ -351,6 +406,12 @@ function isInsideTypeAnnotation(
   const beforeAnnotation = prefix.slice(0, annotationIndex);
   if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
   if (/:\s*\{[^}]*$/.test(beforeAnnotation)) return true;
+  if (
+    /(?:^|[;{}\n])\s*[A-Za-z_$][\w$]*$/.test(beforeAnnotation) &&
+    !/\bclass\b[\s\S]*\{[^}]*$/.test(beforeAnnotation)
+  ) {
+    return false;
+  }
 
   const outerAnnotationIndex = beforeAnnotation.lastIndexOf(':');
   if (outerAnnotationIndex !== -1) {
@@ -721,6 +782,11 @@ function previousNonWhitespaceIndex(
   }
 
   return null;
+}
+
+function previousNonTriviaIndex(content: string, index: number): number | null {
+  const i = skipTriviaBackward(content, index);
+  return i < 0 ? null : i;
 }
 
 function readIdentifierStart(content: string, index: number): number {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -272,15 +272,12 @@ function canStartNativeDynamicImport(
   const statementStart = content.lastIndexOf(';', importIndex - 1);
   const prefix = content.slice(statementStart + 1, importIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
-  const endsAfterTypeAnnotation = /:\s*$/.test(prefix);
   const isNestedTypeReference = /(?:\bas\s*|\bsatisfies\s*|[<|&]\s*)$/.test(prefix);
 
   return !(
     isNestedTypeReference ||
     isInsideTypeDeclaration(prefix) ||
-    (endsAfterTypeAnnotation &&
-      !isTernaryBranch &&
-      !isLikelyObjectLiteralValue(content, importIndex))
+    isInsideTypeAnnotation(prefix, content, importIndex, isTernaryBranch)
   );
 }
 
@@ -298,6 +295,23 @@ function isInsideTypeDeclaration(prefix: string): boolean {
       prefix,
     )
   );
+}
+
+function isInsideTypeAnnotation(
+  prefix: string,
+  content: string,
+  importIndex: number,
+  isTernaryBranch: boolean,
+): boolean {
+  if (isTernaryBranch) return false;
+
+  const annotationIndex = prefix.lastIndexOf(':');
+  if (annotationIndex === -1) return false;
+
+  const annotationSuffix = prefix.slice(annotationIndex + 1);
+  if (/[=;]/.test(annotationSuffix)) return false;
+
+  return !isLikelyObjectLiteralValue(content, importIndex);
 }
 
 function hasTernaryBranchMarker(prefix: string): boolean {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -246,7 +246,10 @@ function readDynamicImportSpecifier(
   const specifier = readDynamicImportArgumentSpecifier(content, i);
   if (!specifier) return null;
 
-  const nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  const nextTokenIndex = skipTypeScriptNonNullAssertion(
+    content,
+    skipImportTrivia(content, specifier.endIndex + 1),
+  );
   const assertedTokenIndex = skipTypeScriptImportArgumentAssertion(
     content,
     nextTokenIndex,
@@ -262,6 +265,11 @@ function readDynamicImportSpecifier(
   }
 
   return specifier;
+}
+
+function skipTypeScriptNonNullAssertion(content: string, index: number): number {
+  if (content[index] !== '!') return index;
+  return skipImportTrivia(content, index + 1);
 }
 
 function skipTypeScriptImportArgumentAssertion(
@@ -341,6 +349,8 @@ function canStartNativeDynamicImport(
 
   return !(
     isNestedTypeReference ||
+    isTypeOnlyImportReferenceUse(prefix, content, importIndex) ||
+    isInsideGenericTypeArgument(prefix, content, importIndex) ||
     isInsideTypeDeclaration(prefix) ||
     isInsideTypeAnnotation(prefix, content, importIndex, isTernaryBranch)
   );
@@ -405,6 +415,9 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
+  if (/(?:\bas\s*|\bsatisfies\s*)\(\s*\)\s*=>\s*$/.test(prefixWithoutTrailingTrivia)) {
+    return true;
+  }
   if (/(?:\bas\s*|\bsatisfies\s*)\s*(?:readonly\s*)?(?:\[\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
@@ -423,7 +436,92 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
 
   if (operator !== '|' && operator !== '&') return false;
 
-  return trimmed.at(-2) !== operator && trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>');
+  return (
+    trimmed.at(-2) !== operator &&
+    (trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>') ||
+      /(?:\bas\b|\bsatisfies\b|:)\s*[\s\S]*[|&]$/.test(trimmed))
+  );
+}
+
+function isInsideGenericTypeArgument(
+  prefix: string,
+  content: string,
+  importIndex: number,
+): boolean {
+  const trimmed = prefix.trimEnd();
+  if (!/[A-Za-z_$][\w$]*<$/.test(trimmed)) return false;
+  if (trimmed.lastIndexOf('<') < trimmed.lastIndexOf('>')) return false;
+
+  const dynamicImport = readDynamicImportSpecifierForTypeContext(
+    content,
+    importIndex + 'import'.length,
+  );
+  if (!dynamicImport) return false;
+
+  let i = skipImportTrivia(content, dynamicImport.endIndex + 1);
+  while (content[i] === '.' || (content[i] === '[' && content[i + 1] === ']')) {
+    if (content[i] === '.') {
+      i = skipImportTrivia(content, i + 1);
+      if (!/[A-Za-z_$]/.test(content[i] ?? '')) return false;
+      while (isIdentifierCharacter(content[i] ?? '')) i += 1;
+      i = skipImportTrivia(content, i);
+      continue;
+    }
+    i = skipImportTrivia(content, i + 2);
+  }
+
+  return content[i] === '>';
+}
+
+function isTypeOnlyImportReferenceUse(
+  prefix: string,
+  content: string,
+  importIndex: number,
+): boolean {
+  const dynamicImport = readDynamicImportSpecifierForTypeContext(
+    content,
+    importIndex + 'import'.length,
+  );
+  if (!dynamicImport) return false;
+
+  const afterImport = skipImportTrivia(content, dynamicImport.endIndex + 1);
+  if (
+    content[afterImport] !== '.' &&
+    content[afterImport] !== '>' &&
+    !(content[afterImport] === '[' && content[afterImport + 1] === ']')
+  ) {
+    return false;
+  }
+
+  const trimmed = prefix.trimEnd();
+  if (/\{\s*(?:return|throw|void|await|yield|case|default)\b[\s\S]*$/.test(trimmed)) {
+    return false;
+  }
+
+  if (/(?:\btype\b|\binterface\b|\bimplements\b|\bkeyof\b|\btypeof\b|\bas\b|\bsatisfies\b)[\s\S]*$/.test(trimmed)) {
+    return true;
+  }
+
+  const colonIndex = trimmed.lastIndexOf(':');
+  if (colonIndex === -1) return false;
+  const openBraceIndex = trimmed.lastIndexOf('{');
+  const semicolonIndex = trimmed.lastIndexOf(';');
+  return colonIndex > semicolonIndex && !/\{\s*(?:return|throw|void|await|yield|case|default)\b[\s\S]*$/.test(trimmed.slice(openBraceIndex));
+}
+
+function readDynamicImportSpecifierForTypeContext(
+  content: string,
+  index: number,
+): StringLiteralRead | null {
+  let i = skipImportTrivia(content, index);
+  if (content[i] !== '(') return null;
+  i = skipImportTrivia(content, i + 1);
+  const specifier = readDynamicImportArgumentSpecifier(content, i);
+  if (!specifier) return null;
+  const nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
+  return content[nextTokenIndex] === ')'
+    ? { value: specifier.value, endIndex: nextTokenIndex }
+    : null;
 }
 
 function stripTrailingTrivia(content: string): string {
@@ -436,6 +534,9 @@ function isInsideTypeDeclaration(prefix: string): boolean {
     /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
     !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
+      prefix,
+    ) &&
+    !/\}\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b[\s\S]*$/.test(
       prefix,
     ) &&
     !/\}\s*(?:export\s+)?$/.test(prefix) &&
@@ -492,7 +593,11 @@ function isInsideTypeAnnotation(
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (/[=;]/.test(annotationSuffix)) return false;
-  if (/=>/.test(annotationSuffix)) return false;
+  if (/=>/.test(annotationSuffix)) {
+    return /^\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*(?:\[\])?)\s*=>\s*$/.test(
+      annotationSuffix,
+    );
+  }
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
     return false;

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -35,11 +35,8 @@ export class GhostDependencyEvaluator implements Evaluator {
     const seen = new Set<string>();
 
     for (const specifier of extractDependencySpecifiers(input.content)) {
-      // Skip relative imports
-      if (specifier.startsWith('.')) continue;
-
-      // Skip absolute local paths used by dynamic import() loaders.
-      if (specifier.startsWith('/')) continue;
+      // Skip local imports, including absolute paths/URLs used by dynamic loaders.
+      if (isLocalImportSpecifier(specifier)) continue;
 
       // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
       if (isNodeBuiltinSpecifier(specifier)) continue;
@@ -74,6 +71,15 @@ export class GhostDependencyEvaluator implements Evaluator {
 
 function isNodeBuiltinSpecifier(specifier: string): boolean {
   return isBuiltin(specifier);
+}
+
+function isLocalImportSpecifier(specifier: string): boolean {
+  return (
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('file:') ||
+    /^[A-Za-z]:/.test(specifier)
+  );
 }
 
 function extractDependencySpecifiers(content: string): string[] {
@@ -264,7 +270,7 @@ function canStartNativeDynamicImport(
 
   const statementStart = content.lastIndexOf(';', importIndex - 1);
   const prefix = content.slice(statementStart + 1, importIndex);
-  const isTernaryBranch = prefix.includes('?');
+  const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const endsAfterTypeAnnotation = /:\s*$/.test(prefix);
 
   return !(
@@ -280,7 +286,20 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
 }
 
 function isInsideTypeDeclaration(prefix: string): boolean {
-  return /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix);
+  return (
+    /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
+    !/\n\s*(?:const|let|var|await|return|throw|if|for|while|switch|try|function|class)\b/.test(
+      prefix,
+    )
+  );
+}
+
+function hasTernaryBranchMarker(prefix: string): boolean {
+  const questionIndex = prefix.lastIndexOf('?');
+  if (questionIndex === -1) return false;
+
+  const afterQuestion = skipWhitespace(prefix, questionIndex + 1);
+  return prefix[afterQuestion] !== ':';
 }
 
 function isLikelyObjectLiteralValue(content: string, importIndex: number): boolean {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -239,12 +239,7 @@ function readDynamicImportSpecifier(
 
   i = skipImportTrivia(content, i + 1);
 
-  const specifier =
-    content[i] === '`'
-      ? readNoSubstitutionTemplateString(content, i)
-      : content[i] === "'" || content[i] === '"'
-        ? readQuotedString(content, i)
-        : null;
+  const specifier = readDynamicImportArgumentSpecifier(content, i);
   if (!specifier) return null;
 
   const nextTokenIndex = skipImportTrivia(content, specifier.endIndex + 1);
@@ -253,6 +248,27 @@ function readDynamicImportSpecifier(
   }
 
   return specifier;
+}
+
+function readDynamicImportArgumentSpecifier(
+  content: string,
+  index: number,
+): StringLiteralRead | null {
+  if (content[index] === '`') return readNoSubstitutionTemplateString(content, index);
+  if (content[index] === "'" || content[index] === '"') {
+    return readQuotedString(content, index);
+  }
+
+  if (content[index] !== '(') return null;
+
+  const nestedStart = skipImportTrivia(content, index + 1);
+  const nested = readDynamicImportArgumentSpecifier(content, nestedStart);
+  if (!nested) return null;
+
+  const closingIndex = skipImportTrivia(content, nested.endIndex + 1);
+  if (content[closingIndex] !== ')') return null;
+
+  return { value: nested.value, endIndex: closingIndex };
 }
 
 function canStartNativeDynamicImport(
@@ -287,7 +303,9 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
 }
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
-  if (/(?:\bas\s*|\bsatisfies\s*)(?:typeof\s*)?$/.test(prefix)) return true;
+  if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)(?:(?:keyof|typeof)\s*)?$/.test(prefix)) {
+    return true;
+  }
 
   const trimmed = prefix.trimEnd();
 
@@ -312,6 +330,7 @@ function isInsideTypeDeclaration(prefix: string): boolean {
     !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
+    !/\}\s*\n\s*(?:export\s+)?$/.test(prefix) &&
     !/\}\s*\n\s*(?:export\s+)?(?:void\s*$|\(|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
       prefix,
     )

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -253,17 +253,17 @@ function canStartNativeDynamicImport(
 
   const statementStart = Math.max(
     content.lastIndexOf(';', importIndex - 1),
-    content.lastIndexOf('\n', importIndex - 1),
     content.lastIndexOf('{', importIndex - 1),
     content.lastIndexOf('}', importIndex - 1),
   );
   const prefix = content.slice(statementStart + 1, importIndex);
   const startsAfterObjectBrace = content[statementStart] === '{';
+  const isTernaryBranch = prefix.includes('?');
 
   return !(
     /\btype\s+[A-Za-z_$][\w$]*(?:\s*<[^;>{}]*>)?\s*=\s*$/.test(prefix) ||
-    /\btypeof\s*$/.test(prefix) ||
-    (!startsAfterObjectBrace && /:\s*$/.test(prefix)) ||
+    (/\btype\b/.test(prefix) && /\btypeof\s*$/.test(prefix)) ||
+    (!startsAfterObjectBrace && !isTernaryBranch && /:\s*$/.test(prefix)) ||
     /\b(?:interface|type)\b[^;{}]*\bextends\s*$/.test(prefix)
   );
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -321,7 +321,15 @@ function readDynamicImportArgumentSpecifier(
   const nested = readDynamicImportArgumentSpecifier(content, nestedStart);
   if (!nested) return null;
 
-  const closingIndex = skipImportTrivia(content, nested.endIndex + 1);
+  const nextTokenIndex = skipTypeScriptNonNullAssertion(
+    content,
+    skipImportTrivia(content, nested.endIndex + 1),
+  );
+  const assertedTokenIndex = skipTypeScriptImportArgumentAssertion(
+    content,
+    nextTokenIndex,
+  );
+  const closingIndex = skipTypeScriptNonNullAssertion(content, assertedTokenIndex);
   if (content[closingIndex] !== ')') return null;
 
   return { value: nested.value, endIndex: closingIndex };
@@ -402,14 +410,23 @@ function findTypeScriptAngleAssertionEnd(content: string, index: number): number
 }
 
 function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boolean {
-  const openBraceIndex = findContainingOpenBrace(content, semicolonIndex);
-  if (openBraceIndex === -1) return false;
+  let searchIndex = semicolonIndex;
+  while (searchIndex > 0) {
+    const openBraceIndex = findContainingOpenBrace(content, searchIndex);
+    if (openBraceIndex === -1) return false;
 
-  const beforeBrace = content.slice(0, openBraceIndex);
-  return (
-    /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace) ||
-    /(?:\bas\s*|\bsatisfies\s*|:)\s*$/.test(beforeBrace.trimEnd())
-  );
+    const beforeBrace = content.slice(0, openBraceIndex);
+    if (
+      /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace) ||
+      /(?:\bas\s*|\bsatisfies\s*|:)\s*$/.test(beforeBrace.trimEnd())
+    ) {
+      return true;
+    }
+
+    searchIndex = openBraceIndex;
+  }
+
+  return false;
 }
 
 function findContainingOpenBrace(content: string, index: number): number {
@@ -445,7 +462,7 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
 
   if (
     /(?:,|\bextends\b|=)$/.test(trimmed) &&
-    trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>')
+    hasUnclosedGenericTypeArgument(trimmed)
   ) {
     return true;
   }
@@ -462,9 +479,20 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
 
   return (
     trimmed.at(-2) !== operator &&
-    (trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>') ||
+    (hasUnclosedGenericTypeArgument(trimmed) ||
       /(?:\bas\b|\bsatisfies\b|:)\s*[\s\S]*[|&]$/.test(trimmed))
   );
+}
+
+function hasUnclosedGenericTypeArgument(trimmed: string): boolean {
+  const lastOpen = trimmed.lastIndexOf('<');
+  if (lastOpen === -1 || lastOpen < trimmed.lastIndexOf('>')) return false;
+
+  // Runtime less-than expressions such as `load(count < limit, import('x'))`
+  // also leave an earlier `<` in the prefix.  Treat it as a generic/type
+  // context only when the `<` is attached to the preceding type/callee token.
+  const beforeOpen = trimmed[lastOpen - 1];
+  return beforeOpen !== undefined && !/\s/.test(beforeOpen);
 }
 
 function isInsideGenericTypeArgument(
@@ -496,10 +524,18 @@ function isInsideGenericTypeArgument(
     i = skipImportTrivia(content, indexedAccessEnd + 1);
   }
 
-  if (content[i] !== '>') return false;
+  if (content[i] !== '>' && content[i] !== ',' && content[i] !== '|' && content[i] !== '&') {
+    return false;
+  }
 
-  const afterClose = skipImportTrivia(content, i + 1);
-  return !isIdentifierCharacter(content[afterClose] ?? '');
+  if (content[i] === ',') return true;
+
+  if (content[i] === '>') {
+    const afterDelimiter = skipImportTrivia(content, i + 1);
+    return !isIdentifierCharacter(content[afterDelimiter] ?? '');
+  }
+
+  return true;
 }
 
 function findBalancedBracketEnd(content: string, openIndex: number): number {
@@ -570,6 +606,8 @@ function isTypeOnlyImportReferenceUse(
   if (colonIndex === -1) return false;
   const openBraceIndex = trimmed.lastIndexOf('{');
   const semicolonIndex = trimmed.lastIndexOf(';');
+  const annotationSuffix = trimmed.slice(colonIndex + 1);
+  if (/[=;]/.test(annotationSuffix)) return false;
   return colonIndex > semicolonIndex && !/\{\s*(?:return|throw|void|await|yield|case|default)\b[\s\S]*$/.test(trimmed.slice(openBraceIndex));
 }
 
@@ -670,12 +708,14 @@ function isInsideTypeAnnotation(
   if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
   if (
     /(?:\bas|\bsatisfies)\s*\{[^}]*$/.test(beforeAnnotation) &&
+    !isLikelyObjectLiteralValue(content, importIndex) &&
     !hasRuntimeAfterAnnotation(prefix, annotationIndex)
   ) {
     return true;
   }
   if (
     /:\s*\{[^}]*$/.test(beforeAnnotation) &&
+    !isLikelyObjectLiteralValue(content, importIndex) &&
     !hasRuntimeAfterAnnotation(prefix, annotationIndex)
   ) {
     return true;
@@ -693,7 +733,8 @@ function isInsideTypeAnnotation(
     if (
       outerAnnotationSuffix.includes('{') &&
       !outerAnnotationSuffix.includes('}') &&
-      !/[=;]/.test(outerAnnotationSuffix)
+      !/[=;]/.test(outerAnnotationSuffix) &&
+      !isLikelyObjectLiteralValue(content, importIndex)
     ) {
       return true;
     }
@@ -701,13 +742,13 @@ function isInsideTypeAnnotation(
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (hasRuntimeAfterClosedTypeContext(annotationSuffix)) return false;
-  if (/[=;]/.test(annotationSuffix)) return false;
   if (/=>/.test(annotationSuffix)) {
     if (/\)\s*:\s*[^=]*=>\s*$/.test(prefix)) return false;
     return /^\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*(?:\[\])?)\s*=>\s*$/.test(
       annotationSuffix,
     );
   }
+  if (/[=;]/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
   if (/\n\s*(?:void\s*)?$|\n\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
     return false;

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -273,7 +273,7 @@ function canStartNativeDynamicImport(
   const prefix = content.slice(statementStart + 1, importIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const endsAfterTypeAnnotation = /:\s*$/.test(prefix);
-  const isNestedTypeReference = /(?:\bas\s*|\bsatisfies\s*|<\s*)$/.test(prefix);
+  const isNestedTypeReference = /(?:\bas\s*|\bsatisfies\s*|[<|&]\s*)$/.test(prefix);
 
   return !(
     isNestedTypeReference ||

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -476,7 +476,8 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   const statementStart = findDynamicImportStatementStart(content, templateIndex);
   const prefix = content.slice(statementStart + 1, templateIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
-  if (/(?:^|[^.])\b(?:as|satisfies)\s*$/.test(prefix.trimEnd())) return true;
+  const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix).trimEnd();
+  if (isOpenTemplateAssertionKeyword(prefixWithoutTrailingTrivia)) return true;
   if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
   const previousIndex = skipTriviaBackward(content, templateIndex - 1);
   if (previousIndex >= 0 && /[\w$)\]]/.test(content[previousIndex] ?? '')) return false;
@@ -485,6 +486,15 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
     isInsideTypeDeclaration(prefix) ||
     isInsideTypeAnnotation(prefix, content, templateIndex, isTernaryBranch)
   );
+}
+
+function isOpenTemplateAssertionKeyword(prefix: string): boolean {
+  const match = /(?:^|[^.])\b(as|satisfies)$/.exec(prefix);
+  if (!match || match.index === undefined) return false;
+
+  const keywordIndex = match.index + match[0].lastIndexOf(match[1]!);
+  const previousIndex = skipTriviaBackward(prefix, keywordIndex - 1);
+  return previousIndex >= 0 && /[\w$)\]}'"`]/.test(prefix[previousIndex] ?? '');
 }
 
 function findTypeScriptAngleAssertionEnd(content: string, index: number): number {
@@ -607,7 +617,12 @@ function hasUnclosedGenericTypeArgument(trimmed: string): boolean {
   const tokenStart = findIdentifierStartBefore(trimmed, lastOpen - 1);
   if (tokenStart === -1) return false;
   const token = trimmed.slice(tokenStart, lastOpen);
-  if (token.length > 0) return true;
+  if (token.length > 0) {
+    if (/^[A-Za-z_$][\w$]*\s*,[\s\S]*=\s*$/.test(typeArgumentPrefix)) {
+      return false;
+    }
+    return true;
+  }
 
   const previousIndex = previousNonTriviaIndex(trimmed, tokenStart - 1);
   return previousIndex !== null && /[.>\]]/.test(trimmed[previousIndex]!);
@@ -852,7 +867,10 @@ function stripTrailingTrivia(content: string): string {
 }
 
 function isInsideTypeDeclaration(prefix: string): boolean {
-  if (/(?:^|[;{}\n])\s*(?:type|interface)\s*[:=]\s*(?:await\s+)?$/.test(prefix.trimEnd())) {
+  if (/(?:^|[;{}\n])\s*(?:type|interface)\s*[:=]\s*(?:await\b\s*)?$/.test(prefix)) {
+    return false;
+  }
+  if (isRuntimeTypeNamedObjectValue(prefix)) {
     return false;
   }
   if (/}\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*(?:=|\(|\[)|module\.exports\s*=)[\s\S]*$/.test(prefix)) {
@@ -873,6 +891,18 @@ function isInsideTypeDeclaration(prefix: string): boolean {
       prefix,
     )
   );
+}
+
+function isRuntimeTypeNamedObjectValue(prefix: string): boolean {
+  const match = /(?:^|[,{])\s*(?:type|interface)\s*:\s*(?:await\b\s*)?(?:\{[\s\S]*)?$/.exec(prefix);
+  if (!match || match.index === undefined) return false;
+
+  const beforeProperty = prefix.slice(0, match.index);
+  if (/(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(beforeProperty)) {
+    return false;
+  }
+
+  return true;
 }
 
 function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -393,7 +393,7 @@ function canStartNativeDynamicImport(
   const statementStart = findDynamicImportStatementStart(content, importIndex);
   const prefix = content.slice(statementStart + 1, importIndex);
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix).trimEnd();
-  if (/\b(?:as|satisfies)$/.test(prefixWithoutTrailingTrivia)) {
+  if (isOpenTemplateAssertionKeyword(prefixWithoutTrailingTrivia)) {
     return false;
   }
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
@@ -768,6 +768,15 @@ function isTypeOnlyImportReferenceUse(
 
   const colonIndex = trimmed.lastIndexOf(':');
   if (colonIndex === -1) return false;
+  if (hasTernaryBranchMarker(prefix) && !isInsideConditionalType(prefix)) {
+    return false;
+  }
+  if (
+    isLikelyObjectLiteralValue(content, importIndex) &&
+    !/:\s*\{[\s\S]*,\s*[A-Za-z_$][\w$]*\s*:\s*$/.test(trimmed)
+  ) {
+    return false;
+  }
   const openBraceIndex = trimmed.lastIndexOf('{');
   const semicolonIndex = trimmed.lastIndexOf(';');
   const annotationSuffix = trimmed.slice(colonIndex + 1);
@@ -791,7 +800,10 @@ function isInsideOpenTypeAssertion(trimmedPrefix: string): boolean {
   let latestAssertionIndex = -1;
   let match: RegExpExecArray | null;
   while ((match = assertionMatch.exec(trimmedPrefix)) !== null) {
-    latestAssertionIndex = match.index;
+    const candidatePrefix = trimmedPrefix.slice(0, match.index + match[0].length).trimEnd();
+    if (isOpenTemplateAssertionKeyword(candidatePrefix)) {
+      latestAssertionIndex = match.index;
+    }
   }
   if (latestAssertionIndex === -1) return false;
 
@@ -880,10 +892,10 @@ function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
-    !/\n\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b/.test(
+    !/\n\s*(?:export\s+)?(?:@|else\b|catch\b|finally\b|default\b|const|let|var|using|await|return|throw|new|if|for|while|do|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b/.test(
       prefix,
     ) &&
-    !/\}\s*(?:export\s+)?(?:@|default\b|const|let|var|using|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b[\s\S]*$/.test(
+    !/\}\s*(?:export\s+)?(?:@|else\b|catch\b|finally\b|default\b|const|let|var|using|await|return|throw|new|if|for|while|do|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b[\s\S]*$/.test(
       prefix,
     ) &&
     !/\}\s*(?:export\s+)?$/.test(prefix) &&
@@ -912,7 +924,7 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   const suffix = prefix.slice(newlineIndex + 1);
   if (
     !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
-    !/^\s*(?:export\s+)?(?:default\b|[!~+\-\[(@]|using\b|abstract\s+class\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*(?:\(|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+    !/^\s*(?:export\s+)?(?:default\b|else\b|catch\b|finally\b|[!~+\-\[(@]|using\b|do\b|abstract\s+class\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*(?:\(|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
       suffix,
     )
   ) {
@@ -981,7 +993,7 @@ function isInsideTypeAnnotation(
   }
   if (/[=;]/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
-  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
+  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|else\b|catch\b|finally\b|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*(?:=|\(|\[)|module\.exports\s*=|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(prefix)) {
     return false;
   }
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
@@ -1013,7 +1025,7 @@ function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boo
 }
 
 function hasRuntimeAfterClosedTypeContext(annotationSuffix: string): boolean {
-  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
+  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|else\b|catch\b|finally\b|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
     annotationSuffix,
   );
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -339,12 +339,12 @@ function readDynamicImportSpecifier(
   content: string,
   index: number,
 ): StringLiteralRead | null {
+  let i = skipImportTrivia(content, index);
+  if (content[i] !== '(') return null;
+
   if (!canStartNativeDynamicImport(content, index - 'import'.length)) {
     return null;
   }
-
-  let i = skipImportTrivia(content, index);
-  if (content[i] !== '(') return null;
 
   i = skipImportTrivia(content, i + 1);
 
@@ -563,6 +563,7 @@ function isTypeOnlyTemplateString(content: string, templateIndex: number): boole
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix).trimEnd();
   if (isOpenTemplateAssertionKeyword(prefixWithoutTrailingTrivia)) return true;
+  if (/(?:^|\n)\s*(?:export\s+)?type\b[^\n]*=\s*$/.test(prefix)) return true;
   if (/(?:^|[;{}\n])\s*(?:const|let|var)\b[\s\S]*=\s*$/.test(prefix)) return false;
   if (/(?:^|[;{}\n])\s*(?:static\s+)?(?:accessor\s+)?[#A-Za-z_$][\w$]*\s*=\s*$/.test(prefix)) return false;
   if (/(?:^|[;{}\n])\s*(?:export\s+)?type\b[\s\S]*=\s*$/.test(prefix)) return true;
@@ -621,7 +622,7 @@ function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boo
 
     const beforeBrace = content.slice(0, openBraceIndex);
     if (
-      /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace) ||
+      /(?:^|[;{}\n])\s*(?:export\s+)?(?:default\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace) ||
       /(?:\bas\s*|\bsatisfies\s*|:)\s*$/.test(beforeBrace.trimEnd())
     ) {
       return true;
@@ -654,6 +655,8 @@ function endsInsideNestedTypeReference(
   prefix: string,
   isObjectLiteralValue = false,
 ): boolean {
+  if (hasCompletedStatementBeforeImport(prefix)) return false;
+
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
   if (/(?:^|[^.])(?:\bas(?:\s+|$)|\bsatisfies(?:\s+|$)|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
@@ -799,7 +802,7 @@ function isInsideGenericTypeArgument(
     return false;
   }
 
-  if (content[i] === ',') return true;
+  if (content[i] === ',') return hasGenericTypeArgumentClose(content, i + 1);
 
   if (content[i] === '>') {
     const afterDelimiter = skipImportTrivia(content, i + 1);
@@ -807,6 +810,36 @@ function isInsideGenericTypeArgument(
   }
 
   return true;
+}
+
+function hasGenericTypeArgumentClose(content: string, index: number): boolean {
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let i = index; i < content.length; i += 1) {
+    const ch = content[i]!;
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipStringLiteral(content, i);
+      continue;
+    }
+    if (ch === '/' && content[i + 1] === '/') break;
+    if (ch === '/' && content[i + 1] === '*') {
+      i = skipMultiLineComment(content, i + 2);
+      continue;
+    }
+    if (ch === '(') parenDepth += 1;
+    else if (ch === ')' && parenDepth > 0) parenDepth -= 1;
+    else if (ch === '[') bracketDepth += 1;
+    else if (ch === ']' && bracketDepth > 0) bracketDepth -= 1;
+    else if (ch === '{') braceDepth += 1;
+    else if (ch === '}' && braceDepth > 0) braceDepth -= 1;
+    else if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      if (ch === '>') return true;
+      if (ch === ';' || ch === '\n') return false;
+    }
+  }
+
+  return false;
 }
 
 function findBalancedBracketEnd(content: string, openIndex: number): number {
@@ -854,7 +887,7 @@ function isTypeOnlyImportReferenceUse(
     return false;
   }
 
-  if (/(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(trimmed)) {
+  if (/(?:^|[;{}\n])\s*(?:export\s+)?(?:default\s+)?(?:declare\s+)?(?:type|interface)\b[\s\S]*$/.test(trimmed)) {
     return true;
   }
   if (/\b(?:declare\s+)?namespace\b[\s\S]*\{\s*(?:export\s+)?type\b[\s\S]*$/.test(trimmed)) {
@@ -1012,7 +1045,7 @@ function isInsideTypeDeclaration(prefix: string): boolean {
   }
 
   return (
-    /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
+    /(?:^|[;{}\n])\s*(?:export\s+)?(?:default\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
     !/\n\s*(?:export\s+)?(?:@|else\b|catch\b|finally\b|default\b|const|let|var|using|await|return|throw|new|if|for|while|do|switch|try|function|async\s+function|class|abstract\s+class|namespace|enum)\b/.test(
       prefix,
@@ -1116,7 +1149,7 @@ function isInsideTypeAnnotation(
   }
   if (/[=;]/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
-  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|else\b|catch\b|finally\b|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*(?:=|\(|\[)|module\.exports\s*=|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(prefix)) {
+  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|else\b|catch\b|finally\b|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|export\s+default\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*(?:=|\(|\[|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])|module\.exports\s*=|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(prefix)) {
     return false;
   }
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -107,6 +107,10 @@ function extractDependencySpecifiers(content: string): string[] {
     }
 
     if (ch === '`') {
+      if (isTypeOnlyTemplateString(content, i)) {
+        i = skipStringLiteral(content, i);
+        continue;
+      }
       const template = readTemplateString(content, i);
       specifiers.push(...template.specifiers);
       i = template.endIndex;
@@ -297,7 +301,7 @@ function readDynamicImportArgumentSpecifier(
   }
 
   if (content[index] === '<') {
-    const assertionEnd = content.indexOf('>', index + 1);
+    const assertionEnd = findTypeScriptAngleAssertionEnd(content, index);
     if (assertionEnd === -1) return null;
     const assertedStart = skipImportTrivia(content, assertionEnd + 1);
     return readDynamicImportArgumentSpecifier(content, assertedStart);
@@ -355,6 +359,34 @@ function findDynamicImportStatementStart(content: string, importIndex: number): 
   return statementStart;
 }
 
+function isTypeOnlyTemplateString(content: string, templateIndex: number): boolean {
+  const statementStart = findDynamicImportStatementStart(content, templateIndex);
+  const prefix = content.slice(statementStart + 1, templateIndex);
+  const isTernaryBranch = hasTernaryBranchMarker(prefix);
+  return (
+    endsInsideNestedTypeReference(prefix) ||
+    isInsideTypeDeclaration(prefix) ||
+    isInsideTypeAnnotation(prefix, content, templateIndex, isTernaryBranch)
+  );
+}
+
+function findTypeScriptAngleAssertionEnd(content: string, index: number): number {
+  let depth = 0;
+  for (let i = index; i < content.length; i++) {
+    const ch = content[i]!;
+    if (ch === '<') depth += 1;
+    if (ch === '>') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipStringLiteral(content, i);
+    }
+  }
+
+  return -1;
+}
+
 function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boolean {
   const openBraceIndex = content.lastIndexOf('{', semicolonIndex);
   if (openBraceIndex === -1) return false;
@@ -362,12 +394,18 @@ function isSemicolonInsideTypeBody(content: string, semicolonIndex: number): boo
   if (closeBraceIndex > openBraceIndex) return false;
 
   const beforeBrace = content.slice(0, openBraceIndex);
-  return /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace);
+  return (
+    /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:interface\s+[A-Za-z_$][\w$]*|type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=)\b[\s\S]*$/.test(beforeBrace) ||
+    /(?:\bas\s*|\bsatisfies\s*|:)\s*$/.test(beforeBrace.trimEnd())
+  );
 }
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
   const prefixWithoutTrailingTrivia = stripTrailingTrivia(prefix);
   if (/(?:\bas\s*|\bsatisfies\s*|\bkeyof\s*|\bimplements\s*)\(*\s*(?:(?:keyof|typeof)\s*)?$/.test(prefixWithoutTrailingTrivia)) {
+    return true;
+  }
+  if (/(?:\bas\s*|\bsatisfies\s*)\s*(?:readonly\s*)?(?:\[\s*)?$/.test(prefixWithoutTrailingTrivia)) {
     return true;
   }
 
@@ -381,7 +419,7 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
   }
 
   const operator = trimmed.at(-1);
-  if (operator === '<') return !/\s<$/.test(trimmed);
+  if (operator === '<') return /(?:[A-Z_$][\w$]*|[>\]])<$/.test(trimmed);
 
   if (operator !== '|' && operator !== '&') return false;
 
@@ -395,12 +433,12 @@ function stripTrailingTrivia(content: string): string {
 
 function isInsideTypeDeclaration(prefix: string): boolean {
   return (
-    /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
+    /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
     !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|new|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
-    !/\}\s*\n\s*(?:export\s+)?$/.test(prefix) &&
+    !/\}\s*(?:export\s+)?$/.test(prefix) &&
     !/\}\s*\n\s*(?:export\s+)?(?:void\s*$|\(|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
       prefix,
     )
@@ -431,6 +469,7 @@ function isInsideTypeAnnotation(
 
   const beforeAnnotation = prefix.slice(0, annotationIndex);
   if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
+  if (/(?:\bas|\bsatisfies)\s*\{[^}]*$/.test(beforeAnnotation)) return true;
   if (/:\s*\{[^}]*$/.test(beforeAnnotation)) return true;
   if (
     /(?:^|[;{}\n])\s*[A-Za-z_$][\w$]*$/.test(beforeAnnotation) &&
@@ -502,6 +541,12 @@ function isLikelyObjectLiteralValue(content: string, importIndex: number): boole
 
   if (content[i] === '{') {
     const beforeBrace = content.slice(0, i).trimEnd();
+    if (/(?:\bas|\bsatisfies)\s*$/.test(beforeBrace)) {
+      return false;
+    }
+    if (/(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?type\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?\s*=\s*$/.test(beforeBrace)) {
+      return false;
+    }
     if (/\bclass\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?$/.test(beforeBrace)) {
       return false;
     }
@@ -536,8 +581,28 @@ function skipTriviaBackward(content: string, index: number): number {
 
 function isInsideLineCommentBackward(content: string, index: number): boolean {
   const lineStart = content.lastIndexOf('\n', index) + 1;
-  const commentStart = content.lastIndexOf('//', index);
-  return commentStart >= lineStart;
+  let quote: string | null = null;
+
+  for (let i = lineStart; i <= index; i++) {
+    const ch = content[i]!;
+    if (quote) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '/' && content[i + 1] === '/') return true;
+  }
+
+  return false;
 }
 
 function skipQuotedKeyBackward(content: string, quoteIndex: number): number {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -272,7 +272,7 @@ function canStartNativeDynamicImport(
   const statementStart = content.lastIndexOf(';', importIndex - 1);
   const prefix = content.slice(statementStart + 1, importIndex);
   const isTernaryBranch = hasTernaryBranchMarker(prefix);
-  const isNestedTypeReference = /(?:\bas\s*|\bsatisfies\s*|[<|&]\s*)$/.test(prefix);
+  const isNestedTypeReference = endsInsideNestedTypeReference(prefix);
 
   return !(
     isNestedTypeReference ||
@@ -285,13 +285,25 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
   return content.slice(dotIndex - 2, dotIndex + 1) === '...';
 }
 
+function endsInsideNestedTypeReference(prefix: string): boolean {
+  if (/(?:\bas\s*|\bsatisfies\s*)$/.test(prefix)) return true;
+
+  const trimmed = prefix.trimEnd();
+  const operator = trimmed.at(-1);
+  if (operator === '<') return true;
+
+  if (operator !== '|' && operator !== '&') return false;
+
+  return trimmed.at(-2) !== operator;
+}
+
 function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !/\n\s*(?:const|let|var|await|return|throw|if|for|while|switch|try|function|class)\b/.test(
       prefix,
     ) &&
-    !/\}\s*\n\s*(?:[A-Za-z_$][\w$]*\s*\(|(?:await\s+)?import\s*\()/.test(
+    !/\}\s*\n\s*(?:void\s*$|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
       prefix,
     )
   );
@@ -308,8 +320,25 @@ function isInsideTypeAnnotation(
   const annotationIndex = prefix.lastIndexOf(':');
   if (annotationIndex === -1) return false;
 
+  const beforeAnnotation = prefix.slice(0, annotationIndex);
+  const outerAnnotationIndex = beforeAnnotation.lastIndexOf(':');
+  if (outerAnnotationIndex !== -1) {
+    const outerAnnotationSuffix = beforeAnnotation.slice(outerAnnotationIndex + 1);
+    if (
+      outerAnnotationSuffix.includes('{') &&
+      !outerAnnotationSuffix.includes('}') &&
+      !/[=;]/.test(outerAnnotationSuffix)
+    ) {
+      return true;
+    }
+  }
+
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (/[=;]/.test(annotationSuffix)) return false;
+  if (/^\s*(?:return|throw|void)\b/.test(annotationSuffix)) return false;
+  if (/\{[\s\S]*\b(?:return|throw|void|case|default)\b/.test(annotationSuffix)) {
+    return false;
+  }
 
   return !isLikelyObjectLiteralValue(content, importIndex);
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -147,6 +147,11 @@ function extractDependencySpecifiers(content: string): string[] {
     }
 
     if (startsWithKeyword(content, i, 'import')) {
+      if (isInsideJsxText(content, i)) {
+        i += 'import'.length;
+        continue;
+      }
+
       const dynamicallyImported = readDynamicImportSpecifier(
         content,
         i + 'import'.length,
@@ -200,6 +205,25 @@ function startsWithKeyword(
     (!before || !IDENTIFIER_PATTERN.test(before)) &&
     (!after || !IDENTIFIER_PATTERN.test(after))
   );
+}
+
+function isInsideJsxText(content: string, index: number): boolean {
+  const previousOpen = content.lastIndexOf('<', index);
+  if (previousOpen === -1 || content[previousOpen + 1] === '/' || content[previousOpen + 1] === '!') return false;
+  if (isIdentifierCharacter(content[previousOpen - 1] ?? '') || content[previousOpen - 1] === ')') return false;
+
+  const previousClose = content.lastIndexOf('>', index);
+  if (previousClose <= previousOpen) return false;
+
+  const openingTag = content.slice(previousOpen, previousClose + 1);
+  const tagMatch = openingTag.match(/^<([A-Za-z][\w.:]*)(?:\s[^<>]*)?>$/);
+  if (!tagMatch) return false;
+  const nextClosingTag = content.indexOf(`</${tagMatch[1]}>`, index);
+  if (nextClosingTag === -1) return false;
+
+  const previousExpressionOpen = content.lastIndexOf('{', index);
+  const previousExpressionClose = content.lastIndexOf('}', index);
+  return previousExpressionOpen <= previousClose || previousExpressionClose > previousExpressionOpen;
 }
 
 function readStaticImportSpecifier(
@@ -614,7 +638,8 @@ function hasUnclosedGenericTypeArgument(trimmed: string): boolean {
   if (/^[A-Za-z_$][\w$]*\s*,\s*$/.test(typeArgumentPrefix)) {
     const tokenStart = findIdentifierStartBefore(trimmed, lastOpen - 1);
     const previousIndex = tokenStart === -1 ? null : previousNonTriviaIndex(trimmed, tokenStart - 1);
-    if (previousIndex !== null && trimmed[previousIndex] === '(') return false;
+    if (previousIndex === null || /[(\[=,{;]/.test(trimmed[previousIndex]!)) return false;
+    if (/\breturn\s*$/.test(trimmed.slice(0, previousIndex + 1))) return false;
   }
 
   const beforeOpen = trimmed[lastOpen - 1];
@@ -650,6 +675,20 @@ function findUnclosedAngleBracketIndex(trimmed: string): number {
 
   for (let i = trimmed.length - 1; i >= 0; i -= 1) {
     const ch = trimmed[i]!;
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipQuotedKeyBackward(trimmed, i);
+      continue;
+    }
+    if (ch === '/' && trimmed[i - 1] === '*') {
+      i -= 2;
+      while (i >= 1 && !(trimmed[i - 1] === '/' && trimmed[i] === '*')) i -= 1;
+      i -= 1;
+      continue;
+    }
+    if (isInsideLineCommentBackward(trimmed, i)) {
+      while (i >= 0 && trimmed[i] !== '\n') i -= 1;
+      continue;
+    }
     if (ch === '>') {
       if (trimmed[i - 1] === '=') continue;
       depth += 1;
@@ -1026,17 +1065,39 @@ function isInsideTypeAnnotation(
 }
 
 function findActiveTypeAnnotationIndex(prefix: string): number {
-  const annotationIndex = prefix.lastIndexOf(':');
+  const annotationIndex = findLastCodeColon(prefix);
   if (annotationIndex === -1) return -1;
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (!/=>\s*$/.test(annotationSuffix)) return annotationIndex;
 
-  const outerAnnotationIndex = prefix.slice(0, annotationIndex).lastIndexOf(':');
+  const outerAnnotationIndex = findLastCodeColon(prefix.slice(0, annotationIndex));
   if (outerAnnotationIndex === -1) return annotationIndex;
 
   const outerSuffix = prefix.slice(outerAnnotationIndex + 1);
   return /=>\s*$/.test(outerSuffix) ? outerAnnotationIndex : annotationIndex;
+}
+
+function findLastCodeColon(content: string): number {
+  for (let i = content.length - 1; i >= 0; i -= 1) {
+    const ch = content[i]!;
+    if (ch === ':') return i;
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipQuotedKeyBackward(content, i);
+      continue;
+    }
+    if (ch === '/' && content[i - 1] === '*') {
+      i -= 2;
+      while (i >= 1 && !(content[i - 1] === '/' && content[i] === '*')) i -= 1;
+      i -= 1;
+      continue;
+    }
+    if (isInsideLineCommentBackward(content, i)) {
+      while (i >= 0 && content[i] !== '\n') i -= 1;
+    }
+  }
+
+  return -1;
 }
 
 function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boolean {
@@ -1212,8 +1273,9 @@ function readNoSubstitutionTemplateString(
     if (ch === '\\') {
       const escaped = content[i + 1];
       if (escaped) {
-        value += escaped;
-        i += 1;
+        const decoded = decodeStringEscape(content, i);
+        value += decoded.value;
+        i = decoded.endIndex;
       }
       continue;
     }
@@ -1280,6 +1342,14 @@ function decodeStringEscape(content: string, slashIndex: number): { value: strin
     if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
       return { value: String.fromCharCode(parseInt(hex, 16)), endIndex: slashIndex + 3 };
     }
+  }
+
+  if (escaped === '\n') return { value: '', endIndex: slashIndex + 1 };
+  if (escaped === '\r') {
+    return {
+      value: '',
+      endIndex: content[slashIndex + 2] === '\n' ? slashIndex + 2 : slashIndex + 1,
+    };
   }
 
   const simpleEscapes: Record<string, string> = {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -226,7 +226,6 @@ function readDynamicImportSpecifier(
   let i = skipImportTrivia(content, index);
   if (content[i] !== '(') return null;
 
-  const openParenIndex = i;
   i = skipImportTrivia(content, i + 1);
 
   const specifier =
@@ -242,10 +241,7 @@ function readDynamicImportSpecifier(
     return null;
   }
 
-  const closeParenIndex = findClosingParen(content, openParenIndex);
-  if (closeParenIndex === null) return null;
-
-  return { value: specifier.value, endIndex: closeParenIndex };
+  return specifier;
 }
 
 function canStartNativeDynamicImport(
@@ -253,7 +249,7 @@ function canStartNativeDynamicImport(
   importIndex: number,
 ): boolean {
   const previous = previousNonWhitespace(content, importIndex - 1);
-  if (previous === '.') return false;
+  if (previous === '.' || previous === '#') return false;
 
   const statementStart = Math.max(
     content.lastIndexOf(';', importIndex - 1),
@@ -262,48 +258,14 @@ function canStartNativeDynamicImport(
     content.lastIndexOf('}', importIndex - 1),
   );
   const prefix = content.slice(statementStart + 1, importIndex);
+  const startsAfterObjectBrace = content[statementStart] === '{';
 
   return !(
     /\btype\s+[A-Za-z_$][\w$]*(?:\s*<[^;>{}]*>)?\s*=\s*$/.test(prefix) ||
-    /:\s*$/.test(prefix) ||
+    /\btypeof\s*$/.test(prefix) ||
+    (!startsAfterObjectBrace && /:\s*$/.test(prefix)) ||
     /\b(?:interface|type)\b[^;{}]*\bextends\s*$/.test(prefix)
   );
-}
-
-function findClosingParen(content: string, openParenIndex: number): number | null {
-  let depth = 1;
-
-  for (let i = openParenIndex + 1; i < content.length; i++) {
-    const ch = content[i]!;
-    const next = content[i + 1];
-
-    if (ch === '/' && next === '/') {
-      i = skipSingleLineComment(content, i + 2);
-      continue;
-    }
-
-    if (ch === '/' && next === '*') {
-      i = skipMultiLineComment(content, i + 2);
-      continue;
-    }
-
-    if (QUOTE_CHARS.has(ch)) {
-      i = skipStringLiteral(content, i);
-      continue;
-    }
-
-    if (ch === '(') {
-      depth += 1;
-      continue;
-    }
-
-    if (ch === ')') {
-      depth -= 1;
-      if (depth === 0) return i;
-    }
-  }
-
-  return null;
 }
 
 function readRequireSpecifier(

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -41,10 +41,12 @@ export class GhostDependencyEvaluator implements Evaluator {
       // Skip Node built-ins, including node: prefixes and bare built-in subpaths.
       if (isNodeBuiltinSpecifier(specifier)) continue;
 
+      const packageSpecifier = normalizePackageUrlSpecifier(specifier);
+
       // Extract package name (handle scoped packages and subpath imports)
-      const packageName = specifier.startsWith('@')
-        ? specifier.split('/').slice(0, 2).join('/')
-        : specifier.split('/')[0]!;
+      const packageName = packageSpecifier.startsWith('@')
+        ? packageSpecifier.split('/').slice(0, 2).join('/')
+        : packageSpecifier.split('/')[0]!;
 
       if (seen.has(packageName)) continue;
       seen.add(packageName);
@@ -73,7 +75,16 @@ function isNodeBuiltinSpecifier(specifier: string): boolean {
   return isBuiltin(specifier);
 }
 
+function normalizePackageUrlSpecifier(specifier: string): string {
+  return specifier
+    .replace(/^(?:npm|jsr):/, '')
+    .replace(/^(@[^/]+\/[^/@]+)@[^/]+/, '$1')
+    .replace(/^([^/@]+)@[^/]+/, '$1');
+}
+
 function isLocalImportSpecifier(specifier: string): boolean {
+  if (/^(?:npm|jsr):/.test(specifier)) return false;
+
   return (
     specifier.startsWith('.') ||
     specifier.startsWith('/') ||
@@ -378,11 +389,58 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
 
 function findDynamicImportStatementStart(content: string, importIndex: number): number {
   let statementStart = content.lastIndexOf(';', importIndex - 1);
-  while (statementStart !== -1 && isSemicolonInsideTypeBody(content, statementStart)) {
+  while (
+    statementStart !== -1 &&
+    (isSemicolonInsideTypeBody(content, statementStart) ||
+      isIndexInsideStringOrComment(content, statementStart))
+  ) {
     statementStart = content.lastIndexOf(';', statementStart - 1);
   }
 
   return statementStart;
+}
+
+function isIndexInsideStringOrComment(content: string, index: number): boolean {
+  let quote: string | null = null;
+  let blockComment = false;
+  let lineComment = false;
+
+  for (let i = 0; i < index; i += 1) {
+    const ch = content[i]!;
+    const next = content[i + 1];
+    if (lineComment) {
+      if (ch === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (ch === '*' && next === '/') {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') quote = ch;
+  }
+
+  return quote !== null || blockComment || lineComment;
 }
 
 function isTypeOnlyTemplateString(content: string, templateIndex: number): boolean {
@@ -475,7 +533,7 @@ function endsInsideNestedTypeReference(
   }
 
   const operator = trimmed.at(-1);
-  if (operator === '<') return /(?:[>\]])<$/.test(trimmed);
+  if (operator === '<') return /(?:[>\]])<$/.test(trimmed) || /^\s*(?:const|let|var)?\s*[A-Za-z_$][\w$]*\s*=\s*<$/.test(trimmed);
 
   if (operator !== '|' && operator !== '&') return false;
   if (isObjectLiteralValue) return false;
@@ -493,14 +551,58 @@ function endsInsideNestedTypeReference(
 }
 
 function hasUnclosedGenericTypeArgument(trimmed: string): boolean {
-  const lastOpen = trimmed.lastIndexOf('<');
-  if (lastOpen === -1 || lastOpen < trimmed.lastIndexOf('>')) return false;
+  const lastOpen = findUnclosedAngleBracketIndex(trimmed);
+  if (lastOpen === -1) return false;
 
   // Runtime less-than expressions such as `load(count < limit, import('x'))`
   // also leave an earlier `<` in the prefix.  Treat it as a generic/type
   // context only when the `<` is attached to the preceding type/callee token.
+  const typeArgumentPrefix = trimmed.slice(lastOpen + 1).trim();
+  if (/^[A-Za-z_$][\w$]*\s*,\s*$/.test(typeArgumentPrefix)) {
+    const tokenStart = findIdentifierStartBefore(trimmed, lastOpen - 1);
+    const previousIndex = tokenStart === -1 ? null : previousNonTriviaIndex(trimmed, tokenStart - 1);
+    if (previousIndex !== null && trimmed[previousIndex] === '(') return false;
+  }
+
   const beforeOpen = trimmed[lastOpen - 1];
-  return beforeOpen !== undefined && !/\s/.test(beforeOpen);
+  if (beforeOpen === undefined) return false;
+  if (/\s/.test(beforeOpen)) {
+    const previousIndex = previousNonTriviaIndex(trimmed, lastOpen - 1);
+    return previousIndex !== null && /[=({[,]/.test(trimmed[previousIndex]!);
+  }
+
+  const tokenStart = findIdentifierStartBefore(trimmed, lastOpen - 1);
+  if (tokenStart === -1) return false;
+  const token = trimmed.slice(tokenStart, lastOpen);
+  if (token.length > 0) return true;
+
+  const previousIndex = previousNonTriviaIndex(trimmed, tokenStart - 1);
+  return previousIndex !== null && /[.>\]]/.test(trimmed[previousIndex]!);
+}
+
+function findIdentifierStartBefore(content: string, index: number): number {
+  let i = index;
+  if (!isIdentifierCharacter(content[i] ?? '')) return -1;
+  while (i >= 0 && isIdentifierCharacter(content[i] ?? '')) i -= 1;
+  return i + 1;
+}
+
+function findUnclosedAngleBracketIndex(trimmed: string): number {
+  let depth = 0;
+
+  for (let i = trimmed.length - 1; i >= 0; i -= 1) {
+    const ch = trimmed[i]!;
+    if (ch === '>') {
+      if (trimmed[i - 1] === '=') continue;
+      depth += 1;
+      continue;
+    }
+    if (ch !== '<') continue;
+    if (depth === 0) return i;
+    depth -= 1;
+  }
+
+  return -1;
 }
 
 function isInsideGenericTypeArgument(
@@ -509,8 +611,7 @@ function isInsideGenericTypeArgument(
   importIndex: number,
 ): boolean {
   const trimmed = prefix.trimEnd();
-  if (!/[A-Za-z_$][\w$]*<$/.test(trimmed)) return false;
-  if (trimmed.lastIndexOf('<') < trimmed.lastIndexOf('>')) return false;
+  if (!hasUnclosedGenericTypeArgument(trimmed)) return false;
 
   const dynamicImport = readDynamicImportSpecifierForTypeContext(
     content,
@@ -600,11 +701,18 @@ function isTypeOnlyImportReferenceUse(
   if (/(?:^|[^.])(?:\bimplements\b|\bkeyof\b)\s*(?:\([^)]*)?$/.test(trimmed)) {
     return true;
   }
+  if (/\bimplements\b[\s\S]*,\s*$/.test(trimmed)) {
+    return true;
+  }
   if (/(?:^|[^.])\bkeyof\s+typeof\s*(?:\([^)]*)?$/.test(trimmed)) {
     return true;
   }
   if (/(?:^|[^.])\btypeof\s*(?:\([^)]*)?$/.test(trimmed)) {
-    return isInsideTypeDeclaration(prefix) || isInsideTypeAnnotation(prefix, content, importIndex, false);
+    return (
+      isInsideGenericTypeArgument(prefix, content, importIndex) ||
+      isInsideTypeDeclaration(prefix) ||
+      isInsideTypeAnnotation(prefix, content, importIndex, false)
+    );
   }
   if (isInsideOpenTypeAssertion(trimmed)) {
     return true;
@@ -646,7 +754,12 @@ function isInsideOpenTypeAssertion(trimmedPrefix: string): boolean {
   const lastComma = suffix.lastIndexOf(',');
   const lastEquals = suffix.lastIndexOf('=');
   const lastArrow = suffix.lastIndexOf('=>');
+  if (hasUnclosedAssertionTypeContainer(suffix)) return lastArrow === -1;
   return lastComma === -1 && lastEquals === -1 && lastArrow === -1;
+}
+
+function hasUnclosedAssertionTypeContainer(suffix: string): boolean {
+  return findUnclosedAngleBracketIndex(suffix) !== -1 || suffix.lastIndexOf('[') > suffix.lastIndexOf(']');
 }
 
 function readDynamicImportSpecifierForTypeContext(
@@ -670,6 +783,13 @@ function stripTrailingTrivia(content: string): string {
 }
 
 function isInsideTypeDeclaration(prefix: string): boolean {
+  if (/(?:^|[;{}\n])\s*(?:type|interface)\s*[:=]\s*(?:await\s+)?$/.test(prefix.trimEnd())) {
+    return false;
+  }
+  if (/}\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*(?:=|\(|\[)|module\.exports\s*=)[\s\S]*$/.test(prefix)) {
+    return false;
+  }
+
   return (
     /(?:^|[;{}\n])\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
     !hasCompletedTypeDeclarationBeforeImport(prefix) &&
@@ -680,7 +800,7 @@ function isInsideTypeDeclaration(prefix: string): boolean {
       prefix,
     ) &&
     !/\}\s*(?:export\s+)?$/.test(prefix) &&
-    !/\}\s*\n\s*(?:export\s+)?(?:void\s*$|\(|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
+    !/\}\s*\n\s*(?:export\s+)?(?:void\s*$|[!~+\-\[(@]|using\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
       prefix,
     )
   );
@@ -693,7 +813,7 @@ function hasCompletedTypeDeclarationBeforeImport(prefix: string): boolean {
   const suffix = prefix.slice(newlineIndex + 1);
   if (
     !/^\s*(?:export\s+)?(?:void\s*)?$/.test(suffix) &&
-    !/^\s*(?:export\s+)?(?:default\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
+    !/^\s*(?:export\s+)?(?:default\b|[!~+\-\[(@]|using\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\(|\s*$)|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(
       suffix,
     )
   ) {
@@ -712,7 +832,7 @@ function isInsideTypeAnnotation(
 ): boolean {
   if (isTernaryBranch && !isInsideConditionalType(prefix)) return false;
 
-  const annotationIndex = prefix.lastIndexOf(':');
+  const annotationIndex = findActiveTypeAnnotationIndex(prefix);
   if (annotationIndex === -1) return false;
   if (hasCompletedStatementBeforeImport(prefix)) return false;
 
@@ -756,13 +876,13 @@ function isInsideTypeAnnotation(
   if (hasRuntimeAfterClosedTypeContext(annotationSuffix)) return false;
   if (/=>/.test(annotationSuffix)) {
     if (/\)\s*:\s*[^=]*=>\s*$/.test(prefix)) return false;
-    return /^\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*(?:\[\])?)\s*=>\s*$/.test(
+    return /^\s*(?:new\s*)?(?:\([\s\S]*\)|<[^>]*>\s*\([\s\S]*\)|[A-Za-z_$][\w$]*(?:\[\])?)\s*=>\s*$/.test(
       annotationSuffix,
     );
   }
   if (/[=;]/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
-  if (/\n\s*(?:void\s*)?$|\n\s*(?:[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
+  if (/\n\s*(?:void\s*)?$|\n\s*(?:[!~+\-\[(@]|using\b|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|(?:void\s+)?import\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b)/.test(annotationSuffix)) {
     return false;
   }
   if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
@@ -775,12 +895,26 @@ function isInsideTypeAnnotation(
   return !isLikelyObjectLiteralValue(content, importIndex);
 }
 
+function findActiveTypeAnnotationIndex(prefix: string): number {
+  const annotationIndex = prefix.lastIndexOf(':');
+  if (annotationIndex === -1) return -1;
+
+  const annotationSuffix = prefix.slice(annotationIndex + 1);
+  if (!/=>\s*$/.test(annotationSuffix)) return annotationIndex;
+
+  const outerAnnotationIndex = prefix.slice(0, annotationIndex).lastIndexOf(':');
+  if (outerAnnotationIndex === -1) return annotationIndex;
+
+  const outerSuffix = prefix.slice(outerAnnotationIndex + 1);
+  return /=>\s*$/.test(outerSuffix) ? outerAnnotationIndex : annotationIndex;
+}
+
 function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boolean {
   return hasRuntimeAfterClosedTypeContext(prefix.slice(annotationIndex + 1));
 }
 
 function hasRuntimeAfterClosedTypeContext(annotationSuffix: string): boolean {
-  return /}\s*\)?(?:\s*\{\s*(?:return|throw|void|await|yield|case|default)\b|[^\S\n]*\n\s*(?:void\s*$|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
+  return /}\s*\)?(?:\s*\{\s*(?:return|throw|void|await|yield|case|default)\b|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|using\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
     annotationSuffix,
   );
 }

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -780,7 +780,11 @@ function isTypeOnlyImportReferenceUse(
   const openBraceIndex = trimmed.lastIndexOf('{');
   const semicolonIndex = trimmed.lastIndexOf(';');
   const annotationSuffix = trimmed.slice(colonIndex + 1);
-  if (/[=;]/.test(annotationSuffix)) return false;
+  if (/=\s*$/.test(trimmed)) return false;
+  if (/=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*$/.test(trimmed)) {
+    return false;
+  }
+  if (/;/.test(annotationSuffix)) return false;
   return colonIndex > semicolonIndex && !/\{\s*(?:return|throw|void|await|yield|case|default)\b[\s\S]*$/.test(trimmed.slice(openBraceIndex));
 }
 
@@ -985,6 +989,7 @@ function isInsideTypeAnnotation(
 
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (hasRuntimeAfterClosedTypeContext(annotationSuffix)) return false;
+  if (/[=;]/.test(annotationSuffix)) return false;
   if (/=>/.test(annotationSuffix)) {
     if (/\)\s*:\s*[^=]*=>\s*$/.test(prefix)) return false;
     return /^\s*(?:new\s*)?(?:\([\s\S]*\)|<[^>]*>\s*\([\s\S]*\)|[A-Za-z_$][\w$]*(?:\[\])?)\s*=>\s*$/.test(
@@ -1025,7 +1030,7 @@ function hasRuntimeAfterAnnotation(prefix: string, annotationIndex: number): boo
 }
 
 function hasRuntimeAfterClosedTypeContext(annotationSuffix: string): boolean {
-  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|else\b|catch\b|finally\b|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\(|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
+  return /}\s*\)?(?:\s*(?:\{\s*(?:return|throw|void|await|yield|case|default)\b|(?:\.|\[|\(|,|&&|\|\||\?\?|[+\-*/%<>=!&|^?:])\s*)|[^\S\n]*\n\s*(?:void\s*$|[!~+\-\[(@]|else\b|catch\b|finally\b|using\b|try\b|do\b|abstract\s+class\b|namespace\b|enum\b|function\b|async\s+function\b|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*(?:=|\()|await\b|return\b|throw\b|new\b|const\b|let\b|var\b))/.test(
     annotationSuffix,
   );
 }
@@ -1221,8 +1226,9 @@ function readQuotedString(
     if (ch === '\\') {
       const escaped = content[i + 1];
       if (escaped) {
-        value += escaped;
-        i += 1;
+        const decoded = decodeStringEscape(content, i);
+        value += decoded.value;
+        i = decoded.endIndex;
       }
       continue;
     }
@@ -1235,6 +1241,44 @@ function readQuotedString(
   }
 
   return null;
+}
+
+function decodeStringEscape(content: string, slashIndex: number): { value: string; endIndex: number } {
+  const escaped = content[slashIndex + 1];
+  if (!escaped) return { value: '', endIndex: slashIndex };
+
+  if (escaped === 'u') {
+    if (content[slashIndex + 2] === '{') {
+      const closeIndex = content.indexOf('}', slashIndex + 3);
+      const hex = closeIndex === -1 ? '' : content.slice(slashIndex + 3, closeIndex);
+      if (/^[0-9A-Fa-f]{1,6}$/.test(hex)) {
+        return { value: String.fromCodePoint(parseInt(hex, 16)), endIndex: closeIndex };
+      }
+    }
+    const hex = content.slice(slashIndex + 2, slashIndex + 6);
+    if (/^[0-9A-Fa-f]{4}$/.test(hex)) {
+      return { value: String.fromCharCode(parseInt(hex, 16)), endIndex: slashIndex + 5 };
+    }
+  }
+
+  if (escaped === 'x') {
+    const hex = content.slice(slashIndex + 2, slashIndex + 4);
+    if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
+      return { value: String.fromCharCode(parseInt(hex, 16)), endIndex: slashIndex + 3 };
+    }
+  }
+
+  const simpleEscapes: Record<string, string> = {
+    b: '\b',
+    f: '\f',
+    n: '\n',
+    r: '\r',
+    t: '\t',
+    v: '\v',
+    '0': '\0',
+  };
+
+  return { value: simpleEscapes[escaped] ?? escaped, endIndex: slashIndex + 1 };
 }
 
 function readTemplateString(content: string, startIndex: number): TemplateRead {

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -79,7 +79,7 @@ function isLocalImportSpecifier(specifier: string): boolean {
     specifier.startsWith('/') ||
     specifier.startsWith('#') ||
     specifier.startsWith('file:') ||
-    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(specifier) ||
+    (!specifier.startsWith('node:') && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(specifier)) ||
     /^[A-Za-z]:/.test(specifier)
   );
 }
@@ -287,9 +287,10 @@ function isSpreadOperand(content: string, dotIndex: number): boolean {
 }
 
 function endsInsideNestedTypeReference(prefix: string): boolean {
-  if (/(?:\bas\s*|\bsatisfies\s*)$/.test(prefix)) return true;
+  if (/(?:\bas\s*|\bsatisfies\s*)(?:typeof\s*)?$/.test(prefix)) return true;
 
   const trimmed = prefix.trimEnd();
+
   if (
     /(?:,|\bextends\b|=)$/.test(trimmed) &&
     trimmed.lastIndexOf('<') > trimmed.lastIndexOf('>')
@@ -308,10 +309,10 @@ function endsInsideNestedTypeReference(prefix: string): boolean {
 function isInsideTypeDeclaration(prefix: string): boolean {
   return (
     /^\s*(?:export\s+)?(?:declare\s+)?(?:type|interface)\b/.test(prefix) &&
-    !/\n\s*(?:const|let|var|await|return|throw|if|for|while|switch|try|function|class)\b/.test(
+    !/\n\s*(?:export\s+)?(?:const|let|var|await|return|throw|if|for|while|switch|try|function|async\s+function|class)\b/.test(
       prefix,
     ) &&
-    !/\}\s*\n\s*(?:void\s*$|\(|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
+    !/\}\s*\n\s*(?:export\s+)?(?:void\s*$|\(|(?:void\s+)?import\s*\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\()/.test(
       prefix,
     )
   );
@@ -329,6 +330,7 @@ function isInsideTypeAnnotation(
   if (annotationIndex === -1) return false;
 
   const beforeAnnotation = prefix.slice(0, annotationIndex);
+  if (/\bcase\s+[\s\S]*$/.test(beforeAnnotation)) return false;
   if (/:\s*\{[^}]*$/.test(beforeAnnotation)) return true;
 
   const outerAnnotationIndex = beforeAnnotation.lastIndexOf(':');
@@ -346,7 +348,10 @@ function isInsideTypeAnnotation(
   const annotationSuffix = prefix.slice(annotationIndex + 1);
   if (/[=;]/.test(annotationSuffix)) return false;
   if (/^\s*(?:return|throw|void|await)\b/.test(annotationSuffix)) return false;
-  if (/\{[\s\S]*\b(?:return|throw|void|await|case|default)\b/.test(annotationSuffix)) {
+  if (/\{[\s\S]*\b(?:return|throw|void|await|yield|case|default)\b/.test(annotationSuffix)) {
+    return false;
+  }
+  if (/\{[\s\S]*$/.test(annotationSuffix)) {
     return false;
   }
 
@@ -385,9 +390,46 @@ function isLikelyObjectLiteralValue(content: string, importIndex: number): boole
     while (i >= 0 && isIdentifierCharacter(content[i]!)) i -= 1;
   }
 
-  while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
+  i = skipTriviaBackward(content, i);
+
+  if (content[i] === '{') {
+    const beforeBrace = content.slice(0, i).trimEnd();
+    if (/\bclass\s+[A-Za-z_$][\w$]*(?:\s*<[^>{}]*)?$/.test(beforeBrace)) {
+      return false;
+    }
+  }
 
   return content[i] === '{' || content[i] === ',';
+}
+
+function skipTriviaBackward(content: string, index: number): number {
+  let i = index;
+
+  while (i >= 0) {
+    while (i >= 0 && /\s/.test(content[i]!)) i -= 1;
+
+    if (content[i] === '/' && content[i - 1] === '*') {
+      i -= 2;
+      while (i >= 1 && !(content[i - 1] === '/' && content[i] === '*')) i -= 1;
+      i -= 2;
+      continue;
+    }
+
+    if (isInsideLineCommentBackward(content, i)) {
+      while (i >= 0 && content[i] !== '\n') i -= 1;
+      continue;
+    }
+
+    return i;
+  }
+
+  return i;
+}
+
+function isInsideLineCommentBackward(content: string, index: number): boolean {
+  const lineStart = content.lastIndexOf('\n', index) + 1;
+  const commentStart = content.lastIndexOf('//', index);
+  return commentStart >= lineStart;
 }
 
 function skipQuotedKeyBackward(content: string, quoteIndex: number): number {

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -250,6 +250,7 @@ describe('GhostDependencyEvaluator', () => {
       const parenthesizedSatisfies = value satisfies (import('ghost-package').Plugin);
       const objectTypeAssertion = value as { loader: import('ghost-package').Loader };
       const templateTypeAssertion = value as \`\${import('template-assertion-ghost').Name}\`;
+      const commentedTemplateTypeAssertion = value as /* generated */ \`\${import('template-assertion-ghost').Name}\`;
       const tupleAssertion = value as [import('ghost-package').Tuple];
       const tupleAssertionWithComma = value as [string, import('ghost-package').Tuple];
       const tupleSatisfiesWithComma = value satisfies [string, import('ghost-package').Tuple];
@@ -356,7 +357,7 @@ describe('GhostDependencyEvaluator', () => {
       const runtimeTernary = kind === 'extends' ? fallback : import('ternary-ghost');
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
-      const compactLessThan = a<b, y = import('compact-less-than-ghost');
+      const compactLessThan = a<b, y = import('compact-less-than-assignment-ghost');
       const lessThanArgument = load(count < limit, import('less-than-argument-ghost'));
       const compactLessThanArgument = load(a<b, import('compact-comparison-argument-ghost'));
       const compactNamedLessThanArgument = load(count<limit, import('compact-named-comparison-argument-ghost'));
@@ -417,6 +418,8 @@ describe('GhostDependencyEvaluator', () => {
       import('chained-after-type-alias-ghost').then(load);
       const runtimeTypeofProperty = typeof import('runtime-typeof-property-ghost').then;
       const objectTypeKey = { type: import('object-type-key-ghost') };
+      const awaitedTypeNamedObject = { type: await import('awaited-type-named-object-ghost') };
+      const nestedTypeNamedObject = { type: { loader: import('nested-type-named-object-ghost') } };
       await import('zod', { with: { type: await import('nested-type-attribute-ghost') } });
       type DecoratedAfterType = {}
       @dec(import('decorator-after-type-ghost'))
@@ -426,11 +429,13 @@ describe('GhostDependencyEvaluator', () => {
       function objectReturn(): { type: string } { return import('object-return-type-key-ghost'); }
       function templateAfterTypedParam(opts: { path: string }) { return \`\${require('template-after-typed-param-ghost')}\`; }
       const assertedPair = value as Foo, chained = import('chained-after-assertion-ghost').then(load);
+      const as = String.raw; as\`\${require('as-tagged-template-ghost')}\`;
+      const satisfies = String.raw; satisfies\`\${require('satisfies-tagged-template-ghost')}\`;
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(80);
+    expect(result.findings).toHaveLength(85);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -466,6 +471,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('ternary-ghost'),
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),
+        expect.stringContaining('compact-less-than-assignment-ghost'),
         expect.stringContaining('less-than-argument-ghost'),
         expect.stringContaining('compact-comparison-argument-ghost'),
         expect.stringContaining('compact-named-comparison-argument-ghost'),
@@ -508,12 +514,16 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('chained-after-type-alias-ghost'),
         expect.stringContaining('runtime-typeof-property-ghost'),
         expect.stringContaining('object-type-key-ghost'),
+        expect.stringContaining('awaited-type-named-object-ghost'),
+        expect.stringContaining('nested-type-named-object-ghost'),
         expect.stringContaining('nested-type-attribute-ghost'),
         expect.stringContaining('decorator-after-type-ghost'),
         expect.stringContaining('using-after-type-ghost'),
         expect.stringContaining('object-return-type-key-ghost'),
         expect.stringContaining('template-after-typed-param-ghost'),
         expect.stringContaining('chained-after-assertion-ghost'),
+        expect.stringContaining('as-tagged-template-ghost'),
+        expect.stringContaining('satisfies-tagged-template-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -319,6 +319,13 @@ describe('GhostDependencyEvaluator', () => {
       type U = {}
       (async () => import('iife-after-type-ghost'))();
       type V = {}
+      else import('else-after-type-ghost');
+      type W = {}
+      do { import('do-after-type-ghost'); } while (false);
+      type X = {}
+      catch { import('catch-after-type-ghost'); }
+      type Y = {}
+      finally { import('finally-after-type-ghost'); }
       export const exported = await import('export-after-type-ghost');
       type BareDynamic = {}
       ready && import('identifier-led-after-type-ghost');
@@ -402,6 +409,10 @@ describe('GhostDependencyEvaluator', () => {
       try { import('try-after-object-assertion-ghost'); } catch {}
       const cfg9 = value satisfies { dep: string }
       do { import('do-after-object-assertion-ghost'); } while (false);
+      const cfg10 = value as { dep: string }
+      catch { import('catch-after-object-assertion-ghost'); }
+      const cfg11 = value satisfies { dep: string }
+      finally { import('finally-after-object-assertion-ghost'); }
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
@@ -418,6 +429,8 @@ describe('GhostDependencyEvaluator', () => {
       import('chained-after-type-alias-ghost').then(load);
       const runtimeTypeofProperty = typeof import('runtime-typeof-property-ghost').then;
       const objectTypeKey = { type: import('object-type-key-ghost') };
+      const chainedObjectValue = { plugin: import('chained-object-value-ghost').then(load) };
+      const chainedTernaryValue = ready ? fallback : import('chained-ternary-value-ghost').then(load);
       const awaitedTypeNamedObject = { type: await import('awaited-type-named-object-ghost') };
       const nestedTypeNamedObject = { type: { loader: import('nested-type-named-object-ghost') } };
       await import('zod', { with: { type: await import('nested-type-attribute-ghost') } });
@@ -431,11 +444,13 @@ describe('GhostDependencyEvaluator', () => {
       const assertedPair = value as Foo, chained = import('chained-after-assertion-ghost').then(load);
       const as = String.raw; as\`\${require('as-tagged-template-ghost')}\`;
       const satisfies = String.raw; satisfies\`\${require('satisfies-tagged-template-ghost')}\`;
+      const asIdentifier = 1; as; import('as-contextual-identifier-ghost');
+      const satisfiesIdentifier = 1; satisfies; import('satisfies-contextual-identifier-ghost');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(85);
+    expect(result.findings).toHaveLength(96);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -445,6 +460,10 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('logical-or-ghost'),
         expect.stringContaining('void-after-type-ghost'),
         expect.stringContaining('iife-after-type-ghost'),
+        expect.stringContaining('else-after-type-ghost'),
+        expect.stringContaining('do-after-type-ghost'),
+        expect.stringContaining('catch-after-type-ghost'),
+        expect.stringContaining('finally-after-type-ghost'),
         expect.stringContaining('export-after-type-ghost'),
         expect.stringContaining('identifier-led-after-type-ghost'),
         expect.stringContaining('simple-type-after-ghost'),
@@ -504,6 +523,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('comma-after-object-assertion-ghost'),
         expect.stringContaining('try-after-object-assertion-ghost'),
         expect.stringContaining('do-after-object-assertion-ghost'),
+        expect.stringContaining('catch-after-object-assertion-ghost'),
+        expect.stringContaining('finally-after-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),
@@ -514,6 +535,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('chained-after-type-alias-ghost'),
         expect.stringContaining('runtime-typeof-property-ghost'),
         expect.stringContaining('object-type-key-ghost'),
+        expect.stringContaining('chained-object-value-ghost'),
+        expect.stringContaining('chained-ternary-value-ghost'),
         expect.stringContaining('awaited-type-named-object-ghost'),
         expect.stringContaining('nested-type-named-object-ghost'),
         expect.stringContaining('nested-type-attribute-ghost'),
@@ -524,6 +547,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('chained-after-assertion-ghost'),
         expect.stringContaining('as-tagged-template-ghost'),
         expect.stringContaining('satisfies-tagged-template-ghost'),
+        expect.stringContaining('as-contextual-identifier-ghost'),
+        expect.stringContaining('satisfies-contextual-identifier-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -200,7 +200,14 @@ describe('GhostDependencyEvaluator', () => {
       class CommentedPlugin implements /* generated */ import('ghost-package').Plugin {}
       const parenthesizedCast = value as (import('ghost-package').Plugin);
       const parenthesizedSatisfies = value satisfies (import('ghost-package').Plugin);
+      const objectTypeAssertion = value as { loader: import('ghost-package').Loader };
+      const tupleAssertion = value as [import('ghost-package').Tuple];
+      const readonlyAssertion = value as readonly import('ghost-package').Readonly[];
       interface Cfg { name: string; plugin: import('ghost-package').Plugin }
+      type InlineObject = { name: string; plugin: import('ghost-package').Plugin };
+      declare namespace N { type T = import('ghost-package').T }
+      type TemplateKey = \`\${import('ghost-package').Name}\`;
+      const url = 'http://example.invalid'; loader.import('ghost-package');
       const plugin = loader.import('unknown-lib');
       loader./* generated */import('unknown-lib');
       this.#import('private-loader');
@@ -234,22 +241,25 @@ describe('GhostDependencyEvaluator', () => {
       void import('void-simple-type-after-ghost');
       interface NewAfterType {}
       new Loader(import('new-after-type-ghost'));
+      interface SameLine {} import('same-line-interface-ghost');
       async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
       const arrow = (opts: Options) => import('arrow-body-ghost');
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
       loadPlugin: import('label-ghost');
       const parenthesized = await import(('parenthesized-ghost'));
       const angleAsserted = await import(<const>'angle-asserted-ghost');
+      const genericAngleAsserted = await import(<Readonly<string>>'generic-angle-ghost');
       const literalAsserted = await import('literal-asserted-ghost' as const);
       const literalSatisfied = await import('literal-satisfied-ghost' satisfies string);
       const runtimeTernary = kind === 'extends' ? fallback : import('ternary-ghost');
       const lessThanRuntime = count < import('less-than-ghost');
+      const compactLessThanRuntime = count<import('compact-less-than-ghost');
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(23);
+    expect(result.findings).toHaveLength(26);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -270,10 +280,12 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('label-ghost'),
         expect.stringContaining('parenthesized-ghost'),
         expect.stringContaining('angle-asserted-ghost'),
+        expect.stringContaining('generic-angle-ghost'),
         expect.stringContaining('literal-asserted-ghost'),
         expect.stringContaining('literal-satisfied-ghost'),
         expect.stringContaining('ternary-ghost'),
         expect.stringContaining('less-than-ghost'),
+        expect.stringContaining('compact-less-than-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
       ]),
     );

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -282,11 +282,22 @@ describe('GhostDependencyEvaluator', () => {
       void import('void-after-typed-decl-ghost');
       let dep3: SomeType
       import('bare-after-typed-decl-ghost');
+      const cfg = value as { dep: string }
+      void import('after-object-assertion-ghost');
+      const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
+      function typedObjectParam(opts: { path: string }) { return import('object-param-body-ghost'); }
+      const url = 'http://example.invalid'
+      import('chained-after-colon-ghost').then(load);
+      type ChainAfterAlias = Foo
+      import('chained-after-type-alias-ghost').then(load);
+      const runtimeTypeofProperty = typeof import('runtime-typeof-property-ghost').then;
+      function templateAfterTypedParam(opts: { path: string }) { return \`\${require('template-after-typed-param-ghost')}\`; }
+      const assertedPair = value as Foo, chained = import('chained-after-assertion-ghost').then(load);
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(40);
+    expect(result.findings).toHaveLength(48);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -328,6 +339,14 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('tagged-template-ghost'),
         expect.stringContaining('void-after-typed-decl-ghost'),
         expect.stringContaining('bare-after-typed-decl-ghost'),
+        expect.stringContaining('after-object-assertion-ghost'),
+        expect.stringContaining('annotated-arrow-body-ghost'),
+        expect.stringContaining('object-param-body-ghost'),
+        expect.stringContaining('chained-after-colon-ghost'),
+        expect.stringContaining('chained-after-type-alias-ghost'),
+        expect.stringContaining('runtime-typeof-property-ghost'),
+        expect.stringContaining('template-after-typed-param-ghost'),
+        expect.stringContaining('chained-after-assertion-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -198,6 +198,9 @@ describe('GhostDependencyEvaluator', () => {
       class Plugin implements import('ghost-package').Plugin {}
       const commentedCast = value as /* generated */ import('ghost-package').Shape;
       class CommentedPlugin implements /* generated */ import('ghost-package').Plugin {}
+      const parenthesizedCast = value as (import('ghost-package').Plugin);
+      const parenthesizedSatisfies = value satisfies (import('ghost-package').Plugin);
+      interface Cfg { name: string; plugin: import('ghost-package').Plugin }
       const plugin = loader.import('unknown-lib');
       loader./* generated */import('unknown-lib');
       this.#import('private-loader');
@@ -229,19 +232,24 @@ describe('GhostDependencyEvaluator', () => {
       import('simple-type-after-ghost');
       type VoidAlias = string
       void import('void-simple-type-after-ghost');
+      interface NewAfterType {}
+      new Loader(import('new-after-type-ghost'));
       async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
+      const arrow = (opts: Options) => import('arrow-body-ghost');
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
       loadPlugin: import('label-ghost');
       const parenthesized = await import(('parenthesized-ghost'));
+      const angleAsserted = await import(<const>'angle-asserted-ghost');
       const literalAsserted = await import('literal-asserted-ghost' as const);
       const literalSatisfied = await import('literal-satisfied-ghost' satisfies string);
+      const runtimeTernary = kind === 'extends' ? fallback : import('ternary-ghost');
       const lessThanRuntime = count < import('less-than-ghost');
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(19);
+    expect(result.findings).toHaveLength(23);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -255,12 +263,16 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('bare-after-type-ghost'),
         expect.stringContaining('simple-type-after-ghost'),
         expect.stringContaining('void-simple-type-after-ghost'),
+        expect.stringContaining('new-after-type-ghost'),
         expect.stringContaining('awaited-function-ghost'),
+        expect.stringContaining('arrow-body-ghost'),
         expect.stringContaining('switch-case-ghost'),
         expect.stringContaining('label-ghost'),
         expect.stringContaining('parenthesized-ghost'),
+        expect.stringContaining('angle-asserted-ghost'),
         expect.stringContaining('literal-asserted-ghost'),
         expect.stringContaining('literal-satisfied-ghost'),
+        expect.stringContaining('ternary-ghost'),
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
       ]),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -360,6 +360,7 @@ describe('GhostDependencyEvaluator', () => {
       interface Cfg { name: string; plugin: import('ghost-package').Plugin }
       type InlineObject = { name: string; plugin: import('ghost-package').Plugin };
       type NestedInlineObject = { nested: { ok: string }; plugin: typeof import('ghost-package') };
+      export default interface DefaultExportedInterface { plugin: import('ghost-package').Plugin }
       declare namespace N { type T = import('ghost-package').T }
       namespace ExportedTypeNamespace { export type T = import('ghost-package').T }
       type TemplateKey = \`\${import('ghost-package').Name}\`;
@@ -439,6 +440,7 @@ describe('GhostDependencyEvaluator', () => {
       const compactLessThanArgument = load(a<b, import('compact-comparison-argument-ghost'));
       const compactNamedLessThanArgument = load(count<limit, import('compact-named-comparison-argument-ghost'));
       const compactUpperLessThanArgument = load(Foo<Bar, import('compact-uppercase-comparison-argument-ghost'), baz);
+      const compactLessThanComma = foo<import('compact-less-than-comma-ghost'), bar;
       const comparisonArgument = load(count <= limit, import('comparison-argument-ghost'));
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
       const bitwiseAfterAnnotation: number = flags | import('bitwise-after-annotation-ghost');
@@ -462,6 +464,10 @@ describe('GhostDependencyEvaluator', () => {
       void import('void-after-typed-decl-ghost');
       let dep3: SomeType
       import('bare-after-typed-decl-ghost');
+      let dep4: SomeType
+      true && import('true-after-typed-decl-ghost');
+      let dep5: SomeType
+      export default foo(import('export-default-after-typed-decl-ghost'));
       const cfg = value as { dep: string }
       void import('after-object-assertion-ghost');
       const cfg2 = value satisfies { dep: string }
@@ -527,11 +533,12 @@ describe('GhostDependencyEvaluator', () => {
       const satisfies = String.raw; satisfies\`\${require('satisfies-tagged-template-ghost')}\`;
       const asIdentifier = 1; as; import('as-contextual-identifier-ghost');
       const satisfiesIdentifier = 1; satisfies; import('satisfies-contextual-identifier-ghost');
+      const keyofIdentifier = 1; keyof; import('keyof-contextual-identifier-ghost');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(103);
+    expect(result.findings).toHaveLength(107);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -576,6 +583,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('compact-comparison-argument-ghost'),
         expect.stringContaining('compact-named-comparison-argument-ghost'),
         expect.stringContaining('compact-uppercase-comparison-argument-ghost'),
+        expect.stringContaining('compact-less-than-comma-ghost'),
         expect.stringContaining('comparison-argument-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
         expect.stringContaining('bitwise-after-annotation-ghost'),
@@ -594,6 +602,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('tagged-template-ghost'),
         expect.stringContaining('void-after-typed-decl-ghost'),
         expect.stringContaining('bare-after-typed-decl-ghost'),
+        expect.stringContaining('true-after-typed-decl-ghost'),
+        expect.stringContaining('export-default-after-typed-decl-ghost'),
         expect.stringContaining('after-object-assertion-ghost'),
         expect.stringContaining('bare-after-object-assertion-ghost'),
         expect.stringContaining('bare-after-commented-object-assertion-ghost'),
@@ -637,6 +647,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('satisfies-tagged-template-ghost'),
         expect.stringContaining('as-contextual-identifier-ghost'),
         expect.stringContaining('satisfies-contextual-identifier-ghost'),
+        expect.stringContaining('keyof-contextual-identifier-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -136,6 +136,7 @@ describe('GhostDependencyEvaluator', () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `
       const local = await import('./local-plugin.js');
+      const absoluteLocal = await import('/tmp/generated/plugin.mjs');
       const fs = await import('node:fs/promises');
     `;
     const result = await evaluator.evaluate(createInput(content));
@@ -170,6 +171,10 @@ describe('GhostDependencyEvaluator', () => {
       type Ghost = import('ghost-package').Ghost;
       type MultilineGhost =
         import('ghost-package').Ghost;
+      type GhostShape = { dep: import('ghost-package').Ghost };
+      type ConditionalGhost<T> = T extends true
+        ? import('ghost-package').Ghost
+        : import('another-ghost').Ghost;
       type GhostModule = typeof import('ghost-package');
       const plugin = loader.import('unknown-lib');
       this.#import('private-loader');
@@ -184,6 +189,8 @@ describe('GhostDependencyEvaluator', () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `
       const loaders = { plugin: import('ghost-package') };
+      const nestedLoaders = { opts: {}, plugin: import('nested-ghost') };
+      const spreadLoader = { ...import('spread-ghost') };
       const multilineLoaders = {
         plugin: import('another-ghost')
       };
@@ -194,10 +201,12 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(5);
+    expect(result.findings).toHaveLength(7);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
+        expect.stringContaining('nested-ghost'),
+        expect.stringContaining('spread-ghost'),
         expect.stringContaining('another-ghost'),
         expect.stringContaining('missing-branch'),
         expect.stringContaining('runtime-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -137,6 +137,8 @@ describe('GhostDependencyEvaluator', () => {
     const content = `
       const local = await import('./local-plugin.js');
       const absoluteLocal = await import('/tmp/generated/plugin.mjs');
+      const fileUrlLocal = await import('file:///tmp/generated/plugin.mjs');
+      const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
       const fs = await import('node:fs/promises');
     `;
     const result = await evaluator.evaluate(createInput(content));
@@ -176,6 +178,8 @@ describe('GhostDependencyEvaluator', () => {
         ? import('ghost-package').Ghost
         : import('another-ghost').Ghost;
       type GhostModule = typeof import('ghost-package');
+      function typedParam(dep?: import('ghost-package').Ghost) {}
+      class TypedField { dep?: import('ghost-package').Ghost }
       const plugin = loader.import('unknown-lib');
       this.#import('private-loader');
     `;
@@ -195,13 +199,15 @@ describe('GhostDependencyEvaluator', () => {
         plugin: import('another-ghost')
       };
       const selected = ready ? import('zod') : import('missing-branch');
+      type AlreadyDeclared = {}
+      const semicolonlessRuntime = await import('semicolonless-ghost');
       const runtimeTypeof = typeof import('runtime-ghost');
       await import('zod', { with: makeOptions(require('unknown-lib')) });
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(7);
+    expect(result.findings).toHaveLength(8);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
@@ -209,6 +215,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('spread-ghost'),
         expect.stringContaining('another-ghost'),
         expect.stringContaining('missing-branch'),
+        expect.stringContaining('semicolonless-ghost'),
         expect.stringContaining('runtime-ghost'),
         expect.stringContaining('unknown-lib'),
       ]),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -168,12 +168,32 @@ describe('GhostDependencyEvaluator', () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `
       type Ghost = import('ghost-package').Ghost;
+      type GhostModule = typeof import('ghost-package');
       const plugin = loader.import('unknown-lib');
+      this.#import('private-loader');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('pass');
     expect(result.findings).toHaveLength(0);
+  });
+
+  it('detects dynamic imports used as object values and nested option expressions', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `
+      const loaders = { plugin: import('ghost-package') };
+      await import('zod', { with: makeOptions(require('unknown-lib')) });
+    `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('ghost-package'),
+        expect.stringContaining('unknown-lib'),
+      ]),
+    );
   });
 
   it('ignores object-literal import keys', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -143,6 +143,8 @@ describe('GhostDependencyEvaluator', () => {
       const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
       const importMap = await import('#internal/tool');
       const fs = await import('node:fs/promises');
+      const fsWithQuery = await import('node:fs/promises?raw');
+      const pathWithFragment = require('path/posix#worker');
       const escapedKnown = await import('z\\u006fd');
     `;
     const result = await evaluator.evaluate(createInput(content));
@@ -418,6 +420,8 @@ describe('GhostDependencyEvaluator', () => {
       const typedArrowInitializer: (x: string) => Promise<unknown> = (x) => import('typed-arrow-initializer-ghost');
       type TemplateAlias = string
       const templateAfterTypeAlias = \`\${require('template-after-type-alias-ghost')}\`;
+      type ClassFieldTemplateAlias = string
+      class ClassFieldTemplateAfterType { loader = \`\${import('class-field-template-after-type-ghost')}\` }
       const angleAssertedArrow = import(<string & (() => void)>'angle-assertion-arrow-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
@@ -460,7 +464,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(102);
+    expect(result.findings).toHaveLength(103);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -538,6 +542,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('typed-arrow-initializer-ghost'),
         expect.stringContaining('template-after-type-alias-ghost'),
+        expect.stringContaining('class-field-template-after-type-ghost'),
         expect.stringContaining('angle-assertion-arrow-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -204,11 +204,13 @@ describe('GhostDependencyEvaluator', () => {
       const tupleAssertion = value as [import('ghost-package').Tuple];
       const readonlyAssertion = value as readonly import('ghost-package').Readonly[];
       const genericCall = createPlugin<import('ghost-package').Options>();
+      const indexedGenericCall = createPlugin<import('ghost-package')['Options']>();
       const unionAssertion = value as string | import('ghost-package').Shape;
       const functionType = (() => {}) as () => import('ghost-package').Factory;
       const typedFunctionValue: () => import('ghost-package').Factory = () => ({}) as never;
       interface Cfg { name: string; plugin: import('ghost-package').Plugin }
       type InlineObject = { name: string; plugin: import('ghost-package').Plugin };
+      type NestedInlineObject = { nested: { ok: string }; plugin: typeof import('ghost-package') };
       declare namespace N { type T = import('ghost-package').T }
       namespace ExportedTypeNamespace { export type T = import('ghost-package').T }
       type TemplateKey = \`\${import('ghost-package').Name}\`;
@@ -273,11 +275,18 @@ describe('GhostDependencyEvaluator', () => {
       Plugin<import('uppercase-less-than-ghost');
       let dep: SomeType
       load(import('after-typed-var-ghost'));
+      async function loadObject(): { plugin: string } { return import('object-shaped-return-ghost'); }
+      type Done = string
+      sql\`\${require('tagged-template-ghost')}\`;
+      let dep2: SomeType
+      void import('void-after-typed-decl-ghost');
+      let dep3: SomeType
+      import('bare-after-typed-decl-ghost');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(36);
+    expect(result.findings).toHaveLength(40);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -315,6 +324,10 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('keyword-helper-ghost'),
         expect.stringContaining('uppercase-less-than-ghost'),
         expect.stringContaining('after-typed-var-ghost'),
+        expect.stringContaining('object-shaped-return-ghost'),
+        expect.stringContaining('tagged-template-ghost'),
+        expect.stringContaining('void-after-typed-decl-ghost'),
+        expect.stringContaining('bare-after-typed-decl-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -113,9 +113,31 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('unknown-lib');
   });
 
-  it('continues to explicitly skip dynamic import expressions', async () => {
+  it('detects ghost dependencies in dynamic import expressions', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const plugin = await import('ghost-package');`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('passes known packages in dynamic import expressions', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const schema = await import("zod");`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('ignores relative and node built-in dynamic import expressions', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `
+      const local = await import('./local-plugin.js');
+      const fs = await import('node:fs/promises');
+    `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('pass');

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -193,6 +193,32 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
+  it('detects runtime imports around TypeScript annotation syntax', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `
+      const cfg: { plugin: import('object-type-ghost').Plugin } = {};
+      async function load(): Promise<unknown> { return import('typed-function-ghost'); }
+      const logicalAnd = ready && import('logical-and-ghost');
+      const logicalOr = fallback || import('logical-or-ghost');
+      type T = {}
+      void import('void-after-type-ghost');
+      switch (kind) { case 'plugin': return import('switch-case-ghost'); }
+    `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(5);
+    expect(result.findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('typed-function-ghost'),
+        expect.stringContaining('logical-and-ghost'),
+        expect.stringContaining('logical-or-ghost'),
+        expect.stringContaining('void-after-type-ghost'),
+        expect.stringContaining('switch-case-ghost'),
+      ]),
+    );
+  });
+
   it('detects dynamic imports used as object values and nested option expressions', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -132,24 +132,22 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
-  it('ignores relative and node built-in dynamic import expressions', async () => {
+  it('ignores relative, URL, and node built-in dynamic import expressions', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
-    it('ignores relative, URL, and node built-in dynamic import expressions', async () => {
-      const evaluator = new GhostDependencyEvaluator(knownPackages);
-      const content = `
-        const local = await import('./local-plugin.js');
-        const absoluteLocal = await import('/tmp/generated/plugin.mjs');
-        const fileUrlLocal = await import('file:///tmp/generated/plugin.mjs');
-        const dataUrl = await import('data:text/javascript,export default 1');
-        const browserUrl = await import('https://cdn.example.test/plugin.mjs');
-        const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
-        const fs = await import('node:fs/promises');
-      `;
-      const result = await evaluator.evaluate(createInput(content));
+    const content = `
+      const local = await import('./local-plugin.js');
+      const absoluteLocal = await import('/tmp/generated/plugin.mjs');
+      const fileUrlLocal = await import('file:///tmp/generated/plugin.mjs');
+      const dataUrl = await import('data:text/javascript,export default 1');
+      const browserUrl = await import('https://cdn.example.test/plugin.mjs');
+      const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
+      const fs = await import('node:fs/promises');
+    `;
+    const result = await evaluator.evaluate(createInput(content));
 
-      expect(result.verdict).toBe('pass');
-      expect(result.findings).toHaveLength(0);
-    });
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
 
   it('detects dynamic import expressions with comments and import attributes', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
@@ -160,7 +158,6 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
-
   it('detects no-substitution template literal dynamic imports', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = 'const plugin = await import(`ghost-package`);';

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -134,18 +134,22 @@ describe('GhostDependencyEvaluator', () => {
 
   it('ignores relative and node built-in dynamic import expressions', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
-    const content = `
-      const local = await import('./local-plugin.js');
-      const absoluteLocal = await import('/tmp/generated/plugin.mjs');
-      const fileUrlLocal = await import('file:///tmp/generated/plugin.mjs');
-      const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
-      const fs = await import('node:fs/promises');
-    `;
-    const result = await evaluator.evaluate(createInput(content));
+    it('ignores relative, URL, and node built-in dynamic import expressions', async () => {
+      const evaluator = new GhostDependencyEvaluator(knownPackages);
+      const content = `
+        const local = await import('./local-plugin.js');
+        const absoluteLocal = await import('/tmp/generated/plugin.mjs');
+        const fileUrlLocal = await import('file:///tmp/generated/plugin.mjs');
+        const dataUrl = await import('data:text/javascript,export default 1');
+        const browserUrl = await import('https://cdn.example.test/plugin.mjs');
+        const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
+        const fs = await import('node:fs/promises');
+      `;
+      const result = await evaluator.evaluate(createInput(content));
 
-    expect(result.verdict).toBe('pass');
-    expect(result.findings).toHaveLength(0);
-  });
+      expect(result.verdict).toBe('pass');
+      expect(result.findings).toHaveLength(0);
+    });
 
   it('detects dynamic import expressions with comments and import attributes', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
@@ -178,6 +182,8 @@ describe('GhostDependencyEvaluator', () => {
         ? import('ghost-package').Ghost
         : import('another-ghost').Ghost;
       type GhostModule = typeof import('ghost-package');
+      const p: Promise<import('ghost-package').Ghost> = Promise.resolve({} as never);
+      const cast = value as import('ghost-package').Ghost;
       function typedParam(dep?: import('ghost-package').Ghost) {}
       class TypedField { dep?: import('ghost-package').Ghost }
       const plugin = loader.import('unknown-lib');
@@ -201,13 +207,18 @@ describe('GhostDependencyEvaluator', () => {
       const selected = ready ? import('zod') : import('missing-branch');
       type AlreadyDeclared = {}
       const semicolonlessRuntime = await import('semicolonless-ghost');
+      interface PreviousDeclaration {}
+      load(import('post-interface-ghost'));
       const runtimeTypeof = typeof import('runtime-ghost');
       await import('zod', { with: makeOptions(require('unknown-lib')) });
+      const quoted = { 'plugin': import('quoted-key-ghost') };
+      const numeric = { 1: import('numeric-key-ghost') };
+      const computed = { [pluginName]: import('computed-key-ghost') };
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(8);
+    expect(result.findings).toHaveLength(12);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
@@ -216,8 +227,12 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('another-ghost'),
         expect.stringContaining('missing-branch'),
         expect.stringContaining('semicolonless-ghost'),
+        expect.stringContaining('post-interface-ghost'),
         expect.stringContaining('runtime-ghost'),
         expect.stringContaining('unknown-lib'),
+        expect.stringContaining('quoted-key-ghost'),
+        expect.stringContaining('numeric-key-ghost'),
+        expect.stringContaining('computed-key-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -244,13 +244,14 @@ describe('GhostDependencyEvaluator', () => {
       "const deps = [a<b, import('array-comparison-ghost')];\n" +
       "return a<b, import('return-comparison-ghost');\n" +
       "load('https://example.invalid', import('colon-string-ghost'));\n" +
-      "const el = <div>import('jsx-text-ghost'){import('jsx-expression-ghost')}</div>;\n" +
+      "const el = <div>import('jsx-text-ghost'){(foo({}), import('jsx-expression-ghost'))}</div>;\n" +
+      "const taggy = '<B>'; import('tag-string-ghost'); const close = '</B>';\n" +
       "await import('z\\\n" +
       "od');";
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(5);
+    expect(result.findings).toHaveLength(6);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('string-angle-ghost'),
@@ -258,11 +259,30 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('return-comparison-ghost'),
         expect.stringContaining('colon-string-ghost'),
         expect.stringContaining('jsx-expression-ghost'),
+        expect.stringContaining('tag-string-ghost'),
       ]),
     );
     expect(result.findings.map((finding) => finding.message)).not.toEqual(
       expect.arrayContaining([expect.stringContaining('jsx-text-ghost')]),
     );
+  });
+
+  it('handles template type and malformed escape Codex regressions', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const typeOnly = await evaluator.evaluate(
+      createInput(
+        "type Mapped<T> = { [K in `${import('mapped-key-ghost').Name}`]: T };\n" +
+          "type Conditional<T> = T extends `${import('conditional-template-ghost').Name}` ? true : false;",
+      ),
+    );
+    const malformedEscape = await evaluator.evaluate(
+      createInput("const plugin = await import('\\u{FFFFFF}');"),
+    );
+
+    expect(typeOnly.verdict).toBe('pass');
+    expect(typeOnly.findings).toHaveLength(0);
+    expect(malformedEscape.verdict).toBe('fail');
+    expect(malformedEscape.findings).toHaveLength(1);
   });
 
   it('ignores method calls and TypeScript import types', async () => {

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -168,6 +168,8 @@ describe('GhostDependencyEvaluator', () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `
       type Ghost = import('ghost-package').Ghost;
+      type MultilineGhost =
+        import('ghost-package').Ghost;
       type GhostModule = typeof import('ghost-package');
       const plugin = loader.import('unknown-lib');
       this.#import('private-loader');
@@ -182,15 +184,23 @@ describe('GhostDependencyEvaluator', () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `
       const loaders = { plugin: import('ghost-package') };
+      const multilineLoaders = {
+        plugin: import('another-ghost')
+      };
+      const selected = ready ? import('zod') : import('missing-branch');
+      const runtimeTypeof = typeof import('runtime-ghost');
       await import('zod', { with: makeOptions(require('unknown-lib')) });
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(2);
+    expect(result.findings).toHaveLength(5);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
+        expect.stringContaining('another-ghost'),
+        expect.stringContaining('missing-branch'),
+        expect.stringContaining('runtime-ghost'),
         expect.stringContaining('unknown-lib'),
       ]),
     );

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -210,7 +210,9 @@ describe('GhostDependencyEvaluator', () => {
       interface Cfg { name: string; plugin: import('ghost-package').Plugin }
       type InlineObject = { name: string; plugin: import('ghost-package').Plugin };
       declare namespace N { type T = import('ghost-package').T }
+      namespace ExportedTypeNamespace { export type T = import('ghost-package').T }
       type TemplateKey = \`\${import('ghost-package').Name}\`;
+      type NestedTemplateKey = \`\${\`\${string}\`} \${import('ghost-package').Name}\`;
       const url = 'http://example.invalid'; loader.import('ghost-package');
       const plugin = loader.import('unknown-lib');
       loader./* generated */import('unknown-lib');
@@ -260,12 +262,14 @@ describe('GhostDependencyEvaluator', () => {
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
+      const bitwiseAfterAnnotation: number = flags | import('bitwise-after-annotation-ghost');
       const chainedAfterTypeValue = import('chained-type-value-ghost').then(load);
       type DoneAlias = string
       load(import('after-type-alias-call-ghost'));
       const typeNamedObject = { type: import('type-named-object-ghost') };
       class TypeNamedField { type = import('type-named-field-ghost') }
       schema.as(import('as-call-ghost'));
+      as(import('keyword-helper-ghost'));
       Plugin<import('uppercase-less-than-ghost');
       let dep: SomeType
       load(import('after-typed-var-ghost'));
@@ -273,7 +277,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(34);
+    expect(result.findings).toHaveLength(36);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -302,11 +306,13 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
+        expect.stringContaining('bitwise-after-annotation-ghost'),
         expect.stringContaining('chained-type-value-ghost'),
         expect.stringContaining('after-type-alias-call-ghost'),
         expect.stringContaining('type-named-object-ghost'),
         expect.stringContaining('type-named-field-ghost'),
         expect.stringContaining('as-call-ghost'),
+        expect.stringContaining('keyword-helper-ghost'),
         expect.stringContaining('uppercase-less-than-ghost'),
         expect.stringContaining('after-typed-var-ghost'),
       ]),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -190,6 +190,9 @@ describe('GhostDependencyEvaluator', () => {
       const cast = value as import('ghost-package').Ghost;
       function typedParam(dep?: import('ghost-package').Ghost) {}
       class TypedField { dep?: import('ghost-package').Ghost }
+      class RequiredTypedField { dep: import('ghost-package').Ghost }
+      const typeofCast = value as typeof import('ghost-package');
+      const typeofSatisfies = value satisfies typeof import('ghost-package');
       const plugin = loader.import('unknown-lib');
       this.#import('private-loader');
     `;
@@ -204,26 +207,33 @@ describe('GhostDependencyEvaluator', () => {
     const content = `
       const cfg: { plugin: import('object-type-ghost').Plugin } = {};
       async function load(): Promise<unknown> { return import('typed-function-ghost'); }
+      async function bare(): Promise<void> { import('bare-function-ghost'); }
+      function* yielded(): Generator { yield import('yielded-function-ghost'); }
       const logicalAnd = ready && import('logical-and-ghost');
       const logicalOr = fallback || import('logical-or-ghost');
       type T = {}
       void import('void-after-type-ghost');
       type U = {}
       (async () => import('iife-after-type-ghost'))();
+      type V = {}
+      export const exported = await import('export-after-type-ghost');
       async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(7);
+    expect(result.findings).toHaveLength(10);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
+        expect.stringContaining('bare-function-ghost'),
+        expect.stringContaining('yielded-function-ghost'),
         expect.stringContaining('logical-and-ghost'),
         expect.stringContaining('logical-or-ghost'),
         expect.stringContaining('void-after-type-ghost'),
         expect.stringContaining('iife-after-type-ghost'),
+        expect.stringContaining('export-after-type-ghost'),
         expect.stringContaining('awaited-function-ghost'),
         expect.stringContaining('switch-case-ghost'),
       ]),
@@ -249,11 +259,13 @@ describe('GhostDependencyEvaluator', () => {
       const quoted = { 'plugin': import('quoted-key-ghost') };
       const numeric = { 1: import('numeric-key-ghost') };
       const computed = { [pluginName]: import('computed-key-ghost') };
+      const commented = { /* generated */ plugin: import('commented-key-ghost') };
+      const invalidNode = await import('node:not-a-real-builtin');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(12);
+    expect(result.findings).toHaveLength(14);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
@@ -268,6 +280,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('quoted-key-ghost'),
         expect.stringContaining('numeric-key-ghost'),
         expect.stringContaining('computed-key-ghost'),
+        expect.stringContaining('commented-key-ghost'),
+        expect.stringContaining('node:not-a-real-builtin'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -181,7 +181,7 @@ describe('GhostDependencyEvaluator', () => {
   it('checks external package URL specifiers', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const known = await evaluator.evaluate(
-      createInput(`await import('npm:zod@3.24.0'); import path from 'jsr:@franken/brain@1';`),
+      createInput(`await import('npm:zod@3.24.0'); import path from 'jsr:@franken/brain@1'; await import('zod?raw'); await import('@franken/brain#worker');`),
     );
     const unknown = await evaluator.evaluate(
       createInput(`import helper from 'npm:ghost-package/subpath';`),
@@ -267,6 +267,7 @@ describe('GhostDependencyEvaluator', () => {
       type SemicolonLiteral = ";" | import('ghost-package').T;
       function typeofGeneric<T extends typeof import('ghost-package')>() {}
       const typeofCall = createPlugin<typeof import('ghost-package')>();
+      const typeofImportAttributes = createPlugin<typeof import('ghost-package', { with: { 'resolution-mode': 'import' } })>();
       const ambientModule = declare module "ambient" { export type T = import('ghost-package').T };
       declare global { type GlobalGhost = import('ghost-package').T }
       declare module "nested-ambient" {
@@ -319,7 +320,7 @@ describe('GhostDependencyEvaluator', () => {
       type V = {}
       export const exported = await import('export-after-type-ghost');
       type BareDynamic = {}
-      import('bare-after-type-ghost');
+      ready && import('identifier-led-after-type-ghost');
       type SimpleAlias = string
       import('simple-type-after-ghost');
       type VoidAlias = string
@@ -440,7 +441,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('void-after-type-ghost'),
         expect.stringContaining('iife-after-type-ghost'),
         expect.stringContaining('export-after-type-ghost'),
-        expect.stringContaining('bare-after-type-ghost'),
+        expect.stringContaining('identifier-led-after-type-ghost'),
         expect.stringContaining('simple-type-after-ghost'),
         expect.stringContaining('void-simple-type-after-ghost'),
         expect.stringContaining('punctuation-array-after-type-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -203,6 +203,10 @@ describe('GhostDependencyEvaluator', () => {
       const objectTypeAssertion = value as { loader: import('ghost-package').Loader };
       const tupleAssertion = value as [import('ghost-package').Tuple];
       const readonlyAssertion = value as readonly import('ghost-package').Readonly[];
+      const genericCall = createPlugin<import('ghost-package').Options>();
+      const unionAssertion = value as string | import('ghost-package').Shape;
+      const functionType = (() => {}) as () => import('ghost-package').Factory;
+      const typedFunctionValue: () => import('ghost-package').Factory = () => ({}) as never;
       interface Cfg { name: string; plugin: import('ghost-package').Plugin }
       type InlineObject = { name: string; plugin: import('ghost-package').Plugin };
       declare namespace N { type T = import('ghost-package').T }
@@ -251,6 +255,7 @@ describe('GhostDependencyEvaluator', () => {
       const genericAngleAsserted = await import(<Readonly<string>>'generic-angle-ghost');
       const literalAsserted = await import('literal-asserted-ghost' as const);
       const literalSatisfied = await import('literal-satisfied-ghost' satisfies string);
+      const nonNullAsserted = await import('non-null-asserted-ghost'!);
       const runtimeTernary = kind === 'extends' ? fallback : import('ternary-ghost');
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
@@ -259,7 +264,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(26);
+    expect(result.findings).toHaveLength(27);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -283,6 +288,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('generic-angle-ghost'),
         expect.stringContaining('literal-asserted-ghost'),
         expect.stringContaining('literal-satisfied-ghost'),
+        expect.stringContaining('non-null-asserted-ghost'),
         expect.stringContaining('ternary-ghost'),
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -160,6 +160,24 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('balances TypeScript assertions inside dynamic import arguments', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `
+      const plugin = await import(('ghost-package' as Record<string, unknown>));
+      const other = await import(('another-ghost' satisfies Record<string, unknown>));
+    `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('ghost-package'),
+        expect.stringContaining('another-ghost'),
+      ]),
+    );
+  });
+
   it('checks external package URL specifiers', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const known = await evaluator.evaluate(
@@ -168,12 +186,23 @@ describe('GhostDependencyEvaluator', () => {
     const unknown = await evaluator.evaluate(
       createInput(`import helper from 'npm:ghost-package/subpath';`),
     );
+    const nonPackageUrl = await evaluator.evaluate(
+      createInput(`await import('zod@999'); import brain from '@franken/brain@1';`),
+    );
 
     expect(known.verdict).toBe('pass');
     expect(known.findings).toHaveLength(0);
     expect(unknown.verdict).toBe('fail');
     expect(unknown.findings).toHaveLength(1);
     expect(unknown.findings[0]!.message).toContain('ghost-package');
+    expect(nonPackageUrl.verdict).toBe('fail');
+    expect(nonPackageUrl.findings).toHaveLength(2);
+    expect(nonPackageUrl.findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('zod@999'),
+        expect.stringContaining('@franken/brain@1'),
+      ]),
+    );
   });
 
   it('detects no-substitution template literal dynamic imports', async () => {
@@ -359,6 +388,9 @@ describe('GhostDependencyEvaluator', () => {
       [import('punctuation-array-after-assertion-ghost')].forEach(load);
       const cfg5 = value satisfies { dep: string }
       !import('punctuation-bang-after-assertion-ghost');
+      (value as { dep: string }).load(import('method-after-object-assertion-ghost'));
+      (value as { dep: string }) && import('logical-after-object-assertion-ghost');
+      const cfg6 = value as { dep: string }, cfg7 = import('comma-after-object-assertion-ghost');
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
@@ -388,7 +420,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(73);
+    expect(result.findings).toHaveLength(76);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -449,6 +481,9 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('bare-after-commented-object-assertion-ghost'),
         expect.stringContaining('punctuation-array-after-assertion-ghost'),
         expect.stringContaining('punctuation-bang-after-assertion-ghost'),
+        expect.stringContaining('method-after-object-assertion-ghost'),
+        expect.stringContaining('logical-after-object-assertion-ghost'),
+        expect.stringContaining('comma-after-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -416,6 +416,9 @@ describe('GhostDependencyEvaluator', () => {
       finally { import('finally-after-object-assertion-ghost'); }
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
       const typedArrowInitializer: (x: string) => Promise<unknown> = (x) => import('typed-arrow-initializer-ghost');
+      type TemplateAlias = string
+      const templateAfterTypeAlias = \`\${require('template-after-type-alias-ghost')}\`;
+      const angleAssertedArrow = import(<string & (() => void)>'angle-assertion-arrow-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
       type DefaultExportExpressionAlias = string
@@ -431,6 +434,7 @@ describe('GhostDependencyEvaluator', () => {
       import('chained-after-type-alias-ghost').then(load);
       const runtimeTypeofProperty = typeof import('runtime-typeof-property-ghost').then;
       const objectTypeKey = { type: import('object-type-key-ghost') };
+      const typeOptionBeforeLoader = { type: 'json', loader: import('type-option-loader-ghost') };
       const chainedObjectValue = { plugin: import('chained-object-value-ghost').then(load) };
       const chainedTernaryValue = ready ? fallback : import('chained-ternary-value-ghost').then(load);
       const awaitedTypeNamedObject = { type: await import('awaited-type-named-object-ghost') };
@@ -456,7 +460,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(99);
+    expect(result.findings).toHaveLength(102);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -533,6 +537,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('finally-after-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('typed-arrow-initializer-ghost'),
+        expect.stringContaining('template-after-type-alias-ghost'),
+        expect.stringContaining('angle-assertion-arrow-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),
         expect.stringContaining('module-exports-after-type-ghost'),
@@ -542,6 +548,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('chained-after-type-alias-ghost'),
         expect.stringContaining('runtime-typeof-property-ghost'),
         expect.stringContaining('object-type-key-ghost'),
+        expect.stringContaining('type-option-loader-ghost'),
         expect.stringContaining('chained-object-value-ghost'),
         expect.stringContaining('chained-ternary-value-ghost'),
         expect.stringContaining('awaited-type-named-object-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -376,6 +376,11 @@ describe('GhostDependencyEvaluator', () => {
       const runtimeTypeofProperty = typeof import('runtime-typeof-property-ghost').then;
       const objectTypeKey = { type: import('object-type-key-ghost') };
       await import('zod', { with: { type: await import('nested-type-attribute-ghost') } });
+      type DecoratedAfterType = {}
+      @dec(import('decorator-after-type-ghost'))
+      class DecoratedAfterTypeClass {}
+      type UsingAfterType = {}
+      using dep = import('using-after-type-ghost');
       function objectReturn(): { type: string } { return import('object-return-type-key-ghost'); }
       function templateAfterTypedParam(opts: { path: string }) { return \`\${require('template-after-typed-param-ghost')}\`; }
       const assertedPair = value as Foo, chained = import('chained-after-assertion-ghost').then(load);
@@ -455,6 +460,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('runtime-typeof-property-ghost'),
         expect.stringContaining('object-type-key-ghost'),
         expect.stringContaining('nested-type-attribute-ghost'),
+        expect.stringContaining('decorator-after-type-ghost'),
+        expect.stringContaining('using-after-type-ghost'),
         expect.stringContaining('object-return-type-key-ghost'),
         expect.stringContaining('template-after-typed-param-ghost'),
         expect.stringContaining('chained-after-assertion-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -193,6 +193,9 @@ describe('GhostDependencyEvaluator', () => {
       class RequiredTypedField { dep: import('ghost-package').Ghost }
       const typeofCast = value as typeof import('ghost-package');
       const typeofSatisfies = value satisfies typeof import('ghost-package');
+      const keyofCast = value as keyof import('ghost-package').Shape;
+      function keyed<T extends keyof typeof import('ghost-package')>() {}
+      class Plugin implements import('ghost-package').Plugin {}
       const plugin = loader.import('unknown-lib');
       this.#import('private-loader');
     `;
@@ -217,13 +220,16 @@ describe('GhostDependencyEvaluator', () => {
       (async () => import('iife-after-type-ghost'))();
       type V = {}
       export const exported = await import('export-after-type-ghost');
+      type BareDynamic = {}
+      import('bare-after-type-ghost');
       async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
+      const parenthesized = await import(('parenthesized-ghost'));
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(10);
+    expect(result.findings).toHaveLength(12);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -234,8 +240,10 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('void-after-type-ghost'),
         expect.stringContaining('iife-after-type-ghost'),
         expect.stringContaining('export-after-type-ghost'),
+        expect.stringContaining('bare-after-type-ghost'),
         expect.stringContaining('awaited-function-ghost'),
         expect.stringContaining('switch-case-ghost'),
+        expect.stringContaining('parenthesized-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -159,6 +159,23 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
+
+  it('checks external package URL specifiers', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const known = await evaluator.evaluate(
+      createInput(`await import('npm:zod@3.24.0'); import path from 'jsr:@franken/brain@1';`),
+    );
+    const unknown = await evaluator.evaluate(
+      createInput(`import helper from 'npm:ghost-package/subpath';`),
+    );
+
+    expect(known.verdict).toBe('pass');
+    expect(known.findings).toHaveLength(0);
+    expect(unknown.verdict).toBe('fail');
+    expect(unknown.findings).toHaveLength(1);
+    expect(unknown.findings[0]!.message).toContain('ghost-package');
+  });
+
   it('detects no-substitution template literal dynamic imports', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = 'const plugin = await import(`ghost-package`);';
@@ -196,18 +213,30 @@ describe('GhostDependencyEvaluator', () => {
       const keyofCast = value as keyof import('ghost-package').Shape;
       function keyed<T extends keyof typeof import('ghost-package')>() {}
       class Plugin implements import('ghost-package').Plugin {}
+      class MultiPlugin implements KnownPlugin, import('ghost-package').Plugin {}
       const commentedCast = value as /* generated */ import('ghost-package').Shape;
+      const angleImportAssertion = <import('ghost-package').Shape>value;
       class CommentedPlugin implements /* generated */ import('ghost-package').Plugin {}
       const parenthesizedCast = value as (import('ghost-package').Plugin);
       const parenthesizedSatisfies = value satisfies (import('ghost-package').Plugin);
       const objectTypeAssertion = value as { loader: import('ghost-package').Loader };
       const tupleAssertion = value as [import('ghost-package').Tuple];
+      const tupleAssertionWithComma = value as [string, import('ghost-package').Tuple];
+      const tupleSatisfiesWithComma = value satisfies [string, import('ghost-package').Tuple];
       const readonlyAssertion = value as readonly import('ghost-package').Readonly[];
       const genericCall = createPlugin<import('ghost-package').Options>();
       const indexedGenericCall = createPlugin<import('ghost-package')['Options']>();
       const nonFinalGenericCall = createPlugin<import('ghost-package').Options, Other>();
       const unionGenericCall = createPlugin<import('ghost-package').Options | Other>();
       const nestedGenericCall = createPlugin<Readonly<import('ghost-package').Options>, Other>();
+      const nestedTypeArgument = createPlugin<Foo<Bar>, import('ghost-package').Options>();
+      const functionTypeArgument = createPlugin<() => void, import('ghost-package').Options>();
+      const genericArrow = <T extends import('ghost-package').Options>() => undefined;
+      function f<T extends import('ghost-package').Foo>() {}
+      class C { f<T extends import('ghost-package').Foo>() {} }
+      type SemicolonLiteral = ";" | import('ghost-package').T;
+      function typeofGeneric<T extends typeof import('ghost-package')>() {}
+      const typeofCall = createPlugin<typeof import('ghost-package')>();
       const ambientModule = declare module "ambient" { export type T = import('ghost-package').T };
       declare global { type GlobalGhost = import('ghost-package').T }
       declare module "nested-ambient" {
@@ -221,6 +250,11 @@ describe('GhostDependencyEvaluator', () => {
       const unionAssertion = value as string | import('ghost-package').Shape;
       const functionType = (() => {}) as () => import('ghost-package').Factory;
       const typedFunctionValue: () => import('ghost-package').Factory = () => ({}) as never;
+      const typedParamFunctionValue: (x: string) => import('ghost-package').Factory = () => ({}) as never;
+      const typedConstructorValue: new () => import('ghost-package').Factory = Impl;
+      const typedGenericFunctionValue: <T>() => import('ghost-package').Factory = impl;
+      const typedNestedFunctionValue: (cb: () => void) => import('ghost-package').Factory = impl;
+      const typedImportParamFunctionValue: (x: import('ghost-package').Input) => import('ghost-package').Factory = impl;
       interface Cfg { name: string; plugin: import('ghost-package').Plugin }
       type InlineObject = { name: string; plugin: import('ghost-package').Plugin };
       type NestedInlineObject = { nested: { ok: string }; plugin: typeof import('ghost-package') };
@@ -260,6 +294,15 @@ describe('GhostDependencyEvaluator', () => {
       import('simple-type-after-ghost');
       type VoidAlias = string
       void import('void-simple-type-after-ghost');
+      type PunctuationArrayAlias = {}
+      [import('punctuation-array-after-type-ghost')].forEach(load);
+      type PunctuationBangAlias = {}
+      !import('punctuation-bang-after-type-ghost');
+      type DecoratorAlias = {}
+      @dec(import('decorator-after-type-ghost'))
+      class DecoratedAfterType {}
+      type UsingAlias = {}
+      using dep = import('using-after-type-ghost');
       interface NewAfterType {}
       new Loader(import('new-after-type-ghost'));
       interface SameLine {} import('same-line-interface-ghost');
@@ -278,8 +321,12 @@ describe('GhostDependencyEvaluator', () => {
       const runtimeTernary = kind === 'extends' ? fallback : import('ternary-ghost');
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
-      load(count < limit, import('less-than-argument-ghost'));
-      load(count < limit ? a : b, import('comparison-argument-ghost'));
+      const compactLessThan = a<b, y = import('compact-less-than-ghost');
+      const lessThanArgument = load(count < limit, import('less-than-argument-ghost'));
+      const compactLessThanArgument = load(a<b, import('compact-comparison-argument-ghost'));
+      const compactNamedLessThanArgument = load(count<limit, import('compact-named-comparison-argument-ghost'));
+      const compactUpperLessThanArgument = load(Foo<Bar, import('compact-uppercase-comparison-argument-ghost'), baz);
+      const comparisonArgument = load(count <= limit, import('comparison-argument-ghost'));
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
       const bitwiseAfterAnnotation: number = flags | import('bitwise-after-annotation-ghost');
       const bitwiseObjectValue = { loader: flags | import('bitwise-object-value-ghost') };
@@ -308,24 +355,35 @@ describe('GhostDependencyEvaluator', () => {
       import('bare-after-object-assertion-ghost');
       const cfg3 = value as { dep: string } /* generated */
       import('bare-after-commented-object-assertion-ghost');
+      const cfg4 = value as { dep: string }
+      [import('punctuation-array-after-assertion-ghost')].forEach(load);
+      const cfg5 = value satisfies { dep: string }
+      !import('punctuation-bang-after-assertion-ghost');
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
       type DefaultExportExpressionAlias = string
       export default import('export-default-expression-after-type-ghost');
+      interface ModuleExportsAfterType {}
+      module.exports = { loader: import('module-exports-after-type-ghost') };
+      interface CallAfterType {}
+      foo(import('call-after-type-ghost'));
       function typedObjectParam(opts: { path: string }) { return import('object-param-body-ghost'); }
       const url = 'http://example.invalid'
       import('chained-after-colon-ghost').then(load);
       type ChainAfterAlias = Foo
       import('chained-after-type-alias-ghost').then(load);
       const runtimeTypeofProperty = typeof import('runtime-typeof-property-ghost').then;
+      const objectTypeKey = { type: import('object-type-key-ghost') };
+      await import('zod', { with: { type: await import('nested-type-attribute-ghost') } });
+      function objectReturn(): { type: string } { return import('object-return-type-key-ghost'); }
       function templateAfterTypedParam(opts: { path: string }) { return \`\${require('template-after-typed-param-ghost')}\`; }
       const assertedPair = value as Foo, chained = import('chained-after-assertion-ghost').then(load);
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(59);
+    expect(result.findings).toHaveLength(73);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -339,6 +397,10 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('bare-after-type-ghost'),
         expect.stringContaining('simple-type-after-ghost'),
         expect.stringContaining('void-simple-type-after-ghost'),
+        expect.stringContaining('punctuation-array-after-type-ghost'),
+        expect.stringContaining('punctuation-bang-after-type-ghost'),
+        expect.stringContaining('decorator-after-type-ghost'),
+        expect.stringContaining('using-after-type-ghost'),
         expect.stringContaining('new-after-type-ghost'),
         expect.stringContaining('awaited-function-ghost'),
         expect.stringContaining('arrow-body-ghost'),
@@ -356,6 +418,9 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),
         expect.stringContaining('less-than-argument-ghost'),
+        expect.stringContaining('compact-comparison-argument-ghost'),
+        expect.stringContaining('compact-named-comparison-argument-ghost'),
+        expect.stringContaining('compact-uppercase-comparison-argument-ghost'),
         expect.stringContaining('comparison-argument-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
         expect.stringContaining('bitwise-after-annotation-ghost'),
@@ -377,13 +442,20 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('after-object-assertion-ghost'),
         expect.stringContaining('bare-after-object-assertion-ghost'),
         expect.stringContaining('bare-after-commented-object-assertion-ghost'),
+        expect.stringContaining('punctuation-array-after-assertion-ghost'),
+        expect.stringContaining('punctuation-bang-after-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),
+        expect.stringContaining('module-exports-after-type-ghost'),
+        expect.stringContaining('call-after-type-ghost'),
         expect.stringContaining('object-param-body-ghost'),
         expect.stringContaining('chained-after-colon-ghost'),
         expect.stringContaining('chained-after-type-alias-ghost'),
         expect.stringContaining('runtime-typeof-property-ghost'),
+        expect.stringContaining('object-type-key-ghost'),
+        expect.stringContaining('nested-type-attribute-ghost'),
+        expect.stringContaining('object-return-type-key-ghost'),
         expect.stringContaining('template-after-typed-param-ghost'),
         expect.stringContaining('chained-after-assertion-ghost'),
       ]),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -260,11 +260,20 @@ describe('GhostDependencyEvaluator', () => {
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
+      const chainedAfterTypeValue = import('chained-type-value-ghost').then(load);
+      type DoneAlias = string
+      load(import('after-type-alias-call-ghost'));
+      const typeNamedObject = { type: import('type-named-object-ghost') };
+      class TypeNamedField { type = import('type-named-field-ghost') }
+      schema.as(import('as-call-ghost'));
+      Plugin<import('uppercase-less-than-ghost');
+      let dep: SomeType
+      load(import('after-typed-var-ghost'));
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(27);
+    expect(result.findings).toHaveLength(34);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -293,6 +302,13 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
+        expect.stringContaining('chained-type-value-ghost'),
+        expect.stringContaining('after-type-alias-call-ghost'),
+        expect.stringContaining('type-named-object-ghost'),
+        expect.stringContaining('type-named-field-ghost'),
+        expect.stringContaining('as-call-ghost'),
+        expect.stringContaining('uppercase-less-than-ghost'),
+        expect.stringContaining('after-typed-var-ghost'),
       ]),
     );
   });

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -205,6 +205,8 @@ describe('GhostDependencyEvaluator', () => {
       const readonlyAssertion = value as readonly import('ghost-package').Readonly[];
       const genericCall = createPlugin<import('ghost-package').Options>();
       const indexedGenericCall = createPlugin<import('ghost-package')['Options']>();
+      const nonFinalGenericCall = createPlugin<import('ghost-package').Options, Other>();
+      const unionGenericCall = createPlugin<import('ghost-package').Options | Other>();
       const unionAssertion = value as string | import('ghost-package').Shape;
       const functionType = (() => {}) as () => import('ghost-package').Factory;
       const typedFunctionValue: () => import('ghost-package').Factory = () => ({}) as never;
@@ -255,6 +257,8 @@ describe('GhostDependencyEvaluator', () => {
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
       loadPlugin: import('label-ghost');
       const parenthesized = await import(('parenthesized-ghost'));
+      const parenthesizedAsserted = await import(('parenthesized-asserted-ghost' as const));
+      const nestedParenthesizedNonNull = await import((('nested-parenthesized-non-null-ghost')!));
       const angleAsserted = await import(<const>'angle-asserted-ghost');
       const genericAngleAsserted = await import(<Readonly<string>>'generic-angle-ghost');
       const literalAsserted = await import('literal-asserted-ghost' as const);
@@ -263,9 +267,11 @@ describe('GhostDependencyEvaluator', () => {
       const runtimeTernary = kind === 'extends' ? fallback : import('ternary-ghost');
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
+      load(count < limit, import('less-than-argument-ghost'));
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
       const bitwiseAfterAnnotation: number = flags | import('bitwise-after-annotation-ghost');
       const chainedAfterTypeValue = import('chained-type-value-ghost').then(load);
+      const typedInitializerChain: Promise<unknown> = import('typed-initializer-chain-ghost').then(load);
       type DoneAlias = string
       load(import('after-type-alias-call-ghost'));
       const typeNamedObject = { type: import('type-named-object-ghost') };
@@ -297,7 +303,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(48);
+    expect(result.findings).toHaveLength(52);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -317,6 +323,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('switch-case-ghost'),
         expect.stringContaining('label-ghost'),
         expect.stringContaining('parenthesized-ghost'),
+        expect.stringContaining('parenthesized-asserted-ghost'),
+        expect.stringContaining('nested-parenthesized-non-null-ghost'),
         expect.stringContaining('angle-asserted-ghost'),
         expect.stringContaining('generic-angle-ghost'),
         expect.stringContaining('literal-asserted-ghost'),
@@ -325,9 +333,11 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('ternary-ghost'),
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),
+        expect.stringContaining('less-than-argument-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
         expect.stringContaining('bitwise-after-annotation-ghost'),
         expect.stringContaining('chained-type-value-ghost'),
+        expect.stringContaining('typed-initializer-chain-ghost'),
         expect.stringContaining('after-type-alias-call-ghost'),
         expect.stringContaining('type-named-object-ghost'),
         expect.stringContaining('type-named-field-ghost'),
@@ -371,12 +381,14 @@ describe('GhostDependencyEvaluator', () => {
       const numeric = { 1: import('numeric-key-ghost') };
       const computed = { [pluginName]: import('computed-key-ghost') };
       const commented = { /* generated */ plugin: import('commented-key-ghost') };
+      const nestedOption = { with: { loader: import('nested-option-ghost') } };
+      await import('zod', { with: { type: await import('nested-import-option-ghost') } });
       const invalidNode = await import('node:not-a-real-builtin');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(14);
+    expect(result.findings).toHaveLength(16);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
@@ -392,6 +404,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('numeric-key-ghost'),
         expect.stringContaining('computed-key-ghost'),
         expect.stringContaining('commented-key-ghost'),
+        expect.stringContaining('nested-option-ghost'),
+        expect.stringContaining('nested-import-option-ghost'),
         expect.stringContaining('node:not-a-real-builtin'),
       ]),
     );

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -249,6 +249,7 @@ describe('GhostDependencyEvaluator', () => {
       const parenthesizedCast = value as (import('ghost-package').Plugin);
       const parenthesizedSatisfies = value satisfies (import('ghost-package').Plugin);
       const objectTypeAssertion = value as { loader: import('ghost-package').Loader };
+      const templateTypeAssertion = value as \`\${import('template-assertion-ghost').Name}\`;
       const tupleAssertion = value as [import('ghost-package').Tuple];
       const tupleAssertionWithComma = value as [string, import('ghost-package').Tuple];
       const tupleSatisfiesWithComma = value satisfies [string, import('ghost-package').Tuple];
@@ -335,6 +336,10 @@ describe('GhostDependencyEvaluator', () => {
       interface NewAfterType {}
       new Loader(import('new-after-type-ghost'));
       interface SameLine {} import('same-line-interface-ghost');
+      interface NamespaceMerge {}
+      namespace NamespaceMerge { export const plugin = import('namespace-merge-ghost'); }
+      interface AbstractMerge {}
+      abstract class AbstractRuntime { static plugin = import('abstract-class-ghost'); }
       async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
       const arrow = (opts: Options) => import('arrow-body-ghost');
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
@@ -391,6 +396,10 @@ describe('GhostDependencyEvaluator', () => {
       (value as { dep: string }).load(import('method-after-object-assertion-ghost'));
       (value as { dep: string }) && import('logical-after-object-assertion-ghost');
       const cfg6 = value as { dep: string }, cfg7 = import('comma-after-object-assertion-ghost');
+      const cfg8 = value as { dep: string }
+      try { import('try-after-object-assertion-ghost'); } catch {}
+      const cfg9 = value satisfies { dep: string }
+      do { import('do-after-object-assertion-ghost'); } while (false);
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
@@ -420,7 +429,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(76);
+    expect(result.findings).toHaveLength(80);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -439,6 +448,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('decorator-after-type-ghost'),
         expect.stringContaining('using-after-type-ghost'),
         expect.stringContaining('new-after-type-ghost'),
+        expect.stringContaining('namespace-merge-ghost'),
+        expect.stringContaining('abstract-class-ghost'),
         expect.stringContaining('awaited-function-ghost'),
         expect.stringContaining('arrow-body-ghost'),
         expect.stringContaining('switch-case-ghost'),
@@ -484,6 +495,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('method-after-object-assertion-ghost'),
         expect.stringContaining('logical-after-object-assertion-ghost'),
         expect.stringContaining('comma-after-object-assertion-ghost'),
+        expect.stringContaining('try-after-object-assertion-ghost'),
+        expect.stringContaining('do-after-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -218,6 +218,53 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings[0]!.message).toContain('ghost-package');
   });
 
+  it('decodes escaped no-substitution template import specifiers', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const known = await evaluator.evaluate(
+      createInput(
+        "const templateKnown = await import(`z\\u006fd`);\n" +
+          "const escapedLocal = await import(`\\u002e/local-plugin.js`);",
+      ),
+    );
+    const unknown = await evaluator.evaluate(
+      createInput("const templateUnknown = await import(`gh\\u006fst-package`);"),
+    );
+
+    expect(known.verdict).toBe('pass');
+    expect(known.findings).toHaveLength(0);
+    expect(unknown.verdict).toBe('fail');
+    expect(unknown.findings).toHaveLength(1);
+    expect(unknown.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('handles Codex scanner regression cases without hiding runtime imports', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content =
+      "foo('x<y', import('string-angle-ghost'));\n" +
+      "const deps = [a<b, import('array-comparison-ghost')];\n" +
+      "return a<b, import('return-comparison-ghost');\n" +
+      "load('https://example.invalid', import('colon-string-ghost'));\n" +
+      "const el = <div>import('jsx-text-ghost'){import('jsx-expression-ghost')}</div>;\n" +
+      "await import('z\\\n" +
+      "od');";
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(5);
+    expect(result.findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('string-angle-ghost'),
+        expect.stringContaining('array-comparison-ghost'),
+        expect.stringContaining('return-comparison-ghost'),
+        expect.stringContaining('colon-string-ghost'),
+        expect.stringContaining('jsx-expression-ghost'),
+      ]),
+    );
+    expect(result.findings.map((finding) => finding.message)).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('jsx-text-ghost')]),
+    );
+  });
+
   it('ignores method calls and TypeScript import types', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -207,6 +207,9 @@ describe('GhostDependencyEvaluator', () => {
       const indexedGenericCall = createPlugin<import('ghost-package')['Options']>();
       const nonFinalGenericCall = createPlugin<import('ghost-package').Options, Other>();
       const unionGenericCall = createPlugin<import('ghost-package').Options | Other>();
+      const nestedGenericCall = createPlugin<Readonly<import('ghost-package').Options>, Other>();
+      const ambientModule = declare module "ambient" { export type T = import('ghost-package').T };
+      declare global { type GlobalGhost = import('ghost-package').T }
       const unionAssertion = value as string | import('ghost-package').Shape;
       const functionType = (() => {}) as () => import('ghost-package').Factory;
       const typedFunctionValue: () => import('ghost-package').Factory = () => ({}) as never;
@@ -268,8 +271,10 @@ describe('GhostDependencyEvaluator', () => {
       const lessThanRuntime = count < import('less-than-ghost');
       const compactLessThanRuntime = count<import('compact-less-than-ghost');
       load(count < limit, import('less-than-argument-ghost'));
+      load(count < limit ? a : b, import('comparison-argument-ghost'));
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
       const bitwiseAfterAnnotation: number = flags | import('bitwise-after-annotation-ghost');
+      const bitwiseObjectValue = { loader: flags | import('bitwise-object-value-ghost') };
       const chainedAfterTypeValue = import('chained-type-value-ghost').then(load);
       const typedInitializerChain: Promise<unknown> = import('typed-initializer-chain-ghost').then(load);
       type DoneAlias = string
@@ -290,7 +295,11 @@ describe('GhostDependencyEvaluator', () => {
       import('bare-after-typed-decl-ghost');
       const cfg = value as { dep: string }
       void import('after-object-assertion-ghost');
+      const cfg2 = value satisfies { dep: string }
+      import('bare-after-object-assertion-ghost');
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
+      type DefaultExportAlias = string
+      export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
       function typedObjectParam(opts: { path: string }) { return import('object-param-body-ghost'); }
       const url = 'http://example.invalid'
       import('chained-after-colon-ghost').then(load);
@@ -303,7 +312,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(52);
+    expect(result.findings).toHaveLength(56);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -334,8 +343,10 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('less-than-ghost'),
         expect.stringContaining('compact-less-than-ghost'),
         expect.stringContaining('less-than-argument-ghost'),
+        expect.stringContaining('comparison-argument-ghost'),
         expect.stringContaining('bitwise-or-ghost'),
         expect.stringContaining('bitwise-after-annotation-ghost'),
+        expect.stringContaining('bitwise-object-value-ghost'),
         expect.stringContaining('chained-type-value-ghost'),
         expect.stringContaining('typed-initializer-chain-ghost'),
         expect.stringContaining('after-type-alias-call-ghost'),
@@ -350,7 +361,9 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('void-after-typed-decl-ghost'),
         expect.stringContaining('bare-after-typed-decl-ghost'),
         expect.stringContaining('after-object-assertion-ghost'),
+        expect.stringContaining('bare-after-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
+        expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('object-param-body-ghost'),
         expect.stringContaining('chained-after-colon-ghost'),
         expect.stringContaining('chained-after-type-alias-ghost'),
@@ -383,12 +396,13 @@ describe('GhostDependencyEvaluator', () => {
       const commented = { /* generated */ plugin: import('commented-key-ghost') };
       const nestedOption = { with: { loader: import('nested-option-ghost') } };
       await import('zod', { with: { type: await import('nested-import-option-ghost') } });
+      const commentedValue = { loader /* generated */: import('commented-value-ghost') };
       const invalidNode = await import('node:not-a-real-builtin');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(16);
+    expect(result.findings).toHaveLength(17);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ghost-package'),
@@ -406,6 +420,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('commented-key-ghost'),
         expect.stringContaining('nested-option-ghost'),
         expect.stringContaining('nested-import-option-ghost'),
+        expect.stringContaining('commented-value-ghost'),
         expect.stringContaining('node:not-a-real-builtin'),
       ]),
     );

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -141,6 +141,7 @@ describe('GhostDependencyEvaluator', () => {
       const dataUrl = await import('data:text/javascript,export default 1');
       const browserUrl = await import('https://cdn.example.test/plugin.mjs');
       const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
+      const importMap = await import('#internal/tool');
       const fs = await import('node:fs/promises');
     `;
     const result = await evaluator.evaluate(createInput(content));
@@ -181,6 +182,11 @@ describe('GhostDependencyEvaluator', () => {
       type GhostModule = typeof import('ghost-package');
       const p: Promise<import('ghost-package').Ghost> = Promise.resolve({} as never);
       const unionType: Promise<string | import('ghost-package').Ghost> = Promise.resolve({} as never);
+      const commaType = value as Foo<Bar, import('ghost-package').Ghost>;
+      const multiField: { name: string, plugin: import('ghost-package').Plugin } = { name: 'x' };
+      const conditional: T extends true ? import('ghost-package').Ghost : string = fallback;
+      function generic<T extends import('ghost-package').Ghost>() {}
+      class Box<T = import('ghost-package').Ghost> {}
       const cast = value as import('ghost-package').Ghost;
       function typedParam(dep?: import('ghost-package').Ghost) {}
       class TypedField { dep?: import('ghost-package').Ghost }
@@ -202,18 +208,23 @@ describe('GhostDependencyEvaluator', () => {
       const logicalOr = fallback || import('logical-or-ghost');
       type T = {}
       void import('void-after-type-ghost');
+      type U = {}
+      (async () => import('iife-after-type-ghost'))();
+      async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(5);
+    expect(result.findings).toHaveLength(7);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
         expect.stringContaining('logical-and-ghost'),
         expect.stringContaining('logical-or-ghost'),
         expect.stringContaining('void-after-type-ghost'),
+        expect.stringContaining('iife-after-type-ghost'),
+        expect.stringContaining('awaited-function-ghost'),
         expect.stringContaining('switch-case-ghost'),
       ]),
     );

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -144,6 +144,38 @@ describe('GhostDependencyEvaluator', () => {
     expect(result.findings).toHaveLength(0);
   });
 
+  it('detects dynamic import expressions with comments and import attributes', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `const plugin = await import /* chunk */ ('ghost-package', { with: { type: 'json' } });`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('detects no-substitution template literal dynamic imports', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = 'const plugin = await import(`ghost-package`);';
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.message).toContain('ghost-package');
+  });
+
+  it('ignores method calls and TypeScript import types', async () => {
+    const evaluator = new GhostDependencyEvaluator(knownPackages);
+    const content = `
+      type Ghost = import('ghost-package').Ghost;
+      const plugin = loader.import('unknown-lib');
+    `;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('ignores object-literal import keys', async () => {
     const evaluator = new GhostDependencyEvaluator(knownPackages);
     const content = `const cfg = { import: { from: 'ghost-package' } };`;

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -143,6 +143,7 @@ describe('GhostDependencyEvaluator', () => {
       const windowsLocal = await import('C:\\tmp\\generated\\plugin.mjs');
       const importMap = await import('#internal/tool');
       const fs = await import('node:fs/promises');
+      const escapedKnown = await import('z\\u006fd');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
@@ -414,6 +415,7 @@ describe('GhostDependencyEvaluator', () => {
       const cfg11 = value satisfies { dep: string }
       finally { import('finally-after-object-assertion-ghost'); }
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
+      const typedArrowInitializer: (x: string) => Promise<unknown> = (x) => import('typed-arrow-initializer-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
       type DefaultExportExpressionAlias = string
@@ -442,6 +444,10 @@ describe('GhostDependencyEvaluator', () => {
       function objectReturn(): { type: string } { return import('object-return-type-key-ghost'); }
       function templateAfterTypedParam(opts: { path: string }) { return \`\${require('template-after-typed-param-ghost')}\`; }
       const assertedPair = value as Foo, chained = import('chained-after-assertion-ghost').then(load);
+      const assertedAssignment = value as { dep: string }
+      foo = import('assignment-after-object-assertion-ghost');
+      const assertedFunction = value satisfies { dep: string }
+      function afterAssertion() { return import('function-after-object-assertion-ghost'); }
       const as = String.raw; as\`\${require('as-tagged-template-ghost')}\`;
       const satisfies = String.raw; satisfies\`\${require('satisfies-tagged-template-ghost')}\`;
       const asIdentifier = 1; as; import('as-contextual-identifier-ghost');
@@ -450,7 +456,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(96);
+    expect(result.findings).toHaveLength(99);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -526,6 +532,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('catch-after-object-assertion-ghost'),
         expect.stringContaining('finally-after-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
+        expect.stringContaining('typed-arrow-initializer-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
         expect.stringContaining('export-default-expression-after-type-ghost'),
         expect.stringContaining('module-exports-after-type-ghost'),
@@ -545,6 +552,8 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('object-return-type-key-ghost'),
         expect.stringContaining('template-after-typed-param-ghost'),
         expect.stringContaining('chained-after-assertion-ghost'),
+        expect.stringContaining('assignment-after-object-assertion-ghost'),
+        expect.stringContaining('function-after-object-assertion-ghost'),
         expect.stringContaining('as-tagged-template-ghost'),
         expect.stringContaining('satisfies-tagged-template-ghost'),
         expect.stringContaining('as-contextual-identifier-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -180,6 +180,7 @@ describe('GhostDependencyEvaluator', () => {
         : import('another-ghost').Ghost;
       type GhostModule = typeof import('ghost-package');
       const p: Promise<import('ghost-package').Ghost> = Promise.resolve({} as never);
+      const unionType: Promise<string | import('ghost-package').Ghost> = Promise.resolve({} as never);
       const cast = value as import('ghost-package').Ghost;
       function typedParam(dep?: import('ghost-package').Ghost) {}
       class TypedField { dep?: import('ghost-package').Ghost }

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -210,6 +210,14 @@ describe('GhostDependencyEvaluator', () => {
       const nestedGenericCall = createPlugin<Readonly<import('ghost-package').Options>, Other>();
       const ambientModule = declare module "ambient" { export type T = import('ghost-package').T };
       declare global { type GlobalGhost = import('ghost-package').T }
+      declare module "nested-ambient" {
+        export type AmbientGhost =
+          typeof import('ghost-package');
+      }
+      declare global {
+        export type NestedGlobalGhost =
+          import('ghost-package').T;
+      }
       const unionAssertion = value as string | import('ghost-package').Shape;
       const functionType = (() => {}) as () => import('ghost-package').Factory;
       const typedFunctionValue: () => import('ghost-package').Factory = () => ({}) as never;
@@ -275,6 +283,7 @@ describe('GhostDependencyEvaluator', () => {
       const bitwiseRuntime = flags | import('bitwise-or-ghost');
       const bitwiseAfterAnnotation: number = flags | import('bitwise-after-annotation-ghost');
       const bitwiseObjectValue = { loader: flags | import('bitwise-object-value-ghost') };
+      const commentedBitwiseObjectValue = { loader /* generated */ : flags | import('commented-bitwise-object-value-ghost') };
       const chainedAfterTypeValue = import('chained-type-value-ghost').then(load);
       const typedInitializerChain: Promise<unknown> = import('typed-initializer-chain-ghost').then(load);
       type DoneAlias = string
@@ -297,9 +306,13 @@ describe('GhostDependencyEvaluator', () => {
       void import('after-object-assertion-ghost');
       const cfg2 = value satisfies { dep: string }
       import('bare-after-object-assertion-ghost');
+      const cfg3 = value as { dep: string } /* generated */
+      import('bare-after-commented-object-assertion-ghost');
       const annotatedArrow = (): any => import('annotated-arrow-body-ghost');
       type DefaultExportAlias = string
       export default async function defaultLoader() { return import('export-default-after-type-ghost'); }
+      type DefaultExportExpressionAlias = string
+      export default import('export-default-expression-after-type-ghost');
       function typedObjectParam(opts: { path: string }) { return import('object-param-body-ghost'); }
       const url = 'http://example.invalid'
       import('chained-after-colon-ghost').then(load);
@@ -312,7 +325,7 @@ describe('GhostDependencyEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(56);
+    expect(result.findings).toHaveLength(59);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -347,6 +360,7 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('bitwise-or-ghost'),
         expect.stringContaining('bitwise-after-annotation-ghost'),
         expect.stringContaining('bitwise-object-value-ghost'),
+        expect.stringContaining('commented-bitwise-object-value-ghost'),
         expect.stringContaining('chained-type-value-ghost'),
         expect.stringContaining('typed-initializer-chain-ghost'),
         expect.stringContaining('after-type-alias-call-ghost'),
@@ -362,8 +376,10 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('bare-after-typed-decl-ghost'),
         expect.stringContaining('after-object-assertion-ghost'),
         expect.stringContaining('bare-after-object-assertion-ghost'),
+        expect.stringContaining('bare-after-commented-object-assertion-ghost'),
         expect.stringContaining('annotated-arrow-body-ghost'),
         expect.stringContaining('export-default-after-type-ghost'),
+        expect.stringContaining('export-default-expression-after-type-ghost'),
         expect.stringContaining('object-param-body-ghost'),
         expect.stringContaining('chained-after-colon-ghost'),
         expect.stringContaining('chained-after-type-alias-ghost'),

--- a/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/ghost-dependency.test.ts
@@ -196,7 +196,10 @@ describe('GhostDependencyEvaluator', () => {
       const keyofCast = value as keyof import('ghost-package').Shape;
       function keyed<T extends keyof typeof import('ghost-package')>() {}
       class Plugin implements import('ghost-package').Plugin {}
+      const commentedCast = value as /* generated */ import('ghost-package').Shape;
+      class CommentedPlugin implements /* generated */ import('ghost-package').Plugin {}
       const plugin = loader.import('unknown-lib');
+      loader./* generated */import('unknown-lib');
       this.#import('private-loader');
     `;
     const result = await evaluator.evaluate(createInput(content));
@@ -222,14 +225,23 @@ describe('GhostDependencyEvaluator', () => {
       export const exported = await import('export-after-type-ghost');
       type BareDynamic = {}
       import('bare-after-type-ghost');
+      type SimpleAlias = string
+      import('simple-type-after-ghost');
+      type VoidAlias = string
+      void import('void-simple-type-after-ghost');
       async function awaited(): Promise<void> { await import('awaited-function-ghost'); }
       switch (kind) { case 'plugin': return import('switch-case-ghost'); }
+      loadPlugin: import('label-ghost');
       const parenthesized = await import(('parenthesized-ghost'));
+      const literalAsserted = await import('literal-asserted-ghost' as const);
+      const literalSatisfied = await import('literal-satisfied-ghost' satisfies string);
+      const lessThanRuntime = count < import('less-than-ghost');
+      const bitwiseRuntime = flags | import('bitwise-or-ghost');
     `;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
-    expect(result.findings).toHaveLength(12);
+    expect(result.findings).toHaveLength(19);
     expect(result.findings.map((finding) => finding.message)).toEqual(
       expect.arrayContaining([
         expect.stringContaining('typed-function-ghost'),
@@ -241,9 +253,16 @@ describe('GhostDependencyEvaluator', () => {
         expect.stringContaining('iife-after-type-ghost'),
         expect.stringContaining('export-after-type-ghost'),
         expect.stringContaining('bare-after-type-ghost'),
+        expect.stringContaining('simple-type-after-ghost'),
+        expect.stringContaining('void-simple-type-after-ghost'),
         expect.stringContaining('awaited-function-ghost'),
         expect.stringContaining('switch-case-ghost'),
+        expect.stringContaining('label-ghost'),
         expect.stringContaining('parenthesized-ghost'),
+        expect.stringContaining('literal-asserted-ghost'),
+        expect.stringContaining('literal-satisfied-ghost'),
+        expect.stringContaining('less-than-ghost'),
+        expect.stringContaining('bitwise-or-ghost'),
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- Detect literal dynamic ESM imports in GhostDependencyEvaluator
- Preserve existing ignores for relative paths and Node built-ins
- Add regression coverage for unknown, known, relative, and node: dynamic imports

## Test Plan
- npm test --workspace @franken/critique -- --run tests/unit/evaluators/ghost-dependency.test.ts
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/types && npm run build --workspace @franken/critique

Closes #1238