### PR TITLE
fix(orchestrator): return 400 for malformed JSON in control-plane routes

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -3,6 +3,7 @@ import { ZodError } from 'zod';
 import type { SkillManager } from '../../skills/skill-manager.js';
 import { SkillHealthChecker } from '../../skills/skill-health-checker.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
+import { HttpError, parseJsonBody } from '../middleware.js';
 
 function isSkillInstallValidationError(err: unknown): boolean {
   return err instanceof ZodError
@@ -72,7 +73,15 @@ export function createSkillRoutes(deps: {
   });
 
   app.post('/', async (c) => {
-    const body = (await c.req.json()) as Record<string, unknown>;
+    let body: Record<string, unknown>;
+    try {
+      body = (await parseJsonBody(c)) as Record<string, unknown>;
+    } catch (err) {
+      if (err instanceof HttpError && err.statusCode === 400) {
+        return c.json({ error: 'Invalid JSON' }, 400);
+      }
+      throw err;
+    }
 
     try {
       if (body['catalogEntry']) {
@@ -100,7 +109,15 @@ export function createSkillRoutes(deps: {
 
   app.patch('/:name', async (c) => {
     const name = c.req.param('name');
-    const body = (await c.req.json()) as { enabled?: boolean };
+    let body: { enabled?: boolean };
+    try {
+      body = (await parseJsonBody(c)) as { enabled?: boolean };
+    } catch (err) {
+      if (err instanceof HttpError && err.statusCode === 400) {
+        return c.json({ error: 'Invalid JSON' }, 400);
+      }
+      throw err;
+    }
 
     try {
       if (body.enabled === true) {
@@ -139,7 +156,15 @@ export function createSkillRoutes(deps: {
 
   app.put('/:name/context', async (c) => {
     const name = c.req.param('name');
-    const body = (await c.req.json()) as { content: string };
+    let body: { content: string };
+    try {
+      body = (await parseJsonBody(c)) as { content: string };
+    } catch (err) {
+      if (err instanceof HttpError && err.statusCode === 400) {
+        return c.json({ error: 'Invalid JSON' }, 400);
+      }
+      throw err;
+    }
     try {
       deps.skillManager.writeContext(name, body.content);
       return c.json({ updated: true });

--- a/packages/franken-orchestrator/tests/integration/security/security-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/security/security-routes.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { createSecurityRoutes } from '../../../src/http/routes/security-routes.js';
+import { PROFILE_DEFAULTS, type SecurityConfig, resolveSecurityConfig } from '../../../src/middleware/security-profiles.js';
+
+describe('security routes', () => {
+  it('returns 400 for malformed JSON payload', async () => {
+    let current = { ...PROFILE_DEFAULTS.standard } as SecurityConfig;
+
+    const app = new Hono();
+    app.route('/api/security', createSecurityRoutes({
+      getSecurityConfig: () => current,
+      setSecurityConfig: (config) => {
+        current = { ...current, ...config };
+      },
+    }));
+
+    const res = await app.request('/api/security', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid JSON' });
+    expect(current).toEqual(resolveSecurityConfig(current.profile));
+  });
+});

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -178,6 +178,22 @@ describe('Skill API routes', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it('returns 400 for malformed JSON payload', async () => {
+      const installSpy = vi.spyOn(manager, 'install');
+      const customSpy = vi.spyOn(manager, 'installCustom');
+
+      const res = await app.request('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{',
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Invalid JSON' });
+      expect(installSpy).not.toHaveBeenCalled();
+      expect(customSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/skills/:name/health', () => {
@@ -281,6 +297,26 @@ describe('Skill API routes', () => {
       const body = await res.json();
       expect(body.error).toBeTruthy();
     });
+
+    it('returns 400 for malformed JSON payload', async () => {
+      await manager.install({
+        name: 'github', description: 'GH', provider: 'cli',
+        installConfig: { command: 'npx' }, authFields: [],
+      });
+      const disableSpy = vi.spyOn(manager, 'disable');
+      const enableSpy = vi.spyOn(manager, 'enable');
+
+      const res = await app.request('/api/skills/github', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{',
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Invalid JSON' });
+      expect(disableSpy).not.toHaveBeenCalled();
+      expect(enableSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('DELETE /api/skills/:name', () => {
@@ -322,6 +358,24 @@ describe('Skill API routes', () => {
       const body = await res.json();
       expect(body.exists).toBe(true);
       expect(body.content).toContain('Always lint first');
+    });
+
+    it('returns 400 for malformed JSON payload', async () => {
+      await manager.install({
+        name: 'github', description: 'GH', provider: 'cli',
+        installConfig: { command: 'npx' }, authFields: [],
+      });
+      const writeContextSpy = vi.spyOn(manager, 'writeContext');
+
+      const res = await app.request('/api/skills/github/context', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{',
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Invalid JSON' });
+      expect(writeContextSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -164,6 +164,21 @@ describe('commsRoutes', () => {
     await expect(external.json()).resolves.toMatchObject({ error: { code: 'FORBIDDEN' } });
   });
 
+  it('rejects malformed generic comms inbound JSON before parsing', async () => {
+    const runtime = mockRuntime();
+    const app = commsRoutes({ config: minimalConfig(), runtime });
+
+    const res = await app.request('/v1/comms/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: { code: 'MALFORMED_JSON' } });
+    expect(runtime.processInbound).not.toHaveBeenCalled();
+  });
+
   it('rejects malformed generic comms inbound payloads before invoking the runtime', async () => {
     const runtime = mockRuntime();
     const app = commsRoutes({ config: minimalConfig(), runtime });

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -4,6 +4,9 @@
 - For Vitest suite-flag fixes, assert false-like env values (`0`, `false`, `no`, blank) preserve the default unit-test include set in package configs, not just helper return values.
 - In Vitest tests, avoid cache-busting variable dynamic imports such as `import(`../vitest.config.ts?case=${...}`)`: Vite cannot statically analyze them. Use a static config import and reset env/argv around each assertion instead.
 
+## 2026-07-10 — Control-plane JSON parse hardening
+- In control-plane mutation routes, prefer centralized JSON parsing helpers (`parseJsonBody`) and explicit malformed-body tests; this prevents runtime 500s and keeps manager/runtime calls from running on bad input.
+
 ## 2026-07-10 — Codex usage-limit handling in issue-to-PR flow
 - If `@codex review` immediately responds with usage-limit, treat it as a hard blocker for the merge gate and stop extra polling. Resume review only after credits are restored and a fresh trigger can produce a current-head clean response.
 
@@ -35,7 +38,7 @@
 - Add a dedicated helper in tests when a fire-and-forget integration must assert non-delivery; this keeps suites stable even if internals switch from direct emits to queued microtasks.
 
 ## 2026-07-10 — Parallel planner deadlock guard
-
+- In ParallelPlanner execution, don't allow the "no tasks ready" path to continue silently as success. Keep cycle checks explicit and fail fast with a clear `CyclicDependencyError` (or similar) before running task waves, and add a unit test that proves executor is never called when readiness stalls due to a dependency cycle.
 - When `@codex review` is usage-limited, classify it as a blocker state and do not merge until a new trigger can produce a current-head clean response.
 
 ## 2026-07-10 — ProcessSupervisor runtime error cleanup


### PR DESCRIPTION
## Summary
- Return HTTP 400 for malformed JSON payloads in control-plane routes before reaching downstream handlers.
- Added regression tests for skill, security, and comms malformed-payload handling.

## Test Plan
- [x] npm run test -- tests/integration/skills/skill-routes.test.ts tests/unit/http/comms-routes.test.ts tests/integration/security/security-routes.test.ts
- [ ] Full package typecheck/build (monorepo workspace resolution still pending in this environment)

Closes #1129