### PR TITLE
test(web): guard chat send against patch markers

### DIFF
--- a/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'src/hooks/use-chat-session.ts'), 'utf8');
+
+describe('useChatSession source hygiene', () => {
+  it('keeps the send implementation free of unresolved patch markers', () => {
+    const sendStart = source.indexOf('async function send(content: string): Promise<void> {');
+    const retryStart = source.indexOf('async function retryMessage(messageId: string): Promise<void> {', sendStart);
+
+    expect(sendStart).toBeGreaterThanOrEqual(0);
+    expect(retryStart).toBeGreaterThan(sendStart);
+
+    const sendImplementation = source.slice(sendStart, retryStart);
+    expect(sendImplementation).not.toMatch(/^\s*\+\s*(?:\/\/|const|if|try|catch|socket|set|return|throw|await)\b/m);
+  });
+});


### PR DESCRIPTION
## Summary
- add a source hygiene regression test for useChatSession send so unresolved patch-marker lines cannot re-enter the WebSocket/HTTP send implementation
- verified the affected hook currently contains no leading diff markers and still parses/builds

## Test Plan
- TMPDIR=$PWD/.tmp npm test --workspace @franken/web -- tests/hooks/use-chat-session-source.test.ts
- TMPDIR=$PWD/.tmp npm test --workspace @franken/web -- tests/hooks/use-chat-session.test.ts
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #963