### PR TITLE
fix(whatsapp): validate inbound message timestamps

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
@@ -70,7 +70,7 @@ export function whatsappRouter(options: WhatsAppRouterOptions) {
               externalChannelId: from,
               externalMessageId: message.id,
               text: message.text.body,
-              receivedAt: new Date(parseInt(message.timestamp, 10) * 1000).toISOString(),
+              receivedAt: new Date(Number(message.timestamp) * 1000).toISOString(),
               rawEvent: body,
             });
           }

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-schemas.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-schemas.ts
@@ -1,5 +1,16 @@
 import { z } from 'zod';
 
+const MAX_VALID_UNIX_SECONDS = 8_640_000_000_000;
+
+const WhatsAppTimestampSchema = z.string().refine((value) => {
+  if (!/^\d+$/.test(value)) {
+    return false;
+  }
+
+  const seconds = Number(value);
+  return Number.isSafeInteger(seconds) && seconds <= MAX_VALID_UNIX_SECONDS;
+}, 'timestamp must be a valid Unix timestamp in seconds');
+
 export const WhatsAppWebhookSchema = z.object({
   object: z.string(),
   entry: z.array(z.object({
@@ -18,7 +29,7 @@ export const WhatsAppWebhookSchema = z.object({
         messages: z.array(z.object({
           from: z.string(),
           id: z.string(),
-          timestamp: z.string(),
+          timestamp: WhatsAppTimestampSchema,
           text: z.object({ body: z.string() }).optional(),
           type: z.string(),
           interactive: z.object({

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
@@ -96,6 +96,50 @@ describe('whatsappRouter', () => {
     expect(gateway.handleAction).not.toHaveBeenCalled();
   });
 
+  it.each(['not-a-number', '123abc', '999999999999999999999999999999'])(
+    'returns 400 for invalid message timestamp %s without invoking handlers',
+    async (timestamp) => {
+      const appWithoutSig = whatsappRouter({
+        gateway,
+        sessionMapper,
+        appSecret,
+        verifyToken,
+        verifySignature: false,
+      });
+      const body = JSON.stringify({
+        object: 'whatsapp_business_account',
+        entry: [{
+          id: '1',
+          changes: [{
+            value: {
+              messaging_product: 'whatsapp',
+              metadata: { display_phone_number: '123', phone_number_id: '1' },
+              messages: [{
+                from: '123456',
+                id: 'm1',
+                timestamp,
+                type: 'text',
+                text: { body: 'hello' },
+              }],
+            },
+            field: 'messages',
+          }],
+        }],
+      });
+
+      const res = await appWithoutSig.request('/webhook', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: 'Invalid payload' });
+      expect(gateway.handleInbound).not.toHaveBeenCalled();
+      expect(gateway.handleAction).not.toHaveBeenCalled();
+    },
+  );
+
   it('routes button reply to gateway', async () => {
     const body = JSON.stringify({
       object: 'whatsapp_business_account',


### PR DESCRIPTION
## Summary
- validate WhatsApp message timestamps in the webhook schema before route handling
- use exact numeric timestamp conversion when constructing receivedAt
- add regression coverage for non-numeric, partially numeric, and out-of-range timestamps returning 400 without invoking handlers

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- tests/unit/comms/whatsapp-router.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #1435