### PR TITLE
fix(beasts): surface Create Agent auto-dispatch failures

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -146,7 +146,18 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
         message: `Dispatch failed: ${errorMessage}`,
         payload: { error: errorMessage },
       });
-      return c.json({ data: deps.agents.getAgent(agent.id) }, 201);
+      const failedAgent = deps.agents.getAgent(agent.id);
+      return c.json({
+        error: {
+          code: 'AGENT_DISPATCH_FAILED',
+          message: `Dispatch failed for tracked agent '${agent.id}': ${errorMessage}`,
+          details: {
+            agentId: agent.id,
+            dispatchError: errorMessage,
+            agent: failedAgent,
+          },
+        },
+      }, 409);
     }
 
     return c.json({ data: deps.agents.getAgent(agent.id) }, 201);

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -958,9 +958,9 @@ describe('agent routes integration', () => {
         initAction: {
           kind: 'design-interview',
           command: '/interview',
-          config: { goal: 'Delete from dashboard' },
+          config: { goal: 'Delete from dashboard', outputPath: 'docs/delete-design.md' },
         },
-        initConfig: { goal: 'Delete from dashboard' },
+        initConfig: { goal: 'Delete from dashboard', outputPath: 'docs/delete-design.md' },
       }),
     });
     expect(createResponse.status).toBe(201);
@@ -1160,6 +1160,7 @@ describe('agent routes integration', () => {
         config: {},
       },
       initConfig: {},
+      autoDispatch: false,
     });
 
     const r1 = await app.request('/v1/beasts/agents', { method: 'POST', headers, body });
@@ -1171,7 +1172,7 @@ describe('agent routes integration', () => {
     expect(r3.status).toBe(429);
   });
 
-  it('marks agent as failed when dispatch throws instead of leaving orphaned initializing agents', async () => {
+  it('returns an explicit error when dispatch throws after creating the tracked agent', async () => {
     const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
@@ -1198,11 +1199,21 @@ describe('agent routes integration', () => {
       }),
     });
 
-    expect(createResponse.status).toBe(201);
-    const created = await createResponse.json() as { data: { id: string; status: string } };
-    expect(created.data.status).toBe('failed');
+    expect(createResponse.status).toBe(409);
+    const created = await createResponse.json() as {
+      error: {
+        code: string;
+        message: string;
+        details: { agentId: string; dispatchError: string; agent: { id: string; status: string } };
+      };
+    };
+    expect(created.error.code).toBe('AGENT_DISPATCH_FAILED');
+    expect(created.error.message).toContain('Dispatch failed for tracked agent');
+    expect(created.error.details.agentId).toBeTruthy();
+    expect(created.error.details.dispatchError).toContain('outputDir');
+    expect(created.error.details.agent.status).toBe('failed');
 
-    const detailResponse = await app.request(`/v1/beasts/agents/${created.data.id}`, {
+    const detailResponse = await app.request(`/v1/beasts/agents/${created.error.details.agentId}`, {
       headers: { authorization: `Bearer ${operatorToken}` },
     });
     const detail = await detailResponse.json() as {
@@ -1253,9 +1264,8 @@ describe('agent routes integration', () => {
       headers: { authorization: `Bearer ${operatorToken}` },
     });
 
-    // Verify the agent is stopped, then use the restart endpoint which already works for stopped
-    // The real test: use the start endpoint with a failed agent (via dispatch failure test above)
-    // Instead, create a new agent with invalid config so it becomes 'failed' with no dispatchRunId
+    // Verify the agent is stopped, then use the restart endpoint which already works for stopped.
+    // The real test: use the start endpoint with a failed agent created by an auto-dispatch failure.
     const failedResponse = await app.request('/v1/beasts/agents', {
       method: 'POST',
       headers,
@@ -1271,13 +1281,15 @@ describe('agent routes integration', () => {
         },
       }),
     });
-    expect(failedResponse.status).toBe(201);
-    const failedAgent = await failedResponse.json() as { data: { id: string; status: string } };
-    expect(failedAgent.data.status).toBe('failed');
+    expect(failedResponse.status).toBe(409);
+    const failedAgent = await failedResponse.json() as {
+      error: { details: { agentId: string; agent: { status: string } } };
+    };
+    expect(failedAgent.error.details.agent.status).toBe('failed');
 
     // Starting a failed agent without a dispatchRunId will try dispatchDetachedAgent
     // which will also fail (same bad config), but the status guard should NOT be the blocker
-    const startResponse = await app.request(`/v1/beasts/agents/${failedAgent.data.id}/start`, {
+    const startResponse = await app.request(`/v1/beasts/agents/${failedAgent.error.details.agentId}/start`, {
       method: 'POST',
       headers: { authorization: `Bearer ${operatorToken}` },
     });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -9,6 +9,7 @@ import { CostBadge } from './cost-badge';
 import { NetworkPage } from '../pages/network-page';
 import {
   BeastApiClient,
+  BeastApiError,
   type BeastContainerRuntimeStatus,
   type BeastCatalogEntry,
   type BeastRunDetail,
@@ -1062,8 +1063,15 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               const definitionId = String(workflow?.workflowType ?? 'martin-loop');
               const executionMode = config.executionMode === 'container' ? 'container' : 'process';
               const initAction = buildInitAction(definitionId, config, selectedSessionId);
-              await beastClient.createAgent({ definitionId, initAction, initConfig: config, executionMode });
-              setBeastRefreshNonce((current) => current + 1);
+              try {
+                await beastClient.createAgent({ definitionId, initAction, initConfig: config, executionMode });
+                setBeastRefreshNonce((current) => current + 1);
+              } catch (error) {
+                if (error instanceof BeastApiError && error.code === 'AGENT_DISPATCH_FAILED') {
+                  setBeastRefreshNonce((current) => current + 1);
+                }
+                throw error;
+              }
             }}
             onDelete={(agentId) => {
               runBeastAgentLifecycleAction({

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ChatShell, buildInitAction } from '../../src/components/chat-shell.js';
+import { BeastApiError } from '../../src/lib/beast-api.js';
 import { FALLBACK_BEAST_CATALOG } from '../../src/components/beasts/wizard-catalog.js';
 import { useDashboardStore } from '../../src/stores/dashboard-store.js';
+import { useBeastStore } from '../../src/stores/beast-store.js';
 
 const mockListSessions = vi.fn().mockResolvedValue([
   {
@@ -236,6 +238,17 @@ vi.mock('../../src/lib/api.js', () => ({
 }));
 
 vi.mock('../../src/lib/beast-api.js', () => ({
+  BeastApiError: class BeastApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+      public readonly code?: string,
+      public readonly details?: unknown,
+    ) {
+      super(message);
+      this.name = 'BeastApiError';
+    }
+  },
   MODULE_CONFIG_KEYS: ['firewall', 'skills', 'memory', 'planner', 'critique', 'governor', 'heartbeat'],
   TRACKED_AGENT_STATUSES: [
     'initializing',
@@ -330,6 +343,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
   useDashboardStore.getState().reset();
+  useBeastStore.getState().resetWizard();
   latestBeastEventHandlers = null;
   mockSubscribeToEvents.mockImplementation((handlers: Record<string, (event: unknown) => void>) => {
     latestBeastEventHandlers = handlers;
@@ -872,6 +886,50 @@ describe('ChatShell', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: 'Beasts' })).toBeDefined();
     expect(mockListAgents).toHaveBeenCalled();
+  });
+
+  it('refreshes the beasts fleet after Create Agent auto-dispatch failures', async () => {
+    window.location.hash = '#/beasts';
+    mockCreateAgent.mockRejectedValueOnce(new BeastApiError(
+      "Dispatch failed for tracked agent 'agent-failed': outputDir is required",
+      409,
+      'AGENT_DISPATCH_FAILED',
+      { agentId: 'agent-failed' },
+    ));
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('agent-1').length).toBeGreaterThan(0);
+    });
+    const initialListCalls = mockListAgents.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: /^\+ create agent$/i }));
+    act(() => {
+      useBeastStore.getState().setStepValues(0, { name: 'Dispatch Failure Agent' });
+      useBeastStore.getState().setStepValues(1, {
+        workflowType: 'martin-loop',
+        provider: 'codex',
+        objective: 'Implement chunks',
+        chunkDirectory: 'tasks/chunks',
+      });
+      useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /launch agent/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('Dispatch failed for tracked agent');
+    });
+    await waitFor(() => {
+      expect(mockListAgents.mock.calls.length).toBeGreaterThan(initialListCalls);
+    });
   });
 
   it('keeps deleted audit rows from being auto-selected on the beasts page', async () => {

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -88,6 +88,46 @@ describe('BeastApiClient', () => {
     );
   });
 
+  it('rejects createAgent when the API reports an auto-dispatch failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({
+        error: {
+          code: 'AGENT_DISPATCH_FAILED',
+          message: "Dispatch failed for tracked agent 'agent-1': Invalid chunk-plan config: outputDir is required",
+          details: {
+            agentId: 'agent-1',
+            dispatchError: 'Invalid chunk-plan config: outputDir is required',
+          },
+        },
+      }),
+    });
+
+    const errorPromise = client.createAgent({
+      definitionId: 'chunk-plan',
+      initAction: {
+        kind: 'chunk-plan',
+        command: '/plan --design-doc docs/plans/design.md',
+        config: { designDocPath: 'docs/plans/design.md' },
+      },
+      initConfig: { designDocPath: 'docs/plans/design.md' },
+    });
+
+    await expect(errorPromise).rejects.toThrow(
+      "Dispatch failed for tracked agent 'agent-1': Invalid chunk-plan config: outputDir is required (HTTP 409, AGENT_DISPATCH_FAILED)",
+    );
+    await expect(errorPromise).rejects.toMatchObject({
+      name: 'BeastApiError',
+      status: 409,
+      code: 'AGENT_DISPATCH_FAILED',
+      details: {
+        agentId: 'agent-1',
+        dispatchError: 'Invalid chunk-plan config: outputDir is required',
+      },
+    });
+  });
+
   it('controls existing beast runs once dispatch has happened', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/packages/franken-web/tests/pages/beasts-page.test.tsx
+++ b/packages/franken-web/tests/pages/beasts-page.test.tsx
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
 import { BeastsPage } from '../../src/pages/beasts-page';
+import { useBeastStore } from '../../src/stores/beast-store';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  useBeastStore.getState().resetWizard();
+});
 
 const baseProps = {
   agents: [
@@ -99,5 +103,42 @@ describe('BeastsPage', () => {
   it('shows error banner when error prop is set', () => {
     render(<BeastsPage {...baseProps} error="Something went wrong" />);
     expect(screen.getByText('Something went wrong')).toBeTruthy();
+  });
+
+  it('keeps the Create Agent wizard open and shows launch errors', async () => {
+    const onLaunch = vi.fn().mockRejectedValue(new Error(
+      "Dispatch failed for tracked agent 'agent-1': Invalid chunk-plan config: outputDir is required",
+    ));
+
+    render(<BeastsPage
+      {...baseProps}
+      catalog={[{
+        id: 'martin-loop',
+        label: 'Martin Loop',
+        description: 'Implementation workflow',
+        executionModeDefault: 'process',
+        interviewPrompts: [],
+      }]}
+      onLaunch={onLaunch}
+    />);
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }));
+    act(() => {
+      useBeastStore.getState().setStepValues(0, { name: 'Dispatch Failure Agent' });
+      useBeastStore.getState().setStepValues(1, {
+        workflowType: 'martin-loop',
+        provider: 'codex',
+        objective: 'Implement chunks',
+        chunkDirectory: 'tasks/chunks',
+      });
+      useBeastStore.setState({ wizardStep: 7, highestCompleted: 6 });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /launch agent/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('Dispatch failed for tracked agent');
+    });
+    expect(screen.getByText('Create Agent')).toBeTruthy();
+    expect(onLaunch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Return a 409 AGENT_DISPATCH_FAILED response when Create Agent auto-dispatch fails after creating the tracked agent
- Include the failed agent snapshot and dispatch error details so clients can surface the failure instead of treating creation as success
- Add backend, API client, and Beasts page regression coverage

## Test Plan
- npm --prefix packages/franken-web test -- tests/pages/beasts-page.test.tsx
- npm --prefix packages/franken-web test -- tests/lib/beast-api.test.ts
- npm --prefix packages/franken-orchestrator test -- tests/integration/beasts/agent-routes.test.ts
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-observer run build
- npm --prefix packages/franken-brain run build
- npm --prefix packages/franken-critique run build
- npm --prefix packages/franken-governor run build
- npm --prefix packages/franken-planner run build
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-orchestrator run lint (passes with pre-existing warnings)
- npm --prefix packages/franken-web run build

Closes #1212