### PR TITLE
fix(orchestrator): quarantine invalid analytics timestamps

### DIFF
--- a/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
+++ b/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
@@ -513,22 +513,37 @@ function matchesFilters(event: AnalyticsEvent, filters: AnalyticsFilters): boole
     }
   }
   const cutoff = cutoffFor(filters.timeWindow);
-  if (cutoff && parseAnalyticsTimestamp(event.timestamp) < cutoff.getTime()) {
-    return false;
+  if (cutoff) {
+    const parsedTimestamp = parseAnalyticsTimestamp(event.timestamp);
+    if (parsedTimestamp === null || parsedTimestamp < cutoff.getTime()) {
+      return false;
+    }
   }
   return true;
 }
 
 function compareTimestampsDesc(left: string, right: string): number {
-  const delta = parseAnalyticsTimestamp(right) - parseAnalyticsTimestamp(left);
+  const leftTimestamp = parseAnalyticsTimestamp(left);
+  const rightTimestamp = parseAnalyticsTimestamp(right);
+  if (leftTimestamp === null && rightTimestamp === null) {
+    return right.localeCompare(left);
+  }
+  if (leftTimestamp === null) {
+    return 1;
+  }
+  if (rightTimestamp === null) {
+    return -1;
+  }
+  const delta = rightTimestamp - leftTimestamp;
   return delta === 0 ? right.localeCompare(left) : delta;
 }
 
-function parseAnalyticsTimestamp(timestamp: string): number {
+function parseAnalyticsTimestamp(timestamp: string): number | null {
   const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(timestamp)
     ? `${timestamp.replace(' ', 'T')}Z`
     : timestamp;
-  return Date.parse(normalized);
+  const parsed = Date.parse(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function cutoffFor(timeWindow: string | undefined): Date | null {

--- a/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/analytics/analytics-service.test.ts
@@ -252,6 +252,46 @@ describe('createSqliteAnalyticsService', () => {
     expect(result.events.map((event) => event.id)).toEqual(['cost:1', 'beast-run:run-early']);
   });
 
+  it('quarantines malformed Analytics timestamps from finite windows and sorts them last otherwise', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+    workDir = await mkdtemp(join(tmpdir(), 'franken-analytics-'));
+    const dbPath = join(workDir, 'beast.db');
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE cost_ledger (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        prompt_tokens INTEGER NOT NULL DEFAULT 0,
+        completion_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_usd REAL NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL
+      );
+    `);
+    const insertCost = db.prepare(`
+      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    insertCost.run('session-recent', 'gpt-5.4', 1, 1, 0.01, '2026-04-28T11:59:00.000Z');
+    insertCost.run('session-invalid', 'gpt-5.4', 1, 1, 0.01, 'not-a-date');
+    insertCost.run('session-sqlite', 'gpt-5.4', 1, 1, 0.01, '2026-04-28 10:30:00');
+    db.close();
+
+    const service = createSqliteAnalyticsService({ dbPath });
+
+    await expect(service.listEvents({ timeWindow: '24h' })).resolves.toMatchObject({
+      total: 2,
+      events: [
+        expect.objectContaining({ id: 'cost:1', sessionId: 'session-recent' }),
+        expect.objectContaining({ id: 'cost:3', sessionId: 'session-sqlite' }),
+      ],
+    });
+
+    const allEvents = await service.listEvents({ timeWindow: 'all' });
+    expect(allEvents.events.map((event) => event.id)).toEqual(['cost:1', 'cost:3', 'cost:2']);
+  });
+
   it('reads failed Beast runs directly from the daemon database without service handles', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-analytics-'));
     const dbPath = join(workDir, 'beast.db');


### PR DESCRIPTION
## Summary
- Treat malformed Analytics timestamps as invalid instead of propagating Date.parse NaN
- Exclude invalid timestamps from finite timeWindow filters
- Sort invalid timestamps deterministically after valid chronological events

## Test Plan
- npm --workspace @franken/orchestrator test -- tests/unit/analytics/analytics-service.test.ts -t "quarantines malformed"
- npm --workspace @franken/orchestrator test -- tests/unit/analytics/analytics-service.test.ts
- npm --workspace @franken/orchestrator run lint
- npm run build
- npm run typecheck
- npm --workspace @franken/orchestrator test

Closes #1234