### PR TITLE
fix: detect parallel plan cycles before execution

### DIFF
--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -1,4 +1,4 @@
-import { RationaleRejectedError, RecursionDepthExceededError } from '../core/errors.js';
+import { CyclicDependencyError, RationaleRejectedError, RecursionDepthExceededError } from '../core/errors.js';
 import { PlanGraph } from '../core/dag.js';
 import type { PlanResult, Task, TaskId, TaskResult } from '../core/types.js';
 import type { PlanContext, PlanningStrategy, TaskExecutor } from './types.js';
@@ -92,7 +92,15 @@ export class ParallelPlanner implements PlanningStrategy {
           graph.getDependencies(t.id).every((dep) => completedIds.has(dep))
       );
 
-      if (ready.length === 0) break; // no progress — cycle guard (should not happen in a valid DAG)
+      if (ready.length === 0) {
+        const blockedTaskIds = tasks
+          .filter((task) => !completedIds.has(task.id))
+          .map((task) => task.id);
+        throw new CyclicDependencyError(
+          `ParallelPlanner cannot make progress on tasks: ${blockedTaskIds.join(', ')}. ` +
+            'This indicates a dependency cycle in the plan graph.'
+        );
+      }
 
       // Run all ready tasks concurrently; convert ordinary task exceptions into
       // failures, but let governance rejections propagate to the Planner so they

--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -400,6 +400,32 @@ describe('ParallelPlanner — cycle handling', () => {
     );
     expect(executor).not.toHaveBeenCalled();
   });
+
+  it('throws CyclicDependencyError when no tasks are ready due to a cycle', async () => {
+    const cyclic: Task[] = [makeTask('a'), makeTask('b')];
+    const a = cyclic[0]!.id;
+    const b = cyclic[1]!.id;
+    const graph = {
+      topoSort: vi.fn().mockReturnValue(cyclic),
+      getTasks: vi.fn().mockReturnValue(cyclic),
+      getDependencies: vi.fn().mockImplementation((taskId: TaskId) => {
+        if (taskId === a) return [b];
+        if (taskId === b) return [a];
+        return [];
+      }),
+    } as unknown as PlanGraph;
+
+    const executor = vi.fn().mockResolvedValue(success('a'));
+
+    const result = new ParallelPlanner().execute(graph, { executor });
+
+    await expect(result).rejects.toBeInstanceOf(CyclicDependencyError);
+    await expect(result).rejects.toMatchObject({
+      name: 'CyclicDependencyError',
+    });
+    await expect(result).rejects.toMatchObject({ message: expect.stringContaining('cannot make progress') });
+    expect(executor).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Dangling dependency handling ─────────────────────────────────────────────

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-10 — Parallel planner deadlock guard
+- In ParallelPlanner execution, don't allow the "no tasks ready" path to continue silently as success. Keep cycle checks explicit and fail fast with a clear `CyclicDependencyError` (or similar) before running task waves, and add a unit test that proves executor is never called when readiness stalls due to a dependency cycle.
+- When `@codex review` is usage-limited, classify it as a blocker state and do not merge until a new trigger can produce a current-head clean response.
+
 ## 2026-07-09 — Franken-web beast wizard catalog data
 - When backend beast definitions expose interview prompts, drive cards, labels, validation, review rows, and launch config from the catalog instead of adding one-off hardcoded UI branches. Preserve old aliases (`docPath`, `chunkDir`, `topic`) only as compatibility fallbacks while preferring backend field names (`designDocPath`, `chunkDirectory`, `goal`).
 


### PR DESCRIPTION
## Summary
- Add an explicit guard in ParallelPlanner execution for the no-ready-wave case with a clear CyclicDependencyError message listing blocked task IDs.
- Add a regression test validating the new no-progress guard and ensuring no executor calls when dependency cycles block task readiness.

## Why
ParallelPlanner previously could break out silently on a wave with no ready tasks, which could hide cycle-related deadlocks in edge cases.

## Testing
- npm test -- tests/unit/planners/parallel.test.ts

Closes #1430