### PR TITLE
fix(web): preserve chat draft on fallback refresh failure

### DIFF
--- a/packages/franken-web/src/components/composer.test.tsx
+++ b/packages/franken-web/src/components/composer.test.tsx
@@ -77,7 +77,13 @@ describe('Composer failed-send recovery', () => {
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toContain('Message sent; refresh failed');
     expect(screen.queryByRole('button', { name: 'Retry send' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Dispatch' })).toHaveProperty('disabled', true);
+    fireEvent.submit(screen.getByRole('form', { name: 'Message composer' }));
+    expect(onSend).toHaveBeenCalledTimes(1);
     expect(input.value).toBe('already accepted prompt');
+
+    fireEvent.change(input, { target: { value: 'different prompt' } });
+    expect(screen.getByRole('button', { name: 'Dispatch' })).toHaveProperty('disabled', false);
   });
 
   it('clears a composer failure only when a matching transcript retry succeeds', async () => {

--- a/packages/franken-web/src/components/composer.test.tsx
+++ b/packages/franken-web/src/components/composer.test.tsx
@@ -64,6 +64,22 @@ describe('Composer failed-send recovery', () => {
     });
   });
 
+  it('keeps the draft without offering resend for accepted messages that need refresh', async () => {
+    const refreshError = new Error('Message sent; refresh failed');
+    (refreshError as Error & { retryableSend?: boolean }).retryableSend = false;
+    const onSend = vi.fn().mockRejectedValueOnce(refreshError);
+    render(<Composer connectionStatus="connected" disabled={false} onSend={onSend} status="idle" />);
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'already accepted prompt' } });
+    fireEvent.submit(screen.getByRole('form', { name: 'Message composer' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Message sent; refresh failed');
+    expect(screen.queryByRole('button', { name: 'Retry send' })).toBeNull();
+    expect(input.value).toBe('already accepted prompt');
+  });
+
   it('clears a composer failure only when a matching transcript retry succeeds', async () => {
     const failedAttempt = deferred<void>();
     const onSend = vi.fn().mockReturnValueOnce(failedAttempt.promise);

--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -94,6 +94,7 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
     ?? 'Type a message, then press Dispatch or Ctrl+Enter to send.';
   const liveStatus = `${connectionStatusLabel(connectionStatus)}. ${sessionStatusLabel(status)}.`;
   const showReconnect = canRetryConnection(connectionStatus);
+  const hasBlockedAcceptedDraft = Boolean(error && !error.retryable && value.trim() === error.content.trim());
 
   useEffect(() => {
     if (!clearedFailedDraft || lastClearedFailedDraftNonceRef.current === clearedFailedDraft.nonce) {
@@ -119,7 +120,7 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
     }
 
     const trimmed = value.trim();
-    if (!trimmed || isSending) {
+    if (!trimmed || isSending || hasBlockedAcceptedDraft) {
       return;
     }
 
@@ -190,7 +191,7 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
               Try reconnecting
             </button>
           ) : null}
-          <button className="button button--primary" type="submit" disabled={disabled || isSending}>
+          <button className="button button--primary" type="submit" disabled={disabled || isSending || hasBlockedAcceptedDraft}>
             {isSending ? 'Dispatching…' : 'Dispatch'}
           </button>
         </div>

--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -11,6 +11,12 @@ export interface ComposerProps {
   status: SessionStatus;
 }
 
+type ComposerError = { content: string; message: string; retryable: boolean };
+
+function isNonRetryableSendError(error: unknown): boolean {
+  return error instanceof Error && (error as Error & { retryableSend?: boolean }).retryableSend === false;
+}
+
 function connectionStatusLabel(connectionStatus: ConnectionStatus): string {
   switch (connectionStatus) {
     case 'connected':
@@ -78,7 +84,7 @@ function canRetryConnection(connectionStatus: ConnectionStatus): boolean {
 }
 
 export function Composer({ connectionStatus, clearedFailedDraft, disabled, disabledReasonText, onReconnect, onSend, status }: ComposerProps) {
-  const [error, setError] = useState<{ content: string; message: string } | null>(null);
+  const [error, setError] = useState<ComposerError | null>(null);
   const [isSending, setIsSending] = useState(false);
   const [value, setValue] = useState('');
   const lastClearedFailedDraftNonceRef = useRef<number | null>(null);
@@ -126,6 +132,7 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
       setError({
         content: trimmed,
         message: err instanceof Error ? err.message : 'Message failed to send. Your draft was kept.',
+        retryable: !isNonRetryableSendError(err),
       });
     } finally {
       setIsSending(false);
@@ -164,9 +171,11 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
       {error && (
         <div className="composer__error" role="alert">
           <span>{error.message}</span>
-          <button className="button button--secondary button--small" type="button" onClick={() => void submitCurrentValue()} disabled={disabled || isSending}>
-            Retry send
-          </button>
+          {error.retryable ? (
+            <button className="button button--secondary button--small" type="button" onClick={() => void submitCurrentValue()} disabled={disabled || isSending}>
+              Retry send
+            </button>
+          ) : null}
         </div>
       )}
       <div className="composer__footer">

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -312,6 +312,16 @@ describe('useChatSession error banners', () => {
         jsonResponse(sessionResponse()),
         jsonResponse({ data: { tier: 'cheap' } }),
         jsonResponse({ error: { message: 'refresh failed' } }, 500),
+        jsonResponse(sessionResponse({
+          transcript: [
+            {
+              id: 'server-user-accepted-after-refresh',
+              role: 'user',
+              content: 'launch beast',
+              timestamp: '2026-07-06T00:00:00.000Z',
+            },
+          ],
+        })),
       ],
     });
     vi.stubGlobal('fetch', fetch);
@@ -342,6 +352,19 @@ describe('useChatSession error banners', () => {
       code: 'session_refresh_failed',
       actionLabel: 'Refresh chat',
     });
+
+    const refreshBanner = result.current.errorBanners[0]!;
+    act(() => {
+      void result.current.retryError(refreshBanner.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toContainEqual(expect.objectContaining({
+        id: 'server-user-accepted-after-refresh',
+        content: 'launch beast',
+      }));
+    });
+    expect(result.current.clearedFailedDraft).toMatchObject({ content: 'launch beast' });
   });
 
   it('rejects sends attempted before a session id exists', async () => {

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -306,7 +306,7 @@ describe('useChatSession error banners', () => {
     expect(MockWebSocket.instances[0]!.send).toHaveBeenCalledTimes(2);
   });
 
-  it('does not offer message retry when delivery succeeded but transcript refresh failed', async () => {
+  it('rejects fallback HTTP sends when the transcript refresh fails', async () => {
     const fetch = chatFetch({
       responses: [
         jsonResponse(sessionResponse()),
@@ -325,14 +325,36 @@ describe('useChatSession error banners', () => {
     MockWebSocket.instances[0]!.readyState = 0;
 
     await act(async () => {
-      await result.current.send('launch beast');
+      await expect(result.current.send('launch beast')).rejects.toThrow('refresh failed');
     });
 
+    expect(result.current.status).toBe('error');
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'launch beast',
+        receipt: 'failed',
+        error: expect.stringContaining('refresh failed'),
+        canRetry: true,
+      }),
+    ]);
     expect(result.current.errorBanners[0]).toMatchObject({
-      title: 'Message sent; refresh failed',
-      code: 'session_refresh_failed',
-      actionLabel: 'Refresh chat',
+      title: 'Message was not sent',
+      code: 'message_send_failed',
+      actionLabel: 'Retry last message',
     });
+  });
+
+  it('rejects sends attempted before a session id exists', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('session bootstrap failed')));
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
+    await expect(result.current.send('keep this draft')).rejects.toThrow('Chat session is not ready yet. Your draft was kept.');
   });
 
   it('waits for fallback HTTP refresh before adding the sent message', async () => {

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -306,7 +306,7 @@ describe('useChatSession error banners', () => {
     expect(MockWebSocket.instances[0]!.send).toHaveBeenCalledTimes(2);
   });
 
-  it('rejects fallback HTTP sends when the transcript refresh fails', async () => {
+  it('preserves the composer draft but does not retry when fallback HTTP refresh fails', async () => {
     const fetch = chatFetch({
       responses: [
         jsonResponse(sessionResponse()),
@@ -325,23 +325,22 @@ describe('useChatSession error banners', () => {
     MockWebSocket.instances[0]!.readyState = 0;
 
     await act(async () => {
-      await expect(result.current.send('launch beast')).rejects.toThrow('refresh failed');
+      await expect(result.current.send('launch beast')).rejects.toMatchObject({ retryableSend: false });
     });
 
-    expect(result.current.status).toBe('error');
+    expect(result.current.status).toBe('idle');
     expect(result.current.messages).toEqual([
       expect.objectContaining({
         role: 'user',
         content: 'launch beast',
-        receipt: 'failed',
-        error: expect.stringContaining('refresh failed'),
-        canRetry: true,
+        receipt: 'accepted',
       }),
     ]);
+    expect(result.current.messages).not.toContainEqual(expect.objectContaining({ receipt: 'failed' }));
     expect(result.current.errorBanners[0]).toMatchObject({
-      title: 'Message was not sent',
-      code: 'message_send_failed',
-      actionLabel: 'Retry last message',
+      title: 'Message sent; refresh failed',
+      code: 'session_refresh_failed',
+      actionLabel: 'Refresh chat',
     });
   });
 

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -312,6 +312,7 @@ describe('useChatSession error banners', () => {
         jsonResponse(sessionResponse()),
         jsonResponse({ data: { tier: 'cheap' } }),
         jsonResponse({ error: { message: 'refresh failed' } }, 500),
+        jsonResponse(sessionResponse()),
         jsonResponse(sessionResponse({
           transcript: [
             {
@@ -356,6 +357,20 @@ describe('useChatSession error banners', () => {
     const refreshBanner = result.current.errorBanners[0]!;
     act(() => {
       void result.current.retryError(refreshBanner.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.errorBanners).toHaveLength(0);
+    });
+    expect(result.current.messages).toContainEqual(expect.objectContaining({
+      content: 'launch beast',
+      receipt: 'accepted',
+      canRetry: false,
+    }));
+    expect(result.current.clearedFailedDraft).toBeUndefined();
+
+    act(() => {
+      result.current.reconnect();
     });
 
     await waitFor(() => {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -94,6 +94,10 @@ interface PendingSend {
   reject: (error: Error) => void;
 }
 
+class NonRetryableSendError extends Error {
+  readonly retryableSend = false;
+}
+
 function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback;
 }
@@ -887,22 +891,23 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           if (!sessionStillCurrent(sessionId)) {
             return;
           }
-          const refreshError = error instanceof Error
-            ? error
-            : new Error('The fallback chat request completed, but the updated transcript could not be loaded.');
+          const refreshMessage = errorMessage(
+            error,
+            'The fallback chat request completed, but the updated transcript could not be loaded.',
+          );
           setMessages((current) => [
             ...current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
-            { ...optimisticMessage, receipt: 'failed', error: refreshError.message, canRetry: true },
+            { ...optimisticMessage, receipt: 'accepted' },
           ]);
           addErrorBanner(makeBanner(
-            'Message was not sent',
-            refreshError.message,
-            'retry-message',
-            'Retry last message',
-            'message_send_failed',
+            'Message sent; refresh failed',
+            refreshMessage,
+            'retry-session',
+            'Refresh chat',
+            'session_refresh_failed',
           ));
-          setStatus('error');
-          fallbackRefreshError = refreshError;
+          setStatus('idle');
+          fallbackRefreshError = new NonRetryableSendError(refreshMessage);
         }
       } catch (error) {
         if (!sessionStillCurrent(sessionId)) {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -300,6 +300,10 @@ function preserveLocalRecoveryMessages(
       return [];
     }
 
+    if (message.role === 'user' && message.receipt === 'accepted' && message.canRetry === false) {
+      return [message];
+    }
+
     if (message.role !== 'user' || !message.receipt || message.canRetry === false) {
       return [];
     }

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -294,7 +294,7 @@ function preserveLocalRecoveryMessages(
     }
 
     if (consumeSnapshotMatch(message)) {
-      if (message.role === 'user' && message.receipt === 'failed') {
+      if (message.role === 'user' && (message.receipt === 'failed' || (message.receipt === 'accepted' && message.canRetry === false))) {
         clearedFailedDrafts.push(message.content);
       }
       return [];
@@ -897,7 +897,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           );
           setMessages((current) => [
             ...current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
-            { ...optimisticMessage, receipt: 'accepted' },
+            { ...optimisticMessage, receipt: 'accepted', canRetry: false },
           ]);
           addErrorBanner(makeBanner(
             'Message sent; refresh failed',

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -861,6 +861,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setStatus('sending');
 
     if (!optimisticAdd) {
+      let fallbackRefreshError: Error | null = null;
       try {
         const result = await clientRef.current.sendMessage(sessionId, content);
         if (!sessionStillCurrent(sessionId)) {
@@ -886,18 +887,22 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           if (!sessionStillCurrent(sessionId)) {
             return;
           }
+          const refreshError = error instanceof Error
+            ? error
+            : new Error('The fallback chat request completed, but the updated transcript could not be loaded.');
           setMessages((current) => [
             ...current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
-            { ...optimisticMessage, receipt: 'accepted' },
+            { ...optimisticMessage, receipt: 'failed', error: refreshError.message, canRetry: true },
           ]);
           addErrorBanner(makeBanner(
-            'Message sent; refresh failed',
-            errorMessage(error, 'The message was accepted, but the updated transcript could not be loaded.'),
-            'retry-session',
-            'Refresh chat',
-            'session_refresh_failed',
+            'Message was not sent',
+            refreshError.message,
+            'retry-message',
+            'Retry last message',
+            'message_send_failed',
           ));
-          setStatus('idle');
+          setStatus('error');
+          fallbackRefreshError = refreshError;
         }
       } catch (error) {
         if (!sessionStillCurrent(sessionId)) {
@@ -932,6 +937,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         ));
         setStatus('error');
         throw sendError;
+      }
+      if (fallbackRefreshError) {
+        throw fallbackRefreshError;
       }
       return;
     }

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -387,7 +387,7 @@ describe('useChatSession', () => {
     }));
   });
 
-  it('keeps HTTP fallback sends retryable when the transcript refresh fails', async () => {
+  it('keeps the draft but does not retry when HTTP fallback refresh fails', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 
     await waitFor(() => {
@@ -397,22 +397,22 @@ describe('useChatSession', () => {
     mockGetSession.mockRejectedValueOnce(new Error('refresh failed'));
 
     await act(async () => {
-      await expect(result.current.send('Already ran on the server')).rejects.toThrow('refresh failed');
+      await expect(result.current.send('Already ran on the server')).rejects.toMatchObject({ retryableSend: false });
     });
 
-    expect(result.current.status).toBe('error');
+    expect(result.current.status).toBe('idle');
     expect(result.current.messages).toContainEqual(expect.objectContaining({
       content: 'Already ran on the server',
-      receipt: 'failed',
-      canRetry: true,
+      receipt: 'accepted',
     }));
+    expect(result.current.messages).not.toContainEqual(expect.objectContaining({ receipt: 'failed' }));
     expect(result.current.errorBanners[0]).toMatchObject({
-      title: 'Message was not sent',
-      actionLabel: 'Retry last message',
+      title: 'Message sent; refresh failed',
+      actionLabel: 'Refresh chat',
     });
   });
 
-  it('keeps stale failed drafts when an HTTP composer retry cannot refresh the transcript', async () => {
+  it('removes stale failed drafts when an HTTP composer retry succeeds but refresh fails', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 
     await waitFor(() => {
@@ -431,15 +431,18 @@ describe('useChatSession', () => {
 
     mockGetSession.mockRejectedValueOnce(new Error('refresh failed'));
     await act(async () => {
-      await expect(result.current.send('retry over HTTP')).rejects.toThrow('refresh failed');
+      await expect(result.current.send('retry over HTTP')).rejects.toMatchObject({ retryableSend: false });
     });
 
-    expect(result.current.status).toBe('error');
+    expect(result.current.status).toBe('idle');
     expect(result.current.messages.filter((message) => message.content === 'retry over HTTP')).toHaveLength(1);
     expect(result.current.messages).toContainEqual(expect.objectContaining({
       content: 'retry over HTTP',
+      receipt: 'accepted',
+    }));
+    expect(result.current.messages).not.toContainEqual(expect.objectContaining({
+      content: 'retry over HTTP',
       receipt: 'failed',
-      canRetry: true,
     }));
   });
 

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -387,7 +387,7 @@ describe('useChatSession', () => {
     }));
   });
 
-  it('does not offer a retry when HTTP send succeeds but refresh fails', async () => {
+  it('keeps HTTP fallback sends retryable when the transcript refresh fails', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 
     await waitFor(() => {
@@ -397,18 +397,22 @@ describe('useChatSession', () => {
     mockGetSession.mockRejectedValueOnce(new Error('refresh failed'));
 
     await act(async () => {
-      await result.current.send('Already ran on the server');
+      await expect(result.current.send('Already ran on the server')).rejects.toThrow('refresh failed');
     });
 
-    expect(result.current.status).toBe('idle');
+    expect(result.current.status).toBe('error');
     expect(result.current.messages).toContainEqual(expect.objectContaining({
       content: 'Already ran on the server',
-      receipt: 'accepted',
+      receipt: 'failed',
+      canRetry: true,
     }));
-    expect(result.current.messages).not.toContainEqual(expect.objectContaining({ receipt: 'failed' }));
+    expect(result.current.errorBanners[0]).toMatchObject({
+      title: 'Message was not sent',
+      actionLabel: 'Retry last message',
+    });
   });
 
-  it('removes stale failed drafts when an HTTP composer retry succeeds but refresh fails', async () => {
+  it('keeps stale failed drafts when an HTTP composer retry cannot refresh the transcript', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 
     await waitFor(() => {
@@ -427,18 +431,15 @@ describe('useChatSession', () => {
 
     mockGetSession.mockRejectedValueOnce(new Error('refresh failed'));
     await act(async () => {
-      await result.current.send('retry over HTTP');
+      await expect(result.current.send('retry over HTTP')).rejects.toThrow('refresh failed');
     });
 
-    expect(result.current.status).toBe('idle');
+    expect(result.current.status).toBe('error');
     expect(result.current.messages.filter((message) => message.content === 'retry over HTTP')).toHaveLength(1);
     expect(result.current.messages).toContainEqual(expect.objectContaining({
       content: 'retry over HTTP',
-      receipt: 'accepted',
-    }));
-    expect(result.current.messages).not.toContainEqual(expect.objectContaining({
-      content: 'retry over HTTP',
       receipt: 'failed',
+      canRetry: true,
     }));
   });
 


### PR DESCRIPTION
## Summary
- reject HTTP fallback sends when the post-send transcript refresh fails so the composer keeps the operator draft
- keep the failed fallback prompt retryable in the transcript and error banner instead of treating it as accepted
- add regressions for failed refresh and missing-session send attempts

## Test Plan
- npm test --workspace @franken/web -- --run src/hooks/use-chat-session.test.tsx tests/hooks/use-chat-session.test.ts
- npm test --workspace @franken/web
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1004