### PR TITLE
fix(observer): validate circuit breaker spend inputs

### DIFF
--- a/packages/franken-observer/src/cost/CircuitBreaker.test.ts
+++ b/packages/franken-observer/src/cost/CircuitBreaker.test.ts
@@ -29,6 +29,15 @@ describe('CircuitBreaker', () => {
       expect(result.limitUsd).toBe(0.50)
       expect(result.spendUsd).toBe(0.75)
     })
+
+    it.each([
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['negative values', -0.01],
+    ])('throws RangeError for invalid spendUsd: %s', (_label, spendUsd) => {
+      expect(() => breaker.check(spendUsd)).toThrow(RangeError)
+      expect(() => breaker.check(spendUsd)).toThrow('spendUsd must be a finite non-negative number')
+    })
   })
 
   describe('HITL event emission', () => {
@@ -106,6 +115,15 @@ describe('CircuitBreaker', () => {
       const strict = new CircuitBreaker({ limitUsd: 0.01 })
       expect(strict.check(0.011).tripped).toBe(true)
       expect(strict.check(0.010).tripped).toBe(false)
+    })
+
+    it.each([
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['negative values', -0.01],
+    ])('throws RangeError for invalid limitUsd: %s', (_label, limitUsd) => {
+      expect(() => new CircuitBreaker({ limitUsd })).toThrow(RangeError)
+      expect(() => new CircuitBreaker({ limitUsd })).toThrow('limitUsd must be a finite non-negative number')
     })
   })
 })

--- a/packages/franken-observer/src/cost/CircuitBreaker.ts
+++ b/packages/franken-observer/src/cost/CircuitBreaker.ts
@@ -12,7 +12,8 @@ type LimitReachedHandler = (result: CircuitBreakerResult) => void
 
 /**
  * Non-blocking budget guard. Emits a 'limit-reached' event when
- * cumulative spend exceeds the configured USD limit. Never throws.
+ * cumulative spend exceeds the configured USD limit. Throws RangeError for
+ * invalid numeric inputs so broken budget accounting cannot be reported safe.
  */
 export class CircuitBreaker {
   private readonly limitUsd: number
@@ -20,10 +21,12 @@ export class CircuitBreaker {
   private tripped = false
 
   constructor(options: CircuitBreakerOptions) {
+    assertFiniteNonNegativeUsd('limitUsd', options.limitUsd)
     this.limitUsd = options.limitUsd
   }
 
   check(spendUsd: number): CircuitBreakerResult {
+    assertFiniteNonNegativeUsd('spendUsd', spendUsd)
     const result: CircuitBreakerResult = {
       tripped: spendUsd > this.limitUsd,
       limitUsd: this.limitUsd,
@@ -59,5 +62,11 @@ export class CircuitBreaker {
 
   off(event: 'limit-reached', handler: LimitReachedHandler): void {
     this.handlers.delete(handler)
+  }
+}
+
+function assertFiniteNonNegativeUsd(name: 'limitUsd' | 'spendUsd', value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${name} must be a finite non-negative number`)
   }
 }


### PR DESCRIPTION
## Summary
- validate CircuitBreaker limitUsd at construction as finite and non-negative
- validate spendUsd before budget comparisons so NaN/Infinity/negative values cannot be reported safe
- add regression coverage for invalid limitUsd and spendUsd values

## Test Plan
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-observer test -- CircuitBreaker.test.ts
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-types run build
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-observer run typecheck
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-observer run build
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-observer test

Closes #1218