### PR TITLE
docs(observer): avoid I/O in W3CTraceContext examples

### DIFF
--- a/packages/franken-observer/src/propagation/W3CTraceContext.ts
+++ b/packages/franken-observer/src/propagation/W3CTraceContext.ts
@@ -45,7 +45,10 @@ const ZEROS_16  = '0'.repeat(16)
  *
  * ```ts
  * const ctx = parseTraceparent(req.headers['traceparent'])
- * if (ctx) process.stdout.write(`${ctx.traceId} ${ctx.sampled}\n`)
+ * if (ctx) {
+ *   const { traceId, sampled } = ctx
+ *   // use `traceId`/`sampled` when wiring a child span
+ * }
  * ```
  */
 export function parseTraceparent(header: string | null | undefined): TraceparentFields | null {
@@ -101,7 +104,10 @@ export function formatTraceparent(fields: TraceparentFields): string {
  *
  * ```ts
  * const state = parseTracestate(req.headers['tracestate'])
- * process.stdout.write(state['vendor-name'])
+ * const vendor = state['vendor-name']
+ * if (vendor) {
+ *   // use vendor value in propagation headers
+ * }
  * ```
  */
 export function parseTracestate(header: string | null | undefined): Record<string, string> {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-10 — Codex usage limits in review loop
+- If `@codex review` immediately returns usage-limit comments, classify the review state as blocked/review unavailable for this round and avoid further triggers. Re-run only after credits/enablement is restored, and prefer a short-lived monitor rather than repeated immediate retries.
+
 ## 2026-07-10 — Observer replay timestamp validation
 - Replay-time timestamp guards should mirror persisted audit-event validation, not just check finite `Date` values. JavaScript accepts parseable malformed values such as impossible dates and date-only strings, so add round-trip ISO instant regressions (`new Date(Date.parse(ts)).toISOString() === ts`) before relying on replay durations.
 


### PR DESCRIPTION
## Summary
- Remove I/O calls from  JSDoc examples so propagation examples do not include runtime side effects.
- Keeps behavior unchanged; only documentation usage examples were updated.

## Test Plan
- [x] npm run test --workspace @franken/observer

Closes #1193