### PR TITLE
fix(orchestrator): reject partial issue review numbers

### DIFF
--- a/packages/franken-orchestrator/src/issues/issue-review.ts
+++ b/packages/franken-orchestrator/src/issues/issue-review.ts
@@ -26,6 +26,7 @@ const SEVERITY_RANK: Record<string, number> = {
 };
 const UNLABELLED_RANK = 4;
 const TITLE_MAX = 50;
+const DECIMAL_ISSUE_NUMBER = /^[1-9]\d*$/;
 
 interface ReviewEntry {
   readonly issue: GithubIssue;
@@ -171,8 +172,13 @@ export class IssueReview {
       const invalid: string[] = [];
 
       for (const part of parts) {
-        const num = parseInt(part, 10);
-        if (isNaN(num) || !validNumbers.has(num)) {
+        if (!DECIMAL_ISSUE_NUMBER.test(part)) {
+          invalid.push(part);
+          continue;
+        }
+
+        const num = Number(part);
+        if (!validNumbers.has(num)) {
           invalid.push(part);
         } else {
           parsed.push(num);

--- a/packages/franken-orchestrator/tests/unit/issues/issue-review.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-review.test.ts
@@ -143,6 +143,28 @@ describe('IssueReview', () => {
       expect(result.approved[0]!.issueNumber).toBe(2);
     });
 
+    it('rejects partially numeric issue numbers and re-prompts', async () => {
+      const issues = [
+        makeIssue({ number: 1 }),
+        makeIssue({ number: 2 }),
+        makeIssue({ number: 3 }),
+      ];
+      const triage = [
+        makeTriage({ issueNumber: 1 }),
+        makeTriage({ issueNumber: 2 }),
+        makeTriage({ issueNumber: 3 }),
+      ];
+      const io = createMockIO(['edit', '1abc, 2 trailing, 03junk', '2', 'Y']);
+      const review = new IssueReview(io);
+
+      const result = await review.review(issues, triage);
+
+      const allOutput = io.output.join('\n');
+      expect(allOutput).toContain('Invalid issue number(s): 1abc, 2 trailing, 03junk');
+      expect(result.action).toBe('execute');
+      expect(result.approved.map((t) => t.issueNumber)).toEqual([1, 3]);
+    });
+
     it('can abort after editing', async () => {
       const issues = [makeIssue({ number: 1 }), makeIssue({ number: 2 })];
       const triage = [


### PR DESCRIPTION
## Summary
- Reject edit-loop removal tokens unless the full token is a strict positive decimal issue number
- Preserve valid listed issue-number removal behavior
- Add regression coverage for partially numeric tokens such as `1abc`, `2 trailing`, and `03junk`

## Test Plan
- [x] `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1199/.tmp npm test --workspace @franken/orchestrator -- --run tests/unit/issues/issue-review.test.ts`
- [x] `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- [x] `npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor`
- [x] `npm run typecheck --workspace @franken/orchestrator`
- [x] `npm run build --workspace @franken/orchestrator`

Closes #1199