### PR TITLE
fix(orchestrator): parse config boolean env vars strictly

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,12 +492,12 @@ frankenbeast issues --label bug --repo owner/repo
 | `FRANKEN_MAX_TOTAL_TOKENS` | `maxTotalTokens` | integer token budget | default `100000`; must be at least `10000` |
 | `FRANKEN_MAX_DURATION_MS` | `maxDurationMs` | integer milliseconds | default `300000`; must be at least `1000` and at least `maxCritiqueIterations * 10000` |
 | `FRANKEN_MAX_CRITIQUE_ITERATIONS` | `maxCritiqueIterations` | integer critique passes | default `3`; valid range `1` through `10` |
-| `FRANKEN_ENABLE_HEARTBEAT` | `enableHeartbeat` | boolean string; only `true` enables it | default `false` |
-| `FRANKEN_ENABLE_TRACING` | `enableTracing` | boolean string; only `true` enables it | default `false`; `--verbose` also enables tracing and wins over env/config |
-| `FRANKEN_ENABLE_REFLECTION` | `enableReflection` | boolean string; only `true` enables it | default `false` |
+| `FRANKEN_ENABLE_HEARTBEAT` | `enableHeartbeat` | boolean string; accepted true values: `true`, `1`, `yes`, `on`; false values: `false`, `0`, `no`, `off` | default `false` |
+| `FRANKEN_ENABLE_TRACING` | `enableTracing` | boolean string; accepted true values: `true`, `1`, `yes`, `on`; false values: `false`, `0`, `no`, `off` | default `false`; `--verbose` also enables tracing and wins over env/config |
+| `FRANKEN_ENABLE_REFLECTION` | `enableReflection` | boolean string; accepted true values: `true`, `1`, `yes`, `on`; false values: `false`, `0`, `no`, `off` | default `false` |
 | `FRANKEN_MIN_CRITIQUE_SCORE` | `minCritiqueScore` | numeric score | default `0.7`; must be `>= 0` and `< 1` |
 
-Numeric env values are parsed as numbers and then validated with the same schema as JSON config files. Unset numeric variables leave the lower-priority source in effect. Boolean env overrides apply whenever the variable is present; set the value to `true` to enable the field, and any other present value disables it.
+Numeric env values are parsed as numbers and then validated with the same schema as JSON config files. Unset numeric variables leave the lower-priority source in effect. Boolean env overrides apply whenever the variable is present. Boolean values are parsed strictly: use `true`, `1`, `yes`, or `on` to enable a field and `false`, `0`, `no`, or `off` to disable it. Other values are rejected unless a higher-priority CLI flag, such as `--verbose`, shadows that field.
 
 ### Operator environment variables
 

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -20,7 +20,7 @@ function parseBooleanEnv(name: string): boolean | undefined {
 }
 
 /** Extract config values from environment variables. */
-function fromEnv(): Partial<OrchestratorConfig> {
+function fromEnv(shadowedFields: ReadonlySet<keyof OrchestratorConfig> = new Set()): Partial<OrchestratorConfig> {
   const env: Partial<OrchestratorConfig> = {};
 
   const maxTokens = process.env[`${ENV_PREFIX}MAX_TOTAL_TOKENS`];
@@ -32,14 +32,20 @@ function fromEnv(): Partial<OrchestratorConfig> {
   const maxCritique = process.env[`${ENV_PREFIX}MAX_CRITIQUE_ITERATIONS`];
   if (maxCritique) env.maxCritiqueIterations = Number(maxCritique);
 
-  const heartbeat = parseBooleanEnv(`${ENV_PREFIX}ENABLE_HEARTBEAT`);
-  if (heartbeat !== undefined) env.enableHeartbeat = heartbeat;
+  if (!shadowedFields.has('enableHeartbeat')) {
+    const heartbeat = parseBooleanEnv(`${ENV_PREFIX}ENABLE_HEARTBEAT`);
+    if (heartbeat !== undefined) env.enableHeartbeat = heartbeat;
+  }
 
-  const tracing = parseBooleanEnv(`${ENV_PREFIX}ENABLE_TRACING`);
-  if (tracing !== undefined) env.enableTracing = tracing;
+  if (!shadowedFields.has('enableTracing')) {
+    const tracing = parseBooleanEnv(`${ENV_PREFIX}ENABLE_TRACING`);
+    if (tracing !== undefined) env.enableTracing = tracing;
+  }
 
-  const reflection = parseBooleanEnv(`${ENV_PREFIX}ENABLE_REFLECTION`);
-  if (reflection !== undefined) env.enableReflection = reflection;
+  if (!shadowedFields.has('enableReflection')) {
+    const reflection = parseBooleanEnv(`${ENV_PREFIX}ENABLE_REFLECTION`);
+    if (reflection !== undefined) env.enableReflection = reflection;
+  }
 
   const minScore = process.env[`${ENV_PREFIX}MIN_CRITIQUE_SCORE`];
   if (minScore) env.minCritiqueScore = Number(minScore);
@@ -108,6 +114,13 @@ function stripRepositoryLocalCommandTrust(fileConfig: Partial<OrchestratorConfig
   return sanitized;
 }
 
+function getCliShadowedFields(args: CliArgs): Set<keyof OrchestratorConfig> {
+  const fields = new Set<keyof OrchestratorConfig>();
+  if (args.verbose) fields.add('enableTracing');
+  if (args.initBackend) fields.add('network');
+  return fields;
+}
+
 /** Extract config overrides from CLI args. */
 function fromCli(args: CliArgs): Partial<OrchestratorConfig> {
   const cli: Partial<OrchestratorConfig> = {};
@@ -143,7 +156,7 @@ export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Pro
     }
   }
 
-  const envConfig = fromEnv();
+  const envConfig = fromEnv(getCliShadowedFields(args));
   const cliConfig = fromCli(args);
 
   let merged = deepMerge<OrchestratorConfig>(

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -114,9 +114,13 @@ function stripRepositoryLocalCommandTrust(fileConfig: Partial<OrchestratorConfig
   return sanitized;
 }
 
+function isNetworkChildSpawningAction(args: CliArgs): boolean {
+  return args.subcommand === 'network' && ['up', 'start', 'restart'].includes(args.networkAction ?? 'help');
+}
+
 function getCliShadowedFields(args: CliArgs): Set<keyof OrchestratorConfig> {
   const fields = new Set<keyof OrchestratorConfig>();
-  if (args.verbose && args.subcommand !== 'network') fields.add('enableTracing');
+  if (args.verbose && !isNetworkChildSpawningAction(args)) fields.add('enableTracing');
   if (args.initBackend) fields.add('network');
   return fields;
 }

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -6,6 +6,19 @@ import type { CliArgs } from './args.js';
 /** Environment variable prefix for orchestrator config. */
 const ENV_PREFIX = 'FRANKEN_';
 
+function parseBooleanEnv(name: string): boolean | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+
+  const normalized = raw.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+  if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+
+  throw new Error(
+    `Invalid boolean value for ${name}: ${JSON.stringify(raw)}. Expected true/false, 1/0, yes/no, or on/off.`,
+  );
+}
+
 /** Extract config values from environment variables. */
 function fromEnv(): Partial<OrchestratorConfig> {
   const env: Partial<OrchestratorConfig> = {};
@@ -19,14 +32,14 @@ function fromEnv(): Partial<OrchestratorConfig> {
   const maxCritique = process.env[`${ENV_PREFIX}MAX_CRITIQUE_ITERATIONS`];
   if (maxCritique) env.maxCritiqueIterations = Number(maxCritique);
 
-  const heartbeat = process.env[`${ENV_PREFIX}ENABLE_HEARTBEAT`];
-  if (heartbeat !== undefined) env.enableHeartbeat = heartbeat === 'true';
+  const heartbeat = parseBooleanEnv(`${ENV_PREFIX}ENABLE_HEARTBEAT`);
+  if (heartbeat !== undefined) env.enableHeartbeat = heartbeat;
 
-  const tracing = process.env[`${ENV_PREFIX}ENABLE_TRACING`];
-  if (tracing !== undefined) env.enableTracing = tracing === 'true';
+  const tracing = parseBooleanEnv(`${ENV_PREFIX}ENABLE_TRACING`);
+  if (tracing !== undefined) env.enableTracing = tracing;
 
-  const reflection = process.env[`${ENV_PREFIX}ENABLE_REFLECTION`];
-  if (reflection !== undefined) env.enableReflection = reflection === 'true';
+  const reflection = parseBooleanEnv(`${ENV_PREFIX}ENABLE_REFLECTION`);
+  if (reflection !== undefined) env.enableReflection = reflection;
 
   const minScore = process.env[`${ENV_PREFIX}MIN_CRITIQUE_SCORE`];
   if (minScore) env.minCritiqueScore = Number(minScore);

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -116,7 +116,7 @@ function stripRepositoryLocalCommandTrust(fileConfig: Partial<OrchestratorConfig
 
 function getCliShadowedFields(args: CliArgs): Set<keyof OrchestratorConfig> {
   const fields = new Set<keyof OrchestratorConfig>();
-  if (args.verbose) fields.add('enableTracing');
+  if (args.verbose && args.subcommand !== 'network') fields.add('enableTracing');
   if (args.initBackend) fields.add('network');
   return fields;
 }

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -17,6 +17,7 @@ describe('Config loader', () => {
     delete process.env['FRANKEN_MAX_TOTAL_TOKENS'];
     delete process.env['FRANKEN_ENABLE_HEARTBEAT'];
     delete process.env['FRANKEN_ENABLE_TRACING'];
+    delete process.env['FRANKEN_ENABLE_REFLECTION'];
     delete process.env['FRANKEN_MIN_CRITIQUE_SCORE'];
   });
 
@@ -128,10 +129,24 @@ describe('Config loader', () => {
     expect(config.network.secureBackend).toBe('1password');
   });
 
-  it('reads boolean env vars', async () => {
-    process.env['FRANKEN_ENABLE_HEARTBEAT'] = 'false';
+  it('reads strict boolean env vars with common true-like and false-like values', async () => {
+    process.env['FRANKEN_ENABLE_HEARTBEAT'] = '1';
+    process.env['FRANKEN_ENABLE_TRACING'] = 'TRUE';
+    process.env['FRANKEN_ENABLE_REFLECTION'] = 'off';
+
     const config = await loadConfig(makeArgs());
-    expect(config.enableHeartbeat).toBe(false);
+
+    expect(config.enableHeartbeat).toBe(true);
+    expect(config.enableTracing).toBe(true);
+    expect(config.enableReflection).toBe(false);
+  });
+
+  it('rejects invalid boolean env vars with a clear error', async () => {
+    process.env['FRANKEN_ENABLE_HEARTBEAT'] = 'definitely';
+
+    await expect(loadConfig(makeArgs())).rejects.toThrow(
+      'Invalid boolean value for FRANKEN_ENABLE_HEARTBEAT',
+    );
   });
 
   it('reads numeric env vars', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -165,6 +165,28 @@ describe('Config loader', () => {
     ).rejects.toThrow('Invalid boolean value for FRANKEN_ENABLE_TRACING');
   });
 
+  it.each(['status', 'logs', 'config'] as const)(
+    'does not reject invalid tracing env shadowed by verbose network %s',
+    async (networkAction) => {
+      process.env['FRANKEN_ENABLE_TRACING'] = 'disabled';
+
+      const config = await loadConfig(makeArgs({ subcommand: 'network', networkAction, verbose: true }));
+
+      expect(config.enableTracing).toBe(true);
+    },
+  );
+
+  it.each(['up', 'start', 'restart'] as const)(
+    'rejects invalid tracing env for verbose network %s because children inherit env',
+    async (networkAction) => {
+      process.env['FRANKEN_ENABLE_TRACING'] = 'disabled';
+
+      await expect(
+        loadConfig(makeArgs({ subcommand: 'network', networkAction, verbose: true })),
+      ).rejects.toThrow('Invalid boolean value for FRANKEN_ENABLE_TRACING');
+    },
+  );
+
   it('reads numeric env vars', async () => {
     process.env['FRANKEN_MIN_CRITIQUE_SCORE'] = '0.9';
     const config = await loadConfig(makeArgs());

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -149,6 +149,14 @@ describe('Config loader', () => {
     );
   });
 
+  it('does not reject invalid env values shadowed by CLI overrides', async () => {
+    process.env['FRANKEN_ENABLE_TRACING'] = 'disabled';
+
+    const config = await loadConfig(makeArgs({ verbose: true }));
+
+    expect(config.enableTracing).toBe(true);
+  });
+
   it('reads numeric env vars', async () => {
     process.env['FRANKEN_MIN_CRITIQUE_SCORE'] = '0.9';
     const config = await loadConfig(makeArgs());

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -157,6 +157,14 @@ describe('Config loader', () => {
     expect(config.enableTracing).toBe(true);
   });
 
+  it('rejects invalid tracing env for verbose network commands inherited by children', async () => {
+    process.env['FRANKEN_ENABLE_TRACING'] = 'disabled';
+
+    await expect(
+      loadConfig(makeArgs({ subcommand: 'network', networkAction: 'up', verbose: true })),
+    ).rejects.toThrow('Invalid boolean value for FRANKEN_ENABLE_TRACING');
+  });
+
   it('reads numeric env vars', async () => {
     process.env['FRANKEN_MIN_CRITIQUE_SCORE'] = '0.9';
     const config = await loadConfig(makeArgs());


### PR DESCRIPTION
## Summary
- parse orchestrator boolean env overrides through one strict, shared parser
- accept common true/false forms case-insensitively instead of silently coercing truthy-looking values to false
- reject invalid boolean env strings with a clear config error

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- --run tests/unit/cli/config-loader.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #1235