### PR TITLE
fix(web): reject unsupported beast workflow definitions

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -251,11 +251,15 @@ export function buildInitAction(
     };
   }
 
-  return {
-    kind: 'martin-loop',
-    command: 'martin-loop',
-    config,
-  };
+  if (definitionId === 'martin-loop') {
+    return {
+      kind: 'martin-loop',
+      command: 'martin-loop',
+      config,
+    };
+  }
+
+  throw new Error(`Unsupported Beast workflow definition: ${definitionId}`);
 }
 
 export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellProps) {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ChatShell, buildInitAction } from '../../src/components/chat-shell.js';
+import { FALLBACK_BEAST_CATALOG } from '../../src/components/beasts/wizard-catalog.js';
 import { useDashboardStore } from '../../src/stores/dashboard-store.js';
 
 const mockListSessions = vi.fn().mockResolvedValue([
@@ -469,6 +470,18 @@ describe('buildInitAction', () => {
       kind: 'chunk-plan',
       command: '/plan --design-doc docs/from-normalized.md',
     });
+  });
+
+  it('keeps every fallback wizard workflow aligned with an init action kind', () => {
+    for (const workflow of FALLBACK_BEAST_CATALOG) {
+      expect(buildInitAction(workflow.id, { workflow: { workflowType: workflow.id } }, undefined).kind).toBe(workflow.id);
+    }
+  });
+
+  it('rejects unsupported wizard definitions instead of coercing them to martin-loop', () => {
+    expect(() => buildInitAction('issues-agent', {
+      workflow: { workflowType: 'issues-agent' },
+    }, undefined)).toThrow(/Unsupported Beast workflow definition/);
   });
 });
 


### PR DESCRIPTION
## Summary
- keep fallback Create Agent workflow entries aligned with supported init actions
- reject unsupported workflow definitions such as issues-agent instead of coercing them to martin-loop
- add regression coverage for fallback workflow/initAction alignment and unsupported definition rejection

## Test Plan
- TMPDIR=$PWD/.tmp npm --workspace @franken/web test -- --run tests/components/chat-shell.test.tsx tests/components/beasts/steps/step-workflow.test.tsx
- TMPDIR=$PWD/.tmp npm run build --workspace @franken/types
- TMPDIR=$PWD/.tmp npm --workspace @franken/web run typecheck
- TMPDIR=$PWD/.tmp npm --workspace @franken/web run build
- TMPDIR=$PWD/.tmp npm run lint:any

Closes #1177