### PR TITLE
fix(web): interleave events and logs chronologically

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-detail-readonly.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-readonly.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import * as Accordion from '@radix-ui/react-accordion';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
 import type { TrackedAgentDetail } from '../../lib/beast-api';
+import { buildLogDisplayEntries } from './log-display-entry';
 
 interface AgentDetailReadonlyProps {
   detail: TrackedAgentDetail;
@@ -11,6 +12,7 @@ interface AgentDetailReadonlyProps {
 
 export function AgentDetailReadonly({ detail, logs, onExpandLogs }: AgentDetailReadonlyProps) {
   const { agent } = detail;
+  const displayEntries = buildLogDisplayEntries(detail.events, logs);
 
   return (
     <ScrollArea.Root className="flex-1 overflow-hidden">
@@ -69,15 +71,12 @@ export function AgentDetailReadonly({ detail, logs, onExpandLogs }: AgentDetailR
             </button>
           }>
             <div className="space-y-1 font-mono text-xs text-beast-muted max-h-48 overflow-y-auto">
-              {detail.events.map((e) => (
-                <div key={e.id} className={`${e.level === 'error' ? 'text-beast-danger' : ''}`}>
-                  [{new Date(e.createdAt).toLocaleTimeString()}] {e.message}
+              {displayEntries.map((entry) => (
+                <div key={entry.key} className={`${entry.level === 'error' ? 'text-beast-danger' : ''}`}>
+                  {entry.label}
                 </div>
               ))}
-              {logs.map((line, i) => (
-                <div key={i}>{line}</div>
-              ))}
-              {detail.events.length === 0 && logs.length === 0 && (
+              {displayEntries.length === 0 && (
                 <p className="text-beast-subtle italic">No events or logs yet</p>
               )}
             </div>

--- a/packages/franken-web/src/components/beasts/log-display-entry.ts
+++ b/packages/franken-web/src/components/beasts/log-display-entry.ts
@@ -1,0 +1,127 @@
+import type { TrackedAgentEvent } from '../../lib/beast-api';
+
+export type LogDisplayEntry =
+  | {
+      kind: 'event';
+      key: string;
+      level: TrackedAgentEvent['level'];
+      timestamp: string;
+      message: string;
+      label: string;
+    }
+  | {
+      kind: 'log';
+      key: string;
+      level?: 'error';
+      timestamp?: string;
+      message: string;
+      label: string;
+    };
+
+interface SortableDisplayEntry {
+  entry: LogDisplayEntry;
+  timestampMs: number | null;
+  fallbackOrder: number;
+}
+
+interface ParsedLogLine {
+  message: string;
+  createdAt?: string;
+  stream?: string;
+}
+
+export function buildLogDisplayEntries(
+  events: TrackedAgentEvent[],
+  logs: string[],
+  search = '',
+): LogDisplayEntry[] {
+  const normalizedQuery = search.trim().toLowerCase();
+  const sortable: SortableDisplayEntry[] = [];
+
+  events.forEach((event) => {
+    const label = `[${formatDisplayTime(event.createdAt)}] [${event.level}] ${event.message}`;
+    sortable.push({
+      entry: {
+        kind: 'event',
+        key: `event-${event.id}`,
+        level: event.level,
+        timestamp: event.createdAt,
+        message: event.message,
+        label,
+      },
+      timestampMs: parseTimestampMs(event.createdAt),
+      fallbackOrder: event.sequence,
+    });
+  });
+
+  logs.forEach((line, index) => {
+    const parsed = parseLogLine(line);
+    const timestampMs = parsed.createdAt ? parseTimestampMs(parsed.createdAt) : null;
+    const timestampPrefix = parsed.createdAt ? `[${formatDisplayTime(parsed.createdAt)}] ` : '';
+    const streamPrefix = parsed.stream ? `[${parsed.stream}] ` : '';
+    sortable.push({
+      entry: {
+        kind: 'log',
+        key: `log-${index}`,
+        level: parsed.stream === 'stderr' ? 'error' : undefined,
+        timestamp: parsed.createdAt,
+        message: parsed.message,
+        label: `${timestampPrefix}${streamPrefix}${parsed.message}`,
+      },
+      timestampMs,
+      // Keep untimestamped legacy logs in their original sequence, after timestamped entries.
+      fallbackOrder: Number.MAX_SAFE_INTEGER / 2 + index,
+    });
+  });
+
+  return sortable
+    .filter(({ entry }) => matchesQuery(entry, normalizedQuery))
+    .sort(compareDisplayEntries)
+    .map(({ entry }) => entry);
+}
+
+function compareDisplayEntries(left: SortableDisplayEntry, right: SortableDisplayEntry): number {
+  if (left.timestampMs !== null && right.timestampMs !== null && left.timestampMs !== right.timestampMs) {
+    return left.timestampMs - right.timestampMs;
+  }
+  if (left.timestampMs !== null && right.timestampMs === null) {
+    return -1;
+  }
+  if (left.timestampMs === null && right.timestampMs !== null) {
+    return 1;
+  }
+  return left.fallbackOrder - right.fallbackOrder;
+}
+
+function matchesQuery(entry: LogDisplayEntry, normalizedQuery: string): boolean {
+  if (!normalizedQuery) return true;
+  return entry.label.toLowerCase().includes(normalizedQuery) || entry.message.toLowerCase().includes(normalizedQuery);
+}
+
+function parseLogLine(line: string): ParsedLogLine {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed === 'object' && parsed !== null) {
+      const candidate = parsed as { message?: unknown; createdAt?: unknown; stream?: unknown };
+      if (typeof candidate.message === 'string') {
+        return {
+          message: candidate.message,
+          ...(typeof candidate.createdAt === 'string' ? { createdAt: candidate.createdAt } : {}),
+          ...(typeof candidate.stream === 'string' ? { stream: candidate.stream } : {}),
+        };
+      }
+    }
+  } catch {
+    // Legacy log lines are plain text.
+  }
+  return { message: line };
+}
+
+function parseTimestampMs(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function formatDisplayTime(value: string): string {
+  return new Date(value).toLocaleTimeString();
+}

--- a/packages/franken-web/src/components/beasts/log-viewer-modal.tsx
+++ b/packages/franken-web/src/components/beasts/log-viewer-modal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
 import type { TrackedAgentEvent } from '../../lib/beast-api';
+import { buildLogDisplayEntries } from './log-display-entry';
 
 interface LogViewerModalProps {
   isOpen: boolean;
@@ -38,12 +39,7 @@ export function LogViewerModal({ isOpen, onClose, logs, events }: LogViewerModal
     return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
   }, []);
 
-  const filteredLogs = search
-    ? logs.filter((l) => l.toLowerCase().includes(search.toLowerCase()))
-    : logs;
-  const filteredEvents = search
-    ? events.filter((e) => e.message.toLowerCase().includes(search.toLowerCase()))
-    : events;
+  const displayEntries = buildLogDisplayEntries(events, logs, search);
 
   async function handleFullscreen() {
     if (!isFullscreenSupported) {
@@ -114,15 +110,12 @@ export function LogViewerModal({ isOpen, onClose, logs, events }: LogViewerModal
           <ScrollArea.Root className="flex-1 overflow-hidden">
             <ScrollArea.Viewport className="h-full w-full p-4">
               <div className="space-y-1 font-mono text-xs text-beast-muted">
-                {filteredEvents.map((e) => (
-                  <div key={e.id} className={e.level === 'error' ? 'text-beast-danger' : ''}>
-                    [{new Date(e.createdAt).toLocaleTimeString()}] [{e.level}] {e.message}
+                {displayEntries.map((entry) => (
+                  <div key={entry.key} className={entry.level === 'error' ? 'text-beast-danger' : ''}>
+                    {entry.label}
                   </div>
                 ))}
-                {filteredLogs.map((line, i) => (
-                  <div key={i}>{line}</div>
-                ))}
-                {filteredEvents.length === 0 && filteredLogs.length === 0 && (
+                {displayEntries.length === 0 && (
                   <p className="text-beast-subtle italic">No matching entries</p>
                 )}
               </div>

--- a/packages/franken-web/tests/components/beasts/agent-detail-readonly.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-detail-readonly.test.tsx
@@ -25,4 +25,45 @@ describe('AgentDetailReadonly', () => {
     render(<AgentDetailReadonly detail={detail} logs={['log line 1']} onExpandLogs={vi.fn()} />);
     expect(screen.getByText('Events & Logs')).toBeTruthy();
   });
+
+  it('renders mixed events and timestamped logs chronologically', () => {
+    const mixedDetail = {
+      ...detail,
+      events: [
+        {
+          id: 'event-after',
+          agentId: 'agent-1',
+          sequence: 2,
+          level: 'info' as const,
+          type: 'agent.event',
+          message: 'agent finished',
+          payload: {},
+          createdAt: '2026-03-15T10:02:00.000Z',
+        },
+        {
+          id: 'event-before',
+          agentId: 'agent-1',
+          sequence: 1,
+          level: 'info' as const,
+          type: 'agent.event',
+          message: 'agent started',
+          payload: {},
+          createdAt: '2026-03-15T10:00:00.000Z',
+        },
+      ],
+    };
+
+    render(<AgentDetailReadonly
+      detail={mixedDetail}
+      logs={[JSON.stringify({ stream: 'stdout', message: 'middle log line', createdAt: '2026-03-15T10:01:00.000Z' })]}
+      onExpandLogs={vi.fn()}
+    />);
+
+    const entries = screen.getAllByText(/agent started|middle log line|agent finished/).map((entry) => entry.textContent);
+    expect(entries).toEqual([
+      expect.stringContaining('agent started'),
+      expect.stringContaining('middle log line'),
+      expect.stringContaining('agent finished'),
+    ]);
+  });
 });

--- a/packages/franken-web/tests/components/beasts/log-viewer-modal.test.tsx
+++ b/packages/franken-web/tests/components/beasts/log-viewer-modal.test.tsx
@@ -46,6 +46,50 @@ describe('LogViewerModal', () => {
     expect(screen.queryByText('info: success')).toBeNull();
   });
 
+  it('interleaves timestamped events and logs chronologically after filtering', () => {
+    render(<LogViewerModal
+      isOpen={true}
+      onClose={vi.fn()}
+      events={[
+        {
+          id: 'event-after',
+          agentId: 'agent-1',
+          sequence: 2,
+          level: 'info',
+          type: 'agent.event',
+          message: 'agent finished',
+          payload: {},
+          createdAt: '2026-03-15T10:02:00.000Z',
+        },
+        {
+          id: 'event-before',
+          agentId: 'agent-1',
+          sequence: 1,
+          level: 'info',
+          type: 'agent.event',
+          message: 'agent started',
+          payload: {},
+          createdAt: '2026-03-15T10:00:00.000Z',
+        },
+      ]}
+      logs={[
+        JSON.stringify({ stream: 'stdout', message: 'middle log line', createdAt: '2026-03-15T10:01:00.000Z' }),
+      ]}
+    />);
+
+    const entries = screen.getAllByText(/agent started|middle log line|agent finished/).map((entry) => entry.textContent);
+    expect(entries).toEqual([
+      expect.stringContaining('agent started'),
+      expect.stringContaining('middle log line'),
+      expect.stringContaining('agent finished'),
+    ]);
+
+    const search = screen.getByPlaceholderText(/search logs/i);
+    fireEvent.change(search, { target: { value: 'middle' } });
+    expect(screen.getByText(/middle log line/)).toBeTruthy();
+    expect(screen.queryByText(/agent started/)).toBeNull();
+  });
+
   it('disables fullscreen toggle when fullscreen is not supported', () => {
     mockFullscreenApi({ requestFullscreen: undefined, exitFullscreen: undefined });
 


### PR DESCRIPTION
## Summary
- normalize agent events and run log lines into a shared display entry model
- sort timestamped events/logs chronologically in both inline and modal views
- keep modal search working across normalized event and log text

## Test Plan
- npm --workspace @franken/types run build
- TMPDIR="$PWD/.tmp/vitest" npm --prefix packages/franken-web test -- tests/components/beasts/log-viewer-modal.test.tsx tests/components/beasts/agent-detail-readonly.test.tsx --pool=forks --maxWorkers=1
- npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build
- TMPDIR="$PWD/.tmp/vitest" npm --prefix packages/franken-web test -- --pool=forks --maxWorkers=1

Closes #1182