### PR TITLE
fix(orchestrator): terminate chat SSE turn streams

### DIFF
--- a/packages/franken-orchestrator/src/chat/turn-runner.ts
+++ b/packages/franken-orchestrator/src/chat/turn-runner.ts
@@ -48,17 +48,21 @@ export class TurnRunner extends EventEmitter {
   async run(outcome: ExecuteOutcome | PlanOutcome, options?: TurnRunOptions): Promise<TurnRunResult> {
     const events: TurnEvent[] = [];
     const sessionId = options?.sessionId ?? 'unknown-session';
+    const emitTurnEvent = (event: TurnEvent): void => {
+      events.push(event);
+      this.emit('event', event);
+      options?.onEvent?.(event);
+    };
 
     if (outcome.kind === 'plan') {
       const summary = `Plan created: ${outcome.planSummary} (${outcome.chunkCount} chunks)`;
+      emitTurnEvent({ type: 'complete', sessionId, data: { status: 'completed' } });
       return { status: 'completed', summary, events };
     }
 
     if (outcome.approvalRequired) {
-      const event: TurnEvent = { type: 'approval_request', sessionId, data: { taskDescription: outcome.taskDescription } };
-      events.push(event);
-      this.emit('event', event);
-      options?.onEvent?.(event);
+      emitTurnEvent({ type: 'approval_request', sessionId, data: { taskDescription: outcome.taskDescription } });
+      emitTurnEvent({ type: 'complete', sessionId, data: { status: 'pending_approval' } });
       return {
         status: 'pending_approval',
         summary: `Approval required: ${outcome.taskDescription}`,
@@ -66,20 +70,24 @@ export class TurnRunner extends EventEmitter {
       };
     }
 
-    const startEvent: TurnEvent = { type: 'start', sessionId, data: { taskDescription: outcome.taskDescription } };
-    events.push(startEvent);
-    this.emit('event', startEvent);
-    options?.onEvent?.(startEvent);
+    emitTurnEvent({ type: 'start', sessionId, data: { taskDescription: outcome.taskDescription } });
 
-    const executionResult = await this.executor.execute({ userInput: outcome.taskDescription });
+    let executionResult: ExecutionResult;
+    try {
+      executionResult = await this.executor.execute({ userInput: outcome.taskDescription });
+    } catch (error) {
+      emitTurnEvent({
+        type: 'complete',
+        sessionId,
+        data: { status: 'failed', error: error instanceof Error ? error.message : String(error) },
+      });
+      throw error;
+    }
 
     const summary = TurnSummarizer.summarize(executionResult);
     const status: TurnRunResult['status'] = executionResult.status === 'success' ? 'completed' : 'failed';
 
-    const completeEvent: TurnEvent = { type: 'complete', sessionId, data: { status: executionResult.status } };
-    events.push(completeEvent);
-    this.emit('event', completeEvent);
-    options?.onEvent?.(completeEvent);
+    emitTurnEvent({ type: 'complete', sessionId, data: { status: executionResult.status } });
 
     return { status, summary, events };
   }

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -75,10 +75,20 @@ function mapTurnEvent(event: TurnEvent): ServerSocketEvent {
     case 'start':
       return { type: 'turn.execution.start', data: event.data as Record<string, unknown> | undefined, timestamp };
     case 'complete':
+      if (isPendingApprovalComplete(event.data)) {
+        return { type: 'turn.execution.progress', data: event.data, timestamp };
+      }
       return { type: 'turn.execution.complete', data: event.data as Record<string, unknown> | undefined, timestamp };
     default:
       return { type: 'turn.execution.progress', data: event.data as Record<string, unknown> | undefined, timestamp };
   }
+}
+
+function isPendingApprovalComplete(data: unknown): data is Record<string, unknown> {
+  return typeof data === 'object'
+    && data !== null
+    && 'status' in data
+    && data.status === 'pending_approval';
 }
 
 function messageIdFromSession(session: ChatSession): string {

--- a/packages/franken-orchestrator/tests/integration/chat/sse.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/sse.test.ts
@@ -136,6 +136,25 @@ describe('SSE Streaming', () => {
     expect(eventLines[eventLines.length - 1]).toContain('complete');
   });
 
+  it('closes approval-request streams after the terminal event without leaking TurnRunner listeners', async () => {
+    const sessionId = await createSession();
+    emitAfterDelay([
+      { type: 'approval_request', sessionId, data: { taskDescription: 'needs approval' } },
+      { type: 'complete', sessionId, data: { status: 'pending_approval' } },
+    ]);
+
+    const res = await app.request(`/v1/chat/sessions/${sessionId}/stream`);
+    const textPromise = res.text();
+
+    await expect(Promise.race([
+      textPromise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('SSE stream did not close')), 500)),
+    ])).resolves.toContain('event: complete');
+
+    expect(await textPromise).toContain('event: approval_request');
+    expect(turnRunner.listenerCount('event')).toBe(0);
+  });
+
   it('only forwards events for the requested session when two streams are open', async () => {
     const firstSessionId = await createSession();
     const secondSessionId = await createSession();

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -361,6 +361,10 @@ describe('ws chat server', () => {
       risk: 'Requires explicit approval before execution.',
       sessionId: session.id,
     }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'turn.execution.complete',
+      data: { status: 'pending_approval' },
+    }));
     expect(store.get(session.id)?.pendingApproval).toEqual(expect.objectContaining({
       description: 'deploy staging',
       tool: 'execution',

--- a/packages/franken-orchestrator/tests/unit/chat/turn-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/turn-runner.test.ts
@@ -48,6 +48,8 @@ describe('TurnRunner', () => {
 
   it('handles plan outcomes without executing', async () => {
     const runner = new TurnRunner(mockExecutor);
+    const events: string[] = [];
+    runner.on('event', (e) => events.push(e.type));
     const outcome: PlanOutcome = {
       kind: 'plan',
       planSummary: 'Add authentication in 3 chunks',
@@ -58,6 +60,44 @@ describe('TurnRunner', () => {
     expect(result.status).toBe('completed');
     expect(result.summary).toContain('3 chunks');
     expect(mockExecutor.execute).not.toHaveBeenCalled();
+    expect(events).toEqual(['complete']);
+    expect(result.events.map((event) => event.type)).toEqual(['complete']);
+  });
+
+  it('emits a terminal complete event after approval-required turns', async () => {
+    const runner = new TurnRunner(mockExecutor);
+    const events: string[] = [];
+    runner.on('event', (e) => events.push(e.type));
+    const outcome: ExecuteOutcome = {
+      kind: 'execute',
+      taskDescription: 'Push to main',
+      approvalRequired: true,
+    };
+
+    const result = await runner.run(outcome, { sessionId: 'session-1' });
+
+    expect(result.status).toBe('pending_approval');
+    expect(events).toEqual(['approval_request', 'complete']);
+    expect(result.events.map((event) => event.type)).toEqual(['approval_request', 'complete']);
+  });
+
+  it('emits a terminal failure event before executor errors propagate', async () => {
+    const erroringExecutor = {
+      execute: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    const runner = new TurnRunner(erroringExecutor);
+    const events: Array<{ type: string; data?: unknown }> = [];
+    runner.on('event', (event) => events.push(event));
+    const outcome: ExecuteOutcome = {
+      kind: 'execute',
+      taskDescription: 'Explode',
+      approvalRequired: false,
+    };
+
+    await expect(runner.run(outcome, { sessionId: 'session-1' })).rejects.toThrow('boom');
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'complete']);
+    expect(events[1]?.data).toMatchObject({ status: 'failed' });
   });
 
   it('emits start and complete events in order', async () => {


### PR DESCRIPTION
## Summary
- Emit terminal `complete` turn events for plan, approval-required, and executor-error outcomes.
- Keep chat SSE streams closing after approval-request terminal events so TurnRunner listeners are released.
- Add focused TurnRunner and chat SSE regression coverage.

## Test Plan
- `npm test -- tests/unit/chat/turn-runner.test.ts tests/integration/chat/sse.test.ts` (from `packages/franken-orchestrator`)
- `npx turbo run typecheck --filter=@franken/orchestrator`
- `npx turbo run lint --filter=@franken/orchestrator` (passes with existing warnings)
- `npx turbo run build --filter=@franken/orchestrator`

Closes #1532
