### PR TITLE
test: wire brain critique integration suites

### DIFF
--- a/packages/franken-brain/docs/RAMP_UP.md
+++ b/packages/franken-brain/docs/RAMP_UP.md
@@ -24,7 +24,7 @@ The `@franken/orchestrator` currently bypasses this package. While the logic her
 ```bash
 npm run build          # tsc
 npm run test           # vitest run (unit)
-npm run test:integration # requires SQLite/ChromaDB mocks
+npm run test:integration # serialize/hydrate lifecycle coverage
 ```
 
 ## Dependencies

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -503,10 +503,17 @@ describe('SqliteBrain', () => {
 
   describe('constructor', () => {
     it('accepts custom db path', () => {
-      const tmpBrain = new SqliteBrain('/tmp/test-brain.db');
-      tmpBrain.working.set('test', 'value');
-      expect(tmpBrain.working.get('test')).toBe('value');
-      tmpBrain.close();
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const tmpBrain = new SqliteBrain(dbPath);
+        tmpBrain.working.set('test', 'value');
+        expect(tmpBrain.working.get('test')).toBe('value');
+        tmpBrain.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('hydrates persisted working memory from an existing SQLite file', () => {

--- a/packages/franken-brain/vitest.integration.config.ts
+++ b/packages/franken-brain/vitest.integration.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,

--- a/packages/franken-critique/docs/RAMP_UP.md
+++ b/packages/franken-critique/docs/RAMP_UP.md
@@ -25,7 +25,7 @@ The `@franken/orchestrator` currently skips the reflection phase by using a stub
 ```bash
 npm run build            # tsc
 npm test                 # vitest run (unit)
-npm run test:integration # full loop verification
+npm run test:integration # full critique loop verification
 ```
 
 ## Dependencies

--- a/packages/franken-critique/vitest.integration.config.ts
+++ b/packages/franken-critique/vitest.integration.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vitest/config';
+import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
 import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: createFrankenSourceAliases(import.meta.url),
+  },
   test: {
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,


### PR DESCRIPTION
## Summary
- Wire brain and critique integration Vitest configs to the repo source aliases so they run against workspace sources.
- Update ramp-up docs so the advertised integration commands describe the actual suites.
- Make the brain custom-db-path unit test use an isolated temp database instead of a shared /tmp filename.

## Test Plan
- npm run build --workspace @franken/types
- npm run test:integration --workspace @franken/brain
- npm run test:integration --workspace @franken/critique
- npm run test --workspace @franken/brain
- npm run test --workspace @franken/critique
- npm run typecheck --workspace @franken/brain
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run lint --workspace @franken/brain
- npm run lint --workspace @franken/critique

Closes #973