### PR TITLE
fix(beasts): return 404 for unknown run actions

### DIFF
--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -10,6 +10,13 @@ export interface BeastRunServiceOptions {
   eventBus?: BeastEventBus;
 }
 
+export class UnknownBeastRunError extends Error {
+  constructor(public readonly runId: string) {
+    super(`Unknown Beast run: ${runId}`);
+    this.name = 'UnknownBeastRunError';
+  }
+}
+
 export class BeastRunService {
   constructor(
     private readonly repository: SQLiteBeastRepository,
@@ -120,7 +127,7 @@ export class BeastRunService {
   private requireRun(runId: string): BeastRun {
     const run = this.repository.getRun(runId);
     if (!run) {
-      throw new Error(`Unknown Beast run: ${runId}`);
+      throw new UnknownBeastRunError(runId);
     }
     this.getDefinitionOrThrow(run.definitionId);
     return run;

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -8,7 +8,7 @@ import { UnknownTrackedAgentError } from '../../beasts/errors.js';
 import { BeastCatalogService } from '../../beasts/services/beast-catalog-service.js';
 import { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
 import { BeastInterviewService } from '../../beasts/services/beast-interview-service.js';
-import { BeastRunService } from '../../beasts/services/beast-run-service.js';
+import { BeastRunService, UnknownBeastRunError } from '../../beasts/services/beast-run-service.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
@@ -69,6 +69,17 @@ function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDep
 
 function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunResponse | undefined {
   return runWithContainerFields(run, attemptsForContainerRun(run, deps));
+}
+
+async function requireKnownRunAction(runId: string, action: () => Promise<BeastRun>): Promise<BeastRun> {
+  try {
+    return await action();
+  } catch (error) {
+    if (error instanceof UnknownBeastRunError) {
+      throw new HttpError(404, 'BEAST_RUN_NOT_FOUND', `Beast run '${runId}' was not found`);
+    }
+    throw error;
+  }
 }
 
 const ModuleConfigSchema = z.object({
@@ -208,22 +219,26 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   });
 
   app.post('/v1/beasts/runs/:runId/start', async (c) => {
-    const run = await deps.runs.start(c.req.param('runId'), 'operator');
+    const runId = c.req.param('runId');
+    const run = await requireKnownRunAction(runId, () => deps.runs.start(runId, 'operator'));
     return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/runs/:runId/stop', async (c) => {
-    const run = await deps.runs.stop(c.req.param('runId'), 'operator');
+    const runId = c.req.param('runId');
+    const run = await requireKnownRunAction(runId, () => deps.runs.stop(runId, 'operator'));
     return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/runs/:runId/kill', async (c) => {
-    const run = await deps.runs.kill(c.req.param('runId'), 'operator');
+    const runId = c.req.param('runId');
+    const run = await requireKnownRunAction(runId, () => deps.runs.kill(runId, 'operator'));
     return c.json({ data: runResponse(run, deps) });
   });
 
   app.post('/v1/beasts/runs/:runId/restart', async (c) => {
-    const run = await deps.runs.restart(c.req.param('runId'), 'operator');
+    const runId = c.req.param('runId');
+    const run = await requireKnownRunAction(runId, () => deps.runs.restart(runId, 'operator'));
     return c.json({ data: runResponse(run, deps) });
   });
 

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -349,6 +349,26 @@ describe('beast routes', () => {
     });
   });
 
+  it.each(['start', 'stop', 'kill', 'restart'] as const)(
+    'returns a structured 404 when the %s action targets an unknown run',
+    async (action) => {
+      const { app, operatorToken } = createBeastApp();
+
+      const response = await app.request(`/v1/beasts/runs/missing-run-id/${action}`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${operatorToken}` },
+      });
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: 'BEAST_RUN_NOT_FOUND',
+          message: "Beast run 'missing-run-id' was not found",
+        },
+      });
+    },
+  );
+
   it('supports interview start and answer flow', async () => {
     const { app, operatorToken } = createBeastApp();
     const startResponse = await app.request('/v1/beasts/interviews/martin-loop/start', {


### PR DESCRIPTION
## Summary
- add a typed unknown Beast run error from the run service
- map unknown run action requests to structured BEAST_RUN_NOT_FOUND 404 responses
- cover start/stop/kill/restart missing run action IDs in integration tests

## Test Plan
- npm run build
- npm --prefix packages/franken-orchestrator test -- tests/integration/beasts/beast-routes.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint

Closes #1211