### PR TITLE
fix(orchestrator): accumulate stream progress input deltas

### DIFF
--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -61,6 +61,7 @@ export function createStreamProgressHandler(
   let lastToolName = '';
   let showedThinking = false;
   let textAccumulator = '';
+  let toolInputAccumulator = '';
   const seenChunkIds = new Set<string>();
 
   return (line: string) => {
@@ -91,6 +92,10 @@ export function createStreamProgressHandler(
 
       if (block['type'] === 'tool_use') {
         lastToolName = block['name'] as string;
+        toolInputAccumulator = '';
+      } else {
+        lastToolName = '';
+        toolInputAccumulator = '';
       }
 
       // Reset text accumulator for new text blocks
@@ -108,12 +113,14 @@ export function createStreamProgressHandler(
       if (delta['type'] === 'input_json_delta' && lastToolName) {
         const partial = delta['partial_json'] as string | undefined;
         if (partial) {
-          const pathMatch = partial.match(/"file_path"\s*:\s*"([^"]+)"/);
+          toolInputAccumulator += partial;
+          const pathMatch = toolInputAccumulator.match(/"file_path"\s*:\s*"([^"]+)"/);
           if (pathMatch?.[1]) {
             const action = toolAction(lastToolName);
             const shortPath = shortenPath(pathMatch[1]);
             write(`  ${ANSI.dim}${action} ${shortPath}${ANSI.reset}\n`);
             lastToolName = ''; // Only show once per tool use
+            toolInputAccumulator = '';
           }
         }
       }

--- a/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
@@ -53,6 +53,58 @@ describe('createStreamProgressHandler', () => {
     expect(writeLines[0]).toContain('foo.ts');
   });
 
+  it('accumulates split input JSON deltas before showing a tool file path once', () => {
+    const lines: string[] = [];
+    const handler = createStreamProgressHandler((t) => lines.push(t));
+
+    handler(JSON.stringify({
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: {} },
+    }));
+
+    handler(JSON.stringify({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: '{"file_' },
+    }));
+    handler(JSON.stringify({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: 'path": "/home/user/project/src/split.ts"' },
+    }));
+    handler(JSON.stringify({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: ', "content": "extra"}' },
+    }));
+
+    const writeLines = lines.filter(l => l.includes('Writing'));
+    expect(writeLines).toHaveLength(1);
+    expect(writeLines[0]).toContain('split.ts');
+  });
+
+  it('resets split input JSON buffering between tool uses', () => {
+    const lines: string[] = [];
+    const handler = createStreamProgressHandler((t) => lines.push(t));
+
+    handler(JSON.stringify({
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: {} },
+    }));
+    handler(JSON.stringify({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: '{"file_' },
+    }));
+
+    handler(JSON.stringify({
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', id: 'toolu_2', name: 'Edit', input: {} },
+    }));
+    handler(JSON.stringify({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: 'path": "/home/user/project/src/leaked.ts"' },
+    }));
+
+    expect(lines.filter(l => l.includes('Writing') || l.includes('Editing'))).toHaveLength(0);
+  });
+
   it('shows completion stats on result event', () => {
     const lines: string[] = [];
     const handler = createStreamProgressHandler((t) => lines.push(t));


### PR DESCRIPTION
## Summary
- Accumulates streamed tool input JSON deltas before scanning for file_path
- Resets the tool input buffer on new content blocks and after emitting a path
- Adds regressions for split file_path chunks, reset behavior, and one-time emission

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/adapters/stream-progress.test.ts
- npm --prefix packages/franken-orchestrator run lint
- npm run build
- npm --prefix packages/franken-orchestrator run typecheck
- npm run typecheck
- TMPDIR="$PWD/.tmp-vitest" npm --prefix packages/franken-orchestrator test

Closes #1237