### PR TITLE
feat(types): add deterministic utility helpers

### DIFF
--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -12,6 +12,10 @@
     "./path-containment": {
       "import": "./dist/path-containment.js",
       "types": "./dist/path-containment.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
     }
   },
   "files": [

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -97,6 +97,8 @@ export {
 // Web/API contract DTOs
 export * from './api-contracts.js';
 
+// Deterministic utilities
+export * from './utils/index.js';
 
 // Skill schemas
 export type { McpConfig, SkillInfo, SkillToolManifest } from './skill.js';

--- a/packages/franken-types/src/utils/deterministicUuid.ts
+++ b/packages/franken-types/src/utils/deterministicUuid.ts
@@ -1,0 +1,20 @@
+import { createSeededRandom } from './seededRandom.js';
+
+function byteToHex(byte: number): string {
+  return byte.toString(16).padStart(2, '0');
+}
+
+export function deterministicUuid(seed: string, counter: number): string {
+  if (!Number.isSafeInteger(counter) || counter < 0) {
+    throw new RangeError('counter must be a non-negative safe integer');
+  }
+
+  const random = createSeededRandom(`${seed}:${counter}`);
+  const bytes = Array.from({ length: 16 }, () => Math.floor(random() * 256));
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.map(byteToHex);
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+}

--- a/packages/franken-types/src/utils/deterministicUuid.ts
+++ b/packages/franken-types/src/utils/deterministicUuid.ts
@@ -9,7 +9,7 @@ function hash128(input: string): number[] {
   let h4 = 0x9e3779b9;
 
   for (const char of input) {
-    const code = char.charCodeAt(0);
+    const code = char.codePointAt(0) ?? 0;
     h1 = Math.imul(h1 ^ code, 2654435761);
     h2 = Math.imul(h2 ^ code, 1597334677);
     h3 = Math.imul(h3 ^ code, 2246822507);

--- a/packages/franken-types/src/utils/deterministicUuid.ts
+++ b/packages/franken-types/src/utils/deterministicUuid.ts
@@ -1,7 +1,40 @@
-import { createSeededRandom } from './seededRandom.js';
-
 function byteToHex(byte: number): string {
   return byte.toString(16).padStart(2, '0');
+}
+
+function hash128(input: string): number[] {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  let h3 = 0xc0decafe;
+  let h4 = 0x9e3779b9;
+
+  for (const char of input) {
+    const code = char.charCodeAt(0);
+    h1 = Math.imul(h1 ^ code, 2654435761);
+    h2 = Math.imul(h2 ^ code, 1597334677);
+    h3 = Math.imul(h3 ^ code, 2246822507);
+    h4 = Math.imul(h4 ^ code, 3266489909);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h3 ^ (h3 >>> 13), 3266489909);
+  h3 = Math.imul(h3 ^ (h3 >>> 16), 2246822507) ^ Math.imul(h4 ^ (h4 >>> 13), 3266489909);
+  h4 = Math.imul(h4 ^ (h4 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+}
+
+function hashBytes(seed: string, counter: number): number[] {
+  const bytes: number[] = [];
+  for (const word of hash128(`${seed}:${counter}`)) {
+    bytes.push(
+      (word >>> 24) & 0xff,
+      (word >>> 16) & 0xff,
+      (word >>> 8) & 0xff,
+      word & 0xff,
+    );
+  }
+  return bytes;
 }
 
 export function deterministicUuid(seed: string, counter: number): string {
@@ -9,8 +42,7 @@ export function deterministicUuid(seed: string, counter: number): string {
     throw new RangeError('counter must be a non-negative safe integer');
   }
 
-  const random = createSeededRandom(`${seed}:${counter}`);
-  const bytes = Array.from({ length: 16 }, () => Math.floor(random() * 256));
+  const bytes = hashBytes(seed, counter);
 
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;

--- a/packages/franken-types/src/utils/index.ts
+++ b/packages/franken-types/src/utils/index.ts
@@ -1,0 +1,4 @@
+export { deterministicUuid } from './deterministicUuid.js';
+export { now } from './now.js';
+export type { RandomGenerator } from './seededRandom.js';
+export { createSeededRandom, random } from './seededRandom.js';

--- a/packages/franken-types/src/utils/now.ts
+++ b/packages/franken-types/src/utils/now.ts
@@ -1,0 +1,28 @@
+import { createSeededRandom } from './seededRandom.js';
+
+const DEFAULT_EPOCH_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
+const DAY_MS = 86_400_000;
+
+function currentSeed(): string | undefined {
+  const maybeProcess = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+  };
+  return maybeProcess.process?.env?.['FRANKENBEAST_SEED'];
+}
+
+let activeSeed: string | undefined;
+let activeNow: number | undefined;
+
+export function now(): number {
+  const seed = currentSeed();
+  if (!seed) {
+    return Date.now();
+  }
+
+  if (activeSeed !== seed || activeNow === undefined) {
+    activeSeed = seed;
+    activeNow = DEFAULT_EPOCH_MS + Math.floor(createSeededRandom(`now:${seed}`)() * DAY_MS);
+  }
+
+  return activeNow;
+}

--- a/packages/franken-types/src/utils/seededRandom.ts
+++ b/packages/franken-types/src/utils/seededRandom.ts
@@ -37,6 +37,8 @@ let activeRandom: RandomGenerator | undefined;
 export function random(): number {
   const seed = currentSeed();
   if (!seed) {
+    activeSeed = undefined;
+    activeRandom = undefined;
     return Math.random();
   }
 

--- a/packages/franken-types/src/utils/seededRandom.ts
+++ b/packages/franken-types/src/utils/seededRandom.ts
@@ -1,0 +1,49 @@
+const MODULUS = 0x100000000;
+const DEFAULT_SEED = 'frankenbeast';
+
+function currentSeed(): string | undefined {
+  const maybeProcess = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+  };
+  return maybeProcess.process?.env?.['FRANKENBEAST_SEED'];
+}
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261;
+  for (const char of seed) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export type RandomGenerator = () => number;
+
+export function createSeededRandom(seed: string = currentSeed() ?? DEFAULT_SEED): RandomGenerator {
+  let state = hashSeed(seed) || 0x6d2b79f5;
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / MODULUS;
+  };
+}
+
+let activeSeed: string | undefined;
+let activeRandom: RandomGenerator | undefined;
+
+export function random(): number {
+  const seed = currentSeed();
+  if (!seed) {
+    return Math.random();
+  }
+
+  if (activeSeed !== seed || activeRandom === undefined) {
+    activeSeed = seed;
+    activeRandom = createSeededRandom(seed);
+  }
+
+  return activeRandom();
+}

--- a/packages/franken-types/src/utils/seededRandom.ts
+++ b/packages/franken-types/src/utils/seededRandom.ts
@@ -11,7 +11,7 @@ function currentSeed(): string | undefined {
 function hashSeed(seed: string): number {
   let hash = 2166136261;
   for (const char of seed) {
-    hash ^= char.charCodeAt(0);
+    hash ^= char.codePointAt(0) ?? 0;
     hash = Math.imul(hash, 16777619);
   }
   return hash >>> 0;

--- a/packages/franken-types/tests/deterministic-utils.test.ts
+++ b/packages/franken-types/tests/deterministic-utils.test.ts
@@ -29,6 +29,14 @@ describe('deterministic utilities', () => {
     expect(first()).not.toBe(different());
   });
 
+  it('keeps non-BMP Unicode seeds distinct', () => {
+    const smile = createSeededRandom('😀');
+    const grin = createSeededRandom('😁');
+
+    expect([smile(), smile(), smile()]).not.toEqual([grin(), grin(), grin()]);
+    expect(deterministicUuid('😀', 1)).not.toBe(deterministicUuid('😁', 1));
+  });
+
   it('uses FRANKENBEAST_SEED for module-level random values', () => {
     setSeed('stable-env-seed');
     const first = random();

--- a/packages/franken-types/tests/deterministic-utils.test.ts
+++ b/packages/franken-types/tests/deterministic-utils.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { deterministicUuid, now, random } from '../src/index.js';
+import { createSeededRandom } from '../src/utils/seededRandom.js';
+
+const originalSeed = process.env['FRANKENBEAST_SEED'];
+
+function setSeed(seed: string | undefined): void {
+  if (seed === undefined) {
+    delete process.env['FRANKENBEAST_SEED'];
+    return;
+  }
+
+  process.env['FRANKENBEAST_SEED'] = seed;
+}
+
+afterEach(() => {
+  setSeed(originalSeed);
+});
+
+describe('deterministic utilities', () => {
+  it('creates repeatable seeded random streams', () => {
+    const first = createSeededRandom('issue-1415');
+    const second = createSeededRandom('issue-1415');
+    const different = createSeededRandom('other-seed');
+
+    expect([first(), first(), first()]).toEqual([second(), second(), second()]);
+    expect(first()).not.toBe(different());
+  });
+
+  it('uses FRANKENBEAST_SEED for module-level random values', () => {
+    setSeed('stable-env-seed');
+    const first = random();
+    const second = random();
+
+    setSeed('different-env-seed');
+    random();
+
+    setSeed('stable-env-seed');
+    expect(random()).toBe(first);
+    expect(random()).toBe(second);
+  });
+
+  it('creates deterministic UUIDs from a seed and counter', () => {
+    const uuid = deterministicUuid('issue-1415', 7);
+
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u);
+    expect(deterministicUuid('issue-1415', 7)).toBe(uuid);
+    expect(deterministicUuid('issue-1415', 8)).not.toBe(uuid);
+    expect(deterministicUuid('other-seed', 7)).not.toBe(uuid);
+  });
+
+  it('returns a fixed timestamp only when FRANKENBEAST_SEED is set', async () => {
+    setSeed('clock-seed');
+    const seededNow = now();
+    expect(now()).toBe(seededNow);
+
+    setSeed(undefined);
+    const before = Date.now();
+    const unseededNow = now();
+    const after = Date.now();
+
+    expect(unseededNow).toBeGreaterThanOrEqual(before);
+    expect(unseededNow).toBeLessThanOrEqual(after);
+  });
+});

--- a/packages/franken-types/tests/deterministic-utils.test.ts
+++ b/packages/franken-types/tests/deterministic-utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { deterministicUuid, now, random } from '../src/index.js';
+import { deterministicUuid as deterministicUuidFromSubpath } from '@franken/types/utils';
 import { createSeededRandom } from '../src/utils/seededRandom.js';
 
 const originalSeed = process.env['FRANKENBEAST_SEED'];
@@ -41,11 +42,25 @@ describe('deterministic utilities', () => {
     expect(random()).toBe(second);
   });
 
+  it('restarts the seeded random stream after an unseeded section', () => {
+    setSeed('restore-env-seed');
+    const first = random();
+    const second = random();
+
+    setSeed(undefined);
+    random();
+
+    setSeed('restore-env-seed');
+    expect(random()).toBe(first);
+    expect(random()).toBe(second);
+  });
+
   it('creates deterministic UUIDs from a seed and counter', () => {
     const uuid = deterministicUuid('issue-1415', 7);
 
     expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u);
     expect(deterministicUuid('issue-1415', 7)).toBe(uuid);
+    expect(deterministicUuidFromSubpath('issue-1415', 7)).toBe(uuid);
     expect(deterministicUuid('issue-1415', 8)).not.toBe(uuid);
     expect(deterministicUuid('other-seed', 7)).not.toBe(uuid);
   });

--- a/scripts/vitest-deterministic-mode.ts
+++ b/scripts/vitest-deterministic-mode.ts
@@ -1,26 +1,8 @@
+import { createSeededRandom } from '../packages/franken-types/src/utils/seededRandom.js';
+
 const DEFAULT_EPOCH_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
-const MODULUS = 0x100000000;
 
-function hashSeed(seed: string): number {
-  let hash = 2166136261;
-  for (const char of seed) {
-    hash ^= char.charCodeAt(0);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-export function seededRandom(seed = process.env['FRANKENBEAST_SEED'] ?? 'frankenbeast'): () => number {
-  let state = hashSeed(seed) || 0x6d2b79f5;
-
-  return () => {
-    state = (state + 0x6d2b79f5) >>> 0;
-    let value = state;
-    value = Math.imul(value ^ (value >>> 15), value | 1);
-    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
-    return ((value ^ (value >>> 14)) >>> 0) / MODULUS;
-  };
-}
+export const seededRandom = createSeededRandom;
 
 export function createDeterministicClock(seed = process.env['FRANKENBEAST_SEED'] ?? 'frankenbeast'): () => number {
   let tick = 0;

--- a/scripts/vitest-source-aliases.ts
+++ b/scripts/vitest-source-aliases.ts
@@ -9,6 +9,7 @@ const FRANKEN_SOURCE_ENTRYPOINTS = {
   '@franken/critique': 'packages/franken-critique/src/index.ts',
   '@franken/governor': 'packages/franken-governor/src/index.ts',
   '@franken/types/path-containment': 'packages/franken-types/src/path-containment.ts',
+  '@franken/types/utils': 'packages/franken-types/src/utils/index.ts',
   '@franken/types': 'packages/franken-types/src/index.ts',
   '@franken/orchestrator': 'packages/franken-orchestrator/src/index.ts',
 } as const;

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -13,6 +13,7 @@ const EXPECTED_ALIASES: Record<string, string> = {
   '@franken/critique': './packages/franken-critique/src/index.ts',
   '@franken/governor': './packages/franken-governor/src/index.ts',
   '@franken/types/path-containment': './packages/franken-types/src/path-containment.ts',
+  '@franken/types/utils': './packages/franken-types/src/utils/index.ts',
   '@franken/types': './packages/franken-types/src/index.ts',
   '@franken/orchestrator': './packages/franken-orchestrator/src/index.ts',
 };
@@ -25,8 +26,8 @@ describe('tsconfig.json path aliases', () => {
     expect(paths).toBeDefined();
   });
 
-  it('has exactly 8 aliases', () => {
-    expect(Object.keys(paths)).toHaveLength(8);
+  it('has exactly 9 aliases', () => {
+    expect(Object.keys(paths)).toHaveLength(9);
   });
 
   for (const [alias, expectedPath] of Object.entries(EXPECTED_ALIASES)) {

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { deterministicUuid } from '@franken/types/utils';
 import { createFrankenSourceAliases } from '../scripts/vitest-source-aliases.js';
 
 const ROOT = join(import.meta.dirname, '..');
@@ -30,6 +31,10 @@ const PACKAGE_CONFIGS = [
 ];
 
 describe('package Vitest source aliases', () => {
+  it('lets root Vitest resolve the @franken/types/utils subpath from source', () => {
+    expect(deterministicUuid('root-vitest-alias', 0)).toMatch(/^[0-9a-f-]+$/u);
+  });
+
   it('maps every first-party package scope to its TypeScript source entrypoint', () => {
     expect(createFrankenSourceAliases(new URL('../packages/franken-orchestrator/vitest.config.ts', import.meta.url))).toEqual(
       EXPECTED_ALIASES,

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_ALIASES = {
   '@franken/critique': resolve(ROOT, 'packages/franken-critique/src/index.ts'),
   '@franken/governor': resolve(ROOT, 'packages/franken-governor/src/index.ts'),
   '@franken/types/path-containment': resolve(ROOT, 'packages/franken-types/src/path-containment.ts'),
+  '@franken/types/utils': resolve(ROOT, 'packages/franken-types/src/utils/index.ts'),
   '@franken/types': resolve(ROOT, 'packages/franken-types/src/index.ts'),
   '@franken/orchestrator': resolve(ROOT, 'packages/franken-orchestrator/src/index.ts'),
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,9 @@
       "@franken/types/path-containment": [
         "./packages/franken-types/src/path-containment.ts"
       ],
+      "@franken/types/utils": [
+        "./packages/franken-types/src/utils/index.ts"
+      ],
       "@franken/types": [
         "./packages/franken-types/src/index.ts"
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
       '@franken/observer': resolve(__dirname, 'packages/franken-observer/src/index.ts'),
       '@franken/critique': resolve(__dirname, 'packages/franken-critique/src/index.ts'),
       '@franken/governor': resolve(__dirname, 'packages/franken-governor/src/index.ts'),
+      '@franken/types/utils': resolve(__dirname, 'packages/franken-types/src/utils/index.ts'),
       '@franken/types': resolve(__dirname, 'packages/franken-types/src/index.ts'),
       '@franken/orchestrator': resolve(__dirname, 'packages/franken-orchestrator/src/index.ts'),
     },


### PR DESCRIPTION
## Summary
- add shared deterministic random, UUID, and timestamp helpers under @franken/types utilities
- export utilities from the package root and @franken/types/utils subpath
- reuse the shared seeded random implementation in Vitest deterministic mode
- keep root/package Vitest source aliases in sync for the new utilities subpath
- address Codex review findings around RNG cache reset, UUID entropy, Unicode seed hashing, and root Vitest aliases

## Test Plan
- npm --prefix packages/franken-types test -- tests/deterministic-utils.test.ts
- npm run test:root -- tests/vitest-package-source-aliases.test.ts tests/tsconfig-paths.test.ts tests/vitest-deterministic-mode.test.ts
- npm --prefix packages/franken-types run typecheck
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-types test
- npm run typecheck
- npm run build
- npm run lint:any
- GitHub CI: build-test-lint (1337) passed
- GitHub CI: publish smoke (pack + offline install + run) passed
- Codex review loop: final current-head pass clean at 2026-07-10T05:19:29Z

Closes #1415