### PR TITLE
test(ci): parse workflow YAML assertions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
       ],
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.3.0",
         "@vitest/coverage-v8": "^4.1.9",
         "acorn": "^8.17.0",
         "better-sqlite3": "^12.6.2",
+        "js-yaml": "^4.3.0",
         "sharp": "^0.34.5",
         "turbo": "^2.10.3",
         "typescript": "^5.9.3",
@@ -2832,6 +2834,13 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,11 @@
       ],
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.3.0",
         "@vitest/coverage-v8": "^4.1.9",
         "acorn": "^8.17.0",
         "better-sqlite3": "^12.6.2",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^5.2.1",
         "sharp": "^0.34.5",
         "turbo": "^2.10.3",
         "typescript": "^5.9.3",
@@ -422,6 +421,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -2837,13 +2859,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -5092,9 +5107,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dev": true,
       "funding": [
         {
@@ -5111,7 +5126,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.0",
     "@vitest/coverage-v8": "^4.1.9",
     "acorn": "^8.17.0",
     "better-sqlite3": "^12.6.2",
+    "js-yaml": "^4.3.0",
     "sharp": "^0.34.5",
     "turbo": "^2.10.3",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,11 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.0",
     "@vitest/coverage-v8": "^4.1.9",
     "acorn": "^8.17.0",
     "better-sqlite3": "^12.6.2",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.2.1",
     "sharp": "^0.34.5",
     "turbo": "^2.10.3",
     "typescript": "^5.9.3",

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -2,11 +2,40 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { execSync } from 'node:child_process';
+import { load } from 'js-yaml';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
 const CI_PATH = resolve(ROOT, '.github/workflows/ci.yml');
 const RELEASE_PATH = resolve(ROOT, '.github/workflows/release-please.yml');
 const WORKFLOW_LINT_PATH = resolve(ROOT, '.github/workflows/workflow-lint.yml');
+
+function parseWorkflowYaml(source: string): Record<string, unknown> {
+  let workflow: unknown;
+  try {
+    workflow = load(source);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`YAML parse error: ${message}`);
+  }
+
+  if (typeof workflow !== 'object' || workflow === null || Array.isArray(workflow)) {
+    throw new Error('YAML workflow must parse to an object');
+  }
+
+  return workflow as Record<string, unknown>;
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  expect(value, `${label} should be an object`).toBeTypeOf('object');
+  expect(value, `${label} should be present`).not.toBeNull();
+  expect(Array.isArray(value), `${label} should not be an array`).toBe(false);
+  return value as Record<string, unknown>;
+}
+
+function expectSteps(job: Record<string, unknown>): Array<Record<string, unknown>> {
+  expect(Array.isArray(job.steps)).toBe(true);
+  return job.steps as Array<Record<string, unknown>>;
+}
 
 describe('CI Workflow (.github/workflows/ci.yml)', () => {
   it('ci.yml file exists', () => {
@@ -15,39 +44,56 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
 
   describe('workflow configuration', () => {
     let content: string;
+    let workflow: Record<string, unknown>;
 
     beforeAll(() => {
       content = readFileSync(CI_PATH, 'utf-8');
+      workflow = parseWorkflowYaml(content);
+    });
+
+    it('rejects syntactically invalid CI workflow YAML even when a name is present', () => {
+      expect(() =>
+        parseWorkflowYaml(`name: CI
+on:
+  push:
+    branches: [main
+`),
+      ).toThrow(/YAML/);
     });
 
     it('is valid YAML (parseable by node)', () => {
-      // Use node's built-in JSON to validate after converting with a simple check
-      // At minimum, it should not throw when we try to parse it
-      expect(content.length).toBeGreaterThan(0);
-      expect(content).toContain('name:');
+      expect(() => parseWorkflowYaml(content)).not.toThrow();
     });
 
     it('has a workflow name', () => {
-      expect(content).toMatch(/^name:/m);
+      expect(workflow.name).toBe('CI');
     });
 
     it('triggers on push to main', () => {
-      expect(content).toMatch(/on:/);
-      expect(content).toMatch(/push:/);
-      expect(content).toMatch(/branches:.*\[?.*main.*\]?/);
+      const triggers = expectRecord(workflow.on, 'workflow.on');
+      const push = expectRecord(triggers.push, 'workflow.on.push');
+      expect(push.branches).toEqual(['main']);
     });
 
     it('triggers on pull_request to main', () => {
-      expect(content).toMatch(/pull_request:/);
+      const triggers = expectRecord(workflow.on, 'workflow.on');
+      const pullRequest = expectRecord(triggers.pull_request, 'workflow.on.pull_request');
+      expect(pullRequest.branches).toEqual(['main']);
     });
 
     it('uses Node.js 22', () => {
-      expect(content).toContain('node-version');
-      expect(content).toMatch(/node-version.*['"]?22['"]?/);
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
+      const setupNode = expectSteps(buildTestLint).find((step) => step.uses === 'actions/setup-node@v4');
+      expect(setupNode).toBeTruthy();
+      const setupNodeWith = expectRecord(setupNode?.with, 'actions/setup-node.with');
+      expect(setupNodeWith['node-version']).toBe('22');
     });
 
     it('runs npm ci for deterministic installs', () => {
-      expect(content).toContain('npm ci');
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
+      expect(expectSteps(buildTestLint).some((step) => step.run === 'npm ci')).toBe(true);
     });
 
     it('runs the guarded security audit after deterministic installs', () => {
@@ -101,17 +147,27 @@ describe('CI Workflow (.github/workflows/ci.yml)', () => {
     });
 
     it('uses actions/setup-node with npm cache', () => {
-      expect(content).toContain('actions/setup-node');
-      expect(content).toMatch(/cache.*npm/);
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
+      const setupNode = expectSteps(buildTestLint).find((step) => step.uses === 'actions/setup-node@v4');
+      expect(setupNode).toBeTruthy();
+      const setupNodeWith = expectRecord(setupNode?.with, 'actions/setup-node.with');
+      expect(setupNodeWith.cache).toBe('npm');
     });
 
     it('uses actions/checkout with full history for root verification tests', () => {
-      expect(content).toContain('actions/checkout');
-      expect(content).toMatch(/actions\/checkout@v4[\s\S]*fetch-depth:\s*0/);
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
+      const checkout = expectSteps(buildTestLint).find((step) => step.uses === 'actions/checkout@v4');
+      expect(checkout).toBeTruthy();
+      const checkoutWith = expectRecord(checkout?.with, 'actions/checkout.with');
+      expect(checkoutWith['fetch-depth']).toBe(0);
     });
 
     it('runs on ubuntu-latest', () => {
-      expect(content).toContain('ubuntu-latest');
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
+      expect(buildTestLint['runs-on']).toBe('ubuntu-latest');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds real YAML parsing for `.github/workflows/ci.yml` in the root CI workflow regression test.
- Converts top-level trigger/job checks to assert against the parsed workflow object instead of only broad string matches.
- Adds an invalid-YAML regression proving the parser path fails even when `name:` is present.

## Test Plan
- [x] `npm run test:root -- tests/unit/ci-workflow.test.ts --pool=threads`
- [x] `TMPDIR="$PWD/.tmp" npm run test:root -- tests/unit/ci-workflow.test.ts`
- [x] `TMPDIR="$PWD/.tmp" npm run test:root`
- [x] `npm run check:package-manager`
- [x] `TMPDIR="$HERMES_KANBAN_WORKSPACE/tmp" npm run lint:security`
- [x] `TMPDIR="$HERMES_KANBAN_WORKSPACE/tmp" npm run build`
- [x] `TMPDIR="$HERMES_KANBAN_WORKSPACE/tmp" npm run typecheck`

Note: `npm test` was also attempted with `TMPDIR="$HERMES_KANBAN_WORKSPACE/tmp"`, but package-level Vitest transforms failed in this constrained workspace with `Unknown system error -122: write` / disk quota errors before executing tests. The root suite and build/typecheck/security checks above pass.

Closes #1230
