### PR TITLE
fix(web): disable unavailable empty-state agent creation

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-list.tsx
+++ b/packages/franken-web/src/components/beasts/agent-list.tsx
@@ -10,9 +10,19 @@ interface AgentListProps {
   selectedAgentId: string | null;
   onSelectAgent: (agentId: string) => void;
   onCreateAgent: () => void;
+  createAgentDisabled?: boolean;
+  createAgentDisabledReason?: string | null;
 }
 
-export function AgentList({ agents, runs, selectedAgentId, onSelectAgent, onCreateAgent }: AgentListProps) {
+export function AgentList({
+  agents,
+  runs,
+  selectedAgentId,
+  onSelectAgent,
+  onCreateAgent,
+  createAgentDisabled = false,
+  createAgentDisabledReason,
+}: AgentListProps) {
   const [density, setDensity] = useState<Density>('comfortable');
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('');
@@ -83,14 +93,23 @@ export function AgentList({ agents, runs, selectedAgentId, onSelectAgent, onCrea
         <div className="flex-1 flex flex-col items-center justify-center gap-6 text-beast-muted p-8">
           <p className="text-sm">{agents.length === 0 ? 'No agents yet' : 'No matching agents'}</p>
           {agents.length === 0 && (
-            <button
-              type="button"
-              onClick={onCreateAgent}
-              className="px-5 py-2.5 rounded-lg border border-beast-border text-beast-muted text-sm
-                hover:text-beast-text hover:bg-beast-elevated transition-colors"
-            >
-              Create your first agent
-            </button>
+            <div className="flex flex-col items-center gap-3 text-center">
+              {createAgentDisabled && createAgentDisabledReason && (
+                <p className="max-w-md text-xs text-beast-subtle">
+                  {createAgentDisabledReason}
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={onCreateAgent}
+                disabled={createAgentDisabled}
+                className="px-5 py-2.5 rounded-lg border border-beast-border text-beast-muted text-sm
+                  hover:text-beast-text hover:bg-beast-elevated transition-colors disabled:cursor-not-allowed
+                  disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-beast-muted"
+              >
+                Create your first agent
+              </button>
+            </div>
           )}
         </div>
       ) : (

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -374,6 +374,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const composerSessionKey = preserveComposerDraft
     ? `anonymous:${sessionSeed}`
     : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
+  const beastCreationDisabled = Boolean(beastError);
 
   useEffect(() => {
     if (preserveComposerDraft || !activeSessionId || selectedSessionId) {
@@ -983,7 +984,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             catalog={beastCatalog}
             runs={beastRuns}
             containerRuntime={beastContainerRuntime}
-            disabled={false}
+            disabled={beastCreationDisabled}
             error={beastError}
             logs={beastAgentDetail?.run?.logs ?? []}
             selectedAgentId={selectedBeastAgentId}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -433,8 +433,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     let cancelled = false;
 
     async function refreshBeasts() {
+      let catalog: Awaited<ReturnType<typeof client.getCatalog>>;
+      let agents: Awaited<ReturnType<typeof client.listAgents>>;
+      let runs: Awaited<ReturnType<typeof client.listRuns>>;
+      let containerRuntime: Awaited<ReturnType<typeof client.getContainerRuntimeStatus>>;
       try {
-        const [catalog, agents, runs, containerRuntime] = await Promise.all([
+        [catalog, agents, runs, containerRuntime] = await Promise.all([
           client.getCatalog(),
           client.listAgents(),
           client.listRuns(),
@@ -446,15 +450,25 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         if (cancelled) {
           return;
         }
-        setBeastError(null);
-        setBeastCreationUnavailableReason(null);
-        setBeastCatalog(catalog);
-        setBeastAgents(agents);
-        setBeastRuns(runs);
-        setBeastContainerRuntime(containerRuntime);
-        const currentAgentId = selectedBeastAgentId ?? (shouldAutoSelectBeastAgentRef.current ? agents[0]?.id ?? null : null);
-        setSelectedBeastAgentId(currentAgentId);
+      } catch (error) {
+        if (!cancelled) {
+          const message = error instanceof Error ? error.message : 'Unable to load Beast dispatch state.';
+          setBeastError(message);
+          setBeastCreationUnavailableReason(message);
+        }
+        return;
+      }
 
+      setBeastError(null);
+      setBeastCreationUnavailableReason(null);
+      setBeastCatalog(catalog);
+      setBeastAgents(agents);
+      setBeastRuns(runs);
+      setBeastContainerRuntime(containerRuntime);
+      const currentAgentId = selectedBeastAgentId ?? (shouldAutoSelectBeastAgentRef.current ? agents[0]?.id ?? null : null);
+      setSelectedBeastAgentId(currentAgentId);
+
+      try {
         if (currentAgentId) {
           const detail = await client.getAgent(currentAgentId);
           if (!cancelled) {
@@ -477,7 +491,6 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         if (!cancelled) {
           const message = error instanceof Error ? error.message : 'Unable to load Beast dispatch state.';
           setBeastError(message);
-          setBeastCreationUnavailableReason(message);
         }
       }
     }

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -286,6 +286,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const beastAgentsRef = useRef<TrackedAgentSummary[]>([]);
   const beastAgentDetailRef = useRef<(TrackedAgentDetail & { run?: BeastRunDetail | null }) | null>(null);
   const [beastError, setBeastError] = useState<string | null>(null);
+  const [beastCreationUnavailableReason, setBeastCreationUnavailableReason] = useState<string | null>(null);
   const [beastRefreshNonce, setBeastRefreshNonce] = useState(0);
   const selectedBeastAgentIdRef = useRef<string | null>(null);
   const shouldAutoSelectBeastAgentRef = useRef(true);
@@ -374,7 +375,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const composerSessionKey = preserveComposerDraft
     ? `anonymous:${sessionSeed}`
     : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
-  const beastCreationDisabled = Boolean(beastError);
+  const beastCreationDisabled = Boolean(beastCreationUnavailableReason);
 
   useEffect(() => {
     if (preserveComposerDraft || !activeSessionId || selectedSessionId) {
@@ -446,6 +447,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           return;
         }
         setBeastError(null);
+        setBeastCreationUnavailableReason(null);
         setBeastCatalog(catalog);
         setBeastAgents(agents);
         setBeastRuns(runs);
@@ -473,7 +475,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         }
       } catch (error) {
         if (!cancelled) {
-          setBeastError(error instanceof Error ? error.message : 'Unable to load Beast dispatch state.');
+          const message = error instanceof Error ? error.message : 'Unable to load Beast dispatch state.';
+          setBeastError(message);
+          setBeastCreationUnavailableReason(message);
         }
       }
     }

--- a/packages/franken-web/src/pages/beasts-page.tsx
+++ b/packages/franken-web/src/pages/beasts-page.tsx
@@ -58,8 +58,10 @@ export function BeastsPage({
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
   const resetWizard = useBeastStore((s) => s.resetWizard);
+  const createAgentDisabledReason = error ?? 'Beast API is not available. Configure the operator token/API client before creating agents.';
 
   function handleOpenWizard() {
+    if (disabled) return;
     resetWizard();
     setLaunchError(null);
     setShowWizard(true);
@@ -105,6 +107,8 @@ export function BeastsPage({
         selectedAgentId={selectedAgentId}
         onSelectAgent={onSelectAgent}
         onCreateAgent={handleOpenWizard}
+        createAgentDisabled={disabled}
+        createAgentDisabledReason={disabled ? createAgentDisabledReason : null}
       />
 
       {agentDetail && (

--- a/packages/franken-web/tests/components/beasts/agent-list.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-list.test.tsx
@@ -55,6 +55,29 @@ describe('AgentList', () => {
     expect(onCreate).toHaveBeenCalled();
   });
 
+  it('disables empty-state create when agent creation is unavailable', () => {
+    const onCreate = vi.fn();
+    render(
+      <AgentList
+        agents={[]}
+        runs={[]}
+        selectedAgentId={null}
+        onSelectAgent={vi.fn()}
+        onCreateAgent={onCreate}
+        createAgentDisabled={true}
+        createAgentDisabledReason="Beast API is not available."
+      />,
+    );
+
+    const createButton = screen.getByRole('button', { name: /create your first agent/i });
+    expect(createButton).toBeTruthy();
+    expect(createButton.hasAttribute('disabled')).toBe(true);
+    expect(screen.getByText('Beast API is not available.')).toBeTruthy();
+
+    fireEvent.click(createButton);
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
   it('shows execution mode from the agent dispatch run rather than an older run', () => {
     const linkedAgent = { ...agents[0]!, dispatchRunId: 'run-new' };
     const runs: BeastRunSummary[] = [

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1213,6 +1213,31 @@ describe('ChatShell', () => {
     expect(screen.queryByText('Identity')).toBeNull();
   });
 
+  it('keeps create-agent enabled for non-creation Beast event errors after state loads', async () => {
+    window.location.hash = '#/beasts';
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('agent-1')).toBeDefined();
+    });
+
+    latestBeastEventHandlers?.error?.(new Error('SSE disconnected'));
+
+    await waitFor(() => {
+      expect(screen.getByText('SSE disconnected')).toBeDefined();
+    });
+
+    const headerCreateButton = screen.getByRole('button', { name: /^\+ create agent$/i });
+    expect(headerCreateButton.hasAttribute('disabled')).toBe(false);
+  });
+
   it('renders initializing agents in the beasts list', async () => {
     window.location.hash = '#/beasts';
     mockListAgents.mockResolvedValue([

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -325,6 +325,30 @@ afterEach(() => {
     latestBeastEventHandlers = handlers;
     return Promise.resolve(vi.fn());
   });
+  mockGetCatalog.mockReset();
+  mockGetCatalog.mockResolvedValue([
+    {
+      id: 'chunk-plan',
+      label: 'Design Doc -> Chunk Creation',
+      description: 'Build chunks from a design doc',
+      executionModeDefault: 'process',
+      interviewPrompts: [
+        { key: 'designDocPath', prompt: 'Design doc', kind: 'file', required: true },
+        { key: 'outputDir', prompt: 'Output directory', kind: 'string', required: true },
+      ],
+    },
+    {
+      id: 'martin-loop',
+      label: 'Martin Loop',
+      description: 'Run Martin loop',
+      executionModeDefault: 'process',
+      interviewPrompts: [
+        { key: 'provider', prompt: 'Provider', kind: 'string', options: ['claude', 'codex'] },
+        { key: 'objective', prompt: 'Objective', kind: 'string' },
+        { key: 'chunkDirectory', prompt: 'Chunk directory', kind: 'directory', required: true },
+      ],
+    },
+  ]);
   mockListSessions.mockResolvedValue([
     {
       id: 'sess-1',
@@ -1161,6 +1185,32 @@ describe('ChatShell', () => {
     await waitFor(() => {
       expect(screen.getByText('agent-1')).toBeDefined();
     });
+  });
+
+  it('disables create-agent entry points when Beast API state cannot load', async () => {
+    window.location.hash = '#/beasts';
+    mockGetCatalog.mockRejectedValue(new Error('Beast API not available'));
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Beast API not available').length).toBeGreaterThan(0);
+    });
+
+    const headerCreateButton = screen.getByRole('button', { name: /^\+ create agent$/i });
+    const emptyStateCreateButton = screen.getByRole('button', { name: /create your first agent/i });
+
+    expect(headerCreateButton.hasAttribute('disabled')).toBe(true);
+    expect(emptyStateCreateButton.hasAttribute('disabled')).toBe(true);
+
+    fireEvent.click(emptyStateCreateButton);
+    expect(screen.queryByText('Identity')).toBeNull();
   });
 
   it('renders initializing agents in the beasts list', async () => {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1238,6 +1238,26 @@ describe('ChatShell', () => {
     expect(headerCreateButton.hasAttribute('disabled')).toBe(false);
   });
 
+  it('keeps create-agent enabled when selected agent detail fails after state loads', async () => {
+    window.location.hash = '#/beasts';
+    mockGetAgent.mockRejectedValue(new Error('Agent detail unavailable'));
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent detail unavailable')).toBeDefined();
+    });
+
+    const headerCreateButton = screen.getByRole('button', { name: /^\+ create agent$/i });
+    expect(headerCreateButton.hasAttribute('disabled')).toBe(false);
+  });
+
   it('renders initializing agents in the beasts list', async () => {
     window.location.hash = '#/beasts';
     mockListAgents.mockResolvedValue([

--- a/packages/franken-web/tests/pages/beasts-page.test.tsx
+++ b/packages/franken-web/tests/pages/beasts-page.test.tsx
@@ -56,6 +56,27 @@ describe('BeastsPage', () => {
     expect(screen.getByText('Identity')).toBeTruthy();
   });
 
+  it('disables every create-agent entry point when the Beast API is unavailable', () => {
+    render(
+      <BeastsPage
+        {...baseProps}
+        agents={[]}
+        disabled={true}
+        error="Beast API not available"
+      />,
+    );
+
+    const headerCreateButton = screen.getByRole('button', { name: /^\+ create agent$/i });
+    const emptyStateCreateButton = screen.getByRole('button', { name: /create your first agent/i });
+
+    expect(headerCreateButton.hasAttribute('disabled')).toBe(true);
+    expect(emptyStateCreateButton.hasAttribute('disabled')).toBe(true);
+    expect(screen.getAllByText('Beast API not available').length).toBeGreaterThan(0);
+
+    fireEvent.click(emptyStateCreateButton);
+    expect(screen.queryByText('Identity')).toBeNull();
+  });
+
   it('drives wizard workflow choices from backend catalog prop', () => {
     render(<BeastsPage {...baseProps} catalog={[{
       id: 'custom-beast',


### PR DESCRIPTION
## Summary
- pass Beast API disabled state through to the empty AgentList create CTA
- show unavailable guidance in the zero-agent empty state
- guard the wizard opener and add regression coverage for disabled zero-agent creation

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm test -- tests/components/beasts/agent-list.test.tsx tests/pages/beasts-page.test.tsx (from packages/franken-web)
- npm run typecheck (from packages/franken-web)
- npm run build (from packages/franken-web)

Closes #1097