### PR TITLE
ci: retry flaky test commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         deterministic-seed: ['1337']
     env:
       FRANKENBEAST_SEED: ${{ matrix.deterministic-seed }}
+      CI_TEST_RETRIES: ${{ vars.CI_TEST_RETRIES || '2' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,7 +58,7 @@ jobs:
       - run: npm run audit:security
 
       - name: Run deterministic root Vitest suite
-        run: npm run test:root
+        run: npm run ci:test:root
 
       - name: Run Docker sandbox build smoke test
         run: npm run test:docker:sandbox
@@ -74,7 +75,7 @@ jobs:
         run: npx turbo run build lint
 
       - name: Run package tests
-        run: npx turbo run test
+        run: npm run ci:test:packages
 
       - name: Phantom dependency check (every runtime import is declared)
         run: node scripts/check-phantom-deps.mjs

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "test": "turbo run test",
+    "ci:test:root": "node scripts/retry-ci-command.mjs -- npm run test:root",
+    "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",
     "test:root": "vitest run",
     "test:docker:sandbox": "node scripts/run-docker-sandbox-smoke.mjs",
     "test:root:watch": "vitest",

--- a/scripts/retry-ci-command.mjs
+++ b/scripts/retry-ci-command.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const RETRY_ENV = 'CI_TEST_RETRIES';
+const DEFAULT_RETRIES = 0;
+
+function parseRetryCount(value) {
+  if (value === undefined || value === '') {
+    return DEFAULT_RETRIES;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${RETRY_ENV} must be a non-negative integer, got ${JSON.stringify(value)}`);
+  }
+
+  return parsed;
+}
+
+function splitCommand(argv) {
+  const separatorIndex = argv.indexOf('--');
+  const command = separatorIndex === -1 ? argv : argv.slice(separatorIndex + 1);
+  if (command.length === 0 || command[0] === '') {
+    throw new Error('Usage: node scripts/retry-ci-command.mjs -- <command> [args...]');
+  }
+  return command;
+}
+
+function runOnce(command, args, attempt, totalAttempts) {
+  console.error(`[ci-retry] attempt ${attempt}/${totalAttempts}: ${[command, ...args].join(' ')}`);
+
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      env: process.env,
+    });
+
+    child.on('error', (error) => {
+      console.error(`[ci-retry] failed to start command: ${error.message}`);
+      resolve(127);
+    });
+
+    child.on('close', (code, signal) => {
+      if (signal) {
+        console.error(`[ci-retry] command terminated by signal ${signal}`);
+        resolve(128);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+async function main() {
+  const [command, ...args] = splitCommand(process.argv.slice(2));
+  const retries = parseRetryCount(process.env[RETRY_ENV]);
+  const totalAttempts = retries + 1;
+
+  let lastExitCode = 1;
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+    lastExitCode = await runOnce(command, args, attempt, totalAttempts);
+    if (lastExitCode === 0) {
+      if (attempt > 1) {
+        console.error(`[ci-retry] command succeeded on retry attempt ${attempt}`);
+      }
+      return;
+    }
+
+    if (attempt < totalAttempts) {
+      console.error(`[ci-retry] command failed with exit code ${lastExitCode}; retrying`);
+    }
+  }
+
+  console.error(`[ci-retry] command failed after ${totalAttempts} attempt(s)`);
+  process.exitCode = lastExitCode;
+}
+
+main().catch((error) => {
+  console.error(`[ci-retry] ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -110,23 +110,37 @@ on:
 
     it('builds before running package tests in CI', () => {
       expect(content).toContain('turbo run');
-      expect(content).toMatch(/turbo run build lint[\s\S]*turbo run test/);
-      expect(content.indexOf('turbo run build lint')).toBeLessThan(content.indexOf('turbo run test'));
+      expect(content).toMatch(/turbo run build lint[\s\S]*npm run ci:test:packages/);
+      expect(content.indexOf('turbo run build lint')).toBeLessThan(content.indexOf('npm run ci:test:packages'));
       expect(content).not.toMatch(/turbo run.*build\s+test\s+lint/);
     });
 
     it('runs the deterministic root Vitest suite separately from Turbo', () => {
       expect(content).toMatch(/name:\s*Run deterministic root Vitest suite/);
-      expect(content).toContain('npm run test:root');
+      expect(content).toContain('npm run ci:test:root');
       expect(content).not.toMatch(/npm run test:root --/);
-      expect(content.indexOf('npm run test:root')).toBeLessThan(content.indexOf('npx turbo run test'));
+      expect(content.indexOf('npm run ci:test:root')).toBeLessThan(content.indexOf('npm run ci:test:packages'));
     });
 
     it('runs CI test commands with a fixed deterministic seed matrix', () => {
       expect(content).toContain('deterministic-seed');
       expect(content).toContain("deterministic-seed: ['1337']");
       expect(content).toContain('FRANKENBEAST_SEED: ${{ matrix.deterministic-seed }}');
-      expect(content.indexOf('FRANKENBEAST_SEED')).toBeLessThan(content.indexOf('npm run test:root'));
+      expect(content.indexOf('FRANKENBEAST_SEED')).toBeLessThan(content.indexOf('npm run ci:test:root'));
+    });
+
+    it('runs test commands through a configurable retry wrapper', () => {
+      const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+        scripts?: Record<string, string>;
+      };
+
+      expect(content).toContain("CI_TEST_RETRIES: ${{ vars.CI_TEST_RETRIES || '2' }}");
+      expect(packageJson.scripts?.['ci:test:root']).toBe('node scripts/retry-ci-command.mjs -- npm run test:root');
+      expect(packageJson.scripts?.['ci:test:packages']).toBe('node scripts/retry-ci-command.mjs -- npx turbo run test');
+      expect(content).toContain('npm run ci:test:root');
+      expect(content).toContain('npm run ci:test:packages');
+      expect(content).not.toContain('run: npm run test:root');
+      expect(content).not.toContain('run: npx turbo run test');
     });
 
     it('documents the root-suite and package-Turbo CI split in step names', () => {

--- a/tests/unit/retry-ci-command.test.ts
+++ b/tests/unit/retry-ci-command.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/retry-ci-command.mjs');
+
+function runRetryCommand(args: string[], env: Record<string, string> = {}) {
+  return spawnSync(process.execPath, [SCRIPT, '--', ...args], {
+    cwd: ROOT,
+    env: { ...process.env, CI_TEST_RETRIES: '', ...env },
+    encoding: 'utf8',
+  });
+}
+
+describe('CI retry command wrapper', () => {
+  it('retries a failing command until it succeeds and logs retry attempts', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'franken-ci-retry-'));
+    const counter = join(dir, 'counter.txt');
+    const childScript = `
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const file = process.argv[1];
+const count = existsSync(file) ? Number(readFileSync(file, 'utf8')) + 1 : 1;
+writeFileSync(file, String(count));
+process.exit(count < 2 ? 7 : 0);
+`;
+
+    const result = runRetryCommand([process.execPath, '-e', childScript, counter], { CI_TEST_RETRIES: '2' });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(counter, 'utf8')).toBe('2');
+    expect(result.stderr).toContain('[ci-retry] attempt 1/3');
+    expect(result.stderr).toContain('[ci-retry] command failed with exit code 7; retrying');
+    expect(result.stderr).toContain('[ci-retry] command succeeded on retry attempt 2');
+  });
+
+  it('preserves the final failure exit code after retries are exhausted', () => {
+    const result = runRetryCommand([process.execPath, '-e', 'process.exit(9)'], { CI_TEST_RETRIES: '1' });
+
+    expect(result.status).toBe(9);
+    expect(result.stderr).toContain('[ci-retry] attempt 1/2');
+    expect(result.stderr).toContain('[ci-retry] attempt 2/2');
+    expect(result.stderr).toContain('[ci-retry] command failed after 2 attempt(s)');
+  });
+
+  it('fails fast when the retry count is not a non-negative integer', () => {
+    const result = runRetryCommand([process.execPath, '-e', 'process.exit(0)'], { CI_TEST_RETRIES: '1.5' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('CI_TEST_RETRIES must be a non-negative integer');
+  });
+});

--- a/tests/unit/todo-markers.test.ts
+++ b/tests/unit/todo-markers.test.ts
@@ -38,7 +38,7 @@ describe('code comment debt marker scanner', () => {
 
     expect(packageJson.scripts?.['audit:todos']).toBe('node scripts/audit-todo-markers.mjs');
     expect(packageJson.scripts?.['lint:security']).toContain('node scripts/audit-todo-markers.mjs');
-    expect(workflow).toContain('npm run test:root');
+    expect(workflow).toContain('npm run ci:test:root');
     expect(workflow).not.toMatch(/npm run test:root --/);
     expect(workflow).toContain('npm run audit:todos');
   });


### PR DESCRIPTION
## Summary
- add a reusable CI retry wrapper for test commands with configurable `CI_TEST_RETRIES`
- route root and package test CI scripts through the wrapper while leaving build/lint/audit steps fail-fast
- add regression coverage for retry behavior and CI wiring

## Test Plan
- `npx vitest run tests/unit/retry-ci-command.test.ts tests/unit/ci-workflow.test.ts`
- `npm run test:root`
- `CI_TEST_RETRIES=2 npm run ci:test:root` (5 consecutive local runs)
- `npx turbo run build lint`
- `npm run typecheck`
- `CI_TEST_RETRIES=2 npm run ci:test:packages`

Closes #1099