### PR TITLE
test(web): guard chat recovery against patch markers

### DIFF
--- a/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
@@ -5,7 +5,12 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(process.cwd(), 'src/hooks/use-chat-session.ts'), 'utf8');
 
 describe('useChatSession source hygiene', () => {
-  const patchAdditionMarker = new RegExp(`^\\s*${'\\+'}\\s*(?:\\/\\/|const|if|try|catch|socket|set|return|throw|await|for|function)\\b`, 'm');
+  const patchAdditionMarker = new RegExp(`^\\s*${'\\+'}\\s*(?:\\/\\/|const|if|try|catch|socket|set\\w*|return|throw|await|for|function)\\b`, 'm');
+
+  it('matches unresolved patch markers before setter calls', () => {
+    expect("+        setStatus('idle')").toMatch(patchAdditionMarker);
+    expect("+        setConnectionStatus('reconnecting')").toMatch(patchAdditionMarker);
+  });
 
   it('keeps the send implementation free of unresolved patch markers', () => {
     const sendStart = source.indexOf('async function send(content: string): Promise<void> {');

--- a/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(process.cwd(), 'src/hooks/use-chat-session.ts'), 'utf8');
 
 describe('useChatSession source hygiene', () => {
+  const patchAdditionMarker = new RegExp(`^\\s*${'\\+'}\\s*(?:\\/\\/|const|if|try|catch|socket|set|return|throw|await|for|function)\\b`, 'm');
+
   it('keeps the send implementation free of unresolved patch markers', () => {
     const sendStart = source.indexOf('async function send(content: string): Promise<void> {');
     const retryStart = source.indexOf('async function retryMessage(messageId: string): Promise<void> {', sendStart);
@@ -13,6 +15,17 @@ describe('useChatSession source hygiene', () => {
     expect(retryStart).toBeGreaterThan(sendStart);
 
     const sendImplementation = source.slice(sendStart, retryStart);
-    expect(sendImplementation).not.toMatch(/^\s*\+\s*(?:\/\/|const|if|try|catch|socket|set|return|throw|await)\b/m);
+    expect(sendImplementation).not.toMatch(patchAdditionMarker);
+  });
+
+  it('keeps session refresh recovery code free of unresolved patch markers', () => {
+    const pendingSendStart = source.indexOf('function failPendingSend(');
+    const retryErrorStart = source.indexOf('async function retryError(id: string): Promise<string | undefined> {', pendingSendStart);
+
+    expect(pendingSendStart).toBeGreaterThanOrEqual(0);
+    expect(retryErrorStart).toBeGreaterThan(pendingSendStart);
+
+    const recoveryImplementation = source.slice(pendingSendStart, retryErrorStart);
+    expect(recoveryImplementation).not.toMatch(patchAdditionMarker);
   });
 });


### PR DESCRIPTION
## Summary
- Confirms the reported diff markers are absent from use-chat-session.ts on the current branch
- Extends the source hygiene regression to cover the session refresh/recovery block called out by issue #1051
- Reuses a constructed marker regex so future literal patch additions in that block fail fast

## Test Plan
- npm run build --workspace @franken/types
- npm --workspace @franken/web test -- --run tests/hooks/use-chat-session-source.test.ts
- npm --workspace @franken/web run typecheck
- npm --workspace @franken/web run build

Closes #1051