### PR TITLE
ci: validate bootstrap dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
 
       - run: npm ci
 
+      - name: Validate bootstrap script (dry-run)
+        env:
+          CI_BOOTSTRAP_DRY_RUN: "1"
+        run: npm run bootstrap:dry-run
+
       - name: Dependency vulnerability audit
         run: npm run audit:dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "better-sqlite3": "^12.6.2",
         "js-yaml": "^5.2.1",
         "sharp": "^0.34.5",
+        "tsx": "^4.23.0",
         "turbo": "^2.10.3",
         "typescript": "^5.9.3",
         "vitest": "^4.1.9"
@@ -4729,17 +4730,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "license": "MIT"
@@ -6367,14 +6357,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -6990,12 +6972,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "bootstrap": "bash scripts/bootstrap.sh",
+    "bootstrap:dry-run": "tsx scripts/verify-setup.ts --dry-run --env-file .env.example",
     "typecheck": "turbo run typecheck",
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "better-sqlite3": "^12.6.2",
     "js-yaml": "^5.2.1",
     "sharp": "^0.34.5",
+    "tsx": "^4.23.0",
     "turbo": "^2.10.3",
     "typescript": "^5.9.3",
     "vitest": "^4.1.9"

--- a/scripts/verify-setup.ts
+++ b/scripts/verify-setup.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env npx tsx
 
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
 function printLine(...args: unknown[]): void {
   console.info(...args);
 }
@@ -8,7 +11,7 @@ function printLine(...args: unknown[]): void {
  * Verify local development setup.
  * Checks that all required services and configs are available.
  *
- * Usage: npm run local:verify-setup
+ * Usage: npx tsx scripts/verify-setup.ts [--dry-run] [--env-file <path>]
  */
 
 interface CheckResult {
@@ -17,12 +20,128 @@ interface CheckResult {
   detail: string;
 }
 
+interface Options {
+  dryRun: boolean;
+  envFile: string;
+}
+
 export {};
+
+const REQUIRED_BOOTSTRAP_ENV_VARS = [
+  'CHROMA_URL',
+  'FRANKEN_MAX_TOTAL_TOKENS',
+  'FRANKEN_MAX_DURATION_MS',
+  'FRANKEN_MAX_CRITIQUE_ITERATIONS',
+  'FRANKEN_ENABLE_HEARTBEAT',
+  'FRANKEN_ENABLE_TRACING',
+  'FRANKEN_ENABLE_REFLECTION',
+  'FRANKEN_MIN_CRITIQUE_SCORE',
+] as const;
 
 const results: CheckResult[] = [];
 
+function parseOptions(argv: string[]): Options {
+  const options: Options = { dryRun: false, envFile: '.env' };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (arg === '--env-file') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--env-file requires a path');
+      }
+      options.envFile = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--env-file=')) {
+      const value = arg.slice('--env-file='.length);
+      if (!value) {
+        throw new Error('--env-file requires a path');
+      }
+      options.envFile = value;
+      continue;
+    }
+
+    if (arg === '-h' || arg === '--help') {
+      printLine('Usage: npx tsx scripts/verify-setup.ts [--dry-run] [--env-file <path>]');
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
 function check(name: string, ok: boolean, detail: string): void {
   results.push({ name, ok, detail });
+}
+
+function parseEnvFile(path: string): Map<string, string> {
+  const env = new Map<string, string>();
+
+  if (!existsSync(path)) {
+    return env;
+  }
+
+  for (const rawLine of readFileSync(path, 'utf8').split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, equalsIndex).trim();
+    const value = line.slice(equalsIndex + 1).trim().replace(/^[ '"]|[ '"]$/gu, '');
+    env.set(key, value);
+  }
+
+  return env;
+}
+
+function checkNpmPackageManager(): void {
+  const manifest = JSON.parse(readFileSync('package.json', 'utf8')) as { packageManager?: string };
+  const expected = manifest.packageManager?.match(/^npm@(\d+\.\d+\.\d+)$/u)?.[1];
+
+  if (!expected) {
+    check('packageManager declares npm', false, manifest.packageManager ?? 'missing');
+    return;
+  }
+
+  try {
+    const actual = execSync('npm --version', {
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    }).trim();
+    check('npm matches packageManager', actual === expected, `expected ${expected}, found ${actual}`);
+  } catch (error) {
+    check('npm matches packageManager', false, error instanceof Error ? error.message : String(error));
+  }
+}
+
+function checkRequiredBootstrapEnv(path: string, parsed: ReadonlyMap<string, string>): void {
+  const missing = REQUIRED_BOOTSTRAP_ENV_VARS.filter((key) => {
+    const value = process.env[key] ?? parsed.get(key);
+    return value === undefined || value === '';
+  });
+
+  check(
+    'Required bootstrap env vars',
+    missing.length === 0,
+    missing.length === 0 ? `Found in ${path} or process.env` : `Missing: ${missing.join(', ')}`,
+  );
 }
 
 async function checkHttp(name: string, url: string): Promise<void> {
@@ -35,7 +154,8 @@ async function checkHttp(name: string, url: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  printLine('Verifying Frankenbeast local setup...\n');
+  const options = parseOptions(process.argv.slice(2));
+  printLine(`Verifying Frankenbeast local setup${options.dryRun ? ' (dry-run)' : ''}...\n`);
 
   // Node version
   const [major, minor, patch] = process.versions.node.split('.').map(Number);
@@ -44,22 +164,32 @@ async function main(): Promise<void> {
     (major! >= 24 && major! < 26);
   check('Node.js >=22.13.0 <23 || >=24.0.0 <26', meetsMinimumNode, `v${process.versions.node}`);
 
+  checkNpmPackageManager();
+
   // Environment file
-  const { existsSync } = await import('node:fs');
-  check('.env file exists', existsSync('.env'), existsSync('.env') ? 'Found' : 'Missing — copy .env.example to .env');
+  const envFileExists = existsSync(options.envFile);
+  const envFile = parseEnvFile(options.envFile);
+  check('Environment file exists', envFileExists, envFileExists ? options.envFile : `Missing — copy .env.example to ${options.envFile}`);
+  if (options.dryRun) {
+    checkRequiredBootstrapEnv(options.envFile, envFile);
+  }
 
   // Config example
   check('Config example', existsSync('frankenbeast.config.example.json'), 'frankenbeast.config.example.json');
 
-  // ChromaDB
-  const chromaUrl = process.env['CHROMA_URL'] ?? 'http://localhost:8000';
-  await checkHttp('ChromaDB', `${chromaUrl}/api/v2/heartbeat`);
+  if (options.dryRun) {
+    check('Live service probes', true, 'Skipping live service probes in dry-run mode');
+  } else {
+    // ChromaDB
+    const chromaUrl = process.env['CHROMA_URL'] ?? envFile.get('CHROMA_URL') ?? 'http://localhost:8000';
+    await checkHttp('ChromaDB', `${chromaUrl}/api/v2/heartbeat`);
 
-  // Grafana
-  await checkHttp('Grafana', 'http://localhost:3000/api/health');
+    // Grafana
+    await checkHttp('Grafana', 'http://localhost:3000/api/health');
 
-  // Tempo
-  await checkHttp('Tempo', 'http://localhost:3200/ready');
+    // Tempo
+    await checkHttp('Tempo', 'http://localhost:3200/ready');
+  }
 
   // Print results
   printLine('Results:\n');
@@ -72,9 +202,9 @@ async function main(): Promise<void> {
 
   printLine();
   if (allOk) {
-    printLine('All checks passed! Ready to develop.');
+    printLine(options.dryRun ? 'Dry-run checks passed. Bootstrap prerequisites are valid.' : 'All checks passed! Ready to develop.');
   } else {
-    printLine('Some checks failed. Run "docker compose up -d" to start services.');
+    printLine(options.dryRun ? 'Dry-run checks failed. Fix bootstrap prerequisites before installing.' : 'Some checks failed. Run "docker compose up -d" to start services.');
     process.exit(1);
   }
 }

--- a/scripts/verify-setup.ts
+++ b/scripts/verify-setup.ts
@@ -11,6 +11,7 @@ function printLine(...args: unknown[]): void {
  * Verify local development setup.
  * Checks that all required services and configs are available.
  *
+ * Usage: npm run local:verify-setup
  * Usage: npx tsx scripts/verify-setup.ts [--dry-run] [--env-file <path>]
  */
 
@@ -104,7 +105,7 @@ function parseEnvFile(path: string): Map<string, string> {
     }
 
     const key = line.slice(0, equalsIndex).trim();
-    const value = line.slice(equalsIndex + 1).trim().replace(/^[ '"]|[ '"]$/gu, '');
+    const value = line.slice(equalsIndex + 1).trim().replace(/^(?:"|')|(?:"|')$/gu, '');
     env.set(key, value);
   }
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -42,6 +42,42 @@ describe('local setup scripts', () => {
     expect(source).not.toContain('Firewall server');
   });
 
+  it('verify-setup supports a dry-run that validates bootstrap prerequisites without probing services', () => {
+    const source = read('scripts/verify-setup.ts');
+    const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+
+    expect(packageJson.scripts?.['bootstrap:dry-run']).toBe('tsx scripts/verify-setup.ts --dry-run --env-file .env.example');
+    expect(source).toContain('--dry-run');
+    expect(source).toContain('--env-file');
+    expect(source).toContain('Required bootstrap env vars');
+    expect(source).toContain('Skipping live service probes in dry-run mode');
+  });
+
+  it('bootstrap dry-run succeeds against .env.example and fails when required env vars are missing', () => {
+    const ok = spawnSync('npx', ['tsx', 'scripts/verify-setup.ts', '--dry-run', '--env-file', '.env.example'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    expect(ok.status).toBe(0);
+    expect(`${ok.stdout}\n${ok.stderr}`).toContain('Skipping live service probes in dry-run mode');
+
+    const dir = mkdtempSync(join(tmpdir(), 'frankenbeast-verify-setup-'));
+    try {
+      const envPath = join(dir, '.env.missing');
+      writeFileSync(envPath, 'CHROMA_URL=http://localhost:8000\n');
+      const missing = spawnSync('npx', ['tsx', 'scripts/verify-setup.ts', '--dry-run', '--env-file', envPath], {
+        cwd: ROOT,
+        encoding: 'utf8',
+      });
+
+      expect(missing.status).not.toBe(0);
+      expect(`${missing.stdout}\n${missing.stderr}`).toContain('Required bootstrap env vars');
+      expect(`${missing.stdout}\n${missing.stderr}`).toContain('FRANKEN_MAX_TOTAL_TOKENS');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('seed script uses the Chroma v2 tenant/database collection API', () => {
     const source = read('scripts/seed.ts');
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -50,6 +50,9 @@ describe('local setup scripts', () => {
     expect(source).toContain('--dry-run');
     expect(source).toContain('--env-file');
     expect(source).toContain('Required bootstrap env vars');
+    expect(source).toContain('if (options.dryRun)');
+    expect(source).toContain("envFile.get('CHROMA_URL')");
+    expect(source).toContain("shell: process.platform === 'win32'");
     expect(source).toContain('Skipping live service probes in dry-run mode');
   });
 
@@ -65,9 +68,23 @@ describe('local setup scripts', () => {
     try {
       const envPath = join(dir, '.env.missing');
       writeFileSync(envPath, 'CHROMA_URL=http://localhost:8000\n');
+      const scrubbedEnv = { ...process.env };
+      for (const key of [
+        'CHROMA_URL',
+        'FRANKEN_MAX_TOTAL_TOKENS',
+        'FRANKEN_MAX_DURATION_MS',
+        'FRANKEN_MAX_CRITIQUE_ITERATIONS',
+        'FRANKEN_ENABLE_HEARTBEAT',
+        'FRANKEN_ENABLE_TRACING',
+        'FRANKEN_ENABLE_REFLECTION',
+        'FRANKEN_MIN_CRITIQUE_SCORE',
+      ]) {
+        delete scrubbedEnv[key];
+      }
       const missing = spawnSync('npx', ['tsx', 'scripts/verify-setup.ts', '--dry-run', '--env-file', envPath], {
         cwd: ROOT,
         encoding: 'utf8',
+        env: scrubbedEnv,
       });
 
       expect(missing.status).not.toBe(0);

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -122,6 +122,14 @@ on:
       expect(content.indexOf('npm run ci:test:root')).toBeLessThan(content.indexOf('npm run ci:test:packages'));
     });
 
+    it('runs a bootstrap dry-run after deterministic install and fails the workflow on prerequisite errors', () => {
+      expect(content).toMatch(/name:\s*Validate bootstrap script \(dry-run\)/);
+      expect(content).toContain('npm run bootstrap:dry-run');
+      expect(content.indexOf('npm ci')).toBeLessThan(content.indexOf('npm run bootstrap:dry-run'));
+      expect(content.indexOf('npm run bootstrap:dry-run')).toBeLessThan(content.indexOf('npm run audit:dependencies'));
+      expect(content).toContain('CI_BOOTSTRAP_DRY_RUN: "1"');
+    });
+
     it('runs CI test commands with a fixed deterministic seed matrix', () => {
       expect(content).toContain('deterministic-seed');
       expect(content).toContain("deterministic-seed: ['1337']");


### PR DESCRIPTION
## Summary
- adds a CI bootstrap dry-run step to the main workflow
- extends verify-setup with a dry-run mode that validates Node, pinned npm, env-file presence, required bootstrap env vars, and config examples without probing live services
- covers the workflow wiring and dry-run success/failure paths in root tests

## Test Plan
- npm run bootstrap:dry-run
- TMPDIR=$PWD/.tmp npm run test:root -- tests/local-setup-scripts.test.ts tests/unit/ci-workflow.test.ts --pool=threads
- TMPDIR=$PWD/.tmp npm run test:root
- npm run typecheck
- npx turbo run build lint
- npm run lint:security

Closes #1413