### PR TITLE
fix(web): show analytics event pagination range

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -263,7 +263,7 @@ describe('AnalyticsPage', () => {
     const next = screen.getByRole('button', { name: 'Next' });
     expect(previous).toHaveProperty('disabled', true);
     expect(next).toHaveProperty('disabled', false);
-    expect(screen.getByText('Page 1 of 2 · 75 events')).toBeTruthy();
+    expect(screen.getByText('Showing 1–50 of 75 events · Page 1 of 2')).toBeTruthy();
 
     fireEvent.click(next);
 
@@ -276,7 +276,7 @@ describe('AnalyticsPage', () => {
     expect(client.fetchEvents).toHaveBeenCalledTimes(2);
 
     resolveSecondPage({ total: 75, page: 2, pageSize: 50, events: [] });
-    expect(await screen.findByText('Page 2 of 2 · 75 events')).toBeTruthy();
+    expect(await screen.findByText('Showing 51–75 of 75 events · Page 2 of 2')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
   });
 
@@ -288,7 +288,7 @@ describe('AnalyticsPage', () => {
       .mockResolvedValueOnce({ total: 75, page: 1, pageSize: 25, events: [] });
 
     render(<AnalyticsPage client={client} />);
-    await screen.findByText('Page 1 of 2 · 75 events');
+    await screen.findByText('Showing 1–50 of 75 events · Page 1 of 2');
 
     expect(client.fetchSummary).toHaveBeenCalledTimes(1);
     expect(client.fetchSessions).toHaveBeenCalledTimes(1);
@@ -339,7 +339,7 @@ describe('AnalyticsPage', () => {
 
     expect(await screen.findByText('HTTP 500')).toBeTruthy();
     expect(screen.queryByText('First page event')).toBeNull();
-    expect(screen.getByText('Page 2 of 2 · 0 events')).toBeTruthy();
+    expect(screen.getByText('Showing 0 of 0 events · Page 2 of 2')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Previous' })).toHaveProperty('disabled', false);
   });
 
@@ -377,7 +377,7 @@ describe('AnalyticsPage', () => {
     expect(await screen.findByText('events timeout')).toBeTruthy();
     expect(screen.queryByText('Old filter event')).toBeNull();
     expect(screen.getByText('0 normalized events')).toBeTruthy();
-    expect(screen.getByText('Page 1 of 1 · 0 events')).toBeTruthy();
+    expect(screen.getByText('Showing 0 of 0 events · Page 1 of 1')).toBeTruthy();
     expect(screen.getAllByText('No events match the current filters.').length).toBeGreaterThan(0);
   });
 

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -124,6 +124,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const currentPage = page;
   const currentPageSize = eventPage?.pageSize ?? pageSize;
   const totalPages = Math.max(currentPage, 1, Math.ceil(totalEvents / currentPageSize));
+  const loadedRangeLabel = formatEventRange(currentPage, currentPageSize, totalEvents);
   const canGoPrevious = currentPage > 1 && !isEventsLoading;
   const canGoNext = currentPage < totalPages && !isEventsLoading;
   const loadError = [overviewError, eventsError].filter(Boolean).join('; ') || null;
@@ -339,7 +340,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
 
       <section className="analytics-pagination" aria-label="Analytics pagination">
         <div>
-          Page {currentPage} of {totalPages} · {totalEvents} events
+          {loadedRangeLabel} · Page {currentPage} of {totalPages}
         </div>
         <div className="analytics-pagination__actions">
           <button
@@ -394,6 +395,13 @@ function filtersForSessionOptions(filters: AnalyticsFilters): AnalyticsFilters {
   const sessionFilters = { ...filters };
   delete sessionFilters.sessionId;
   return sessionFilters;
+}
+
+function formatEventRange(page: number, pageSize: number, total: number): string {
+  if (total <= 0) return 'Showing 0 of 0 events';
+  const start = Math.min(total, (page - 1) * pageSize + 1);
+  const end = Math.min(total, page * pageSize);
+  return `Showing ${start}–${end} of ${total} events`;
 }
 
 function MetricCard({


### PR DESCRIPTION
## Summary
- shows the loaded analytics event range alongside the current page count
- keeps empty/error pagination states explicit as 0 of 0
- updates analytics page tests for first/next-page range labels

## Test Plan
- npm --prefix packages/franken-web test -- src/pages/analytics-page.test.tsx src/lib/analytics-api.test.ts
- npm --prefix packages/franken-web test
- npm --prefix packages/franken-types run build && npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build

Closes #992