### PR TITLE
test(cli): cover invalid budget flag regression

### DIFF
--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -535,7 +535,7 @@ describe('parseArgs', () => {
       expect(issueArgs.issueLimit).toBe(50);
     });
 
-    it.each(['NaN', 'Infinity', '12abc'])('rejects invalid budget value %s', (value) => {
+    it.each(['abc', 'NaN', 'Infinity', '12abc'])('rejects invalid budget value %s', (value) => {
       expect(() => parseArgs(['--budget', value])).toThrow(/Invalid --budget/);
     });
 


### PR DESCRIPTION
## Summary
- Adds explicit regression coverage for `--budget abc` failing in CLI argument validation before summary budget rendering.
- Confirms non-finite and partially numeric budget values still fail through the same parser path.

## Test Plan
- `TMPDIR=/home/pfkagent/.cache/issue1449-tmp NODE_COMPILE_CACHE=/home/pfkagent/.cache/issue1449-node-cache npm -w packages/franken-orchestrator test -- tests/unit/cli/args.test.ts`
- `TMPDIR=/home/pfkagent/.cache/issue1449-tmp NODE_COMPILE_CACHE=/home/pfkagent/.cache/issue1449-node-cache npm run build`
- `TMPDIR=/home/pfkagent/.cache/issue1449-tmp NODE_COMPILE_CACHE=/home/pfkagent/.cache/issue1449-node-cache npm -w packages/franken-orchestrator run typecheck`
- `TMPDIR=/home/pfkagent/.cache/issue1449-tmp NODE_COMPILE_CACHE=/home/pfkagent/.cache/issue1449-node-cache npm -w packages/franken-orchestrator run lint` (passes with existing warnings)

Closes #1449