### PR TITLE
fix(web): gate network service controls by status

### DIFF
--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -29,6 +29,19 @@ const actionLabels: Record<ServiceAction, { present: string; past: string }> = {
   restart: { present: 'Restarting', past: 'Restarted' },
 };
 
+function normalizeServiceStatus(status: string): string {
+  return status.trim().toLowerCase();
+}
+
+function canStartService(service: NetworkServiceItem): boolean {
+  const status = normalizeServiceStatus(service.status);
+  return status === 'stopped' || status === 'failed';
+}
+
+function canStopOrRestartService(service: NetworkServiceItem): boolean {
+  return !service.inProcess && normalizeServiceStatus(service.status) === 'running';
+}
+
 export function NetworkServiceList({
   services,
   onStart,
@@ -37,9 +50,17 @@ export function NetworkServiceList({
 }: NetworkServiceListProps) {
   const [actionStateByService, setActionStateByService] = useState<Record<string, ServiceActionState>>({});
 
-  const runAction = (serviceId: string, action: ServiceAction, callback: (serviceId: string) => Promise<void> | void) => {
+  const runAction = (
+    service: NetworkServiceItem,
+    action: ServiceAction,
+    callback: (serviceId: string) => Promise<void> | void,
+  ) => {
+    const serviceId = service.id;
     const current = actionStateByService[serviceId];
-    if (current?.status === 'pending') {
+    const isAllowed = action === 'start'
+      ? canStartService(service)
+      : canStopOrRestartService(service);
+    if (current?.status === 'pending' || !isAllowed) {
       return;
     }
     setActionStateByService((states) => ({
@@ -80,7 +101,8 @@ export function NetworkServiceList({
         {services.map((service) => {
           const actionState = actionStateByService[service.id];
           const hasPendingAction = actionState?.status === 'pending';
-          const disableInProcessControls = Boolean(service.inProcess) || hasPendingAction;
+          const startDisabled = hasPendingAction || !canStartService(service);
+          const stopOrRestartDisabled = hasPendingAction || !canStopOrRestartService(service);
           return (
           <article key={service.id} className="network-services__item">
             <div>
@@ -100,9 +122,9 @@ export function NetworkServiceList({
               )}
             </div>
             <div className="network-services__actions">
-              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service.id, 'start', onStart)} aria-label={`Start ${service.id}`} disabled={hasPendingAction}>Start</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service.id, 'stop', onStop)} aria-label={`Stop ${service.id}`} disabled={disableInProcessControls}>Stop</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service.id, 'restart', onRestart)} aria-label={`Restart ${service.id}`} disabled={disableInProcessControls}>Restart</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'start', onStart)} aria-label={`Start ${service.id}`} disabled={startDisabled}>Start</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'stop', onStop)} aria-label={`Stop ${service.id}`} disabled={stopOrRestartDisabled}>Stop</button>
+              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'restart', onRestart)} aria-label={`Restart ${service.id}`} disabled={stopOrRestartDisabled}>Restart</button>
             </div>
           </article>
           );

--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -39,7 +39,8 @@ function canStartService(service: NetworkServiceItem): boolean {
 }
 
 function canStopOrRestartService(service: NetworkServiceItem): boolean {
-  return !service.inProcess && normalizeServiceStatus(service.status) === 'running';
+  const status = normalizeServiceStatus(service.status);
+  return !service.inProcess && (status === 'running' || status === 'stale');
 }
 
 export function NetworkServiceList({

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -701,9 +701,14 @@ describe('ChatShell', () => {
     });
   });
 
-  it('shows pending and failure feedback for network service actions', async () => {
+  it('shows pending and failure feedback for valid network service actions', async () => {
     window.location.hash = '#/network';
     let rejectStart!: (error: Error) => void;
+    mockNetworkGetStatus.mockResolvedValueOnce({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      services: [{ id: 'chat-server', status: 'stopped' }],
+    });
     mockNetworkStart.mockImplementationOnce(() => new Promise((_, reject) => {
       rejectStart = reject;
     }));

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -46,7 +46,7 @@ describe('NetworkPage', () => {
     expect(screen.getByRole('button', { name: 'Save config' }).getAttribute('class')).toContain('button--primary');
   });
 
-  it('invokes service controls and saves all changed config assignments atomically', async () => {
+  it('gates service controls by status and saves all changed config assignments atomically', async () => {
     const onStart = vi.fn().mockResolvedValue(undefined);
     const onStop = vi.fn().mockResolvedValue(undefined);
     const onRestart = vi.fn().mockResolvedValue(undefined);
@@ -69,17 +69,37 @@ describe('NetworkPage', () => {
             explanation: 'CLI-parity websocket chat',
             url: 'http://127.0.0.1:3737',
           },
+          {
+            id: 'dashboard',
+            status: 'stopped',
+            explanation: 'Dashboard is offline',
+          },
         ]}
         status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start chat-server' }));
-    await waitFor(() => expect(screen.getByText('Started chat-server.')).toBeDefined());
+    const runningStart = screen.getByRole('button', { name: 'Start chat-server' });
+    const stoppedStop = screen.getByRole('button', { name: 'Stop dashboard' });
+    const stoppedRestart = screen.getByRole('button', { name: 'Restart dashboard' });
+
+    expect(runningStart).toHaveProperty('disabled', true);
+    expect(stoppedStop).toHaveProperty('disabled', true);
+    expect(stoppedRestart).toHaveProperty('disabled', true);
+
+    fireEvent.click(runningStart);
+    fireEvent.click(stoppedStop);
+    fireEvent.click(stoppedRestart);
+    expect(onStart).not.toHaveBeenCalledWith('chat-server');
+    expect(onStop).not.toHaveBeenCalledWith('dashboard');
+    expect(onRestart).not.toHaveBeenCalledWith('dashboard');
+
     fireEvent.click(screen.getByRole('button', { name: 'Stop chat-server' }));
     await waitFor(() => expect(screen.getByText('Stopped chat-server.')).toBeDefined());
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat-server' }));
     await waitFor(() => expect(screen.getByText('Restarted chat-server.')).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: 'Start dashboard' }));
+    await waitFor(() => expect(screen.getByText('Started dashboard.')).toBeDefined());
     fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'insecure' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
     fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });
@@ -87,7 +107,7 @@ describe('NetworkPage', () => {
     fireEvent.click(screen.getByLabelText('Comms enabled'));
     fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
 
-    expect(onStart).toHaveBeenCalledWith('chat-server');
+    expect(onStart).toHaveBeenCalledWith('dashboard');
     expect(onStop).toHaveBeenCalledWith('chat-server');
     expect(onRestart).toHaveBeenCalledWith('chat-server');
     expect(onSaveConfig).toHaveBeenCalledWith([
@@ -97,6 +117,37 @@ describe('NetworkPage', () => {
       'dashboard.port=5173',
       'comms.enabled=true',
     ]);
+  });
+
+  it('disables duplicate service actions while a request is pending', async () => {
+    let resolveStop!: () => void;
+    const onStop = vi.fn().mockImplementation(() => new Promise<void>((resolve) => { resolveStop = resolve; }));
+
+    render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={vi.fn()}
+        onStart={vi.fn()}
+        onStop={onStop}
+        services={[{ id: 'chat-server', status: 'running' }]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    const stopButton = screen.getByRole('button', { name: 'Stop chat-server' });
+    fireEvent.click(stopButton);
+    fireEvent.click(stopButton);
+
+    await waitFor(() => expect(stopButton).toHaveProperty('disabled', true));
+    expect(screen.getByRole('button', { name: 'Restart chat-server' })).toHaveProperty('disabled', true);
+    expect(onStop).toHaveBeenCalledTimes(1);
+
+    resolveStop();
+    await waitFor(() => expect(screen.getByText('Stopped chat-server.')).toBeDefined());
   });
 
   it('keeps Save disabled until valid config changes are pending and previews assignments', () => {
@@ -259,7 +310,7 @@ describe('NetworkPage', () => {
     await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('HTTP 400'));
   });
 
-  it('disables unsupported stop and restart controls for in-process services', () => {
+  it('disables unsupported service controls for in-process services', () => {
     const onStart = vi.fn();
     const onStop = vi.fn();
     const onRestart = vi.fn();
@@ -289,16 +340,18 @@ describe('NetworkPage', () => {
       />,
     );
 
+    const startButton = screen.getByRole('button', { name: 'Start comms-gateway' });
     const stopButton = screen.getByRole('button', { name: 'Stop comms-gateway' });
     const restartButton = screen.getByRole('button', { name: 'Restart comms-gateway' });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start comms-gateway' }));
+    fireEvent.click(startButton);
     fireEvent.click(stopButton);
     fireEvent.click(restartButton);
 
+    expect(startButton).toHaveProperty('disabled', true);
     expect(stopButton).toHaveProperty('disabled', true);
     expect(restartButton).toHaveProperty('disabled', true);
-    expect(onStart).toHaveBeenCalledWith('comms-gateway');
+    expect(onStart).not.toHaveBeenCalled();
     expect(onStop).not.toHaveBeenCalled();
     expect(onRestart).not.toHaveBeenCalled();
   });

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -74,6 +74,11 @@ describe('NetworkPage', () => {
             status: 'stopped',
             explanation: 'Dashboard is offline',
           },
+          {
+            id: 'worker',
+            status: 'stale',
+            explanation: 'Healthcheck failed',
+          },
         ]}
         status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
       />,
@@ -82,10 +87,12 @@ describe('NetworkPage', () => {
     const runningStart = screen.getByRole('button', { name: 'Start chat-server' });
     const stoppedStop = screen.getByRole('button', { name: 'Stop dashboard' });
     const stoppedRestart = screen.getByRole('button', { name: 'Restart dashboard' });
+    const staleStart = screen.getByRole('button', { name: 'Start worker' });
 
     expect(runningStart).toHaveProperty('disabled', true);
     expect(stoppedStop).toHaveProperty('disabled', true);
     expect(stoppedRestart).toHaveProperty('disabled', true);
+    expect(staleStart).toHaveProperty('disabled', true);
 
     fireEvent.click(runningStart);
     fireEvent.click(stoppedStop);
@@ -100,6 +107,10 @@ describe('NetworkPage', () => {
     await waitFor(() => expect(screen.getByText('Restarted chat-server.')).toBeDefined());
     fireEvent.click(screen.getByRole('button', { name: 'Start dashboard' }));
     await waitFor(() => expect(screen.getByText('Started dashboard.')).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: 'Stop worker' }));
+    await waitFor(() => expect(screen.getByText('Stopped worker.')).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: 'Restart worker' }));
+    await waitFor(() => expect(screen.getByText('Restarted worker.')).toBeDefined());
     fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'insecure' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
     fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });
@@ -109,7 +120,9 @@ describe('NetworkPage', () => {
 
     expect(onStart).toHaveBeenCalledWith('dashboard');
     expect(onStop).toHaveBeenCalledWith('chat-server');
+    expect(onStop).toHaveBeenCalledWith('worker');
     expect(onRestart).toHaveBeenCalledWith('chat-server');
+    expect(onRestart).toHaveBeenCalledWith('worker');
     expect(onSaveConfig).toHaveBeenCalledWith([
       'network.mode=insecure',
       'chat.model=gpt-5',


### PR DESCRIPTION
## Summary
- gate Network service Start/Stop/Restart buttons from the current service status
- keep in-process services protected from unsupported service controls
- add regression coverage for running/stopped services and pending action duplicate clicks

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- --run tests/components/network-page.test.tsx
- npm test --workspace @franken/web -- --run tests/components/chat-shell.test.tsx -t "network service actions"
- npm test --workspace @franken/web
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1088