### PR TITLE
test(orchestrator): cover queued Beast start failures

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -461,27 +461,34 @@ export class ProcessBeastExecutor implements BeastExecutor {
     }
 
     const startedAt = new Date(wallClockNow()).toISOString();
-    const attempt = this.repository.createAttempt(run.id, {
-      status: 'running',
-      pid: handle.pid,
-      startedAt,
-      executorMetadata: this.options.attemptMetadata?.(run, processSpec, spawnedSpec, handle) ?? {
-        backend: 'process',
-        command: processSpec.command,
-        args: [...processSpec.args],
-        ...(worktree
-          ? {
-              worktreeIsolation: true,
-              worktreePath: worktree.worktreePath,
-              worktreeBranch: worktree.branchName,
-              worktreeCreated: worktree.created,
-              worktreeAgentId: worktree.agentId,
-              worktreeExecutionCwd: worktree.executionCwd,
-              worktreeProjectRoot: worktree.projectRoot,
-            }
-          : {}),
-      },
-    });
+    let attempt: BeastRunAttempt;
+    try {
+      attempt = this.repository.createAttempt(run.id, {
+        status: 'running',
+        pid: handle.pid,
+        startedAt,
+        executorMetadata: this.options.attemptMetadata?.(run, processSpec, spawnedSpec, handle) ?? {
+          backend: 'process',
+          command: processSpec.command,
+          args: [...processSpec.args],
+          ...(worktree
+            ? {
+                worktreeIsolation: true,
+                worktreePath: worktree.worktreePath,
+                worktreeBranch: worktree.branchName,
+                worktreeCreated: worktree.created,
+                worktreeAgentId: worktree.agentId,
+                worktreeExecutionCwd: worktree.executionCwd,
+                worktreeProjectRoot: worktree.projectRoot,
+              }
+            : {}),
+        },
+      });
+    } catch (error) {
+      await this.supervisor.kill(handle.pid);
+      this.cleanupRunResources(run.id);
+      throw error;
+    }
 
     // Once an attempt owns the worktree, preserve it for PR/merge or debugging per ADR-028.
     // The pending allocation map is only for pre-attempt spawn failures.

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -485,8 +485,14 @@ export class ProcessBeastExecutor implements BeastExecutor {
         },
       });
     } catch (error) {
-      await this.supervisor.kill(handle.pid);
-      this.cleanupRunResources(run.id);
+      try {
+        await this.supervisor.kill(handle.pid);
+      } catch {
+        // Preserve the original attempt-persistence failure while still
+        // releasing pre-attempt config/worktree resources below.
+      } finally {
+        this.cleanupRunResources(run.id);
+      }
       throw error;
     }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -40,7 +40,7 @@ interface CreateAttemptInput {
 interface UpdateRunPatch {
   status?: BeastRunStatus | undefined;
   configSnapshot?: Readonly<Record<string, unknown>> | undefined;
-  startedAt?: string | undefined;
+  startedAt?: string | null | undefined;
   finishedAt?: string | undefined;
   currentAttemptId?: string | null | undefined;
   attemptCount?: number | undefined;
@@ -283,7 +283,11 @@ export class SQLiteBeastRepository {
       ...current,
       ...(patch.status !== undefined ? { status: patch.status } : {}),
       ...(patch.configSnapshot !== undefined ? { configSnapshot: patch.configSnapshot } : {}),
-      ...(patch.startedAt !== undefined ? { startedAt: patch.startedAt } : {}),
+      ...(patch.startedAt !== undefined
+        ? patch.startedAt === null
+          ? { startedAt: undefined }
+          : { startedAt: patch.startedAt }
+        : {}),
       ...(patch.finishedAt !== undefined ? { finishedAt: patch.finishedAt } : {}),
       ...(patch.currentAttemptId !== undefined
         ? patch.currentAttemptId === null

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -42,11 +42,11 @@ interface UpdateRunPatch {
   configSnapshot?: Readonly<Record<string, unknown>> | undefined;
   startedAt?: string | undefined;
   finishedAt?: string | undefined;
-  currentAttemptId?: string | undefined;
+  currentAttemptId?: string | null | undefined;
   attemptCount?: number | undefined;
   lastHeartbeatAt?: string | undefined;
   stopReason?: string | undefined;
-  latestExitCode?: number | undefined;
+  latestExitCode?: number | null | undefined;
 }
 
 interface UpdateAttemptPatch {
@@ -285,11 +285,19 @@ export class SQLiteBeastRepository {
       ...(patch.configSnapshot !== undefined ? { configSnapshot: patch.configSnapshot } : {}),
       ...(patch.startedAt !== undefined ? { startedAt: patch.startedAt } : {}),
       ...(patch.finishedAt !== undefined ? { finishedAt: patch.finishedAt } : {}),
-      ...(patch.currentAttemptId !== undefined ? { currentAttemptId: patch.currentAttemptId } : {}),
+      ...(patch.currentAttemptId !== undefined
+        ? patch.currentAttemptId === null
+          ? { currentAttemptId: undefined }
+          : { currentAttemptId: patch.currentAttemptId }
+        : {}),
       ...(patch.attemptCount !== undefined ? { attemptCount: patch.attemptCount } : {}),
       ...(patch.lastHeartbeatAt !== undefined ? { lastHeartbeatAt: patch.lastHeartbeatAt } : {}),
       ...(patch.stopReason !== undefined ? { stopReason: patch.stopReason } : {}),
-      ...(patch.latestExitCode !== undefined ? { latestExitCode: patch.latestExitCode } : {}),
+      ...(patch.latestExitCode !== undefined
+        ? patch.latestExitCode === null
+          ? { latestExitCode: undefined }
+          : { latestExitCode: patch.latestExitCode }
+        : {}),
     };
 
     this.db.prepare(

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -41,11 +41,11 @@ interface UpdateRunPatch {
   status?: BeastRunStatus | undefined;
   configSnapshot?: Readonly<Record<string, unknown>> | undefined;
   startedAt?: string | null | undefined;
-  finishedAt?: string | undefined;
+  finishedAt?: string | null | undefined;
   currentAttemptId?: string | null | undefined;
   attemptCount?: number | undefined;
   lastHeartbeatAt?: string | undefined;
-  stopReason?: string | undefined;
+  stopReason?: string | null | undefined;
   latestExitCode?: number | null | undefined;
 }
 
@@ -288,7 +288,11 @@ export class SQLiteBeastRepository {
           ? { startedAt: undefined }
           : { startedAt: patch.startedAt }
         : {}),
-      ...(patch.finishedAt !== undefined ? { finishedAt: patch.finishedAt } : {}),
+      ...(patch.finishedAt !== undefined
+        ? patch.finishedAt === null
+          ? { finishedAt: undefined }
+          : { finishedAt: patch.finishedAt }
+        : {}),
       ...(patch.currentAttemptId !== undefined
         ? patch.currentAttemptId === null
           ? { currentAttemptId: undefined }
@@ -296,7 +300,11 @@ export class SQLiteBeastRepository {
         : {}),
       ...(patch.attemptCount !== undefined ? { attemptCount: patch.attemptCount } : {}),
       ...(patch.lastHeartbeatAt !== undefined ? { lastHeartbeatAt: patch.lastHeartbeatAt } : {}),
-      ...(patch.stopReason !== undefined ? { stopReason: patch.stopReason } : {}),
+      ...(patch.stopReason !== undefined
+        ? patch.stopReason === null
+          ? { stopReason: undefined }
+          : { stopReason: patch.stopReason }
+        : {}),
       ...(patch.latestExitCode !== undefined
         ? patch.latestExitCode === null
           ? { latestExitCode: undefined }

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -91,6 +91,8 @@ export class BeastRunService {
         const updatedRun = this.repository.updateRun(run.id, {
           status: 'failed',
           finishedAt: failedAt,
+          currentAttemptId: null,
+          latestExitCode: null,
           stopReason: 'start_failed',
         });
         const startFailedEvent = this.repository.appendEvent(run.id, {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -72,45 +72,16 @@ export class BeastRunService {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const currentRun = this.repository.getRun(run.id);
-      if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
-        const failedAt = currentRun.finishedAt;
-        await this.appendLogSafely(run.id, 'system', 'stderr', `start_failed: ${errorMessage}`);
-        const publications: Array<Omit<BeastSseEvent, 'id'>> = [];
-        if (currentRun.trackedAgentId) {
-          const trackedAgent = this.repository.getTrackedAgent(currentRun.trackedAgentId);
-          if (trackedAgent && trackedAgent.status !== 'deleted') {
-            this.repository.transaction(() => {
-              this.repository.updateTrackedAgent(currentRun.trackedAgentId!, {
-                status: 'failed',
-                dispatchRunId: currentRun.id,
-                updatedAt: failedAt,
-              });
-              publications.push({
-                type: 'agent.status',
-                data: { agentId: currentRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
-              });
-              const failedEvent = {
-                level: 'error' as const,
-                type: 'agent.dispatch.failed',
-                message: `Failed to start Beast run ${currentRun.id}`,
-                payload: { runId: currentRun.id, error: errorMessage },
-                createdAt: failedAt,
-              };
-              this.repository.appendTrackedAgentEvent(currentRun.trackedAgentId!, failedEvent);
-              publications.push({
-                type: 'agent.event',
-                data: { agentId: currentRun.trackedAgentId, event: failedEvent },
-              });
-            });
-          }
-        }
-        for (const publication of publications) {
-          this.serviceOptions.eventBus?.publish(publication);
-        }
-        return currentRun;
-      }
       const priorAttempt = priorAttemptId ? this.repository.getAttempt(priorAttemptId) : undefined;
       if (priorAttempt?.status === 'running') {
+        this.repository.updateRun(run.id, {
+          status: run.status,
+          startedAt: run.startedAt ?? priorAttempt.startedAt,
+          finishedAt: run.finishedAt ?? null,
+          currentAttemptId: priorAttemptId,
+          latestExitCode: run.latestExitCode ?? null,
+          stopReason: run.stopReason ?? null,
+        });
         throw error;
       }
       if (
@@ -121,6 +92,49 @@ export class BeastRunService {
         )
       ) {
         throw error;
+      }
+      if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
+        const failedAt = currentRun.finishedAt;
+        await this.appendLogSafely(run.id, 'system', 'stderr', `start_failed: ${errorMessage}`);
+        const { failedRun, publications } = this.repository.transaction(() => {
+          const normalizedRun = this.repository.updateRun(run.id, {
+            startedAt: null,
+            currentAttemptId: null,
+            latestExitCode: null,
+          });
+          const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [];
+          if (normalizedRun.trackedAgentId) {
+            const trackedAgent = this.repository.getTrackedAgent(normalizedRun.trackedAgentId);
+            if (trackedAgent && trackedAgent.status !== 'deleted') {
+              this.repository.updateTrackedAgent(normalizedRun.trackedAgentId, {
+                status: 'failed',
+                dispatchRunId: normalizedRun.id,
+                updatedAt: failedAt,
+              });
+              pendingPublications.push({
+                type: 'agent.status',
+                data: { agentId: normalizedRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
+              });
+              const failedEvent = {
+                level: 'error' as const,
+                type: 'agent.dispatch.failed',
+                message: `Failed to start Beast run ${normalizedRun.id}`,
+                payload: { runId: normalizedRun.id, error: errorMessage },
+                createdAt: failedAt,
+              };
+              this.repository.appendTrackedAgentEvent(normalizedRun.trackedAgentId, failedEvent);
+              pendingPublications.push({
+                type: 'agent.event',
+                data: { agentId: normalizedRun.trackedAgentId, event: failedEvent },
+              });
+            }
+          }
+          return { failedRun: normalizedRun, publications: pendingPublications };
+        });
+        for (const publication of publications) {
+          this.serviceOptions.eventBus?.publish(publication);
+        }
+        return failedRun;
       }
 
       const failedAt = isoNow();

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -64,9 +64,22 @@ export class BeastRunService {
     const definition = this.getDefinitionOrThrow(run.definitionId);
     const priorAttemptId = run.currentAttemptId;
     const priorAttemptCount = run.attemptCount;
+    const trackedAgentStatusBeforeStart = run.trackedAgentId
+      ? this.repository.getTrackedAgent(run.trackedAgentId)?.status
+      : undefined;
     try {
       await this.executorFor(run).start(run, definition);
-      const updated = this.requireRun(runId);
+      let updated = this.requireRun(runId);
+      if (
+        updated.status === 'running'
+        && (updated.finishedAt !== undefined || updated.stopReason !== undefined || updated.latestExitCode !== undefined)
+      ) {
+        updated = this.repository.updateRun(runId, {
+          finishedAt: null,
+          latestExitCode: null,
+          stopReason: null,
+        });
+      }
       this.syncTrackedAgent(updated);
       return updated;
     } catch (error) {
@@ -83,7 +96,7 @@ export class BeastRunService {
       }
       const priorAttempt = priorAttemptId ? this.repository.getAttempt(priorAttemptId) : undefined;
       if (priorAttempt?.status === 'running') {
-        this.repository.updateRun(run.id, {
+        const restoredRun = this.repository.updateRun(run.id, {
           status: run.status,
           startedAt: run.startedAt ?? priorAttempt.startedAt,
           finishedAt: run.finishedAt ?? null,
@@ -91,6 +104,7 @@ export class BeastRunService {
           latestExitCode: run.latestExitCode ?? null,
           stopReason: run.stopReason ?? null,
         });
+        this.syncTrackedAgent(restoredRun);
         throw error;
       }
       if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
@@ -105,16 +119,7 @@ export class BeastRunService {
           const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [];
           if (normalizedRun.trackedAgentId) {
             const trackedAgent = this.repository.getTrackedAgent(normalizedRun.trackedAgentId);
-            if (trackedAgent && trackedAgent.status !== 'deleted' && trackedAgent.status !== 'failed') {
-              this.repository.updateTrackedAgent(normalizedRun.trackedAgentId, {
-                status: 'failed',
-                dispatchRunId: normalizedRun.id,
-                updatedAt: failedAt,
-              });
-              pendingPublications.push({
-                type: 'agent.status',
-                data: { agentId: normalizedRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
-              });
+            if (trackedAgent && trackedAgent.status !== 'deleted') {
               const failedEvent = {
                 level: 'error' as const,
                 type: 'agent.dispatch.failed',
@@ -122,11 +127,28 @@ export class BeastRunService {
                 payload: { runId: normalizedRun.id, error: errorMessage },
                 createdAt: failedAt,
               };
-              this.repository.appendTrackedAgentEvent(normalizedRun.trackedAgentId, failedEvent);
-              pendingPublications.push({
-                type: 'agent.event',
-                data: { agentId: normalizedRun.trackedAgentId, event: failedEvent },
-              });
+              if (trackedAgent.status !== 'failed') {
+                this.repository.updateTrackedAgent(normalizedRun.trackedAgentId, {
+                  status: 'failed',
+                  dispatchRunId: normalizedRun.id,
+                  updatedAt: failedAt,
+                });
+                pendingPublications.push({
+                  type: 'agent.status',
+                  data: { agentId: normalizedRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
+                });
+                this.repository.appendTrackedAgentEvent(normalizedRun.trackedAgentId, failedEvent);
+                pendingPublications.push({
+                  type: 'agent.event',
+                  data: { agentId: normalizedRun.trackedAgentId, event: failedEvent },
+                });
+              } else if (trackedAgentStatusBeforeStart === 'failed') {
+                this.repository.appendTrackedAgentEvent(normalizedRun.trackedAgentId, failedEvent);
+                pendingPublications.push({
+                  type: 'agent.event',
+                  data: { agentId: normalizedRun.trackedAgentId, event: failedEvent },
+                });
+              }
             }
           }
           return { failedRun: normalizedRun, publications: pendingPublications };

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -70,8 +70,10 @@ export class BeastRunService {
       this.syncTrackedAgent(updated);
       return updated;
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       const currentRun = this.repository.getRun(run.id);
       if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
+        await this.appendLogSafely(run.id, 'system', 'stderr', `start_failed: ${errorMessage}`);
         this.syncTrackedAgent(currentRun);
         return currentRun;
       }
@@ -86,7 +88,6 @@ export class BeastRunService {
       }
 
       const failedAt = isoNow();
-      const errorMessage = error instanceof Error ? error.message : String(error);
       const { failedRun, publications } = this.repository.transaction(() => {
         const updatedRun = this.repository.updateRun(run.id, {
           status: 'failed',

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -72,6 +72,15 @@ export class BeastRunService {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const currentRun = this.repository.getRun(run.id);
+      if (
+        currentRun
+        && (
+          (currentRun.currentAttemptId !== undefined && currentRun.currentAttemptId !== priorAttemptId)
+          || currentRun.attemptCount > priorAttemptCount
+        )
+      ) {
+        throw error;
+      }
       const priorAttempt = priorAttemptId ? this.repository.getAttempt(priorAttemptId) : undefined;
       if (priorAttempt?.status === 'running') {
         this.repository.updateRun(run.id, {
@@ -82,15 +91,6 @@ export class BeastRunService {
           latestExitCode: run.latestExitCode ?? null,
           stopReason: run.stopReason ?? null,
         });
-        throw error;
-      }
-      if (
-        currentRun
-        && (
-          (currentRun.currentAttemptId !== undefined && currentRun.currentAttemptId !== priorAttemptId)
-          || currentRun.attemptCount > priorAttemptCount
-        )
-      ) {
         throw error;
       }
       if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
@@ -105,7 +105,7 @@ export class BeastRunService {
           const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [];
           if (normalizedRun.trackedAgentId) {
             const trackedAgent = this.repository.getTrackedAgent(normalizedRun.trackedAgentId);
-            if (trackedAgent && trackedAgent.status !== 'deleted') {
+            if (trackedAgent && trackedAgent.status !== 'deleted' && trackedAgent.status !== 'failed') {
               this.repository.updateTrackedAgent(normalizedRun.trackedAgentId, {
                 status: 'failed',
                 dispatchRunId: normalizedRun.id,

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -62,6 +62,8 @@ export class BeastRunService {
   async start(runId: string, _actor: string): Promise<BeastRun> {
     const run = this.requireRun(runId);
     const definition = this.getDefinitionOrThrow(run.definitionId);
+    const priorAttemptId = run.currentAttemptId;
+    const priorAttemptCount = run.attemptCount;
     try {
       await this.executorFor(run).start(run, definition);
       const updated = this.requireRun(runId);
@@ -69,7 +71,17 @@ export class BeastRunService {
       return updated;
     } catch (error) {
       const currentRun = this.repository.getRun(run.id);
-      if (currentRun?.currentAttemptId) {
+      if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
+        this.syncTrackedAgent(currentRun);
+        return currentRun;
+      }
+      if (
+        currentRun
+        && (
+          (currentRun.currentAttemptId !== undefined && currentRun.currentAttemptId !== priorAttemptId)
+          || currentRun.attemptCount > priorAttemptCount
+        )
+      ) {
         throw error;
       }
 

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -62,10 +62,59 @@ export class BeastRunService {
   async start(runId: string, _actor: string): Promise<BeastRun> {
     const run = this.requireRun(runId);
     const definition = this.getDefinitionOrThrow(run.definitionId);
-    await this.executorFor(run).start(run, definition);
-    const updated = this.requireRun(runId);
-    this.syncTrackedAgent(updated);
-    return updated;
+    try {
+      await this.executorFor(run).start(run, definition);
+      const updated = this.requireRun(runId);
+      this.syncTrackedAgent(updated);
+      return updated;
+    } catch (error) {
+      const failedAt = isoNow();
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const { failedRun, publications } = this.repository.transaction(() => {
+        const updatedRun = this.repository.updateRun(run.id, {
+          status: 'failed',
+          finishedAt: failedAt,
+          stopReason: 'start_failed',
+        });
+        this.repository.appendEvent(run.id, {
+          type: 'run.start_failed',
+          payload: { error: errorMessage },
+          createdAt: failedAt,
+        });
+
+        const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [];
+        if (updatedRun.trackedAgentId) {
+          this.repository.updateTrackedAgent(updatedRun.trackedAgentId, {
+            status: 'failed',
+            dispatchRunId: updatedRun.id,
+            updatedAt: failedAt,
+          });
+          pendingPublications.push({
+            type: 'agent.status',
+            data: { agentId: updatedRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
+          });
+          const failedEvent = {
+            level: 'error' as const,
+            type: 'agent.dispatch.failed',
+            message: `Failed to start Beast run ${updatedRun.id}`,
+            payload: { runId: updatedRun.id, error: errorMessage },
+            createdAt: failedAt,
+          };
+          this.repository.appendTrackedAgentEvent(updatedRun.trackedAgentId, failedEvent);
+          pendingPublications.push({
+            type: 'agent.event',
+            data: { agentId: updatedRun.trackedAgentId, event: failedEvent },
+          });
+        }
+
+        return { failedRun: updatedRun, publications: pendingPublications };
+      });
+      await this.appendLogSafely(run.id, 'system', 'stderr', `start_failed: ${errorMessage}`);
+      for (const publication of publications) {
+        this.serviceOptions.eventBus?.publish(publication);
+      }
+      return failedRun;
+    }
   }
 
   async stop(runId: string, _actor: string): Promise<BeastRun> {
@@ -117,6 +166,19 @@ export class BeastRunService {
       await this.stop(runId, actor);
     }
     return this.start(runId, actor);
+  }
+
+  private async appendLogSafely(
+    runId: string,
+    attemptId: string,
+    stream: 'stdout' | 'stderr',
+    message: string,
+  ): Promise<void> {
+    try {
+      await this.logs.append(runId, attemptId, stream, message);
+    } catch {
+      // Logging is best-effort and must not turn a persisted run into an API failure.
+    }
   }
 
   private executorFor(run: BeastRun) {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -54,7 +54,7 @@ export class BeastRunService {
     const run = this.requireRun(runId);
     const attemptId = run.currentAttemptId;
     if (!attemptId) {
-      return [];
+      return this.logs.read(run.id, 'system');
     }
     return this.logs.read(run.id, attemptId);
   }
@@ -68,6 +68,11 @@ export class BeastRunService {
       this.syncTrackedAgent(updated);
       return updated;
     } catch (error) {
+      const currentRun = this.repository.getRun(run.id);
+      if (currentRun?.currentAttemptId) {
+        throw error;
+      }
+
       const failedAt = isoNow();
       const errorMessage = error instanceof Error ? error.message : String(error);
       const { failedRun, publications } = this.repository.transaction(() => {
@@ -76,35 +81,47 @@ export class BeastRunService {
           finishedAt: failedAt,
           stopReason: 'start_failed',
         });
-        this.repository.appendEvent(run.id, {
+        const startFailedEvent = this.repository.appendEvent(run.id, {
           type: 'run.start_failed',
           payload: { error: errorMessage },
           createdAt: failedAt,
         });
 
-        const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [];
+        const pendingPublications: Array<Omit<BeastSseEvent, 'id'>> = [
+          {
+            type: 'run.event',
+            data: { runId: run.id, event: startFailedEvent },
+          },
+          {
+            type: 'run.status',
+            data: { runId: run.id, status: 'failed', updatedAt: failedAt },
+          },
+        ];
         if (updatedRun.trackedAgentId) {
-          this.repository.updateTrackedAgent(updatedRun.trackedAgentId, {
-            status: 'failed',
-            dispatchRunId: updatedRun.id,
-            updatedAt: failedAt,
-          });
-          pendingPublications.push({
-            type: 'agent.status',
-            data: { agentId: updatedRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
-          });
-          const failedEvent = {
-            level: 'error' as const,
-            type: 'agent.dispatch.failed',
-            message: `Failed to start Beast run ${updatedRun.id}`,
-            payload: { runId: updatedRun.id, error: errorMessage },
-            createdAt: failedAt,
-          };
-          this.repository.appendTrackedAgentEvent(updatedRun.trackedAgentId, failedEvent);
-          pendingPublications.push({
-            type: 'agent.event',
-            data: { agentId: updatedRun.trackedAgentId, event: failedEvent },
-          });
+          const trackedAgent = this.repository.getTrackedAgent(updatedRun.trackedAgentId);
+          if (trackedAgent && trackedAgent.status !== 'deleted') {
+            this.repository.updateTrackedAgent(updatedRun.trackedAgentId, {
+              status: 'failed',
+              dispatchRunId: updatedRun.id,
+              updatedAt: failedAt,
+            });
+            pendingPublications.push({
+              type: 'agent.status',
+              data: { agentId: updatedRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
+            });
+            const failedEvent = {
+              level: 'error' as const,
+              type: 'agent.dispatch.failed',
+              message: `Failed to start Beast run ${updatedRun.id}`,
+              payload: { runId: updatedRun.id, error: errorMessage },
+              createdAt: failedAt,
+            };
+            this.repository.appendTrackedAgentEvent(updatedRun.trackedAgentId, failedEvent);
+            pendingPublications.push({
+              type: 'agent.event',
+              data: { agentId: updatedRun.trackedAgentId, event: failedEvent },
+            });
+          }
         }
 
         return { failedRun: updatedRun, publications: pendingPublications };

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -73,9 +73,45 @@ export class BeastRunService {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const currentRun = this.repository.getRun(run.id);
       if (currentRun?.status === 'failed' && currentRun.finishedAt && currentRun.finishedAt !== run.finishedAt) {
+        const failedAt = currentRun.finishedAt;
         await this.appendLogSafely(run.id, 'system', 'stderr', `start_failed: ${errorMessage}`);
-        this.syncTrackedAgent(currentRun);
+        const publications: Array<Omit<BeastSseEvent, 'id'>> = [];
+        if (currentRun.trackedAgentId) {
+          const trackedAgent = this.repository.getTrackedAgent(currentRun.trackedAgentId);
+          if (trackedAgent && trackedAgent.status !== 'deleted') {
+            this.repository.transaction(() => {
+              this.repository.updateTrackedAgent(currentRun.trackedAgentId!, {
+                status: 'failed',
+                dispatchRunId: currentRun.id,
+                updatedAt: failedAt,
+              });
+              publications.push({
+                type: 'agent.status',
+                data: { agentId: currentRun.trackedAgentId, status: 'failed', updatedAt: failedAt },
+              });
+              const failedEvent = {
+                level: 'error' as const,
+                type: 'agent.dispatch.failed',
+                message: `Failed to start Beast run ${currentRun.id}`,
+                payload: { runId: currentRun.id, error: errorMessage },
+                createdAt: failedAt,
+              };
+              this.repository.appendTrackedAgentEvent(currentRun.trackedAgentId!, failedEvent);
+              publications.push({
+                type: 'agent.event',
+                data: { agentId: currentRun.trackedAgentId, event: failedEvent },
+              });
+            });
+          }
+        }
+        for (const publication of publications) {
+          this.serviceOptions.eventBus?.publish(publication);
+        }
         return currentRun;
+      }
+      const priorAttempt = priorAttemptId ? this.repository.getAttempt(priorAttemptId) : undefined;
+      if (priorAttempt?.status === 'running') {
+        throw error;
       }
       if (
         currentRun
@@ -91,6 +127,7 @@ export class BeastRunService {
       const { failedRun, publications } = this.repository.transaction(() => {
         const updatedRun = this.repository.updateRun(run.id, {
           status: 'failed',
+          startedAt: null,
           finishedAt: failedAt,
           currentAttemptId: null,
           latestExitCode: null,

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -594,6 +594,129 @@ describe('BeastRunService', () => {
     }));
   });
 
+  it('clears stale attempt metadata when preserving executor-recorded retry failures', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          const failedAt = '2026-03-10T00:03:00.000Z';
+          repo.updateRun(run.id, {
+            status: 'failed',
+            finishedAt: failedAt,
+            stopReason: 'spawn_failed',
+          });
+          repo.appendEvent(run.id, {
+            type: 'run.spawn_failed',
+            payload: { error: 'spawn ENOENT' },
+            createdAt: failedAt,
+          });
+          throw new Error('spawn ENOENT');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Retry failed work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+    const previousAttempt = repo.createAttempt(run.id, {
+      status: 'failed',
+      startedAt: '2026-03-10T00:00:00.000Z',
+      finishedAt: '2026-03-10T00:01:00.000Z',
+      stopReason: 'exit_1',
+      exitCode: 1,
+    });
+    repo.updateRun(run.id, {
+      status: 'failed',
+      startedAt: previousAttempt.startedAt,
+      finishedAt: previousAttempt.finishedAt,
+      stopReason: 'exit_1',
+      latestExitCode: 1,
+    });
+
+    const failed = await runs.start(run.id, 'operator');
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      stopReason: 'spawn_failed',
+      attemptCount: 1,
+    });
+    expect(failed.currentAttemptId).toBeUndefined();
+    expect(failed.latestExitCode).toBeUndefined();
+    expect(failed.startedAt).toBeUndefined();
+    await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
+  });
+
+  it('does not overwrite a live run when an executor-recorded duplicate start failure occurs', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          repo.updateRun(run.id, {
+            status: 'failed',
+            finishedAt: '2026-03-10T00:06:00.000Z',
+            stopReason: 'spawn_failed',
+          });
+          throw new Error('duplicate start failed');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Already running work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+    const attempt = repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 31337,
+      startedAt: '2026-03-10T00:03:00.000Z',
+      executorMetadata: { backend: 'process' },
+    });
+    repo.updateRun(run.id, {
+      status: 'running',
+      startedAt: attempt.startedAt,
+    });
+
+    await expect(runs.start(run.id, 'operator')).rejects.toThrow('duplicate start failed');
+
+    expect(repo.getRun(run.id)).toMatchObject({
+      id: run.id,
+      currentAttemptId: attempt.id,
+      attemptCount: 1,
+    });
+    expect(repo.getAttempt(attempt.id)).toMatchObject({ status: 'running' });
+  });
+
   it('does not overwrite a run that already started when a later start step throws', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -478,6 +478,7 @@ describe('BeastRunService', () => {
       status: 'failed',
       finishedAt: '2026-03-10T00:01:00.000Z',
       stopReason: 'exit_1',
+      latestExitCode: 1,
     });
 
     const failed = await runs.start(run.id, 'operator');
@@ -487,6 +488,9 @@ describe('BeastRunService', () => {
       stopReason: 'start_failed',
       attemptCount: 1,
     });
+    expect(failed.currentAttemptId).toBeUndefined();
+    expect(failed.latestExitCode).toBeUndefined();
+    await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: config invalid'));
     expect(repo.listEvents(run.id).at(-1)).toMatchObject({
       type: 'run.start_failed',
       payload: { error: 'config invalid' },

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -490,6 +490,7 @@ describe('BeastRunService', () => {
     });
     expect(failed.currentAttemptId).toBeUndefined();
     expect(failed.latestExitCode).toBeUndefined();
+    expect(failed.startedAt).toBeUndefined();
     await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: config invalid'));
     expect(repo.listEvents(run.id).at(-1)).toMatchObject({
       type: 'run.start_failed',
@@ -502,6 +503,9 @@ describe('BeastRunService', () => {
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
     const metrics = new PrometheusBeastMetrics();
+    const eventBus = new BeastEventBus();
+    const publish = vi.spyOn(eventBus, 'publish');
+    const agents = new AgentService(repo, () => '2026-03-10T00:02:00.000Z');
     const executors = {
       process: {
         start: vi.fn(async (run: { id: string }) => {
@@ -524,9 +528,36 @@ describe('BeastRunService', () => {
       container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
     };
     const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
-    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(
+      repo,
+      new BeastCatalogService(),
+      executors,
+      metrics,
+      logs,
+      { eventBus },
+    );
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Spawn work',
+          chunkDirectory: 'docs/chunks',
+        },
+      },
+      initConfig: {
+        provider: 'claude',
+        objective: 'Spawn work',
+        chunkDirectory: 'docs/chunks',
+      },
+    });
     const run = await dispatch.createRun({
       definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
       config: {
         provider: 'claude',
         objective: 'Spawn work',
@@ -546,6 +577,21 @@ describe('BeastRunService', () => {
     });
     await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
     expect(repo.listEvents(run.id).map((event) => event.type)).toEqual(['run.created', 'run.spawn_failed']);
+    expect(repo.listTrackedAgentEvents(agent.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        level: 'error',
+        type: 'agent.dispatch.failed',
+        message: `Failed to start Beast run ${run.id}`,
+        payload: { runId: run.id, error: 'spawn ENOENT' },
+      }),
+    ]));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.event',
+      data: expect.objectContaining({
+        agentId: agent.id,
+        event: expect.objectContaining({ type: 'agent.dispatch.failed' }),
+      }),
+    }));
   });
 
   it('does not overwrite a run that already started when a later start step throws', async () => {
@@ -589,6 +635,57 @@ describe('BeastRunService', () => {
     expect(repo.getRun(run.id)).toMatchObject({
       id: run.id,
       status: 'running',
+      attemptCount: 1,
+    });
+    expect(repo.listEvents(run.id).some((event) => event.type === 'run.start_failed')).toBe(false);
+  });
+
+  it('preserves an existing live attempt when a duplicate start fails before creating a new attempt', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async () => {
+          throw new Error('transient config write failed');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Already running work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+    const attempt = repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 31337,
+      startedAt: '2026-03-10T00:03:00.000Z',
+      executorMetadata: { backend: 'process' },
+    });
+    repo.updateRun(run.id, {
+      status: 'running',
+      startedAt: attempt.startedAt,
+    });
+
+    await expect(runs.start(run.id, 'operator')).rejects.toThrow('transient config write failed');
+
+    expect(repo.getRun(run.id)).toMatchObject({
+      id: run.id,
+      status: 'running',
+      currentAttemptId: attempt.id,
       attemptCount: 1,
     });
     expect(repo.listEvents(run.id).some((event) => event.type === 'run.start_failed')).toBe(false);

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -744,6 +744,25 @@ describe('BeastRunService', () => {
     expect(failed.latestExitCode).toBeUndefined();
     expect(failed.startedAt).toBeUndefined();
     await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
+
+    executors.process.start.mockImplementationOnce(async (retryRun: { id: string }) => {
+      repo.createAttempt(retryRun.id, {
+        status: 'running',
+        pid: 444,
+        startedAt: '2026-03-10T00:04:00.000Z',
+        executorMetadata: { backend: 'process' },
+      });
+    });
+
+    const retried = await runs.start(run.id, 'operator');
+
+    expect(retried).toMatchObject({
+      status: 'running',
+      attemptCount: 2,
+    });
+    expect(retried.finishedAt).toBeUndefined();
+    expect(retried.latestExitCode).toBeUndefined();
+    expect(retried.stopReason).toBeUndefined();
   });
 
   it('does not overwrite a live run when an executor-recorded duplicate start failure occurs', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -594,6 +594,90 @@ describe('BeastRunService', () => {
     }));
   });
 
+  it('does not duplicate tracked-agent failure notifications already emitted by the executor callback', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const eventBus = new BeastEventBus();
+    const publish = vi.spyOn(eventBus, 'publish');
+    const agents = new AgentService(repo, () => '2026-03-10T00:02:00.000Z');
+    let notifyRunStatusChange = (_runId: string): void => {};
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          const failedAt = '2026-03-10T00:02:00.000Z';
+          repo.updateRun(run.id, {
+            status: 'failed',
+            finishedAt: failedAt,
+            stopReason: 'spawn_failed',
+          });
+          repo.appendEvent(run.id, {
+            type: 'run.spawn_failed',
+            payload: { error: 'spawn ENOENT' },
+            createdAt: failedAt,
+          });
+          notifyRunStatusChange(run.id);
+          throw new Error('spawn ENOENT');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(
+      repo,
+      new BeastCatalogService(),
+      executors,
+      metrics,
+      logs,
+      { eventBus },
+    );
+    notifyRunStatusChange = (runId: string) => runs.notifyRunStatusChange(runId);
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Spawn work',
+          chunkDirectory: 'docs/chunks',
+        },
+      },
+      initConfig: {
+        provider: 'claude',
+        objective: 'Spawn work',
+        chunkDirectory: 'docs/chunks',
+      },
+    });
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
+      config: {
+        provider: 'claude',
+        objective: 'Spawn work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+
+    const failed = await runs.start(run.id, 'operator');
+
+    expect(failed.status).toBe('failed');
+    expect(repo.getTrackedAgent(agent.id)?.status).toBe('failed');
+    expect(repo.listTrackedAgentEvents(agent.id).filter((event) => event.level === 'error')).toHaveLength(1);
+    expect(repo.listTrackedAgentEvents(agent.id).filter((event) => event.type === 'agent.dispatch.failed')).toHaveLength(0);
+    expect(publish.mock.calls.filter(([event]) => event.type === 'agent.status')).toHaveLength(1);
+    expect(publish.mock.calls.filter(([event]) => event.type === 'agent.event')).toHaveLength(1);
+  });
+
   it('clears stale attempt metadata when preserving executor-recorded retry failures', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
@@ -760,6 +844,62 @@ describe('BeastRunService', () => {
       status: 'running',
       attemptCount: 1,
     });
+    expect(repo.listEvents(run.id).some((event) => event.type === 'run.start_failed')).toBe(false);
+  });
+
+  it('keeps a newly created running attempt current when an older running attempt also exists', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          repo.createAttempt(run.id, {
+            status: 'running',
+            pid: 888,
+            startedAt: '2026-03-10T00:06:00.000Z',
+            executorMetadata: { backend: 'process' },
+          });
+          throw new Error('post-start tracking failed');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Start queued work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+    const priorAttempt = repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 777,
+      startedAt: '2026-03-10T00:05:00.000Z',
+      executorMetadata: { backend: 'process' },
+    });
+
+    await expect(runs.start(run.id, 'operator')).rejects.toThrow('post-start tracking failed');
+
+    const attempts = repo.listAttempts(run.id);
+    expect(attempts).toHaveLength(2);
+    expect(repo.getRun(run.id)).toMatchObject({
+      id: run.id,
+      status: 'running',
+      currentAttemptId: attempts[1].id,
+      attemptCount: 2,
+    });
+    expect(repo.getRun(run.id)?.currentAttemptId).not.toBe(priorAttempt.id);
     expect(repo.listEvents(run.id).some((event) => event.type === 'run.start_failed')).toBe(false);
   });
 

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -441,6 +441,108 @@ describe('BeastRunService', () => {
     }));
   });
 
+  it('records a new start failure when a run with a prior attempt fails before creating another attempt', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async () => {
+          throw new Error('config invalid');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Retry failed work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+    repo.createAttempt(run.id, {
+      status: 'failed',
+      startedAt: '2026-03-10T00:00:00.000Z',
+    });
+    repo.updateRun(run.id, {
+      status: 'failed',
+      finishedAt: '2026-03-10T00:01:00.000Z',
+      stopReason: 'exit_1',
+    });
+
+    const failed = await runs.start(run.id, 'operator');
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      stopReason: 'start_failed',
+      attemptCount: 1,
+    });
+    expect(repo.listEvents(run.id).at(-1)).toMatchObject({
+      type: 'run.start_failed',
+      payload: { error: 'config invalid' },
+    });
+  });
+
+  it('preserves executor-recorded spawn failures instead of rewriting them', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          const failedAt = '2026-03-10T00:02:00.000Z';
+          repo.updateRun(run.id, {
+            status: 'failed',
+            finishedAt: failedAt,
+            stopReason: 'spawn_failed',
+          });
+          repo.appendEvent(run.id, {
+            type: 'run.spawn_failed',
+            payload: { error: 'spawn ENOENT' },
+            createdAt: failedAt,
+          });
+          throw new Error('spawn ENOENT');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Spawn work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+
+    const failed = await runs.start(run.id, 'operator');
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      stopReason: 'spawn_failed',
+    });
+    expect(repo.listEvents(run.id).map((event) => event.type)).toEqual(['run.created', 'run.spawn_failed']);
+  });
+
   it('does not overwrite a run that already started when a later start step throws', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -544,6 +544,7 @@ describe('BeastRunService', () => {
       status: 'failed',
       stopReason: 'spawn_failed',
     });
+    await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
     expect(repo.listEvents(run.id).map((event) => event.type)).toEqual(['run.created', 'run.spawn_failed']);
   });
 

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -326,6 +326,109 @@ describe('BeastRunService', () => {
     });
   });
 
+  it('marks queued tracked runs failed when executor start throws', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const eventBus = new BeastEventBus();
+    const publish = vi.spyOn(eventBus, 'publish');
+    const agents = new AgentService(repo, () => '2026-03-11T00:00:00.000Z');
+    const executors = {
+      process: {
+        start: vi.fn(async () => {
+          throw new Error('spawn ENOENT');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(
+      repo,
+      new BeastCatalogService(),
+      executors,
+      metrics,
+      logs,
+      { eventBus },
+    );
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Start queued work',
+          chunkDirectory: 'docs/chunks',
+        },
+      },
+      initConfig: {
+        provider: 'claude',
+        objective: 'Start queued work',
+        chunkDirectory: 'docs/chunks',
+      },
+    });
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
+      config: {
+        provider: 'claude',
+        objective: 'Start queued work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+
+    const failed = await runs.start(run.id, 'operator');
+
+    expect(failed).toMatchObject({
+      id: run.id,
+      status: 'failed',
+      stopReason: 'start_failed',
+    });
+    expect(repo.listEvents(run.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'run.start_failed',
+        payload: { error: 'spawn ENOENT' },
+      }),
+    ]));
+    await expect(logs.read(run.id, 'system')).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({
+      status: 'failed',
+      dispatchRunId: run.id,
+    });
+    expect(repo.listTrackedAgentEvents(agent.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        level: 'error',
+        type: 'agent.dispatch.failed',
+        message: `Failed to start Beast run ${run.id}`,
+        payload: { runId: run.id, error: 'spawn ENOENT' },
+      }),
+    ]));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.status',
+      data: expect.objectContaining({ agentId: agent.id, status: 'failed' }),
+    }));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.event',
+      data: expect.objectContaining({
+        agentId: agent.id,
+        event: expect.objectContaining({ type: 'agent.dispatch.failed' }),
+      }),
+    }));
+  });
+
   it('rolls back tracked-agent status sync when persisting its terminal event fails', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -404,6 +404,7 @@ describe('BeastRunService', () => {
       }),
     ]));
     await expect(logs.read(run.id, 'system')).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
+    await expect(runs.readLogs(run.id)).resolves.toContainEqual(expect.stringContaining('start_failed: spawn ENOENT'));
     expect(repo.getTrackedAgent(agent.id)).toMatchObject({
       status: 'failed',
       dispatchRunId: run.id,
@@ -417,6 +418,17 @@ describe('BeastRunService', () => {
       }),
     ]));
     expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'run.status',
+      data: expect.objectContaining({ runId: run.id, status: 'failed' }),
+    }));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'run.event',
+      data: expect.objectContaining({
+        runId: run.id,
+        event: expect.objectContaining({ type: 'run.start_failed' }),
+      }),
+    }));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
       type: 'agent.status',
       data: expect.objectContaining({ agentId: agent.id, status: 'failed' }),
     }));
@@ -426,6 +438,139 @@ describe('BeastRunService', () => {
         agentId: agent.id,
         event: expect.objectContaining({ type: 'agent.dispatch.failed' }),
       }),
+    }));
+  });
+
+  it('does not overwrite a run that already started when a later start step throws', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          repo.createAttempt(run.id, {
+            status: 'running',
+            pid: 777,
+            startedAt: '2026-03-10T00:05:00.000Z',
+            executorMetadata: { backend: 'process' },
+          });
+          throw new Error('post-start tracking failed');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Start queued work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+
+    await expect(runs.start(run.id, 'operator')).rejects.toThrow('post-start tracking failed');
+
+    expect(repo.getRun(run.id)).toMatchObject({
+      id: run.id,
+      status: 'running',
+      attemptCount: 1,
+    });
+    expect(repo.listEvents(run.id).some((event) => event.type === 'run.start_failed')).toBe(false);
+  });
+
+  it('does not resurrect soft-deleted tracked agents when queued start fails', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const eventBus = new BeastEventBus();
+    const publish = vi.spyOn(eventBus, 'publish');
+    const agents = new AgentService(repo, () => '2026-03-11T00:00:00.000Z');
+    const executors = {
+      process: {
+        start: vi.fn(async () => {
+          throw new Error('spawn ENOENT');
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(
+      repo,
+      new BeastCatalogService(),
+      executors,
+      metrics,
+      logs,
+      { eventBus },
+    );
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Start deleted linked work',
+          chunkDirectory: 'docs/chunks',
+        },
+      },
+      initConfig: {
+        provider: 'claude',
+        objective: 'Start deleted linked work',
+        chunkDirectory: 'docs/chunks',
+      },
+    });
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
+      config: {
+        provider: 'claude',
+        objective: 'Start deleted linked work',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    });
+    repo.updateTrackedAgent(agent.id, {
+      status: 'deleted',
+      dispatchRunId: run.id,
+      updatedAt: '2026-03-11T00:00:01.000Z',
+    });
+
+    const failed = await runs.start(run.id, 'operator');
+
+    expect(failed.status).toBe('failed');
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({
+      status: 'deleted',
+      dispatchRunId: run.id,
+    });
+    expect(repo.listTrackedAgentEvents(agent.id).some((event) => event.type === 'agent.dispatch.failed')).toBe(false);
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.status',
+      data: expect.objectContaining({ agentId: agent.id }),
+    }));
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.event',
+      data: expect.objectContaining({ agentId: agent.id }),
+    }));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'run.status',
+      data: expect.objectContaining({ runId: run.id, status: 'failed' }),
     }));
   });
 

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -118,6 +118,27 @@ describe('ProcessBeastExecutor', () => {
     ]);
   });
 
+  it('kills a spawned process when attempt creation fails', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = createSupervisorMock();
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor);
+    const run = createTestRun(repo);
+    vi.spyOn(repo, 'createAttempt').mockImplementation(() => {
+      throw new Error('attempt insert failed');
+    });
+
+    await expect(executor.start(run, martinLoopDefinition)).rejects.toThrow('attempt insert failed');
+
+    expect(supervisor.kill).toHaveBeenCalledWith(4242);
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'queued',
+      attemptCount: 0,
+    });
+    expect(repo.getRun(run.id)?.currentAttemptId).toBeUndefined();
+  });
+
   it('creates an isolated git worktree and spawns the process inside it when enabled', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -139,6 +139,26 @@ describe('ProcessBeastExecutor', () => {
     expect(repo.getRun(run.id)?.currentAttemptId).toBeUndefined();
   });
 
+  it('cleans pending run resources and preserves the insert error when kill fails after spawn', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const supervisor = createSupervisorMock();
+    supervisor.kill.mockRejectedValue(new Error('kill denied'));
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor);
+    const run = createTestRun(repo);
+    vi.spyOn(repo, 'createAttempt').mockImplementation(() => {
+      throw new Error('attempt insert failed');
+    });
+
+    await expect(executor.start(run, martinLoopDefinition)).rejects.toThrow('attempt insert failed');
+
+    const [spawnedSpec] = supervisor.spawn.mock.calls[0];
+    const configPath = (spawnedSpec as { env: Record<string, string> }).env.FRANKENBEAST_RUN_CONFIG;
+    expect(supervisor.kill).toHaveBeenCalledWith(4242);
+    expect(existsSync(configPath)).toBe(false);
+  });
+
   it('creates an isolated git worktree and spawns the process inside it when enabled', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -74,3 +74,7 @@
 
 ## 2026-07-10 — Network stop/restart target validation
 - Validate stop and restart target IDs through `filterNetworkServices` before invoking supervisor operations, so unknown names fail fast with 400 instead of becoming no-op successes. Keep this as a shared pattern for all service-targeted control-plane endpoints where missing resources must be surfaced as client errors.
+
+## 2026-07-10 — BeastRunService start failure retries
+- When `executor.start()` throws after mutating run state, compare the current attempt id/count to the pre-start snapshot before accepting service-level fallback handling. If a prior attempt is still running, restore live run metadata and rethrow so the live process remains controllable.
+- Executor-recorded pre-attempt failures should preserve the executor's specific stop reason/event while clearing stale run-level `startedAt`, `currentAttemptId`, and `latestExitCode` from older terminal attempts; add retry and duplicate-start regressions before retriggering Codex.


### PR DESCRIPTION
## Summary
- Handle executor start failures in BeastRunService.start for queued/tracked runs by persisting failed run state, run.start_failed events, stderr logs, and tracked-agent failure notifications.
- Add regression coverage for a queued linked run whose executor throws during start.

## Test Plan
- npm run test -- tests/unit/beasts/beast-run-service.test.ts
- npm run lint (0 errors; existing warnings remain)
- npx turbo run typecheck --filter=@franken/orchestrator...
- npx turbo run build --filter=@franken/orchestrator...

Closes #1130