### PR TITLE
test(critique): add real worker-timeout regression

### DIFF
--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -25,14 +25,39 @@ interface RegexPrefixExpansion {
   truncated: boolean;
 }
 
+type RegexWorkerFactory = {
+  (pattern: string, content: string): Worker;
+};
+
 export class SafetyEvaluator implements Evaluator {
   readonly name = 'safety';
   readonly category = 'deterministic' as const;
 
   private readonly guardrails: GuardrailsPort;
+  private readonly createRegexWorker: RegexWorkerFactory;
 
-  constructor(guardrails: GuardrailsPort) {
+  constructor(
+    guardrails: GuardrailsPort,
+    options?: {
+      createRegexWorker?: RegexWorkerFactory;
+    },
+  ) {
     this.guardrails = guardrails;
+    this.createRegexWorker =
+      options?.createRegexWorker ??
+      ((pattern, content) =>
+        new Worker(
+          `
+        import { parentPort, workerData } from 'node:worker_threads';
+        try {
+          const regex = new RegExp(workerData.pattern, 'g');
+          parentPort.postMessage({ matches: regex.test(workerData.content) });
+        } catch (error) {
+          parentPort.postMessage({ error: error instanceof Error ? error.message : String(error) });
+        }
+      `,
+          { eval: true, workerData: { pattern, content } },
+        ));
   }
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
@@ -95,18 +120,7 @@ export class SafetyEvaluator implements Evaluator {
     pattern: string,
     content: string,
   ): Promise<boolean | 'timeout'> {
-    const worker = new Worker(
-      `
-        import { parentPort, workerData } from 'node:worker_threads';
-        try {
-          const regex = new RegExp(workerData.pattern, 'g');
-          parentPort.postMessage({ matches: regex.test(workerData.content) });
-        } catch (error) {
-          parentPort.postMessage({ error: error instanceof Error ? error.message : String(error) });
-        }
-      `,
-      { eval: true, workerData: { pattern, content } },
-    );
+    const worker = this.createRegexWorker(pattern, content);
 
     return new Promise<boolean | 'timeout'>((resolve, reject) => {
       let settled = false;

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -45,7 +45,7 @@ export class SafetyEvaluator implements Evaluator {
     this.guardrails = guardrails;
     this.createRegexWorker =
       options?.createRegexWorker ??
-      ((pattern, content) =>
+      ((pattern, content): Worker =>
         new Worker(
           `
         import { parentPort, workerData } from 'node:worker_threads';

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -154,6 +154,54 @@ describe('SafetyEvaluator', () => {
     ]);
   });
 
+  it('surfaces timeout findings from evaluate when worker evaluation exceeds timeout', async () => {
+    const hangingWorker = {
+      once: vi.fn(),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const createRegexWorker = vi.fn(() => hangingWorker);
+    const evaluator = new SafetyEvaluator(
+      createMockGuardrailsPort([
+        {
+          id: 'slow-warn-real-path',
+          description: 'slow worker path',
+          pattern: 'safe-pattern',
+          severity: 'warn',
+        },
+      ]),
+      {
+        createRegexWorker,
+      },
+    );
+    const timeoutMs = (
+      evaluator as unknown as {
+        regexEvaluationTimeoutMs(contentLength: number): number;
+      }
+    ).regexEvaluationTimeoutMs('large review payload'.length);
+
+    vi.useFakeTimers();
+    try {
+      const resultPromise = evaluator.evaluate(createInput('large review payload'));
+      await vi.advanceTimersByTimeAsync(timeoutMs);
+
+      const result = await resultPromise;
+
+      expect(createRegexWorker).toHaveBeenCalledTimes(1);
+      expect(hangingWorker.once).toHaveBeenCalledTimes(2);
+      expect(hangingWorker.terminate).toHaveBeenCalledTimes(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.findings).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining('Safety rule regex evaluation timed out'),
+          severity: 'warning',
+        }),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('scales runtime regex timeout budget with input size', () => {
     const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
       regexEvaluationTimeoutMs(contentLength: number): number;


### PR DESCRIPTION
## Summary
- Add injectable worker factory seam in SafetyEvaluator for deterministic timeout-path testing.
- Add a regression test that exercises timeout behavior through evaluate() without stubbing regexMatchesWithTimeout.
- Keep static regex prevalidation unchanged while validating worker cleanup on timeout.

Closes #1124