### PR TITLE
fix(mcp-suite): recover invalid JSON settings

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -5,7 +5,7 @@ import { codexServerName } from './codex-server-names.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 
 function tmpDir(): string {
   const dir = join(tmpdir(), `fbeast-init-${randomUUID()}`);
@@ -15,6 +15,10 @@ function tmpDir(): string {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function jsonBackups(dir: string): string[] {
+  return readdirSync(dir).filter((name) => name.startsWith('settings.json.invalid-'));
 }
 
 describe('fbeast init', () => {
@@ -76,6 +80,38 @@ describe('fbeast init', () => {
     ]);
     const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
     expect(settings.mcpServers).toBeUndefined();
+  });
+
+  it('backs up invalid Claude settings.json and initializes without SyntaxError', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.json'), '{ invalid json');
+
+    expect(() => runInit({ root, claudeDir, hooks: false, client: 'claude' })).not.toThrow();
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers).toBeUndefined();
+    const backups = jsonBackups(claudeDir);
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(claudeDir, backups[0]!), 'utf-8')).toBe('{ invalid json');
+  });
+
+  it('backs up invalid Gemini settings.json and initializes MCP entries', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const geminiDir = join(root, '.gemini');
+    mkdirSync(geminiDir, { recursive: true });
+    writeFileSync(join(geminiDir, 'settings.json'), '{ invalid json');
+
+    expect(() => runInit({ root, claudeDir: geminiDir, hooks: false, client: 'gemini' })).not.toThrow();
+
+    const settings = JSON.parse(readFileSync(join(geminiDir, 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers['fbeast-memory']).toBeDefined();
+    const backups = jsonBackups(geminiDir);
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(geminiDir, backups[0]!), 'utf-8')).toBe('{ invalid json');
   });
 
   it('merges with existing Claude .mcp.json comments and trailing commas without overwriting', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -14,7 +14,7 @@ import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { writeHookScripts } from './hook-scripts.js';
 import { codexServerName, ensureCodexProjectId } from './codex-server-names.js';
-import { parseJsonObjectWithComments, writeJsonFileAtomic } from './settings-json.js';
+import { readJsonObjectFileOrRecover, writeJsonFileAtomic } from './settings-json.js';
 
 const ALL_SERVERS: FbeastServer[] = [
   'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
@@ -92,7 +92,7 @@ function initJsonClient(options: {
   const settingsPath = join(claudeDir, 'settings.json');
   let settings: Record<string, unknown> = {};
   if (existsSync(settingsPath)) {
-    settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
+    settings = readJsonObjectFileOrRecover(settingsPath, readFileSync(settingsPath, 'utf-8'));
   }
 
   // Add MCP server entries. Claude project-scoped MCP registrations belong in
@@ -102,7 +102,7 @@ function initJsonClient(options: {
   const mcpConfigPath = client === 'claude' ? join(root, '.mcp.json') : settingsPath;
   let mcpConfig: Record<string, unknown> = client === 'claude' ? {} : settings;
   if (client === 'claude' && existsSync(mcpConfigPath)) {
-    mcpConfig = parseJsonObjectWithComments(readFileSync(mcpConfigPath, 'utf-8'));
+    mcpConfig = readJsonObjectFileOrRecover(mcpConfigPath, readFileSync(mcpConfigPath, 'utf-8'));
   }
   if (client === 'claude') {
     pruneFbeastMcpServerEntries(settings);

--- a/packages/franken-mcp-suite/src/cli/settings-json.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.ts
@@ -1,4 +1,4 @@
-import { chmodSync, closeSync, fsyncSync, lstatSync, openSync, readlinkSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, closeSync, copyFileSync, fsyncSync, lstatSync, openSync, readlinkSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
@@ -12,6 +12,22 @@ export function parseJsonObjectWithComments(content: string): Record<string, unk
 
 export function readSettingsJson(content: string): Record<string, unknown> {
   return parseJsonObjectWithComments(content);
+}
+
+export function recoverInvalidJsonFile(path: string, error: unknown): Record<string, unknown> {
+  const backupPath = join(dirname(path), `${basename(path)}.invalid-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomUUID()}.bak`);
+  copyFileSync(path, backupPath);
+  const reason = error instanceof Error ? error.message : String(error);
+  console.warn(`fbeast: ${path} is not valid JSON (${reason}); backed it up to ${backupPath} and will recreate it.`);
+  return {};
+}
+
+export function readJsonObjectFileOrRecover(path: string, content: string): Record<string, unknown> {
+  try {
+    return parseJsonObjectWithComments(content);
+  } catch (error) {
+    return recoverInvalidJsonFile(path, error);
+  }
 }
 
 export function writeJsonFileAtomic(path: string, value: unknown): void {

--- a/packages/franken-mcp-suite/src/cli/uninstall.test.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.test.ts
@@ -6,13 +6,17 @@ import { codexServerName, codexServerNames } from './codex-server-names.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { PassThrough } from 'node:stream';
 
 function tmpDir(): string {
   const dir = join(tmpdir(), `fbeast-uninst-${randomUUID()}`);
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function jsonBackups(dir: string): string[] {
+  return readdirSync(dir).filter((name) => name.startsWith('settings.json.invalid-'));
 }
 
 describe('fbeast uninstall', () => {
@@ -59,6 +63,38 @@ describe('fbeast uninstall', () => {
     const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
     expect(after.mcpServers['my-server']).toBeDefined();
     expect(after.mcpServers['fbeast-memory']).toBeUndefined();
+  });
+
+  it('backs up invalid Claude settings.json during uninstall without SyntaxError', async () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.json'), '{ invalid json');
+
+    await expect(runUninstall({ root, claudeDir, purge: false })).resolves.toBeUndefined();
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers).toEqual({});
+    const backups = jsonBackups(claudeDir);
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(claudeDir, backups[0]!), 'utf-8')).toBe('{ invalid json');
+  });
+
+  it('backs up invalid Gemini settings.json during uninstall without SyntaxError', async () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const geminiDir = join(root, '.gemini');
+    mkdirSync(geminiDir, { recursive: true });
+    writeFileSync(join(geminiDir, 'settings.json'), '{ invalid json');
+
+    await expect(runUninstall({ root, claudeDir: geminiDir, client: 'gemini', purge: false })).resolves.toBeUndefined();
+
+    const settings = JSON.parse(readFileSync(join(geminiDir, 'settings.json'), 'utf-8'));
+    expect(settings.mcpServers).toEqual({});
+    const backups = jsonBackups(geminiDir);
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(geminiDir, backups[0]!), 'utf-8')).toBe('{ invalid json');
   });
 
   it('removes fbeast-instructions.md', async () => {

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -11,7 +11,7 @@ import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { confirmYesNo } from './prompt.js';
 import { codexProjectIds, codexServerNamesForProjectIds } from './codex-server-names.js';
-import { parseJsonObjectWithComments, writeJsonFileAtomic } from './settings-json.js';
+import { readJsonObjectFileOrRecover, writeJsonFileAtomic } from './settings-json.js';
 import type { FbeastServer } from '../shared/config.js';
 
 export interface UninstallOptions {
@@ -110,7 +110,7 @@ function uninstallJsonClient(options: { root: string; claudeDir: string; client:
 function pruneFbeastMcpServers(settingsPath: string): Record<string, unknown> {
   if (!existsSync(settingsPath)) return {};
 
-  const settings = parseJsonObjectWithComments(readFileSync(settingsPath, 'utf-8'));
+  const settings = readJsonObjectFileOrRecover(settingsPath, readFileSync(settingsPath, 'utf-8'));
   const mcpServers = (settings['mcpServers'] as Record<string, unknown>) ?? {};
   for (const key of Object.keys(mcpServers)) {
     if (key.startsWith('fbeast-')) delete mcpServers[key];


### PR DESCRIPTION
## Summary
- recover invalid JSON settings/config files by backing them up and recreating clean JSON instead of throwing
- apply recovery to MCP init for Claude/Gemini settings and Claude .mcp.json config
- apply recovery to MCP uninstall pruning for Claude/Gemini settings

## Test Plan
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-969/.tmp npm run test --workspace=@franken/mcp-suite -- --run src/cli/init.test.ts src/cli/uninstall.test.ts --pool=threads --fileParallelism=false
- npm run typecheck --workspace=@franken/mcp-suite
- npm run build --workspace=@franken/mcp-suite
- git diff --check

Closes #969