### PR TITLE
test(critique): cover SafetyEvaluator worker timeout recovery

### DIFF
--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -160,13 +160,31 @@ describe('SafetyEvaluator', () => {
       terminate: vi.fn().mockResolvedValue(undefined),
     };
 
-    const createRegexWorker = vi.fn(() => hangingWorker);
+    const matchingWorker = {
+      once: vi.fn((event: string, callback: (message: unknown) => void) => {
+        if (event === 'message') {
+          queueMicrotask(() => callback({ matches: true }));
+        }
+        return matchingWorker;
+      }),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const createRegexWorker = vi.fn((pattern: string) =>
+      pattern === 'safe-pattern' ? hangingWorker : matchingWorker,
+    );
     const evaluator = new SafetyEvaluator(
       createMockGuardrailsPort([
         {
           id: 'slow-warn-real-path',
           description: 'slow worker path',
           pattern: 'safe-pattern',
+          severity: 'warn',
+        },
+        {
+          id: 'later-warning',
+          description: 'later warning still runs',
+          pattern: 'console\\.log',
           severity: 'warn',
         },
       ]),
@@ -178,22 +196,29 @@ describe('SafetyEvaluator', () => {
       evaluator as unknown as {
         regexEvaluationTimeoutMs(contentLength: number): number;
       }
-    ).regexEvaluationTimeoutMs('large review payload'.length);
+    ).regexEvaluationTimeoutMs('console.log("large review payload")'.length);
 
     vi.useFakeTimers();
     try {
-      const resultPromise = evaluator.evaluate(createInput('large review payload'));
+      const resultPromise = evaluator.evaluate(
+        createInput('console.log("large review payload")'),
+      );
       await vi.advanceTimersByTimeAsync(timeoutMs);
 
       const result = await resultPromise;
 
-      expect(createRegexWorker).toHaveBeenCalledTimes(1);
+      expect(createRegexWorker).toHaveBeenCalledTimes(2);
       expect(hangingWorker.once).toHaveBeenCalledTimes(2);
       expect(hangingWorker.terminate).toHaveBeenCalledTimes(1);
+      expect(matchingWorker.terminate).toHaveBeenCalledTimes(1);
       expect(result.verdict).toBe('pass');
       expect(result.findings).toEqual([
         expect.objectContaining({
           message: expect.stringContaining('Safety rule regex evaluation timed out'),
+          severity: 'warning',
+        }),
+        expect.objectContaining({
+          message: expect.stringContaining('Safety rule violated: later warning still runs'),
           severity: 'warning',
         }),
       ]);


### PR DESCRIPTION
## Summary
- Extends the SafetyEvaluator worker-timeout regression to prove evaluation continues after a timed-out regex worker.
- Verifies both the timeout warning and a later matching warning are surfaced, avoiding silent timeout skips.

## Test Plan
- npm --workspace packages/franken-critique test -- tests/unit/evaluators/safety.test.ts
- npm --workspace packages/franken-types run build
- npm --workspace packages/franken-critique run typecheck
- npm --workspace packages/franken-critique run build
- npm --workspace packages/franken-critique run lint

Closes #1127