### PR TITLE
fix(mcp): quote Gemini hook script paths

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -5,6 +5,7 @@ import { codexServerName } from './codex-server-names.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 
 function tmpDir(): string {
@@ -267,6 +268,33 @@ describe('fbeast init', () => {
     expect(afterCmd).toContain('cd "$p"');
     expect(afterCmd).not.toContain('do;');
     expect(afterCmd).toContain('gemini-after-tool.sh');
+  });
+
+  it('quotes Gemini hook commands so hostile project roots cannot inject shell commands', () => {
+    const parent = tmpDir();
+    dirs.push(parent);
+    const marker = join(parent, 'gemini-injection-marker');
+    const root = join(parent, `project with spaces ; $(touch ${marker}) and quote's`);
+    mkdirSync(root, { recursive: true });
+    const geminiDir = join(root, '.gemini');
+
+    runInit({ root, claudeDir: geminiDir, hooks: true, client: 'gemini' });
+
+    const settings = JSON.parse(readFileSync(join(geminiDir, 'settings.json'), 'utf-8'));
+    const beforeCmd = (settings.hooks.BeforeTool[0] as any).hooks[0].command as string;
+    const result = spawnSync(beforeCmd, {
+      cwd: parent,
+      env: { ...process.env, GEMINI_PROJECT_ROOT: root, FBEAST_DISABLE_HOOKS: '1' },
+      shell: true,
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    expect(beforeCmd).toContain('script=');
+    expect(beforeCmd).toContain('.fbeast/hooks/gemini-before-tool.sh');
+    expect(beforeCmd).toContain('exec "$executable"');
+    expect(beforeCmd).not.toContain(root);
   });
 
   it('merges Gemini hooks without clobbering existing BeforeTool entries', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -270,16 +270,17 @@ function tomlString(value: string): string {
 
 function projectRootHookCommand(scriptPath: string): string {
   const normalizedPath = scriptPath.split('\\').join('/');
-  const executablePath = `./${normalizedPath}`;
   const lookup = [
+    `script=${shellQuote(normalizedPath)}`,
+    'executable="./$script"',
     `p=\${CLAUDE_PROJECT_DIR:-\${GEMINI_PROJECT_ROOT:-}}`,
-    `if [ -n "$p" ] && [ -x "$p/${normalizedPath}" ]; then cd "$p" && exec "${executablePath}"; fi`,
+    'if [ -n "$p" ] && [ -x "$p/$script" ]; then cd "$p" && exec "$executable"; fi',
     'd=$PWD',
     'while [ "$d" != / ]; do '
-      + `if [ -x "$d/${normalizedPath}" ]; then cd "$d" && exec "${executablePath}"; fi; `
+      + 'if [ -x "$d/$script" ]; then cd "$d" && exec "$executable"; fi; '
       + 'd=$(dirname "$d")',
     'done',
-    `echo "fbeast hook script not found: ${normalizedPath}" >&2`,
+    'echo "fbeast hook script not found: $script" >&2',
     'exit 127',
   ].join('; ');
   return `sh -c ${shellQuote(lookup)}`;


### PR DESCRIPTION
## Summary
- stores Gemini hook script names in shell-quoted variables before lookup/execution
- executes hook scripts through quoted variables so hostile project roots cannot alter shell parsing
- adds regression coverage for spaces, quotes, semicolons, and command substitution in Gemini project roots

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/cli/init.test.ts
- npm run build -- --filter=@franken/mcp-suite
- npx turbo run test --filter=@franken/mcp-suite
- npx turbo run typecheck --filter=@franken/mcp-suite

Closes #1040