### PR TITLE
fix(governor): handle trigger evaluator exceptions

### DIFF
--- a/packages/franken-governor/src/gateway/governor-critique-adapter.ts
+++ b/packages/franken-governor/src/gateway/governor-critique-adapter.ts
@@ -5,6 +5,7 @@ import { ApprovalGateway, type AuditRecorder } from './approval-gateway.js';
 import type { SignatureVerifier } from '../security/signature-verifier.js';
 import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
 import { BudgetTrigger, type BudgetTriggerContext } from '../triggers/budget-trigger.js';
+import { evaluateTrigger } from '../triggers/evaluate-trigger.js';
 import { SkillTrigger, type SkillTriggerContext } from '../triggers/skill-trigger.js';
 import type { RationaleBlock, VerificationResult } from '@franken/types';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
@@ -113,7 +114,7 @@ export class GovernorCritiqueAdapter {
       // from the rationale + injected sources, so it must not be fed a
       // RationaleBlock it was never typed for (see issue #490).
       if (triggerContext.skip) continue;
-      const result = evaluator.evaluate(triggerContext.context);
+      const result = evaluateTrigger(evaluator, triggerContext.context);
       if (result.triggered) return result;
     }
     return { triggered: false, triggerId: 'none' };

--- a/packages/franken-governor/src/triggers/evaluate-trigger.ts
+++ b/packages/franken-governor/src/triggers/evaluate-trigger.ts
@@ -1,0 +1,31 @@
+import type { TriggerResult } from '../core/types.js';
+import { TriggerEvaluationError } from '../errors/trigger-evaluation-error.js';
+import type { TriggerEvaluator } from './trigger-evaluator.js';
+
+function describeEvaluationFailure(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'unknown error';
+}
+
+/**
+ * Evaluates one trigger and converts evaluator failures into a deterministic,
+ * fail-closed trigger result so governor callers share one safety policy.
+ */
+export function evaluateTrigger(evaluator: TriggerEvaluator, context: unknown): TriggerResult {
+  try {
+    return evaluator.evaluate(context);
+  } catch (error) {
+    const evaluationError = new TriggerEvaluationError(
+      evaluator.triggerId,
+      describeEvaluationFailure(error),
+    );
+
+    return {
+      triggered: true,
+      triggerId: evaluator.triggerId,
+      reason: evaluationError.message,
+      severity: 'critical',
+    };
+  }
+}

--- a/packages/franken-governor/src/triggers/trigger-registry.ts
+++ b/packages/franken-governor/src/triggers/trigger-registry.ts
@@ -1,4 +1,5 @@
 import type { TriggerResult } from '../core/types.js';
+import { evaluateTrigger } from './evaluate-trigger.js';
 import type { TriggerEvaluator } from './trigger-evaluator.js';
 
 export class TriggerRegistry {
@@ -6,7 +7,7 @@ export class TriggerRegistry {
 
   evaluateAll(context: unknown): TriggerResult {
     for (const evaluator of this.evaluators) {
-      const result = evaluator.evaluate(context);
+      const result = evaluateTrigger(evaluator, context);
       if (result.triggered) {
         return result;
       }

--- a/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
@@ -328,4 +328,42 @@ describe('GovernorCritiqueAdapter per-trigger context construction (issue #490)'
     await adapter.verifyRationale(rationale);
     expect(seen).toEqual([rationale]);
   });
+
+  it('turns evaluator exceptions into the same fail-closed approval request as TriggerRegistry', async () => {
+    const channel = makeFakeChannel('ABORT');
+    let laterCalled = false;
+    const adapter = new GovernorCritiqueAdapter({
+      channel,
+      auditRecorder: makeFakeAuditRecorder(),
+      evaluators: [
+        {
+          triggerId: 'stale-trigger',
+          evaluate: () => {
+            throw new Error('missing expected field');
+          },
+        },
+        {
+          triggerId: 'later-trigger',
+          evaluate: () => {
+            laterCalled = true;
+            return { triggered: true, triggerId: 'later-trigger', reason: 'later', severity: 'high' };
+          },
+        },
+      ],
+      projectId: 'proj-001',
+    });
+
+    const result = await adapter.verifyRationale(makeRationale());
+
+    expect(result.verdict).toBe('rejected');
+    expect(channel.requestApproval).toHaveBeenCalledOnce();
+    const request = vi.mocked(channel.requestApproval).mock.calls[0]![0] as ApprovalRequest;
+    expect(request.trigger).toEqual({
+      triggered: true,
+      triggerId: 'stale-trigger',
+      reason: "Trigger 'stale-trigger' evaluation failed: missing expected field",
+      severity: 'critical',
+    });
+    expect(laterCalled).toBe(false);
+  });
 });

--- a/packages/franken-governor/tests/unit/triggers/trigger-registry.test.ts
+++ b/packages/franken-governor/tests/unit/triggers/trigger-registry.test.ts
@@ -52,4 +52,33 @@ describe('TriggerRegistry', () => {
     expect(result.triggerId).toBe('a');
     expect(secondCalled).toBe(false);
   });
+
+  it('converts evaluator exceptions into a deterministic critical trigger result', () => {
+    let secondCalled = false;
+    const registry = new TriggerRegistry([
+      {
+        triggerId: 'stale-trigger',
+        evaluate: () => {
+          throw new Error('missing expected field');
+        },
+      },
+      {
+        triggerId: 'later-trigger',
+        evaluate: () => {
+          secondCalled = true;
+          return { triggered: true, triggerId: 'later-trigger', reason: 'later', severity: 'high' };
+        },
+      },
+    ]);
+
+    const result = registry.evaluateAll({});
+
+    expect(result).toEqual({
+      triggered: true,
+      triggerId: 'stale-trigger',
+      reason: "Trigger 'stale-trigger' evaluation failed: missing expected field",
+      severity: 'critical',
+    });
+    expect(secondCalled).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Centralizes trigger evaluator execution behind a shared fail-closed helper
- Converts evaluator exceptions into deterministic critical trigger results using TriggerEvaluationError
- Adds regression coverage for TriggerRegistry and GovernorCritiqueAdapter exception handling

## Test Plan
- npm test -- --run tests/unit/triggers/trigger-registry.test.ts tests/unit/gateway/governor-critique-adapter.test.ts
- npm test
- npm run typecheck -- --filter=@franken/governor
- npm run build -- --filter=@franken/governor
- npm run lint:any -- packages/franken-governor/src packages/franken-governor/tests/unit/triggers/trigger-registry.test.ts packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts

Closes #1184
