### PR TITLE
fix(live-bench): reject empty benchmark assertions

### DIFF
--- a/packages/live-bench/src/corpus/schema.ts
+++ b/packages/live-bench/src/corpus/schema.ts
@@ -52,7 +52,7 @@ const BenchmarkCheckSchema = z.preprocess((value) => {
   z.object({
     type: z.literal('tool-call'),
     tool: z.string().min(1),
-    requiredParams: z.array(z.string().min(1)),
+    requiredParams: z.array(z.string().min(1)).min(1, 'tool-call checks must require at least one parameter'),
   }).strict(),
 ]));
 
@@ -62,8 +62,8 @@ const BenchmarkTaskShape = z.object({
   taskClass: z.enum(['tool-critical', 'workflow-critical', 'artifact-critical']),
   projectFixture: z.string().min(1),
   prompt: z.string().min(1),
-  expectedArtifacts: z.array(z.string().min(1)),
-  requiredChecks: z.array(BenchmarkCheckSchema),
+  expectedArtifacts: z.array(z.string().min(1)).min(1, 'benchmark tasks must expect at least one artifact'),
+  requiredChecks: z.array(BenchmarkCheckSchema).min(1, 'benchmark tasks must require at least one check'),
   timeoutMs: z.number().int().positive(),
   allowedNondeterminism: z.array(z.string()),
   baselineSupported: z.boolean(),

--- a/packages/live-bench/tests/corpus-loader.test.ts
+++ b/packages/live-bench/tests/corpus-loader.test.ts
@@ -61,6 +61,29 @@ describe('corpus loader', () => {
     expect(() => loadTaskFile(taskPath)).toThrow(/Invalid benchmark task/);
   });
 
+  it('rejects benchmark tasks with empty assertion arrays', () => {
+    const root = tempCorpus();
+
+    const emptyExpectedArtifactsPath = writeTask(root, 'core/empty-artifacts.task.json', {
+      ...validTask,
+      expectedArtifacts: [],
+    });
+    const emptyRequiredChecksPath = writeTask(root, 'core/empty-checks.task.json', {
+      ...validTask,
+      taskId: 'empty-checks',
+      requiredChecks: [],
+    });
+    const emptyToolParamsPath = writeTask(root, 'core/empty-tool-params.task.json', {
+      ...validTask,
+      taskId: 'empty-tool-params',
+      requiredChecks: [{ type: 'tool-call', tool: 'write_file', requiredParams: [] }],
+    });
+
+    expect(() => loadTaskFile(emptyExpectedArtifactsPath)).toThrow(/Invalid benchmark task/);
+    expect(() => loadTaskFile(emptyRequiredChecksPath)).toThrow(/Invalid benchmark task/);
+    expect(() => loadTaskFile(emptyToolParamsPath)).toThrow(/Invalid benchmark task/);
+  });
+
   it('rejects unknown normalized task and check fields', () => {
     const root = tempCorpus();
     const taskPath = writeTask(root, 'core/unknown-fields.task.json', {


### PR DESCRIPTION
## Summary
- Require live-bench benchmark tasks to include at least one expected artifact and one required check.
- Require tool-call checks to declare at least one required parameter.
- Add corpus-loader regression coverage for empty assertion arrays.

## Test Plan
- TMPDIR=$PWD/.tmp npm --prefix packages/live-bench test -- tests/corpus-loader.test.ts -t "rejects benchmark tasks with empty assertion arrays"
- TMPDIR=$PWD/.tmp npm --prefix packages/live-bench test
- npm --prefix packages/live-bench run typecheck
- npm --prefix packages/live-bench run build

Closes #1229