### PR TITLE
fix(planner): sync task dependsOn during graph mutations

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -145,7 +145,7 @@ export class PlanGraph {
       }
     }
     const newNodes = new Map(this._nodes);
-    newNodes.set(task.id, task);
+    newNodes.set(task.id, { ...task, dependsOn: [...dependsOn] });
     const newEdges = new Map(this._edges);
     newEdges.set(task.id, new Set(dependsOn));
     return new PlanGraph(newNodes, newEdges, this.version, this.reason);
@@ -163,6 +163,10 @@ export class PlanGraph {
       const cleaned = new Set(deps);
       cleaned.delete(taskId);
       newEdges.set(id, cleaned);
+      const task = newNodes.get(id);
+      if (task) {
+        newNodes.set(id, { ...task, dependsOn: [...cleaned] });
+      }
     }
     return new PlanGraph(newNodes, newEdges, this.version, this.reason);
   }

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -61,6 +61,17 @@ describe('PlanGraph — construction', () => {
     expect(g.getDependencies(createTaskId('b'))).toContain(createTaskId('a'));
   });
 
+  it('addTask synchronizes the stored task dependsOn with declared deps', () => {
+    const b = makeTask('b');
+    const g = PlanGraph.empty().addTask(makeTask('a')).addTask(b, [createTaskId('a')]);
+
+    expect(g.getTask(createTaskId('b'))?.dependsOn).toEqual([createTaskId('a')]);
+    expect(g.getTasks().find((task) => task.id === createTaskId('b'))?.dependsOn).toEqual([
+      createTaskId('a'),
+    ]);
+    expect(b.dependsOn).toEqual([]);
+  });
+
   it('getTasks returns all tasks in insertion order', () => {
     const [a, b] = [makeTask('a'), makeTask('b')];
     const g = PlanGraph.empty().addTask(a).addTask(b);
@@ -90,7 +101,7 @@ describe('PlanGraph — topoSort', () => {
       .addTask(c, [createTaskId('b')]);
     const sorted = g.topoSort();
     expect(sorted[0]).toEqual(a);
-    expect(sorted[2]).toEqual(c);
+    expect(sorted[2]?.id).toBe(c.id);
     expect(sorted).toHaveLength(3);
   });
 
@@ -106,7 +117,7 @@ describe('PlanGraph — topoSort', () => {
       .addTask(d, [createTaskId('b'), createTaskId('c')]);
     const sorted = g.topoSort();
     expect(sorted[0]).toEqual(a);
-    expect(sorted[3]).toEqual(d);
+    expect(sorted[3]?.id).toBe(d.id);
   });
 
   it('two independent tasks both appear in result', () => {
@@ -215,6 +226,17 @@ describe('PlanGraph — removeTask', () => {
       .addTask(makeTask('b'), [createTaskId('a')]);
     const g2 = g.removeTask(createTaskId('a'));
     expect(g2.getDependencies(createTaskId('b'))).toEqual([]);
+  });
+
+  it('synchronizes stored task dependsOn after stripping a removed dependency', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+    const g2 = g.removeTask(createTaskId('a'));
+
+    expect(g2.getTask(createTaskId('b'))?.dependsOn).toEqual([]);
+    expect(g2.getTasks()).toEqual([makeTask('b')]);
+    expect(g.getTask(createTaskId('b'))?.dependsOn).toEqual([createTaskId('a')]);
   });
 
   it('throws TaskNotFoundError for unknown id', () => {


### PR DESCRIPTION
## Summary
- Sync stored Task.dependsOn values when PlanGraph.addTask receives explicit dependencies
- Sync remaining stored Task.dependsOn values after PlanGraph.removeTask strips a removed dependency
- Add regression coverage for direct task-object readers staying aligned with edge maps

## Test Plan
- npm --prefix packages/franken-planner test -- tests/unit/core/dag.test.ts
- npm --prefix packages/franken-planner test
- npm --prefix packages/franken-planner run typecheck
- npm --prefix packages/franken-planner run build
- npm --prefix packages/franken-planner run lint
- npx turbo run test --filter=@franken/planner

Closes #1105