### PR TITLE
fix: enforce immutable audit_trail writes

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -6,6 +6,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import { createAuditEvent, hashContent } from '@franken/observer';
 import { createObserverAdapter } from './observer-adapter.js';
+import { createSqliteStore } from '../shared/sqlite-store.js';
 
 function tmpDbPath(): string {
   const dir = join(tmpdir(), `fbeast-observer-${randomUUID()}`);
@@ -20,6 +21,17 @@ function legacy16(content: string): string {
 function legacy16AuditHash(metadata: string, parentHash?: string): string {
   const inputHash = `sha256:${createHash('sha256').update(metadata).digest('hex')}`;
   return parentHash ? legacy16(`${parentHash}:${inputHash}`) : inputHash.slice(0, 16);
+}
+
+function mutateAuditTrailDirectly(dbPath: string, mutation: (db: ReturnType<typeof createSqliteStore>['db']) => void): void {
+  const store = createSqliteStore(dbPath);
+  store.setAuditTrailMutationEnabled(true);
+  try {
+    mutation(store.db);
+  } finally {
+    store.setAuditTrailMutationEnabled(false);
+    store.close();
+  }
 }
 
 function fullAuditHash(sessionId: string, eventType: string, metadata: string, parentHash?: string): string {
@@ -125,9 +137,9 @@ describe('ObserverAdapter', () => {
     const observer = createObserverAdapter(dbPath);
 
     await observer.log({ event: 'tool_call', metadata: JSON.stringify({ tool: 'memory' }), sessionId: 'session-a' });
-    const db = new Database(dbPath);
-    db.prepare('UPDATE audit_trail SET session_id = ? WHERE session_id = ?').run('session-b', 'session-a');
-    db.close();
+    mutateAuditTrailDirectly(dbPath, (db) => {
+      db.prepare('UPDATE audit_trail SET session_id = ? WHERE session_id = ?').run('session-b', 'session-a');
+    });
 
     const verification = await observer.verify('session-b');
 
@@ -394,9 +406,9 @@ describe('ObserverAdapter', () => {
     const sessionId = randomUUID();
 
     await observer.log({ event: 'tool_call', metadata: JSON.stringify({ tool: 'memory' }), sessionId });
-    const db = new Database(dbPath);
-    db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run(JSON.stringify({ tool: 'memory', tampered: true }), sessionId);
-    db.close();
+    mutateAuditTrailDirectly(dbPath, (db) => {
+      db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run(JSON.stringify({ tool: 'memory', tampered: true }), sessionId);
+    });
 
     const verification = await observer.verify(sessionId);
 
@@ -410,9 +422,9 @@ describe('ObserverAdapter', () => {
     const sessionId = randomUUID();
 
     await observer.log({ event: 'tool_call', metadata: JSON.stringify({ tool: 'memory' }), sessionId });
-    const db = new Database(dbPath);
-    db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run('{ "tool": "memory" }', sessionId);
-    db.close();
+    mutateAuditTrailDirectly(dbPath, (db) => {
+      db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run('{ "tool": "memory" }', sessionId);
+    });
 
     const verification = await observer.verify(sessionId);
 

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -382,7 +382,12 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 function migrateAuditRow(store: ReturnType<typeof createSqliteStore>, id: number, hash: string, parentHash?: string): void {
-  store.db.prepare('UPDATE audit_trail SET hash = ?, parent_hash = ? WHERE id = ?').run(hash, parentHash ?? null, id);
+  store.setAuditTrailMutationEnabled(true);
+  try {
+    store.db.prepare('UPDATE audit_trail SET hash = ?, parent_hash = ? WHERE id = ?').run(hash, parentHash ?? null, id);
+  } finally {
+    store.setAuditTrailMutationEnabled(false);
+  }
 }
 
 function parseMetadata(metadata: string): unknown {

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
@@ -101,4 +101,32 @@ describe('SqliteStore', () => {
 
     store.close();
   });
+
+  it('blocks audit_trail mutation unless explicitly unlocked for migration', () => {
+    const dbPath = tracked(tmpDbPath());
+    const store = createSqliteStore(dbPath);
+
+    store.db
+      .prepare('INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash) VALUES (?, ?, ?, ?, ?)')
+      .run('session-immutable', 'tool_call', 'payload', 'sha256:0', null);
+
+    expect(() => {
+      store.db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run('tampered', 'session-immutable');
+    }).toThrowError(/append-only/i);
+
+    expect(() => {
+      store.db.prepare('DELETE FROM audit_trail WHERE session_id = ?').run('session-immutable');
+    }).toThrowError(/append-only/i);
+
+    store.setAuditTrailMutationEnabled(true);
+    expect(() => {
+      store.db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run('tampered', 'session-immutable');
+    }).not.toThrow();
+
+    expect(store.db.prepare('SELECT payload FROM audit_trail WHERE session_id = ?').get('session-immutable')).toMatchObject({
+      payload: 'tampered',
+    });
+
+    store.close();
+  });
 });

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -5,6 +5,7 @@ import { dirname } from 'node:path';
 export interface SqliteStore {
   readonly db: Database.Database;
   close(): void;
+  setAuditTrailMutationEnabled(enabled: boolean): void;
 }
 
 const SCHEMA = `
@@ -71,7 +72,34 @@ export function createSqliteStore(dbPath: string): SqliteStore {
   const db = new Database(dbPath);
   db.pragma('journal_mode = WAL');
   db.pragma('busy_timeout = 5000');
+  const auditTrailMutation = { enabled: false };
+
+  db.function(
+    'fbeast_can_mutate_audit_trail',
+    {
+      deterministic: true,
+    },
+    () => (auditTrailMutation.enabled ? 1 : 0),
+  );
+
   db.exec(SCHEMA);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS audit_trail_prevent_update
+    BEFORE UPDATE ON audit_trail
+    WHEN fbeast_can_mutate_audit_trail() = 0
+    BEGIN
+      SELECT RAISE(ABORT, 'audit_trail is append-only');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS audit_trail_prevent_delete
+    BEFORE DELETE ON audit_trail
+    WHEN fbeast_can_mutate_audit_trail() = 0
+    BEGIN
+      SELECT RAISE(ABORT, 'audit_trail is append-only');
+    END;
+  `);
+
   const costColumns = db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
   if (!costColumns.some((column) => column.name === 'cost_source')) {
     try {
@@ -87,6 +115,9 @@ export function createSqliteStore(dbPath: string): SqliteStore {
     db,
     close() {
       db.close();
+    },
+    setAuditTrailMutationEnabled(enabled: boolean) {
+      auditTrailMutation.enabled = enabled;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Enforce append-only semantics for audit_trail by adding DB-level mutation guards.
- Keep trusted hash-migration writes working via a scoped internal mutation toggle.
- Add unit coverage for blocked row updates/deletes and trusted migration path.
- Preserve existing audit migration and tamper-detection coverage in observer adapter tests.

Closes #1120