### PR TITLE
fix(web): hide deep module config keys in review

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-review.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-review.tsx
@@ -18,13 +18,24 @@ type WorkflowReviewValues = {
   chunkDir?: string;
 };
 
+const CANONICAL_MODULE_KEYS = [
+  'firewall',
+  'skills',
+  'memory',
+  'planner',
+  'critique',
+  'governor',
+  'heartbeat',
+] as const;
+
 export function StepReview({ catalog }: { catalog?: readonly BeastCatalogEntry[] }) {
   const { stepValues, setWizardStep } = useBeastStore();
 
   const identity = stepValues[0] as { name?: string; description?: string } | undefined;
   const workflow = stepValues[1] as WorkflowReviewValues | undefined;
   const llm = stepValues[2] as { defaultProvider?: string; defaultModel?: string } | undefined;
-  const modules = stepValues[3] as Record<string, boolean> | undefined;
+  const modules = stepValues[3] as Record<string, unknown> | undefined;
+  const selectedModuleKeys = getSelectedModuleKeys(modules);
   const skills = stepValues[4] as { selectedSkills?: string[] } | undefined;
   const prompts = stepValues[5] as { promptText?: string; files?: Array<{ name: string }> } | undefined;
   const git = stepValues[6] as { preset?: string; baseBranch?: string } | undefined;
@@ -51,10 +62,10 @@ export function StepReview({ catalog }: { catalog?: readonly BeastCatalogEntry[]
       <ReviewSection title="Modules" stepIndex={3} onEdit={setWizardStep}>
         {modules ? (
           <div className="flex flex-wrap gap-1">
-            {Object.entries(modules).filter(([, v]) => v).map(([k]) => (
+            {selectedModuleKeys.map((k) => (
               <span key={k} className="text-xs px-2 py-0.5 rounded-full bg-beast-accent-soft text-beast-accent border border-beast-accent/30">{k}</span>
             ))}
-            {Object.values(modules).filter(Boolean).length === 0 && <p className="text-xs text-beast-subtle">None selected</p>}
+            {selectedModuleKeys.length === 0 && <p className="text-xs text-beast-subtle">None selected</p>}
           </div>
         ) : (
           <p className="text-xs text-beast-subtle">Default configuration</p>
@@ -89,6 +100,11 @@ export function StepReview({ catalog }: { catalog?: readonly BeastCatalogEntry[]
 
     </div>
   );
+}
+
+function getSelectedModuleKeys(modules: Record<string, unknown> | undefined): string[] {
+  if (!modules) return [];
+  return CANONICAL_MODULE_KEYS.filter((key) => modules[key] === true);
 }
 
 function WorkflowReview({ workflow, stepValues, catalog }: {

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -48,6 +48,37 @@ describe('StepReview', () => {
     expect(screen.getByText('Design interview output path is required.')).toBeTruthy();
   });
 
+  it('renders only canonical enabled module toggles in the modules summary', () => {
+    useBeastStore.getState().setStepValues(3, {
+      firewall: true,
+      planner: false,
+      firewallConfig: { ruleSet: 'strict' },
+      plannerConfig: { maxDagDepth: 12 },
+      arbitraryConfig: { enabled: true },
+    });
+
+    render(<StepReview />);
+
+    expect(screen.getByText('firewall')).toBeTruthy();
+    expect(screen.queryByText('planner')).toBeNull();
+    expect(screen.queryByText('firewallConfig')).toBeNull();
+    expect(screen.queryByText('plannerConfig')).toBeNull();
+    expect(screen.queryByText('arbitraryConfig')).toBeNull();
+  });
+
+  it('shows no selected modules when only deep config objects are present', () => {
+    useBeastStore.getState().setStepValues(3, {
+      firewallConfig: { ruleSet: 'strict' },
+      heartbeatConfig: { interval: 60 },
+    });
+
+    render(<StepReview />);
+
+    expect(screen.getByText('None selected')).toBeTruthy();
+    expect(screen.queryByText('firewallConfig')).toBeNull();
+    expect(screen.queryByText('heartbeatConfig')).toBeNull();
+  });
+
   it('has edit links that call setWizardStep', () => {
     render(<StepReview />);
     const editLinks = screen.getAllByText('Edit');


### PR DESCRIPTION
## Summary
- filter Create Agent review module chips to canonical module toggle keys only
- treat nested deep config objects as configuration data, not selected modules
- add regression coverage for deep module config objects in the review step

## Test Plan
- npm test --workspace @franken/web -- --run tests/components/beasts/steps/step-review.test.tsx
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1183