### PR TITLE
fix(web): hash root package version in turbo cache

### DIFF
--- a/packages/franken-web/turbo.json
+++ b/packages/franken-web/turbo.json
@@ -1,0 +1,16 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/package.json"]
+    },
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/scripts/vitest-*.ts",
+        "$TURBO_ROOT$/packages/*/src/**"
+      ]
+    }
+  }
+}

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -69,6 +69,33 @@ describe('Turborepo configuration', () => {
     });
   });
 
+  describe('franken-web package turbo.json', () => {
+    it('hashes the root manifest for cached web builds and tests that read the root version', () => {
+      const turbo = readJson('packages/franken-web/turbo.json');
+      expect(turbo.extends).toEqual(['//']);
+
+      const buildTask = turbo.tasks?.build;
+      expect(buildTask).toBeDefined();
+      expect(buildTask.inputs).toEqual(
+        expect.arrayContaining([
+          '$TURBO_DEFAULT$',
+          '$TURBO_ROOT$/package.json',
+        ]),
+      );
+
+      const testTask = turbo.tasks?.test;
+      expect(testTask).toBeDefined();
+      expect(testTask.inputs).toEqual(
+        expect.arrayContaining([
+          '$TURBO_DEFAULT$',
+          '$TURBO_ROOT$/package.json',
+          '$TURBO_ROOT$/scripts/vitest-*.ts',
+          '$TURBO_ROOT$/packages/*/src/**',
+        ]),
+      );
+    });
+  });
+
   describe('root package.json scripts', () => {
     const rootPkg = readJson('package.json');
 


### PR DESCRIPTION
## Summary
- add a package-level Turbo config for @franken/web so build/test cache keys include the root package manifest read by Vite/Vitest
- preserve package defaults and existing cross-package Vitest inputs while adding the root package version input
- add a root Turborepo regression test for the web package override

## Test Plan
- npm run test:root -- tests/turborepo.test.ts
- npm --workspace @franken/web run test
- npx turbo run test --filter=@franken/web
- npx turbo run build typecheck --filter=@franken/web
- npx turbo run build --filter=@franken/web --dry=json
- npx turbo run test --filter=@franken/web --dry=json
- git diff --check

Closes #1534