### PR TITLE
fix(observer): reject invalid replay timestamps

### DIFF
--- a/packages/franken-observer/src/execution-replayer.test.ts
+++ b/packages/franken-observer/src/execution-replayer.test.ts
@@ -20,6 +20,10 @@ function buildTrail(
   return trail;
 }
 
+function corruptTimestamp(trail: AuditTrail, index: number, timestamp: string): void {
+  (trail.getAll()[index] as { timestamp: string }).timestamp = timestamp;
+}
+
 describe('ExecutionReplayer', () => {
   const replayer = new ExecutionReplayer();
 
@@ -69,6 +73,32 @@ describe('ExecutionReplayer', () => {
     const timeline = replayer.replay(trail);
     expect(timeline.phases[0]!.durationMs).toBe(1000); // 1 second apart
     expect(timeline.totalDurationMs).toBe(1000);
+  });
+
+  it('rejects invalid total timeline timestamps with event context', () => {
+    const trail = buildTrail([
+      { type: 'run.start', phase: 'planning', provider: 'claude-cli' },
+      { type: 'phase.end', phase: 'planning', provider: 'claude-cli' },
+    ]);
+    corruptTimestamp(trail, 0, 'not-a-date');
+
+    expect(() => replayer.replay(trail)).toThrow(
+      /Invalid audit event timestamp during replay \(phase planning\): eventId=.*phase=planning, type=run\.start, timestamp="not-a-date"/,
+    );
+  });
+
+  it('rejects invalid phase timestamps with phase context before emitting NaN durations', () => {
+    const trail = buildTrail([
+      { type: 'phase.start', phase: 'planning', provider: 'claude-cli' },
+      { type: 'phase.end', phase: 'planning', provider: 'claude-cli' },
+      { type: 'phase.start', phase: 'execution', provider: 'codex-cli' },
+      { type: 'phase.end', phase: 'execution', provider: 'codex-cli' },
+    ]);
+    corruptTimestamp(trail, 3, 'still-not-a-date');
+
+    expect(() => replayer.replay(trail)).toThrow(
+      /Invalid audit event timestamp during replay \(phase execution\): eventId=.*phase=execution, type=phase\.end, timestamp="still-not-a-date"/,
+    );
   });
 
   it('generates human-readable summary', () => {

--- a/packages/franken-observer/src/execution-replayer.test.ts
+++ b/packages/franken-observer/src/execution-replayer.test.ts
@@ -101,6 +101,18 @@ describe('ExecutionReplayer', () => {
     );
   });
 
+  it('rejects parseable but malformed timestamps', () => {
+    const trail = buildTrail([
+      { type: 'phase.start', phase: 'planning', provider: 'claude-cli' },
+      { type: 'phase.end', phase: 'planning', provider: 'claude-cli' },
+    ]);
+    corruptTimestamp(trail, 1, '2026-02-31T00:00:00.000Z');
+
+    expect(() => replayer.replay(trail)).toThrow(
+      /Invalid audit event timestamp during replay \(phase planning\): eventId=.*phase=planning, type=phase\.end, timestamp="2026-02-31T00:00:00.000Z"/,
+    );
+  });
+
   it('generates human-readable summary', () => {
     const trail = buildTrail([
       { type: 'phase.start', phase: 'planning', provider: 'claude-cli' },

--- a/packages/franken-observer/src/execution-replayer.ts
+++ b/packages/franken-observer/src/execution-replayer.ts
@@ -45,19 +45,24 @@ export class ExecutionReplayer {
       throw new Error('Cannot replay empty audit trail');
     }
 
+    this.validateEventTimestamps(events);
+
     const phases = this.groupByPhase(events);
     const switches = this.extractProviderSwitches(events);
     const errors = this.extractErrors(events);
 
-    const startTime = events[0]!.timestamp;
-    const endTime = events[events.length - 1]!.timestamp;
+    const startEvent = events[0]!;
+    const endEvent = events[events.length - 1]!;
+    const startTime = startEvent.timestamp;
+    const endTime = endEvent.timestamp;
 
     return {
       runId: this.extractRunId(events),
       startTime,
       endTime,
       totalDurationMs:
-        new Date(endTime).getTime() - new Date(startTime).getTime(),
+        this.parseEventTimestamp(endEvent, 'execution timeline end') -
+        this.parseEventTimestamp(startEvent, 'execution timeline start'),
       phases,
       providerSwitches: switches,
       errors,
@@ -73,17 +78,37 @@ export class ExecutionReplayer {
       phaseMap.set(event.phase, existing);
     }
 
-    return [...phaseMap.entries()].map(([phase, phaseEvents]) => ({
-      phase,
-      startTime: phaseEvents[0]!.timestamp,
-      endTime: phaseEvents[phaseEvents.length - 1]!.timestamp,
-      durationMs:
-        new Date(phaseEvents[phaseEvents.length - 1]!.timestamp).getTime() -
-        new Date(phaseEvents[0]!.timestamp).getTime(),
-      provider: phaseEvents[phaseEvents.length - 1]!.provider,
-      eventCount: phaseEvents.length,
-      events: phaseEvents,
-    }));
+    return [...phaseMap.entries()].map(([phase, phaseEvents]) => {
+      const startEvent = phaseEvents[0]!;
+      const endEvent = phaseEvents[phaseEvents.length - 1]!;
+      return {
+        phase,
+        startTime: startEvent.timestamp,
+        endTime: endEvent.timestamp,
+        durationMs:
+          this.parseEventTimestamp(endEvent, `phase ${phase} end`) -
+          this.parseEventTimestamp(startEvent, `phase ${phase} start`),
+        provider: endEvent.provider,
+        eventCount: phaseEvents.length,
+        events: phaseEvents,
+      };
+    });
+  }
+
+  private validateEventTimestamps(events: readonly AuditEvent[]): void {
+    for (const event of events) {
+      this.parseEventTimestamp(event, `phase ${event.phase}`);
+    }
+  }
+
+  private parseEventTimestamp(event: AuditEvent, context: string): number {
+    const timestampMs = new Date(event.timestamp).getTime();
+    if (!Number.isFinite(timestampMs)) {
+      throw new Error(
+        `Invalid audit event timestamp during replay (${context}): eventId=${event.eventId}, phase=${event.phase}, type=${event.type}, timestamp=${JSON.stringify(event.timestamp)}`,
+      );
+    }
+    return timestampMs;
   }
 
   private extractProviderSwitches(

--- a/packages/franken-observer/src/execution-replayer.ts
+++ b/packages/franken-observer/src/execution-replayer.ts
@@ -1,6 +1,8 @@
 import type { AuditEvent } from './audit-event.js';
 import { AuditTrail } from './audit-event.js';
 
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
 export interface ExecutionTimeline {
   runId: string;
   startTime: string;
@@ -102,8 +104,12 @@ export class ExecutionReplayer {
   }
 
   private parseEventTimestamp(event: AuditEvent, context: string): number {
-    const timestampMs = new Date(event.timestamp).getTime();
-    if (!Number.isFinite(timestampMs)) {
+    const timestampMs = Date.parse(event.timestamp);
+    if (
+      !ISO_TIMESTAMP_PATTERN.test(event.timestamp) ||
+      !Number.isFinite(timestampMs) ||
+      new Date(timestampMs).toISOString() !== event.timestamp
+    ) {
       throw new Error(
         `Invalid audit event timestamp during replay (${context}): eventId=${event.eventId}, phase=${event.phase}, type=${event.type}, timestamp=${JSON.stringify(event.timestamp)}`,
       );

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-10 — Observer replay timestamp validation
+- Replay-time timestamp guards should mirror persisted audit-event validation, not just check finite `Date` values. JavaScript accepts parseable malformed values such as impossible dates and date-only strings, so add round-trip ISO instant regressions (`new Date(Date.parse(ts)).toISOString() === ts`) before relying on replay durations.
+
 ## 2026-07-10 — Parallel planner deadlock guard
 - In ParallelPlanner execution, don't allow the "no tasks ready" path to continue silently as success. Keep cycle checks explicit and fail fast with a clear `CyclicDependencyError` (or similar) before running task waves, and add a unit test that proves executor is never called when readiness stalls due to a dependency cycle.
 - When `@codex review` is usage-limited, classify it as a blocker state and do not merge until a new trigger can produce a current-head clean response.


### PR DESCRIPTION
## Summary
- validate audit event timestamps before replay duration calculations
- reject malformed replay timestamps with event/phase/type context instead of emitting NaN durations
- add regression coverage for invalid total-timeline and phase timestamps

## Test Plan
- npm --prefix packages/franken-observer test -- execution-replayer.test.ts
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run build
- npm --prefix packages/franken-observer test

Closes #1143
