### PR TITLE
chore(critique): add package typecheck script

### DIFF
--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- Add a package-level `typecheck` script for `@franken/critique` using `tsc --noEmit`
- Ensure root Turbo `typecheck` can include the critique workspace

## Test Plan
- `npm run build --workspace=@franken/types`
- `npm run typecheck --workspace=@franken/critique`
- `npm run typecheck -- --filter=@franken/critique`

Closes #943
