### PR TITLE
fix(observer): validate persisted audit trail shape

### DIFF
--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -122,6 +122,11 @@ describe('AuditTrail', () => {
     expect(() => AuditTrail.fromJSON([event])).toThrow(/events\[0\]: timestamp must be an ISO timestamp/i);
   });
 
+  it('fromJSON rejects impossible timestamp dates', () => {
+    const event = { ...createAuditEvent('a', {}, { phase: 'p', provider: 'pr' }), timestamp: '2026-02-31T00:00:00.000Z' };
+    expect(() => AuditTrail.fromJSON([event])).toThrow(/events\[0\]: timestamp must be an ISO timestamp/i);
+  });
+
   it('verify() passes with correct hashes', () => {
     const trail = new AuditTrail();
     const event = createAuditEvent('test', {}, { phase: 'p', provider: 'pr', input: 'hello' });

--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -96,12 +96,30 @@ describe('AuditTrail', () => {
     expect(restored.getAll()).toEqual(json);
   });
 
+  it('toJSON normalizes undefined payloads before persistence', () => {
+    const trail = new AuditTrail();
+    trail.append(createAuditEvent('empty.payload', undefined, { phase: 'p', provider: 'pr' }));
+
+    expect(trail.toJSON()[0]!.payload).toBeNull();
+    expect(AuditTrail.fromJSON(trail.toJSON()).getAll()[0]!.payload).toBeNull();
+  });
+
   it('fromJSON rejects non-array input', () => {
     expect(() => AuditTrail.fromJSON({})).toThrow(/events must be an array/i);
   });
 
   it('fromJSON rejects events missing required fields', () => {
     expect(() => AuditTrail.fromJSON([{}])).toThrow(/events\[0\]: eventId must be a non-empty string/i);
+  });
+
+  it('fromJSON rejects malformed optional hashes', () => {
+    const event = { ...createAuditEvent('a', {}, { phase: 'p', provider: 'pr' }), inputHash: '' };
+    expect(() => AuditTrail.fromJSON([event])).toThrow(/events\[0\]: inputHash must be a sha256 hash/i);
+  });
+
+  it('fromJSON rejects malformed timestamps', () => {
+    const event = { ...createAuditEvent('a', {}, { phase: 'p', provider: 'pr' }), timestamp: 'not-a-date' };
+    expect(() => AuditTrail.fromJSON([event])).toThrow(/events\[0\]: timestamp must be an ISO timestamp/i);
   });
 
   it('verify() passes with correct hashes', () => {

--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -96,6 +96,14 @@ describe('AuditTrail', () => {
     expect(restored.getAll()).toEqual(json);
   });
 
+  it('fromJSON rejects non-array input', () => {
+    expect(() => AuditTrail.fromJSON({})).toThrow(/events must be an array/i);
+  });
+
+  it('fromJSON rejects events missing required fields', () => {
+    expect(() => AuditTrail.fromJSON([{}])).toThrow(/events\[0\]: eventId must be a non-empty string/i);
+  });
+
   it('verify() passes with correct hashes', () => {
     const trail = new AuditTrail();
     const event = createAuditEvent('test', {}, { phase: 'p', provider: 'pr', input: 'hello' });

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -17,10 +17,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function requireStringField(record: Record<string, unknown>, field: keyof AuditEvent, context: string): void {
+const AUDIT_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function requireStringField(record: Record<string, unknown>, field: keyof AuditEvent, context: string): string {
   if (typeof record[field] !== 'string' || record[field].length === 0) {
     throw new Error(`Invalid audit event at ${context}: ${String(field)} must be a non-empty string`);
   }
+  return record[field];
 }
 
 function requireOptionalStringField(
@@ -33,13 +37,30 @@ function requireOptionalStringField(
   }
 }
 
+function requireOptionalHashField(record: Record<string, unknown>, field: keyof AuditEvent, context: string): void {
+  if (record[field] === undefined) {
+    return;
+  }
+  if (typeof record[field] !== 'string' || !AUDIT_HASH_PATTERN.test(record[field])) {
+    throw new Error(`Invalid audit event at ${context}: ${String(field)} must be a sha256 hash when present`);
+  }
+}
+
+function requireIsoTimestamp(record: Record<string, unknown>, context: string): void {
+  const timestamp = requireStringField(record, 'timestamp', context);
+  const parsed = Date.parse(timestamp);
+  if (!ISO_TIMESTAMP_PATTERN.test(timestamp) || Number.isNaN(parsed)) {
+    throw new Error(`Invalid audit event at ${context}: timestamp must be an ISO timestamp`);
+  }
+}
+
 export function assertAuditEvent(value: unknown, context = 'event'): asserts value is AuditEvent {
   if (!isRecord(value)) {
     throw new Error(`Invalid audit event at ${context}: expected object`);
   }
 
   requireStringField(value, 'eventId', context);
-  requireStringField(value, 'timestamp', context);
+  requireIsoTimestamp(value, context);
   requireStringField(value, 'phase', context);
   requireStringField(value, 'provider', context);
   requireStringField(value, 'type', context);
@@ -48,8 +69,8 @@ export function assertAuditEvent(value: unknown, context = 'event'): asserts val
     throw new Error(`Invalid audit event at ${context}: payload is required`);
   }
 
-  requireOptionalStringField(value, 'inputHash', context);
-  requireOptionalStringField(value, 'outputHash', context);
+  requireOptionalHashField(value, 'inputHash', context);
+  requireOptionalHashField(value, 'outputHash', context);
   requireOptionalStringField(value, 'parentEventId', context);
 }
 
@@ -123,7 +144,10 @@ export class AuditTrail {
   }
 
   toJSON(): AuditEvent[] {
-    return [...this.events];
+    return this.events.map((event) => ({
+      ...event,
+      payload: event.payload === undefined ? null : event.payload,
+    }));
   }
 
   static fromJSON(events: unknown): AuditTrail {

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -13,6 +13,53 @@ export interface AuditEvent {
   parentEventId?: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireStringField(record: Record<string, unknown>, field: keyof AuditEvent, context: string): void {
+  if (typeof record[field] !== 'string' || record[field].length === 0) {
+    throw new Error(`Invalid audit event at ${context}: ${String(field)} must be a non-empty string`);
+  }
+}
+
+function requireOptionalStringField(
+  record: Record<string, unknown>,
+  field: keyof AuditEvent,
+  context: string,
+): void {
+  if (record[field] !== undefined && typeof record[field] !== 'string') {
+    throw new Error(`Invalid audit event at ${context}: ${String(field)} must be a string when present`);
+  }
+}
+
+export function assertAuditEvent(value: unknown, context = 'event'): asserts value is AuditEvent {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid audit event at ${context}: expected object`);
+  }
+
+  requireStringField(value, 'eventId', context);
+  requireStringField(value, 'timestamp', context);
+  requireStringField(value, 'phase', context);
+  requireStringField(value, 'provider', context);
+  requireStringField(value, 'type', context);
+
+  if (!Object.prototype.hasOwnProperty.call(value, 'payload')) {
+    throw new Error(`Invalid audit event at ${context}: payload is required`);
+  }
+
+  requireOptionalStringField(value, 'inputHash', context);
+  requireOptionalStringField(value, 'outputHash', context);
+  requireOptionalStringField(value, 'parentEventId', context);
+}
+
+export function assertAuditEventArray(value: unknown, context = 'events'): asserts value is AuditEvent[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid audit trail: ${context} must be an array`);
+  }
+  value.forEach((event, index) => assertAuditEvent(event, `${context}[${index}]`));
+}
+
 export interface CreateAuditEventOptions {
   phase: string;
   provider: string;
@@ -79,7 +126,8 @@ export class AuditTrail {
     return [...this.events];
   }
 
-  static fromJSON(events: AuditEvent[]): AuditTrail {
+  static fromJSON(events: unknown): AuditTrail {
+    assertAuditEventArray(events);
     const trail = new AuditTrail();
     for (const event of events) {
       trail.append(event);

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -49,7 +49,7 @@ function requireOptionalHashField(record: Record<string, unknown>, field: keyof 
 function requireIsoTimestamp(record: Record<string, unknown>, context: string): void {
   const timestamp = requireStringField(record, 'timestamp', context);
   const parsed = Date.parse(timestamp);
-  if (!ISO_TIMESTAMP_PATTERN.test(timestamp) || Number.isNaN(parsed)) {
+  if (!ISO_TIMESTAMP_PATTERN.test(timestamp) || Number.isNaN(parsed) || new Date(parsed).toISOString() !== timestamp) {
     throw new Error(`Invalid audit event at ${context}: timestamp must be an ISO timestamp`);
   }
 }

--- a/packages/franken-observer/src/audit-trail-store.test.ts
+++ b/packages/franken-observer/src/audit-trail-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { AuditTrail, createAuditEvent } from './audit-event.js';
@@ -67,6 +67,59 @@ describe('AuditTrailStore', () => {
     expect(raw.runId).toBe('run-1');
     expect(raw.createdAt).toBeTruthy();
     expect(raw.events).toHaveLength(4);
+  });
+
+  it('rejects persisted artifacts with an unsupported version', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    raw.version = 2;
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/invalid persisted audit trail: version must be 1/i);
+  });
+
+  it('rejects persisted artifacts with missing events', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    delete raw.events;
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/events must be an array/i);
+  });
+
+  it('rejects persisted artifacts with non-array events', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    raw.events = {};
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/events must be an array/i);
+  });
+
+  it('rejects persisted events missing required identity and type fields', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    raw.events = [{ phase: 'planning', provider: 'claude-cli', type: 'phase.start', payload: {} }];
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/events\[0\]: eventId must be a non-empty string/i);
+  });
+
+  it('rejects persisted events missing payload', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    raw.events = [
+      {
+        eventId: 'event-1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        phase: 'planning',
+        provider: 'claude-cli',
+        type: 'phase.start',
+      },
+    ];
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/events\[0\]: payload is required/i);
   });
 
   it('writes a replay manifest next to the audit trail when provided', () => {

--- a/packages/franken-observer/src/audit-trail-store.test.ts
+++ b/packages/franken-observer/src/audit-trail-store.test.ts
@@ -122,6 +122,33 @@ describe('AuditTrailStore', () => {
     expect(() => store.load('run-1')).toThrow(/events\[0\]: payload is required/i);
   });
 
+  it('round-trips events whose original payload was undefined', () => {
+    const trail = new AuditTrail();
+    trail.append(createAuditEvent('payload.undefined', undefined, { phase: 'planning', provider: 'claude-cli' }));
+
+    store.save('run-1', trail);
+
+    expect(store.load('run-1').getAll()[0]!.payload).toBeNull();
+  });
+
+  it('rejects persisted events with malformed hashes', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    raw.events[0].inputHash = '';
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/events\[0\]: inputHash must be a sha256 hash/i);
+  });
+
+  it('rejects persisted events with malformed timestamps', () => {
+    const filePath = store.save('run-1', sampleTrail());
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    raw.events[0].timestamp = 'not-a-date';
+    writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(() => store.load('run-1')).toThrow(/events\[0\]: timestamp must be an ISO timestamp/i);
+  });
+
   it('writes a replay manifest next to the audit trail when provided', () => {
     store.save('run-1', sampleTrail(), [
       { version: 1, kind: 'llm.response', runId: 'run-1', timestamp: 't', contentRef: 'abc123' },

--- a/packages/franken-observer/src/audit-trail-store.test.ts
+++ b/packages/franken-observer/src/audit-trail-store.test.ts
@@ -105,7 +105,7 @@ describe('AuditTrailStore', () => {
     expect(() => store.load('run-1')).toThrow(/events\[0\]: eventId must be a non-empty string/i);
   });
 
-  it('rejects persisted events missing payload', () => {
+  it('normalizes legacy persisted events missing payload to null', () => {
     const filePath = store.save('run-1', sampleTrail());
     const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
     raw.events = [
@@ -119,7 +119,7 @@ describe('AuditTrailStore', () => {
     ];
     writeFileSync(filePath, JSON.stringify(raw));
 
-    expect(() => store.load('run-1')).toThrow(/events\[0\]: payload is required/i);
+    expect(store.load('run-1').getAll()[0]!.payload).toBeNull();
   });
 
   it('round-trips events whose original payload was undefined', () => {

--- a/packages/franken-observer/src/audit-trail-store.ts
+++ b/packages/franken-observer/src/audit-trail-store.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
-import { AuditTrail } from './audit-event.js';
+import { AuditTrail, assertAuditEventArray } from './audit-event.js';
 import type { ReplayRecord } from './replay/replay-record.js';
 
 export interface PersistedAuditTrail {
@@ -8,6 +8,26 @@ export interface PersistedAuditTrail {
   runId: string;
   createdAt: string;
   events: import('./audit-event.js').AuditEvent[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertPersistedAuditTrail(value: unknown): asserts value is PersistedAuditTrail {
+  if (!isRecord(value)) {
+    throw new Error('Invalid persisted audit trail: expected object');
+  }
+  if (value.version !== 1) {
+    throw new Error('Invalid persisted audit trail: version must be 1');
+  }
+  if (typeof value.runId !== 'string' || value.runId.length === 0) {
+    throw new Error('Invalid persisted audit trail: runId must be a non-empty string');
+  }
+  if (typeof value.createdAt !== 'string' || value.createdAt.length === 0) {
+    throw new Error('Invalid persisted audit trail: createdAt must be a non-empty string');
+  }
+  assertAuditEventArray(value.events, 'events');
 }
 
 /**
@@ -79,7 +99,8 @@ export class AuditTrailStore {
     if (!existsSync(filePath)) {
       throw new Error(`Audit trail not found: ${filePath}`);
     }
-    const raw = JSON.parse(readFileSync(filePath, 'utf-8')) as PersistedAuditTrail;
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+    assertPersistedAuditTrail(raw);
     return AuditTrail.fromJSON(raw.events);
   }
 

--- a/packages/franken-observer/src/audit-trail-store.ts
+++ b/packages/franken-observer/src/audit-trail-store.ts
@@ -30,6 +30,22 @@ function assertPersistedAuditTrail(value: unknown): asserts value is PersistedAu
   assertAuditEventArray(value.events, 'events');
 }
 
+function normalizePersistedAuditTrail(value: unknown): unknown {
+  if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.events)) {
+    return value;
+  }
+
+  return {
+    ...value,
+    events: value.events.map((event) => {
+      if (!isRecord(event) || Object.prototype.hasOwnProperty.call(event, 'payload')) {
+        return event;
+      }
+      return { ...event, payload: null };
+    }),
+  };
+}
+
 /**
  * Allowed run ID characters. Restricting to a single safe filename segment
  * prevents path traversal (`../`), absolute paths, and separator injection
@@ -99,7 +115,7 @@ export class AuditTrailStore {
     if (!existsSync(filePath)) {
       throw new Error(`Audit trail not found: ${filePath}`);
     }
-    const raw = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+    const raw = normalizePersistedAuditTrail(JSON.parse(readFileSync(filePath, 'utf-8')) as unknown);
     assertPersistedAuditTrail(raw);
     return AuditTrail.fromJSON(raw.events);
   }


### PR DESCRIPTION
## Summary
- validate persisted audit artifacts before hydrating audit trails
- reject unsupported artifact versions, non-array/missing events, and malformed event records
- add regression coverage for malformed persisted audit trail shapes

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/observer -- audit-event.test.ts audit-trail-store.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint:any
- npm test --workspace @franken/observer

Closes #1241