### PR TITLE
fix(orchestrator): avoid console.warn in console logger

### DIFF
--- a/packages/franken-orchestrator/src/logger.ts
+++ b/packages/franken-orchestrator/src/logger.ts
@@ -37,7 +37,7 @@ export class ConsoleLogger implements ILogger {
   }
 
   warn(msg: string, _data?: unknown): void {
-    console.warn(formatLine('[beast:warn]', msg));
+    printLine(formatLine('[beast:warn]', msg));
   }
 
   error(msg: string, _data?: unknown): void {

--- a/packages/franken-orchestrator/tests/unit/logger.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logger.test.ts
@@ -41,14 +41,16 @@ describe('ConsoleLogger', () => {
     );
   });
 
-  it('logs warn with timestamp and prefix', () => {
+  it('logs warn through the shared output path without calling console.warn', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const logger = new ConsoleLogger({ verbose: false });
 
     logger.warn('heads up');
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0]?.[0]).toBe(
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0]?.[0]).toBe(
       '2025-02-01T12:00:00.000Z [beast:warn] heads up',
     );
   });


### PR DESCRIPTION
## Summary
- routes ConsoleLogger.warn through the shared info output path instead of direct console.warn
- updates logger regression coverage to assert console.warn is not invoked

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/logger.test.ts
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor && npm run typecheck --workspace @franken/orchestrator && npm run lint --workspace @franken/orchestrator && npm run build --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #1076