### PR TITLE
fix(web): confirm destructive beast actions

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-action-bar.tsx
+++ b/packages/franken-web/src/components/beasts/agent-action-bar.tsx
@@ -4,6 +4,7 @@ import * as AlertDialog from '@radix-ui/react-alert-dialog';
 interface AgentActionBarProps {
   status: string;
   hasLinkedRun: boolean;
+  agentLabel?: string;
   onStart: () => void;
   onStop: () => void;
   onRestart: () => void;
@@ -22,7 +23,48 @@ function ActionButton({ label, onClick, variant = 'default' }: {
   return <button type="button" onClick={onClick} className={styles}>{label}</button>;
 }
 
-export function AgentActionBar({ status, hasLinkedRun, onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
+function ConfirmDangerAction({
+  label,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+}: {
+  label: string;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog.Root>
+      <AlertDialog.Trigger asChild>
+        <button type="button" className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors bg-beast-danger/20 text-beast-danger hover:bg-beast-danger/30 border border-beast-danger/30">
+          {label}
+        </button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay data-beast-dialog-layer="overlay" className="fixed inset-0 bg-black/50 z-[60]" />
+        <AlertDialog.Content data-beast-dialog-layer="content" className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
+          <AlertDialog.Title className="text-beast-text font-semibold">{title}</AlertDialog.Title>
+          <AlertDialog.Description className="text-beast-muted text-sm mt-2">
+            {description}
+          </AlertDialog.Description>
+          <div className="flex gap-3 mt-4 justify-end">
+            <AlertDialog.Cancel asChild>
+              <button type="button" className="px-3 py-1.5 rounded-lg text-sm bg-beast-control text-beast-text border border-beast-border">Cancel</button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <button type="button" onClick={onConfirm} className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white">{confirmLabel}</button>
+            </AlertDialog.Action>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+}
+
+export function AgentActionBar({ status, hasLinkedRun, agentLabel = 'this tracked agent', onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
   const [forceRestart, setForceRestart] = useState(false);
 
   const isInitOrDispatch = status === 'initializing' || status === 'dispatching';
@@ -44,8 +86,8 @@ export function AgentActionBar({ status, hasLinkedRun, onStart, onStop, onRestar
                 </button>
               </AlertDialog.Trigger>
               <AlertDialog.Portal>
-                <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
-                <AlertDialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
+                <AlertDialog.Overlay data-beast-dialog-layer="overlay" className="fixed inset-0 bg-black/50 z-[60]" />
+                <AlertDialog.Content data-beast-dialog-layer="content" className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
                   <AlertDialog.Title className="text-beast-text font-semibold">Force Restart</AlertDialog.Title>
                   <AlertDialog.Description className="text-beast-muted text-sm mt-2">
                     Force restart will interrupt the agent mid-turn. Continue?
@@ -64,7 +106,13 @@ export function AgentActionBar({ status, hasLinkedRun, onStart, onStop, onRestar
           ) : (
             <ActionButton label="Restart" onClick={onRestart} />
           )}
-          <ActionButton label="Kill" onClick={onKill} variant="danger" />
+          <ConfirmDangerAction
+            label="Kill"
+            title="Kill tracked agent"
+            description={`Kill ${agentLabel}? This interrupts the linked run immediately and cannot be undone from the dashboard.`}
+            confirmLabel="Kill agent"
+            onConfirm={onKill}
+          />
           <label className="flex items-center gap-1.5 text-xs text-beast-subtle ml-2 cursor-pointer">
             <input type="checkbox" checked={forceRestart} onChange={(e) => setForceRestart(e.target.checked)} className="accent-beast-danger" />
             Force
@@ -74,7 +122,15 @@ export function AgentActionBar({ status, hasLinkedRun, onStart, onStop, onRestar
 
       {(isStopped || isTerminal) && <ActionButton label="Start" onClick={onStart} />}
       {isStopped && hasLinkedRun && <ActionButton label="Resume" onClick={onResume} />}
-      {(isStopped || isTerminal) && <ActionButton label="Delete" onClick={onDelete} variant="danger" />}
+      {(isStopped || isTerminal) && (
+        <ConfirmDangerAction
+          label="Delete"
+          title="Delete tracked agent"
+          description={`Delete ${agentLabel}? This removes the tracked agent from the Beasts dashboard.`}
+          confirmLabel="Delete agent"
+          onConfirm={onDelete}
+        />
+      )}
     </div>
   );
 }

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -126,6 +126,7 @@ export function AgentDetailPanel({
         <AgentActionBar
           status={agent.status}
           hasLinkedRun={!!agent.dispatchRunId}
+          agentLabel={agent.name?.trim() ? agent.name : agent.id}
           onStart={onStart}
           onStop={onStop}
           onRestart={onRestart}

--- a/packages/franken-web/src/components/beasts/slide-in-panel.tsx
+++ b/packages/franken-web/src/components/beasts/slide-in-panel.tsx
@@ -11,6 +11,7 @@ export function SlideInPanel({ isOpen, onClose, children }: SlideInPanelProps) {
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      if (document.querySelector('[data-beast-dialog-layer]')) return;
       if (e.key === 'Escape' && isOpen) onClose();
     }
     document.addEventListener('keydown', handleKeyDown);
@@ -19,7 +20,10 @@ export function SlideInPanel({ isOpen, onClose, children }: SlideInPanelProps) {
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (isOpen && panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+      if (target instanceof Element && target.closest('[data-beast-dialog-layer]')) return;
+      if (isOpen && panelRef.current && !panelRef.current.contains(target)) {
         onClose();
       }
     }

--- a/packages/franken-web/tests/components/beasts/agent-action-bar.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-action-bar.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { AgentActionBar } from '../../../src/components/beasts/agent-action-bar';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe('AgentActionBar', () => {
   const handlers = {
@@ -20,20 +23,58 @@ describe('AgentActionBar', () => {
     render(<AgentActionBar status="running" hasLinkedRun={true} {...handlers} />);
     expect(screen.getByText('Stop')).toBeTruthy();
     expect(screen.getByText('Restart')).toBeTruthy();
-    expect(screen.getByText('Kill')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Kill' })).toBeTruthy();
+  });
+
+  it('requires cancelable confirmation before killing a running agent', () => {
+    render(<AgentActionBar status="running" hasLinkedRun={true} agentLabel="Scout A" {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+
+    expect(handlers.onKill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(screen.getByText('Kill tracked agent')).toBeTruthy();
+    expect(screen.getByText(/Kill Scout A\?/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(handlers.onKill).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Kill agent' }));
+
+    expect(handlers.onKill).toHaveBeenCalledTimes(1);
   });
 
   it('shows Start, Resume, Delete for stopped with linked run', () => {
     render(<AgentActionBar status="stopped" hasLinkedRun={true} {...handlers} />);
     expect(screen.getByText('Start')).toBeTruthy();
     expect(screen.getByText('Resume')).toBeTruthy();
-    expect(screen.getByText('Delete')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
+  });
+
+  it('requires cancelable confirmation before deleting a stopped agent', () => {
+    render(<AgentActionBar status="stopped" hasLinkedRun={true} agentLabel="Scout A" {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(screen.getByText('Delete tracked agent')).toBeTruthy();
+    expect(screen.getByText(/Delete Scout A\?/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent' }));
+
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
   });
 
   it('shows Start, Delete for failed agent', () => {
     render(<AgentActionBar status="failed" hasLinkedRun={false} {...handlers} />);
     expect(screen.getByText('Start')).toBeTruthy();
-    expect(screen.getByText('Delete')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
     expect(screen.queryByText('Resume')).toBeNull();
   });
 });

--- a/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
@@ -58,6 +58,49 @@ describe('AgentDetailPanel', () => {
     expect(screen.getByText('Stop')).toBeTruthy();
   });
 
+  it('keeps portaled action confirmations from closing the slide-in panel before confirm click', () => {
+    render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+    const confirmButton = screen.getByRole('button', { name: 'Kill agent' });
+    fireEvent.mouseDown(confirmButton);
+    expect(handlers.onClose).not.toHaveBeenCalled();
+    fireEvent.click(confirmButton);
+
+    expect(handlers.onKill).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps dialog backdrop and Escape events from closing the slide-in panel', () => {
+    render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+    const overlay = document.querySelector('[data-beast-dialog-layer="overlay"]');
+    expect(overlay).toBeTruthy();
+    fireEvent.mouseDown(overlay!);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(handlers.onClose).not.toHaveBeenCalled();
+  });
+
+  it('identifies destructive confirmations by id when the saved agent name is blank', () => {
+    render(<AgentDetailPanel
+      isOpen={true}
+      detail={{
+        ...detail,
+        agent: {
+          ...detail.agent,
+          name: '   ',
+        },
+      }}
+      logs={[]}
+      {...handlers}
+    />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+
+    expect(screen.getByText(/Kill agent-1\?/)).toBeTruthy();
+  });
+
   it('shows edit form when Edit mode is selected', () => {
     render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
     fireEvent.click(screen.getByText('Edit'));


### PR DESCRIPTION
## Summary
- Wrap Beasts Kill and Delete danger buttons in AlertDialog confirmations
- Pass the selected agent name/id into confirmation copy so the action is explicit
- Add cancel-vs-confirm regression coverage for both destructive actions

## Test Plan
- npm run build --workspace=@franken/types
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-web test -- tests/components/beasts/agent-action-bar.test.tsx --reporter=verbose
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-web test -- tests/components/beasts/agent-detail-panel.test.tsx tests/pages/beasts-page.test.tsx
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-web run typecheck
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-web run build
- TMPDIR=$PWD/.tmp npm --prefix packages/franken-web test

Closes #1159