### PR TITLE
test(critique): cover postfix division and nested function bodies

### DIFF
--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -113,6 +113,34 @@ describe('ComplexityEvaluator', () => {
     );
   });
 
+  it('preserves code after postfix division when scanning for later nesting', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = [
+      'function score(items, total) {',
+      '  let index = 0;',
+      '  const ratio = index++ / total;',
+      '  if (ratio > 0) {',
+      '    if (items.length > 1) {',
+      '      if (items[0]) {',
+      '        if (items[1]) {',
+      '          if (items[2]) {',
+      '            return items[index];',
+      '          }',
+      '        }',
+      '      }',
+      '    }',
+      '  }',
+      '  return null;',
+      '}',
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('nesting'))).toBe(
+      true,
+    );
+  });
+
   it('does not treat JSX closing tags as regex literals', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `const el = <div></div>; if (a) { if (b) { if (c) { if (d) { if (e) { work(); } } } } }`;
@@ -688,6 +716,40 @@ describe('ComplexityEvaluator', () => {
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.verdict).toBe('fail');
+    expect(result.findings.some((f) => f.message.includes('long'))).toBe(true);
+  });
+
+  it('counts nested named function body braces toward function length', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const prefix = [
+      '  if (enabled) {',
+      "    const config = { mode: 'strict' };",
+      '    if (config.mode) {',
+      '      use(config);',
+      '    }',
+      '  }',
+    ];
+    const lines = Array.from({ length: 51 }, (_, i) => `  const x${i} = ${i};`);
+    const content = `function longNested() {\n${prefix.concat(lines).join('\n')}\n}`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((f) => f.message.includes('long'))).toBe(true);
+  });
+
+  it('counts nested arrow function body braces toward function length', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const prefix = [
+      '  if (enabled) {',
+      "    const config = { mode: 'strict' };",
+      '    if (config.mode) {',
+      '      use(config);',
+      '    }',
+      '  }',
+    ];
+    const lines = Array.from({ length: 51 }, (_, i) => `  const x${i} = ${i};`);
+    const content = `const longNested = () => {\n${prefix.concat(lines).join('\n')}\n};`;
+    const result = await evaluator.evaluate(createInput(content));
+
     expect(result.findings.some((f) => f.message.includes('long'))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- add a postfix-division regression to prove complexity scanning preserves later active code after x++ / y
- add named and arrow function-length regressions with nested body braces before the long tail

## Test Plan
- npm test -- --run tests/unit/evaluators/complexity.test.ts
- npm test
- npm run typecheck
- npm run build
- npm run lint

Closes #1043