### PR TITLE
docs(skills): clarify SkillManager phase status

### DIFF
--- a/docs/plans/consolidation/phase5-skill-loading.md
+++ b/docs/plans/consolidation/phase5-skill-loading.md
@@ -67,6 +67,29 @@ This keeps dashboard toggles durable without rewriting user-authored YAML on eve
 - `GET /api/skills` returns provider origin and MCP status metadata needed by the advanced dashboard
 - Dashboard can browse, install, toggle, and manage skills
 
+## Current implementation status
+
+The Phase 5 SkillManager work is not a TODO placeholder. The live code now has
+these supported surfaces:
+
+- `packages/franken-orchestrator/src/skills/skill-manager.ts` owns the
+  directory-backed installed-skill registry, enable/disable persistence,
+  `mcp.json` reads, optional `context.md` reads/writes, `tools.json` manifest
+  reads, and provider-specific translation through `loadForProvider()`.
+- `packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts`
+  advertises enabled MCP skill descriptors to the execution graph, including
+  tool-level ids, namespaced ids, and `requiresHitl` metadata.
+- Direct execution through `SkillManagerAdapter.execute()` intentionally fails
+  closed. Runtime MCP execution requires an `IMcpModule` dispatch path in
+  `runExecution`; CLI, function, or LLM skills require executors for those
+  execution types. This prevents the old placeholder-success behavior from
+  implying a skill ran when no MCP transport was available.
+
+Remaining work should therefore be tracked as a concrete execution-dispatch or
+transport gap, not as a generic "Phase 5 SkillManager placeholder". Historical
+references to "Phase 5 SkillManager" in type comments or planning documents are
+phase labels only; they are not evidence that skill loading is still stubbed.
+
 ## Chunks
 
 | # | Chunk | Committable Unit | Can Parallel? |

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -156,7 +156,7 @@ export interface ProviderCritiqueFinding {
  */
 export type CritiqueResult = ProviderCritiqueFinding;
 
-// --- Skill Loading Types (used by Phase 5 SkillManager + Phase 8 Beast Loop) ---
+// --- Skill Loading Types (used by SkillManager provider translation + Beast Loop spawn wiring) ---
 
 export interface ProviderSkillConfig {
   tools?: ToolDefinition[];


### PR DESCRIPTION
## Summary
- Clarifies that Phase 5 SkillManager is implemented, not a TODO placeholder
- Documents current supported skill surfaces and the explicit execution-dispatch boundary
- Removes stale phase wording from ProviderSkillConfig comments

## Test Plan
- npm ci
- npm --workspace @franken/orchestrator run test -- --run tests/unit/adapters/mcp-execution-adapters.test.ts (with TMPDIR set after /tmp write error)
- npm --workspace @franken/types run typecheck
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/types run build
- npm --workspace @franken/orchestrator run build
- npm run audit:todos

Closes #986