### PR TITLE
fix(mcp): point planner guidance at status tool

### DIFF
--- a/packages/franken-mcp-suite/src/servers/planner.test.ts
+++ b/packages/franken-mcp-suite/src/servers/planner.test.ts
@@ -35,9 +35,18 @@ describe('Planner Server', () => {
 
     const decomposeResult = await decomposeTool.handler({ objective: 'ship', constraints: 'small PRs' });
     expect(planner.decompose).toHaveBeenCalledWith({ objective: 'ship', constraints: 'small PRs' });
-    expect(decomposeResult.content[0]!.text).toContain('p1');
-    expect(decomposeResult.content[0]!.text).toContain('**Provenance:** generic-scaffold');
-    expect(decomposeResult.content[0]!.text).toContain('not by an objective-specific planner');
+    const decomposeText = decomposeResult.content[0]!.text;
+    expect(decomposeText).toContain('p1');
+    expect(decomposeText).toContain('**Provenance:** generic-scaffold');
+    expect(decomposeText).toContain('not by an objective-specific planner');
+    expect(decomposeText).toContain('fbeast_plan_status');
+    expect(decomposeText).not.toContain('fbeast_plan_visualize');
+    const registeredToolNames = new Set(server.tools.map((t) => t.name));
+    const mentionedPlannerTools = [...decomposeText.matchAll(/fbeast_plan_[a-z_]+/g)].map((match) => match[0]);
+    expect(mentionedPlannerTools.length).toBeGreaterThan(0);
+    for (const toolName of mentionedPlannerTools) {
+      expect(registeredToolNames.has(toolName)).toBe(true);
+    }
 
     const visualizeResult = await visualizeTool.handler({ planId: 'p1' });
     expect(planner.visualize).toHaveBeenCalledWith('p1');

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -182,7 +182,22 @@ const TOOLS: ToolFull[] = [
       const constraints = args['constraints'] ? String(args['constraints']) : undefined;
       const result = await planner.decompose(constraints ? { objective, constraints } : { objective });
       const taskList = result.tasks.map((t) => `  ${t.id}: ${t.title}${t.deps.length > 0 ? ` (after: ${t.deps.join(', ')})` : ''}`).join('\n');
-      const text = [`## Plan created: ${result.planId}`, ``, `**Objective:** ${result.objective}`, constraints ? `**Constraints:** ${constraints}` : '', `**Provenance:** ${result.provenance}`, `**Provenance note:** ${result.provenanceNote}`, ``, `**Tasks:**`, taskList, ``, `Use fbeast_plan_validate with planId "${result.planId}" to check for issues.`].filter(Boolean).join('\n');
+      const text = [
+        `## Plan created: ${result.planId}`,
+        ``,
+        `**Objective:** ${result.objective}`,
+        constraints ? `**Constraints:** ${constraints}` : '',
+        `**Provenance:** ${result.provenance}`,
+        `**Provenance note:** ${result.provenanceNote}`,
+        ``,
+        `**Tasks:**`,
+        taskList,
+        ``,
+        `Use fbeast_plan_status with planId "${result.planId}" to view the DAG.`,
+        `Use fbeast_plan_validate with planId "${result.planId}" to check for issues.`,
+      ]
+        .filter(Boolean)
+        .join('\n');
       return { content: [{ type: 'text', text }] };
     },
   },


### PR DESCRIPTION
## Summary
- Updates planner decompose guidance to point users at the registered `fbeast_plan_status` DAG tool.
- Adds regression coverage that planner decompose output does not mention `fbeast_plan_visualize` and only references registered planner tools.

## Test Plan
- `npm test --workspace @franken/mcp-suite -- --run src/servers/planner.test.ts` (RED first: failed before fix because output omitted `fbeast_plan_status`)
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run build --workspace @franken/mcp-suite`
- `npm test --workspace @franken/mcp-suite`

Closes #1132