### PR TITLE
test(deps): enforce Vitest workspace alignment

### DIFF
--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -66,6 +66,53 @@ describe('npm workspaces configuration', () => {
         .filter((entry) => entry.isDirectory())
         .map((entry) => `packages/${entry.name}/package.json`),
     ];
+    const getDirectDependency = (pkg: Record<string, Record<string, string> | undefined>, dependencyName: string) => {
+      for (const dependencySection of [
+        'dependencies',
+        'devDependencies',
+        'optionalDependencies',
+        'peerDependencies',
+      ]) {
+        const version = pkg[dependencySection]?.[dependencyName];
+        if (version !== undefined) return version;
+      }
+      return undefined;
+    };
+    const majorOf = (version: string) => majorMinorPatch(version)[0];
+
+    it('keeps workspace Vitest declarations on the root Vitest major', () => {
+      const rootPkg = readPkg('package.json');
+      const rootVitest = rootPkg.devDependencies?.vitest;
+
+      expect(rootVitest).toBeDefined();
+      const rootVitestMajor = majorOf(rootVitest);
+
+      for (const path of packageJsonPaths) {
+        const pkg = readPkg(path);
+        const vitest = getDirectDependency(pkg, 'vitest');
+        if (vitest === undefined) continue;
+
+        expect(
+          majorOf(vitest),
+          `vitest in ${path} must stay on root major ${rootVitestMajor}`,
+        ).toBe(rootVitestMajor);
+      }
+    });
+
+    it('keeps workspace coverage-v8 declarations on the same major as Vitest', () => {
+      for (const path of packageJsonPaths) {
+        const pkg = readPkg(path);
+        const vitest = getDirectDependency(pkg, 'vitest');
+        const coverage = getDirectDependency(pkg, '@vitest/coverage-v8');
+        if (coverage === undefined) continue;
+
+        expect(vitest, `${path} declares @vitest/coverage-v8 without vitest`).toBeDefined();
+        expect(
+          majorOf(coverage),
+          `@vitest/coverage-v8 in ${path} must match vitest major`,
+        ).toBe(majorOf(vitest));
+      }
+    });
 
     it('keeps every Vitest and coverage dependency on the non-vulnerable floor', () => {
       for (const path of packageJsonPaths) {

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -66,18 +66,18 @@ describe('npm workspaces configuration', () => {
         .filter((entry) => entry.isDirectory())
         .map((entry) => `packages/${entry.name}/package.json`),
     ];
-    const getDirectDependency = (pkg: Record<string, Record<string, string> | undefined>, dependencyName: string) => {
-      for (const dependencySection of [
-        'dependencies',
-        'devDependencies',
-        'optionalDependencies',
-        'peerDependencies',
-      ]) {
-        const version = pkg[dependencySection]?.[dependencyName];
-        if (version !== undefined) return version;
-      }
-      return undefined;
-    };
+    const dependencySections = [
+      'dependencies',
+      'devDependencies',
+      'optionalDependencies',
+      'peerDependencies',
+    ] as const;
+    const getDirectDependencies = (pkg: Record<string, Record<string, string> | undefined>, dependencyName: string) => dependencySections
+      .map((dependencySection) => ({
+        dependencySection,
+        version: pkg[dependencySection]?.[dependencyName],
+      }))
+      .filter((entry): entry is { dependencySection: typeof dependencySections[number]; version: string } => entry.version !== undefined);
     const majorOf = (version: string) => majorMinorPatch(version)[0];
 
     it('keeps workspace Vitest declarations on the root Vitest major', () => {
@@ -89,28 +89,32 @@ describe('npm workspaces configuration', () => {
 
       for (const path of packageJsonPaths) {
         const pkg = readPkg(path);
-        const vitest = getDirectDependency(pkg, 'vitest');
-        if (vitest === undefined) continue;
+        const vitestDeclarations = getDirectDependencies(pkg, 'vitest');
 
-        expect(
-          majorOf(vitest),
-          `vitest in ${path} must stay on root major ${rootVitestMajor}`,
-        ).toBe(rootVitestMajor);
+        for (const { dependencySection, version } of vitestDeclarations) {
+          expect(
+            majorOf(version),
+            `vitest in ${path} ${dependencySection} must stay on root major ${rootVitestMajor}`,
+          ).toBe(rootVitestMajor);
+        }
       }
     });
 
     it('keeps workspace coverage-v8 declarations on the same major as Vitest', () => {
       for (const path of packageJsonPaths) {
         const pkg = readPkg(path);
-        const vitest = getDirectDependency(pkg, 'vitest');
-        const coverage = getDirectDependency(pkg, '@vitest/coverage-v8');
-        if (coverage === undefined) continue;
+        const vitestDeclarations = getDirectDependencies(pkg, 'vitest');
+        const coverageDeclarations = getDirectDependencies(pkg, '@vitest/coverage-v8');
+        if (coverageDeclarations.length === 0) continue;
 
-        expect(vitest, `${path} declares @vitest/coverage-v8 without vitest`).toBeDefined();
-        expect(
-          majorOf(coverage),
-          `@vitest/coverage-v8 in ${path} must match vitest major`,
-        ).toBe(majorOf(vitest));
+        expect(vitestDeclarations.length, `${path} declares @vitest/coverage-v8 without vitest`).toBeGreaterThan(0);
+        const vitestMajors = new Set(vitestDeclarations.map(({ version }) => majorOf(version)));
+        for (const { dependencySection, version } of coverageDeclarations) {
+          expect(
+            vitestMajors.has(majorOf(version)),
+            `@vitest/coverage-v8 in ${path} ${dependencySection} must match a declared vitest major`,
+          ).toBe(true);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- add root workspace regression coverage that enforces all declared Vitest dependencies stay on the root Vitest major
- enforce @vitest/coverage-v8 declarations match the local Vitest major when coverage is declared
- verifies the already-aligned workspace manifests stay aligned across future package changes

## Test Plan
- npm run test:root -- tests/workspaces.test.ts
- npm run ci:test:root
- node inline verification: Vitest workspace declarations aligned on major 4; coverage-v8 majors match Vitest where declared

Note: `npx tsc --noEmit` was attempted at the root but the root tsconfig intentionally has an empty include set and exits with TS18003 (no inputs).

Closes #946