### PR TITLE
fix(web): keep analytics session options stable

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -17,6 +17,7 @@ function mockClient(): AnalyticsApiClient {
     }),
     fetchSessions: vi.fn().mockResolvedValue([
       { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
+      { id: 'session-b', lastActivityAt: '2026-04-28T12:02:00.000Z', eventCount: 1, failureCount: 0 },
     ]),
     fetchEvents: vi.fn().mockResolvedValue({
       total: 2,
@@ -99,6 +100,23 @@ describe('AnalyticsPage', () => {
       expect(client.fetchSummary).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a' }));
       expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a', page: 1 }));
     });
+  });
+
+  it('keeps in-scope session picker options available after selecting one session', async () => {
+    const client = mockClient();
+
+    render(<AnalyticsPage client={client} />);
+    const select = await screen.findByLabelText('Session');
+    expect(screen.getByRole('option', { name: 'session-b' })).toBeTruthy();
+
+    fireEvent.change(select, { target: { value: 'session-a' } });
+
+    await waitFor(() => {
+      expect(client.fetchSummary).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a' }));
+      expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a', page: 1 }));
+      expect(client.fetchSessions).toHaveBeenLastCalledWith({ timeWindow: '24h' });
+    });
+    expect(screen.getByRole('option', { name: 'session-b' })).toBeTruthy();
   });
 
   it('marks summary metrics as updating instead of silently showing stale filter values', async () => {
@@ -513,6 +531,8 @@ describe('AnalyticsPage', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).toBeNull();
       expect(client.fetchEvents).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-a' }));
+      expect(client.fetchSessions).toHaveBeenLastCalledWith({ timeWindow: '24h' });
+      expect(screen.getByRole('option', { name: 'session-b' })).toBeTruthy();
       expect(document.activeElement).toBe(screen.getByRole('button', { name: 'View details for Denied destructive command' }));
     });
   });

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -68,7 +68,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 
     void Promise.allSettled([
       client.fetchSummary(filters),
-      client.fetchSessions(filters),
+      client.fetchSessions(filtersForSessionOptions(filters)),
     ]).then(([summaryResult, sessionsResult]) => {
       if (cancelled) return;
       const errors = [summaryResult, sessionsResult]
@@ -382,6 +382,12 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       )}
     </main>
   );
+}
+
+function filtersForSessionOptions(filters: AnalyticsFilters): AnalyticsFilters {
+  const sessionFilters = { ...filters };
+  delete sessionFilters.sessionId;
+  return sessionFilters;
 }
 
 function MetricCard({


### PR DESCRIPTION
## Summary
- Fetch Analytics session picker options without the currently selected sessionId
- Keep broader time/tool/outcome filters for session options while summary/events still use the selected session
- Add regression coverage for dropdown and drawer-driven session filtering

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- analytics-page.test.tsx
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1144