### PR TITLE
fix(web): surface Beasts API structured errors

### DIFF
--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -1,6 +1,7 @@
 import { MODULE_CONFIG_KEYS } from '@franken/types';
 import type {
   ApiDataEnvelope,
+  ApiErrorEnvelope,
   BeastCatalogEntry,
   BeastContainerRuntimeStatus,
   BeastInterviewPrompt,
@@ -44,6 +45,18 @@ export type {
   TrackedAgentInitAction,
   TrackedAgentSummary,
 } from '@franken/types';
+
+export class BeastApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'BeastApiError';
+  }
+}
 
 export class BeastApiClient {
   constructor(private readonly baseUrl: string) {}
@@ -272,7 +285,7 @@ export class BeastApiClient {
       headers,
     });
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+      throw await this.toError(response);
     }
     return response.json() as Promise<T>;
   }
@@ -285,8 +298,29 @@ export class BeastApiClient {
       headers,
     });
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+      throw await this.toError(response);
     }
+  }
+
+  private async toError(response: Response): Promise<BeastApiError> {
+    const fallbackMessage = `HTTP ${response.status}`;
+    try {
+      const body = await response.json() as ApiErrorEnvelope;
+      const serverMessage = body.error?.message;
+      if (serverMessage) {
+        const code = body.error.code;
+        const codeSuffix = code ? `, ${code}` : '';
+        return new BeastApiError(
+          `${serverMessage} (HTTP ${response.status}${codeSuffix})`,
+          response.status,
+          code,
+          body.error.details,
+        );
+      }
+    } catch {
+      // Fall through with HTTP status message for empty, malformed, or non-JSON bodies.
+    }
+    return new BeastApiError(fallbackMessage, response.status);
   }
 }
 

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { BeastApiClient } from '../../src/lib/beast-api';
+import { BeastApiClient, BeastApiError } from '../../src/lib/beast-api';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -231,7 +231,55 @@ describe('BeastApiClient', () => {
       }),
     });
 
-    await expect(client.killAgent('agent-1')).rejects.toThrow('HTTP 409');
+    const errorPromise = client.killAgent('agent-1');
+
+    await expect(errorPromise).rejects.toThrow(
+      "Tracked agent 'agent-1' has no linked run to kill (HTTP 409, TRACKED_AGENT_NOT_KILLABLE)",
+    );
+    await expect(errorPromise).rejects.toMatchObject({
+      name: 'BeastApiError',
+      status: 409,
+      code: 'TRACKED_AGENT_NOT_KILLABLE',
+    });
+  });
+
+  it('surfaces structured errors for void Beasts API requests', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({
+        error: {
+          code: 'BEAST_DELETE_UNAVAILABLE',
+          message: 'Beast deletion is temporarily unavailable',
+          details: { retryAfterMs: 1_000 },
+        },
+      }),
+    });
+
+    const errorPromise = client.deleteAgent('agent-1');
+
+    await expect(errorPromise).rejects.toThrow(
+      'Beast deletion is temporarily unavailable (HTTP 503, BEAST_DELETE_UNAVAILABLE)',
+    );
+    await expect(errorPromise).rejects.toMatchObject({
+      name: 'BeastApiError',
+      status: 503,
+      code: 'BEAST_DELETE_UNAVAILABLE',
+      details: { retryAfterMs: 1_000 },
+    });
+  });
+
+  it('falls back to the HTTP status when Beasts API error bodies are malformed', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new SyntaxError('not json')),
+    });
+
+    const errorPromise = client.killAgent('agent-1');
+
+    await expect(errorPromise).rejects.toThrow('HTTP 502');
+    await expect(errorPromise).rejects.toBeInstanceOf(BeastApiError);
   });
 
   it('opens the ticket-authenticated Beast event stream', async () => {


### PR DESCRIPTION
## Summary
- Parse structured Beasts API error envelopes before throwing client errors
- Include backend error message, HTTP status, and error code in surfaced UI-facing messages
- Add coverage for JSON-returning, void/DELETE, and malformed-body fallback paths

## Test Plan
- npm --workspace @franken/types run build
- TMPDIR="$PWD/.tmp" npm --prefix packages/franken-web test -- tests/lib/beast-api.test.ts --reporter=verbose
- TMPDIR="$PWD/.tmp" npm --prefix packages/franken-web run typecheck
- TMPDIR="$PWD/.tmp" npm --prefix packages/franken-web run build

Closes #1175
