### PR TITLE
test(tsconfig): derive workspace coverage expectations

### DIFF
--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, posix } from 'node:path';
 
 const ROOT = join(import.meta.dirname, '..');
 const readJson = (rel: string) =>
@@ -27,7 +27,7 @@ const expandWorkspacePackageDirs = (workspaces: string[]): string[] => {
         if (!entry.isDirectory()) continue;
         const manifestPath = join(parentDir, entry.name, 'package.json');
         if (existsSync(join(ROOT, manifestPath))) {
-          packageDirs.add(join(parentDir, entry.name));
+          packageDirs.add(posix.join(parentDir, entry.name));
         }
       }
       continue;
@@ -49,14 +49,14 @@ const hasTypeScriptSource = (relDir: string): boolean => {
   if (!existsSync(absDir)) return false;
 
   for (const entry of readdirSync(absDir, { withFileTypes: true })) {
-    const relPath = join(relDir, entry.name);
+    const relPath = `${relDir}/${entry.name}`;
     if (entry.isDirectory()) {
       if (entry.name === 'dist' || entry.name === 'node_modules') continue;
       if (hasTypeScriptSource(relPath)) return true;
       continue;
     }
 
-    if (entry.isFile() && /\.tsx?$/u.test(entry.name)) {
+    if (entry.isFile() && /\.(?:[cm]?ts|tsx)$/u.test(entry.name)) {
       return true;
     }
   }
@@ -154,6 +154,7 @@ describe('tsconfig.json path aliases', () => {
     const workspacePackageNames = new Set(workspacePackages.map((workspacePackage) => workspacePackage.name));
     for (const [packageName, reason] of Object.entries(PATH_ALIAS_ALLOWLIST)) {
       expect(workspacePackageNames.has(packageName), `${packageName} is no longer a workspace package`).toBe(true);
+      expect(ALIASED_WORKSPACE_PACKAGES.has(packageName), `${packageName} now has a root alias; remove it from PATH_ALIAS_ALLOWLIST`).toBe(false);
       expect(reason.trim(), `${packageName} allowlist entry must explain why no root alias is expected`).not.toBe('');
     }
   });
@@ -200,6 +201,11 @@ describe('tsconfig.test.json includes', () => {
     const workspacePackageNames = new Set(workspacePackages.map((workspacePackage) => workspacePackage.name));
     for (const [packageName, reason] of Object.entries(TSCONFIG_TEST_INCLUDE_ALLOWLIST)) {
       expect(workspacePackageNames.has(packageName), `${packageName} is no longer a workspace package`).toBe(true);
+      const workspacePackage = workspacePackages.find((candidate) => candidate.name === packageName);
+      expect(
+        includes.includes(`${workspacePackage?.dir}/src/**/*`),
+        `${packageName} is now included in tsconfig.test.json; remove it from TSCONFIG_TEST_INCLUDE_ALLOWLIST`,
+      ).toBe(false);
       expect(reason.trim(), `${packageName} tsconfig.test include allowlist entry must explain the exclusion`).not.toBe('');
     }
   });

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -1,10 +1,83 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = join(import.meta.dirname, '..');
 const readJson = (rel: string) =>
   JSON.parse(readFileSync(join(ROOT, rel), 'utf8'));
+
+type PackageJson = {
+  name?: string;
+  workspaces?: string[];
+};
+
+type WorkspacePackage = {
+  dir: string;
+  manifestPath: string;
+  name: string;
+};
+
+const expandWorkspacePackageDirs = (workspaces: string[]): string[] => {
+  const packageDirs = new Set<string>();
+
+  for (const workspace of workspaces) {
+    if (workspace.endsWith('/*') && workspace.indexOf('*') === workspace.length - 1) {
+      const parentDir = workspace.slice(0, -2);
+      for (const entry of readdirSync(join(ROOT, parentDir), { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const manifestPath = join(parentDir, entry.name, 'package.json');
+        if (existsSync(join(ROOT, manifestPath))) {
+          packageDirs.add(join(parentDir, entry.name));
+        }
+      }
+      continue;
+    }
+
+    if (!workspace.includes('*') && existsSync(join(ROOT, workspace, 'package.json'))) {
+      packageDirs.add(workspace);
+      continue;
+    }
+
+    throw new Error(`Unsupported workspace glob in tsconfig path test: ${workspace}`);
+  }
+
+  return [...packageDirs].sort();
+};
+
+const hasTypeScriptSource = (relDir: string): boolean => {
+  const absDir = join(ROOT, relDir);
+  if (!existsSync(absDir)) return false;
+
+  for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    const relPath = join(relDir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'dist' || entry.name === 'node_modules') continue;
+      if (hasTypeScriptSource(relPath)) return true;
+      continue;
+    }
+
+    if (entry.isFile() && /\.tsx?$/u.test(entry.name)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const getWorkspacePackages = (): WorkspacePackage[] => {
+  const rootPkg = readJson('package.json') as PackageJson;
+  return expandWorkspacePackageDirs(rootPkg.workspaces ?? []).map((dir) => {
+    const manifestPath = `${dir}/package.json`;
+    const pkg = readJson(manifestPath) as PackageJson;
+    if (typeof pkg.name !== 'string' || pkg.name.length === 0) {
+      throw new Error(`${manifestPath} must declare a package name`);
+    }
+
+    return { dir, manifestPath, name: pkg.name };
+  });
+};
+
+const workspacePackages = getWorkspacePackages();
 
 const EXPECTED_ALIASES: Record<string, string> = {
   '@franken/brain': './packages/franken-brain/src/index.ts',
@@ -18,6 +91,27 @@ const EXPECTED_ALIASES: Record<string, string> = {
   '@franken/orchestrator': './packages/franken-orchestrator/src/index.ts',
 };
 
+const ALIASED_WORKSPACE_PACKAGES = new Set(
+  workspacePackages
+    .filter((workspacePackage) =>
+      Object.keys(EXPECTED_ALIASES).some(
+        (alias) => alias === workspacePackage.name || alias.startsWith(`${workspacePackage.name}/`),
+      ),
+    )
+    .map((workspacePackage) => workspacePackage.name),
+);
+
+const PATH_ALIAS_ALLOWLIST: Record<string, string> = {
+  '@franken/live-bench': 'CLI-only benchmark workspace; consumers should use the package build/bin instead of a root source alias.',
+  '@franken/mcp-suite': 'CLI/server package with package-level Vitest aliases; no root @franken source alias is exported intentionally.',
+  '@franken/web': 'Vite application workspace, not an importable library entrypoint.',
+};
+
+const TSCONFIG_TEST_INCLUDE_ALLOWLIST: Record<string, string> = {
+  '@franken/live-bench': 'Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI package settings.',
+  '@franken/mcp-suite': 'Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI/server package settings.',
+};
+
 describe('tsconfig.json path aliases', () => {
   const tsconfig = readJson('tsconfig.json');
   const paths = tsconfig.compilerOptions?.paths;
@@ -26,8 +120,8 @@ describe('tsconfig.json path aliases', () => {
     expect(paths).toBeDefined();
   });
 
-  it('has exactly 9 aliases', () => {
-    expect(Object.keys(paths)).toHaveLength(9);
+  it('has the expected aliases', () => {
+    expect(Object.keys(paths)).toHaveLength(Object.keys(EXPECTED_ALIASES).length);
   });
 
   for (const [alias, expectedPath] of Object.entries(EXPECTED_ALIASES)) {
@@ -40,6 +134,27 @@ describe('tsconfig.json path aliases', () => {
     expect(Object.keys(paths).sort()).toEqual(Object.keys(EXPECTED_ALIASES).sort());
     for (const alias of Object.keys(paths)) {
       expect(alias, `${alias} must use the canonical @franken scope`).toMatch(/^@franken\//);
+    }
+  });
+
+  it('keeps every source workspace either aliased or explicitly allowlisted', () => {
+    for (const workspacePackage of workspacePackages) {
+      if (!hasTypeScriptSource(`${workspacePackage.dir}/src`)) continue;
+      const isAliased = ALIASED_WORKSPACE_PACKAGES.has(workspacePackage.name);
+      const allowlistReason = PATH_ALIAS_ALLOWLIST[workspacePackage.name];
+
+      expect(
+        isAliased || allowlistReason !== undefined,
+        `${workspacePackage.name} (${workspacePackage.dir}) is missing from tsconfig.json paths; add an alias or document it in PATH_ALIAS_ALLOWLIST`,
+      ).toBe(true);
+    }
+  });
+
+  it('has no stale path alias allowlist entries', () => {
+    const workspacePackageNames = new Set(workspacePackages.map((workspacePackage) => workspacePackage.name));
+    for (const [packageName, reason] of Object.entries(PATH_ALIAS_ALLOWLIST)) {
+      expect(workspacePackageNames.has(packageName), `${packageName} is no longer a workspace package`).toBe(true);
+      expect(reason.trim(), `${packageName} allowlist entry must explain why no root alias is expected`).not.toBe('');
     }
   });
 
@@ -69,19 +184,34 @@ describe('tsconfig.test.json includes', () => {
     expect(includes).toContain('tests/**/*');
   });
 
-  const modulesInTestConfig = [
-    'franken-brain',
-    'franken-critique',
-    'franken-governor',
-    'franken-observer',
-    'franken-planner',
-  ];
+  it('includes or explicitly allowlists every workspace package with TypeScript source in src/', () => {
+    const missingPackages = workspacePackages
+      .filter((workspacePackage) => hasTypeScriptSource(`${workspacePackage.dir}/src`))
+      .filter((workspacePackage) => !includes.includes(`${workspacePackage.dir}/src/**/*`))
+      .filter((workspacePackage) => TSCONFIG_TEST_INCLUDE_ALLOWLIST[workspacePackage.name] === undefined);
 
-  for (const mod of modulesInTestConfig) {
-    it(`includes packages/${mod}/src/**/*`, () => {
-      expect(includes).toContain(`packages/${mod}/src/**/*`);
-    });
-  }
+    expect(
+      missingPackages.map((workspacePackage) => workspacePackage.name),
+      'Workspace packages with TypeScript source must be included in tsconfig.test.json or intentionally allowlisted by this test',
+    ).toEqual([]);
+  });
+
+  it('has no stale tsconfig.test include allowlist entries', () => {
+    const workspacePackageNames = new Set(workspacePackages.map((workspacePackage) => workspacePackage.name));
+    for (const [packageName, reason] of Object.entries(TSCONFIG_TEST_INCLUDE_ALLOWLIST)) {
+      expect(workspacePackageNames.has(packageName), `${packageName} is no longer a workspace package`).toBe(true);
+      expect(reason.trim(), `${packageName} tsconfig.test include allowlist entry must explain the exclusion`).not.toBe('');
+    }
+  });
+
+  it('has no stale workspace package src includes', () => {
+    const workspacePackageDirs = new Set(workspacePackages.map((workspacePackage) => workspacePackage.dir));
+    const staleIncludes = includes
+      .filter((include: string) => include.startsWith('packages/') && include.endsWith('/src/**/*'))
+      .filter((include: string) => !workspacePackageDirs.has(include.slice(0, -'/src/**/*'.length)));
+
+    expect(staleIncludes, 'tsconfig.test.json contains includes for packages that are no longer workspaces').toEqual([]);
+  });
 
   it('has no root-level module paths (no franken-*/src or frankenfirewall/src)', () => {
     const raw = readFileSync(join(ROOT, 'tsconfig.test.json'), 'utf8');


### PR DESCRIPTION
## Summary
- derive tsconfig/test workspace coverage assertions from root npm workspaces
- require every TypeScript source workspace to be included in tsconfig.test.json or explicitly allowlisted with a rationale
- make path-alias exclusions explicit for non-library workspaces

## Test Plan
- npm run test:root -- tests/tsconfig-paths.test.ts
- npm run test:root
- npm run typecheck
- npm run build

Closes #1071