### PR TITLE
chore(types): ignore package test tmp output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .superpowers
 .worktrees
 .turbo
+.tmp/
 dist
 # Frankenbeast project-local state (build logs, checkpoints, plans)
 .frankenbeast/

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -83,10 +83,15 @@ describe('Turborepo configuration', () => {
     });
   });
 
-  describe('.gitignore includes .turbo', () => {
+  describe('.gitignore includes generated workspace artifacts', () => {
     it('has .turbo entry', () => {
       const gitignore = readFileSync(join(ROOT, '.gitignore'), 'utf8');
       expect(gitignore).toMatch(/^\.turbo$/m);
+    });
+
+    it('ignores the root .tmp directory used by package test scripts', () => {
+      const gitignore = readFileSync(join(ROOT, '.gitignore'), 'utf8');
+      expect(gitignore).toMatch(/^\.tmp\/$/m);
     });
   });
 


### PR DESCRIPTION
## Summary
- add the root `.tmp/` test scratch directory to `.gitignore`
- add a regression check that root `.gitignore` covers the temp directory used by `@franken/types` tests

## Test Plan
- `npm run test:root -- tests/turborepo.test.ts`
- `npm test --workspace @franken/types`
- `git check-ignore -v .tmp/franken-types`
- `npm run typecheck --workspace @franken/types`
- `npm run build --workspace @franken/types`

Closes #1537
