### PR TITLE
fix(web): prevent unavailable container launches

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -11,6 +11,10 @@ interface StepWorkflowProps {
 
 const DEFAULT_CONTAINER_UNAVAILABLE_REASON = 'Container runtime availability has not been reported by the backend.';
 
+function isContainerRuntimeUnavailable(status: BeastContainerRuntimeStatus | undefined): boolean {
+  return status?.available === false;
+}
+
 export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
   const { stepValues, setStepValues } = useBeastStore();
   const values = (stepValues[1] ?? {}) as { workflowType?: string; executionMode?: BeastExecutionMode; [key: string]: unknown };
@@ -38,7 +42,10 @@ export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
     }
 
     const nextWorkflow = workflows.find((entry) => entry.id === id);
-    const executionMode = values.executionMode ?? nextWorkflow?.executionModeDefault;
+    const requestedExecutionMode = values.executionMode ?? nextWorkflow?.executionModeDefault;
+    const executionMode = requestedExecutionMode === 'container' && isContainerRuntimeUnavailable(nextWorkflow?.containerRuntime ?? containerRuntime)
+      ? 'process'
+      : requestedExecutionMode;
     setStepValues(1, { workflowType: id, ...(executionMode ? { executionMode } : {}) });
   }
 

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -83,7 +83,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRunt
     }
 
     clearValidationErrors(wizardStep);
-    onLaunch(buildWizardLaunchConfig(stepValues, catalog));
+    onLaunch(buildWizardLaunchConfig(stepValues, catalog, containerRuntime));
   }
 
   function handleNext() {

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -1,4 +1,4 @@
-import type { BeastCatalogEntry } from '../../lib/beast-api';
+import type { BeastCatalogEntry, BeastContainerRuntimeStatus, BeastExecutionMode } from '../../lib/beast-api';
 import { findCatalogEntry, getPromptValue, isBlankCatalogValue } from './wizard-catalog';
 
 export const WIZARD_SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 'skills', 'prompts', 'git'] as const;
@@ -8,6 +8,22 @@ type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
 interface PromptFile {
   name?: unknown;
   content?: unknown;
+}
+
+function resolveLaunchExecutionMode(
+  workflow: Record<string, unknown> | undefined,
+  selectedWorkflow: BeastCatalogEntry | undefined,
+  containerRuntime: BeastContainerRuntimeStatus | undefined,
+): BeastExecutionMode {
+  const requestedMode = workflow?.executionMode === 'process' || workflow?.executionMode === 'container'
+    ? workflow.executionMode
+    : 'process';
+
+  if (requestedMode === 'container' && (selectedWorkflow?.containerRuntime ?? containerRuntime)?.available === false) {
+    return 'process';
+  }
+
+  return requestedMode;
 }
 
 function buildPromptFrontload(prompts: Record<string, unknown> | undefined): string | undefined {
@@ -32,6 +48,7 @@ function buildPromptFrontload(prompts: Record<string, unknown> | undefined): str
 export function buildWizardLaunchConfig(
   stepValues: WizardStepValues,
   catalog?: readonly BeastCatalogEntry[],
+  containerRuntime?: BeastContainerRuntimeStatus,
 ): Record<string, unknown> {
   const config: Record<string, unknown> = {};
 
@@ -50,11 +67,7 @@ export function buildWizardLaunchConfig(
     config.promptConfig = { text: promptFrontload };
     delete config.prompts;
   }
-  if (workflow?.executionMode === 'process' || workflow?.executionMode === 'container') {
-    config.executionMode = workflow.executionMode;
-  } else {
-    config.executionMode = 'process';
-  }
+  config.executionMode = resolveLaunchExecutionMode(workflow, selectedWorkflow, containerRuntime);
 
   if (selectedWorkflow && workflow) {
     for (const prompt of selectedWorkflow.interviewPrompts) {

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -156,4 +156,22 @@ describe('StepWorkflow', () => {
       expect(useBeastStore.getState().stepValues[1]?.executionMode).toBe('process');
     });
   });
+
+  it('stores process immediately when selecting a catalog beast whose default container runtime is unavailable', () => {
+    render(<StepWorkflow catalog={[{
+      id: 'container-default-beast',
+      label: 'Container Default Beast',
+      description: 'Defaults to an unavailable container runtime',
+      executionModeDefault: 'container',
+      containerRuntime: { available: false, reason: 'Docker daemon is offline' },
+      interviewPrompts: [],
+    }]} />);
+
+    fireEvent.click(screen.getByText('Container Default Beast'));
+
+    expect(useBeastStore.getState().stepValues[1]).toMatchObject({
+      workflowType: 'container-default-beast',
+      executionMode: 'process',
+    });
+  });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { buildWizardLaunchConfig } from '../../../src/components/beasts/wizard-launch-config';
+import type { BeastCatalogEntry } from '../../../src/lib/beast-api';
+
+const catalogWithUnavailableContainerDefault: BeastCatalogEntry[] = [
+  {
+    id: 'container-default-beast',
+    label: 'Container Default Beast',
+    description: 'Defaults to a container runtime that is unavailable',
+    executionModeDefault: 'container',
+    containerRuntime: { available: false, reason: 'Docker daemon is offline' },
+    interviewPrompts: [],
+  },
+];
+
+describe('buildWizardLaunchConfig', () => {
+  it('falls back to process when stale wizard state requests an unavailable default container runtime', () => {
+    const config = buildWizardLaunchConfig({
+      1: { workflowType: 'container-default-beast', executionMode: 'container' },
+    }, catalogWithUnavailableContainerDefault);
+
+    expect(config.executionMode).toBe('process');
+  });
+
+  it('falls back to process when only global container runtime status is unavailable', () => {
+    const config = buildWizardLaunchConfig({
+      1: { workflowType: 'container-default-beast', executionMode: 'container' },
+    }, [{
+      id: 'container-default-beast',
+      label: 'Container Default Beast',
+      description: 'Production catalog entry without embedded runtime status',
+      executionModeDefault: 'container',
+      interviewPrompts: [],
+    }], { available: false, reason: 'Docker daemon is offline' });
+
+    expect(config.executionMode).toBe('process');
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize catalog default container launches to process when the selected Beast reports container runtime unavailable
- Guard launch config building against stale container execution mode state
- Add regression coverage for selection-time and submit-time unavailable-container cases

## Test Plan
- npm --prefix packages/franken-web test -- tests/components/beasts/wizard-launch-config.test.ts tests/components/beasts/steps/step-workflow.test.tsx
- npm --prefix packages/franken-web test
- npm run build --workspace=@franken/types
- npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build
- npm run lint:any -- --include packages/franken-web/src/components/beasts/steps/step-workflow.tsx packages/franken-web/src/components/beasts/wizard-launch-config.ts packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx

Closes #1207