### PR TITLE
test(mcp-suite): assert Windows fbeast shim passthrough

### DIFF
--- a/packages/franken-mcp-suite/src/cli/main.test.ts
+++ b/packages/franken-mcp-suite/src/cli/main.test.ts
@@ -193,10 +193,10 @@ describe('fbeast main CLI', () => {
     mockExit.mockRestore();
   });
 
-  it('launches Windows .cmd shims through cmd.exe without enabling shell mode', async () => {
+  it('resolves Windows npm .cmd shims for non-mcp passthrough commands', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     const binDir = tmpDir();
-    const shimPath = join(binDir, 'frankenbeast.CMD');
+    const shimPath = join(binDir, 'frankenbeast.cmd');
     writeFileSync(shimPath, '@echo off\r\n');
     vi.stubEnv('PATH', binDir);
     vi.stubEnv('PATHEXT', '.COM;.EXE;.BAT;.CMD');

--- a/packages/franken-mcp-suite/src/cli/main.ts
+++ b/packages/franken-mcp-suite/src/cli/main.ts
@@ -31,10 +31,12 @@ function getEnvPath(env: NodeJS.ProcessEnv): string {
 }
 
 function windowsCommandCandidates(command: string): string[] {
-  const pathext = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+  const pathext = [...new Set((process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
     .split(';')
-    .map((ext) => ext.trim())
-    .filter(Boolean);
+    .flatMap((ext) => {
+      const trimmed = ext.trim();
+      return trimmed ? [trimmed, trimmed.toLowerCase(), trimmed.toUpperCase()] : [];
+    }))];
   const hasWindowsPathSeparator = command.includes('/') || command.includes('\\');
   const commandHasExt = win32.extname(command) !== '';
 


### PR DESCRIPTION
## Summary
- strengthen the Windows `fbeast` passthrough regression to model a lowercase npm `.cmd` shim
- resolve PATHEXT candidates case-insensitively so mocked Windows tests and real npm shim casing stay aligned
- keep POSIX passthrough on `shell: false`

## Test Plan
- [x] `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1228/.tmp npx vitest run src/cli/main.test.ts --reporter=verbose --no-color -t 'resolves Windows npm .cmd shims'` (failed before implementation, passed after)
- [x] `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1228/.tmp npx vitest run src/cli/main.test.ts --reporter=dot --no-color`
- [x] `npm run build --workspace @franken/types`
- [x] `npm run build --workspace @franken/brain`
- [x] `npm run build --workspace @franken/critique`
- [x] `npm run build --workspace @franken/governor`
- [x] `npm run build --workspace @franken/observer`
- [x] `npm run build --workspace @franken/planner`
- [x] `npm run build --workspace @franken/orchestrator`
- [x] `npm --prefix packages/franken-mcp-suite run typecheck`
- [x] `npm --prefix packages/franken-mcp-suite run build`
- [x] `npm --prefix packages/franken-mcp-suite test -- --run src/cli/main.test.ts`

Closes #1228
