### PR TITLE
fix(turbo): hash test cache inputs and suite env

### DIFF
--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -27,6 +27,28 @@ describe('Turborepo configuration', () => {
       expect(testTask.dependsOn).toBeUndefined();
     });
 
+    it('hashes cross-package Vitest source aliases and root setup scripts for cached test tasks', () => {
+      const turbo = readJson('turbo.json');
+      const testTask = turbo.tasks?.test;
+      expect(testTask).toBeDefined();
+      expect(testTask.inputs).toEqual(
+        expect.arrayContaining([
+          '$TURBO_DEFAULT$',
+          '$TURBO_ROOT$/scripts/vitest-*.ts',
+          '$TURBO_ROOT$/packages/*/src/**',
+        ]),
+      );
+    });
+
+    it('hashes suite-selection environment variables for cached test tasks', () => {
+      const turbo = readJson('turbo.json');
+      const testTask = turbo.tasks?.test;
+      expect(testTask).toBeDefined();
+      expect(testTask.env).toEqual(
+        expect.arrayContaining(['INTEGRATION', 'E2E', 'EVAL', 'DOCKER_BUILD']),
+      );
+    });
+
     it('defines test:ci task with package build dependency for CI ordering', () => {
       const turbo = readJson('turbo.json');
       const testCiTask = turbo.tasks?.['test:ci'];

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,14 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
-    "test": {},
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/scripts/vitest-*.ts",
+        "$TURBO_ROOT$/packages/*/src/**"
+      ],
+      "env": ["INTEGRATION", "E2E", "EVAL", "DOCKER_BUILD"]
+    },
     "test:ci": {
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
## Summary
- Adds explicit Turbo test inputs for root Vitest setup/helpers and cross-package source aliases
- Hashes suite-selection env vars so unit/integration/e2e/eval/docker test modes do not share stale cache entries
- Adds regression assertions for the test task cache inputs and env list

## Test Plan
- npm run test:root -- tests/turborepo.test.ts (RED: failed before the turbo.json fix)
- npm run test:root -- tests/turborepo.test.ts tests/vitest-env.test.ts
- npx turbo run test --filter=@franken/observer --dry=json
- INTEGRATION=true npx turbo run test --filter=@franken/observer --dry=json
- npm run typecheck
- npm run build
- npm run lint:any
- npm test

Closes #1531