### PR TITLE
fix(orchestrator): probe long-running MCP health checks

### DIFF
--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import type { McpConfig } from '@franken/types';
 
 export type McpHealthStatus = 'connected' | 'error' | 'unknown';
@@ -24,6 +25,9 @@ export interface SkillHealthOptions {
 
 const UNTRUSTED_HEALTH_CHECK_MESSAGE =
   'MCP health check command was not executed because the skill is not trusted';
+
+const HEALTH_CHECK_TIMEOUT_MS = 2000;
+const MCP_INITIALIZE_ID = 1;
 
 /**
  * Check health of MCP servers in a skill's mcp.json.
@@ -81,30 +85,148 @@ export class SkillHealthChecker {
     args: string[],
   ): Promise<McpHealthStatus> {
     return new Promise((resolve) => {
+      let proc: ChildProcessWithoutNullStreams;
+      let settled = false;
+      let stdoutBuffer = '';
+      let timer: NodeJS.Timeout;
+
+      const settle = (status: McpHealthStatus) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        if (status !== 'error' && proc.exitCode === null && !proc.killed) {
+          proc.kill();
+        }
+        resolve(status);
+      };
+
       try {
-        const proc = spawn(command, args, {
+        proc = spawn(command, args, {
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 5000,
         });
 
-        const timer = setTimeout(() => {
-          // Timeout without MCP readiness signal — cannot confirm connectivity
-          proc.kill();
-          resolve('unknown');
-        }, 2000);
+        timer = setTimeout(() => {
+          // Timeout without MCP readiness signal — cannot confirm connectivity.
+          settle('unknown');
+        }, HEALTH_CHECK_TIMEOUT_MS);
 
         proc.on('error', () => {
-          clearTimeout(timer);
-          resolve('error');
+          settle('error');
         });
 
         proc.on('close', (code) => {
-          clearTimeout(timer);
-          resolve(code === 0 ? 'connected' : 'error');
+          settle(code === 0 ? 'connected' : 'error');
         });
+
+        proc.stdout.on('data', (chunk: Buffer | string) => {
+          stdoutBuffer += chunk.toString('utf8');
+          const messages = readMcpMessages(stdoutBuffer);
+          stdoutBuffer = messages.remaining;
+          if (messages.messages.some(isSuccessfulInitializeResponse)) {
+            settle('connected');
+          }
+        });
+
+        proc.stdin.write(formatMcpMessage({
+          jsonrpc: '2.0',
+          id: MCP_INITIALIZE_ID,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: {
+              name: 'frankenbeast-skill-health-checker',
+              version: '0.0.0',
+            },
+          },
+        }));
       } catch {
         resolve('error');
       }
     });
   }
+}
+
+interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: string | number | null;
+  result?: unknown;
+  error?: unknown;
+}
+
+interface ReadMessagesResult {
+  messages: JsonRpcMessage[];
+  remaining: string;
+}
+
+function formatMcpMessage(message: unknown): string {
+  const body = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
+}
+
+function readMcpMessages(input: string): ReadMessagesResult {
+  const messages: JsonRpcMessage[] = [];
+  let remaining = input;
+
+  while (remaining.length > 0) {
+    const headerEnd = remaining.indexOf('\r\n\r\n');
+    if (headerEnd !== -1) {
+      const headers = remaining.slice(0, headerEnd);
+      const lengthMatch = /^content-length:\s*(\d+)$/im.exec(headers);
+      if (!lengthMatch) {
+        remaining = remaining.slice(headerEnd + 4);
+        continue;
+      }
+
+      const bodyLength = Number(lengthMatch[1]);
+      const bodyStart = headerEnd + 4;
+      const bodyEnd = bodyStart + bodyLength;
+      if (remaining.length < bodyEnd) {
+        break;
+      }
+
+      const parsed = tryParseJsonRpcMessage(remaining.slice(bodyStart, bodyEnd));
+      if (parsed) {
+        messages.push(parsed);
+      }
+      remaining = remaining.slice(bodyEnd);
+      continue;
+    }
+
+    const newlineIndex = remaining.indexOf('\n');
+    if (newlineIndex === -1) {
+      break;
+    }
+
+    const parsed = tryParseJsonRpcMessage(remaining.slice(0, newlineIndex).trim());
+    if (parsed) {
+      messages.push(parsed);
+    }
+    remaining = remaining.slice(newlineIndex + 1);
+  }
+
+  return { messages, remaining };
+}
+
+function tryParseJsonRpcMessage(raw: string): JsonRpcMessage | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as JsonRpcMessage;
+    return parsed && typeof parsed === 'object' ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSuccessfulInitializeResponse(message: JsonRpcMessage): boolean {
+  return message.jsonrpc === '2.0'
+    && message.id === MCP_INITIALIZE_ID
+    && message.result !== undefined
+    && message.error === undefined;
 }

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -122,7 +122,10 @@ export class SkillHealthChecker {
         });
 
         proc.stdin.on('error', () => {
-          settle('error');
+          // Defer to the process error/close/timeout paths. Some commands exit
+          // successfully before reading the initialize probe; in that case the
+          // stdin stream can emit EPIPE before close(0), and the clean-exit
+          // fallback should remain connected.
         });
 
         proc.stdout.on('data', (chunk: Buffer | string) => {

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -87,7 +87,7 @@ export class SkillHealthChecker {
     return new Promise((resolve) => {
       let proc: ChildProcessWithoutNullStreams;
       let settled = false;
-      let stdoutBuffer = '';
+      let stdoutBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
       let timer: NodeJS.Timeout;
 
       const settle = (status: McpHealthStatus) => {
@@ -121,8 +121,15 @@ export class SkillHealthChecker {
           settle(code === 0 ? 'connected' : 'error');
         });
 
+        proc.stdin.on('error', () => {
+          settle('error');
+        });
+
         proc.stdout.on('data', (chunk: Buffer | string) => {
-          stdoutBuffer += chunk.toString('utf8');
+          stdoutBuffer = Buffer.concat([
+            stdoutBuffer,
+            Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8'),
+          ]);
           const messages = readMcpMessages(stdoutBuffer);
           stdoutBuffer = messages.remaining;
           if (messages.messages.some(isSuccessfulInitializeResponse)) {
@@ -159,7 +166,7 @@ interface JsonRpcMessage {
 
 interface ReadMessagesResult {
   messages: JsonRpcMessage[];
-  remaining: string;
+  remaining: Buffer<ArrayBufferLike>;
 }
 
 function formatMcpMessage(message: unknown): string {
@@ -167,33 +174,39 @@ function formatMcpMessage(message: unknown): string {
   return `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
 }
 
-function readMcpMessages(input: string): ReadMessagesResult {
+function readMcpMessages(input: Buffer<ArrayBufferLike>): ReadMessagesResult {
   const messages: JsonRpcMessage[] = [];
   let remaining = input;
 
-  while (remaining.length > 0) {
+  while (remaining.byteLength > 0) {
     const headerEnd = remaining.indexOf('\r\n\r\n');
     if (headerEnd !== -1) {
-      const headers = remaining.slice(0, headerEnd);
+      const headers = remaining.subarray(0, headerEnd).toString('ascii');
       const lengthMatch = /^content-length:\s*(\d+)$/im.exec(headers);
       if (!lengthMatch) {
-        remaining = remaining.slice(headerEnd + 4);
+        remaining = remaining.subarray(headerEnd + 4);
         continue;
       }
 
       const bodyLength = Number(lengthMatch[1]);
       const bodyStart = headerEnd + 4;
       const bodyEnd = bodyStart + bodyLength;
-      if (remaining.length < bodyEnd) {
+      if (remaining.byteLength < bodyEnd) {
         break;
       }
 
-      const parsed = tryParseJsonRpcMessage(remaining.slice(bodyStart, bodyEnd));
+      const parsed = tryParseJsonRpcMessage(
+        remaining.subarray(bodyStart, bodyEnd).toString('utf8'),
+      );
       if (parsed) {
         messages.push(parsed);
       }
-      remaining = remaining.slice(bodyEnd);
+      remaining = remaining.subarray(bodyEnd);
       continue;
+    }
+
+    if (looksLikePartialContentLengthHeader(remaining)) {
+      break;
     }
 
     const newlineIndex = remaining.indexOf('\n');
@@ -201,14 +214,20 @@ function readMcpMessages(input: string): ReadMessagesResult {
       break;
     }
 
-    const parsed = tryParseJsonRpcMessage(remaining.slice(0, newlineIndex).trim());
+    const parsed = tryParseJsonRpcMessage(
+      remaining.subarray(0, newlineIndex).toString('utf8').trim(),
+    );
     if (parsed) {
       messages.push(parsed);
     }
-    remaining = remaining.slice(newlineIndex + 1);
+    remaining = remaining.subarray(newlineIndex + 1);
   }
 
   return { messages, remaining };
+}
+
+function looksLikePartialContentLengthHeader(input: Buffer<ArrayBufferLike>): boolean {
+  return /^content-length\s*:/i.test(input.toString('ascii'));
 }
 
 function tryParseJsonRpcMessage(raw: string): JsonRpcMessage | undefined {

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -90,13 +90,16 @@ export class SkillHealthChecker {
       let stdoutBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
       let timer: NodeJS.Timeout;
 
-      const settle = (status: McpHealthStatus) => {
+      const settle = (
+        status: McpHealthStatus,
+        { killRunningProcess = true }: { killRunningProcess?: boolean } = {},
+      ) => {
         if (settled) {
           return;
         }
         settled = true;
         clearTimeout(timer);
-        if (status !== 'error' && proc.exitCode === null && !proc.killed) {
+        if (killRunningProcess && proc.exitCode === null && !proc.killed) {
           proc.kill();
         }
         resolve(status);
@@ -114,11 +117,11 @@ export class SkillHealthChecker {
         }, HEALTH_CHECK_TIMEOUT_MS);
 
         proc.on('error', () => {
-          settle('error');
+          settle('error', { killRunningProcess: false });
         });
 
         proc.on('close', (code) => {
-          settle(code === 0 ? 'connected' : 'error');
+          settle(code === 0 ? 'connected' : 'error', { killRunningProcess: false });
         });
 
         proc.stdin.on('error', () => {
@@ -176,7 +179,7 @@ interface ReadMessagesResult {
 
 function formatMcpMessage(message: unknown): string {
   const body = JSON.stringify(message);
-  return `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
+  return `${body}\n`;
 }
 
 function readMcpMessages(input: Buffer<ArrayBufferLike>): ReadMessagesResult {

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -135,7 +135,9 @@ export class SkillHealthChecker {
           ]);
           const messages = readMcpMessages(stdoutBuffer);
           stdoutBuffer = messages.remaining;
-          if (messages.messages.some(isSuccessfulInitializeResponse)) {
+          if (messages.messages.some(isFailedInitializeResponse)) {
+            settle('error');
+          } else if (messages.messages.some(isSuccessfulInitializeResponse)) {
             settle('connected');
           }
         });
@@ -251,4 +253,10 @@ function isSuccessfulInitializeResponse(message: JsonRpcMessage): boolean {
     && message.id === MCP_INITIALIZE_ID
     && message.result !== undefined
     && message.error === undefined;
+}
+
+function isFailedInitializeResponse(message: JsonRpcMessage): boolean {
+  return message.jsonrpc === '2.0'
+    && message.id === MCP_INITIALIZE_ID
+    && message.error !== undefined;
 }

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -80,8 +80,13 @@ describe('SkillHealthChecker', () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();
     proc.stdin.write.mockImplementation((message: string) => {
-      expect(message).toContain('Content-Length:');
-      expect(message).toContain('"method":"initialize"');
+      expect(message).not.toContain('Content-Length:');
+      expect(message.endsWith('\n')).toBe(true);
+      expect(JSON.parse(message)).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+      });
       setTimeout(() => {
         proc.stdout.emit('data', formatMcpMessage({
           jsonrpc: '2.0',
@@ -221,6 +226,7 @@ describe('SkillHealthChecker', () => {
     const result = await checker.getStatus('rejecting', config, { trustMcpServerCommands: true });
 
     expect(result.status).toBe('error');
+    expect(proc.kill).toHaveBeenCalledTimes(1);
   });
 
   it('returns unknown and cleans up when a trusted MCP server stays open without responding', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -7,10 +7,14 @@ vi.mock('node:child_process', async () => {
   const { EventEmitter } = await import('node:events');
   return {
     spawn: vi.fn(() => {
+      const stdin = Object.assign(new EventEmitter(), {
+        write: vi.fn(),
+        end: vi.fn(),
+      });
       const proc = Object.assign(new EventEmitter(), {
         stdout: new EventEmitter(),
         stderr: new EventEmitter(),
-        stdin: { write: vi.fn(), end: vi.fn() },
+        stdin,
         kill: vi.fn(),
         pid: 123,
         exitCode: null,
@@ -108,6 +112,88 @@ describe('SkillHealthChecker', () => {
     expect(proc.kill).toHaveBeenCalledTimes(1);
   });
 
+  it('returns error instead of crashing when stdin rejects an initialize probe', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation(() => {
+      setTimeout(() => {
+        proc.stdin.emit('error', new Error('write EPIPE'));
+      }, 10);
+      return false;
+    });
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+    const config: McpConfig = {
+      mcpServers: {
+        exitsEarly: { command: 'true' },
+      },
+    };
+
+    const result = await checker.getStatus('epipe', config, { trustMcpServerCommands: true });
+
+    expect(result.status).toBe('error');
+  });
+
+  it('parses framed initialize responses by UTF-8 byte length', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation(() => {
+      setTimeout(() => {
+        proc.stdout.emit('data', formatMcpMessage({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            serverInfo: { name: 'servidor-salud-é', version: '1.0.0' },
+          },
+        }));
+      }, 10);
+      return true;
+    });
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+    const config: McpConfig = {
+      mcpServers: {
+        localized: { command: 'node', args: ['server.js'] },
+      },
+    };
+
+    const result = await checker.getStatus('localized', config, { trustMcpServerCommands: true });
+
+    expect(result.status).toBe('connected');
+  });
+
+  it('preserves partial Content-Length frame headers across stdout chunks', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation(() => {
+      const message = formatMcpMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          serverInfo: { name: 'chunked-test-server', version: '1.0.0' },
+        },
+      });
+      const headerSplit = message.indexOf('\r\n') + 2;
+      setTimeout(() => {
+        proc.stdout.emit('data', message.slice(0, headerSplit));
+        proc.stdout.emit('data', message.slice(headerSplit));
+      }, 10);
+      return true;
+    });
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+    const config: McpConfig = {
+      mcpServers: {
+        chunked: { command: 'node', args: ['server.js'] },
+      },
+    };
+
+    const result = await checker.getStatus('chunked', config, { trustMcpServerCommands: true });
+
+    expect(result.status).toBe('connected');
+  });
+
   it('returns unknown and cleans up when a trusted MCP server stays open without responding', async () => {
     vi.useFakeTimers();
     const { spawn } = await import('node:child_process');
@@ -158,10 +244,14 @@ describe('SkillHealthChecker', () => {
 });
 
 function makeMockProcess() {
+  const stdin = Object.assign(new EventEmitter(), {
+    write: vi.fn(),
+    end: vi.fn(),
+  });
   return Object.assign(new EventEmitter(), {
     stdout: new EventEmitter(),
     stderr: new EventEmitter(),
-    stdin: { write: vi.fn(), end: vi.fn() },
+    stdin,
     kill: vi.fn(function kill(this: { killed: boolean }) {
       this.killed = true;
     }),

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -196,6 +196,33 @@ describe('SkillHealthChecker', () => {
     expect(result.status).toBe('connected');
   });
 
+  it('returns error when a trusted MCP server rejects initialize then exits cleanly', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation(() => {
+      setTimeout(() => {
+        proc.stdout.emit('data', formatMcpMessage({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: -32602, message: 'Unsupported protocol version' },
+        }));
+        proc.exitCode = 0;
+        proc.emit('close', 0);
+      }, 10);
+      return true;
+    });
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+    const config: McpConfig = {
+      mcpServers: {
+        rejecting: { command: 'node', args: ['server.js'] },
+      },
+    };
+
+    const result = await checker.getStatus('rejecting', config, { trustMcpServerCommands: true });
+
+    expect(result.status).toBe('error');
+  });
+
   it('returns unknown and cleans up when a trusted MCP server stays open without responding', async () => {
     vi.useFakeTimers();
     const { spawn } = await import('node:child_process');

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -112,12 +112,14 @@ describe('SkillHealthChecker', () => {
     expect(proc.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('returns error instead of crashing when stdin rejects an initialize probe', async () => {
+  it('defers stdin EPIPE to the process close status', async () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();
     proc.stdin.write.mockImplementation(() => {
       setTimeout(() => {
         proc.stdin.emit('error', new Error('write EPIPE'));
+        proc.exitCode = 0;
+        proc.emit('close', 0);
       }, 10);
       return false;
     });
@@ -130,7 +132,7 @@ describe('SkillHealthChecker', () => {
 
     const result = await checker.getStatus('epipe', config, { trustMcpServerCommands: true });
 
-    expect(result.status).toBe('error');
+    expect(result.status).toBe('connected');
   });
 
   it('parses framed initialize responses by UTF-8 byte length', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { McpConfig } from '@franken/types';
 import { SkillHealthChecker } from '../../../src/skills/skill-health-checker.js';
 
@@ -12,9 +13,14 @@ vi.mock('node:child_process', async () => {
         stdin: { write: vi.fn(), end: vi.fn() },
         kill: vi.fn(),
         pid: 123,
+        exitCode: null,
+        killed: false,
       });
-      // Simulate process exiting successfully after 100ms
-      setTimeout(() => proc.emit('close', 0), 100);
+      // Simulate process exiting successfully after 100ms.
+      setTimeout(() => {
+        proc.exitCode = 0;
+        proc.emit('close', 0);
+      }, 100);
       return proc;
     }),
   };
@@ -25,6 +31,11 @@ describe('SkillHealthChecker', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('does not spawn manifest commands without explicit trust', async () => {
@@ -61,6 +72,64 @@ describe('SkillHealthChecker', () => {
     expect(result.serverStatuses).toHaveLength(1);
   });
 
+  it('returns connected when a long-running trusted MCP server responds to initialize', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation((message: string) => {
+      expect(message).toContain('Content-Length:');
+      expect(message).toContain('"method":"initialize"');
+      setTimeout(() => {
+        proc.stdout.emit('data', formatMcpMessage({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            serverInfo: { name: 'healthy-test-server', version: '1.0.0' },
+          },
+        }));
+      }, 10);
+      return true;
+    });
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+
+    const config: McpConfig = {
+      mcpServers: {
+        github: { command: 'node', args: ['server.js'] },
+      },
+    };
+
+    const result = await checker.getStatus('github', config, { trustMcpServerCommands: true });
+
+    expect(result.status).toBe('connected');
+    expect(result.serverStatuses).toEqual([
+      { serverName: 'github', status: 'connected' },
+    ]);
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns unknown and cleans up when a trusted MCP server stays open without responding', async () => {
+    vi.useFakeTimers();
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+    const config: McpConfig = {
+      mcpServers: {
+        silent: { command: 'node', args: ['silent-server.js'] },
+      },
+    };
+
+    const resultPromise = checker.getStatus('silent', config, { trustMcpServerCommands: true });
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await resultPromise;
+
+    expect(result.status).toBe('unknown');
+    expect(result.serverStatuses).toEqual([
+      { serverName: 'silent', status: 'unknown' },
+    ]);
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+  });
+
   it('handles multiple trusted servers', async () => {
     const config: McpConfig = {
       mcpServers: {
@@ -74,14 +143,8 @@ describe('SkillHealthChecker', () => {
 
   it('returns error when trusted spawn fails', async () => {
     const { spawn } = await import('node:child_process');
-    const { EventEmitter } = await import('node:events');
+    const proc = makeMockProcess();
     (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
-      const proc = Object.assign(new EventEmitter(), {
-        stdout: new EventEmitter(),
-        stderr: new EventEmitter(),
-        stdin: { write: vi.fn(), end: vi.fn() },
-        kill: vi.fn(),
-      });
       setTimeout(() => proc.emit('error', new Error('not found')), 10);
       return proc;
     });
@@ -93,3 +156,22 @@ describe('SkillHealthChecker', () => {
     expect(result.status).toBe('error');
   });
 });
+
+function makeMockProcess() {
+  return Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: { write: vi.fn(), end: vi.fn() },
+    kill: vi.fn(function kill(this: { killed: boolean }) {
+      this.killed = true;
+    }),
+    pid: 123,
+    exitCode: null as number | null,
+    killed: false,
+  });
+}
+
+function formatMcpMessage(message: unknown): string {
+  const body = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
+}

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -61,4 +61,4 @@
 - Validate stop and restart target IDs through `filterNetworkServices` before invoking supervisor operations, so unknown names fail fast with 400 instead of becoming no-op successes. Keep this as a shared pattern for all service-targeted control-plane endpoints where missing resources must be surfaced as client errors.
 
 ## 2026-07-10 — MCP stdio health probes
-- MCP stdio probes need stream-level `stdin` error handlers that defer EPIPE to the process close/timeout path, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for clean-exit EPIPE races, non-ASCII framed JSON bodies, and split `Content-Length` headers before retriggering Codex.
+- MCP stdio probes need stream-level `stdin` error handlers that defer EPIPE to the process close/timeout path, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for clean-exit EPIPE races, explicit initialize error responses before close(0), non-ASCII framed JSON bodies, and split `Content-Length` headers before retriggering Codex.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -62,3 +62,4 @@
 
 ## 2026-07-10 — MCP stdio health probes
 - MCP stdio probes need stream-level `stdin` error handlers that defer EPIPE to the process close/timeout path, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for clean-exit EPIPE races, explicit initialize error responses before close(0), non-ASCII framed JSON bodies, and split `Content-Length` headers before retriggering Codex.
+- For SDK-backed stdio MCP servers, send newline-delimited JSON initialize requests while still accepting framed responses; on explicit initialize error responses, kill the still-running probe child instead of treating generic error status as a reason to skip cleanup.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -59,3 +59,6 @@
 
 ## 2026-07-10 — Network stop/restart target validation
 - Validate stop and restart target IDs through `filterNetworkServices` before invoking supervisor operations, so unknown names fail fast with 400 instead of becoming no-op successes. Keep this as a shared pattern for all service-targeted control-plane endpoints where missing resources must be surfaced as client errors.
+
+## 2026-07-10 — MCP stdio health probes
+- MCP stdio probes need stream-level `stdin` error handling for early-exiting commands, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for non-ASCII framed JSON bodies and split `Content-Length` headers before retriggering Codex.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -61,4 +61,4 @@
 - Validate stop and restart target IDs through `filterNetworkServices` before invoking supervisor operations, so unknown names fail fast with 400 instead of becoming no-op successes. Keep this as a shared pattern for all service-targeted control-plane endpoints where missing resources must be surfaced as client errors.
 
 ## 2026-07-10 — MCP stdio health probes
-- MCP stdio probes need stream-level `stdin` error handling for early-exiting commands, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for non-ASCII framed JSON bodies and split `Content-Length` headers before retriggering Codex.
+- MCP stdio probes need stream-level `stdin` error handlers that defer EPIPE to the process close/timeout path, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for clean-exit EPIPE races, non-ASCII framed JSON bodies, and split `Content-Length` headers before retriggering Codex.


### PR DESCRIPTION
## Summary
- send a minimal MCP initialize probe during trusted skill health checks instead of waiting only for process exit
- parse MCP stdio Content-Length frames/newline JSON responses and treat a valid initialize response as connected
- keep timeout/nonzero/error paths cleaned up and covered by targeted regressions

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- tests/unit/skills/skill-health-checker.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator -- src/skills/skill-health-checker.ts tests/unit/skills/skill-health-checker.test.ts (passes with pre-existing warnings)
- npm run build --workspace @franken/orchestrator

Closes #1133