### PR TITLE
fix(web): prevent blank module numbers saving zero

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-modules.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-modules.tsx
@@ -39,7 +39,13 @@ export function StepModules() {
   function updateDeepConfig(moduleKey: string, field: string, value: unknown) {
     const deepKey = `${moduleKey}Config`;
     const current = (values[deepKey] ?? {}) as Record<string, unknown>;
-    setStepValues(3, { ...values, [deepKey]: { ...current, [field]: value } });
+    const nextConfig = { ...current };
+    if (value === undefined) {
+      delete nextConfig[field];
+    } else {
+      nextConfig[field] = value;
+    }
+    setStepValues(3, { ...values, [deepKey]: nextConfig });
   }
 
   function getDeepConfig(moduleKey: string): Record<string, unknown> {
@@ -98,6 +104,13 @@ export function StepModules() {
 
 const inputClass = 'w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent';
 const labelClass = 'block text-xs font-medium text-beast-muted mb-1.5';
+
+function parseBoundedNumberInput(value: string, min: number, max: number): number | undefined {
+  if (value.trim() === '') return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return undefined;
+  return Math.min(max, Math.max(min, parsed));
+}
 
 function renderModuleConfig(
   moduleKey: string,
@@ -177,7 +190,7 @@ function renderModuleConfig(
               min={1}
               max={50}
               value={(config.maxDagDepth as number) ?? 10}
-              onChange={(e) => update('maxDagDepth', Number(e.target.value))}
+              onChange={(e) => update('maxDagDepth', parseBoundedNumberInput(e.target.value, 1, 50))}
               className={inputClass}
             />
           </div>
@@ -189,7 +202,7 @@ function renderModuleConfig(
               min={1}
               max={20}
               value={(config.parallelTaskLimit as number) ?? 4}
-              onChange={(e) => update('parallelTaskLimit', Number(e.target.value))}
+              onChange={(e) => update('parallelTaskLimit', parseBoundedNumberInput(e.target.value, 1, 20))}
               className={inputClass}
             />
           </div>
@@ -207,7 +220,7 @@ function renderModuleConfig(
               min={1}
               max={10}
               value={(config.maxIterations as number) ?? 3}
-              onChange={(e) => update('maxIterations', Number(e.target.value))}
+              onChange={(e) => update('maxIterations', parseBoundedNumberInput(e.target.value, 1, 10))}
               className={inputClass}
             />
           </div>
@@ -268,7 +281,7 @@ function renderModuleConfig(
               min={10}
               max={600}
               value={(config.reflectionInterval as number) ?? 60}
-              onChange={(e) => update('reflectionInterval', Number(e.target.value))}
+              onChange={(e) => update('reflectionInterval', parseBoundedNumberInput(e.target.value, 10, 600))}
               className={inputClass}
             />
           </div>

--- a/packages/franken-web/src/components/beasts/steps/step-modules.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-modules.tsx
@@ -105,10 +105,16 @@ export function StepModules() {
 const inputClass = 'w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent';
 const labelClass = 'block text-xs font-medium text-beast-muted mb-1.5';
 
-function parseBoundedNumberInput(value: string, min: number, max: number): number | undefined {
+function parseNumberInput(value: string): number | undefined {
   if (value.trim() === '') return undefined;
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return undefined;
+  return parsed;
+}
+
+function clampNumberInput(value: string, min: number, max: number): number | undefined {
+  const parsed = parseNumberInput(value);
+  if (parsed === undefined) return undefined;
   return Math.min(max, Math.max(min, parsed));
 }
 
@@ -190,7 +196,8 @@ function renderModuleConfig(
               min={1}
               max={50}
               value={(config.maxDagDepth as number) ?? 10}
-              onChange={(e) => update('maxDagDepth', parseBoundedNumberInput(e.target.value, 1, 50))}
+              onChange={(e) => update('maxDagDepth', parseNumberInput(e.target.value))}
+              onBlur={(e) => update('maxDagDepth', clampNumberInput(e.target.value, 1, 50))}
               className={inputClass}
             />
           </div>
@@ -202,7 +209,8 @@ function renderModuleConfig(
               min={1}
               max={20}
               value={(config.parallelTaskLimit as number) ?? 4}
-              onChange={(e) => update('parallelTaskLimit', parseBoundedNumberInput(e.target.value, 1, 20))}
+              onChange={(e) => update('parallelTaskLimit', parseNumberInput(e.target.value))}
+              onBlur={(e) => update('parallelTaskLimit', clampNumberInput(e.target.value, 1, 20))}
               className={inputClass}
             />
           </div>
@@ -220,7 +228,8 @@ function renderModuleConfig(
               min={1}
               max={10}
               value={(config.maxIterations as number) ?? 3}
-              onChange={(e) => update('maxIterations', parseBoundedNumberInput(e.target.value, 1, 10))}
+              onChange={(e) => update('maxIterations', parseNumberInput(e.target.value))}
+              onBlur={(e) => update('maxIterations', clampNumberInput(e.target.value, 1, 10))}
               className={inputClass}
             />
           </div>
@@ -281,7 +290,8 @@ function renderModuleConfig(
               min={10}
               max={600}
               value={(config.reflectionInterval as number) ?? 60}
-              onChange={(e) => update('reflectionInterval', parseBoundedNumberInput(e.target.value, 10, 600))}
+              onChange={(e) => update('reflectionInterval', parseNumberInput(e.target.value))}
+              onBlur={(e) => update('reflectionInterval', clampNumberInput(e.target.value, 10, 600))}
               className={inputClass}
             />
           </div>

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -5,6 +5,19 @@ export const WIZARD_SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 's
 
 type WizardStepValues = Record<number, Record<string, unknown> | undefined>;
 
+const MODULE_NUMBER_BOUNDS = {
+  plannerConfig: {
+    maxDagDepth: { min: 1, max: 50 },
+    parallelTaskLimit: { min: 1, max: 20 },
+  },
+  critiqueConfig: {
+    maxIterations: { min: 1, max: 10 },
+  },
+  heartbeatConfig: {
+    reflectionInterval: { min: 10, max: 600 },
+  },
+} as const;
+
 interface PromptFile {
   name?: unknown;
   content?: unknown;
@@ -45,6 +58,37 @@ function buildPromptFrontload(prompts: Record<string, unknown> | undefined): str
   return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
 }
 
+function sanitizeModuleNumber(value: unknown, min: number, max: number): number | undefined {
+  if (typeof value === 'string' && value.trim().length === 0) return undefined;
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) return undefined;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function sanitizeModuleConfig(modules: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!modules) return undefined;
+
+  const nextModules = { ...modules };
+  for (const [configKey, fields] of Object.entries(MODULE_NUMBER_BOUNDS)) {
+    const current = nextModules[configKey];
+    if (!current || typeof current !== 'object' || Array.isArray(current)) continue;
+
+    const nextConfig = { ...(current as Record<string, unknown>) };
+    for (const [field, bounds] of Object.entries(fields)) {
+      if (!(field in nextConfig)) continue;
+      const sanitized = sanitizeModuleNumber(nextConfig[field], bounds.min, bounds.max);
+      if (sanitized === undefined) {
+        delete nextConfig[field];
+      } else {
+        nextConfig[field] = sanitized;
+      }
+    }
+    nextModules[configKey] = nextConfig;
+  }
+
+  return nextModules;
+}
+
 export function buildWizardLaunchConfig(
   stepValues: WizardStepValues,
   catalog?: readonly BeastCatalogEntry[],
@@ -59,6 +103,7 @@ export function buildWizardLaunchConfig(
   }
 
   const workflow = config.workflow as Record<string, unknown> | undefined;
+  config.modules = sanitizeModuleConfig(config.modules as Record<string, unknown> | undefined);
   const selectedWorkflow = typeof workflow?.workflowType === 'string'
     ? findCatalogEntry(catalog, workflow.workflowType)
     : undefined;

--- a/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
@@ -66,19 +66,37 @@ describe('StepModules', () => {
     fireEvent.click(screen.getByText('Planner'));
     fireEvent.click(screen.getByRole('button', { name: /planner configuration/i }));
     fireEvent.change(screen.getByLabelText('Max DAG Depth'), { target: { value: '0' } });
+    fireEvent.blur(screen.getByLabelText('Max DAG Depth'));
     fireEvent.change(screen.getByLabelText('Parallel Task Limit'), { target: { value: '99' } });
+    fireEvent.blur(screen.getByLabelText('Parallel Task Limit'));
 
     fireEvent.click(screen.getByText('Critique'));
     fireEvent.click(screen.getByRole('button', { name: /critique configuration/i }));
     fireEvent.change(screen.getByLabelText('Max Iterations'), { target: { value: '0' } });
+    fireEvent.blur(screen.getByLabelText('Max Iterations'));
 
     fireEvent.click(screen.getByText('Heartbeat'));
     fireEvent.click(screen.getByRole('button', { name: /heartbeat configuration/i }));
     fireEvent.change(screen.getByLabelText('Reflection Interval (seconds)'), { target: { value: '0' } });
+    fireEvent.blur(screen.getByLabelText('Reflection Interval (seconds)'));
 
     const modules = useBeastStore.getState().stepValues[3] as Record<string, Record<string, unknown>>;
     expect(modules?.plannerConfig).toMatchObject({ maxDagDepth: 1, parallelTaskLimit: 20 });
     expect(modules?.critiqueConfig).toMatchObject({ maxIterations: 1 });
     expect(modules?.heartbeatConfig).toMatchObject({ reflectionInterval: 10 });
+  });
+
+  it('allows transient heartbeat interval edits below the minimum until blur', () => {
+    render(<StepModules />);
+
+    fireEvent.click(screen.getByText('Heartbeat'));
+    fireEvent.click(screen.getByRole('button', { name: /heartbeat configuration/i }));
+
+    const intervalInput = screen.getByLabelText('Reflection Interval (seconds)');
+    fireEvent.change(intervalInput, { target: { value: '3' } });
+    expect(useBeastStore.getState().stepValues[3]?.heartbeatConfig).toMatchObject({ reflectionInterval: 3 });
+
+    fireEvent.change(intervalInput, { target: { value: '30' } });
+    expect(useBeastStore.getState().stepValues[3]?.heartbeatConfig).toMatchObject({ reflectionInterval: 30 });
   });
 });

--- a/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
@@ -27,4 +27,58 @@ describe('StepModules', () => {
     const modules = useBeastStore.getState().stepValues[3] as Record<string, boolean>;
     expect(modules?.firewall).toBe(true);
   });
+
+  it('does not save zero when positive planner numeric fields are cleared', () => {
+    render(<StepModules />);
+
+    fireEvent.click(screen.getByText('Planner'));
+    fireEvent.click(screen.getByRole('button', { name: /planner configuration/i }));
+    fireEvent.change(screen.getByLabelText('Max DAG Depth'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Parallel Task Limit'), { target: { value: '' } });
+
+    const modules = useBeastStore.getState().stepValues[3] as Record<string, Record<string, unknown>>;
+    expect(modules?.plannerConfig).toEqual({});
+    expect(modules?.plannerConfig?.maxDagDepth).not.toBe(0);
+    expect(modules?.plannerConfig?.parallelTaskLimit).not.toBe(0);
+  });
+
+  it('does not save zero when positive critique and heartbeat numeric fields are cleared', () => {
+    render(<StepModules />);
+
+    fireEvent.click(screen.getByText('Critique'));
+    fireEvent.click(screen.getByRole('button', { name: /critique configuration/i }));
+    fireEvent.change(screen.getByLabelText('Max Iterations'), { target: { value: '' } });
+
+    fireEvent.click(screen.getByText('Heartbeat'));
+    fireEvent.click(screen.getByRole('button', { name: /heartbeat configuration/i }));
+    fireEvent.change(screen.getByLabelText('Reflection Interval (seconds)'), { target: { value: '' } });
+
+    const modules = useBeastStore.getState().stepValues[3] as Record<string, Record<string, unknown>>;
+    expect(modules?.critiqueConfig).toEqual({});
+    expect(modules?.heartbeatConfig).toEqual({});
+    expect(modules?.critiqueConfig?.maxIterations).not.toBe(0);
+    expect(modules?.heartbeatConfig?.reflectionInterval).not.toBe(0);
+  });
+
+  it('clamps positive module numeric fields before saving wizard state', () => {
+    render(<StepModules />);
+
+    fireEvent.click(screen.getByText('Planner'));
+    fireEvent.click(screen.getByRole('button', { name: /planner configuration/i }));
+    fireEvent.change(screen.getByLabelText('Max DAG Depth'), { target: { value: '0' } });
+    fireEvent.change(screen.getByLabelText('Parallel Task Limit'), { target: { value: '99' } });
+
+    fireEvent.click(screen.getByText('Critique'));
+    fireEvent.click(screen.getByRole('button', { name: /critique configuration/i }));
+    fireEvent.change(screen.getByLabelText('Max Iterations'), { target: { value: '0' } });
+
+    fireEvent.click(screen.getByText('Heartbeat'));
+    fireEvent.click(screen.getByRole('button', { name: /heartbeat configuration/i }));
+    fireEvent.change(screen.getByLabelText('Reflection Interval (seconds)'), { target: { value: '0' } });
+
+    const modules = useBeastStore.getState().stepValues[3] as Record<string, Record<string, unknown>>;
+    expect(modules?.plannerConfig).toMatchObject({ maxDagDepth: 1, parallelTaskLimit: 20 });
+    expect(modules?.critiqueConfig).toMatchObject({ maxIterations: 1 });
+    expect(modules?.heartbeatConfig).toMatchObject({ reflectionInterval: 10 });
+  });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts
@@ -35,4 +35,23 @@ describe('buildWizardLaunchConfig', () => {
 
     expect(config.executionMode).toBe('process');
   });
+
+  it('sanitizes positive-only module numeric values before launch', () => {
+    const config = buildWizardLaunchConfig({
+      3: {
+        planner: true,
+        plannerConfig: { maxDagDepth: 0, parallelTaskLimit: '99' },
+        critique: true,
+        critiqueConfig: { maxIterations: '' },
+        heartbeat: true,
+        heartbeatConfig: { reflectionInterval: 0 },
+      },
+    });
+
+    expect(config.modules).toMatchObject({
+      plannerConfig: { maxDagDepth: 1, parallelTaskLimit: 20 },
+      critiqueConfig: {},
+      heartbeatConfig: { reflectionInterval: 10 },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Prevent blank Beast module numeric fields from being coerced through `Number('')` into `0`.
- Remove cleared positive numeric module config values so the wizard falls back to safe defaults.
- Clamp out-of-range values on blur and sanitize launch config as a final guard against zero/blank/non-finite positive-only module numeric payloads.

## Test Plan
- `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1173/.tmp npm test -- tests/components/beasts/steps/step-modules.test.tsx tests/components/beasts/wizard-launch-config.test.ts`
- `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1173/.tmp npm run typecheck` after building `@franken/types`
- `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1173/.tmp npm run build`

Closes #1173
