### PR TITLE
fix(web): avoid mutating provider order during render

### DIFF
--- a/packages/franken-web/src/components/providers/provider-panel.tsx
+++ b/packages/franken-web/src/components/providers/provider-panel.tsx
@@ -8,7 +8,7 @@ export function ProviderPanel({ providers }: ProviderPanelProps) {
       <h3>Providers</h3>
       {providers.length === 0 && <p>No providers configured.</p>}
       <ul className="provider-panel__list">
-        {providers
+        {[...providers]
           .sort((a, b) => a.failoverOrder - b.failoverOrder)
           .map((p) => (
             <li key={p.name} className="provider-panel__item">

--- a/packages/franken-web/tests/components/providers/provider-panel.test.tsx
+++ b/packages/franken-web/tests/components/providers/provider-panel.test.tsx
@@ -35,6 +35,18 @@ describe('ProviderPanel', () => {
     expect(items[2]!.textContent).toContain('gemini');
   });
 
+  it('does not mutate provider order while sorting for display', () => {
+    const providers = [
+      { name: 'gemini', type: 'gemini-cli', available: true, failoverOrder: 2 },
+      { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
+      { name: 'codex', type: 'codex-cli', available: true, failoverOrder: 1 },
+    ];
+
+    render(<ProviderPanel providers={providers} />);
+
+    expect(providers.map((provider) => provider.name)).toEqual(['gemini', 'claude', 'codex']);
+  });
+
   it('shows empty message when no providers', () => {
     render(<ProviderPanel providers={[]} />);
     expect(screen.getByText('No providers configured.')).toBeDefined();


### PR DESCRIPTION
## Summary
- Sort ProviderPanel providers through a copied array so render does not mutate caller-owned dashboard state
- Add a regression test that preserves the original provider order while keeping sorted display order

## Test Plan
- npm run build --workspace @franken/types
- TMPDIR=$PWD/.tmp XDG_CACHE_HOME=$PWD/.cache VITEST_CACHE_DIR=$PWD/.cache/vitest npm test --workspace @franken/web -- --run tests/components/providers/provider-panel.test.tsx --no-cache --maxWorkers=1 --pool=forks --reporter=verbose
- TMPDIR=$PWD/.tmp XDG_CACHE_HOME=$PWD/.cache VITEST_CACHE_DIR=$PWD/.cache/vitest npm run typecheck --workspace @franken/web
- TMPDIR=$PWD/.tmp XDG_CACHE_HOME=$PWD/.cache VITEST_CACHE_DIR=$PWD/.cache/vitest npm run build --workspace @franken/web
- git diff --check

Closes #1032