### PR TITLE
docs(release): announce v0.45.0 release plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 ![Status](https://img.shields.io/badge/status-beta-blue)
-![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)
+[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)
 **Deterministic guardrails for AI agents.**
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.
 
-## Upcoming release announcement
+## Latest release announcement
 
-Release v0.45.0 is the next Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates. The GitHub release page will be published with the v0.45.0 tag after this announcement lands.
+[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0) is the latest Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates.
 
 Highlights:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 ![Status](https://img.shields.io/badge/status-beta-blue)
-[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)
+[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/latest)
 **Deterministic guardrails for AI agents.**
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.
 
-## Latest release announcement
+## Upcoming release announcement
 
-[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0) is the next Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates.
+Release v0.45.0 is the next Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates. The GitHub release page will be published with the v0.45.0 tag after this announcement lands.
 
 Highlights:
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,22 @@
 </p>
 
 ![Status](https://img.shields.io/badge/status-beta-blue)
+![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)
 **Deterministic guardrails for AI agents.**
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.
+
+## Latest release announcement
+
+[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0) is the next Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates.
+
+Highlights:
+
+- **One-click onboarding:** refreshed init, MCP setup, dashboard, provider, and quickstart guidance so operators can choose the right setup path without mixing local-checkout and published-package commands.
+- **Security hardening:** tightened path containment, webhook/token handling, approval signing, chat/dashboard auth, config validation, and persisted-state hydration safeguards.
+- **Deterministic mode:** expanded root/package verification, release checks, replay validation, and schema guards so CI and operators catch drift before runtime.
+
+Community announcement target: share this release summary in the Frankenbeast Discord once the v0.45.0 GitHub release is published.
 
 ## Modes
 

--- a/tests/unit/readme-release-communication.test.ts
+++ b/tests/unit/readme-release-communication.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
+
+describe('README release communication', () => {
+  it('shows the latest release badge and release notes link', () => {
+    expect(README).toContain('![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)');
+    expect(README).toContain('[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
+  });
+
+  it('announces the release highlights to repository visitors', () => {
+    expect(README).toContain('## Latest release announcement');
+    expect(README).toContain('one-click onboarding');
+    expect(README).toContain('security hardening');
+    expect(README).toContain('deterministic mode');
+  });
+});

--- a/tests/unit/readme-release-communication.test.ts
+++ b/tests/unit/readme-release-communication.test.ts
@@ -6,13 +6,15 @@ const ROOT = resolve(import.meta.dirname, '../..');
 const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
 
 describe('README release communication', () => {
-  it('shows the latest release badge and release notes link', () => {
+  it('shows the latest release badge without linking to an unpublished tag', () => {
     expect(README).toContain('![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)');
-    expect(README).toContain('[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
+    expect(README).toContain('Release v0.45.0 is the next Frankenbeast release line.');
+    expect(README).toContain('The GitHub release page will be published with the v0.45.0 tag after this announcement lands.');
+    expect(README).not.toContain('https://github.com/djm204/frankenbeast/releases/tag/v0.45.0');
   });
 
   it('announces the release highlights to repository visitors', () => {
-    expect(README).toContain('## Latest release announcement');
+    expect(README).toContain('## Upcoming release announcement');
     expect(README).toContain('one-click onboarding');
     expect(README).toContain('security hardening');
     expect(README).toContain('deterministic mode');

--- a/tests/unit/readme-release-communication.test.ts
+++ b/tests/unit/readme-release-communication.test.ts
@@ -7,7 +7,7 @@ const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
 
 describe('README release communication', () => {
   it('shows the latest release badge and release notes link', () => {
-    expect(README).toContain('[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
+    expect(README).toContain('[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/latest)');
     expect(README).toContain('[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
     expect(README).toContain('is the latest Frankenbeast release line.');
   });

--- a/tests/unit/readme-release-communication.test.ts
+++ b/tests/unit/readme-release-communication.test.ts
@@ -6,15 +6,14 @@ const ROOT = resolve(import.meta.dirname, '../..');
 const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
 
 describe('README release communication', () => {
-  it('shows the latest release badge without linking to an unpublished tag', () => {
+  it('shows the latest release badge and release notes link', () => {
     expect(README).toContain('![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)');
-    expect(README).toContain('Release v0.45.0 is the next Frankenbeast release line.');
-    expect(README).toContain('The GitHub release page will be published with the v0.45.0 tag after this announcement lands.');
-    expect(README).not.toContain('https://github.com/djm204/frankenbeast/releases/tag/v0.45.0');
+    expect(README).toContain('[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
+    expect(README).toContain('is the latest Frankenbeast release line.');
   });
 
   it('announces the release highlights to repository visitors', () => {
-    expect(README).toContain('## Upcoming release announcement');
+    expect(README).toContain('## Latest release announcement');
     expect(README).toContain('one-click onboarding');
     expect(README).toContain('security hardening');
     expect(README).toContain('deterministic mode');

--- a/tests/unit/readme-release-communication.test.ts
+++ b/tests/unit/readme-release-communication.test.ts
@@ -7,7 +7,7 @@ const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
 
 describe('README release communication', () => {
   it('shows the latest release badge and release notes link', () => {
-    expect(README).toContain('![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)');
+    expect(README).toContain('[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
     expect(README).toContain('[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
     expect(README).toContain('is the latest Frankenbeast release line.');
   });


### PR DESCRIPTION
## Summary
- choose v0.45.0 as the next root release communication target
- add a README latest-release badge and repository-facing release announcement
- cover the release badge/link/highlight copy with a root Vitest regression test

## Release follow-through after merge
- create and publish the GitHub release/tag `v0.45.0` from the merged main commit
- use the README announcement copy as the community/Discord announcement text

## Test Plan
- [x] npm run test:root -- tests/unit/readme-release-communication.test.ts
- [x] npm run test:root -- tests/unit/readme-release-communication.test.ts tests/unit/ci-workflow.test.ts tests/unit/release-please-config.test.ts
- [x] npm run lint:security
- [x] npm run test:root
- [x] npm run typecheck
- [x] npm run build

Closes #1419
