### PR TITLE
fix(web): keep ActivityPane from crashing on unserializable runtime event data

### DIFF
--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -169,6 +169,39 @@ function viewModelForActivity(event: ActivityEvent): ActivityViewModel {
   };
 }
 
+const UNABLE_TO_STRINGIFY_EVENT_DATA = '[unserializable event data]';
+
+function formatEventData(data: Record<string, unknown>): string {
+  const seen = new WeakSet<object>();
+  const replacer = (_key: string, value: unknown): unknown => {
+    if (typeof value === 'bigint') {
+      return `BigInt(${value.toString()})`;
+    }
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+
+  try {
+    return JSON.stringify(data, replacer, 2);
+  } catch {
+    return UNABLE_TO_STRINGIFY_EVENT_DATA;
+  }
+}
+
+function safeEventDataSummary(data: Record<string, unknown>): string {
+  const serialized = formatEventData(data);
+  if (serialized === UNABLE_TO_STRINGIFY_EVENT_DATA) {
+    return UNABLE_TO_STRINGIFY_EVENT_DATA;
+  }
+
+  return serialized;
+}
+
 export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
   const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll<HTMLOListElement, HTMLLIElement>(
     events.length,
@@ -210,7 +243,7 @@ export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
               )}
               <details className="activity-event__details">
                 <summary>Raw event details</summary>
-                <pre>{JSON.stringify(event.data ?? {}, null, 2)}</pre>
+                <pre>{safeEventDataSummary(event.data ?? {})}</pre>
               </details>
             </li>
           );

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -172,16 +172,19 @@ function viewModelForActivity(event: ActivityEvent): ActivityViewModel {
 const UNABLE_TO_STRINGIFY_EVENT_DATA = '[unserializable event data]';
 
 function formatEventData(data: Record<string, unknown>): string {
-  const seen = new WeakSet<object>();
-  const replacer = (_key: string, value: unknown): unknown => {
+  const ancestors: object[] = [];
+  const replacer = function (this: unknown, _key: string, value: unknown): unknown {
     if (typeof value === 'bigint') {
       return `BigInt(${value.toString()})`;
     }
     if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) {
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop();
+      }
+      if (ancestors.includes(value)) {
         return '[Circular]';
       }
-      seen.add(value);
+      ancestors.push(value);
     }
     return value;
   };

--- a/packages/franken-web/tests/components/activity-pane.test.tsx
+++ b/packages/franken-web/tests/components/activity-pane.test.tsx
@@ -61,4 +61,23 @@ describe('ActivityPane', () => {
 
     expect(screen.getByText((text) => text.includes('BigInt(12)'))).toBeTruthy();
   });
+
+  it('does not mark repeated sibling references as circular', () => {
+    const shared = { message: 'shared runtime payload' };
+    const events: ActivityEvent[] = [
+      {
+        type: 'turn.execution.start',
+        data: {
+          first: shared,
+          second: shared,
+        },
+        timestamp: '2026-07-10T13:00:00.000Z',
+      },
+    ];
+
+    render(<ActivityPane events={events} />);
+
+    expect(screen.getByText((text) => text.includes('"first"') && text.includes('"second"'))).toBeTruthy();
+    expect(screen.queryByText((text) => text.includes('[Circular]'))).toBeNull();
+  });
 });

--- a/packages/franken-web/tests/components/activity-pane.test.tsx
+++ b/packages/franken-web/tests/components/activity-pane.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { ActivityPane } from '../../src/components/activity-pane';
+import type { ActivityEvent } from '../../src/hooks/use-chat-session';
+
+afterEach(cleanup);
+
+describe('ActivityPane', () => {
+  it('renders circular event payloads with explicit circular markers', () => {
+    const circular: Record<string, unknown> = { message: 'circular runtime payload' };
+    circular.self = circular;
+
+    const events: ActivityEvent[] = [
+      {
+        type: 'turn.execution.start',
+        data: circular,
+        timestamp: '2026-07-10T10:00:00.000Z',
+      },
+    ];
+
+    render(<ActivityPane events={events} />);
+
+    expect(screen.getByText('Raw event details')).toBeTruthy();
+    expect(screen.getByText((text) => text.includes('[Circular]'))).toBeTruthy();
+  });
+
+  it('falls back to an explicit message when event data cannot be stringified', () => {
+    const badJson = {
+      message: 'cannot stringify',
+      toJSON: () => {
+        throw new Error('serialize error');
+      },
+    };
+
+    const events: ActivityEvent[] = [
+      {
+        type: 'turn.execution.start',
+        data: badJson as unknown as Record<string, unknown>,
+        timestamp: '2026-07-10T12:00:00.000Z',
+      },
+    ];
+
+    render(<ActivityPane events={events} />);
+
+    expect(screen.getByText('[unserializable event data]')).toBeTruthy();
+  });
+
+  it('renders bigint event values with a clear string representation', () => {
+    const events: ActivityEvent[] = [
+      {
+        type: 'turn.execution.complete',
+        data: {
+          summary: 'execution complete',
+          messageCount: 12n,
+        },
+        timestamp: '2026-07-10T11:00:00.000Z',
+      },
+    ];
+
+    render(<ActivityPane events={events} />);
+
+    expect(screen.getByText((text) => text.includes('BigInt(12)'))).toBeTruthy();
+  });
+});

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -8,6 +8,9 @@
 ## 2026-07-10 — Codex usage limits in review loop
 - If `@codex review` immediately returns usage-limit comments, classify the review state as blocked/review unavailable for this round and avoid further triggers. Re-run only after credits/enablement is restored, and prefer a short-lived monitor rather than repeated immediate retries.
 
+## 2026-07-10 — Activity pane runtime event serialization safety
+- Render failures from runtime events should never take down the Activity pane. When an event payload is shown in UI, pass it through a tiny safe formatter before `JSON.stringify` so `BigInt`/circular/toJSON-throwing values render deterministically (or a clear fallback) instead of crashing the chat shell.
+
 ## 2026-07-10 — Observer replay timestamp validation
 - Replay-time timestamp guards should mirror persisted audit-event validation, not just check finite `Date` values. JavaScript accepts parseable malformed values such as impossible dates and date-only strings, so add round-trip ISO instant guards (`new Date(Date.parse(ts)).toISOString() === ts`) before relying on replay durations.
 


### PR DESCRIPTION
## Summary
- Added a safe formatter in ActivityPane for runtime event payload rendering to prevent render-time JSON exceptions.
- Added serialization fallbacks for unsupported values and explicit handling for BigInt and circular references.
- Added regression tests covering circular payloads, toJSON-throwing payloads, and BigInt rendering.

## Testing
- npm --prefix packages/franken-web run test -- tests/components/activity-pane.test.tsx
- npm --prefix packages/franken-web run test -- tests/components/chat-shell.test.tsx

Closes #1111