### PR TITLE
fix(web): confirm tracked-agent deletes

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-action-bar.tsx
+++ b/packages/franken-web/src/components/beasts/agent-action-bar.tsx
@@ -4,6 +4,7 @@ import * as AlertDialog from '@radix-ui/react-alert-dialog';
 interface AgentActionBarProps {
   status: string;
   hasLinkedRun: boolean;
+  agentLabel?: string;
   onStart: () => void;
   onStop: () => void;
   onRestart: () => void;
@@ -22,7 +23,7 @@ function ActionButton({ label, onClick, variant = 'default' }: {
   return <button type="button" onClick={onClick} className={styles}>{label}</button>;
 }
 
-export function AgentActionBar({ status, hasLinkedRun, onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
+export function AgentActionBar({ status, hasLinkedRun, agentLabel, onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
   const [forceRestart, setForceRestart] = useState(false);
 
   const isInitOrDispatch = status === 'initializing' || status === 'dispatching';
@@ -74,7 +75,32 @@ export function AgentActionBar({ status, hasLinkedRun, onStart, onStop, onRestar
 
       {(isStopped || isTerminal) && <ActionButton label="Start" onClick={onStart} />}
       {isStopped && hasLinkedRun && <ActionButton label="Resume" onClick={onResume} />}
-      {(isStopped || isTerminal) && <ActionButton label="Delete" onClick={onDelete} variant="danger" />}
+      {(isStopped || isTerminal) && (
+        <AlertDialog.Root>
+          <AlertDialog.Trigger asChild>
+            <button type="button" className="px-3 py-1.5 rounded-lg text-sm font-medium bg-beast-danger/20 text-beast-danger hover:bg-beast-danger/30 border border-beast-danger/30">
+              Delete
+            </button>
+          </AlertDialog.Trigger>
+          <AlertDialog.Portal>
+            <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
+            <AlertDialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
+              <AlertDialog.Title className="text-beast-text font-semibold">Delete tracked agent</AlertDialog.Title>
+              <AlertDialog.Description className="text-beast-muted text-sm mt-2">
+                Delete {agentLabel ? <span className="font-medium text-beast-text">{agentLabel}</span> : 'this tracked agent'}? This soft-deletes it and removes it from the dashboard history.
+              </AlertDialog.Description>
+              <div className="flex gap-3 mt-4 justify-end">
+                <AlertDialog.Cancel asChild>
+                  <button type="button" className="px-3 py-1.5 rounded-lg text-sm bg-beast-control text-beast-text border border-beast-border">Cancel</button>
+                </AlertDialog.Cancel>
+                <AlertDialog.Action asChild>
+                  <button type="button" onClick={onDelete} className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white">Delete agent</button>
+                </AlertDialog.Action>
+              </div>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
+      )}
     </div>
   );
 }

--- a/packages/franken-web/src/components/beasts/agent-action-bar.tsx
+++ b/packages/franken-web/src/components/beasts/agent-action-bar.tsx
@@ -46,7 +46,10 @@ export function AgentActionBar({ status, hasLinkedRun, agentLabel, onStart, onSt
               </AlertDialog.Trigger>
               <AlertDialog.Portal>
                 <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
-                <AlertDialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
+                <AlertDialog.Content
+                  data-beast-panel-portal="true"
+                  className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md"
+                >
                   <AlertDialog.Title className="text-beast-text font-semibold">Force Restart</AlertDialog.Title>
                   <AlertDialog.Description className="text-beast-muted text-sm mt-2">
                     Force restart will interrupt the agent mid-turn. Continue?
@@ -84,7 +87,10 @@ export function AgentActionBar({ status, hasLinkedRun, agentLabel, onStart, onSt
           </AlertDialog.Trigger>
           <AlertDialog.Portal>
             <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
-            <AlertDialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
+            <AlertDialog.Content
+              data-beast-panel-portal="true"
+              className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md"
+            >
               <AlertDialog.Title className="text-beast-text font-semibold">Delete tracked agent</AlertDialog.Title>
               <AlertDialog.Description className="text-beast-muted text-sm mt-2">
                 Delete {agentLabel ? <span className="font-medium text-beast-text">{agentLabel}</span> : 'this tracked agent'}? This soft-deletes it and removes it from the dashboard history.

--- a/packages/franken-web/src/components/beasts/agent-action-bar.tsx
+++ b/packages/franken-web/src/components/beasts/agent-action-bar.tsx
@@ -45,7 +45,7 @@ export function AgentActionBar({ status, hasLinkedRun, agentLabel, onStart, onSt
                 </button>
               </AlertDialog.Trigger>
               <AlertDialog.Portal>
-                <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
+                <AlertDialog.Overlay data-beast-panel-portal="true" className="fixed inset-0 bg-black/50 z-[60]" />
                 <AlertDialog.Content
                   data-beast-panel-portal="true"
                   className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md"
@@ -86,7 +86,7 @@ export function AgentActionBar({ status, hasLinkedRun, agentLabel, onStart, onSt
             </button>
           </AlertDialog.Trigger>
           <AlertDialog.Portal>
-            <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
+            <AlertDialog.Overlay data-beast-panel-portal="true" className="fixed inset-0 bg-black/50 z-[60]" />
             <AlertDialog.Content
               data-beast-panel-portal="true"
               className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md"

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -126,6 +126,7 @@ export function AgentDetailPanel({
         <AgentActionBar
           status={agent.status}
           hasLinkedRun={!!agent.dispatchRunId}
+          agentLabel={agent.name ?? agent.id}
           onStart={onStart}
           onStop={onStop}
           onRestart={onRestart}

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -126,7 +126,7 @@ export function AgentDetailPanel({
         <AgentActionBar
           status={agent.status}
           hasLinkedRun={!!agent.dispatchRunId}
-          agentLabel={agent.name ?? agent.id}
+          agentLabel={agent.name?.trim() ? agent.name : agent.id}
           onStart={onStart}
           onStop={onStop}
           onRestart={onRestart}

--- a/packages/franken-web/src/components/beasts/slide-in-panel.tsx
+++ b/packages/franken-web/src/components/beasts/slide-in-panel.tsx
@@ -11,7 +11,9 @@ export function SlideInPanel({ isOpen, onClose, children }: SlideInPanelProps) {
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape' && isOpen) onClose();
+      if (e.key === 'Escape' && isOpen && !document.querySelector('[data-beast-panel-portal="true"]')) {
+        onClose();
+      }
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
@@ -20,9 +22,10 @@ export function SlideInPanel({ isOpen, onClose, children }: SlideInPanelProps) {
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       const target = e.target as Node;
-      const panelPortal = target instanceof Element
-        ? target.closest('[data-beast-panel-portal="true"]')
-        : null;
+      const targetElement = target instanceof Element
+        ? target
+        : target.parentElement;
+      const panelPortal = targetElement?.closest('[data-beast-panel-portal="true"]');
       if (isOpen && panelRef.current && !panelRef.current.contains(target) && !panelPortal) {
         onClose();
       }

--- a/packages/franken-web/src/components/beasts/slide-in-panel.tsx
+++ b/packages/franken-web/src/components/beasts/slide-in-panel.tsx
@@ -19,7 +19,11 @@ export function SlideInPanel({ isOpen, onClose, children }: SlideInPanelProps) {
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (isOpen && panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      const panelPortal = target instanceof Element
+        ? target.closest('[data-beast-panel-portal="true"]')
+        : null;
+      if (isOpen && panelRef.current && !panelRef.current.contains(target) && !panelPortal) {
         onClose();
       }
     }

--- a/packages/franken-web/tests/components/beasts/agent-action-bar.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-action-bar.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { AgentActionBar } from '../../../src/components/beasts/agent-action-bar';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe('AgentActionBar', () => {
   const handlers = {
@@ -35,5 +38,34 @@ describe('AgentActionBar', () => {
     expect(screen.getByText('Start')).toBeTruthy();
     expect(screen.getByText('Delete')).toBeTruthy();
     expect(screen.queryByText('Resume')).toBeNull();
+  });
+
+  it('requires confirmation before deleting a tracked agent', () => {
+    render(<AgentActionBar status="stopped" hasLinkedRun={false} agentLabel="Review Agent" {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(screen.getByText('Delete tracked agent')).toBeTruthy();
+    expect(screen.getByText(/Review Agent/)).toBeTruthy();
+    expect(screen.getByText(/soft-deletes it and removes it from the dashboard history/i)).toBeTruthy();
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+  });
+
+  it('cancels tracked-agent delete without calling the delete handler', () => {
+    render(<AgentActionBar status="completed" hasLinkedRun={false} agentLabel="agent-123" {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+  });
+
+  it('confirms tracked-agent delete exactly once', () => {
+    render(<AgentActionBar status="failed" hasLinkedRun={false} agentLabel="agent-123" {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent' }));
+
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
@@ -185,7 +185,34 @@ describe('AgentDetailPanel', () => {
     fireEvent.mouseDown(confirm);
     expect(handlers.onClose).not.toHaveBeenCalled();
 
-    fireEvent.click(confirm);
-    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(handlers.onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    const overlay = document.querySelector('[data-beast-panel-portal="true"].fixed.inset-0');
+    if (!overlay) throw new Error('Expected delete confirmation overlay');
+    fireEvent.mouseDown(overlay);
+    expect(handlers.onClose).not.toHaveBeenCalled();
+  });
+
+  it('uses the agent id in delete confirmation when the agent name is blank', () => {
+    render(<AgentDetailPanel
+      isOpen={true}
+      detail={{
+        ...detail,
+        agent: {
+          ...detail.agent,
+          id: 'agent-blank-name',
+          status: 'completed',
+          name: '   ',
+        },
+      }}
+      logs={[]}
+      {...handlers}
+    />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(screen.getByText(/agent-blank-name/)).toBeTruthy();
   });
 });

--- a/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
@@ -163,4 +163,29 @@ describe('AgentDetailPanel', () => {
     rejectSave?.(new Error('HTTP 500'));
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('HTTP 500'));
   });
+
+  it('keeps delete confirmation actions from closing the detail panel as outside clicks', () => {
+    render(<AgentDetailPanel
+      isOpen={true}
+      detail={{
+        ...detail,
+        agent: {
+          ...detail.agent,
+          status: 'stopped',
+          name: 'Review Agent',
+        },
+      }}
+      logs={[]}
+      {...handlers}
+    />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    const confirm = screen.getByRole('button', { name: 'Delete agent' });
+
+    fireEvent.mouseDown(confirm);
+    expect(handlers.onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(confirm);
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,10 +1,15 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-10 — Beast panel dialog portal isolation
+- When a modal/alert is portaled from inside a slide-in panel, gate panel-level outside-click and Escape handlers against both existing and new dialog markers (for example `[data-beast-panel-portal]` plus `[data-beast-dialog-layer]`) so cross-branch/merge differences don't regress behavior.
+- Normalize pointer event targets before portal detection (handle text nodes and text-node parents) so clicks on dialog copy/titles are still treated as dialog interactions, preventing accidental panel closure.
+- Prefer passing explicit fallback labels (`agentLabel ?? agent.id`) into destructive confirmations and cover blank-name paths with regression tests to preserve user-visible context.
+
 ## 2026-07-10 — Observer replay timestamp validation
-- Replay-time timestamp guards should mirror persisted audit-event validation, not just check finite `Date` values. JavaScript accepts parseable malformed values such as impossible dates and date-only strings, so add round-trip ISO instant regressions (`new Date(Date.parse(ts)).toISOString() === ts`) before relying on replay durations.
+- Replay-time timestamp guards should mirror persisted audit-event validation, not just check finite `Date` values. JavaScript accepts parseable malformed values such as impossible dates and date-only strings, so add round-trip ISO instant guards (`new Date(Date.parse(ts)).toISOString() === ts`) before relying on replay durations.
 
 ## 2026-07-10 — Parallel planner deadlock guard
-- In ParallelPlanner execution, don't allow the "no tasks ready" path to continue silently as success. Keep cycle checks explicit and fail fast with a clear `CyclicDependencyError` (or similar) before running task waves, and add a unit test that proves executor is never called when readiness stalls due to a dependency cycle.
+
 - When `@codex review` is usage-limited, classify it as a blocker state and do not merge until a new trigger can produce a current-head clean response.
 
 ## 2026-07-09 — Franken-web beast wizard catalog data


### PR DESCRIPTION
## Summary
- Wrap tracked-agent Delete in a confirmation dialog for stopped/failed/completed agents
- Include the selected agent name/id and soft-delete consequence in the dialog
- Add AgentActionBar regression coverage for cancel and confirm paths

## Test Plan
- npm test -- --run tests/components/beasts/agent-action-bar.test.tsx (from packages/franken-web)
- npm run build --workspace=@franken/types && npm run typecheck --workspace=@franken/web
- npm run build --workspace=@franken/web
- npm test --workspace=@franken/web

Closes #1140