### PR TITLE
fix(network): return 400 for unknown network service targets

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -57,6 +57,7 @@ export interface ChatAppOptions {
     root: string;
     frankenbeastDir: string;
     configFile: string;
+    allowTrustedProviderCommandOverrides?: boolean | undefined;
     getConfig(): OrchestratorConfig;
     setConfig(config: OrchestratorConfig): void;
   };

--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -67,6 +67,13 @@ function withValidTarget(
   }
 }
 
+function assertKnownRunningTarget(services: Array<{ id: string }>, target: string): void {
+  if (target === 'all' || services.some((service) => service.id === target)) {
+    return;
+  }
+  throw new HttpError(400, 'UNKNOWN_NETWORK_SERVICE_TARGET', `Unknown network service target: ${target}`);
+}
+
 export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   const app = new Hono();
 
@@ -140,15 +147,8 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   app.post('/v1/network/stop', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
-    const config = deps.getConfig();
-    withValidTarget(
-      resolveNetworkServices(config, {
-        repoRoot: deps.root,
-        configFile: deps.configFile,
-        allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides,
-      }),
-      body.target,
-    );
+    const status = await supervisor.status();
+    assertKnownRunningTarget(status.services, body.target);
     await supervisor.stop(body.target);
     return c.json({ data: { ok: true } });
   });

--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -5,7 +5,7 @@ import { join, dirname } from 'node:path';
 import { spawn } from 'node:child_process';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../../network/network-config-paths.js';
-import { filterNetworkServices, resolveNetworkServices } from '../../network/network-registry.js';
+import { filterNetworkServices, resolveNetworkServices, type ResolvedNetworkService } from '../../network/network-registry.js';
 import { NetworkLogStore } from '../../network/network-logs.js';
 import { redactSensitiveConfig } from '../../network/network-secrets.js';
 import { NetworkStateStore } from '../../network/network-state-store.js';
@@ -51,6 +51,20 @@ function createSupervisor(frankenbeastDir: string): NetworkSupervisor {
     healthcheck: healthcheckNetworkService,
     preflightService: preflightNetworkService,
   });
+}
+
+function withValidTarget(
+  services: ReturnType<typeof resolveNetworkServices>,
+  target: string,
+): ResolvedNetworkService[] {
+  try {
+    return filterNetworkServices(services, target);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Unknown network service')) {
+      throw new HttpError(400, 'UNKNOWN_NETWORK_SERVICE_TARGET', error.message);
+    }
+    throw error;
+  }
 }
 
 export function networkRoutes(deps: NetworkRoutesDeps): Hono {
@@ -106,7 +120,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
     const config = deps.getConfig();
-    const services = filterNetworkServices(
+    const services = withValidTarget(
       resolveNetworkServices(config, {
         repoRoot: deps.root,
         configFile: deps.configFile,
@@ -126,16 +140,8 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   app.post('/v1/network/stop', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
-    await supervisor.stop(body.target);
-    return c.json({ data: { ok: true } });
-  });
-
-  app.post('/v1/network/restart', async (c) => {
-    const body = validateBody(TargetBody, await parseJsonBody(c));
-    const supervisor = createSupervisor(deps.frankenbeastDir);
-    await supervisor.stop(body.target);
     const config = deps.getConfig();
-    const services = filterNetworkServices(
+    withValidTarget(
       resolveNetworkServices(config, {
         repoRoot: deps.root,
         configFile: deps.configFile,
@@ -143,6 +149,23 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
       }),
       body.target,
     );
+    await supervisor.stop(body.target);
+    return c.json({ data: { ok: true } });
+  });
+
+  app.post('/v1/network/restart', async (c) => {
+    const body = validateBody(TargetBody, await parseJsonBody(c));
+    const supervisor = createSupervisor(deps.frankenbeastDir);
+    const config = deps.getConfig();
+    const services = withValidTarget(
+      resolveNetworkServices(config, {
+        repoRoot: deps.root,
+        configFile: deps.configFile,
+        allowTrustedProviderCommandOverrides: deps.allowTrustedProviderCommandOverrides,
+      }),
+      body.target,
+    );
+    await supervisor.stop(body.target);
     const state = await supervisor.up({
       services,
       detached: true,

--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -5,7 +5,7 @@ import { join, dirname } from 'node:path';
 import { spawn } from 'node:child_process';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../../network/network-config-paths.js';
-import { filterNetworkServices, resolveNetworkServices, type ResolvedNetworkService } from '../../network/network-registry.js';
+import { filterNetworkServices, resolveNetworkServices, createNetworkRegistry, type NetworkServiceId, type ResolvedNetworkService } from '../../network/network-registry.js';
 import { NetworkLogStore } from '../../network/network-logs.js';
 import { redactSensitiveConfig } from '../../network/network-secrets.js';
 import { NetworkStateStore } from '../../network/network-state-store.js';
@@ -67,8 +67,8 @@ function withValidTarget(
   }
 }
 
-function assertKnownRunningTarget(services: Array<{ id: string }>, target: string): void {
-  if (target === 'all' || services.some((service) => service.id === target)) {
+function assertKnownStopTarget(target: string): void {
+  if (target === 'all' || createNetworkRegistry().has(target as NetworkServiceId)) {
     return;
   }
   throw new HttpError(400, 'UNKNOWN_NETWORK_SERVICE_TARGET', `Unknown network service target: ${target}`);
@@ -147,8 +147,7 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   app.post('/v1/network/stop', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
     const supervisor = createSupervisor(deps.frankenbeastDir);
-    const status = await supervisor.status();
-    assertKnownRunningTarget(status.services, body.target);
+    assertKnownStopTarget(body.target);
     await supervisor.stop(body.target);
     return c.json({ data: { ok: true } });
   });

--- a/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
@@ -46,6 +46,42 @@ describe('network routes', () => {
     expect(body.data.network.mode).toBe('insecure');
   });
 
+  it.each(['start', 'stop', 'restart'] as const)(
+    'returns 400 for unknown network service target on %s',
+    async (action) => {
+      mkdirSync(TMP, { recursive: true });
+      let config = defaultConfig();
+      const app = createChatApp({
+        sessionStoreDir: join(TMP, 'chat'),
+        llm: { complete: vi.fn().mockResolvedValue('hello') },
+        projectName: 'network-project',
+        networkControl: {
+          root: TMP,
+          frankenbeastDir: TMP,
+          configFile: join(TMP, 'config.json'),
+          getConfig: () => config,
+          setConfig: (nextConfig) => {
+            config = nextConfig;
+          },
+        },
+      });
+
+      const response = await app.request(`/v1/network/${action}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ target: 'not-a-service' }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: 'UNKNOWN_NETWORK_SERVICE_TARGET',
+          message: 'Unknown network service target: not-a-service',
+        },
+      });
+    },
+  );
+
   it('preserves already-approved provider command overrides when persisting config updates', async () => {
     mkdirSync(TMP, { recursive: true });
     const configFile = join(TMP, 'config.json');
@@ -63,6 +99,7 @@ describe('network routes', () => {
         },
       },
     };
+
     const app = createChatApp({
       sessionStoreDir: join(TMP, 'chat'),
       llm: { complete: vi.fn().mockResolvedValue('hello') },
@@ -71,7 +108,6 @@ describe('network routes', () => {
         root: TMP,
         frankenbeastDir: TMP,
         configFile,
-        allowTrustedProviderCommandOverrides: true,
         getConfig: () => config,
         setConfig: (nextConfig) => {
           config = nextConfig;

--- a/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createChatApp } from '../../../src/http/chat-app.js';
@@ -82,6 +82,58 @@ describe('network routes', () => {
     },
   );
 
+  it('stops persisted running services even after they are disabled in config', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const stateFile = join(TMP, 'network/state.json');
+    mkdirSync(join(TMP, 'network'), { recursive: true });
+    writeFileSync(stateFile, JSON.stringify({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: true,
+      startedAt: '2026-07-10T00:00:00.000Z',
+      services: [{
+        id: 'dashboard-web',
+        pid: 0,
+        detached: true,
+        dependsOn: [],
+        startedAt: '2026-07-10T00:00:00.000Z',
+        status: 'started',
+      }],
+    }), 'utf8');
+    let config = defaultConfig();
+    config = {
+      ...config,
+      dashboard: {
+        ...config.dashboard,
+        enabled: false,
+      },
+    };
+    const app = createChatApp({
+      sessionStoreDir: join(TMP, 'chat'),
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'network-project',
+      networkControl: {
+        root: TMP,
+        frankenbeastDir: TMP,
+        configFile: join(TMP, 'config.json'),
+        getConfig: () => config,
+        setConfig: (nextConfig) => {
+          config = nextConfig;
+        },
+      },
+    });
+
+    const response = await app.request('/v1/network/stop', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'dashboard-web' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { ok: true } });
+    expect(existsSync(stateFile)).toBe(false);
+  });
+
   it('preserves already-approved provider command overrides when persisting config updates', async () => {
     mkdirSync(TMP, { recursive: true });
     const configFile = join(TMP, 'config.json');
@@ -108,6 +160,7 @@ describe('network routes', () => {
         root: TMP,
         frankenbeastDir: TMP,
         configFile,
+        allowTrustedProviderCommandOverrides: true,
         getConfig: () => config,
         setConfig: (nextConfig) => {
           config = nextConfig;

--- a/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
@@ -82,6 +82,31 @@ describe('network routes', () => {
     },
   );
 
+  it('allows idempotent stops for known service IDs when no service is running', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const app = createChatApp({
+      sessionStoreDir: join(TMP, 'chat'),
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'network-project',
+      networkControl: {
+        root: TMP,
+        frankenbeastDir: TMP,
+        configFile: join(TMP, 'config.json'),
+        getConfig: () => defaultConfig(),
+        setConfig: () => {},
+      },
+    });
+
+    const response = await app.request('/v1/network/stop', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'chat-server' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { ok: true } });
+  });
+
   it('stops persisted running services even after they are disabled in config', async () => {
     mkdirSync(TMP, { recursive: true });
     const stateFile = join(TMP, 'network/state.json');

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -56,3 +56,6 @@
 
 ## 2026-07-10 — Example scaffolding script review edges
 - For Bash scaffolding helpers, reject `.`/`..` names even when dots are otherwise allowed, avoid GNU-only `find -printf` in user-facing paths, check symlinked target directories via `target/.` before copying, and assert generated npm scripts actually load the scaffolded `.env`.
+
+## 2026-07-10 — Network stop/restart target validation
+- Validate stop and restart target IDs through `filterNetworkServices` before invoking supervisor operations, so unknown names fail fast with 400 instead of becoming no-op successes. Keep this as a shared pattern for all service-targeted control-plane endpoints where missing resources must be surfaced as client errors.


### PR DESCRIPTION
## Summary
- Return HTTP 400 for unknown network service targets in POST /v1/network/start, /v1/network/stop, and /v1/network/restart.
- Added target validation using existing network service resolution logic before invoking supervisor operations so invalid IDs fail fast.
- Added integration regression tests for unknown-target behavior on start/stop/restart.

## Test Plan
- Added integration test coverage in `packages/franken-orchestrator/tests/integration/network/network-routes.test.ts` for unknown target responses.
- Attempted local run of targeted integration test, but runtime in this environment fails with:
  - `Error: Unknown system error -122: Unknown system error -122, write`
- No additional repository-wide blockers are known.

Closes #1456
