### PR TITLE
fix(orchestrator): guard CLI provider spawns against startup failures

### DIFF
--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -56,6 +56,11 @@ export class ClaudeCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
+    let spawnState: { message: string | undefined } = { message: undefined };
+    proc.once('error', (error) => {
+      spawnState.message = error.message;
+    });
+
     const userContent = request.messages
       .map((m) =>
         typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
@@ -64,7 +69,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
     proc.stdin!.write(userContent);
     proc.stdin!.end();
 
-    yield* this.parseStream(proc);
+    yield* this.parseStream(proc, spawnState);
   }
 
   formatHandoff(snapshot: BrainSnapshot): string {
@@ -140,8 +145,14 @@ export class ClaudeCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
+    spawnState: { message: string | undefined },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
+    proc.once('error', () => {
+      if (!rl.closed) {
+        rl.close();
+      }
+    });
     let currentToolUse: { id: string; name: string; inputJson: string } | null =
       null;
     let totalInputTokens = 0;
@@ -329,10 +340,19 @@ export class ClaudeCliAdapter implements ILlmProvider {
         }
       }
 
-      // If process exited without message_stop, check exit code
+      // If process exited without message_stop, check spawn/exit status
       const exitCode = await new Promise<number | null>((resolve) => {
         proc.on('close', resolve);
       });
+      if (spawnState.message) {
+        streamCompleted = true;
+        yield {
+          type: 'error',
+          error: `claude process failed to start: ${spawnState.message}`,
+          retryable: false,
+        };
+        return;
+      }
       if (exitCode !== 0) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -56,7 +56,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    let spawnState: { message: string | undefined } = { message: undefined };
+    const spawnState: { message: string | undefined } = { message: undefined };
     proc.once('error', (error) => {
       spawnState.message = error.message;
     });
@@ -149,9 +149,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
     proc.once('error', () => {
-      if (!rl.closed) {
-        rl.close();
-      }
+      rl.close();
     });
     let currentToolUse: { id: string; name: string; inputJson: string } | null =
       null;

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -53,6 +53,11 @@ export class CodexCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
+    const spawnState: { message: string | undefined } = { message: undefined };
+    proc.once('error', (error) => {
+      spawnState.message = error.message;
+    });
+
     const userContent = request.messages
       .map((m) =>
         typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
@@ -61,7 +66,7 @@ export class CodexCliAdapter implements ILlmProvider {
     proc.stdin!.write(userContent);
     proc.stdin!.end();
 
-    yield* this.parseStream(proc);
+    yield* this.parseStream(proc, spawnState);
   }
 
   formatHandoff(snapshot: BrainSnapshot): string {
@@ -127,8 +132,14 @@ export class CodexCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
+    spawnState: { message: string | undefined },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
+    proc.once('error', () => {
+      if (!rl.closed) {
+        rl.close();
+      }
+    });
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let streamCompleted = false;
@@ -185,10 +196,19 @@ export class CodexCliAdapter implements ILlmProvider {
         }
       }
 
-      // Stream ended without a done/error frame — check exit code
+      // Stream ended without a done/error frame — check spawn/exit status
       const exitCode = await new Promise<number | null>((resolve) => {
         proc.on('close', resolve);
       });
+      if (spawnState.message) {
+        streamCompleted = true;
+        yield {
+          type: 'error',
+          error: `codex process failed to start: ${spawnState.message}`,
+          retryable: false,
+        };
+        return;
+      }
       if (exitCode !== 0 && exitCode !== null) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -136,9 +136,7 @@ export class CodexCliAdapter implements ILlmProvider {
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
     proc.once('error', () => {
-      if (!rl.closed) {
-        rl.close();
-      }
+      rl.close();
     });
     let totalInputTokens = 0;
     let totalOutputTokens = 0;

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -503,9 +503,7 @@ export class GeminiCliAdapter implements ILlmProvider {
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
     proc.once('error', () => {
-      if (!rl.closed) {
-        rl.close();
-      }
+      rl.close();
     });
     let totalInputTokens = 0;
     let totalOutputTokens = 0;

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -90,6 +90,11 @@ export class GeminiCliAdapter implements ILlmProvider {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
+      const spawnState: { message: string | undefined } = { message: undefined };
+      proc.once('error', (error) => {
+        spawnState.message = error.message;
+      });
+
       const userContent = request.messages
         .map((m) =>
           typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
@@ -98,7 +103,7 @@ export class GeminiCliAdapter implements ILlmProvider {
       proc.stdin!.write(userContent);
       proc.stdin!.end();
 
-      yield* this.parseStream(proc);
+      yield* this.parseStream(proc, spawnState);
     } finally {
       if (managedContextFileName) this.removeManagedGeminiMd(contextWorkingDir, managedContextFileName);
       rmSync(contextWorkingDir, { recursive: true, force: true });
@@ -494,8 +499,14 @@ export class GeminiCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
+    spawnState: { message: string | undefined },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
+    proc.once('error', () => {
+      if (!rl.closed) {
+        rl.close();
+      }
+    });
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let emittedText = false;
@@ -683,6 +694,15 @@ export class GeminiCliAdapter implements ILlmProvider {
       const exitCode = await new Promise<number | null>((resolve) => {
         proc.on('close', resolve);
       });
+      if (spawnState.message) {
+        streamCompleted = true;
+        yield {
+          type: 'error',
+          error: `gemini process failed to start: ${spawnState.message}`,
+          retryable: false,
+        };
+        return;
+      }
       if (exitCode !== 0 && exitCode !== null) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -38,6 +38,32 @@ function mockSpawn(stdoutLines: string[], exitCode = 0) {
   return proc;
 }
 
+function mockSpawnError(errorMessage = 'spawn command not found') {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1234,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
+  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+
+  setImmediate(() => {
+    proc.emit('error', Object.assign(new Error(errorMessage), { code: 'ENOENT' }));
+    setImmediate(() => {
+      stdout.end();
+      proc.exitCode = 127;
+      proc.emit('close', 127);
+    });
+  });
+
+  return proc;
+}
+
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
   const events: LlmStreamEvent[] = [];
   for await (const e of iterable) events.push(e);
@@ -134,6 +160,19 @@ describe('ClaudeCliAdapter', () => {
   });
 
   describe('execute()', () => {
+    it('handles spawn failure errors without leaking unhandled events', async () => {
+      const proc = mockSpawnError('claude: command not found');
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'error',
+        error: expect.stringContaining('claude process failed to start: claude: command not found'),
+        retryable: false,
+      });
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
     it('parses text stream events', async () => {
       mockSpawn([
         JSON.stringify({ type: 'message_start', message: { usage: { input_tokens: 50 } } }),

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -33,6 +33,30 @@ function mockSpawn(stdoutLines: string[], exitCode = 0) {
   return proc;
 }
 
+function mockSpawnError(errorMessage = 'spawn command not found') {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
+  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+  setImmediate(() => {
+    proc.emit('error', Object.assign(new Error(errorMessage), { code: 'ENOENT' }));
+    setImmediate(() => {
+      stdout.end();
+      proc.exitCode = 127;
+      proc.emit('close', 127);
+    });
+  });
+  return proc;
+}
+
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
   const events: LlmStreamEvent[] = [];
   for await (const e of iterable) events.push(e);
@@ -102,6 +126,19 @@ describe('CodexCliAdapter', () => {
       const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
       expect(events[0]).toEqual({ type: 'text', content: 'Hello from Codex' });
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 80, outputTokens: 20, totalTokens: 100 } });
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('handles spawn failure errors without leaking unhandled events', async () => {
+      const proc = mockSpawnError('codex: command not found');
+      const events = await collectEvents(adapter.execute({ systemPrompt: '', messages: [{ role: 'user', content: 'Hi' }] }));
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'error',
+        error: expect.stringContaining('codex process failed to start: codex: command not found'),
+        retryable: false,
+      });
       expect(proc.kill).not.toHaveBeenCalled();
     });
 

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -35,6 +35,30 @@ function mockSpawn(stdoutLines: string[], exitCode = 0) {
   return proc;
 }
 
+function mockSpawnError(errorMessage = 'spawn command not found') {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
+  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+  setImmediate(() => {
+    proc.emit('error', Object.assign(new Error(errorMessage), { code: 'ENOENT' }));
+    setImmediate(() => {
+      stdout.end();
+      proc.exitCode = 127;
+      proc.emit('close', 127);
+    });
+  });
+  return proc;
+}
+
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
   const events: LlmStreamEvent[] = [];
   for await (const e of iterable) events.push(e);
@@ -234,6 +258,19 @@ describe('GeminiCliAdapter', () => {
   });
 
   describe('execute()', () => {
+    it('handles spawn failure errors without leaking unhandled events', async () => {
+      const proc = mockSpawnError('gemini: command not found');
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [{ role: 'user', content: 'Hi' }] }));
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'error',
+        error: expect.stringContaining('gemini process failed to start: gemini: command not found'),
+        retryable: false,
+      });
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
     it('parses stream-json text events', async () => {
       mockSpawn([
         JSON.stringify({ type: 'message_start', message: { usage: { input_tokens: 30 } } }),


### PR DESCRIPTION
## Summary
- Add spawn-failure error handling to all orchestrator CLI provider adapters that spawn external processes (Claude/Codex/Gemini).
- Capture spawn errors via `error` listeners, propagate a structured adapter error event, and avoid force-killing when spawn fails.
- Close readline loops on spawn error to prevent hanging stream consumption.
- Extend unit tests for spawn-failure behavior in all three providers.

## Testing
- npm run test -- --run tests/unit/providers/claude-cli-adapter.test.ts tests/unit/providers/codex-cli-adapter.test.ts tests/unit/providers/gemini-cli-adapter.test.ts
- npm run test -- --run tests/unit/beasts/execution/process-supervisor.test.ts

Closes #1112
