### PR TITLE
fix(critique): count only top-level parameters

### DIFF
--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -299,6 +299,8 @@ function hasUnmatchedAngleCloseBeforeNextTopLevelComma(
 
   for (let index = commaIndex + 1; index < params.length; index++) {
     const char = params[index];
+    if (char === undefined) continue;
+
     if (char === '(') {
       parenDepth++;
     } else if (char === ')') {

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -76,15 +76,49 @@ function findArrowParameterOpenParen(
   let index = openParenIndex + 1;
   while (/\s/.test(content[index] ?? '')) index++;
 
+  if (content[index] === '(') {
+    return index;
+  }
+
   if (content.slice(index, index + 5) === 'async') {
     index += 5;
     while (/\s/.test(content[index] ?? '')) index++;
-    if (content[index] === '(') {
-      return index;
+  }
+
+  if (content[index] === '<') {
+    const typeParameters = readBalancedAngleContent(content, index);
+    if (typeParameters !== null) {
+      index = typeParameters.closeAngleIndex + 1;
+      while (/\s/.test(content[index] ?? '')) index++;
     }
   }
 
+  if (content[index] === '(') {
+    return index;
+  }
+
   return openParenIndex;
+}
+
+function readBalancedAngleContent(
+  content: string,
+  openAngleIndex: number,
+): { closeAngleIndex: number } | null {
+  let depth = 1;
+
+  for (let index = openAngleIndex + 1; index < content.length; index++) {
+    const char = content[index];
+    if (char === '<') {
+      depth++;
+    } else if (char === '>' && content[index - 1] !== '=') {
+      depth--;
+      if (depth === 0) {
+        return { closeAngleIndex: index };
+      }
+    }
+  }
+
+  return null;
 }
 
 function readBalancedParenthesizedContent(
@@ -123,8 +157,67 @@ function hasFunctionBodyAfterParameterList(
   content: string,
   closeParenIndex: number,
 ): boolean {
-  const afterParams = content.slice(closeParenIndex + 1);
-  return /^\s*(?::[^;{]+)?\{/.test(afterParams);
+  let index = closeParenIndex + 1;
+  while (/\s/.test(content[index] ?? '')) index++;
+
+  if (content[index] !== ':') {
+    return content[index] === '{';
+  }
+
+  index++;
+  let returnTypeStarted = false;
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let angleDepth = 0;
+
+  for (; index < content.length; index++) {
+    const char = content[index];
+    if (char === undefined) continue;
+
+    if (!returnTypeStarted && /\s/.test(char)) continue;
+    returnTypeStarted = true;
+
+    if (char === '(') {
+      parenDepth++;
+    } else if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === '{') {
+      braceDepth++;
+    } else if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+    } else if (char === '[') {
+      bracketDepth++;
+    } else if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === '<') {
+      angleDepth++;
+    } else if (char === '>' && content[index - 1] !== '=') {
+      angleDepth = Math.max(0, angleDepth - 1);
+    } else if (
+      char === ';' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      angleDepth === 0
+    ) {
+      return false;
+    }
+
+    const nextIndex = index + 1;
+    if (
+      returnTypeStarted &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      angleDepth === 0 &&
+      /^\s*\{/.test(content.slice(nextIndex))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function hasGenericCloseBeforeTopLevelComma(
@@ -183,6 +276,7 @@ function countTopLevelParameters(params: string): number {
   let braceDepth = 0;
   let bracketDepth = 0;
   let angleDepth = 0;
+  let currentParameterHasDefaultValue = false;
 
   for (let index = 0; index < params.length; index++) {
     const char = params[index];
@@ -206,7 +300,17 @@ function countTopLevelParameters(params: string): number {
     } else if (char === ']') {
       bracketDepth = Math.max(0, bracketDepth - 1);
     } else if (
+      char === '=' &&
+      params[index + 1] !== '>' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      angleDepth === 0
+    ) {
+      currentParameterHasDefaultValue = true;
+    } else if (
       char === '<' &&
+      !currentParameterHasDefaultValue &&
       hasGenericCloseBeforeTopLevelComma(params, index)
     ) {
       angleDepth++;
@@ -221,6 +325,7 @@ function countTopLevelParameters(params: string): number {
     ) {
       count++;
       hasParameterContent = false;
+      currentParameterHasDefaultValue = false;
     }
   }
 

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -14,8 +14,12 @@ const FUNCTION_PATTERN = /function\s+\w+\s*\(([^)]*)\)\s*\{([\s\S]*?)\}/g;
 const ARROW_FUNCTION_PATTERN =
   /(?:const|let|var)\s+\w+\s*=\s*\(([^)]*)\)\s*(?::\s*\w+\s*)?=>\s*\{([\s\S]*?)\}/g;
 const PARAMETER_LIST_START_PATTERNS = [
-  { pattern: /function\s+\w+\s*\(/g, requiresArrow: false },
-  { pattern: /(?:const|let|var)\s+\w+\s*=\s*\(/g, requiresArrow: true },
+  { pattern: /function\s+\w+\s*\(/g, requiresArrow: false, requiresBody: true },
+  {
+    pattern: /(?:const|let|var)\s+\w+\s*=\s*\(+/g,
+    requiresArrow: true,
+    requiresBody: false,
+  },
 ];
 
 type ParameterList = {
@@ -26,7 +30,11 @@ type ParameterList = {
 function extractParameterLists(content: string): string[] {
   const parameterLists: string[] = [];
 
-  for (const { pattern, requiresArrow } of PARAMETER_LIST_START_PATTERNS) {
+  for (const {
+    pattern,
+    requiresArrow,
+    requiresBody,
+  } of PARAMETER_LIST_START_PATTERNS) {
     for (const match of content.matchAll(pattern)) {
       const openParenIndex = (match.index ?? 0) + match[0].length - 1;
       const parameterList = readBalancedParenthesizedContent(
@@ -36,7 +44,12 @@ function extractParameterLists(content: string): string[] {
       if (
         parameterList !== null &&
         (!requiresArrow ||
-          hasArrowAfterParameterList(content, parameterList.closeParenIndex))
+          hasArrowAfterParameterList(content, parameterList.closeParenIndex)) &&
+        (!requiresBody ||
+          hasFunctionBodyAfterParameterList(
+            content,
+            parameterList.closeParenIndex,
+          ))
       ) {
         parameterLists.push(parameterList.params);
       }
@@ -78,6 +91,14 @@ function hasArrowAfterParameterList(
   return /^\s*(?::\s*[^=]+?)?=>/.test(afterParams);
 }
 
+function hasFunctionBodyAfterParameterList(
+  content: string,
+  closeParenIndex: number,
+): boolean {
+  const afterParams = content.slice(closeParenIndex + 1);
+  return /^\s*(?::[^;{]+)?\{/.test(afterParams);
+}
+
 function hasGenericCloseBeforeTopLevelComma(
   params: string,
   startIndex: number,
@@ -85,6 +106,7 @@ function hasGenericCloseBeforeTopLevelComma(
   let parenDepth = 0;
   let braceDepth = 0;
   let bracketDepth = 0;
+  let angleDepth = 1;
 
   for (let index = startIndex + 1; index < params.length; index++) {
     const char = params[index];
@@ -103,12 +125,12 @@ function hasGenericCloseBeforeTopLevelComma(
     } else if (char === ']') {
       bracketDepth = Math.max(0, bracketDepth - 1);
     } else if (
-      char === ',' &&
+      char === '<' &&
       parenDepth === 0 &&
       braceDepth === 0 &&
       bracketDepth === 0
     ) {
-      return false;
+      angleDepth++;
     } else if (
       char === '>' &&
       parenDepth === 0 &&
@@ -116,7 +138,10 @@ function hasGenericCloseBeforeTopLevelComma(
       bracketDepth === 0 &&
       params[index - 1] !== '='
     ) {
-      return true;
+      angleDepth--;
+      if (angleDepth === 0) {
+        return true;
+      }
     }
   }
 

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -14,22 +14,31 @@ const FUNCTION_PATTERN = /function\s+\w+\s*\(([^)]*)\)\s*\{([\s\S]*?)\}/g;
 const ARROW_FUNCTION_PATTERN =
   /(?:const|let|var)\s+\w+\s*=\s*\(([^)]*)\)\s*(?::\s*\w+\s*)?=>\s*\{([\s\S]*?)\}/g;
 const PARAMETER_LIST_START_PATTERNS = [
-  /function\s+\w+\s*\(/g,
-  /(?:const|let|var)\s+\w+\s*=\s*\(/g,
+  { pattern: /function\s+\w+\s*\(/g, requiresArrow: false },
+  { pattern: /(?:const|let|var)\s+\w+\s*=\s*\(/g, requiresArrow: true },
 ];
+
+type ParameterList = {
+  params: string;
+  closeParenIndex: number;
+};
 
 function extractParameterLists(content: string): string[] {
   const parameterLists: string[] = [];
 
-  for (const pattern of PARAMETER_LIST_START_PATTERNS) {
+  for (const { pattern, requiresArrow } of PARAMETER_LIST_START_PATTERNS) {
     for (const match of content.matchAll(pattern)) {
       const openParenIndex = (match.index ?? 0) + match[0].length - 1;
       const parameterList = readBalancedParenthesizedContent(
         content,
         openParenIndex,
       );
-      if (parameterList !== null) {
-        parameterLists.push(parameterList);
+      if (
+        parameterList !== null &&
+        (!requiresArrow ||
+          hasArrowAfterParameterList(content, parameterList.closeParenIndex))
+      ) {
+        parameterLists.push(parameterList.params);
       }
     }
   }
@@ -40,7 +49,7 @@ function extractParameterLists(content: string): string[] {
 function readBalancedParenthesizedContent(
   content: string,
   openParenIndex: number,
-): string | null {
+): ParameterList | null {
   let depth = 0;
 
   for (let index = openParenIndex + 1; index < content.length; index++) {
@@ -49,13 +58,69 @@ function readBalancedParenthesizedContent(
       depth++;
     } else if (char === ')') {
       if (depth === 0) {
-        return content.slice(openParenIndex + 1, index);
+        return {
+          params: content.slice(openParenIndex + 1, index),
+          closeParenIndex: index,
+        };
       }
       depth--;
     }
   }
 
   return null;
+}
+
+function hasArrowAfterParameterList(
+  content: string,
+  closeParenIndex: number,
+): boolean {
+  const afterParams = content.slice(closeParenIndex + 1);
+  return /^\s*(?::\s*[^=]+?)?=>/.test(afterParams);
+}
+
+function hasGenericCloseBeforeTopLevelComma(
+  params: string,
+  startIndex: number,
+): boolean {
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+
+  for (let index = startIndex + 1; index < params.length; index++) {
+    const char = params[index];
+    if (char === undefined) continue;
+
+    if (char === '(') {
+      parenDepth++;
+    } else if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === '{') {
+      braceDepth++;
+    } else if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+    } else if (char === '[') {
+      bracketDepth++;
+    } else if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (
+      char === ',' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0
+    ) {
+      return false;
+    } else if (
+      char === '>' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      params[index - 1] !== '='
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function countTopLevelParameters(params: string): number {
@@ -87,7 +152,10 @@ function countTopLevelParameters(params: string): number {
       bracketDepth++;
     } else if (char === ']') {
       bracketDepth = Math.max(0, bracketDepth - 1);
-    } else if (char === '<') {
+    } else if (
+      char === '<' &&
+      hasGenericCloseBeforeTopLevelComma(params, index)
+    ) {
       angleDepth++;
     } else if (char === '>' && previousChar !== '=') {
       angleDepth = Math.max(0, angleDepth - 1);

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -13,6 +13,98 @@ const MAX_FUNCTION_LINES = 50;
 const FUNCTION_PATTERN = /function\s+\w+\s*\(([^)]*)\)\s*\{([\s\S]*?)\}/g;
 const ARROW_FUNCTION_PATTERN =
   /(?:const|let|var)\s+\w+\s*=\s*\(([^)]*)\)\s*(?::\s*\w+\s*)?=>\s*\{([\s\S]*?)\}/g;
+const PARAMETER_LIST_START_PATTERNS = [
+  /function\s+\w+\s*\(/g,
+  /(?:const|let|var)\s+\w+\s*=\s*\(/g,
+];
+
+function extractParameterLists(content: string): string[] {
+  const parameterLists: string[] = [];
+
+  for (const pattern of PARAMETER_LIST_START_PATTERNS) {
+    for (const match of content.matchAll(pattern)) {
+      const openParenIndex = (match.index ?? 0) + match[0].length - 1;
+      const parameterList = readBalancedParenthesizedContent(
+        content,
+        openParenIndex,
+      );
+      if (parameterList !== null) {
+        parameterLists.push(parameterList);
+      }
+    }
+  }
+
+  return parameterLists;
+}
+
+function readBalancedParenthesizedContent(
+  content: string,
+  openParenIndex: number,
+): string | null {
+  let depth = 0;
+
+  for (let index = openParenIndex + 1; index < content.length; index++) {
+    const char = content[index];
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      if (depth === 0) {
+        return content.slice(openParenIndex + 1, index);
+      }
+      depth--;
+    }
+  }
+
+  return null;
+}
+
+function countTopLevelParameters(params: string): number {
+  let count = 0;
+  let hasParameterContent = false;
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let angleDepth = 0;
+
+  for (let index = 0; index < params.length; index++) {
+    const char = params[index];
+    if (char === undefined) continue;
+    const previousChar = params[index - 1];
+
+    if (char.trim()) {
+      hasParameterContent = true;
+    }
+
+    if (char === '(') {
+      parenDepth++;
+    } else if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === '{') {
+      braceDepth++;
+    } else if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+    } else if (char === '[') {
+      bracketDepth++;
+    } else if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === '<') {
+      angleDepth++;
+    } else if (char === '>' && previousChar !== '=') {
+      angleDepth = Math.max(0, angleDepth - 1);
+    } else if (
+      char === ',' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      angleDepth === 0
+    ) {
+      count++;
+      hasParameterContent = false;
+    }
+  }
+
+  return hasParameterContent ? count + 1 : count;
+}
 
 export class ComplexityEvaluator implements Evaluator {
   readonly name = 'complexity';
@@ -49,19 +141,16 @@ export class ComplexityEvaluator implements Evaluator {
     content: string,
     findings: EvaluationFinding[],
   ): void {
-    for (const pattern of [FUNCTION_PATTERN, ARROW_FUNCTION_PATTERN]) {
-      for (const match of content.matchAll(pattern)) {
-        const params = match[1]?.trim();
-        if (!params) continue;
-        const count = params.split(',').filter((p) => p.trim()).length;
-        if (count > MAX_PARAMS) {
-          findings.push({
-            message: `Function has ${count} parameters (max ${MAX_PARAMS}). Consider using an options object.`,
-            severity: 'warning',
-            suggestion:
-              'Group related parameters into an options/config object',
-          });
-        }
+    for (const params of extractParameterLists(content)) {
+      const trimmedParams = params.trim();
+      if (!trimmedParams) continue;
+      const count = countTopLevelParameters(trimmedParams);
+      if (count > MAX_PARAMS) {
+        findings.push({
+          message: `Function has ${count} parameters (max ${MAX_PARAMS}). Consider using an options object.`,
+          severity: 'warning',
+          suggestion: 'Group related parameters into an options/config object',
+        });
       }
     }
   }

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -36,7 +36,13 @@ function extractParameterLists(content: string): string[] {
     requiresBody,
   } of PARAMETER_LIST_START_PATTERNS) {
     for (const match of content.matchAll(pattern)) {
-      const openParenIndex = (match.index ?? 0) + match[0].length - 1;
+      let openParenIndex = (match.index ?? 0) + match[0].length - 1;
+      if (requiresBody && hasDeclareBeforeMatch(content, match.index ?? 0)) {
+        continue;
+      }
+      if (requiresArrow) {
+        openParenIndex = findArrowParameterOpenParen(content, openParenIndex);
+      }
       const parameterList = readBalancedParenthesizedContent(
         content,
         openParenIndex,
@@ -57,6 +63,28 @@ function extractParameterLists(content: string): string[] {
   }
 
   return parameterLists;
+}
+
+function hasDeclareBeforeMatch(content: string, matchIndex: number): boolean {
+  return /\bdeclare\s*$/.test(content.slice(0, matchIndex));
+}
+
+function findArrowParameterOpenParen(
+  content: string,
+  openParenIndex: number,
+): number {
+  let index = openParenIndex + 1;
+  while (/\s/.test(content[index] ?? '')) index++;
+
+  if (content.slice(index, index + 5) === 'async') {
+    index += 5;
+    while (/\s/.test(content[index] ?? '')) index++;
+    if (content[index] === '(') {
+      return index;
+    }
+  }
+
+  return openParenIndex;
 }
 
 function readBalancedParenthesizedContent(

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -202,6 +202,15 @@ function hasFunctionBodyAfterParameterList(
       angleDepth === 0
     ) {
       return false;
+    } else if (
+      char === '\n' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      angleDepth === 0 &&
+      !/^\s*\{/.test(content.slice(index + 1))
+    ) {
+      return false;
     }
 
     const nextIndex = index + 1;
@@ -263,6 +272,68 @@ function hasGenericCloseBeforeTopLevelComma(
       if (angleDepth === 0) {
         return true;
       }
+    } else if (
+      char === ',' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      angleDepth === 1
+    ) {
+      if (!hasUnmatchedAngleCloseBeforeNextTopLevelComma(params, index)) {
+        return false;
+      }
+    }
+  }
+
+  return false;
+}
+
+function hasUnmatchedAngleCloseBeforeNextTopLevelComma(
+  params: string,
+  commaIndex: number,
+): boolean {
+  let nestedAngleDepth = 0;
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+
+  for (let index = commaIndex + 1; index < params.length; index++) {
+    const char = params[index];
+    if (char === '(') {
+      parenDepth++;
+    } else if (char === ')') {
+      if (parenDepth === 0) return false;
+      parenDepth--;
+    } else if (char === '{') {
+      braceDepth++;
+    } else if (char === '}') {
+      if (braceDepth === 0) return false;
+      braceDepth--;
+    } else if (char === '[') {
+      bracketDepth++;
+    } else if (char === ']') {
+      if (bracketDepth === 0) return false;
+      bracketDepth--;
+    } else if (char === '<') {
+      nestedAngleDepth++;
+    } else if (char === '>' && params[index - 1] !== '=') {
+      if (
+        nestedAngleDepth === 0 &&
+        parenDepth === 0 &&
+        braceDepth === 0 &&
+        bracketDepth === 0
+      ) {
+        return true;
+      }
+      nestedAngleDepth = Math.max(0, nestedAngleDepth - 1);
+    } else if (
+      (char === ',' || char === '=' || char === ':') &&
+      nestedAngleDepth === 0 &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0
+    ) {
+      return false;
     }
   }
 
@@ -276,7 +347,6 @@ function countTopLevelParameters(params: string): number {
   let braceDepth = 0;
   let bracketDepth = 0;
   let angleDepth = 0;
-  let currentParameterHasDefaultValue = false;
 
   for (let index = 0; index < params.length; index++) {
     const char = params[index];
@@ -300,21 +370,20 @@ function countTopLevelParameters(params: string): number {
     } else if (char === ']') {
       bracketDepth = Math.max(0, bracketDepth - 1);
     } else if (
-      char === '=' &&
-      params[index + 1] !== '>' &&
+      char === '<' &&
       parenDepth === 0 &&
       braceDepth === 0 &&
       bracketDepth === 0 &&
-      angleDepth === 0
-    ) {
-      currentParameterHasDefaultValue = true;
-    } else if (
-      char === '<' &&
-      !currentParameterHasDefaultValue &&
       hasGenericCloseBeforeTopLevelComma(params, index)
     ) {
       angleDepth++;
-    } else if (char === '>' && previousChar !== '=') {
+    } else if (
+      char === '>' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      previousChar !== '='
+    ) {
       angleDepth = Math.max(0, angleDepth - 1);
     } else if (
       char === ',' &&
@@ -325,7 +394,6 @@ function countTopLevelParameters(params: string): number {
     ) {
       count++;
       hasParameterContent = false;
-      currentParameterHasDefaultValue = false;
     }
   }
 

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -205,6 +205,36 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('does not let comparisons before later generic parameters hide top-level parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function complex(limit = n < max, map: Map<string, number>, a, b, c, d) { return map; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
+  it('ignores declared functions returning object literal types', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `declare function external(a, b, c, d, e, f): { ok: boolean };`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
+  it('counts parameters for wrapped async arrow functions', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const fn = (async (a, b, c, d, e, f) => { return a; });`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
   it('flags functions with too many top-level parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -255,6 +255,39 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('ignores semicolonless overload signatures before implementations', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = [
+      'function parse(a, b, c, d, e, f): void',
+      'function parse(a, b) { return a; }',
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
+  it('does not let nested default comparisons hide top-level parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function complex({ x = a < b }, c = d > e, p1, p2, p3, p4) { return x; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
+  it('keeps generic call commas nested inside default values', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function ok(value = make<string, number>(), a, b, c, d): void { return value; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
   it('counts parameters for wrapped generic arrow functions', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `const fn = (<T,>(a, b, c, d, e, f) => { return a; });`;

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -155,6 +155,26 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('does not let default comparison expressions hide top-level parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function complex(limit = n < max, a, b, c, d, e) { return limit; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
+  it('does not count parenthesized variable expressions as arrow parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const value = (a, b, c, d, e, f);`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
   it('flags functions with too many top-level parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -235,6 +235,46 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('does not let paired default comparisons hide top-level parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function complex(limit = n < max, threshold = x > y, a, b, c, d) { return limit; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
+  it('ignores non-declare overload signatures returning object literal types', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function parse(a, b, c, d, e, f): { ok: boolean };`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
+  it('counts parameters for wrapped generic arrow functions', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const fn = (<T,>(a, b, c, d, e, f) => { return a; });`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
+  it('counts parameters for whitespace-wrapped arrow functions', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const fn = (\n  (a, b, c, d, e, f) => { return a; }\n);`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
   it('flags functions with too many top-level parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -175,6 +175,36 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('ignores TypeScript declarations without implementation bodies', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `declare function external(a, b, c, d, e, f): void;`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
+  it('keeps generic argument commas nested while counting parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function usesMap(a: Map<string, number>, b, c, d, e) { return a; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
+  it('counts parameters for wrapped arrow functions', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `const fn = ((a, b, c, d, e, f) => { return a; });`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      true,
+    );
+  });
+
   it('flags functions with too many top-level parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -136,7 +136,26 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
-  it('flags functions with too many parameters', async () => {
+  it('ignores nested TypeScript commas inside function parameters', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = [
+      'function configure(options: {',
+      '  alpha: string,',
+      '  beta: [string, number],',
+      '  gamma: Map<string, { id: string, label: string }>,',
+      '  delta: { enabled: boolean, retries: number },',
+      "} = { alpha: 'a', beta: ['b', 1], gamma: undefined, delta: { enabled: true, retries: 3 } }) {",
+      '  return options.alpha;',
+      '}',
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('parameter'))).toBe(
+      false,
+    );
+  });
+
+  it('flags functions with too many top-level parameters', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f, g) { return a; }`;
     const result = await evaluator.evaluate(createInput(content));


### PR DESCRIPTION
## Summary
- replace raw parameter comma splitting with balanced top-level parameter counting
- cover TypeScript object, tuple, generic, and default-value commas as one options parameter
- preserve true-positive detection for excessive top-level parameters

## Test Plan
- npm test -- --run tests/unit/evaluators/complexity.test.ts -t 'ignores nested TypeScript commas' (fails before fix)
- npm test -- --run tests/unit/evaluators/complexity.test.ts -t 'ignores nested TypeScript commas|flags functions with too many top-level parameters'
- npm test -- --run tests/unit/evaluators/complexity.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/critique
- npm test --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npx prettier --check packages/franken-critique/src/evaluators/complexity.ts packages/franken-critique/tests/unit/evaluators/complexity.test.ts

Closes #1240