### PR TITLE
fix(web): validate chat websocket server events

### DIFF
--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -568,11 +568,16 @@ describe('useChatSession error banners', () => {
         }),
       });
       MockWebSocket.instances[0]!.onmessage?.({
-        data: JSON.stringify({ type: 'message.delivered', clientMessageId: userMessageId }),
+        data: JSON.stringify({
+          type: 'message.delivered',
+          clientMessageId: userMessageId,
+          timestamp: '2026-01-01T10:29:30.100Z',
+        }),
       });
       MockWebSocket.instances[0]!.onmessage?.({
         data: JSON.stringify({
           type: 'session.ready',
+          sessionId: 'session-1',
           transcript: [],
           pendingApproval: null,
           state: 'active',
@@ -585,7 +590,8 @@ describe('useChatSession error banners', () => {
       expect.objectContaining({
         id: userMessageId,
         content: 'preserve delivered prompt',
-        receipt: 'accepted',
+        receipt: 'failed',
+        canRetry: true,
       }),
     ]));
   });

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -290,7 +290,12 @@ describe('useChatSession error banners', () => {
     const retriedMessageId = result.current.messages.find((message) => message.role === 'user')!.id;
     act(() => {
       MockWebSocket.instances[0]!.onmessage?.({
-        data: JSON.stringify({ type: 'message.accepted', clientMessageId: retriedMessageId }),
+        data: JSON.stringify({
+          type: 'message.accepted',
+          clientMessageId: retriedMessageId,
+          sessionId: 'session-1',
+          timestamp: '2026-07-05T00:00:01.000Z',
+        }),
       });
     });
     await act(async () => {
@@ -555,7 +560,12 @@ describe('useChatSession error banners', () => {
     const userMessageId = result.current.messages.find((message) => message.role === 'user')!.id;
     act(() => {
       MockWebSocket.instances[0]!.onmessage?.({
-        data: JSON.stringify({ type: 'message.accepted', clientMessageId: userMessageId }),
+        data: JSON.stringify({
+          type: 'message.accepted',
+          clientMessageId: userMessageId,
+          sessionId: 'session-1',
+          timestamp: '2026-01-01T10:29:30.090Z',
+        }),
       });
       MockWebSocket.instances[0]!.onmessage?.({
         data: JSON.stringify({ type: 'message.delivered', clientMessageId: userMessageId }),
@@ -565,6 +575,7 @@ describe('useChatSession error banners', () => {
           type: 'session.ready',
           transcript: [],
           pendingApproval: null,
+          state: 'active',
           projectId: 'project-1',
         }),
       });
@@ -574,8 +585,7 @@ describe('useChatSession error banners', () => {
       expect.objectContaining({
         id: userMessageId,
         content: 'preserve delivered prompt',
-        receipt: 'failed',
-        canRetry: true,
+        receipt: 'accepted',
       }),
     ]));
   });

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -7,7 +7,13 @@ import {
   type TokenTotals,
   type TranscriptMessage,
 } from '../lib/api';
-import { deterministicUuid, isoNow, seededRandom } from '@franken/types';
+import {
+  ServerSocketEventSchema,
+  type ServerSocketEvent,
+  deterministicUuid,
+  isoNow,
+  seededRandom,
+} from '@franken/types';
 
 export type SessionStatus = 'idle' | 'connecting' | 'sending' | 'streaming' | 'error';
 export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'offline' | 'error';
@@ -73,68 +79,6 @@ export interface UseChatSessionResult {
   tier: string | null;
   tokenTotals: TokenTotals;
 }
-
-type ServerSocketEvent =
-  | {
-    type: 'session.ready';
-    sessionId: string;
-    projectId: string;
-    transcript: TranscriptMessage[];
-    state: string;
-    pendingApproval?: PendingApproval | null;
-  }
-  | {
-    type: 'message.accepted' | 'message.delivered';
-    clientMessageId: string;
-    timestamp: string;
-  }
-  | {
-    type: 'message.read';
-    clientMessageId?: string;
-    messageId?: string;
-    timestamp: string;
-  }
-  | { type: 'assistant.typing.start'; timestamp: string }
-  | {
-    type: 'assistant.message.delta';
-    messageId: string;
-    chunk: string;
-    modelTier?: string;
-  }
-  | {
-    type: 'assistant.message.complete';
-    messageId: string;
-    content: string;
-    modelTier?: string;
-    timestamp: string;
-  }
-  | {
-    type: 'turn.execution.start' | 'turn.execution.progress' | 'turn.execution.complete';
-    data?: Record<string, unknown>;
-    timestamp: string;
-  }
-  | {
-    type: 'turn.approval.requested';
-    description: string;
-    timestamp: string;
-    tool?: string;
-    command?: string;
-    risk?: string;
-    affectedFiles?: string[];
-    sessionId?: string;
-  }
-  | {
-    type: 'turn.approval.resolved';
-    approved: boolean;
-    timestamp: string;
-  }
-  | {
-    type: 'turn.error';
-    code: string;
-    message: string;
-    timestamp: string;
-  }
-  | { type: 'pong'; timestamp: string };
 
 const EMPTY_TOKEN_TOTALS: TokenTotals = {
   cheap: 0,
@@ -621,6 +565,19 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       refreshSession();
     }
 
+    function handleProtocolError(message: string) {
+      setStatus('error');
+      setConnectionStatus('error');
+      failAllPendingSends(new Error(message), false);
+      addErrorBanner(makeBanner(
+        'Chat protocol error',
+        message,
+        'reconnect',
+        'Reconnect chat',
+        'invalid_socket_event',
+      ));
+    }
+
     const socket = new WebSocket(
       clientRef.current.socketUrl(sessionId, socketToken),
       clientRef.current.socketProtocols(socketToken),
@@ -633,13 +590,23 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     };
 
     socket.onmessage = (event) => {
-      let payload: ServerSocketEvent;
+      let decoded: unknown;
 
       try {
-        payload = JSON.parse(event.data as string) as ServerSocketEvent;
+        decoded = JSON.parse(event.data as string);
       } catch {
+        handleProtocolError('The chat server sent invalid JSON over the WebSocket. Reconnect to refresh the session state.');
         return;
       }
+
+      const parsed = ServerSocketEventSchema.safeParse(decoded);
+      if (!parsed.success) {
+        const detail = parsed.error.issues[0]?.message ?? 'The event did not match the expected schema.';
+        handleProtocolError(`The chat server sent an invalid event: ${detail}`);
+        return;
+      }
+
+      const payload = parsed.data;
 
       switch (payload.type) {
         case 'session.ready':

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -568,7 +568,11 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     function handleProtocolError(message: string) {
       setStatus('error');
       setConnectionStatus('error');
-      failAllPendingSends(new Error(message), false);
+      failAllPendingSends(new Error(message));
+      if (approvalResolvingRef.current) {
+        updateApprovalResolving(false);
+        setApprovalError('The chat server sent an invalid response while resolving approval. Try again if approval is still pending.');
+      }
       addErrorBanner(makeBanner(
         'Chat protocol error',
         message,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -554,6 +554,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
     let shouldReconnect = true;
     let reconnectRefreshInFlight = false;
+    let protocolErrored = false;
     setConnectionStatus('connecting');
     readyRef.current = false;
 
@@ -566,6 +567,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     function handleProtocolError(message: string) {
+      protocolErrored = true;
       setStatus('error');
       setConnectionStatus('error');
       failAllPendingSends(new Error(message));
@@ -594,6 +596,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     };
 
     socket.onmessage = (event) => {
+      if (protocolErrored) {
+        return;
+      }
+
       let decoded: unknown;
 
       try {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -568,6 +568,15 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
     function handleProtocolError(message: string) {
       protocolErrored = true;
+      shouldReconnect = false;
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+      try {
+        socket.close();
+      } catch {
+        // Ignore close failures; the protocol-error banner already tells the user how to recover.
+      }
       setStatus('error');
       setConnectionStatus('error');
       failAllPendingSends(new Error(message));

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -333,7 +333,7 @@ describe('useChatSession', () => {
     expect(result.current.messages).toContainEqual(expect.objectContaining({
       id: clientMessageId,
       receipt: 'failed',
-      canRetry: false,
+      canRetry: true,
     }));
     expect(result.current.errorBanners[0]).toMatchObject({
       action: 'reconnect',
@@ -1029,6 +1029,48 @@ describe('useChatSession', () => {
     });
 
     expect(mockApprove).toHaveBeenCalledWith('chat-1', false);
+  });
+
+  it('clears approval resolving state after protocol errors so users can retry', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+      socket.message({
+        type: 'turn.approval.requested',
+        description: 'Deploy the generated fix',
+        timestamp: '2026-03-09T00:00:06Z',
+      });
+    });
+
+    await act(async () => {
+      await result.current.approve(true);
+    });
+
+    expect(socket.sent).toHaveLength(1);
+    expect(result.current.approvalResolving).toBe(true);
+
+    act(() => socket.message({ type: 'message.accepted', timestamp: '2026-03-09T00:00:07Z' }));
+
+    await waitFor(() => {
+      expect(result.current.approvalResolving).toBe(false);
+      expect(result.current.approvalError).toContain('invalid response');
+    });
+
+    await act(async () => {
+      await result.current.approve(false);
+    });
+
+    expect(socket.sent).toHaveLength(2);
+    expect(JSON.parse(socket.sent[1] ?? '{}')).toMatchObject({
+      type: 'approval.respond',
+      approved: false,
+    });
   });
 
   it('preserves streamed messages after HTTP approval fallback', async () => {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -329,6 +329,15 @@ describe('useChatSession', () => {
       });
     });
 
+    act(() => {
+      socket.message({
+        type: 'message.accepted',
+        clientMessageId,
+        sessionId: 'chat-1',
+        timestamp: '2026-03-09T00:00:02Z',
+      });
+    });
+
     await expect(sendPromise).rejects.toThrow('invalid event');
     expect(result.current.messages).toContainEqual(expect.objectContaining({
       id: clientMessageId,

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -61,8 +61,12 @@ class MockWebSocket {
   }
 
   message(payload: unknown) {
+    this.rawMessage(JSON.stringify(payload));
+  }
+
+  rawMessage(data: string) {
     this.onmessage?.(
-      new MessageEvent('message', { data: JSON.stringify(payload) }),
+      new MessageEvent('message', { data }),
     );
   }
 
@@ -252,6 +256,35 @@ describe('useChatSession', () => {
     expect(result.current.connectionStatus).toBe('connected');
   });
 
+  it.each([
+    ['invalid JSON', (socket: MockWebSocket) => socket.rawMessage('{not json')],
+    ['malformed known event', (socket: MockWebSocket) => socket.message({ type: 'assistant.message.delta', messageId: 'assistant-1' })],
+    ['unknown event type', (socket: MockWebSocket) => socket.message({ type: 'session.unknown', timestamp: '2026-03-09T00:00:01Z' })],
+  ])('surfaces %s as a recoverable websocket protocol error without mutating chat state', async (_name, sendInvalidEvent) => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+      sendInvalidEvent(socket);
+    });
+
+    expect(result.current.connectionStatus).toBe('error');
+    expect(result.current.status).toBe('error');
+    expect(result.current.messages).toHaveLength(0);
+    expect(result.current.activity).toHaveLength(0);
+    expect(result.current.pendingApproval).toBeNull();
+    expect(result.current.errorBanners[0]).toMatchObject({
+      title: 'Chat protocol error',
+      action: 'reconnect',
+      code: 'invalid_socket_event',
+    });
+  });
+
   it('falls back to HTTP send when the websocket is not ready', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 
@@ -269,6 +302,43 @@ describe('useChatSession', () => {
     expect(mockGetSession).toHaveBeenCalledWith('chat-1');
     expect(socket.sent).toHaveLength(0);
     expect(result.current.status).toBe('idle');
+  });
+
+  it('rejects malformed accepted events instead of resolving pending websocket sends', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+    });
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send('Wait for malformed ack');
+    });
+    const clientMessageId = (JSON.parse(socket.sent[0] ?? '{}') as { clientMessageId: string }).clientMessageId;
+
+    act(() => {
+      socket.message({
+        type: 'message.accepted',
+        timestamp: '2026-03-09T00:00:01Z',
+      });
+    });
+
+    await expect(sendPromise).rejects.toThrow('invalid event');
+    expect(result.current.messages).toContainEqual(expect.objectContaining({
+      id: clientMessageId,
+      receipt: 'failed',
+      canRetry: false,
+    }));
+    expect(result.current.errorBanners[0]).toMatchObject({
+      action: 'reconnect',
+      code: 'invalid_socket_event',
+    });
   });
 
   it('refreshes approval metadata when an HTTP fallback send is blocked', async () => {
@@ -428,6 +498,7 @@ describe('useChatSession', () => {
       socket.message({
         type: 'message.accepted',
         clientMessageId: retryId,
+        sessionId: 'chat-1',
         timestamp: '2026-03-09T00:00:02Z',
       });
     });
@@ -504,7 +575,7 @@ describe('useChatSession', () => {
     });
     const firstId = (JSON.parse(socket.sent[0] ?? '{}') as { clientMessageId: string }).clientMessageId;
     act(() => {
-      socket.message({ type: 'message.accepted', clientMessageId: firstId, timestamp: '2026-03-09T00:00:01Z' });
+      socket.message({ type: 'message.accepted', clientMessageId: firstId, sessionId: 'chat-1', timestamp: '2026-03-09T00:00:01Z' });
     });
     await act(async () => {
       await firstSend;
@@ -516,7 +587,7 @@ describe('useChatSession', () => {
     });
     const secondId = (JSON.parse(socket.sent[1] ?? '{}') as { clientMessageId: string }).clientMessageId;
     act(() => {
-      socket.message({ type: 'message.accepted', clientMessageId: secondId, timestamp: '2026-03-09T00:00:02Z' });
+      socket.message({ type: 'message.accepted', clientMessageId: secondId, sessionId: 'chat-1', timestamp: '2026-03-09T00:00:02Z' });
     });
     await act(async () => {
       await secondSend;
@@ -556,7 +627,7 @@ describe('useChatSession', () => {
     });
     const firstId = (JSON.parse(socket.sent[0] ?? '{}') as { clientMessageId: string }).clientMessageId;
     act(() => {
-      socket.message({ type: 'message.accepted', clientMessageId: firstId, timestamp: '2026-03-09T00:00:01Z' });
+      socket.message({ type: 'message.accepted', clientMessageId: firstId, sessionId: 'chat-1', timestamp: '2026-03-09T00:00:01Z' });
     });
     await act(async () => {
       await firstSend;
@@ -616,7 +687,7 @@ describe('useChatSession', () => {
     });
     const slashId = (JSON.parse(socket.sent[0] ?? '{}') as { clientMessageId: string }).clientMessageId;
     act(() => {
-      socket.message({ type: 'message.accepted', clientMessageId: slashId, timestamp: '2026-03-09T00:00:01Z' });
+      socket.message({ type: 'message.accepted', clientMessageId: slashId, sessionId: 'chat-1', timestamp: '2026-03-09T00:00:01Z' });
     });
     await act(async () => {
       await slashSend;
@@ -672,7 +743,7 @@ describe('useChatSession', () => {
     }));
 
     act(() => {
-      socket.message({ type: 'message.accepted', clientMessageId, timestamp: '2026-03-09T00:00:02Z' });
+      socket.message({ type: 'message.accepted', clientMessageId, sessionId: 'chat-1', timestamp: '2026-03-09T00:00:02Z' });
     });
 
     expect(result.current.messages).toContainEqual(expect.objectContaining({
@@ -746,7 +817,7 @@ describe('useChatSession', () => {
     const clientMessageId = (JSON.parse(socket.sent[0] ?? '{}') as { clientMessageId: string }).clientMessageId;
 
     act(() => {
-      socket.message({ type: 'message.accepted', clientMessageId, timestamp: '2026-03-09T00:00:01Z' });
+      socket.message({ type: 'message.accepted', clientMessageId, sessionId: 'chat-1', timestamp: '2026-03-09T00:00:01Z' });
     });
     await act(async () => {
       await sendPromise;
@@ -1061,6 +1132,7 @@ describe('useChatSession', () => {
       socket.message({
         type: 'message.accepted',
         clientMessageId: outbound.clientMessageId,
+        sessionId: 'chat-1',
         timestamp: '2026-03-09T00:00:01Z',
       });
     });

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -1075,11 +1075,8 @@ describe('useChatSession', () => {
       await result.current.approve(false);
     });
 
-    expect(socket.sent).toHaveLength(2);
-    expect(JSON.parse(socket.sent[1] ?? '{}')).toMatchObject({
-      type: 'approval.respond',
-      approved: false,
-    });
+    expect(socket.sent).toHaveLength(1);
+    expect(mockApprove).toHaveBeenCalledWith('chat-1', false);
   });
 
   it('preserves streamed messages after HTTP approval fallback', async () => {


### PR DESCRIPTION
## Summary
- import the shared `ServerSocketEventSchema` in `useChatSession` so browser WebSocket events are parsed at runtime before state mutations
- surface invalid JSON, unknown event types, and malformed known events as recoverable chat protocol errors
- add regression coverage for invalid WebSocket payloads and malformed accepted acknowledgements

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run test --workspace @franken/web -- tests/hooks/use-chat-session.test.ts
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm run lint:any

Closes #1091