### PR TITLE
docs(security): add security policy and badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-security-and-maintenance:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 ![Status](https://img.shields.io/badge/status-beta-blue)
 [![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/latest)
+[![Daily security scan](https://github.com/djm204/frankenbeast/actions/workflows/daily-security-scan.yml/badge.svg)](https://github.com/djm204/frankenbeast/actions/workflows/daily-security-scan.yml)
+[![Dependabot](https://img.shields.io/badge/dependabot-configured-025E8C?logo=dependabot)](.github/dependabot.yml)
+
 **Deterministic guardrails for AI agents.**
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.
@@ -34,6 +37,10 @@ Both modes share `.fbeast/beast.db`.
 LLM-based agents routinely lose safety constraints when context windows compress, hallucinate tool calls that violate architectural rules, and take destructive actions without human oversight. Frankenbeast solves this by placing safety enforcement in a deterministic pipeline that the LLM cannot bypass, forget, or summarise away.
 
 **The key guarantee:** Safety constraints survive context-window compression because they are enforced by the firewall pipeline, not by the LLM prompt.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for vulnerability reporting, dependency update expectations, secret handling, HTTPS guidance, and runtime hardening recommendations.
 
 ## Architecture
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+Frankenbeast is a deterministic guardrails framework, so security reports and operational hardening guidance are handled as first-class project work.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately instead of opening a public issue. Use GitHub's private vulnerability reporting flow for this repository when available:
+
+- https://github.com/djm204/frankenbeast/security/advisories/new
+
+If private reporting is unavailable, contact the repository owner and include enough detail to reproduce the issue safely:
+
+- affected package, command, route, or workflow;
+- impact and prerequisites;
+- minimal reproduction steps or proof-of-concept details;
+- whether credentials, secrets, or user data may be exposed.
+
+We will acknowledge actionable reports as quickly as possible, triage severity, and coordinate a fix before public disclosure when warranted.
+
+## Supported versions
+
+Frankenbeast is pre-1.0 and evolves quickly. Security fixes are applied to `main` first and included in the next tagged release. Operators should track the latest release line and review release notes for security-related changes.
+
+## Dependency updates
+
+- Dependabot is configured for npm workspace dependencies and GitHub Actions updates.
+- Keep npm dependencies on the repository-pinned package manager (`packageManager` in `package.json`).
+- Run `npm run audit:dependencies` and `npm run audit:security` before shipping security-sensitive changes.
+- The CI workflow runs dependency vulnerability checks, major-version freshness checks, and SBOM generation on pull requests.
+- The daily deterministic security scan runs Semgrep, Gitleaks, and dependency audit jobs; treat its filed issues as active security work until closed.
+- Prefer targeted dependency upgrades with lockfile review over broad updates that mix unrelated changes.
+
+## Secret handling
+
+- Never commit real API keys, webhook secrets, tokens, private keys, cookies, session dumps, or customer data.
+- Use `.env.example` for placeholder configuration only; keep local `.env` files untracked.
+- Prefer runtime secret stores and environment injection over hard-coded config values.
+- Redact secrets from logs, traces, screenshots, SARIF output, and issue/PR comments.
+- Rotate any secret that may have been exposed in a branch, artifact, dependency report, or chat transcript.
+
+## HTTPS and network exposure
+
+- Use HTTPS for production deployments and public callbacks.
+- Keep dashboard and chat-server traffic same-origin through a trusted proxy/BFF when browser clients need protected routes.
+- Do not expose operator-token-protected endpoints directly to untrusted networks without TLS, authentication, and rate limiting.
+- Treat loopback development defaults as local-only conveniences, not production security settings.
+
+## Runtime hardening
+
+When deploying Frankenbeast services, apply defense-in-depth controls around the Node.js runtime and HTTP surface:
+
+- Run services with the least privileges and a dedicated service account.
+- Set explicit project roots (`--base-dir` where supported) so file access and generated artifacts stay inside the intended checkout.
+- Keep human-in-the-loop approval gateways enabled for destructive or high-risk actions.
+- Validate webhook signatures and operator tokens before processing privileged requests.
+- Use secure HTTP headers such as Helmet-compatible defaults at the edge or application layer.
+- Apply rate limits to authentication, webhook, chat, and operator-action endpoints.
+- Store logs and traces in locations with restricted access and retention appropriate for their sensitivity.
+- Monitor security scan output and GitHub security alerts regularly.
+
+## Security checks
+
+Useful local checks before opening or merging security-sensitive changes:
+
+```bash
+npm run audit:dependencies
+npm run audit:security
+npm run lint:security
+```
+
+Pull requests also run the CI security gates and the scheduled daily security workflow reports deterministic SAST, secret-scan, and dependency-audit findings.


### PR DESCRIPTION
## Summary
- add SECURITY.md with vulnerability reporting, dependency, secret, HTTPS, and runtime hardening guidance
- configure Dependabot for npm and GitHub Actions updates
- add README security scan and Dependabot badges plus a SECURITY.md link

## Verification
- git diff --check
- npm run lint:security
- npm run audit:security
- verified security badge/link URLs return HTTP 200

Closes #1412