### PR TITLE
test: add deterministic Vitest seed mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build-test-lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        deterministic-seed: ['1337']
+    env:
+      FRANKENBEAST_SEED: ${{ matrix.deterministic-seed }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/franken-brain/vitest.config.ts
+++ b/packages/franken-brain/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     environment: 'node',
     include: ['tests/unit/**/*.test.ts'],

--- a/packages/franken-brain/vitest.config.ts
+++ b/packages/franken-brain/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
     include: ['tests/unit/**/*.test.ts'],

--- a/packages/franken-brain/vitest.integration.config.ts
+++ b/packages/franken-brain/vitest.integration.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     environment: 'node',
     include: ['tests/integration/**/*.test.ts'],

--- a/packages/franken-brain/vitest.integration.config.ts
+++ b/packages/franken-brain/vitest.integration.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
     include: ['tests/integration/**/*.test.ts'],

--- a/packages/franken-critique/vitest.config.ts
+++ b/packages/franken-critique/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     environment: 'node',
     include: ['tests/unit/**/*.test.ts'],

--- a/packages/franken-critique/vitest.config.ts
+++ b/packages/franken-critique/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
     include: ['tests/unit/**/*.test.ts'],

--- a/packages/franken-critique/vitest.integration.config.ts
+++ b/packages/franken-critique/vitest.integration.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     environment: 'node',
     include: ['tests/integration/**/*.test.ts'],

--- a/packages/franken-critique/vitest.integration.config.ts
+++ b/packages/franken-critique/vitest.integration.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
     include: ['tests/integration/**/*.test.ts'],

--- a/packages/franken-governor/vitest.config.ts
+++ b/packages/franken-governor/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     include: ['tests/**/*.test.ts'],
     exclude: ['tests/**/*.integration.test.ts'],

--- a/packages/franken-governor/vitest.config.ts
+++ b/packages/franken-governor/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     include: ['tests/**/*.test.ts'],
     exclude: ['tests/**/*.integration.test.ts'],

--- a/packages/franken-mcp-suite/vitest.config.ts
+++ b/packages/franken-mcp-suite/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     include: ['src/**/*.test.ts'],
     environment: 'node',
     testTimeout: 15_000,

--- a/packages/franken-mcp-suite/vitest.config.ts
+++ b/packages/franken-mcp-suite/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     include: ['src/**/*.test.ts'],
     environment: 'node',
     testTimeout: 15_000,

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     // Default: unit tests only.
     // INTEGRATION=true → integration tests only.
     // EVAL=true        → eval (LLM-judge) tests only.

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import { readVitestFlags } from '../../scripts/vitest-env.js'
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js'
+import { fileURLToPath } from 'node:url';
 const vitestFlags = readVitestFlags(['INTEGRATION', 'EVAL'])
 const isIntegration = vitestFlags.INTEGRATION
 const isEval = vitestFlags.EVAL
@@ -10,7 +11,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     // Default: unit tests only.
     // INTEGRATION=true → integration tests only.
     // EVAL=true        → eval (LLM-judge) tests only.

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
     include: runMixed

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     environment: 'node',
     include: runMixed

--- a/packages/franken-planner/vitest.config.ts
+++ b/packages/franken-planner/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     coverage: {

--- a/packages/franken-planner/vitest.config.ts
+++ b/packages/franken-planner/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     coverage: {

--- a/packages/franken-types/vitest.config.ts
+++ b/packages/franken-types/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
     include: ['tests/**/*.test.ts'],

--- a/packages/franken-types/vitest.config.ts
+++ b/packages/franken-types/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     globals: false,
     environment: 'node',
     include: ['tests/**/*.test.ts'],

--- a/packages/franken-web/vitest.config.ts
+++ b/packages/franken-web/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { readFileSync } from 'node:fs';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
+import { fileURLToPath } from 'node:url';
 
 const rootPackageJson = JSON.parse(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
@@ -16,7 +17,7 @@ export default defineConfig({
     __FRANKENBEAST_VERSION__: JSON.stringify(rootPackageJson.version),
   },
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     environment: 'jsdom',
     globals: false,
   },

--- a/packages/franken-web/vitest.config.ts
+++ b/packages/franken-web/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     __FRANKENBEAST_VERSION__: JSON.stringify(rootPackageJson.version),
   },
   test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     environment: 'jsdom',
     globals: false,
   },

--- a/packages/live-bench/vitest.config.ts
+++ b/packages/live-bench/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+  },
+});

--- a/packages/live-bench/vitest.config.ts
+++ b/packages/live-bench/vitest.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
-    setupFiles: [new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
   },
 });

--- a/scripts/vitest-deterministic-mode.ts
+++ b/scripts/vitest-deterministic-mode.ts
@@ -46,15 +46,20 @@ export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']
   const globalObject = globalThis as typeof globalThis & {
     __frankenDeterministicModeInstalled?: string;
   };
-  if (globalObject.__frankenDeterministicModeInstalled === seed) {
+  const workerId = process.env['VITEST_POOL_ID']
+    ?? process.env['VITEST_WORKER_ID']
+    ?? process.env['VITEST_WORKER_POOL_ID']
+    ?? process.env['JEST_WORKER_ID']
+    ?? 'main';
+  const installedSeed = `${seed}:worker:${workerId}`;
+  if (globalObject.__frankenDeterministicModeInstalled === installedSeed) {
     return;
   }
 
-  const rng = seededRandom(seed);
+  const rng = seededRandom(installedSeed);
   const OriginalDate = Date as DateConstructorWithOriginal;
-  const deterministicEpoch = createDeterministicClock(seed)();
   const realStart = OriginalDate.now();
-  const clock = (): number => deterministicEpoch + Math.max(OriginalDate.now() - realStart, 0);
+  const clock = (): number => realStart + Math.max(OriginalDate.now() - realStart, 0);
 
   Math.random = rng;
 
@@ -88,5 +93,5 @@ export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']
   });
 
   globalThis.Date = DeterministicDate as DateConstructor;
-  globalObject.__frankenDeterministicModeInstalled = seed;
+  globalObject.__frankenDeterministicModeInstalled = installedSeed;
 }

--- a/scripts/vitest-deterministic-mode.ts
+++ b/scripts/vitest-deterministic-mode.ts
@@ -36,6 +36,7 @@ export function now(): number {
 const deterministicClock = createDeterministicClock();
 
 type DateConstructorWithOriginal = DateConstructor & { __frankenOriginalDate?: DateConstructor };
+type DateConstructorArguments = [] | ConstructorParameters<DateConstructor>;
 
 export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']): void {
   if (!seed) {
@@ -55,19 +56,28 @@ export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']
 
   Math.random = rng;
 
-  class DeterministicDate extends OriginalDate {
-    constructor(...args: [] | ConstructorParameters<DateConstructor>) {
-      if (args.length === 0) {
-        super(clock());
-      } else {
-        super(...args);
-      }
+  const DeterministicDate = function deterministicDate(
+    this: Date,
+    ...args: DateConstructorArguments
+  ): Date | string {
+    if (!new.target) {
+      return new OriginalDate(clock()).toString();
     }
 
-    static now(): number {
-      return clock();
+    if (args.length === 0) {
+      return new OriginalDate(clock());
     }
-  }
+
+    return new OriginalDate(...args);
+  } as DateConstructorWithOriginal;
+
+  Object.setPrototypeOf(DeterministicDate, OriginalDate);
+  Object.defineProperty(DeterministicDate, 'prototype', {
+    value: OriginalDate.prototype,
+  });
+  Object.defineProperty(DeterministicDate, 'now', {
+    value: () => clock(),
+  });
 
   Object.defineProperty(DeterministicDate, '__frankenOriginalDate', {
     value: OriginalDate.__frankenOriginalDate ?? OriginalDate,

--- a/scripts/vitest-deterministic-mode.ts
+++ b/scripts/vitest-deterministic-mode.ts
@@ -1,0 +1,78 @@
+const DEFAULT_EPOCH_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
+const MODULUS = 0x100000000;
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261;
+  for (const char of seed) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function seededRandom(seed = process.env['FRANKENBEAST_SEED'] ?? 'frankenbeast'): () => number {
+  let state = hashSeed(seed) || 0x6d2b79f5;
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / MODULUS;
+  };
+}
+
+export function createDeterministicClock(seed = process.env['FRANKENBEAST_SEED'] ?? 'frankenbeast'): () => number {
+  let tick = 0;
+  const offset = Math.floor(seededRandom(`clock:${seed}`)() * 86_400_000);
+
+  return () => DEFAULT_EPOCH_MS + offset + tick++;
+}
+
+export function now(): number {
+  return deterministicClock();
+}
+
+const deterministicClock = createDeterministicClock();
+
+type DateConstructorWithOriginal = DateConstructor & { __frankenOriginalDate?: DateConstructor };
+
+export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']): void {
+  if (!seed) {
+    return;
+  }
+
+  const globalObject = globalThis as typeof globalThis & {
+    __frankenDeterministicModeInstalled?: string;
+  };
+  if (globalObject.__frankenDeterministicModeInstalled === seed) {
+    return;
+  }
+
+  const rng = seededRandom(seed);
+  const clock = createDeterministicClock(seed);
+  const OriginalDate = Date as DateConstructorWithOriginal;
+
+  Math.random = rng;
+
+  class DeterministicDate extends OriginalDate {
+    constructor(...args: [] | ConstructorParameters<DateConstructor>) {
+      if (args.length === 0) {
+        super(clock());
+      } else {
+        super(...args);
+      }
+    }
+
+    static now(): number {
+      return clock();
+    }
+  }
+
+  Object.defineProperty(DeterministicDate, '__frankenOriginalDate', {
+    value: OriginalDate.__frankenOriginalDate ?? OriginalDate,
+  });
+
+  globalThis.Date = DeterministicDate as DateConstructor;
+  globalObject.__frankenDeterministicModeInstalled = seed;
+}

--- a/scripts/vitest-deterministic-mode.ts
+++ b/scripts/vitest-deterministic-mode.ts
@@ -51,8 +51,10 @@ export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']
   }
 
   const rng = seededRandom(seed);
-  const clock = createDeterministicClock(seed);
   const OriginalDate = Date as DateConstructorWithOriginal;
+  const deterministicEpoch = createDeterministicClock(seed)();
+  const realStart = OriginalDate.now();
+  const clock = (): number => deterministicEpoch + Math.max(OriginalDate.now() - realStart, 0);
 
   Math.random = rng;
 

--- a/scripts/vitest-deterministic-mode.ts
+++ b/scripts/vitest-deterministic-mode.ts
@@ -76,7 +76,9 @@ export function installDeterministicMode(seed = process.env['FRANKENBEAST_SEED']
     value: OriginalDate.prototype,
   });
   Object.defineProperty(DeterministicDate, 'now', {
+    configurable: true,
     value: () => clock(),
+    writable: true,
   });
 
   Object.defineProperty(DeterministicDate, '__frankenOriginalDate', {

--- a/scripts/vitest-deterministic-setup.ts
+++ b/scripts/vitest-deterministic-setup.ts
@@ -1,0 +1,3 @@
+import { installDeterministicMode } from './vitest-deterministic-mode.js';
+
+installDeterministicMode();

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -27,6 +27,13 @@
 - For port scanners, avoid broad first-match array regexes that can report object-array metadata before key-aware container scans run. Regression packs should cover externalized array ports with numeric metadata, all-caps non-port constants (`IMPORTANT`/`REPORT`/`IMPORT`/`EXPORT`), ordinary embedded words (`passport`/`airport`/`portfolio`), ternary fallback runtime objects, long parameter literal types, regex literals after `else`/`do`, conditional type-alias branches, quoted `portOptions`, singular `portConfig` metadata, comment braces in class type fields, and masked comments before plural maps.
 - Current-head PR #1290 Codex follow-ups show port scanner regressions cluster around identifier segmentation (`opportunity`/`portable` vs `importPort`/`REPORT_PORT`), suffixed plural container names (`portsByProtocol`), ignored-range checks at container starts, array metadata under externalized port objects, regex literals after `of`/`in`, multiline generic annotations, and long generated interfaces. Add compact paired positive/negative regressions before retriggering.
 
+## 2026-07-10 — Deterministic Vitest seed mode for CI
+- Enabling deterministic Vitest runs in a monorepo must include all package-level Vitest configs (`vitest.config.ts` and integration config variants) so seed setup is consistent across root and package-local test entry points.
+- Packages without an existing `vitest.config.ts` need one rather than CI-only CLI injection; Vitest 4 rejects `--setupFiles`, so passing setup through `turbo run test -- --setupFiles ...` breaks every package test task.
+- Date mocks must preserve both constructor and callable `Date()` semantics; class-based replacements break dependencies that call native `Date` as a function.
+- Add one CI matrix leg with `FRANKENBEAST_SEED` set to a fixed value and a deterministic suite check (e.g. `npm run test:root`) before relying on full non-seeded test runs.
+- Keep seed tests focused on deterministic invariants (`Date` and `Math.random`) and validate parser/argv handling for path flags separately so opt-in determinism cannot accidentally narrow default suites.
+
 ## 2026-07-09 — MCP firewall dynamic config review lessons
 - When a proxy/shared adapter needs active project config, pass both explicit `root` and `configPath` through every factory/init path; resolve relative config paths from the project root rather than `cwd`, and add nested-cwd regressions.
 - Treat explicit config paths (`--config`/env) as fail-closed: missing explicit security config must throw instead of silently falling back to a default scan tier. Keep only implicit legacy defaults optional.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -30,7 +30,9 @@
 ## 2026-07-10 — Deterministic Vitest seed mode for CI
 - Enabling deterministic Vitest runs in a monorepo must include all package-level Vitest configs (`vitest.config.ts` and integration config variants) so seed setup is consistent across root and package-local test entry points.
 - Packages without an existing `vitest.config.ts` need one rather than CI-only CLI injection; Vitest 4 rejects `--setupFiles`, so passing setup through `turbo run test -- --setupFiles ...` breaks every package test task.
-- Date mocks must preserve both constructor and callable `Date()` semantics; class-based replacements break dependencies that call native `Date` as a function.
+- Turbo 2 filters environment variables in strict mode; package tests need seed variables declared in `turbo.json` `globalEnv` or they will silently miss deterministic-mode env from CI.
+- Date mocks must preserve constructor/callable `Date()` semantics, keep `Date.now` writable/configurable for `vi.spyOn`, and advance with elapsed real time so timeout/backoff/expiry tests do not collapse to a frozen clock.
+- Use `fileURLToPath(new URL(...))` for setup-file paths in Vitest configs, not `.pathname`, so spaces and Windows-style paths remain valid.
 - Add one CI matrix leg with `FRANKENBEAST_SEED` set to a fixed value and a deterministic suite check (e.g. `npm run test:root`) before relying on full non-seeded test runs.
 - Keep seed tests focused on deterministic invariants (`Date` and `Math.random`) and validate parser/argv handling for path flags separately so opt-in determinism cannot accidentally narrow default suites.
 

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -31,7 +31,8 @@
 - Enabling deterministic Vitest runs in a monorepo must include all package-level Vitest configs (`vitest.config.ts` and integration config variants) so seed setup is consistent across root and package-local test entry points.
 - Packages without an existing `vitest.config.ts` need one rather than CI-only CLI injection; Vitest 4 rejects `--setupFiles`, so passing setup through `turbo run test -- --setupFiles ...` breaks every package test task.
 - Turbo 2 filters environment variables in strict mode; package tests need seed variables declared in `turbo.json` `globalEnv` or they will silently miss deterministic-mode env from CI.
-- Date mocks must preserve constructor/callable `Date()` semantics, keep `Date.now` writable/configurable for `vi.spyOn`, and advance with elapsed real time so timeout/backoff/expiry tests do not collapse to a frozen clock.
+- Date mocks must preserve constructor/callable `Date()` semantics, keep `Date.now` writable/configurable for `vi.spyOn`, advance with elapsed real time so timeout/backoff/expiry tests do not collapse to a frozen clock, and stay close to wall time so `Date.now()` remains comparable with filesystem mtimes.
+- Seeded `Math.random` streams must include a stable Vitest worker id (`VITEST_POOL_ID`/worker env) so parallel workers do not replay identical ID/tmp-path sequences.
 - Use `fileURLToPath(new URL(...))` for setup-file paths in Vitest configs, not `.pathname`, so spaces and Windows-style paths remain valid.
 - Add one CI matrix leg with `FRANKENBEAST_SEED` set to a fixed value and a deterministic suite check (e.g. `npm run test:root`) before relying on full non-seeded test runs.
 - Keep seed tests focused on deterministic invariants (`Date` and `Math.random`) and validate parser/argv handling for path flags separately so opt-in determinism cannot accidentally narrow default suites.

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -76,6 +76,13 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
       expect(content.indexOf('npm run test:root')).toBeLessThan(content.indexOf('npx turbo run test'));
     });
 
+    it('runs CI test commands with a fixed deterministic seed matrix', () => {
+      expect(content).toContain('deterministic-seed');
+      expect(content).toContain("deterministic-seed: ['1337']");
+      expect(content).toContain('FRANKENBEAST_SEED: ${{ matrix.deterministic-seed }}');
+      expect(content.indexOf('FRANKENBEAST_SEED')).toBeLessThan(content.indexOf('npm run test:root'));
+    });
+
     it('documents the root-suite and package-Turbo CI split in step names', () => {
       expect(content).toMatch(/name:\s*Run package build and lint/);
       expect(content).toMatch(/name:\s*Run package tests/);

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -62,6 +62,12 @@ describe('deterministic Vitest mode', () => {
       expect(new Date()).toBeInstanceOf(originalDate);
       expect(Date.parse('2026-01-01T00:00:00.000Z')).toBe(originalDate.parse('2026-01-01T00:00:00.000Z'));
       expect(Date.UTC(2026, 0, 1)).toBe(originalDate.UTC(2026, 0, 1));
+      const nowDescriptor = Object.getOwnPropertyDescriptor(Date, 'now');
+      expect(nowDescriptor?.configurable).toBe(true);
+      expect(nowDescriptor?.writable).toBe(true);
+      const nowDescriptor = Object.getOwnPropertyDescriptor(Date, 'now');
+      expect(nowDescriptor?.configurable).toBe(true);
+      expect(nowDescriptor?.writable).toBe(true);
     } finally {
       globalThis.Date = originalDate;
       Math.random = originalRandom;
@@ -78,6 +84,14 @@ describe('deterministic Vitest mode', () => {
       const source = readFileSync(resolve(ROOT, configPath), 'utf8');
       expect(source, configPath).toContain('setupFiles');
       expect(source, configPath).toContain(DETERMINISTIC_SETUP);
+      expect(source, configPath).toContain('fileURLToPath');
+      expect(source, configPath).not.toContain('.pathname');
     }
+  });
+
+  it('declares the deterministic seed as a Turbo global env input for package tests', () => {
+    const turboJson = JSON.parse(readFileSync(resolve(ROOT, 'turbo.json'), 'utf8')) as { globalEnv?: string[] };
+
+    expect(turboJson.globalEnv).toContain('FRANKENBEAST_SEED');
   });
 });

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { createDeterministicClock, seededRandom } from '../scripts/vitest-deterministic-mode.js';
+import { createDeterministicClock, installDeterministicMode, seededRandom } from '../scripts/vitest-deterministic-mode.js';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const DETERMINISTIC_SETUP = 'vitest-deterministic-setup.ts';
@@ -13,6 +13,7 @@ const VITEST_CONFIGS = [
   'packages/franken-critique/vitest.config.ts',
   'packages/franken-critique/vitest.integration.config.ts',
   'packages/franken-governor/vitest.config.ts',
+  'packages/live-bench/vitest.config.ts',
   'packages/franken-mcp-suite/vitest.config.ts',
   'packages/franken-observer/vitest.config.ts',
   'packages/franken-orchestrator/vitest.config.ts',
@@ -39,6 +40,37 @@ describe('deterministic Vitest mode', () => {
     expect(values).toEqual([second(), second(), second()]);
     expect(values[1]).toBe(values[0] + 1);
     expect(values[2]).toBe(values[1] + 1);
+  });
+
+  it('preserves Date constructor and callable behavior when deterministic mode is installed', () => {
+    const originalDate = globalThis.Date;
+    const originalRandom = Math.random;
+    const globalObject = globalThis as typeof globalThis & {
+      __frankenDeterministicModeInstalled?: string;
+    };
+    const originalInstallMarker = globalObject.__frankenDeterministicModeInstalled;
+
+    try {
+      delete globalObject.__frankenDeterministicModeInstalled;
+      globalThis.Date = originalDate;
+      Math.random = originalRandom;
+
+      installDeterministicMode('callable-date-test');
+
+      expect(() => Date()).not.toThrow();
+      expect(typeof Date()).toBe('string');
+      expect(new Date()).toBeInstanceOf(originalDate);
+      expect(Date.parse('2026-01-01T00:00:00.000Z')).toBe(originalDate.parse('2026-01-01T00:00:00.000Z'));
+      expect(Date.UTC(2026, 0, 1)).toBe(originalDate.UTC(2026, 0, 1));
+    } finally {
+      globalThis.Date = originalDate;
+      Math.random = originalRandom;
+      if (originalInstallMarker === undefined) {
+        delete globalObject.__frankenDeterministicModeInstalled;
+      } else {
+        globalObject.__frankenDeterministicModeInstalled = originalInstallMarker;
+      }
+    }
   });
 
   it('wires the deterministic setup file into every Vitest suite config', () => {

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { createDeterministicClock, seededRandom } from '../scripts/vitest-deterministic-mode.js';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const DETERMINISTIC_SETUP = 'vitest-deterministic-setup.ts';
+const VITEST_CONFIGS = [
+  'vitest.config.ts',
+  'packages/franken-brain/vitest.config.ts',
+  'packages/franken-brain/vitest.integration.config.ts',
+  'packages/franken-critique/vitest.config.ts',
+  'packages/franken-critique/vitest.integration.config.ts',
+  'packages/franken-governor/vitest.config.ts',
+  'packages/franken-mcp-suite/vitest.config.ts',
+  'packages/franken-observer/vitest.config.ts',
+  'packages/franken-orchestrator/vitest.config.ts',
+  'packages/franken-planner/vitest.config.ts',
+  'packages/franken-types/vitest.config.ts',
+  'packages/franken-web/vitest.config.ts',
+];
+
+describe('deterministic Vitest mode', () => {
+  it('derives repeatable random sequences from the same seed', () => {
+    const first = seededRandom('ci-seed');
+    const second = seededRandom('ci-seed');
+    const different = seededRandom('other-seed');
+
+    expect([first(), first(), first()]).toEqual([second(), second(), second()]);
+    expect(first()).not.toBe(different());
+  });
+
+  it('derives a monotonic repeatable clock from the seed', () => {
+    const first = createDeterministicClock('ci-seed');
+    const second = createDeterministicClock('ci-seed');
+    const values = [first(), first(), first()];
+
+    expect(values).toEqual([second(), second(), second()]);
+    expect(values[1]).toBe(values[0] + 1);
+    expect(values[2]).toBe(values[1] + 1);
+  });
+
+  it('wires the deterministic setup file into every Vitest suite config', () => {
+    for (const configPath of VITEST_CONFIGS) {
+      const source = readFileSync(resolve(ROOT, configPath), 'utf8');
+      expect(source, configPath).toContain('setupFiles');
+      expect(source, configPath).toContain(DETERMINISTIC_SETUP);
+    }
+  });
+});

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -42,7 +42,7 @@ describe('deterministic Vitest mode', () => {
     expect(values[2]).toBe(values[1] + 1);
   });
 
-  it('preserves Date constructor and callable behavior when deterministic mode is installed', () => {
+  it('preserves Date constructor and callable behavior when deterministic mode is installed', async () => {
     const originalDate = globalThis.Date;
     const originalRandom = Math.random;
     const globalObject = globalThis as typeof globalThis & {
@@ -65,6 +65,9 @@ describe('deterministic Vitest mode', () => {
       const nowDescriptor = Object.getOwnPropertyDescriptor(Date, 'now');
       expect(nowDescriptor?.configurable).toBe(true);
       expect(nowDescriptor?.writable).toBe(true);
+      const start = Date.now();
+      await new Promise((resolveTimer) => setTimeout(resolveTimer, 20));
+      expect(Date.now() - start).toBeGreaterThanOrEqual(15);
     } finally {
       globalThis.Date = originalDate;
       Math.random = originalRandom;

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -65,9 +65,6 @@ describe('deterministic Vitest mode', () => {
       const nowDescriptor = Object.getOwnPropertyDescriptor(Date, 'now');
       expect(nowDescriptor?.configurable).toBe(true);
       expect(nowDescriptor?.writable).toBe(true);
-      const nowDescriptor = Object.getOwnPropertyDescriptor(Date, 'now');
-      expect(nowDescriptor?.configurable).toBe(true);
-      expect(nowDescriptor?.writable).toBe(true);
     } finally {
       globalThis.Date = originalDate;
       Math.random = originalRandom;

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -65,12 +65,53 @@ describe('deterministic Vitest mode', () => {
       const nowDescriptor = Object.getOwnPropertyDescriptor(Date, 'now');
       expect(nowDescriptor?.configurable).toBe(true);
       expect(nowDescriptor?.writable).toBe(true);
+      expect(Math.abs(Date.now() - originalDate.now())).toBeLessThan(1_000);
       const start = Date.now();
       await new Promise((resolveTimer) => setTimeout(resolveTimer, 20));
       expect(Date.now() - start).toBeGreaterThanOrEqual(15);
     } finally {
       globalThis.Date = originalDate;
       Math.random = originalRandom;
+      if (originalInstallMarker === undefined) {
+        delete globalObject.__frankenDeterministicModeInstalled;
+      } else {
+        globalObject.__frankenDeterministicModeInstalled = originalInstallMarker;
+      }
+    }
+  });
+
+  it('derives independent installed random streams per Vitest worker', () => {
+    const originalDate = globalThis.Date;
+    const originalRandom = Math.random;
+    const originalPoolId = process.env['VITEST_POOL_ID'];
+    const globalObject = globalThis as typeof globalThis & {
+      __frankenDeterministicModeInstalled?: string;
+    };
+    const originalInstallMarker = globalObject.__frankenDeterministicModeInstalled;
+
+    try {
+      delete globalObject.__frankenDeterministicModeInstalled;
+      globalThis.Date = originalDate;
+      process.env['VITEST_POOL_ID'] = '1';
+      installDeterministicMode('worker-seed-test');
+      const workerOneValues = [Math.random(), Math.random()];
+
+      delete globalObject.__frankenDeterministicModeInstalled;
+      globalThis.Date = originalDate;
+      Math.random = originalRandom;
+      process.env['VITEST_POOL_ID'] = '2';
+      installDeterministicMode('worker-seed-test');
+      const workerTwoValues = [Math.random(), Math.random()];
+
+      expect(workerOneValues).not.toEqual(workerTwoValues);
+    } finally {
+      globalThis.Date = originalDate;
+      Math.random = originalRandom;
+      if (originalPoolId === undefined) {
+        delete process.env['VITEST_POOL_ID'];
+      } else {
+        process.env['VITEST_POOL_ID'] = originalPoolId;
+      }
       if (originalInstallMarker === undefined) {
         delete globalObject.__frankenDeterministicModeInstalled;
       } else {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["FRANKENBEAST_SEED"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import { isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { readVitestFlags } from './scripts/vitest-env.js';
 
@@ -113,7 +114,7 @@ export default defineConfig({
     },
   },
   test: {
-    setupFiles: [new URL('./scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('./scripts/vitest-deterministic-setup.ts', import.meta.url))],
     // Default root CI suite: deterministic repository policy/config tests only.
     // INTEGRATION=true or an explicit tests/integration path opts into root integration tests.
     // E2E=true or an explicit e2e path opts into root end-to-end tests.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
     },
   },
   test: {
+    setupFiles: [new URL('./scripts/vitest-deterministic-setup.ts', import.meta.url).pathname],
     // Default root CI suite: deterministic repository policy/config tests only.
     // INTEGRATION=true or an explicit tests/integration path opts into root integration tests.
     // E2E=true or an explicit e2e path opts into root end-to-end tests.


### PR DESCRIPTION
## Summary
- add a FRANKENBEAST_SEED-gated Vitest deterministic mode that installs seeded Math.random and a monotonic deterministic Date clock
- wire the setup file into root, package, and integration Vitest configs
- run the CI test job through a fixed deterministic seed matrix

## Test Plan
- npm ci
- npm run test:root -- tests/vitest-deterministic-mode.test.ts tests/unit/ci-workflow.test.ts
- FRANKENBEAST_SEED=1337 npm run test:root -- tests/vitest-deterministic-mode.test.ts tests/unit/ci-workflow.test.ts
- FRANKENBEAST_SEED=1337 npm run test:root
- npm run typecheck
- FRANKENBEAST_SEED=1337 npm test
- npx turbo run build lint
- npm run lint:security
- git diff --check

Closes #1417
