### PR TITLE
fix(web): preserve chat session for martin-loop launches

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -1,6 +1,18 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ChatShell } from './chat-shell';
+import { buildInitAction, ChatShell } from './chat-shell';
+
+const mocks = vi.hoisted(() => ({
+  createAgent: vi.fn(),
+  launchConfig: {
+    executionMode: 'process',
+    workflow: {
+      workflowType: 'martin-loop',
+      provider: 'codex',
+      objective: 'Implement chunks',
+    },
+  },
+}));
 
 vi.mock('../hooks/use-chat-session', () => ({
   useChatSession: () => ({
@@ -52,11 +64,13 @@ vi.mock('../lib/network-api', () => ({
 
 vi.mock('../lib/beast-api', () => ({
   BeastApiClient: class {
+    createAgent = mocks.createAgent;
     listCatalog = vi.fn().mockResolvedValue([]);
     listAgents = vi.fn().mockResolvedValue([]);
     listRuns = vi.fn().mockResolvedValue([]);
     getContainerRuntime = vi.fn().mockResolvedValue(undefined);
     subscribe = vi.fn().mockResolvedValue(() => undefined);
+    subscribeToEvents = vi.fn().mockResolvedValue(() => undefined);
   },
 }));
 
@@ -73,7 +87,9 @@ vi.mock('../pages/dashboard-page', () => ({
 }));
 
 vi.mock('../pages/beasts-page', () => ({
-  BeastsPage: () => <div>Beasts module</div>,
+  BeastsPage: ({ onLaunch }: { onLaunch: (config: Record<string, unknown>) => Promise<void> }) => (
+    <button type="button" onClick={() => { void onLaunch(mocks.launchConfig); }}>Launch test Beast</button>
+  ),
 }));
 
 vi.mock('../pages/analytics-page', () => ({
@@ -106,6 +122,8 @@ describe('ChatShell route heading', () => {
   });
 
   beforeEach(() => {
+    mocks.createAgent.mockReset();
+    mocks.createAgent.mockResolvedValue({ id: 'agent-1' });
     window.location.hash = '#/network';
     window.matchMedia = vi.fn().mockReturnValue({
       matches: false,
@@ -149,5 +167,38 @@ describe('ChatShell route heading', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Chat' })).toBeTruthy();
     expect(screen.queryByRole('heading', { level: 2, name: 'Sessions' })).toBeNull();
     expect(window.location.hash).toBe('#/chat');
+  });
+
+  it('preserves the selected chat session when launching the default martin-loop Beast workflow', async () => {
+    window.location.hash = '#/beasts';
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" sessionId="chat-session-42" version="0.2.1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Launch test Beast' }));
+
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
+    expect(mocks.createAgent).toHaveBeenCalledWith(expect.objectContaining({
+      definitionId: 'martin-loop',
+      chatSessionId: 'chat-session-42',
+      initAction: expect.objectContaining({
+        kind: 'martin-loop',
+        chatSessionId: 'chat-session-42',
+      }),
+    }));
+  });
+});
+
+describe('buildInitAction', () => {
+  it('carries chat session context for every supported Beast workflow', () => {
+    const config = {
+      designDocPath: 'docs/design.md',
+      workflow: { docPath: 'docs/fallback.md' },
+    };
+
+    for (const definitionId of ['design-interview', 'chunk-plan', 'martin-loop']) {
+      expect(buildInitAction(definitionId, config, 'chat-session-42')).toEqual(expect.objectContaining({
+        kind: definitionId,
+        chatSessionId: 'chat-session-42',
+      }));
+    }
   });
 });

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/network-api', () => ({
 vi.mock('../lib/beast-api', () => ({
   BeastApiClient: class {
     createAgent = mocks.createAgent;
+    getCatalog = vi.fn().mockResolvedValue([]);
+    getContainerRuntimeStatus = vi.fn().mockResolvedValue(undefined);
     listCatalog = vi.fn().mockResolvedValue([]);
     listAgents = vi.fn().mockResolvedValue([]);
     listRuns = vi.fn().mockResolvedValue([]);
@@ -87,8 +89,14 @@ vi.mock('../pages/dashboard-page', () => ({
 }));
 
 vi.mock('../pages/beasts-page', () => ({
-  BeastsPage: ({ onLaunch }: { onLaunch: (config: Record<string, unknown>) => Promise<void> }) => (
-    <button type="button" onClick={() => { void onLaunch(mocks.launchConfig); }}>Launch test Beast</button>
+  BeastsPage: ({
+    disabled,
+    onLaunch,
+  }: {
+    disabled?: boolean;
+    onLaunch: (config: Record<string, unknown>) => Promise<void>;
+  }) => (
+    <button type="button" disabled={disabled} onClick={() => { void onLaunch(mocks.launchConfig); }}>Launch test Beast</button>
   ),
 }));
 
@@ -173,7 +181,9 @@ describe('ChatShell route heading', () => {
     window.location.hash = '#/beasts';
 
     render(<ChatShell baseUrl="http://localhost:3737" projectId="default" sessionId="chat-session-42" version="0.2.1" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Launch test Beast' }));
+    const launchButton = await screen.findByRole('button', { name: 'Launch test Beast' });
+    expect((launchButton as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(launchButton);
 
     await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
     expect(mocks.createAgent).toHaveBeenCalledWith(expect.objectContaining({
@@ -182,6 +192,25 @@ describe('ChatShell route heading', () => {
       initAction: expect.objectContaining({
         kind: 'martin-loop',
         chatSessionId: 'chat-session-42',
+      }),
+    }));
+  });
+
+  it('falls back to the active chat session when launching the default martin-loop Beast workflow', async () => {
+    window.location.hash = '#/beasts';
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    const launchButton = await screen.findByRole('button', { name: 'Launch test Beast' });
+    expect((launchButton as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(launchButton);
+
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
+    expect(mocks.createAgent).toHaveBeenCalledWith(expect.objectContaining({
+      definitionId: 'martin-loop',
+      chatSessionId: 'session-1',
+      initAction: expect.objectContaining({
+        kind: 'martin-loop',
+        chatSessionId: 'session-1',
       }),
     }));
   });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -258,6 +258,7 @@ export function buildInitAction(
       kind: 'martin-loop',
       command: 'martin-loop',
       config,
+      ...(chatSessionId ? { chatSessionId } : {}),
     };
   }
 
@@ -1064,7 +1065,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               const executionMode = config.executionMode === 'container' ? 'container' : 'process';
               const initAction = buildInitAction(definitionId, config, selectedSessionId);
               try {
-                await beastClient.createAgent({ definitionId, initAction, initConfig: config, executionMode });
+                await beastClient.createAgent({
+                  definitionId,
+                  initAction,
+                  initConfig: config,
+                  executionMode,
+                  ...(selectedSessionId ? { chatSessionId: selectedSessionId } : {}),
+                });
                 setBeastRefreshNonce((current) => current + 1);
               } catch (error) {
                 if (error instanceof BeastApiError && error.code === 'AGENT_DISPATCH_FAILED') {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1063,14 +1063,15 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               const workflow = config.workflow as Record<string, unknown> | undefined;
               const definitionId = String(workflow?.workflowType ?? 'martin-loop');
               const executionMode = config.executionMode === 'container' ? 'container' : 'process';
-              const initAction = buildInitAction(definitionId, config, selectedSessionId);
+              const launchChatSessionId = selectedSessionId ?? activeSessionId ?? undefined;
+              const initAction = buildInitAction(definitionId, config, launchChatSessionId);
               try {
                 await beastClient.createAgent({
                   definitionId,
                   initAction,
                   initConfig: config,
                   executionMode,
-                  ...(selectedSessionId ? { chatSessionId: selectedSessionId } : {}),
+                  ...(launchChatSessionId ? { chatSessionId: launchChatSessionId } : {}),
                 });
                 setBeastRefreshNonce((current) => current + 1);
               } catch (error) {


### PR DESCRIPTION
## Summary
- Carry selected chat session ids into martin-loop init actions
- Pass the selected chat session as the top-level createAgent payload so tracked Beast agents stay bound to the chat session
- Add regression coverage for martin-loop launch payloads and all supported buildInitAction branches

## Test Plan
- npm --workspace @franken/web test -- --run src/components/chat-shell.test.tsx
- npm run build --workspace @franken/types
- npm --workspace @franken/web run typecheck
- npm --workspace @franken/web run build

Closes #994