### PR TITLE
fix(observer): bound webhook retry jitter

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -204,6 +204,60 @@ describe('WebhookNotifier', () => {
       expect(delays[3]).toBe(250) // capped
     })
 
+    it('clamps jittered delay at maxDelayMs', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
+      const sleepFn = vi.fn().mockResolvedValue(undefined)
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9)
+      const notifier = new WebhookNotifier({
+        url: 'https://hooks.example.com/signal',
+        fetch: mockFetch,
+        retry: { maxRetries: 1, baseDelayMs: 100, maxDelayMs: 100, jitter: true },
+        sleep: sleepFn,
+      })
+
+      try {
+        await expect(notifier.send({ type: 'test' })).rejects.toThrow()
+
+        expect(sleepFn).toHaveBeenCalledWith(100)
+      } finally {
+        randomSpy.mockRestore()
+      }
+    })
+
+    it('does not retry non-transient 4xx responses', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' })
+      const sleepFn = vi.fn().mockResolvedValue(undefined)
+      const notifier = new WebhookNotifier({
+        url: 'https://hooks.example.com/signal',
+        fetch: mockFetch,
+        retry: { maxRetries: 3 },
+        sleep: sleepFn,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow('401')
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(sleepFn).not.toHaveBeenCalled()
+    })
+
+    it('still retries 429 responses', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests' })
+        .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
+      const sleepFn = vi.fn().mockResolvedValue(undefined)
+      const notifier = new WebhookNotifier({
+        url: 'https://hooks.example.com/signal',
+        fetch: mockFetch,
+        retry: { maxRetries: 2, jitter: false },
+        sleep: sleepFn,
+      })
+
+      await notifier.send({ type: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(sleepFn).toHaveBeenCalledTimes(1)
+    })
+
     it('retries on network errors (fetch rejection)', async () => {
       mockFetch
         .mockRejectedValueOnce(new Error('ECONNREFUSED'))

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -57,6 +57,10 @@ export interface WebhookNotifierOptions {
  * })
  * ```
  */
+function isTransientStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599)
+}
+
 export class WebhookNotifier {
   private readonly url: string
   private readonly extraHeaders: Record<string, string>
@@ -87,12 +91,14 @@ export class WebhookNotifier {
       if (attempt > 0 && this.retry) {
         const { baseDelayMs, maxDelayMs, jitter } = this.retry
         const base = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs)
-        const delay = jitter ? base + Math.random() * baseDelayMs : base
+        const jittered = jitter ? base + Math.random() * baseDelayMs : base
+        const delay = Math.min(jittered, maxDelayMs)
         await this.sleepFn(delay)
       }
 
+      let response: Awaited<ReturnType<FetchFn>>
       try {
-        const response = await this.fetchFn(this.url, {
+        response = await this.fetchFn(this.url, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -100,16 +106,21 @@ export class WebhookNotifier {
           },
           body: JSON.stringify(payload),
         })
-        if (!response.ok) {
-          lastError = new Error(
-            `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`,
-          )
-          continue
-        }
-        return
       } catch (err) {
         lastError = err
+        continue
       }
+
+      if (!response.ok) {
+        lastError = new Error(
+          `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`,
+        )
+        if (!this.retry || !isTransientStatus(response.status) || attempt === maxAttempts - 1) {
+          throw lastError
+        }
+        continue
+      }
+      return
     }
 
     throw lastError


### PR DESCRIPTION
## Summary
- Clamp WebhookNotifier retry delays after jitter so maxDelayMs remains a hard cap
- Retry only transient webhook failures: network errors, HTTP 429, and 5xx responses
- Add regressions for jitter clamping, non-transient 4xx fail-fast, and 429 retry behavior

## Test Plan
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-observer test -- WebhookNotifier.test.ts --pool=forks
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-observer test -- --pool=forks
- npm --prefix packages/franken-types run build && npm --prefix packages/franken-observer run typecheck && npm --prefix packages/franken-observer run build
- npm run lint:any
- npm run lint:security

Closes #971