### PR TITLE
fix(planner): recover recursive subgraph failures

### DIFF
--- a/packages/franken-planner/src/core/types.ts
+++ b/packages/franken-planner/src/core/types.ts
@@ -3,6 +3,7 @@
 // =============================================================================
 
 import type { TaskId } from '@franken/types';
+import type { PlanGraph } from './dag.js';
 export type { TaskId };
 export { createTaskId } from '@franken/types';
 
@@ -55,7 +56,17 @@ export type TaskResult = TaskResultSuccess | TaskResultExpand | TaskResultFailur
 
 export type PlanResult =
   | { status: 'completed'; taskResults: TaskResult[] }
-  | { status: 'failed'; taskResults: TaskResult[]; failedTaskId: TaskId; error: Error }
+  | {
+      status: 'failed';
+      taskResults: TaskResult[];
+      failedTaskId: TaskId;
+      error: Error;
+      /**
+       * Graph that owns failedTaskId when it differs from the current top-level
+       * graph, e.g. a recursive dynamic expansion sub-graph.
+       */
+      recoveryGraph?: PlanGraph;
+    }
   | { status: 'aborted'; reason: string }
   | { status: 'rationale_rejected'; taskId: TaskId };
 

--- a/packages/franken-planner/src/core/types.ts
+++ b/packages/franken-planner/src/core/types.ts
@@ -66,6 +66,12 @@ export type PlanResult =
        * graph, e.g. a recursive dynamic expansion sub-graph.
        */
       recoveryGraph?: PlanGraph;
+      /**
+       * Outer graphs to resume, nearest first, after the owning recovery graph
+       * completes. Recursive planners use this to recover nested dynamic tasks
+       * without losing the parent plan context.
+       */
+      recoveryContinuationGraphs?: PlanGraph[];
     }
   | { status: 'aborted'; reason: string }
   | { status: 'rationale_rejected'; taskId: TaskId };

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -74,6 +74,7 @@ export class Planner {
     const recoveryAttemptsByTask = new Map<TaskId, number>();
     const completedTaskIds = new Set<TaskId>();
     const completedTaskResults = new Map<TaskId, TaskResult>();
+    const recoveryContinuationGraphs: PlanGraph[] = [];
 
     for (;;) {
       let result: PlanResult;
@@ -91,6 +92,11 @@ export class Planner {
 
       if (result.status === 'completed') {
         Planner.recordCompletedTasks(result.taskResults, completedTaskIds, completedTaskResults);
+        const continuationGraph = recoveryContinuationGraphs.shift();
+        if (continuationGraph) {
+          currentGraph = continuationGraph;
+          continue;
+        }
         return { status: 'completed', taskResults: Array.from(completedTaskResults.values()) };
       }
       if (result.status !== 'failed') return result; // defensive: unexpected status
@@ -108,6 +114,7 @@ export class Planner {
           recoveryGraph,
           attempt
         );
+        recoveryContinuationGraphs.unshift(...(result.recoveryContinuationGraphs ?? []));
         recoveryAttemptsByTask.set(failedTaskLineage, attempt);
       } catch (recoveryErr) {
         if (

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -101,10 +101,11 @@ export class Planner {
       const failedTaskLineage = Planner.getRecoveryLineageRoot(result.failedTaskId);
       const attempt = (recoveryAttemptsByTask.get(failedTaskLineage) ?? 0) + 1;
       try {
+        const recoveryGraph = result.recoveryGraph ?? currentGraph;
         currentGraph = await this.recovery.recover(
           result.failedTaskId,
           result.error,
-          currentGraph,
+          recoveryGraph,
           attempt
         );
         recoveryAttemptsByTask.set(failedTaskLineage, attempt);

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -75,7 +75,9 @@ export class RecursivePlanner implements PlanningStrategy {
         const subGraph = this._buildSubGraph(result.newTasks, completedTaskIdsForExpansion);
         const subResult = await this._exec(subGraph, context, depth + 1, completedTaskIdsForExpansion);
         if (subResult.status !== 'completed') {
-          return subResult;
+          return subResult.status === 'failed' && !subResult.recoveryGraph
+            ? { ...subResult, recoveryGraph: subGraph }
+            : subResult;
         }
         allResults.push(result, ...subResult.taskResults);
       } else {

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -75,9 +75,16 @@ export class RecursivePlanner implements PlanningStrategy {
         const subGraph = this._buildSubGraph(result.newTasks, completedTaskIdsForExpansion);
         const subResult = await this._exec(subGraph, context, depth + 1, completedTaskIdsForExpansion);
         if (subResult.status !== 'completed') {
-          return subResult.status === 'failed' && !subResult.recoveryGraph
-            ? { ...subResult, recoveryGraph: subGraph }
-            : subResult;
+          if (subResult.status !== 'failed') return subResult;
+          return {
+            ...subResult,
+            taskResults: [result, ...subResult.taskResults],
+            recoveryGraph: subResult.recoveryGraph ?? subGraph,
+            recoveryContinuationGraphs: [
+              ...(subResult.recoveryContinuationGraphs ?? []),
+              graph,
+            ],
+          };
         }
         allResults.push(result, ...subResult.taskResults);
       } else {

--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -78,7 +78,7 @@ export class RecursivePlanner implements PlanningStrategy {
           if (subResult.status !== 'failed') return subResult;
           return {
             ...subResult,
-            taskResults: [result, ...subResult.taskResults],
+            taskResults: [...allResults, result, ...subResult.taskResults],
             recoveryGraph: subResult.recoveryGraph ?? subGraph,
             recoveryContinuationGraphs: [
               ...(subResult.recoveryContinuationGraphs ?? []),

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -371,7 +371,8 @@ describe('Planner — self-correction loop', () => {
   it('recovers failed dynamic sub-tasks within their recursive sub-graph', async () => {
     const parent = makeTask('parent');
     const child = makeTask('child');
-    const graph = PlanGraph.empty().addTask(parent);
+    const sibling = makeTask('sibling');
+    const graph = PlanGraph.empty().addTask(parent).addTask(sibling);
     const executedTaskIds: TaskId[] = [];
     const executor = vi.fn().mockImplementation((task: Task) => {
       executedTaskIds.push(task.id);
@@ -411,6 +412,14 @@ describe('Planner — self-correction loop', () => {
       createTaskId('child'),
       createTaskId('fix-child-attempt-1'),
       createTaskId('child'),
+      createTaskId('sibling'),
+    ]);
+    if (result.status !== 'completed') throw new Error('unexpected');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('parent'),
+      createTaskId('fix-child-attempt-1'),
+      createTaskId('child'),
+      createTaskId('sibling'),
     ]);
   });
 });

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Planner } from '../../src/planner';
 import { LinearPlanner } from '../../src/planners/linear';
+import { RecursivePlanner } from '../../src/planners/recursive';
 import { StubHITLGate } from '../../src/hitl/stub-hitl-gate';
 import { RecoveryController } from '../../src/recovery/recovery-controller';
 import { PlanGraph } from '../../src/core/dag';
@@ -365,6 +366,52 @@ describe('Planner — self-correction loop', () => {
     const result = await planner.plan('do something');
 
     expect(result.status).toBe('failed');
+  });
+
+  it('recovers failed dynamic sub-tasks within their recursive sub-graph', async () => {
+    const parent = makeTask('parent');
+    const child = makeTask('child');
+    const graph = PlanGraph.empty().addTask(parent);
+    const executedTaskIds: TaskId[] = [];
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      executedTaskIds.push(task.id);
+      if (task.id === createTaskId('parent')) {
+        return Promise.resolve(expand('parent', [child]));
+      }
+      if (task.id === createTaskId('child') && !executedTaskIds.includes(createTaskId('fix-child-attempt-1'))) {
+        return Promise.resolve(failure('child', 'disk full'));
+      }
+      return Promise.resolve(success(task.id));
+    });
+    const recovery = {
+      recover: vi.fn(async (failedTaskId: TaskId, _err: Error, recoveryGraph: PlanGraph, attempt: number) => {
+        const fixTask: Task = {
+          id: createTaskId(`fix-${failedTaskId}-attempt-${attempt}`),
+          objective: `Fix ${failedTaskId}`,
+          requiredSkills: [],
+          dependsOn: [],
+          status: 'pending',
+        };
+        return recoveryGraph.insertFixItTask(failedTaskId, fixTask);
+      }),
+    };
+
+    const { planner } = buildPlanner({ graph, executor, recovery, strategy: new RecursivePlanner() });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('completed');
+    expect(recovery.recover).toHaveBeenCalledWith(
+      createTaskId('child'),
+      expect.any(Error),
+      expect.objectContaining({ reason: 'recursive expansion' }),
+      1
+    );
+    expect(executedTaskIds).toEqual([
+      createTaskId('parent'),
+      createTaskId('child'),
+      createTaskId('fix-child-attempt-1'),
+      createTaskId('child'),
+    ]);
   });
 });
 

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -369,10 +369,11 @@ describe('Planner — self-correction loop', () => {
   });
 
   it('recovers failed dynamic sub-tasks within their recursive sub-graph', async () => {
+    const setup = makeTask('setup');
     const parent = makeTask('parent');
     const child = makeTask('child');
     const sibling = makeTask('sibling');
-    const graph = PlanGraph.empty().addTask(parent).addTask(sibling);
+    const graph = PlanGraph.empty().addTask(setup).addTask(parent).addTask(sibling);
     const executedTaskIds: TaskId[] = [];
     const executor = vi.fn().mockImplementation((task: Task) => {
       executedTaskIds.push(task.id);
@@ -408,6 +409,7 @@ describe('Planner — self-correction loop', () => {
       1
     );
     expect(executedTaskIds).toEqual([
+      createTaskId('setup'),
       createTaskId('parent'),
       createTaskId('child'),
       createTaskId('fix-child-attempt-1'),
@@ -416,6 +418,7 @@ describe('Planner — self-correction loop', () => {
     ]);
     if (result.status !== 'completed') throw new Error('unexpected');
     expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('setup'),
       createTaskId('parent'),
       createTaskId('fix-child-attempt-1'),
       createTaskId('child'),


### PR DESCRIPTION
## Summary
- Propagate the recursive dynamic expansion sub-graph that owns a failed sub-task in failed plan results
- Run recovery against that owning sub-graph instead of the parent graph
- Add a regression test covering dynamic sub-task recovery without TaskNotFoundError crashes

## Test Plan
- npm --prefix packages/franken-planner test
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-planner run typecheck
- npm --prefix packages/franken-planner run lint
- npm --prefix packages/franken-planner run build
- npx turbo run test --filter=@franken/planner
- npx turbo run typecheck lint build --filter=@franken/planner

Closes #1104