### PR TITLE
feat(dx): add onboarding bootstrap script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Verify npm matches packageManager
         run: node scripts/check-package-manager.mjs
 
+      - name: Validate bootstrap dry-run
+        run: ./scripts/bootstrap.sh --dry-run
+
       - run: npm ci
 
       - name: Dependency vulnerability audit

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -41,18 +41,21 @@ Use this checklist for a first local checkout or when rebuilding a development e
   cd frankenbeast
   ```
 
-- [ ] Re-activate the repository-pinned npm version from inside the checkout, then install dependencies:
+- [ ] Run the one-click bootstrap. It validates Node.js and Corepack, activates the repository-pinned npm version, creates `.env` from `.env.example` when needed, validates required env vars, runs `npm ci`, and skips optional Docker services unless you ask for them:
 
   ```bash
-  corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
-  npm run check:package-manager
-  npm install
+  npm run bootstrap -- --no-docker
   ```
 
-- [ ] Create a local environment file and fill in only the values you need:
+  To preview checks without mutating files or installing dependencies, run:
 
   ```bash
-  cp .env.example .env
+  ./scripts/bootstrap.sh --dry-run
+  ```
+
+- [ ] Review `.env` and fill in only the values you need:
+
+  ```bash
   $EDITOR .env
   ```
 

--- a/README.md
+++ b/README.md
@@ -553,10 +553,17 @@ cd packages/franken-orchestrator && npm run test:e2e
 
 ## Local Dev Environment
 
+For first-time setup, use the onboarding checklist and bootstrap script:
+
 ```bash
-# Configure local services. Generate a unique Grafana password before starting
-# the full compose stack; Grafana requires GRAFANA_USER=admin with a non-default password.
-cp .env.example .env
+# Validate prerequisites and create .env without starting optional services.
+npm run bootstrap -- --no-docker
+
+# CI-style prerequisite validation without mutating files or installing packages.
+./scripts/bootstrap.sh --dry-run
+
+# Generate a unique Grafana password before starting the full compose stack;
+# Grafana requires GRAFANA_USER=admin with a non-default password.
 $EDITOR .env  # uncomment GRAFANA_USER=admin, set a unique GRAFANA_PASSWORD, and adjust CHROMA_URL if needed
 
 # .env.example defaults CHROMA_URL to http://localhost:8000 for local compose.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -32,8 +32,9 @@ npm run audit:security
 ## 2. Configure environment
 
 ```bash
-cp .env.example .env
-# Edit .env with provider API keys or local runtime settings as needed:
+# Bootstrap creates .env when it is missing; edit the existing file without overwriting it.
+${EDITOR:-vi} .env
+# Add provider API keys or local runtime settings as needed:
 #   ANTHROPIC_API_KEY for Claude, OPENAI_API_KEY for OpenAI,
 #   or GOOGLE_API_KEY / GEMINI_API_KEY for Gemini.
 # Before starting the full Docker stack, uncomment GRAFANA_USER=admin and set a
@@ -43,7 +44,8 @@ cp .env.example .env
 ## 3. Optional: start infrastructure
 
 ```bash
-docker compose up -d
+# The bootstrap script validates Grafana credentials before starting compose.
+npm run bootstrap -- --with-docker
 ```
 
 This starts the services defined in `docker-compose.yml`:

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -11,12 +11,16 @@ Get Frankenbeast running locally.
 ## 1. Install dependencies
 
 ```bash
-if ! command -v corepack >/dev/null 2>&1; then npm install -g corepack; fi
-corepack enable npm
-corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
-npm run check:package-manager
-npm install
+npm run bootstrap -- --no-docker
 ```
+
+For CI-style validation without mutating files or installing dependencies, run:
+
+```bash
+./scripts/bootstrap.sh --dry-run
+```
+
+If Corepack is not available yet, install it first with `npm install -g corepack`; the bootstrap script then activates and verifies the root `packageManager` pin.
 
 Run reproducible dependency audits through the guarded script so the live npm
 binary still matches the root `packageManager` pin before `npm audit` runs:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
+    "bootstrap": "bash scripts/bootstrap.sh",
     "typecheck": "turbo run typecheck",
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,10 +14,9 @@ Bootstraps a Frankenbeast checkout for local development:
   1. validates Node.js, npm, and Corepack prerequisites;
   2. activates the repository-pinned npm version;
   3. creates .env from .env.example when missing;
-  4. prompts for any required env vars that are blank;
+  4. merges documented default env vars into existing .env files without clobbering local secrets;
   5. runs npm ci;
-  6. optionally starts docker compose services;
-  7. validates required env vars before exiting.
+  6. optionally validates Grafana credentials and starts docker compose services.
 
 Options:
   --dry-run       Validate prerequisites and planned actions without mutating files,
@@ -73,7 +72,7 @@ expected_npm="${expected_pm#npm@}"
 actual_npm="$(npm --version)"
 if [[ "$actual_npm" != "$expected_npm" ]]; then
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    log "dry-run: npm $actual_npm does not match packageManager $expected_pm; would run corepack enable npm and corepack prepare \"$expected_pm\" --activate"
+    fail "npm $actual_npm does not match packageManager $expected_pm. A real bootstrap would run: corepack enable npm && corepack prepare \"$expected_pm\" --activate"
   else
     log "Activating repository package manager pin $expected_pm with Corepack."
     corepack enable npm
@@ -96,50 +95,32 @@ else
   log ".env already exists; leaving it unchanged."
 fi
 
-# Required keys are the uncommented KEY=VALUE assignments in .env.example. Most
-# provider keys are intentionally commented because they are only required for
-# specific provider paths.
-required_keys="$({ grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .env.example || true; } | cut -d= -f1)"
-missing_keys=()
-blank_keys=()
-if [[ -n "$required_keys" ]]; then
-  source_file=.env
-  [[ -f "$source_file" ]] || source_file=.env.example
+# Merge uncommented defaults from .env.example into existing local .env files
+# without overwriting provider keys, local secrets, or operator overrides.
+default_keys="$({ grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .env.example || true; } | cut -d= -f1)"
+if [[ -n "$default_keys" && -f .env ]]; then
+  defaults_to_add=()
   while IFS= read -r key; do
     [[ -n "$key" ]] || continue
-    if ! grep -Eq "^${key}=" "$source_file"; then
-      missing_keys+=("$key")
-      continue
+    if ! grep -Eq "^${key}=" .env; then
+      defaults_to_add+=("$(grep -E "^${key}=" .env.example | tail -n 1)")
     fi
-    value="$(grep -E "^${key}=" "$source_file" | tail -n 1 | cut -d= -f2-)"
-    if [[ -z "$value" ]]; then
-      blank_keys+=("$key")
-    fi
-  done <<< "$required_keys"
-fi
+  done <<< "$default_keys"
 
-if [[ "${#missing_keys[@]}" -gt 0 || "${#blank_keys[@]}" -gt 0 ]]; then
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    fail "Required env vars are missing or blank: ${missing_keys[*]} ${blank_keys[*]}. Copy .env.example to .env and fill them in."
-  fi
-  if [[ -t 0 ]]; then
-    for key in "${missing_keys[@]}" "${blank_keys[@]}"; do
-      [[ -n "$key" ]] || continue
-      read -r -p "Enter value for required env var $key: " value
-      [[ -n "$value" ]] || fail "$key cannot be blank."
-      if grep -Eq "^${key}=" .env; then
-        tmp="$(mktemp)"
-        awk -v k="$key" -v v="$value" 'BEGIN{done=0} $0 ~ "^" k "=" {$0=k "=" v; done=1} {print} END{if(!done) print k "=" v}' .env > "$tmp"
-        mv "$tmp" .env
-      else
-        printf '%s=%s\n' "$key" "$value" >> .env
-      fi
-    done
+  if [[ "${#defaults_to_add[@]}" -gt 0 ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      log "dry-run: would append missing .env defaults: ${defaults_to_add[*]%%=*}"
+    else
+      {
+        printf '\n# Defaults appended by scripts/bootstrap.sh\n'
+        printf '%s\n' "${defaults_to_add[@]}"
+      } >> .env
+      log "Appended missing documented defaults to .env."
+    fi
   else
-    fail "Required env vars are missing or blank: ${missing_keys[*]} ${blank_keys[*]}. Edit .env and rerun."
+    log ".env includes documented defaults."
   fi
 fi
-log "Required env vars are present."
 
 run npm ci
 
@@ -153,9 +134,24 @@ fi
 
 if [[ "$START_DOCKER" -eq 1 ]]; then
   command -v docker >/dev/null 2>&1 || fail "Docker is required for --with-docker. Install Docker or rerun with --no-docker."
+  env_value() {
+    local key="$1"
+    [[ -f .env ]] || return 0
+    grep -E "^${key}=" .env | tail -n 1 | cut -d= -f2-
+  }
+  grafana_user="$(env_value GRAFANA_USER)"
+  grafana_password="$(env_value GRAFANA_PASSWORD)"
+  if [[ -z "$grafana_user" || -z "$grafana_password" || "$grafana_password" == "admin" ]]; then
+    fail "--with-docker requires GRAFANA_USER=admin and a unique non-default GRAFANA_PASSWORD in .env before starting Grafana."
+  fi
+  [[ "$grafana_user" == "admin" ]] || fail "docker-compose.yml requires GRAFANA_USER=admin for the local Grafana service."
   run docker compose up -d
 else
   log "Skipping optional Docker compose services. Use --with-docker to start them."
 fi
 
-log "Bootstrap ${DRY_RUN:+dry-run }completed successfully."
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "Bootstrap dry-run completed successfully."
+else
+  log "Bootstrap completed successfully."
+fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -143,7 +143,7 @@ if [[ "$START_DOCKER" -eq 1 ]]; then
   }
   grafana_user="$(env_value GRAFANA_USER)"
   grafana_password="$(env_value GRAFANA_PASSWORD)"
-  if [[ -z "$grafana_user" || -z "$grafana_password" || "$grafana_password" == "admin" ]]; then
+  if [[ -z "$grafana_user" || -z "$grafana_password" || "$grafana_password" == "admin" || "$grafana_password" == "change-me-random-grafana-password" ]]; then
     fail "--with-docker requires GRAFANA_USER=admin and a unique non-default GRAFANA_PASSWORD in .env before starting Grafana."
   fi
   [[ "$grafana_user" == "admin" ]] || fail "docker-compose.yml requires GRAFANA_USER=admin for the local Grafana service."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -72,16 +72,18 @@ expected_npm="${expected_pm#npm@}"
 actual_npm="$(npm --version)"
 if [[ "$actual_npm" != "$expected_npm" ]]; then
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    fail "npm $actual_npm does not match packageManager $expected_pm. A real bootstrap would run: corepack enable npm && corepack prepare \"$expected_pm\" --activate"
+    log "dry-run: npm $actual_npm does not match packageManager $expected_pm; a real bootstrap would run corepack enable npm and corepack prepare \"$expected_pm\" --activate"
   else
     log "Activating repository package manager pin $expected_pm with Corepack."
     corepack enable npm
     corepack prepare "$expected_pm" --activate
     actual_npm="$(npm --version)"
     [[ "$actual_npm" == "$expected_npm" ]] || fail "npm $actual_npm does not match packageManager $expected_pm after Corepack activation."
+    log "npm $actual_npm matches packageManager $expected_pm."
   fi
+else
+  log "npm $actual_npm matches packageManager $expected_pm."
 fi
-log "npm $actual_npm matches packageManager $expected_pm."
 
 [[ -f .env.example ]] || fail ".env.example is missing; cannot bootstrap local environment."
 if [[ ! -f .env ]]; then
@@ -137,7 +139,7 @@ if [[ "$START_DOCKER" -eq 1 ]]; then
   env_value() {
     local key="$1"
     [[ -f .env ]] || return 0
-    grep -E "^${key}=" .env | tail -n 1 | cut -d= -f2-
+    { grep -E "^${key}=" .env || true; } | tail -n 1 | cut -d= -f2-
   }
   grafana_user="$(env_value GRAFANA_USER)"
   grafana_password="$(env_value GRAFANA_PASSWORD)"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -72,11 +72,11 @@ expected_npm="${expected_pm#npm@}"
 actual_npm="$(npm --version)"
 if [[ "$actual_npm" != "$expected_npm" ]]; then
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    log "dry-run: npm $actual_npm does not match packageManager $expected_pm; a real bootstrap would run corepack enable npm and corepack prepare \"$expected_pm\" --activate"
+    log "dry-run: npm $actual_npm does not match packageManager $expected_pm; a real bootstrap would run corepack prepare \"$expected_pm\" --activate and corepack enable npm"
   else
     log "Activating repository package manager pin $expected_pm with Corepack."
-    corepack enable npm
     corepack prepare "$expected_pm" --activate
+    corepack enable npm
     actual_npm="$(npm --version)"
     [[ "$actual_npm" == "$expected_npm" ]] || fail "npm $actual_npm does not match packageManager $expected_pm after Corepack activation."
     log "npm $actual_npm matches packageManager $expected_pm."
@@ -139,7 +139,7 @@ if [[ "$START_DOCKER" -eq 1 ]]; then
   env_value() {
     local key="$1"
     [[ -f .env ]] || return 0
-    { grep -E "^${key}=" .env || true; } | tail -n 1 | cut -d= -f2-
+    { grep -E "^${key}=" .env || true; } | tail -n 1 | cut -d= -f2- | sed -E 's/^"(.*)"$/\1/; s/^'"'"'(.*)'"'"'$/\1/'
   }
   grafana_user="$(env_value GRAFANA_USER)"
   grafana_password="$(env_value GRAFANA_PASSWORD)"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN=0
+START_DOCKER=0
+PROMPT_DOCKER=1
+ASSUME_YES=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/bootstrap.sh [--dry-run] [--with-docker|--no-docker] [--yes]
+
+Bootstraps a Frankenbeast checkout for local development:
+  1. validates Node.js, npm, and Corepack prerequisites;
+  2. activates the repository-pinned npm version;
+  3. creates .env from .env.example when missing;
+  4. prompts for any required env vars that are blank;
+  5. runs npm ci;
+  6. optionally starts docker compose services;
+  7. validates required env vars before exiting.
+
+Options:
+  --dry-run       Validate prerequisites and planned actions without mutating files,
+                  installing packages, or starting Docker.
+  --with-docker   Start docker compose services after npm ci.
+  --no-docker     Skip docker compose without prompting.
+  --yes           Accept defaults for prompts; currently skips optional Docker.
+  -h, --help      Show this help.
+USAGE
+}
+
+log() { printf '[bootstrap] %s\n' "$*"; }
+fail() { printf '[bootstrap] ERROR: %s\n' "$*" >&2; exit 1; }
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "dry-run: $*"
+  else
+    "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --with-docker) START_DOCKER=1; PROMPT_DOCKER=0 ;;
+    --no-docker) START_DOCKER=0; PROMPT_DOCKER=0 ;;
+    --yes|-y) ASSUME_YES=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+  shift
+done
+
+cd "$(dirname "$0")/.."
+
+command -v node >/dev/null 2>&1 || fail "Node.js is required. Install Node.js >=22.13.0 <23 or >=24.0.0 <26."
+command -v npm >/dev/null 2>&1 || fail "npm is required. Enable Corepack and activate the repository packageManager pin."
+command -v corepack >/dev/null 2>&1 || fail "Corepack is required. Install it with: npm install -g corepack"
+
+node <<'NODE'
+const version = process.versions.node.split('.').map(Number);
+const [major, minor, patch] = version;
+const ok = (major === 22 && (minor > 13 || (minor === 13 && patch >= 0))) || (major >= 24 && major < 26);
+if (!ok) {
+  console.error(`[bootstrap] ERROR: Node.js ${process.version} is unsupported. Expected >=22.13.0 <23 or >=24.0.0 <26.`);
+  process.exit(1);
+}
+NODE
+log "Node.js $(node --version) satisfies the repository engine range."
+
+expected_pm="$(node -p "require('./package.json').packageManager")"
+expected_npm="${expected_pm#npm@}"
+actual_npm="$(npm --version)"
+if [[ "$actual_npm" != "$expected_npm" ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "dry-run: npm $actual_npm does not match packageManager $expected_pm; would run corepack enable npm and corepack prepare \"$expected_pm\" --activate"
+  else
+    log "Activating repository package manager pin $expected_pm with Corepack."
+    corepack enable npm
+    corepack prepare "$expected_pm" --activate
+    actual_npm="$(npm --version)"
+    [[ "$actual_npm" == "$expected_npm" ]] || fail "npm $actual_npm does not match packageManager $expected_pm after Corepack activation."
+  fi
+fi
+log "npm $actual_npm matches packageManager $expected_pm."
+
+[[ -f .env.example ]] || fail ".env.example is missing; cannot bootstrap local environment."
+if [[ ! -f .env ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "dry-run: would copy .env.example to .env"
+  else
+    cp .env.example .env
+    log "Created .env from .env.example."
+  fi
+else
+  log ".env already exists; leaving it unchanged."
+fi
+
+# Required keys are the uncommented KEY=VALUE assignments in .env.example. Most
+# provider keys are intentionally commented because they are only required for
+# specific provider paths.
+required_keys="$({ grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .env.example || true; } | cut -d= -f1)"
+missing_keys=()
+blank_keys=()
+if [[ -n "$required_keys" ]]; then
+  source_file=.env
+  [[ -f "$source_file" ]] || source_file=.env.example
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    if ! grep -Eq "^${key}=" "$source_file"; then
+      missing_keys+=("$key")
+      continue
+    fi
+    value="$(grep -E "^${key}=" "$source_file" | tail -n 1 | cut -d= -f2-)"
+    if [[ -z "$value" ]]; then
+      blank_keys+=("$key")
+    fi
+  done <<< "$required_keys"
+fi
+
+if [[ "${#missing_keys[@]}" -gt 0 || "${#blank_keys[@]}" -gt 0 ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    fail "Required env vars are missing or blank: ${missing_keys[*]} ${blank_keys[*]}. Copy .env.example to .env and fill them in."
+  fi
+  if [[ -t 0 ]]; then
+    for key in "${missing_keys[@]}" "${blank_keys[@]}"; do
+      [[ -n "$key" ]] || continue
+      read -r -p "Enter value for required env var $key: " value
+      [[ -n "$value" ]] || fail "$key cannot be blank."
+      if grep -Eq "^${key}=" .env; then
+        tmp="$(mktemp)"
+        awk -v k="$key" -v v="$value" 'BEGIN{done=0} $0 ~ "^" k "=" {$0=k "=" v; done=1} {print} END{if(!done) print k "=" v}' .env > "$tmp"
+        mv "$tmp" .env
+      else
+        printf '%s=%s\n' "$key" "$value" >> .env
+      fi
+    done
+  else
+    fail "Required env vars are missing or blank: ${missing_keys[*]} ${blank_keys[*]}. Edit .env and rerun."
+  fi
+fi
+log "Required env vars are present."
+
+run npm ci
+
+if [[ "$PROMPT_DOCKER" -eq 1 && "$ASSUME_YES" -eq 0 && "$DRY_RUN" -eq 0 && -t 0 ]]; then
+  read -r -p "Start optional Docker compose services now? [y/N] " docker_answer
+  case "$docker_answer" in
+    y|Y|yes|YES) START_DOCKER=1 ;;
+    *) START_DOCKER=0 ;;
+  esac
+fi
+
+if [[ "$START_DOCKER" -eq 1 ]]; then
+  command -v docker >/dev/null 2>&1 || fail "Docker is required for --with-docker. Install Docker or rerun with --no-docker."
+  run docker compose up -d
+else
+  log "Skipping optional Docker compose services. Use --with-docker to start them."
+fi
+
+log "Bootstrap ${DRY_RUN:+dry-run }completed successfully."

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -19,9 +19,11 @@ describe('local setup scripts', () => {
 
     expect(read('.nvmrc').trim()).toBe('22.13.0');
     expect(read('.npmrc')).toContain('engine-strict=true');
+    expect(read('docs/guides/quickstart.md')).toContain('npm run bootstrap -- --no-docker');
     expect(read('docs/guides/quickstart.md')).toContain('npm install -g corepack');
-    expect(read('docs/guides/quickstart.md')).toContain('corepack enable npm');
-    expect(read('docs/guides/quickstart.md')).toContain('npm run check:package-manager');
+    expect(read('scripts/bootstrap.sh')).toContain('command -v corepack');
+    expect(read('scripts/bootstrap.sh')).toContain('corepack enable npm');
+    expect(read('scripts/bootstrap.sh')).toContain('corepack prepare "$expected_pm" --activate');
 
     for (const packagePath of packagePaths) {
       const manifest = JSON.parse(read(packagePath)) as { engines?: { node?: string } };
@@ -66,6 +68,40 @@ describe('local setup scripts', () => {
     expect(onboarding).toContain('npm run local:verify-setup');
     expect(seedScript).toContain('Usage: npm run local:seed');
     expect(verifyScript).toContain('Usage: npm run local:verify-setup');
+  });
+
+  it('provides a one-click bootstrap script and CI dry-run gate', () => {
+    const manifest = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+    const scriptPath = join(ROOT, 'scripts/bootstrap.sh');
+    const script = read('scripts/bootstrap.sh');
+    const readme = read('README.md');
+    const onboarding = read('ONBOARDING.md');
+    const quickstart = read('docs/guides/quickstart.md');
+    const ci = read('.github/workflows/ci.yml');
+
+    expect(manifest.scripts?.bootstrap).toBe('bash scripts/bootstrap.sh');
+    expect(statSync(scriptPath).mode & 0o111).not.toBe(0);
+    expect(script).toContain('--dry-run');
+    expect(script).toContain('Node.js >=22.13.0 <23 or >=24.0.0 <26');
+    expect(script).toContain('cp .env.example .env');
+    expect(script).toContain('required_keys');
+    expect(script).toContain('npm ci');
+    expect(script).toContain('docker compose up -d');
+    expect(readme).toContain('npm run bootstrap -- --no-docker');
+    expect(onboarding).toContain('./scripts/bootstrap.sh --dry-run');
+    expect(quickstart).toContain('./scripts/bootstrap.sh --dry-run');
+    expect(ci).toContain('Validate bootstrap dry-run');
+    expect(ci).toContain('./scripts/bootstrap.sh --dry-run');
+    expect(ci.indexOf('./scripts/bootstrap.sh --dry-run')).toBeLessThan(ci.indexOf('npm ci'));
+
+    const dryRun = spawnSync('bash', [scriptPath, '--dry-run'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    expect(dryRun.status, dryRun.stderr || dryRun.stdout).toBe(0);
+    expect(dryRun.stdout).toContain('Required env vars are present.');
+    expect(dryRun.stdout).toContain('dry-run: npm ci');
   });
 
   it('docker compose healthcheck targets the Chroma v2 heartbeat', () => {

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -84,7 +84,8 @@ describe('local setup scripts', () => {
     expect(script).toContain('--dry-run');
     expect(script).toContain('Node.js >=22.13.0 <23 or >=24.0.0 <26');
     expect(script).toContain('cp .env.example .env');
-    expect(script).toContain('required_keys');
+    expect(script).toContain('default_keys');
+    expect(script).toContain('GRAFANA_USER=admin');
     expect(script).toContain('npm ci');
     expect(script).toContain('docker compose up -d');
     expect(readme).toContain('npm run bootstrap -- --no-docker');
@@ -100,7 +101,7 @@ describe('local setup scripts', () => {
       timeout: 60_000,
     });
     expect(dryRun.status, dryRun.stderr || dryRun.stdout).toBe(0);
-    expect(dryRun.stdout).toContain('Required env vars are present.');
+    expect(dryRun.stdout).toContain('dry-run: would copy .env.example to .env');
     expect(dryRun.stdout).toContain('dry-run: npm ci');
   });
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -101,7 +101,7 @@ describe('local setup scripts', () => {
       timeout: 60_000,
     });
     expect(dryRun.status, dryRun.stderr || dryRun.stdout).toBe(0);
-    expect(dryRun.stdout).toContain('dry-run: would copy .env.example to .env');
+    expect(dryRun.stdout).toMatch(/dry-run: would copy \.env\.example to \.env|\.env already exists; leaving it unchanged\./);
     expect(dryRun.stdout).toContain('dry-run: npm ci');
   });
 


### PR DESCRIPTION
## Summary
- add a one-click bootstrap script for local onboarding with dry-run, Docker, and non-interactive flags
- wire the bootstrap dry-run into CI before dependency installation
- update README, ONBOARDING, quickstart docs, and local setup regression tests

## Test Plan
- [x] bash -n scripts/bootstrap.sh
- [x] ./scripts/bootstrap.sh --dry-run
- [x] TMPDIR=$PWD/.tmp npm run test:root
- [x] npx turbo run build lint
- [x] npm run typecheck
- [ ] npm test (local runner hit environment write error -122 in package Vitest workers; CI will verify)

Closes #1399