### PR TITLE
fix(observer): validate ModelAttribution token counts

### DIFF
--- a/packages/franken-observer/src/cost/ModelAttribution.test.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.test.ts
@@ -21,6 +21,47 @@ describe('ModelAttribution', () => {
       expect(row.successfulCalls).toBe(1)
       expect(row.failedCalls).toBe(1)
     })
+
+    it.each([
+      ['negative prompt tokens', { promptTokens: -1, completionTokens: 0 }],
+      ['negative completion tokens', { promptTokens: 0, completionTokens: -1 }],
+      ['fractional prompt tokens', { promptTokens: 1.5, completionTokens: 0 }],
+      ['fractional completion tokens', { promptTokens: 0, completionTokens: 1.5 }],
+      ['unsafe prompt tokens', { promptTokens: Number.MAX_SAFE_INTEGER + 1, completionTokens: 0 }],
+      ['unsafe completion tokens', { promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER + 1 }],
+    ])('rejects %s before mutating state', (_name, tokens) => {
+      const attr = new ModelAttribution(DEFAULT_PRICING)
+      attr.record({ model: 'gpt-4o', promptTokens: 100, completionTokens: 50, success: true })
+      const before = attr.report()
+
+      expect(() =>
+        attr.record({
+          model: 'gpt-4o',
+          promptTokens: tokens.promptTokens,
+          completionTokens: tokens.completionTokens,
+          success: false,
+        }),
+      ).toThrow(RangeError)
+
+      expect(attr.report()).toEqual(before)
+    })
+
+    it('rejects token totals that would overflow before mutating state', () => {
+      const attr = new ModelAttribution(DEFAULT_PRICING)
+      attr.record({
+        model: 'gpt-4o',
+        promptTokens: Number.MAX_SAFE_INTEGER,
+        completionTokens: 0,
+        success: true,
+      })
+      const before = attr.report()
+
+      expect(() =>
+        attr.record({ model: 'gpt-4o', promptTokens: 1, completionTokens: 0, success: false }),
+      ).toThrow(RangeError)
+
+      expect(attr.report()).toEqual(before)
+    })
   })
 
   describe('report()', () => {

--- a/packages/franken-observer/src/cost/ModelAttribution.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.ts
@@ -32,18 +32,45 @@ export class ModelAttribution {
     this.calc = new CostCalculator(pricing)
   }
 
+  /** A token delta must be a non-negative safe integer. */
+  private static assertValidDelta(value: number, label: string): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(
+        `ModelAttribution: ${label} must be a non-negative safe integer, received ${value}`,
+      )
+    }
+  }
+
+  /** Add two token counts, throwing if the result would leave the safe-integer range. */
+  private static safeAdd(a: number, b: number): number {
+    const sum = a + b
+    if (!Number.isSafeInteger(sum)) {
+      throw new RangeError(
+        `ModelAttribution: token total ${sum} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+      )
+    }
+    return sum
+  }
+
   record(entry: AttributionEntry): void {
+    ModelAttribution.assertValidDelta(entry.promptTokens, 'promptTokens')
+    ModelAttribution.assertValidDelta(entry.completionTokens, 'completionTokens')
+
     const existing = this.state.get(entry.model) ?? {
       totalCalls: 0,
       successfulCalls: 0,
       promptTokens: 0,
       completionTokens: 0,
     }
+    const promptTokens = ModelAttribution.safeAdd(existing.promptTokens, entry.promptTokens)
+    const completionTokens = ModelAttribution.safeAdd(existing.completionTokens, entry.completionTokens)
+    ModelAttribution.safeAdd(promptTokens, completionTokens)
+
     this.state.set(entry.model, {
       totalCalls: existing.totalCalls + 1,
       successfulCalls: existing.successfulCalls + (entry.success ? 1 : 0),
-      promptTokens: existing.promptTokens + entry.promptTokens,
-      completionTokens: existing.completionTokens + entry.completionTokens,
+      promptTokens,
+      completionTokens,
     })
   }
 


### PR DESCRIPTION
## Summary
- Validate ModelAttribution prompt/completion token deltas as non-negative safe integers before aggregation
- Reject safe-integer overflow before mutating model attribution state
- Add regression coverage for invalid deltas and atomicity

## Test Plan
- npm test --workspace @franken/observer -- ModelAttribution.test.ts
- npm run build --workspace @franken/types && npm test --workspace @franken/observer && npm run typecheck --workspace @franken/observer && npm run build --workspace @franken/observer
- npm run lint:any (reports existing explicit-any inventory; exits 0)

Closes #1138