### PR TITLE
test(orchestrator): guard provider helper debug logs

### DIFF
--- a/packages/franken-orchestrator/tests/unit/providers/discover-skills-helpers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/discover-skills-helpers.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+const helpersSourceUrl = new URL(
+  '../../../src/providers/discover-skills-helpers.ts',
+  import.meta.url,
+);
+
+describe('discover-skills helpers source hygiene', () => {
+  it('does not ship stray console.log debug output', async () => {
+    const source = await readFile(helpersSourceUrl, 'utf-8');
+
+    expect(source).not.toMatch(/console\.log\s*\(/);
+    expect(source).not.toContain("console.log('debug')");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused regression test that asserts the provider helper source does not contain stray console.log debug output.
- Verified the reported helper path is already clean on current main and keeps it guarded against recurrence.

## Test Plan
- npm run test --workspace @franken/orchestrator -- --run tests/unit/providers/discover-skills-helpers.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)

Closes #1075