### PR TITLE
fix(observer): tolerate invalid post-mortem timestamps

### DIFF
--- a/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.test.ts
@@ -120,6 +120,14 @@ describe('PostMortemGenerator', () => {
       const content = gen.generateContent(trace, signal)
       expect(content).toContain('2023-11-14') // ISO date for that Unix ms
     })
+
+    it('uses a safe fallback for out-of-range timestamps', () => {
+      const gen = new PostMortemGenerator({ outputDir })
+      const trace = makeTrace()
+      const content = gen.generateContent(trace, makeSignal(trace.id, { timestamp: Number.MAX_VALUE }))
+
+      expect(content).toContain('**Detected at:** Invalid timestamp')
+    })
   })
 
   describe('generate()', () => {
@@ -285,6 +293,19 @@ describe('PostMortemGenerator', () => {
       expect(filePath).not.toBeNull()
       expect(filePath!).toMatch(/post-mortem-[a-f0-9]{64}-invalid-timestamp\.md$/)
       expect(existsSync(filePath!)).toBe(true)
+    })
+
+    it('does not throw when the interrupt timestamp is out of range', async () => {
+      const gen = new PostMortemGenerator({ outputDir })
+      const trace = makeTraceWithId('trace-with-out-of-range-timestamp')
+      const filePath = await gen.generate(trace, makeSignal(trace.id, { timestamp: Number.MAX_VALUE }))
+
+      expect(filePath).not.toBeNull()
+      expect(filePath!).toMatch(/post-mortem-[a-f0-9]{64}-invalid-timestamp\.md$/)
+      expect(existsSync(filePath!)).toBe(true)
+
+      const content = readFileSync(filePath!, 'utf-8')
+      expect(content).toContain('**Detected at:** Invalid timestamp')
     })
   })
 

--- a/packages/franken-observer/src/incident/PostMortemGenerator.ts
+++ b/packages/franken-observer/src/incident/PostMortemGenerator.ts
@@ -15,8 +15,15 @@ function traceIdHashForFilename(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex')
 }
 
+function dateFromTimestamp(timestamp: number): Date | null {
+  if (!Number.isFinite(timestamp)) return null
+
+  const date = new Date(timestamp)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
 function timestampForFilename(timestamp: number): string {
-  return Number.isFinite(timestamp) ? String(Math.trunc(timestamp)) : 'invalid-timestamp'
+  return dateFromTimestamp(timestamp) ? String(Math.trunc(timestamp)) : 'invalid-timestamp'
 }
 
 async function writeNewReportFile(filePath: string, content: string): Promise<void> {
@@ -48,9 +55,7 @@ export class PostMortemGenerator {
   }
 
   generateContent(trace: Trace, signal: InterruptSignal): string {
-    const detectedAt = Number.isFinite(signal.timestamp)
-      ? new Date(signal.timestamp).toISOString()
-      : 'Invalid timestamp'
+    const detectedAt = dateFromTimestamp(signal.timestamp)?.toISOString() ?? 'Invalid timestamp'
     const patternList = signal.detectedPattern.map(p => `  - \`${p}\``).join('\n')
 
     const spansTable = trace.spans


### PR DESCRIPTION
## Summary
- Validate interrupt timestamps by checking the constructed Date before ISO formatting
- Fall back to the existing invalid timestamp marker for non-finite and out-of-range values
- Add regression coverage for out-of-range post-mortem timestamps

## Test Plan
- npm --workspace=@franken/observer test -- src/incident/PostMortemGenerator.test.ts
- npm --workspace=@franken/types run build
- npm --workspace=@franken/observer run typecheck
- npm --workspace=@franken/observer run build
- npm run lint:any
- git diff --check

Closes #1146