### PR TITLE
fix(web): clear stale analytics refresh data

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -215,6 +215,27 @@ describe('AnalyticsPage', () => {
     expect(screen.getByText('3')).toBeTruthy();
   });
 
+  it('clears stale session options when a filtered session refresh fails', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchSessions)
+      .mockResolvedValueOnce([
+        { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
+        { id: 'session-b', lastActivityAt: '2026-04-28T12:02:00.000Z', eventCount: 1, failureCount: 0 },
+      ])
+      .mockRejectedValueOnce(new Error('sessions timeout'));
+
+    render(<AnalyticsPage client={client} />);
+
+    expect(await screen.findByRole('option', { name: 'session-b' })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Outcome'), { target: { value: 'denied' } });
+
+    expect(await screen.findByText('sessions timeout')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'session-b' })).toBeNull();
+    });
+  });
+
   it('navigates event pages and exposes disabled pagination states', async () => {
     const client = mockClient();
     let resolveSecondPage!: (page: AnalyticsEventPage) => void;
@@ -307,8 +328,46 @@ describe('AnalyticsPage', () => {
 
     expect(await screen.findByText('HTTP 500')).toBeTruthy();
     expect(screen.queryByText('First page event')).toBeNull();
-    expect(screen.getByText('Page 2 of 2 · 75 events')).toBeTruthy();
+    expect(screen.getByText('Page 2 of 2 · 0 events')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Previous' })).toHaveProperty('disabled', false);
+  });
+
+  it('clears stale event rows and totals when a filtered event refresh fails', async () => {
+    const client = mockClient();
+    vi.mocked(client.fetchEvents)
+      .mockResolvedValueOnce({
+        total: 2,
+        page: 1,
+        pageSize: 50,
+        events: [
+          {
+            id: 'audit:old-filter',
+            timestamp: '2026-04-28T12:00:00.000Z',
+            sessionId: 'session-a',
+            toolName: 'fbeast_observer_log',
+            source: 'observer',
+            category: 'tool_call',
+            outcome: 'approved',
+            summary: 'Old filter event',
+            severity: 'info',
+            raw: { event: 'tool_call' },
+            links: {},
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error('events timeout'));
+
+    render(<AnalyticsPage client={client} />);
+    expect(await screen.findByText('Old filter event')).toBeTruthy();
+    expect(screen.getByText('2 normalized events')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Outcome'), { target: { value: 'denied' } });
+
+    expect(await screen.findByText('events timeout')).toBeTruthy();
+    expect(screen.queryByText('Old filter event')).toBeNull();
+    expect(screen.getByText('0 normalized events')).toBeTruthy();
+    expect(screen.getByText('Page 1 of 1 · 0 events')).toBeTruthy();
+    expect(screen.getAllByText('No events match the current filters.').length).toBeGreaterThan(0);
   });
 
   it('resets to the first page when filters or page size change', async () => {

--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -215,9 +215,13 @@ describe('AnalyticsPage', () => {
     expect(screen.getByText('3')).toBeTruthy();
   });
 
-  it('clears stale session options when a filtered session refresh fails', async () => {
+  it('clears stale session options while preserving the active session when a filtered session refresh fails', async () => {
     const client = mockClient();
     vi.mocked(client.fetchSessions)
+      .mockResolvedValueOnce([
+        { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
+        { id: 'session-b', lastActivityAt: '2026-04-28T12:02:00.000Z', eventCount: 1, failureCount: 0 },
+      ])
       .mockResolvedValueOnce([
         { id: 'session-a', lastActivityAt: '2026-04-28T12:00:00.000Z', eventCount: 2, failureCount: 1 },
         { id: 'session-b', lastActivityAt: '2026-04-28T12:02:00.000Z', eventCount: 1, failureCount: 0 },
@@ -228,10 +232,17 @@ describe('AnalyticsPage', () => {
 
     expect(await screen.findByRole('option', { name: 'session-b' })).toBeTruthy();
 
+    fireEvent.change(screen.getByLabelText('Session'), { target: { value: 'session-a' } });
+    await waitFor(() => {
+      expect(client.fetchSessions).toHaveBeenLastCalledWith({ timeWindow: '24h' });
+    });
+
     fireEvent.change(screen.getByLabelText('Outcome'), { target: { value: 'denied' } });
 
     expect(await screen.findByText('sessions timeout')).toBeTruthy();
     await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'session-a' })).toBeTruthy();
+      expect(screen.getByLabelText('Session')).toHaveProperty('value', 'session-a');
       expect(screen.queryByRole('option', { name: 'session-b' })).toBeNull();
     });
   });

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -81,7 +81,11 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       if (sessionsResult.status === 'fulfilled') {
         setSessions(sessionsResult.value);
       } else {
-        setSessions([]);
+        setSessions((current) => {
+          if (!filters.sessionId) return [];
+          const activeSession = current.find((session) => session.id === filters.sessionId);
+          return [activeSession ?? { id: filters.sessionId, lastActivityAt: '', eventCount: 0, failureCount: 0 }];
+        });
       }
       setOverviewError(errors.length > 0 ? errors.join('; ') : null);
       setIsOverviewLoading(false);

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -80,6 +80,8 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       }
       if (sessionsResult.status === 'fulfilled') {
         setSessions(sessionsResult.value);
+      } else {
+        setSessions([]);
       }
       setOverviewError(errors.length > 0 ? errors.join('; ') : null);
       setIsOverviewLoading(false);
@@ -100,7 +102,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
       setEventPage(eventsResult);
     }).catch((error: unknown) => {
       if (cancelled) return;
-      setEventPage((current) => current ? { ...current, events: [] } : null);
+      setEventPage({ events: [], total: 0, page, pageSize });
       setEventsError(error instanceof Error ? error.message : 'Unable to load analytics.');
     }).finally(() => {
       if (!cancelled) {
@@ -117,7 +119,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const totalEvents = eventPage?.total ?? 0;
   const currentPage = page;
   const currentPageSize = eventPage?.pageSize ?? pageSize;
-  const totalPages = Math.max(1, Math.ceil(totalEvents / currentPageSize));
+  const totalPages = Math.max(currentPage, 1, Math.ceil(totalEvents / currentPageSize));
   const canGoPrevious = currentPage > 1 && !isEventsLoading;
   const canGoNext = currentPage < totalPages && !isEventsLoading;
   const loadError = [overviewError, eventsError].filter(Boolean).join('; ') || null;


### PR DESCRIPTION
## Summary
- clear stale session picker options when filtered session-option refreshes fail
- clear stale analytics event rows and totals when event refreshes fail
- add AnalyticsPage regression coverage for failed filtered session and event refetches

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/web -- analytics-page.test.tsx
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- git diff --check

Closes #1089