### PR TITLE
fix(comms): acknowledge Discord interactions before processing

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/discord/discord-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/discord/discord-router.ts
@@ -58,18 +58,20 @@ export function discordRouter(options: DiscordRouterOptions) {
 
       const text = commandName === 'franken' ? query : `/${commandName} ${query}`.trim();
 
-      await gateway.handleInbound({
-        channelType: 'discord',
-        externalUserId: userId,
-        externalChannelId: channelId,
-        externalMessageId: interaction.id,
-        text,
-        receivedAt: isoNow(),
-        rawEvent: body,
-      });
+      runGatewayTaskInBackground('Discord slash command processing', () =>
+        gateway.handleInbound({
+          channelType: 'discord',
+          externalUserId: userId,
+          externalChannelId: channelId,
+          externalMessageId: interaction.id,
+          text,
+          receivedAt: isoNow(),
+          rawEvent: body,
+        }),
+      );
 
-      // Acknowledge the interaction immediately to avoid timeout
-      // In a real scenario, we might use a deferred response
+      // Acknowledge the interaction immediately to avoid timeout.
+      // Gateway processing continues in the background and follows up through the normal channel.
       return c.json({
         type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
         data: { content: 'Processing your request...' },
@@ -87,7 +89,9 @@ export function discordRouter(options: DiscordRouterOptions) {
         externalChannelId: channelId,
       });
 
-      await gateway.handleAction('discord', sessionId, customId);
+      runGatewayTaskInBackground('Discord button action processing', () =>
+        gateway.handleAction('discord', sessionId, customId),
+      );
 
       return c.json({
         type: 4,
@@ -106,4 +110,14 @@ function shouldVerifySignature(verifySignature: DiscordRouterOptions['verifySign
     return verifySignature(c);
   }
   return verifySignature !== false;
+}
+
+function runGatewayTaskInBackground(label: string, task: () => Promise<void>): void {
+  try {
+    void task().catch((error: unknown) => {
+      console.error(`[discord-router] ${label} failed`, error);
+    });
+  } catch (error) {
+    console.error(`[discord-router] ${label} failed`, error);
+  }
 }

--- a/packages/franken-orchestrator/tests/unit/comms/discord-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-router.test.ts
@@ -95,6 +95,56 @@ describe('discordRouter', () => {
     }));
   });
 
+  it('acknowledges slash commands before delayed gateway processing resolves', async () => {
+    let resolveInbound!: () => void;
+    let inboundResolved = false;
+    vi.mocked(gateway.handleInbound).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveInbound = () => {
+          inboundResolved = true;
+          resolve();
+        };
+      }),
+    );
+    const app = discordRouter({
+      gateway,
+      sessionMapper,
+      publicKey: rawPublicKey,
+      verifySignature: false,
+    });
+
+    const responsePromise = app.request('/interactions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: DiscordInteractionType.APPLICATION_COMMAND,
+        id: '1',
+        token: 't',
+        application_id: 'a',
+        channel_id: 'C1',
+        user: { id: 'U1', username: 'user' },
+        data: {
+          name: 'franken',
+          options: [{ name: 'query', value: 'hello', type: 3 }],
+        },
+      }),
+    });
+
+    const earlyResult = await Promise.race([
+      responsePromise.then(() => 'responded'),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 20)),
+    ]);
+    if (earlyResult !== 'responded') {
+      resolveInbound();
+      await responsePromise;
+    }
+
+    expect(earlyResult).toBe('responded');
+    expect(inboundResolved).toBe(false);
+    expect(gateway.handleInbound).toHaveBeenCalledWith(expect.objectContaining({ text: 'hello' }));
+    resolveInbound();
+  });
+
   it('routes button click to gateway', async () => {
     const app = discordRouter({
       gateway,
@@ -128,6 +178,56 @@ describe('discordRouter', () => {
 
     expect(res.status).toBe(200);
     expect(gateway.handleAction).toHaveBeenCalledWith('discord', 'session-123', 'approve');
+  });
+
+  it('acknowledges button clicks before delayed gateway action processing resolves', async () => {
+    let resolveAction!: () => void;
+    let actionResolved = false;
+    vi.mocked(gateway.handleAction).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveAction = () => {
+          actionResolved = true;
+          resolve();
+        };
+      }),
+    );
+    const app = discordRouter({
+      gateway,
+      sessionMapper,
+      publicKey: rawPublicKey,
+      verifySignature: false,
+    });
+
+    const responsePromise = app.request('/interactions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: DiscordInteractionType.MESSAGE_COMPONENT,
+        id: '1',
+        token: 't',
+        application_id: 'a',
+        channel_id: 'C1',
+        user: { id: 'U1', username: 'user' },
+        data: {
+          custom_id: 'approve',
+          component_type: 2,
+        },
+      }),
+    });
+
+    const earlyResult = await Promise.race([
+      responsePromise.then(() => 'responded'),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 20)),
+    ]);
+    if (earlyResult !== 'responded') {
+      resolveAction();
+      await responsePromise;
+    }
+
+    expect(earlyResult).toBe('responded');
+    expect(actionResolved).toBe(false);
+    expect(gateway.handleAction).toHaveBeenCalledWith('discord', 'session-123', 'approve');
+    resolveAction();
   });
 
   it('returns 400 for invalid interaction payloads without invoking handlers', async () => {


### PR DESCRIPTION
## Summary
- acknowledge Discord slash commands before gateway message handling finishes
- acknowledge Discord button interactions before action handling finishes
- add delayed gateway regression coverage for both interaction paths

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)
- npm test --workspace @franken/orchestrator -- tests/unit/comms/discord-router.test.ts

Closes #997