### PR TITLE
fix(web): expose tracked agent status filters

### DIFF
--- a/packages/franken-orchestrator/src/beasts/agent-types.ts
+++ b/packages/franken-orchestrator/src/beasts/agent-types.ts
@@ -1,17 +1,9 @@
+import { TRACKED_AGENT_STATUSES } from '@franken/types';
+import type { TrackedAgentStatus } from '@franken/types';
 import type { BeastDispatchSource, BeastExecutionMode, ModuleConfig } from './types.js';
 
-export const TRACKED_AGENT_STATUSES = [
-  'initializing',
-  'awaiting_approval',
-  'dispatching',
-  'running',
-  'completed',
-  'failed',
-  'stopped',
-  'deleted',
-] as const;
-
-export type TrackedAgentStatus = (typeof TRACKED_AGENT_STATUSES)[number];
+export { TRACKED_AGENT_STATUSES };
+export type { TrackedAgentStatus };
 
 export const TRACKED_AGENT_INIT_ACTION_KINDS = [
   'design-interview',

--- a/packages/franken-orchestrator/src/beasts/errors.ts
+++ b/packages/franken-orchestrator/src/beasts/errors.ts
@@ -5,3 +5,11 @@ export class UnknownTrackedAgentError extends Error {
     super(`Unknown tracked agent: ${agentId}`);
   }
 }
+
+export class DeletedTrackedAgentError extends Error {
+  constructor(
+    public readonly agentId: string,
+  ) {
+    super(`Tracked agent '${agentId}' has been deleted`);
+  }
+}

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -65,12 +65,12 @@ export class AgentService {
   }
 
   listAgents(): TrackedAgent[] {
-    return this.repository.listTrackedAgents().filter((agent) => isVisibleAgent(agent));
+    return this.repository.listTrackedAgents();
   }
 
   getAgent(agentId: string): TrackedAgent {
     const agent = this.repository.getTrackedAgent(agentId);
-    if (!agent || !isVisibleAgent(agent)) {
+    if (!agent) {
       throw new UnknownTrackedAgentError(agentId);
     }
     return agent;
@@ -119,8 +119,4 @@ export class AgentService {
       updatedAt: this.now(),
     });
   }
-}
-
-function isVisibleAgent(agent: TrackedAgent): boolean {
-  return agent.status !== 'deleted';
 }

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -6,7 +6,7 @@ import type {
   TrackedAgentInitAction,
 } from '../types.js';
 import { isoNow } from '@franken/types';
-import { UnknownTrackedAgentError } from '../errors.js';
+import { DeletedTrackedAgentError, UnknownTrackedAgentError } from '../errors.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 
 export interface CreateTrackedAgentRequest {
@@ -72,6 +72,14 @@ export class AgentService {
     const agent = this.repository.getTrackedAgent(agentId);
     if (!agent) {
       throw new UnknownTrackedAgentError(agentId);
+    }
+    return agent;
+  }
+
+  getMutableAgent(agentId: string): TrackedAgent {
+    const agent = this.getAgent(agentId);
+    if (agent.status === 'deleted') {
+      throw new DeletedTrackedAgentError(agentId);
     }
     return agent;
   }

--- a/packages/franken-orchestrator/src/cli/beast-control-client.ts
+++ b/packages/franken-orchestrator/src/cli/beast-control-client.ts
@@ -12,7 +12,7 @@ export function createBeastControlClient(paths: ProjectPaths, serviceBundle?: Be
     stopRun: (runId: string, actor: string) => services.runs.stop(runId, actor),
     restartRun: (runId: string, actor: string) => services.runs.restart(runId, actor),
     resumeAgent: async (agentId: string, actor: string) => {
-      const agent = services.agents.getAgent(agentId);
+      const agent = services.agents.getMutableAgent(agentId);
       if (!agent.dispatchRunId) {
         throw new Error(`Tracked agent '${agentId}' has no linked run to resume`);
       }

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
-import { UnknownTrackedAgentError } from '../../beasts/errors.js';
+import { DeletedTrackedAgentError, UnknownTrackedAgentError } from '../../beasts/errors.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
 import type { BeastRunService } from '../../beasts/services/beast-run-service.js';
@@ -479,15 +479,18 @@ function getMutableAgent(
   deps: AgentRoutesDeps,
   agentId: string,
 ): ReturnType<AgentService['getAgent']> {
-  const agent = deps.agents.getAgent(agentId);
-  if (agent.status === 'deleted') {
+  try {
+    return deps.agents.getMutableAgent(agentId);
+  } catch (error) {
+    if (!(error instanceof DeletedTrackedAgentError)) {
+      throw error;
+    }
     throw new HttpError(
       409,
       'TRACKED_AGENT_DELETED',
       `Tracked agent '${agentId}' has been deleted`,
     );
   }
-  return agent;
 }
 
 function shouldDispatchOnCreate(kind: z.infer<typeof CreateAgentBody>['initAction']['kind']): boolean {

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -182,7 +182,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
     const agentId = c.req.param('agentId');
     const body = validateBody(PatchAgentConfigBody, await parseJsonBody(c));
     try {
-      const current = deps.agents.getAgent(agentId);
+      const current = getMutableAgent(deps, agentId);
       const hasIdentityPatch = body.name !== undefined || body.description !== undefined;
       const updated = deps.agents.updateAgent(agentId, {
         ...(hasIdentityPatch ? { initConfig: patchInitConfigIdentity(current.initConfig, body) } : {}),
@@ -224,7 +224,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   app.post('/v1/beasts/agents/:agentId/start', async (c) => {
     const agentId = c.req.param('agentId');
     try {
-      const agent = deps.agents.getAgent(agentId);
+      const agent = getMutableAgent(deps, agentId);
       if (agent.status !== 'stopped' && agent.status !== 'failed' && agent.status !== 'completed') {
         throw new HttpError(
           409,
@@ -274,7 +274,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   app.post('/v1/beasts/agents/:agentId/stop', async (c) => {
     const agentId = c.req.param('agentId');
     try {
-      const agent = deps.agents.getAgent(agentId);
+      const agent = getMutableAgent(deps, agentId);
       if (agent.dispatchRunId) {
         const run = await deps.runs.stop(agent.dispatchRunId, 'operator');
         deps.agents.appendEvent(agentId, {
@@ -311,7 +311,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   app.post('/v1/beasts/agents/:agentId/restart', async (c) => {
     const agentId = c.req.param('agentId');
     try {
-      const agent = deps.agents.getAgent(agentId);
+      const agent = getMutableAgent(deps, agentId);
       if (agent.dispatchRunId) {
         const existingRun = deps.runs.getRun(agent.dispatchRunId);
         const run = shouldDispatchFreshRunForModuleConfig(agent, existingRun)
@@ -361,7 +361,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   app.post('/v1/beasts/agents/:agentId/kill', async (c) => {
     const agentId = c.req.param('agentId');
     try {
-      const agent = deps.agents.getAgent(agentId);
+      const agent = getMutableAgent(deps, agentId);
       if (!agent.dispatchRunId) {
         throw new HttpError(
           409,
@@ -401,7 +401,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   app.post('/v1/beasts/agents/:agentId/resume', async (c) => {
     const agentId = c.req.param('agentId');
     try {
-      const agent = deps.agents.getAgent(agentId);
+      const agent = getMutableAgent(deps, agentId);
       if (!agent.dispatchRunId) {
         throw new HttpError(
           409,
@@ -444,7 +444,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   app.delete('/v1/beasts/agents/:agentId', (c) => {
     const agentId = c.req.param('agentId');
     try {
-      const agent = deps.agents.getAgent(agentId);
+      const agent = getMutableAgent(deps, agentId);
       if (agent.status !== 'stopped' && agent.status !== 'failed' && agent.status !== 'completed') {
         throw new HttpError(
           409,
@@ -473,6 +473,21 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
   });
 
   return app;
+}
+
+function getMutableAgent(
+  deps: AgentRoutesDeps,
+  agentId: string,
+): ReturnType<AgentService['getAgent']> {
+  const agent = deps.agents.getAgent(agentId);
+  if (agent.status === 'deleted') {
+    throw new HttpError(
+      409,
+      'TRACKED_AGENT_DELETED',
+      `Tracked agent '${agentId}' has been deleted`,
+    );
+  }
+  return agent;
 }
 
 function shouldDispatchOnCreate(kind: z.infer<typeof CreateAgentBody>['initAction']['kind']): boolean {
@@ -521,7 +536,7 @@ async function dispatchDetachedAgent(
   deps: AgentRoutesDeps,
   agentId: string,
 ) {
-  const agent = deps.agents.getAgent(agentId);
+  const agent = getMutableAgent(deps, agentId);
   if (!deps.dispatch || !shouldDispatchOnCreate(agent.initAction.kind)) {
     throw new HttpError(
       409,

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -943,7 +943,7 @@ describe('agent routes integration', () => {
     });
   });
 
-  it('soft-deletes stopped tracked agents so they disappear from the dashboard list', async () => {
+  it('soft-deletes stopped tracked agents while keeping them visible for audit filters', async () => {
     const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
@@ -987,15 +987,33 @@ describe('agent routes integration', () => {
         authorization: `Bearer ${operatorToken}`,
       },
     });
-    const list = await listResponse.json() as { data: { agents: Array<{ id: string }> } };
-    expect(list.data.agents).toEqual([]);
+    const list = await listResponse.json() as { data: { agents: Array<{ id: string; status: string }> } };
+    expect(list.data.agents.map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: created.data.id, status: 'deleted' },
+    ]);
 
     const detailResponse = await app.request(`/v1/beasts/agents/${created.data.id}`, {
       headers: {
         authorization: `Bearer ${operatorToken}`,
       },
     });
-    expect(detailResponse.status).toBe(404);
+    expect(detailResponse.status).toBe(200);
+    const detail = await detailResponse.json() as { data: { agent: { id: string; status: string } } };
+    expect(detail.data.agent).toMatchObject({ id: created.data.id, status: 'deleted' });
+
+    const stopAgainResponse = await app.request(`/v1/beasts/agents/${created.data.id}/stop`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${operatorToken}`,
+      },
+    });
+    expect(stopAgainResponse.status).toBe(409);
+    expect(await stopAgainResponse.json()).toEqual({
+      error: {
+        code: 'TRACKED_AGENT_DELETED',
+        message: `Tracked agent '${created.data.id}' has been deleted`,
+      },
+    });
   });
 
   it('patches tracked agent identity and module configuration', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
@@ -145,7 +145,7 @@ describe('AgentService', () => {
     expect(existsSync(worktreePath)).toBe(true);
   });
 
-  it('hides soft-deleted tracked agents from list and detail lookups', async () => {
+  it('keeps soft-deleted tracked agents available for list and detail audit views', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-agent-service-'));
     const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const service = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
@@ -165,7 +165,9 @@ describe('AgentService', () => {
     service.updateAgent(agent.id, { status: 'stopped' });
     service.softDeleteAgent(agent.id);
 
-    expect(service.listAgents()).toEqual([]);
-    expect(() => service.getAgent(agent.id)).toThrow(`Unknown tracked agent: ${agent.id}`);
+    expect(service.listAgents().map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: agent.id, status: 'deleted' },
+    ]);
+    expect(service.getAgent(agent.id).status).toBe('deleted');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service.test.ts
@@ -169,5 +169,6 @@ describe('AgentService', () => {
       { id: agent.id, status: 'deleted' },
     ]);
     expect(service.getAgent(agent.id).status).toBe('deleted');
+    expect(() => service.getMutableAgent(agent.id)).toThrow(`Tracked agent '${agent.id}' has been deleted`);
   });
 });

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -192,6 +192,19 @@ export interface BeastSseSnapshot {
   agents?: Array<Partial<TrackedAgentSummary> & { id: string }>;
 }
 
+export const TRACKED_AGENT_STATUSES = [
+  'initializing',
+  'awaiting_approval',
+  'dispatching',
+  'running',
+  'completed',
+  'failed',
+  'stopped',
+  'deleted',
+] as const;
+
+export type TrackedAgentStatus = (typeof TRACKED_AGENT_STATUSES)[number];
+
 export interface BeastSseAgentStatusEvent {
   agentId: string;
   status: string;

--- a/packages/franken-web/src/components/beasts/agent-list.tsx
+++ b/packages/franken-web/src/components/beasts/agent-list.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
-import type { BeastRunSummary, TrackedAgentSummary } from '../../lib/beast-api';
+import { TRACKED_AGENT_STATUSES, type BeastRunSummary, type TrackedAgentSummary } from '../../lib/beast-api';
 import { AgentRow, type Density } from './agent-row';
 
 interface AgentListProps {
@@ -52,7 +52,7 @@ export function AgentList({ agents, runs, selectedAgentId, onSelectAgent, onCrea
             text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
         >
           <option value="">All statuses</option>
-          {['running', 'initializing', 'dispatching', 'stopped', 'completed', 'failed'].map((s) => (
+          {TRACKED_AGENT_STATUSES.map((s) => (
             <option key={s} value={s}>{s}</option>
           ))}
         </select>

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1006,8 +1006,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               if (!beastClient) return;
               void beastClient.deleteAgent(agentId).then(() => {
                 shouldAutoSelectBeastAgentRef.current = false;
-                selectedBeastAgentIdRef.current = null;
-                setSelectedBeastAgentId((current) => current === agentId ? null : current);
+                setSelectedBeastAgentId((current) => {
+                  if (current !== agentId) return current;
+                  selectedBeastAgentIdRef.current = null;
+                  return null;
+                });
                 setBeastAgentDetail((current) => current?.agent.id === agentId ? null : current);
                 setBeastRefreshNonce((current) => current + 1);
               }).catch((err) => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -449,7 +449,8 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         setBeastAgents(agents);
         setBeastRuns(runs);
         setBeastContainerRuntime(containerRuntime);
-        const currentAgentId = selectedBeastAgentId ?? (shouldAutoSelectBeastAgentRef.current ? agents[0]?.id ?? null : null);
+        const autoSelectedAgentId = agents.find((agent) => agent.status !== 'deleted')?.id ?? null;
+        const currentAgentId = selectedBeastAgentId ?? (shouldAutoSelectBeastAgentRef.current ? autoSelectedAgentId : null);
         setSelectedBeastAgentId(currentAgentId);
 
         if (currentAgentId) {
@@ -1004,7 +1005,10 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             onDelete={(agentId) => {
               if (!beastClient) return;
               void beastClient.deleteAgent(agentId).then(() => {
+                shouldAutoSelectBeastAgentRef.current = false;
+                selectedBeastAgentIdRef.current = null;
                 setSelectedBeastAgentId((current) => current === agentId ? null : current);
+                setBeastAgentDetail((current) => current?.agent.id === agentId ? null : current);
                 setBeastRefreshNonce((current) => current + 1);
               }).catch((err) => {
                 setBeastError(err instanceof Error ? err.message : 'Unable to delete tracked agent.');

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -1,4 +1,4 @@
-import { MODULE_CONFIG_KEYS } from '@franken/types';
+import { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 import type {
   ApiDataEnvelope,
   ApiErrorEnvelope,
@@ -23,7 +23,7 @@ import type {
   TrackedAgentSummary,
 } from '@franken/types';
 
-export { MODULE_CONFIG_KEYS } from '@franken/types';
+export { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 export type {
   BeastCatalogEntry,
   BeastContainerRuntimeStatus,

--- a/packages/franken-web/tests/components/beasts/agent-list.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-list.test.tsx
@@ -18,6 +18,18 @@ const agents: TrackedAgentSummary[] = [
     initAction: { kind: 'chunk-plan', command: '/plan', config: {} },
     initConfig: {}, createdAt: '2026-03-15T09:00:00Z', updatedAt: '2026-03-15T09:30:00Z',
   },
+  {
+    id: 'agent-3', definitionId: 'design-interview', status: 'awaiting_approval',
+    source: 'dashboard', createdByUser: 'pfk',
+    initAction: { kind: 'design-interview', command: '/interview', config: {} },
+    initConfig: {}, createdAt: '2026-03-15T08:00:00Z', updatedAt: '2026-03-15T08:30:00Z',
+  },
+  {
+    id: 'agent-4', definitionId: 'chunk-plan', status: 'deleted',
+    source: 'dashboard', createdByUser: 'pfk',
+    initAction: { kind: 'chunk-plan', command: '/plan', config: {} },
+    initConfig: {}, createdAt: '2026-03-15T07:00:00Z', updatedAt: '2026-03-15T07:30:00Z',
+  },
 ];
 
 describe('AgentList', () => {
@@ -46,6 +58,36 @@ describe('AgentList', () => {
     fireEvent.change(statusSelect, { target: { value: 'running' } });
     expect(screen.getByText('agent-1')).toBeTruthy();
     expect(screen.queryByText('agent-2')).toBeNull();
+    expect(screen.queryByText('agent-3')).toBeNull();
+    expect(screen.queryByText('agent-4')).toBeNull();
+  });
+
+  it('exposes backend-only tracked agent statuses in the status filter', () => {
+    render(<AgentList agents={agents} runs={[]} selectedAgentId={null} onSelectAgent={vi.fn()} onCreateAgent={vi.fn()} />);
+    const statusSelect = screen.getByLabelText(/filter by status/i) as HTMLSelectElement;
+
+    const optionValues = Array.from(statusSelect.options).map((option) => option.value);
+    expect(optionValues).toEqual([
+      '',
+      'initializing',
+      'awaiting_approval',
+      'dispatching',
+      'running',
+      'completed',
+      'failed',
+      'stopped',
+      'deleted',
+    ]);
+
+    fireEvent.change(statusSelect, { target: { value: 'awaiting_approval' } });
+    expect(screen.getByText('agent-3')).toBeTruthy();
+    expect(screen.queryByText('agent-1')).toBeNull();
+    expect(screen.queryByText('agent-4')).toBeNull();
+
+    fireEvent.change(statusSelect, { target: { value: 'deleted' } });
+    expect(screen.getByText('agent-4')).toBeTruthy();
+    expect(screen.queryByText('agent-1')).toBeNull();
+    expect(screen.queryByText('agent-3')).toBeNull();
   });
 
   it('has create agent button in empty state', () => {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -845,6 +845,53 @@ describe('ChatShell', () => {
     expect(mockListAgents).toHaveBeenCalled();
   });
 
+  it('keeps deleted audit rows from being auto-selected on the beasts page', async () => {
+    window.location.hash = '#/beasts';
+    const deletedAgent = {
+      id: 'agent-deleted',
+      definitionId: 'chunk-plan',
+      status: 'deleted',
+      source: 'chat',
+      createdByUser: 'chat-session:sess-1',
+      initAction: {
+        kind: 'chunk-plan',
+        command: '/plan --design-doc docs/plans/deleted.md',
+        config: { designDocPath: 'docs/plans/deleted.md' },
+        chatSessionId: 'sess-1',
+      },
+      initConfig: { designDocPath: 'docs/plans/deleted.md' },
+      chatSessionId: 'sess-1',
+      createdAt: '2026-03-11T00:00:00.000Z',
+      updatedAt: '2026-03-11T00:00:03.000Z',
+    };
+    const activeAgent = {
+      ...deletedAgent,
+      id: 'agent-active',
+      status: 'stopped',
+      updatedAt: '2026-03-11T00:00:02.000Z',
+    };
+    mockListAgents.mockResolvedValue([deletedAgent, activeAgent]);
+    mockGetAgent.mockImplementation(async (agentId: string) => ({
+      agent: agentId === 'agent-active' ? activeAgent : deletedAgent,
+      events: [],
+    }));
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('agent-deleted')).toBeDefined();
+      expect(screen.getByText('agent-active')).toBeDefined();
+      expect(mockGetAgent).toHaveBeenCalledWith('agent-active');
+    });
+    expect(mockGetAgent).not.toHaveBeenCalledWith('agent-deleted');
+  });
+
   it('applies Beast SSE status and log updates incrementally', async () => {
     window.location.hash = '#/beasts';
     render(

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -237,6 +237,16 @@ vi.mock('../../src/lib/api.js', () => ({
 
 vi.mock('../../src/lib/beast-api.js', () => ({
   MODULE_CONFIG_KEYS: ['firewall', 'skills', 'memory', 'planner', 'critique', 'governor', 'heartbeat'],
+  TRACKED_AGENT_STATUSES: [
+    'initializing',
+    'awaiting_approval',
+    'dispatching',
+    'running',
+    'completed',
+    'failed',
+    'stopped',
+    'deleted',
+  ],
   BeastApiClient: vi.fn(function (this: {
     getCatalog: typeof mockGetCatalog;
     listAgents: typeof mockListAgents;


### PR DESCRIPTION
## Summary
- Add `TRACKED_AGENT_STATUSES` to the shared API contract package and re-export it through orchestrator/web surfaces.
- Drive AgentList status filter options from the shared tracked-agent status list so `awaiting_approval` and `deleted` are available.
- Add regression coverage for filtering `awaiting_approval` and `deleted` tracked agents.

## Test Plan
- `npm run build --workspace @franken/types`
- `npm run test --workspace @franken/web -- tests/components/beasts/agent-list.test.tsx`
- `npm run typecheck --workspace @franken/web`
- `npm run build --workspace @franken/web`
- `npm run test --workspace @franken/orchestrator -- tests/unit/beasts/types.test.ts`
- `npm run typecheck --workspace @franken/orchestrator`

Closes #1102