### PR TITLE
fix(web): guard tracked-agent lifecycle actions

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-action-bar.tsx
+++ b/packages/franken-web/src/components/beasts/agent-action-bar.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 
+export type AgentLifecycleAction = 'start' | 'stop' | 'restart' | 'resume' | 'delete' | 'kill';
+
 interface AgentActionBarProps {
   status: string;
   hasLinkedRun: boolean;
   agentLabel?: string;
+  pendingAction?: AgentLifecycleAction | null;
   onStart: () => void;
   onStop: () => void;
   onRestart: () => void;
@@ -13,14 +16,14 @@ interface AgentActionBarProps {
   onKill: () => void;
 }
 
-function ActionButton({ label, onClick, variant = 'default' }: {
-  label: string; onClick: () => void; variant?: 'default' | 'danger';
+function ActionButton({ label, onClick, variant = 'default', disabled = false }: {
+  label: string; onClick: () => void; variant?: 'default' | 'danger'; disabled?: boolean;
 }) {
   const base = 'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors';
   const styles = variant === 'danger'
-    ? `${base} bg-beast-danger/20 text-beast-danger hover:bg-beast-danger/30 border border-beast-danger/30`
-    : `${base} bg-beast-control text-beast-text hover:bg-beast-elevated border border-beast-border`;
-  return <button type="button" onClick={onClick} className={styles}>{label}</button>;
+    ? `${base} bg-beast-danger/20 text-beast-danger hover:bg-beast-danger/30 border border-beast-danger/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-beast-danger/20`
+    : `${base} bg-beast-control text-beast-text hover:bg-beast-elevated border border-beast-border disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-beast-control`;
+  return <button type="button" onClick={onClick} disabled={disabled} className={styles}>{label}</button>;
 }
 
 function ConfirmDangerAction({
@@ -29,17 +32,19 @@ function ConfirmDangerAction({
   description,
   confirmLabel,
   onConfirm,
+  disabled = false,
 }: {
   label: string;
   title: string;
   description: string;
   confirmLabel: string;
   onConfirm: () => void;
+  disabled?: boolean;
 }) {
   return (
     <AlertDialog.Root>
       <AlertDialog.Trigger asChild>
-        <button type="button" className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors bg-beast-danger/20 text-beast-danger hover:bg-beast-danger/30 border border-beast-danger/30">
+        <button type="button" disabled={disabled} className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors bg-beast-danger/20 text-beast-danger hover:bg-beast-danger/30 border border-beast-danger/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-beast-danger/20">
           {label}
         </button>
       </AlertDialog.Trigger>
@@ -59,7 +64,7 @@ function ConfirmDangerAction({
               <button type="button" className="px-3 py-1.5 rounded-lg text-sm bg-beast-control text-beast-text border border-beast-border">Cancel</button>
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
-              <button type="button" onClick={onConfirm} className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white">{confirmLabel}</button>
+              <button type="button" onClick={onConfirm} disabled={disabled} className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white disabled:opacity-50 disabled:cursor-not-allowed">{confirmLabel}</button>
             </AlertDialog.Action>
           </div>
         </AlertDialog.Content>
@@ -68,25 +73,39 @@ function ConfirmDangerAction({
   );
 }
 
-export function AgentActionBar({ status, hasLinkedRun, agentLabel = 'this tracked agent', onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
+const PENDING_LABELS: Record<AgentLifecycleAction, string> = {
+  start: 'Starting...',
+  stop: 'Stopping...',
+  restart: 'Restarting...',
+  resume: 'Resuming...',
+  delete: 'Deleting...',
+  kill: 'Killing...',
+};
+
+function actionLabel(action: AgentLifecycleAction, label: string, pendingAction: AgentLifecycleAction | null | undefined): string {
+  return pendingAction === action ? PENDING_LABELS[action] : label;
+}
+
+export function AgentActionBar({ status, hasLinkedRun, agentLabel = 'this tracked agent', pendingAction = null, onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
   const [forceRestart, setForceRestart] = useState(false);
 
   const isInitOrDispatch = status === 'initializing' || status === 'dispatching';
   const isRunning = status === 'running';
   const isStopped = status === 'stopped';
   const isTerminal = status === 'failed' || status === 'completed';
+  const lifecyclePending = pendingAction !== null;
 
   return (
     <div className="flex items-center gap-2 flex-wrap p-4 border-t border-beast-border">
-      {(isInitOrDispatch || isRunning) && <ActionButton label="Stop" onClick={onStop} />}
+      {(isInitOrDispatch || isRunning) && <ActionButton label={actionLabel('stop', 'Stop', pendingAction)} onClick={onStop} disabled={lifecyclePending} />}
 
       {isRunning && (
         <>
           {forceRestart ? (
             <AlertDialog.Root>
               <AlertDialog.Trigger asChild>
-                <button type="button" className="px-3 py-1.5 rounded-lg text-sm font-medium bg-beast-danger/20 text-beast-danger border border-beast-danger/30">
-                  Restart
+                <button type="button" disabled={lifecyclePending} className="px-3 py-1.5 rounded-lg text-sm font-medium bg-beast-danger/20 text-beast-danger border border-beast-danger/30 disabled:opacity-50 disabled:cursor-not-allowed">
+                  {actionLabel('restart', 'Restart', pendingAction)}
                 </button>
               </AlertDialog.Trigger>
               <AlertDialog.Portal>
@@ -105,38 +124,40 @@ export function AgentActionBar({ status, hasLinkedRun, agentLabel = 'this tracke
                       <button type="button" className="px-3 py-1.5 rounded-lg text-sm bg-beast-control text-beast-text border border-beast-border">Cancel</button>
                     </AlertDialog.Cancel>
                     <AlertDialog.Action asChild>
-                      <button type="button" onClick={onRestart} className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white">Force Restart</button>
+                      <button type="button" onClick={onRestart} disabled={lifecyclePending} className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white disabled:opacity-50 disabled:cursor-not-allowed">Force Restart</button>
                     </AlertDialog.Action>
                   </div>
                 </AlertDialog.Content>
               </AlertDialog.Portal>
             </AlertDialog.Root>
           ) : (
-            <ActionButton label="Restart" onClick={onRestart} />
+            <ActionButton label={actionLabel('restart', 'Restart', pendingAction)} onClick={onRestart} disabled={lifecyclePending} />
           )}
           <ConfirmDangerAction
-            label="Kill"
+            label={actionLabel('kill', 'Kill', pendingAction)}
             title="Kill tracked agent"
             description={`Kill ${agentLabel}? This interrupts the linked run immediately and cannot be undone from the dashboard.`}
             confirmLabel="Kill agent"
             onConfirm={onKill}
+            disabled={lifecyclePending}
           />
-          <label className="flex items-center gap-1.5 text-xs text-beast-subtle ml-2 cursor-pointer">
-            <input type="checkbox" checked={forceRestart} onChange={(e) => setForceRestart(e.target.checked)} className="accent-beast-danger" />
+          <label className={`flex items-center gap-1.5 text-xs text-beast-subtle ml-2 ${lifecyclePending ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}>
+            <input type="checkbox" checked={forceRestart} disabled={lifecyclePending} onChange={(e) => setForceRestart(e.target.checked)} className="accent-beast-danger" />
             Force
           </label>
         </>
       )}
 
-      {(isStopped || isTerminal) && <ActionButton label="Start" onClick={onStart} />}
-      {isStopped && hasLinkedRun && <ActionButton label="Resume" onClick={onResume} />}
+      {(isStopped || isTerminal) && <ActionButton label={actionLabel('start', 'Start', pendingAction)} onClick={onStart} disabled={lifecyclePending} />}
+      {isStopped && hasLinkedRun && <ActionButton label={actionLabel('resume', 'Resume', pendingAction)} onClick={onResume} disabled={lifecyclePending} />}
       {(isStopped || isTerminal) && (
         <ConfirmDangerAction
-          label="Delete"
+          label={actionLabel('delete', 'Delete', pendingAction)}
           title="Delete tracked agent"
           description={`Delete ${agentLabel}? This soft-deletes it and removes it from the dashboard history.`}
           confirmLabel="Delete agent"
           onConfirm={onDelete}
+          disabled={lifecyclePending}
         />
       )}
     </div>

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -6,7 +6,7 @@ import { SlideInPanel } from './slide-in-panel';
 import { StatusLight } from './status-light';
 import { AgentDetailReadonly } from './agent-detail-readonly';
 import { AgentDetailEdit } from './agent-detail-edit';
-import { AgentActionBar } from './agent-action-bar';
+import { AgentActionBar, type AgentLifecycleAction } from './agent-action-bar';
 import { LogViewerModal } from './log-viewer-modal';
 
 type Mode = 'readonly' | 'edit';
@@ -22,12 +22,13 @@ interface AgentDetailPanelProps {
   onResume: () => void;
   onDelete: () => void;
   onKill: () => void;
+  pendingAction?: AgentLifecycleAction | null;
   onSaveConfig: (values: Record<string, unknown>) => Promise<void>;
 }
 
 export function AgentDetailPanel({
   isOpen, detail, logs, onClose,
-  onStart, onStop, onRestart, onResume, onDelete, onKill, onSaveConfig,
+  onStart, onStop, onRestart, onResume, onDelete, onKill, pendingAction = null, onSaveConfig,
 }: AgentDetailPanelProps) {
   const [mode, setMode] = useState<Mode>('readonly');
   const [showLogModal, setShowLogModal] = useState(false);
@@ -127,6 +128,7 @@ export function AgentDetailPanel({
           status={agent.status}
           hasLinkedRun={!!agent.dispatchRunId}
           agentLabel={agent.name?.trim() ? agent.name : agent.id}
+          pendingAction={pendingAction}
           onStart={onStart}
           onStop={onStop}
           onRestart={onRestart}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -20,6 +20,7 @@ import {
 import { ChatApiClient, type ChatSessionSummary } from '../lib/api';
 import { NetworkApiClient, type NetworkConfigResponse, type NetworkStatusResponse } from '../lib/network-api';
 import { BeastsPage } from '../pages/beasts-page';
+import type { AgentLifecycleAction } from './beasts/agent-action-bar';
 import { AnalyticsApiClient } from '../lib/analytics-api';
 import { AnalyticsPage } from '../pages/analytics-page';
 import { DashboardApiClient } from '../lib/dashboard-api';
@@ -287,6 +288,8 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const beastAgentDetailRef = useRef<(TrackedAgentDetail & { run?: BeastRunDetail | null }) | null>(null);
   const [beastError, setBeastError] = useState<string | null>(null);
   const [beastRefreshNonce, setBeastRefreshNonce] = useState(0);
+  const [pendingBeastAgentActions, setPendingBeastAgentActions] = useState<Record<string, AgentLifecycleAction | undefined>>({});
+  const pendingBeastAgentActionsRef = useRef<Record<string, AgentLifecycleAction | undefined>>({});
   const selectedBeastAgentIdRef = useRef<string | null>(null);
   const shouldAutoSelectBeastAgentRef = useRef(true);
   const [networkStatus, setNetworkStatus] = useState<NetworkStatusResponse>({
@@ -725,6 +728,47 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     getSidebarFocusableElements(sidebar).at(-1)?.focus();
   }
 
+  function setPendingBeastAgentAction(agentId: string, action: AgentLifecycleAction | undefined) {
+    const next = { ...pendingBeastAgentActionsRef.current };
+    if (action) {
+      next[agentId] = action;
+    } else {
+      delete next[agentId];
+    }
+    pendingBeastAgentActionsRef.current = next;
+    setPendingBeastAgentActions(next);
+  }
+
+  function runBeastAgentLifecycleAction({
+    agentId,
+    action,
+    request,
+    onSuccess,
+    errorMessage,
+  }: {
+    agentId: string;
+    action: AgentLifecycleAction;
+    request: () => Promise<unknown>;
+    onSuccess?: () => void;
+    errorMessage: string;
+  }) {
+    if (!beastClient || pendingBeastAgentActionsRef.current[agentId]) return;
+
+    setBeastError(null);
+    setPendingBeastAgentAction(agentId, action);
+    void request()
+      .then(() => {
+        onSuccess?.();
+        setBeastRefreshNonce((current) => current + 1);
+      })
+      .catch((err) => {
+        setBeastError(err instanceof Error ? err.message : errorMessage);
+      })
+      .finally(() => {
+        setPendingBeastAgentAction(agentId, undefined);
+      });
+  }
+
   const hasPendingApproval = Boolean(pendingApproval) || sessionState === 'pending_approval';
   const composerDisabled = status === 'connecting'
     || status === 'sending'
@@ -986,6 +1030,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             disabled={false}
             error={beastError}
             logs={beastAgentDetail?.run?.logs ?? []}
+            pendingAgentActions={pendingBeastAgentActions}
             selectedAgentId={selectedBeastAgentId}
             onClose={() => {
               shouldAutoSelectBeastAgentRef.current = false;
@@ -1002,36 +1047,36 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               setBeastRefreshNonce((current) => current + 1);
             }}
             onDelete={(agentId) => {
-              if (!beastClient) return;
-              void beastClient.deleteAgent(agentId).then(() => {
-                setSelectedBeastAgentId((current) => current === agentId ? null : current);
-                setBeastRefreshNonce((current) => current + 1);
-              }).catch((err) => {
-                setBeastError(err instanceof Error ? err.message : 'Unable to delete tracked agent.');
+              runBeastAgentLifecycleAction({
+                agentId,
+                action: 'delete',
+                request: () => beastClient.deleteAgent(agentId),
+                onSuccess: () => setSelectedBeastAgentId((current) => current === agentId ? null : current),
+                errorMessage: 'Unable to delete tracked agent.',
               });
             }}
             onKill={(agentId) => {
-              if (!beastClient) return;
-              void beastClient.killAgent(agentId).then(() => {
-                setBeastRefreshNonce((current) => current + 1);
-              }).catch((err) => {
-                setBeastError(err instanceof Error ? err.message : 'Unable to kill tracked agent.');
+              runBeastAgentLifecycleAction({
+                agentId,
+                action: 'kill',
+                request: () => beastClient.killAgent(agentId),
+                errorMessage: 'Unable to kill tracked agent.',
               });
             }}
             onRestart={(agentId) => {
-              if (!beastClient) return;
-              void beastClient.restartAgent(agentId).then(() => {
-                setBeastRefreshNonce((current) => current + 1);
-              }).catch((err) => {
-                setBeastError(err instanceof Error ? err.message : 'Unable to restart tracked agent.');
+              runBeastAgentLifecycleAction({
+                agentId,
+                action: 'restart',
+                request: () => beastClient.restartAgent(agentId),
+                errorMessage: 'Unable to restart tracked agent.',
               });
             }}
             onResume={(agentId) => {
-              if (!beastClient) return;
-              void beastClient.resumeAgent(agentId).then(() => {
-                setBeastRefreshNonce((current) => current + 1);
-              }).catch((err) => {
-                setBeastError(err instanceof Error ? err.message : 'Unable to resume tracked agent.');
+              runBeastAgentLifecycleAction({
+                agentId,
+                action: 'resume',
+                request: () => beastClient.resumeAgent(agentId),
+                errorMessage: 'Unable to resume tracked agent.',
               });
             }}
             onSaveAgentConfig={async (agentId, values) => {
@@ -1049,19 +1094,19 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               setSelectedBeastAgentId(agentId);
             }}
             onStart={(agentId) => {
-              if (!beastClient) return;
-              void beastClient.startAgent(agentId).then(() => {
-                setBeastRefreshNonce((current) => current + 1);
-              }).catch((err) => {
-                setBeastError(err instanceof Error ? err.message : 'Unable to start tracked agent.');
+              runBeastAgentLifecycleAction({
+                agentId,
+                action: 'start',
+                request: () => beastClient.startAgent(agentId),
+                errorMessage: 'Unable to start tracked agent.',
               });
             }}
             onStop={(agentId) => {
-              if (!beastClient) return;
-              void beastClient.stopAgent(agentId).then(() => {
-                setBeastRefreshNonce((current) => current + 1);
-              }).catch((err) => {
-                setBeastError(err instanceof Error ? err.message : 'Unable to stop tracked agent.');
+              runBeastAgentLifecycleAction({
+                agentId,
+                action: 'stop',
+                request: () => beastClient.stopAgent(agentId),
+                errorMessage: 'Unable to stop tracked agent.',
               });
             }}
           />

--- a/packages/franken-web/src/pages/beasts-page.tsx
+++ b/packages/franken-web/src/pages/beasts-page.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../lib/beast-api';
 import { AgentList } from '../components/beasts/agent-list';
 import { AgentDetailPanel } from '../components/beasts/agent-detail-panel';
+import type { AgentLifecycleAction } from '../components/beasts/agent-action-bar';
 import { WizardDialog } from '../components/beasts/wizard-dialog';
 import { useBeastStore } from '../stores/beast-store';
 
@@ -20,6 +21,7 @@ interface BeastsPageProps {
   disabled: boolean;
   error: string | null;
   logs: string[];
+  pendingAgentActions?: Record<string, AgentLifecycleAction | undefined>;
   selectedAgentId: string | null;
   onClose: () => void;
   onLaunch: (config: Record<string, unknown>) => Promise<void>;
@@ -42,6 +44,7 @@ export function BeastsPage({
   disabled,
   error,
   logs,
+  pendingAgentActions = {},
   selectedAgentId,
   onClose,
   onLaunch,
@@ -113,6 +116,7 @@ export function BeastsPage({
           detail={agentDetail}
           logs={logs}
           onClose={onClose}
+          pendingAction={pendingAgentActions[agentDetail.agent.id] ?? null}
           onStart={() => onStart(agentDetail.agent.id)}
           onStop={() => onStop(agentDetail.agent.id)}
           onRestart={() => onRestart(agentDetail.agent.id)}

--- a/packages/franken-web/tests/components/beasts/agent-action-bar.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-action-bar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
-import { AgentActionBar } from '../../../src/components/beasts/agent-action-bar';
+import { useState } from 'react';
+import { AgentActionBar, type AgentLifecycleAction } from '../../../src/components/beasts/agent-action-bar';
 
 afterEach(() => {
   cleanup();
@@ -24,6 +25,47 @@ describe('AgentActionBar', () => {
     expect(screen.getByText('Stop')).toBeTruthy();
     expect(screen.getByText('Restart')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Kill' })).toBeTruthy();
+  });
+
+  it('disables running-agent controls while a stop request is pending', () => {
+    render(<AgentActionBar status="running" hasLinkedRun={true} pendingAction="stop" {...handlers} />);
+
+    expect(screen.getByRole('button', { name: 'Stopping...' }).getAttribute('disabled')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Restart' }).getAttribute('disabled')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Kill' }).getAttribute('disabled')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stopping...' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Restart' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+
+    expect(handlers.onStop).not.toHaveBeenCalled();
+    expect(handlers.onRestart).not.toHaveBeenCalled();
+    expect(handlers.onKill).not.toHaveBeenCalled();
+  });
+
+  it('guards duplicate running-agent action clicks after a request enters pending state', () => {
+    function PendingHarness() {
+      const [pendingAction, setPendingAction] = useState<AgentLifecycleAction | null>(null);
+      return (
+        <AgentActionBar
+          status="running"
+          hasLinkedRun={true}
+          pendingAction={pendingAction}
+          {...handlers}
+          onStop={() => {
+            handlers.onStop();
+            setPendingAction('stop');
+          }}
+        />
+      );
+    }
+
+    render(<PendingHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stopping...' }));
+
+    expect(handlers.onStop).toHaveBeenCalledTimes(1);
   });
 
   it('requires cancelable confirmation before killing a running agent', () => {
@@ -50,6 +92,47 @@ describe('AgentActionBar', () => {
     expect(screen.getByText('Start')).toBeTruthy();
     expect(screen.getByText('Resume')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
+  });
+
+  it('disables stopped-agent controls while a start request is pending', () => {
+    render(<AgentActionBar status="stopped" hasLinkedRun={true} pendingAction="start" {...handlers} />);
+
+    expect(screen.getByRole('button', { name: 'Starting...' }).getAttribute('disabled')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Resume' }).getAttribute('disabled')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Delete' }).getAttribute('disabled')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Starting...' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resume' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(handlers.onStart).not.toHaveBeenCalled();
+    expect(handlers.onResume).not.toHaveBeenCalled();
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+  });
+
+  it('guards duplicate stopped-agent action clicks after a request enters pending state', () => {
+    function PendingHarness() {
+      const [pendingAction, setPendingAction] = useState<AgentLifecycleAction | null>(null);
+      return (
+        <AgentActionBar
+          status="stopped"
+          hasLinkedRun={true}
+          pendingAction={pendingAction}
+          {...handlers}
+          onStart={() => {
+            handlers.onStart();
+            setPendingAction('start');
+          }}
+        />
+      );
+    }
+
+    render(<PendingHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Starting...' }));
+
+    expect(handlers.onStart).toHaveBeenCalledTimes(1);
   });
 
   it('requires cancelable confirmation before deleting a stopped agent', () => {


### PR DESCRIPTION
## Summary
- Add per-agent pending lifecycle action tracking in the dashboard shell to ignore duplicate/conflicting tracked-agent actions while a request is in flight.
- Pass pending action state through the Beasts detail panel into the action bar.
- Disable lifecycle controls and show pending labels such as Starting.../Stopping... during in-flight actions.

## Test Plan
- npm test --workspace @franken/web -- agent-action-bar.test.tsx
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm test --workspace @franken/web

Closes #1090