### PR TITLE
fix(orchestrator): bound chat gateway route metadata

### DIFF
--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -8,15 +8,24 @@ import type {
   ChannelType,
 } from '../core/types.js';
 
+export interface ChatGatewayOptions {
+  /** Maximum number of session route metadata records kept for action callbacks. */
+  routeMetadataMaxEntries?: number;
+}
+
+const DEFAULT_ROUTE_METADATA_MAX_ENTRIES = 10_000;
+
 export class ChatGateway extends EventEmitter {
   private readonly adapters = new Map<ChannelType, ChannelAdapter>();
   private readonly sessionMapper = new SessionMapper();
   private readonly routeMetadataBySession = new Map<string, Record<string, unknown>>();
   private readonly runtime: CommsRuntimePort;
+  private readonly routeMetadataMaxEntries: number;
 
-  constructor(runtime: CommsRuntimePort) {
+  constructor(runtime: CommsRuntimePort, options: ChatGatewayOptions = {}) {
     super();
     this.runtime = runtime;
+    this.routeMetadataMaxEntries = this.normalizeRouteMetadataLimit(options.routeMetadataMaxEntries);
   }
 
   registerAdapter(adapter: ChannelAdapter): void {
@@ -31,7 +40,7 @@ export class ChatGateway extends EventEmitter {
       externalThreadId: message.externalThreadId,
     });
     const routeMetadata = this.toRouteMetadata(message);
-    this.routeMetadataBySession.set(sessionId, routeMetadata);
+    this.rememberRouteMetadata(sessionId, routeMetadata);
 
     const result = await this.runtime.processInbound({
       sessionId,
@@ -74,10 +83,10 @@ export class ChatGateway extends EventEmitter {
     });
 
     const outboundRouteMetadata = routeMetadata
-      ?? this.routeMetadataBySession.get(sessionId)
+      ?? this.getRememberedRouteMetadata(sessionId)
       ?? result.metadata;
     if (outboundRouteMetadata) {
-      this.routeMetadataBySession.set(sessionId, outboundRouteMetadata);
+      this.rememberRouteMetadata(sessionId, outboundRouteMetadata);
     }
     const outbound: ChannelOutboundMessage = {
       text: result.text,
@@ -107,6 +116,33 @@ export class ChatGateway extends EventEmitter {
     };
   }
 
+  private rememberRouteMetadata(sessionId: string, routeMetadata: Record<string, unknown>): void {
+    // Refresh insertion order so the least-recently used session falls off first.
+    this.routeMetadataBySession.delete(sessionId);
+    this.routeMetadataBySession.set(sessionId, routeMetadata);
+
+    while (this.routeMetadataBySession.size > this.routeMetadataMaxEntries) {
+      const oldestSessionId = this.routeMetadataBySession.keys().next().value;
+      if (typeof oldestSessionId !== 'string') break;
+      this.routeMetadataBySession.delete(oldestSessionId);
+    }
+  }
+
+  private getRememberedRouteMetadata(sessionId: string): Record<string, unknown> | undefined {
+    const routeMetadata = this.routeMetadataBySession.get(sessionId);
+    if (!routeMetadata) return undefined;
+    this.rememberRouteMetadata(sessionId, routeMetadata);
+    return routeMetadata;
+  }
+
+  private normalizeRouteMetadataLimit(routeMetadataMaxEntries: number | undefined): number {
+    if (routeMetadataMaxEntries === undefined) return DEFAULT_ROUTE_METADATA_MAX_ENTRIES;
+    if (!Number.isSafeInteger(routeMetadataMaxEntries) || routeMetadataMaxEntries < 1) {
+      throw new Error('ChatGateway routeMetadataMaxEntries must be a positive safe integer');
+    }
+    return routeMetadataMaxEntries;
+  }
+
   private relayToChannel(
     sessionId: string,
     channelType: ChannelType,
@@ -126,6 +162,6 @@ export class ChatGateway extends EventEmitter {
   }
 
   close(): void {
-    // No bridges to clean up — in-process calls are stateless
+    this.routeMetadataBySession.clear();
   }
 }

--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -75,6 +75,8 @@ export class ChatGateway extends EventEmitter {
         ? '/approve'
         : `Action rejected by user: ${actionId}`;
 
+    const cachedRouteMetadata = routeMetadata ?? this.getRememberedRouteMetadata(sessionId);
+
     const result = await this.runtime.processInbound({
       sessionId,
       channelType,
@@ -82,9 +84,7 @@ export class ChatGateway extends EventEmitter {
       externalUserId: 'system',
     });
 
-    const outboundRouteMetadata = routeMetadata
-      ?? this.getRememberedRouteMetadata(sessionId)
-      ?? result.metadata;
+    const outboundRouteMetadata = cachedRouteMetadata ?? result.metadata;
     if (outboundRouteMetadata) {
       this.rememberRouteMetadata(sessionId, outboundRouteMetadata);
     }

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -246,6 +246,73 @@ describe('ChatGateway', () => {
     );
   });
 
+  it('keeps action route metadata stable while runtime processing is in flight', async () => {
+    let resolveAction!: (result: CommsInboundResult) => void;
+    const actionResult = new Promise<CommsInboundResult>((resolve) => {
+      resolveAction = resolve;
+    });
+    runtime = {
+      processInbound: vi.fn((input) => {
+        if (input.externalUserId === 'system') return actionResult;
+        return Promise.resolve({ text: 'pong', status: 'reply' } satisfies CommsInboundResult);
+      }),
+    };
+    gateway = new ChatGateway(runtime, { routeMetadataMaxEntries: 2 });
+    const slackAdapter = mockAdapter('slack');
+    gateway.registerAdapter(slackAdapter);
+
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U1',
+      externalChannelId: 'C1',
+      externalMessageId: 'M1',
+      text: 'one',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U2',
+      externalChannelId: 'C2',
+      externalMessageId: 'M2',
+      text: 'two',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+    const firstSessionId = (runtime.processInbound as ReturnType<typeof vi.fn>).mock.calls[0]![0].sessionId;
+
+    (slackAdapter.send as ReturnType<typeof vi.fn>).mockClear();
+    const action = gateway.handleAction('slack', firstSessionId, 'approve');
+    await Promise.resolve();
+
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U3',
+      externalChannelId: 'C3',
+      externalMessageId: 'M3',
+      text: 'three',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U4',
+      externalChannelId: 'C4',
+      externalMessageId: 'M4',
+      text: 'four',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+
+    resolveAction({ text: 'approved', status: 'reply' });
+    await action;
+
+    expect(slackAdapter.send).toHaveBeenLastCalledWith(
+      firstSessionId,
+      expect.objectContaining({ metadata: expect.objectContaining({ channelId: 'C1' }) }),
+    );
+  });
+
   it('close() clears remembered route metadata', async () => {
     const slackAdapter = mockAdapter('slack');
     gateway.registerAdapter(slackAdapter);

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -192,7 +192,88 @@ describe('ChatGateway', () => {
     );
   });
 
-  it('close() does not throw', () => {
-    expect(() => gateway.close()).not.toThrow();
+  it('evicts least-recently used route metadata when the session cache reaches its cap', async () => {
+    gateway = new ChatGateway(runtime, { routeMetadataMaxEntries: 2 });
+    const slackAdapter = mockAdapter('slack');
+    gateway.registerAdapter(slackAdapter);
+
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U1',
+      externalChannelId: 'C1',
+      externalMessageId: 'M1',
+      text: 'one',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U2',
+      externalChannelId: 'C2',
+      externalMessageId: 'M2',
+      text: 'two',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+
+    const firstSessionId = (runtime.processInbound as ReturnType<typeof vi.fn>).mock.calls[0]![0].sessionId;
+    const secondSessionId = (runtime.processInbound as ReturnType<typeof vi.fn>).mock.calls[1]![0].sessionId;
+
+    // Touch the first session so the second session becomes the LRU entry.
+    await gateway.handleAction('slack', firstSessionId, 'approve');
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U3',
+      externalChannelId: 'C3',
+      externalMessageId: 'M3',
+      text: 'three',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+
+    (slackAdapter.send as ReturnType<typeof vi.fn>).mockClear();
+
+    await gateway.handleAction('slack', firstSessionId, 'approve');
+    expect(slackAdapter.send).toHaveBeenLastCalledWith(
+      firstSessionId,
+      expect.objectContaining({ metadata: expect.objectContaining({ channelId: 'C1' }) }),
+    );
+
+    await gateway.handleAction('slack', secondSessionId, 'approve');
+    expect(slackAdapter.send).toHaveBeenLastCalledWith(
+      secondSessionId,
+      expect.not.objectContaining({ metadata: expect.anything() }),
+    );
+  });
+
+  it('close() clears remembered route metadata', async () => {
+    const slackAdapter = mockAdapter('slack');
+    gateway.registerAdapter(slackAdapter);
+
+    await gateway.handleInbound({
+      channelType: 'slack',
+      externalUserId: 'U1',
+      externalChannelId: 'C1',
+      externalMessageId: 'M1',
+      text: 'ping',
+      receivedAt: new Date().toISOString(),
+      rawEvent: {},
+    });
+    const sessionId = (runtime.processInbound as ReturnType<typeof vi.fn>).mock.calls[0]![0].sessionId;
+    (slackAdapter.send as ReturnType<typeof vi.fn>).mockClear();
+
+    gateway.close();
+    await gateway.handleAction('slack', sessionId, 'approve');
+
+    expect(slackAdapter.send).toHaveBeenLastCalledWith(
+      sessionId,
+      expect.not.objectContaining({ metadata: expect.anything() }),
+    );
+  });
+
+  it('rejects invalid route metadata cache limits', () => {
+    expect(() => new ChatGateway(runtime, { routeMetadataMaxEntries: 0 })).toThrow(
+      'routeMetadataMaxEntries must be a positive safe integer',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Bound ChatGateway's remembered route metadata with an LRU-style max-entry cache.
- Clear remembered route metadata on gateway shutdown.
- Add regression coverage for eviction, LRU refresh, close cleanup, and invalid cache limits.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/comms/chat-gateway.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/observer
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #1533
