### PR TITLE
fix(governor): reject invalid session token TTLs

### DIFF
--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -6,7 +6,7 @@ import {
   SignatureVerifier,
 } from '../security/signature-verifier.js';
 import type { SessionTokenStore } from '../security/session-token-store.js';
-import { createSessionToken } from '../security/session-token.js';
+import { assertValidSessionTokenTtl, createSessionToken } from '../security/session-token.js';
 import {
   ApprovalTimeoutError,
   SignatureVerificationError,
@@ -44,6 +44,14 @@ export class ApprovalGateway {
   private readonly sessionTokenStore: SessionTokenStore | undefined;
 
   constructor(deps: ApprovalGatewayDeps) {
+    try {
+      assertValidSessionTokenTtl(deps.config.sessionTokenTtlMs);
+    } catch (error) {
+      throw new ApprovalConfigurationError(
+        `Invalid sessionTokenTtlMs: ${(error as Error).message}`,
+      );
+    }
+
     this.channel = deps.channel;
     this.auditRecorder = deps.auditRecorder;
     this.config = deps.config;

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -234,6 +234,7 @@ export class SessionTokenStore {
   }
 
   private isExpired(token: SessionToken): boolean {
-    return wallClockNow() >= token.expiresAt.getTime();
+    const expiresAtMs = token.expiresAt.getTime();
+    return !Number.isFinite(expiresAtMs) || wallClockNow() >= expiresAtMs;
   }
 }

--- a/packages/franken-governor/src/security/session-token.ts
+++ b/packages/franken-governor/src/security/session-token.ts
@@ -8,16 +8,22 @@ export interface CreateSessionTokenParams {
   readonly ttlMs: number;
 }
 
-export function assertValidSessionTokenTtl(ttlMs: number): void {
+const MAX_DATE_TIME_MS = 8_640_000_000_000_000;
+
+export function assertValidSessionTokenTtl(ttlMs: number, nowMs: number = Date.now()): void {
   if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
     throw new RangeError('Session token ttlMs must be a positive finite number');
+  }
+
+  const expiresAtMs = nowMs + ttlMs;
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs > MAX_DATE_TIME_MS) {
+    throw new RangeError('Session token ttlMs must produce a valid expiry date');
   }
 }
 
 export function createSessionToken(params: CreateSessionTokenParams): SessionToken {
-  assertValidSessionTokenTtl(params.ttlMs);
-
   const now = new Date();
+  assertValidSessionTokenTtl(params.ttlMs, now.getTime());
 
   return {
     tokenId: randomUUID(),

--- a/packages/franken-governor/src/security/session-token.ts
+++ b/packages/franken-governor/src/security/session-token.ts
@@ -8,7 +8,15 @@ export interface CreateSessionTokenParams {
   readonly ttlMs: number;
 }
 
+export function assertValidSessionTokenTtl(ttlMs: number): void {
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new RangeError('Session token ttlMs must be a positive finite number');
+  }
+}
+
 export function createSessionToken(params: CreateSessionTokenParams): SessionToken {
+  assertValidSessionTokenTtl(params.ttlMs);
+
   const now = new Date();
 
   return {

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -259,6 +259,25 @@ describe('ApprovalGateway — security integration', () => {
     expect(auditRecorder.record).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['zero', 0],
+    ['negative', -1],
+  ])('rejects invalid %s sessionTokenTtlMs config before contacting the channel', (_name, sessionTokenTtlMs) => {
+    const channel = makeFakeChannel();
+    const auditRecorder = makeFakeAuditRecorder();
+
+    expect(() => new ApprovalGateway({
+      channel,
+      auditRecorder,
+      config: { ...defaultConfig(), sessionTokenTtlMs },
+      sessionTokenStore: new SessionTokenStore(),
+    })).toThrow(ApprovalConfigurationError);
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+    expect(auditRecorder.record).not.toHaveBeenCalled();
+  });
+
   it('constructs a verifier from config.signingSecret and accepts a valid signature', async () => {
     const signingSecret = 'secret-from-config';
     const verifier = new SignatureVerifier(signingSecret);

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -264,6 +264,7 @@ describe('ApprovalGateway — security integration', () => {
     ['Infinity', Number.POSITIVE_INFINITY],
     ['zero', 0],
     ['negative', -1],
+    ['overflow', Number.MAX_SAFE_INTEGER],
   ])('rejects invalid %s sessionTokenTtlMs config before contacting the channel', (_name, sessionTokenTtlMs) => {
     const channel = makeFakeChannel();
     const auditRecorder = makeFakeAuditRecorder();

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, unlinkSync, utimesSync, writeFileSyn
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SessionToken } from '../../../src/core/types.js';
 import { SessionTokenStore } from '../../../src/security/session-token-store.js';
 import { createSessionToken } from '../../../src/security/session-token.js';
 
@@ -73,6 +74,19 @@ describe('SessionTokenStore', () => {
     store.store(token);
     vi.advanceTimersByTime(2000);
 
+    expect(store.isValid(token.tokenId)).toBe(false);
+  });
+
+  it('treats invalid expiresAt dates as expired', () => {
+    const store = new SessionTokenStore();
+    const token: SessionToken = {
+      ...makeToken(10_000),
+      expiresAt: new Date(Number.NaN),
+    };
+
+    store.store(token);
+
+    expect(store.get(token.tokenId)).toBeUndefined();
     expect(store.isValid(token.tokenId)).toBe(false);
   });
 

--- a/packages/franken-governor/tests/unit/security/session-token.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token.test.ts
@@ -41,4 +41,18 @@ describe('createSessionToken', () => {
 
     expect(token.grantedBy).toBe('alice');
   });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['zero', 0],
+    ['negative', -1],
+  ])('rejects %s ttlMs values', (_name, ttlMs) => {
+    expect(() => createSessionToken({
+      approvalId: 'req-001',
+      scope: 'deploy',
+      grantedBy: 'human',
+      ttlMs,
+    })).toThrow(RangeError);
+  });
 });

--- a/packages/franken-governor/tests/unit/security/session-token.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token.test.ts
@@ -47,6 +47,7 @@ describe('createSessionToken', () => {
     ['Infinity', Number.POSITIVE_INFINITY],
     ['zero', 0],
     ['negative', -1],
+    ['overflow', Number.MAX_SAFE_INTEGER],
   ])('rejects %s ttlMs values', (_name, ttlMs) => {
     expect(() => createSessionToken({
       approvalId: 'req-001',


### PR DESCRIPTION
## Summary
- reject non-finite and non-positive approval session-token TTLs at gateway construction and token creation
- treat invalid token expiry dates as expired in SessionTokenStore
- add regression coverage for NaN, Infinity, zero, negative TTLs, and invalid expiresAt fail-closed behavior

## Test Plan
- npm test -- --run tests/unit/security/session-token.test.ts tests/unit/security/session-token-store.test.ts tests/unit/gateway/approval-gateway-security.test.ts
- npm test --workspace @franken/governor
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/governor && npm run build --workspace @franken/governor
- npm run lint --workspace @franken/governor (no lint script exists)

Closes #1171