### PR TITLE
fix(mcp-suite): validate init mcpServers shape

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -115,6 +115,70 @@ describe('fbeast init', () => {
     expect(readFileSync(join(geminiDir, backups[0]!), 'utf-8')).toBe('{ invalid json');
   });
 
+  it('throws with a clear error and preserves Claude .mcp.json when mcpServers is an array', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const mcpPath = join(root, '.mcp.json');
+    const original = JSON.stringify({ mcpServers: [] });
+    writeFileSync(mcpPath, original);
+
+    expect(() => runInit({ root, claudeDir, hooks: false, client: 'claude' })).toThrow(
+      '.mcp.json mcpServers must be a JSON object',
+    );
+
+    expect(readFileSync(mcpPath, 'utf-8')).toBe(original);
+  });
+
+  it('throws with a clear error and preserves Claude .mcp.json when mcpServers is primitive', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const mcpPath = join(root, '.mcp.json');
+    const original = JSON.stringify({ mcpServers: 'bad' });
+    writeFileSync(mcpPath, original);
+
+    expect(() => runInit({ root, claudeDir, hooks: false, client: 'claude' })).toThrow(
+      '.mcp.json mcpServers must be a JSON object',
+    );
+
+    expect(readFileSync(mcpPath, 'utf-8')).toBe(original);
+  });
+
+  it('throws with a clear error and preserves Gemini settings.json when mcpServers is an array', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const geminiDir = join(root, '.gemini');
+    mkdirSync(geminiDir, { recursive: true });
+    const settingsPath = join(geminiDir, 'settings.json');
+    const original = JSON.stringify({ mcpServers: [] });
+    writeFileSync(settingsPath, original);
+
+    expect(() => runInit({ root, claudeDir: geminiDir, hooks: false, client: 'gemini' })).toThrow(
+      'settings.json mcpServers must be a JSON object',
+    );
+
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(original);
+  });
+
+  it('throws with a clear error and preserves Gemini settings.json when mcpServers is primitive', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const geminiDir = join(root, '.gemini');
+    mkdirSync(geminiDir, { recursive: true });
+    const settingsPath = join(geminiDir, 'settings.json');
+    const original = JSON.stringify({ mcpServers: 'bad' });
+    writeFileSync(settingsPath, original);
+
+    expect(() => runInit({ root, claudeDir: geminiDir, hooks: false, client: 'gemini' })).toThrow(
+      'settings.json mcpServers must be a JSON object',
+    );
+
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(original);
+  });
+
   it('merges with existing Claude .mcp.json comments and trailing commas without overwriting', () => {
     const root = tmpDir();
     dirs.push(root);

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -108,7 +108,10 @@ function initJsonClient(options: {
     pruneFbeastMcpServerEntries(settings);
   }
   pruneFbeastMcpServerEntries(mcpConfig);
-  const mcpServers = (mcpConfig['mcpServers'] as Record<string, unknown>) ?? {};
+  const mcpServers = readMcpServersObject(
+    mcpConfig,
+    client === 'claude' ? '.mcp.json' : 'settings.json',
+  );
   const dbPath = client === 'claude' ? '${CLAUDE_PROJECT_DIR}/.fbeast/beast.db' : join('.fbeast', 'beast.db');
   const configPath = join('.fbeast', 'config.json');
   const proxyArgs = ['--db', dbPath, '--config', configPath];
@@ -500,12 +503,26 @@ function pruneFbeastMcpServerEntries(config: Record<string, unknown>): void {
   config['mcpServers'] = mcpServers;
 }
 
+function readMcpServersObject(
+  config: Record<string, unknown>,
+  configLabel: string,
+): Record<string, unknown> {
+  const mcpServers = config['mcpServers'];
+  if (mcpServers === undefined) return {};
+  if (isObjectRecord(mcpServers)) return mcpServers;
+
+  throw new Error(
+    `fbeast init: ${configLabel} mcpServers must be a JSON object; `
+      + 'remove or replace the existing mcpServers value before running init again.',
+  );
+}
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 // Re-export for test access


### PR DESCRIPTION
## Summary
- Validate existing JSON-client mcpServers before merging fbeast entries
- Fail with a clear actionable error for array/primitive mcpServers instead of reporting success with dropped entries
- Add Claude and Gemini regression coverage for malformed mcpServers values

## Test Plan
- npm test --workspace @franken/mcp-suite -- src/cli/init.test.ts
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite
- npm run lint:any

Closes #1176