### PR TITLE
docs(observer): clarify ESM-only build output contract

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -780,7 +780,7 @@ dist/index.d.ts     # TypeScript declarations
 dist/index.d.ts.map # TypeScript declaration map
 ```
 
-The build is plain `tsc` and the output is **ESM-only** (`"type": "module"`). The `exports` map has `types` and `import` conditions but no `require` entry, so the package cannot be `require()`d from CommonJS — consumers must use `import` (or a dynamic `import()` from CJS).
+The build is plain `tsc` and the output is **ESM-only** (`"type": "module"`). The package does **not** emit CommonJS artifacts such as `dist/index.cjs` or `dist/index.d.cts`, and consumers must use `import` (or a dynamic `import()` from CJS).
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated packages/franken-observer/README.md to explicitly state that the package build does not emit CommonJS artifacts.
- The build section now clearly lists only existing ESM outputs and explicitly excludes dist/index.cjs and dist/index.d.cts.

## Typecheck/Build
- npm run build (observer package): fails in current workspace due missing local/type dependencies (for example @types/node and better-sqlite3 type wiring), pre-existing environment issue.
- npm run typecheck (observer package): same dependency resolution errors in this environment.

Closes #1453
