### PR TITLE
docs: clarify init non-interactive and CI secret backend flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config
 ```bash
 frankenbeast init   # interactive — prompts for a passphrase, generates and stores the token
 ```
-When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/headless runtime flows, mount or persist both `.fbeast/config.json` (which selects the backend and stores logical refs) and `.fbeast/secrets.enc` (the encrypted vault), then set `FRANKENBEAST_PASSPHRASE` in the environment so runtime commands can decrypt the vault without prompting; this is used by commands like `frankenbeast run`, not as a replacement for interactive setup.
+When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`, with key-derivation metadata in `.fbeast/secrets.meta.json`. For CI/headless runtime flows, mount or persist `.fbeast/config.json` (which selects the backend and stores logical refs), `.fbeast/secrets.enc`, and `.fbeast/secrets.meta.json` — or persist the whole `.fbeast` secret-store state — then set `FRANKENBEAST_PASSPHRASE` in the environment so runtime commands can decrypt the vault without prompting; this is used by commands like `frankenbeast run`, not as a replacement for interactive setup.
 
 **OS keychain:**
 ```json

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config
 ```bash
 frankenbeast init   # interactive — prompts for a passphrase, generates and stores the token
 ```
-When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/CD, set `FRANKENBEAST_PASSPHRASE` in the environment; `frankenbeast init --non-interactive` verifies an already-complete `.fbeast/config.json` and init state rather than creating a fresh vault.
+When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/headless runtime flows, set `FRANKENBEAST_PASSPHRASE` in the environment so runtime commands can decrypt the local vault in `.fbeast/config.json` without prompting; this is used by commands like `frankenbeast run`, not as a replacement for interactive setup.
 
 **OS keychain:**
 ```json

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config
 ```bash
 frankenbeast init   # interactive — prompts for a passphrase, generates and stores the token
 ```
-When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/headless runtime flows, set `FRANKENBEAST_PASSPHRASE` in the environment so runtime commands can decrypt the local vault in `.fbeast/config.json` without prompting; this is used by commands like `frankenbeast run`, not as a replacement for interactive setup.
+When `network.secureBackend` is unset, init defaults to `local-encrypted`: the passphrase encrypts the local vault at `.fbeast/secrets.enc`. For CI/headless runtime flows, mount or persist both `.fbeast/config.json` (which selects the backend and stores logical refs) and `.fbeast/secrets.enc` (the encrypted vault), then set `FRANKENBEAST_PASSPHRASE` in the environment so runtime commands can decrypt the vault without prompting; this is used by commands like `frankenbeast run`, not as a replacement for interactive setup.
 
 **OS keychain:**
 ```json


### PR DESCRIPTION
## Summary
- Clarifies `frankenbeast init --backend` and `frankenbeast init --non-interactive` usage in the root README.
- Corrects CI guidance so `FRANKENBEAST_PASSPHRASE` is documented as runtime decryption input, not a replacement for interactive initialization.
- Documents the complete `local-encrypted` headless runtime state: `.fbeast/config.json`, `.fbeast/secrets.enc`, and `.fbeast/secrets.meta.json` (or the whole `.fbeast` secret-store state).

## Why
Issue #1454 reports that README instructions mixed up `init --non-interactive` usage with first-time setup.

## Test notes
- Local: `git diff --check`
- GitHub CI on head `7269d9bf`: `build-test-lint (1337)` passed; `publish smoke (pack + offline install + run)` passed.

## Codex review
- Addressed and resolved Codex inline findings from the 2026-07-10T09:59:10Z and 2026-07-10T10:02:33Z review rounds.
- Current blocker: this PR has reached the default 5 `@codex review` invocation cap before a clean current-head review could be obtained for head `7269d9bf`.

Closes #1454
