### PR TITLE
fix(mcp-suite): validate memory query limits

### DIFF
--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createMemoryServer } from './memory.js';
 
 describe('Memory Server', () => {
@@ -87,5 +88,41 @@ describe('Memory Server', () => {
     const forgetResult = await forgetTool.handler({ key: 'adr' });
     expect(brain.forget).toHaveBeenCalledWith('adr');
     expect(forgetResult.content[0]!.text).toContain('Removed memory: adr');
+  });
+
+  it('rejects invalid query limits before calling the brain adapter', async () => {
+    for (const invalidLimit of ['abc', 'NaN', 'Infinity', '0', '-1']) {
+      const brain = {
+        query: vi.fn().mockResolvedValue([]),
+        store: vi.fn(),
+        frontload: vi.fn(),
+        forget: vi.fn(),
+      };
+      const server = createMemoryServer({ brain });
+      const result = await server.callTool('fbeast_memory_query', { query: 'adr', limit: invalidLimit });
+
+      expect(result.isError, invalidLimit).toBe(true);
+      expect(result.content[0]!.text).toContain('limit must be a positive integer');
+      expect(brain.query, invalidLimit).not.toHaveBeenCalled();
+    }
+  });
+
+  it('applies shared registry query limit defaults and validation', async () => {
+    const brain = {
+      query: vi.fn().mockResolvedValue([]),
+      store: vi.fn(),
+      frontload: vi.fn(),
+      forget: vi.fn(),
+    };
+    const queryTool = createToolDefsForServer('memory', { brain }).find((t) => t.name === 'fbeast_memory_query')!;
+
+    await queryTool.handler({ query: 'adr' });
+    await queryTool.handler({ query: 'adr', limit: '7' });
+    const invalidResult = await queryTool.handler({ query: 'adr', limit: 'NaN' });
+
+    expect(brain.query).toHaveBeenNthCalledWith(1, { query: 'adr', limit: 20 });
+    expect(brain.query).toHaveBeenNthCalledWith(2, { query: 'adr', limit: 7 });
+    expect(invalidResult.isError).toBe(true);
+    expect(brain.query).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -38,6 +38,25 @@ function splitCsvArg(value: unknown, fallback?: string[]): string[] | undefined 
   return parsed.length > 0 ? parsed : fallback;
 }
 
+const DEFAULT_MEMORY_QUERY_LIMIT = 20;
+const MAX_MEMORY_QUERY_LIMIT = 1000;
+
+function parseMemoryQueryLimit(value: unknown): { ok: true; value: number } | { ok: false; message: string } {
+  if (value === undefined) return { ok: true, value: DEFAULT_MEMORY_QUERY_LIMIT };
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return { ok: false, message: `limit must be a positive integer between 1 and ${MAX_MEMORY_QUERY_LIMIT}` };
+  }
+  const raw = typeof value === 'string' ? value.trim() : String(value);
+  if (raw.length === 0) {
+    return { ok: false, message: `limit must be a positive integer between 1 and ${MAX_MEMORY_QUERY_LIMIT}` };
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1 || parsed > MAX_MEMORY_QUERY_LIMIT) {
+    return { ok: false, message: `limit must be a positive integer between 1 and ${MAX_MEMORY_QUERY_LIMIT}` };
+  }
+  return { ok: true, value: parsed };
+}
+
 export function createAdapterSet(dbPath: string, options: { root?: string | undefined; configPath?: string | undefined } = {}): AdapterSet {
   return {
     brain: createBrainAdapter(dbPath),
@@ -89,7 +108,11 @@ const TOOLS: ToolFull[] = [
     makeHandler: ({ brain }) => async (args) => {
       const query = String(args['query']);
       const type = args['type'] ? String(args['type']) : undefined;
-      const limit = args['limit'] ? Number(args['limit']) : 20;
+      const parsedLimit = parseMemoryQueryLimit(args['limit']);
+      if (!parsedLimit.ok) {
+        return { content: [{ type: 'text', text: `Error: fbeast_memory_query ${parsedLimit.message}` }], isError: true };
+      }
+      const limit = parsedLimit.value;
       const rows = await brain.query(type ? { query, type, limit } : { query, limit });
       if (rows.length === 0) {
         return { content: [{ type: 'text', text: `No memory entries found for query: "${query}"` }] };


### PR DESCRIPTION
## Summary
- validate fbeast_memory_query limit values before calling the brain adapter
- preserve the default limit of 20 and valid numeric string limits
- add standalone memory server and shared registry coverage for invalid/default/valid limits

## Test Plan
- TMPDIR=$PWD/.tmp npm exec -- vitest run src/servers/memory.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --no-file-parallelism (from packages/franken-mcp-suite)
- TMPDIR=$PWD/.tmp npm run typecheck (from packages/franken-mcp-suite)
- TMPDIR=$PWD/.tmp npm run build (from packages/franken-mcp-suite)
- TMPDIR=$PWD/.tmp npm test -- --pool=forks --maxWorkers=1 --no-file-parallelism (from packages/franken-mcp-suite; known unrelated failure in src/servers/firewall.test.ts path containment expectation)

Closes #972