### PR TITLE
fix(observer): validate LoopDetector numeric options

### DIFF
--- a/packages/franken-observer/src/incident/LoopDetector.test.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.test.ts
@@ -70,6 +70,53 @@ describe('LoopDetector', () => {
     })
   })
 
+  describe('option validation', () => {
+    it.each([
+      ['windowSize', { windowSize: 0 }],
+      ['windowSize', { windowSize: -1 }],
+      ['windowSize', { windowSize: 1.5 }],
+      ['windowSize', { windowSize: Number.NaN }],
+      ['repeatThreshold', { repeatThreshold: 0 }],
+      ['repeatThreshold', { repeatThreshold: -1 }],
+      ['repeatThreshold', { repeatThreshold: 1.5 }],
+      ['repeatThreshold', { repeatThreshold: Number.POSITIVE_INFINITY }],
+      ['historyLimit', { historyLimit: 0 }],
+      ['historyLimit', { historyLimit: -1 }],
+      ['historyLimit', { historyLimit: 1.5 }],
+      ['historyLimit', { historyLimit: Number.NaN }],
+    ])('rejects invalid positive integer option %s=%j', (optionName, options) => {
+      expect(() => new LoopDetector(options)).toThrow(new RangeError(`${optionName} must be a finite positive integer`))
+    })
+
+    it.each([
+      ['maxGapBetweenRepetitions', { maxGapBetweenRepetitions: -1 }],
+      ['maxGapBetweenRepetitions', { maxGapBetweenRepetitions: 1.5 }],
+      ['maxGapBetweenRepetitions', { maxGapBetweenRepetitions: Number.NaN }],
+    ])('rejects invalid non-negative integer option %s=%j', (optionName, options) => {
+      expect(() => new LoopDetector(options)).toThrow(
+        new RangeError(`${optionName} must be a finite non-negative integer`),
+      )
+    })
+
+    it.each([
+      ['similarityThreshold', { similarityThreshold: -0.01 }],
+      ['similarityThreshold', { similarityThreshold: 1.01 }],
+      ['similarityThreshold', { similarityThreshold: Number.NaN }],
+      ['similarityThreshold', { similarityThreshold: Number.POSITIVE_INFINITY }],
+    ])('rejects invalid threshold option %s=%j', (optionName, options) => {
+      expect(() => new LoopDetector(options)).toThrow(new RangeError(`${optionName} must be a finite number between 0 and 1`))
+    })
+
+    it('allows zero maxGapBetweenRepetitions and threshold bounds', () => {
+      expect(() => new LoopDetector({ maxGapBetweenRepetitions: 0, similarityThreshold: 0 })).not.toThrow()
+      expect(() => new LoopDetector({ similarityThreshold: 1 })).not.toThrow()
+    })
+
+    it('rejects windowSize 0 before it can emit an empty detected pattern', () => {
+      expect(() => new LoopDetector({ windowSize: 0, repeatThreshold: 3 })).toThrow(RangeError)
+    })
+  })
+
   describe('varied repetition patterns', () => {
     it('detects fuzzy span-name repetitions with volatile metadata differences', () => {
       const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 3 })

--- a/packages/franken-observer/src/incident/LoopDetector.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.ts
@@ -33,17 +33,45 @@ export class LoopDetector {
   private history: string[] = []
 
   constructor(options: LoopDetectorOptions = {}) {
-    this.windowSize = options.windowSize ?? 3
-    this.repeatThreshold = options.repeatThreshold ?? 3
-    this.similarityThreshold = options.similarityThreshold ?? 0.85
-    this.maxGapBetweenRepetitions = options.maxGapBetweenRepetitions ?? 1
+    this.windowSize = LoopDetector.validatePositiveInteger('windowSize', options.windowSize ?? 3)
+    this.repeatThreshold = LoopDetector.validatePositiveInteger('repeatThreshold', options.repeatThreshold ?? 3)
+    this.similarityThreshold = LoopDetector.validateThreshold('similarityThreshold', options.similarityThreshold ?? 0.85)
+    this.maxGapBetweenRepetitions = LoopDetector.validateNonNegativeInteger(
+      'maxGapBetweenRepetitions',
+      options.maxGapBetweenRepetitions ?? 1,
+    )
+    const configuredHistoryLimit = LoopDetector.validatePositiveInteger('historyLimit', options.historyLimit ?? 100)
     // Never retain fewer spans than a full detection span needs, otherwise
     // check() would trim history below detectLoop()'s minLength gate and no
     // loop could ever be reported for larger window/threshold configurations.
     const spanNeededForDetection =
       this.windowSize * this.repeatThreshold +
       Math.max(0, this.repeatThreshold - 1) * this.maxGapBetweenRepetitions
-    this.historyLimit = Math.max(options.historyLimit ?? 100, spanNeededForDetection)
+    this.historyLimit = Math.max(configuredHistoryLimit, spanNeededForDetection)
+  }
+
+  private static validatePositiveInteger(optionName: string, value: number): number {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+      throw new RangeError(`${optionName} must be a finite positive integer`)
+    }
+
+    return value
+  }
+
+  private static validateNonNegativeInteger(optionName: string, value: number): number {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+      throw new RangeError(`${optionName} must be a finite non-negative integer`)
+    }
+
+    return value
+  }
+
+  private static validateThreshold(optionName: string, value: number): number {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new RangeError(`${optionName} must be a finite number between 0 and 1`)
+    }
+
+    return value
   }
 
   check(spanName: string): LoopDetectionResult {


### PR DESCRIPTION
## Summary
- validate LoopDetector numeric options at construction time
- reject invalid window/repetition/history/gap/threshold values with clear RangeError messages
- add regression coverage for zero, negative, fractional, NaN, and infinite option values

## Test Plan
- [x] `npm --workspace=@franken/observer test -- LoopDetector.test.ts`
- [x] `npm --workspace=@franken/observer test`
- [x] `npm --workspace=@franken/types run build && npm --workspace=@franken/observer run typecheck && npm --workspace=@franken/observer run build`

Closes #1232
