### PR TITLE
fix(web): surface network action failures

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -338,6 +338,41 @@ describe('ChatShell route heading', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
+  it('surfaces a stale service action refresh when the superseding manual refresh fails', async () => {
+    let resolveStaleActionRefresh!: (status: { mode: string; secureBackend: string; services: Array<{ id: string; status: string; inProcess: boolean }> }) => void;
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      })
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveStaleActionRefresh = resolve;
+      }))
+      .mockRejectedValueOnce(new Error('HTTP 503'));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    expect(await screen.findByText('chat')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network status: HTTP 503');
+
+    await act(async () => {
+      resolveStaleActionRefresh({
+        mode: 'insecure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').some((alert) => alert.textContent?.includes('Unable to restart chat'))).toBe(true);
+    });
+  });
+
   it('surfaces a service action failure when the follow-up status refresh is rejected', async () => {
     networkApiMocks.getStatus
       .mockResolvedValueOnce({

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildInitAction, ChatShell } from './chat-shell';
 
@@ -266,6 +266,39 @@ describe('ChatShell route heading', () => {
     expect(await screen.findByText('insecure')).toBeTruthy();
 
     rejectStaleRefresh(new Error('HTTP 500'));
+
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(3));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('ignores stale manual refresh failures after a newer service action refresh succeeds', async () => {
+    let rejectStaleRefresh!: (error: Error) => void;
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      })
+      .mockImplementationOnce(() => new Promise((_, reject) => {
+        rejectStaleRefresh = reject;
+      }))
+      .mockResolvedValueOnce({
+        mode: 'insecure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      });
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    expect(await screen.findByText('chat')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+
+    expect(await screen.findByText('insecure')).toBeTruthy();
+
+    await act(async () => {
+      rejectStaleRefresh(new Error('HTTP 500'));
+    });
 
     await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(3));
     expect(screen.queryByRole('alert')).toBeNull();

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -14,6 +14,16 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
+const networkApiMocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  getLogs: vi.fn(),
+  getStatus: vi.fn(),
+  restart: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
 vi.mock('../hooks/use-chat-session', () => ({
   useChatSession: () => ({
     activity: [],
@@ -48,17 +58,13 @@ vi.mock('../lib/api', () => ({
 
 vi.mock('../lib/network-api', () => ({
   NetworkApiClient: class {
-    getStatus = vi.fn().mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
-    getConfig = vi.fn().mockResolvedValue({
-      network: { mode: 'secure', secureBackend: 'local-encrypted' },
-      chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
-    });
-    getLogs = vi.fn().mockResolvedValue({ logs: [] });
-    restart = vi.fn().mockResolvedValue(undefined);
-    updateConfig = vi.fn().mockResolvedValue({
-      network: { mode: 'secure', secureBackend: 'local-encrypted' },
-      chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
-    });
+    getStatus = networkApiMocks.getStatus;
+    getConfig = networkApiMocks.getConfig;
+    getLogs = networkApiMocks.getLogs;
+    restart = networkApiMocks.restart;
+    start = networkApiMocks.start;
+    stop = networkApiMocks.stop;
+    updateConfig = networkApiMocks.updateConfig;
   },
 }));
 
@@ -138,6 +144,20 @@ describe('ChatShell route heading', () => {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
     });
+    vi.clearAllMocks();
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig.mockResolvedValue({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
+    networkApiMocks.getLogs.mockResolvedValue({ logs: [] });
+    networkApiMocks.restart.mockResolvedValue(undefined);
+    networkApiMocks.start.mockResolvedValue(undefined);
+    networkApiMocks.stop.mockResolvedValue(undefined);
+    networkApiMocks.updateConfig.mockResolvedValue({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
   });
 
   it('uses the active route label as the primary heading and demotes project context to metadata', () => {
@@ -214,9 +234,39 @@ describe('ChatShell route heading', () => {
       }),
     }));
   });
+
+  it('surfaces a failed network refresh instead of leaving stale status silently visible', async () => {
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({ mode: 'secure', secureBackend: 'local-encrypted', services: [] })
+      .mockRejectedValueOnce(new Error('HTTP 503'));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network status: HTTP 503');
+  });
+
+  it('surfaces a service action failure when the follow-up status refresh is rejected', async () => {
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      })
+      .mockRejectedValueOnce(new Error('HTTP 502'));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    expect(await screen.findByText('chat')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to restart chat: HTTP 502');
+  });
 });
 
-describe('buildInitAction', () => {
+ describe('buildInitAction', () => {
   it('carries chat session context for every supported Beast workflow', () => {
     const config = {
       designDocPath: 'docs/design.md',
@@ -229,5 +279,6 @@ describe('buildInitAction', () => {
         chatSessionId: 'chat-session-42',
       }));
     }
+
   });
 });

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -248,6 +248,29 @@ describe('ChatShell route heading', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network status: HTTP 503');
   });
 
+  it('ignores stale refresh failures after a newer network refresh succeeds', async () => {
+    let rejectStaleRefresh!: (error: Error) => void;
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({ mode: 'secure', secureBackend: 'local-encrypted', services: [] })
+      .mockImplementationOnce(() => new Promise((_, reject) => {
+        rejectStaleRefresh = reject;
+      }))
+      .mockResolvedValueOnce({ mode: 'insecure', secureBackend: 'local-encrypted', services: [] });
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(1));
+
+    const refreshButton = screen.getByRole('button', { name: 'Refresh' });
+    fireEvent.click(refreshButton);
+    fireEvent.click(refreshButton);
+    expect(await screen.findByText('insecure')).toBeTruthy();
+
+    rejectStaleRefresh(new Error('HTTP 500'));
+
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(3));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('surfaces a service action failure when the follow-up status refresh is rejected', async () => {
     networkApiMocks.getStatus
       .mockResolvedValueOnce({

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -304,6 +304,40 @@ describe('ChatShell route heading', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
+  it('ignores stale service action refresh failures after a newer manual refresh succeeds', async () => {
+    let rejectStaleActionRefresh!: (error: Error) => void;
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      })
+      .mockImplementationOnce(() => new Promise((_, reject) => {
+        rejectStaleActionRefresh = reject;
+      }))
+      .mockResolvedValueOnce({
+        mode: 'insecure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat', status: 'running', inProcess: false }],
+      });
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    expect(await screen.findByText('chat')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(await screen.findByText('insecure')).toBeTruthy();
+
+    await act(async () => {
+      rejectStaleActionRefresh(new Error('HTTP 500'));
+    });
+
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(3));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('surfaces a service action failure when the follow-up status refresh is rejected', async () => {
     networkApiMocks.getStatus
       .mockResolvedValueOnce({

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -115,6 +115,10 @@ function routeFromHash(hash: string): RouteId {
   return PRIMARY_NAV_ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
 }
 
+function networkErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
 function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {
   const route = ROUTES.find((item) => item.id === routeId)!;
 
@@ -308,6 +312,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [selectedNetworkLogServiceId, setSelectedNetworkLogServiceId] = useState<string | undefined>(undefined);
   const [networkLogsLoading, setNetworkLogsLoading] = useState(false);
   const [networkLogsError, setNetworkLogsError] = useState<string | null>(null);
+  const [networkError, setNetworkError] = useState<string | null>(null);
   const networkLogsRequestIdRef = useRef(0);
   const {
     activity,
@@ -370,6 +375,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     void Promise.allSettled([client.getStatus(), client.getConfig()]).then(([statusResult, configResult]) => {
       if (statusResult.status === 'fulfilled') {
         setNetworkStatus(statusResult.value);
+        setNetworkError(null);
+      } else {
+        setNetworkError(`Unable to load network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
       }
       if (configResult.status === 'fulfilled') {
         setNetworkConfig(configResult.value);
@@ -1158,6 +1166,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         ) : route === 'network' ? (
           <NetworkPage
             config={networkConfig}
+            error={networkError}
             logs={networkLogs}
             logsError={networkLogsError}
             logsLoading={networkLogsLoading}
@@ -1173,6 +1182,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 .then(([statusResult, logsResult]) => {
                   if (statusResult.status === 'fulfilled') {
                     setNetworkStatus(statusResult.value);
+                    setNetworkError(null);
+                  } else {
+                    setNetworkError(`Unable to refresh network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
                   }
                   if (requestId !== networkLogsRequestIdRef.current) {
                     return;
@@ -1194,13 +1206,17 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             onRestart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
               return client.restart(serviceId).then(() => {
-                void client.getStatus().then(setNetworkStatus).catch(() => undefined);
+                return client.getStatus().then((nextStatus) => {
+                  setNetworkStatus(nextStatus);
+                  setNetworkError(null);
+                });
               });
             }}
             onSaveConfig={(assignments) => {
               const client = new NetworkApiClient(baseUrl);
               return client.updateConfig(assignments).then((nextConfig) => {
                 setNetworkConfig(nextConfig);
+                setNetworkError(null);
               });
             }}
             onSelectLogService={(serviceId) => {
@@ -1239,13 +1255,19 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             onStart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
               return client.start(serviceId).then(() => {
-                void client.getStatus().then(setNetworkStatus).catch(() => undefined);
+                return client.getStatus().then((nextStatus) => {
+                  setNetworkStatus(nextStatus);
+                  setNetworkError(null);
+                });
               });
             }}
             onStop={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
               return client.stop(serviceId).then(() => {
-                void client.getStatus().then(setNetworkStatus).catch(() => undefined);
+                return client.getStatus().then((nextStatus) => {
+                  setNetworkStatus(nextStatus);
+                  setNetworkError(null);
+                });
               });
             }}
             selectedLogServiceId={selectedNetworkLogServiceId}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -314,6 +314,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [networkLogsError, setNetworkLogsError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
   const networkStatusRequestIdRef = useRef(0);
+  const networkStatusSuccessRequestIdRef = useRef(0);
   const networkLogsRequestIdRef = useRef(0);
   const {
     activity,
@@ -378,6 +379,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       if (statusRequestId === networkStatusRequestIdRef.current) {
         if (statusResult.status === 'fulfilled') {
           setNetworkStatus(statusResult.value);
+          networkStatusSuccessRequestIdRef.current = statusRequestId;
           setNetworkError(null);
         } else {
           setNetworkError(`Unable to load network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
@@ -399,14 +401,21 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     return client.getStatus()
       .then((nextStatus) => {
         if (statusRequestId !== networkStatusRequestIdRef.current) {
-          return;
+          if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
+            return;
+          }
+          throw new Error('Network status refresh was superseded before it completed.');
         }
         setNetworkStatus(nextStatus);
+        networkStatusSuccessRequestIdRef.current = statusRequestId;
         setNetworkError(null);
       })
       .catch((error: unknown) => {
         if (statusRequestId !== networkStatusRequestIdRef.current) {
-          return;
+          if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
+            return;
+          }
+          throw new Error('Network status refresh was superseded before it completed.');
         }
         throw error;
       });
@@ -1206,6 +1215,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                   if (statusRequestId === networkStatusRequestIdRef.current) {
                     if (statusResult.status === 'fulfilled') {
                       setNetworkStatus(statusResult.value);
+                      networkStatusSuccessRequestIdRef.current = statusRequestId;
                       setNetworkError(null);
                     } else {
                       setNetworkError(`Unable to refresh network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -394,6 +394,17 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     : selectedSessionId ?? activeSessionId ?? `anonymous:${sessionSeed}`;
   const beastCreationDisabled = Boolean(beastCreationUnavailableReason);
 
+  const refreshNetworkStatusAfterAction = (client: NetworkApiClient): Promise<void> => {
+    const statusRequestId = ++networkStatusRequestIdRef.current;
+    return client.getStatus().then((nextStatus) => {
+      if (statusRequestId !== networkStatusRequestIdRef.current) {
+        return;
+      }
+      setNetworkStatus(nextStatus);
+      setNetworkError(null);
+    });
+  };
+
   useEffect(() => {
     if (preserveComposerDraft || !activeSessionId || selectedSessionId) {
       return;
@@ -1213,10 +1224,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             onRestart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
               return client.restart(serviceId).then(() => {
-                return client.getStatus().then((nextStatus) => {
-                  setNetworkStatus(nextStatus);
-                  setNetworkError(null);
-                });
+                return refreshNetworkStatusAfterAction(client);
               });
             }}
             onSaveConfig={(assignments) => {
@@ -1261,19 +1269,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             onStart={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
               return client.start(serviceId).then(() => {
-                return client.getStatus().then((nextStatus) => {
-                  setNetworkStatus(nextStatus);
-                  setNetworkError(null);
-                });
+                return refreshNetworkStatusAfterAction(client);
               });
             }}
             onStop={(serviceId) => {
               const client = new NetworkApiClient(baseUrl);
               return client.stop(serviceId).then(() => {
-                return client.getStatus().then((nextStatus) => {
-                  setNetworkStatus(nextStatus);
-                  setNetworkError(null);
-                });
+                return refreshNetworkStatusAfterAction(client);
               });
             }}
             selectedLogServiceId={selectedNetworkLogServiceId}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -313,6 +313,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [networkLogsLoading, setNetworkLogsLoading] = useState(false);
   const [networkLogsError, setNetworkLogsError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
+  const networkStatusRequestIdRef = useRef(0);
   const networkLogsRequestIdRef = useRef(0);
   const {
     activity,
@@ -372,12 +373,15 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   useEffect(() => {
     const client = new NetworkApiClient(baseUrl);
+    const statusRequestId = ++networkStatusRequestIdRef.current;
     void Promise.allSettled([client.getStatus(), client.getConfig()]).then(([statusResult, configResult]) => {
-      if (statusResult.status === 'fulfilled') {
-        setNetworkStatus(statusResult.value);
-        setNetworkError(null);
-      } else {
-        setNetworkError(`Unable to load network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
+      if (statusRequestId === networkStatusRequestIdRef.current) {
+        if (statusResult.status === 'fulfilled') {
+          setNetworkStatus(statusResult.value);
+          setNetworkError(null);
+        } else {
+          setNetworkError(`Unable to load network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
+        }
       }
       if (configResult.status === 'fulfilled') {
         setNetworkConfig(configResult.value);
@@ -1173,6 +1177,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             onRefresh={() => {
               const client = new NetworkApiClient(baseUrl);
               const logServiceId = selectedNetworkLogServiceId;
+              const statusRequestId = ++networkStatusRequestIdRef.current;
               const requestId = ++networkLogsRequestIdRef.current;
               if (logServiceId) {
                 setNetworkLogsLoading(true);
@@ -1180,11 +1185,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               }
               void Promise.allSettled([client.getStatus(), logServiceId ? client.getLogs(logServiceId) : Promise.resolve(null)])
                 .then(([statusResult, logsResult]) => {
-                  if (statusResult.status === 'fulfilled') {
-                    setNetworkStatus(statusResult.value);
-                    setNetworkError(null);
-                  } else {
-                    setNetworkError(`Unable to refresh network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
+                  if (statusRequestId === networkStatusRequestIdRef.current) {
+                    if (statusResult.status === 'fulfilled') {
+                      setNetworkStatus(statusResult.value);
+                      setNetworkError(null);
+                    } else {
+                      setNetworkError(`Unable to refresh network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
+                    }
                   }
                   if (requestId !== networkLogsRequestIdRef.current) {
                     return;
@@ -1216,7 +1223,6 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               const client = new NetworkApiClient(baseUrl);
               return client.updateConfig(assignments).then((nextConfig) => {
                 setNetworkConfig(nextConfig);
-                setNetworkError(null);
               });
             }}
             onSelectLogService={(serviceId) => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -315,6 +315,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [networkError, setNetworkError] = useState<string | null>(null);
   const networkStatusRequestIdRef = useRef(0);
   const networkStatusSuccessRequestIdRef = useRef(0);
+  const networkStatusSettledRequestIdRef = useRef(0);
   const networkLogsRequestIdRef = useRef(0);
   const {
     activity,
@@ -380,8 +381,10 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         if (statusResult.status === 'fulfilled') {
           setNetworkStatus(statusResult.value);
           networkStatusSuccessRequestIdRef.current = statusRequestId;
+          networkStatusSettledRequestIdRef.current = statusRequestId;
           setNetworkError(null);
         } else {
+          networkStatusSettledRequestIdRef.current = statusRequestId;
           setNetworkError(`Unable to load network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
         }
       }
@@ -398,25 +401,42 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   const refreshNetworkStatusAfterAction = (client: NetworkApiClient): Promise<void> => {
     const statusRequestId = ++networkStatusRequestIdRef.current;
+    const waitForSupersedingStatusRefresh = (): Promise<void> => new Promise((resolve, reject) => {
+      const checkSupersedingStatus = () => {
+        if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
+          resolve();
+          return;
+        }
+        if (networkStatusSettledRequestIdRef.current > statusRequestId) {
+          reject(new Error('Network status refresh was superseded before a newer refresh succeeded.'));
+          return;
+        }
+        window.setTimeout(checkSupersedingStatus, 25);
+      };
+      checkSupersedingStatus();
+    });
     return client.getStatus()
       .then((nextStatus) => {
         if (statusRequestId !== networkStatusRequestIdRef.current) {
           if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
-            return;
+            return undefined;
           }
-          throw new Error('Network status refresh was superseded before it completed.');
+          return waitForSupersedingStatusRefresh();
         }
         setNetworkStatus(nextStatus);
         networkStatusSuccessRequestIdRef.current = statusRequestId;
+        networkStatusSettledRequestIdRef.current = statusRequestId;
         setNetworkError(null);
+        return undefined;
       })
       .catch((error: unknown) => {
         if (statusRequestId !== networkStatusRequestIdRef.current) {
           if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
-            return;
+            return undefined;
           }
-          throw new Error('Network status refresh was superseded before it completed.');
+          return waitForSupersedingStatusRefresh();
         }
+        networkStatusSettledRequestIdRef.current = statusRequestId;
         throw error;
       });
   };
@@ -1210,30 +1230,40 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 setNetworkLogsLoading(true);
                 setNetworkLogsError(null);
               }
-              void Promise.allSettled([client.getStatus(), logServiceId ? client.getLogs(logServiceId) : Promise.resolve(null)])
-                .then(([statusResult, logsResult]) => {
+              void client.getStatus()
+                .then((nextStatus) => {
                   if (statusRequestId === networkStatusRequestIdRef.current) {
-                    if (statusResult.status === 'fulfilled') {
-                      setNetworkStatus(statusResult.value);
-                      networkStatusSuccessRequestIdRef.current = statusRequestId;
-                      setNetworkError(null);
-                    } else {
-                      setNetworkError(`Unable to refresh network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
-                    }
+                    setNetworkStatus(nextStatus);
+                    networkStatusSuccessRequestIdRef.current = statusRequestId;
+                    networkStatusSettledRequestIdRef.current = statusRequestId;
+                    setNetworkError(null);
                   }
+                })
+                .catch((error: unknown) => {
+                  if (statusRequestId === networkStatusRequestIdRef.current) {
+                    networkStatusSettledRequestIdRef.current = statusRequestId;
+                    setNetworkError(`Unable to refresh network status: ${networkErrorMessage(error, 'Request failed.')}`);
+                  }
+                });
+              if (!logServiceId) {
+                return;
+              }
+              void client.getLogs(logServiceId)
+                .then((logsResult) => {
                   if (requestId !== networkLogsRequestIdRef.current) {
                     return;
                   }
-                  if (logsResult.status === 'fulfilled' && logsResult.value) {
-                    setNetworkLogs(logsResult.value.logs);
-                    setNetworkLogsError(null);
-                  } else if (logServiceId && logsResult.status === 'rejected') {
+                  setNetworkLogs(logsResult.logs);
+                  setNetworkLogsError(null);
+                })
+                .catch((error: unknown) => {
+                  if (requestId === networkLogsRequestIdRef.current) {
                     setNetworkLogs([]);
-                    setNetworkLogsError(logsResult.reason instanceof Error ? logsResult.reason.message : 'Unable to refresh logs.');
+                    setNetworkLogsError(error instanceof Error ? error.message : 'Unable to refresh logs.');
                   }
                 })
                 .finally(() => {
-                  if (requestId === networkLogsRequestIdRef.current && logServiceId) {
+                  if (requestId === networkLogsRequestIdRef.current) {
                     setNetworkLogsLoading(false);
                   }
                 });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -376,22 +376,26 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   useEffect(() => {
     const client = new NetworkApiClient(baseUrl);
     const statusRequestId = ++networkStatusRequestIdRef.current;
-    void Promise.allSettled([client.getStatus(), client.getConfig()]).then(([statusResult, configResult]) => {
-      if (statusRequestId === networkStatusRequestIdRef.current) {
-        if (statusResult.status === 'fulfilled') {
-          setNetworkStatus(statusResult.value);
+    void client.getStatus()
+      .then((nextStatus) => {
+        if (statusRequestId === networkStatusRequestIdRef.current) {
+          setNetworkStatus(nextStatus);
           networkStatusSuccessRequestIdRef.current = statusRequestId;
           networkStatusSettledRequestIdRef.current = statusRequestId;
           setNetworkError(null);
-        } else {
-          networkStatusSettledRequestIdRef.current = statusRequestId;
-          setNetworkError(`Unable to load network status: ${networkErrorMessage(statusResult.reason, 'Request failed.')}`);
         }
-      }
-      if (configResult.status === 'fulfilled') {
-        setNetworkConfig(configResult.value);
-      }
-    });
+      })
+      .catch((error: unknown) => {
+        if (statusRequestId === networkStatusRequestIdRef.current) {
+          networkStatusSettledRequestIdRef.current = statusRequestId;
+          setNetworkError(`Unable to load network status: ${networkErrorMessage(error, 'Request failed.')}`);
+        }
+      });
+    void client.getConfig()
+      .then((nextConfig) => {
+        setNetworkConfig(nextConfig);
+      })
+      .catch(() => undefined);
   }, [baseUrl]);
 
   const composerSessionKey = preserveComposerDraft

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -405,9 +405,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   const refreshNetworkStatusAfterAction = (client: NetworkApiClient): Promise<void> => {
     const statusRequestId = ++networkStatusRequestIdRef.current;
-    let statusRefreshDone = false;
+    let done = false;
     const waitForSupersedingStatusRefresh = (): Promise<void> => new Promise((resolve, reject) => {
       const checkSupersedingStatus = () => {
+        if (done) {
+          resolve();
+          return;
+        }
         if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
           resolve();
           return;
@@ -416,9 +420,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           reject(new Error('Network status refresh was superseded before a newer refresh succeeded.'));
           return;
         }
-        if (!statusRefreshDone) {
-          window.setTimeout(checkSupersedingStatus, 25);
-        }
+        window.setTimeout(checkSupersedingStatus, 25);
       };
       checkSupersedingStatus();
     });
@@ -445,15 +447,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         }
         networkStatusSettledRequestIdRef.current = statusRequestId;
         throw error;
-      })
-      .finally(() => {
-        statusRefreshDone = true;
       });
-
-    return Promise.race([
-      statusRefresh,
-      waitForSupersedingStatusRefresh(),
-    ]);
+    return Promise.race([statusRefresh, waitForSupersedingStatusRefresh()])
+      .finally(() => {
+        done = true;
+      });
   };
 
   useEffect(() => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -396,13 +396,20 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   const refreshNetworkStatusAfterAction = (client: NetworkApiClient): Promise<void> => {
     const statusRequestId = ++networkStatusRequestIdRef.current;
-    return client.getStatus().then((nextStatus) => {
-      if (statusRequestId !== networkStatusRequestIdRef.current) {
-        return;
-      }
-      setNetworkStatus(nextStatus);
-      setNetworkError(null);
-    });
+    return client.getStatus()
+      .then((nextStatus) => {
+        if (statusRequestId !== networkStatusRequestIdRef.current) {
+          return;
+        }
+        setNetworkStatus(nextStatus);
+        setNetworkError(null);
+      })
+      .catch((error: unknown) => {
+        if (statusRequestId !== networkStatusRequestIdRef.current) {
+          return;
+        }
+        throw error;
+      });
   };
 
   useEffect(() => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -405,6 +405,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   const refreshNetworkStatusAfterAction = (client: NetworkApiClient): Promise<void> => {
     const statusRequestId = ++networkStatusRequestIdRef.current;
+    let statusRefreshDone = false;
     const waitForSupersedingStatusRefresh = (): Promise<void> => new Promise((resolve, reject) => {
       const checkSupersedingStatus = () => {
         if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
@@ -415,11 +416,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           reject(new Error('Network status refresh was superseded before a newer refresh succeeded.'));
           return;
         }
-        window.setTimeout(checkSupersedingStatus, 25);
+        if (!statusRefreshDone) {
+          window.setTimeout(checkSupersedingStatus, 25);
+        }
       };
       checkSupersedingStatus();
     });
-    return client.getStatus()
+    const statusRefresh = client.getStatus()
       .then((nextStatus) => {
         if (statusRequestId !== networkStatusRequestIdRef.current) {
           if (networkStatusSuccessRequestIdRef.current > statusRequestId) {
@@ -442,7 +445,15 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         }
         networkStatusSettledRequestIdRef.current = statusRequestId;
         throw error;
+      })
+      .finally(() => {
+        statusRefreshDone = true;
       });
+
+    return Promise.race([
+      statusRefresh,
+      waitForSupersedingStatusRefresh(),
+    ]);
   };
 
   useEffect(() => {

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -7,6 +7,7 @@ import type { NetworkConfigResponse, NetworkStatusResponse } from '../lib/networ
 interface NetworkPageProps {
   status: Pick<NetworkStatusResponse, 'mode' | 'secureBackend'>;
   services: NetworkStatusResponse['services'];
+  error?: string | null;
   logs: string[];
   selectedLogServiceId?: string;
   logsLoading?: boolean;
@@ -23,6 +24,7 @@ interface NetworkPageProps {
 export function NetworkPage({
   status,
   services,
+  error = null,
   logs,
   selectedLogServiceId,
   logsLoading,
@@ -44,6 +46,8 @@ export function NetworkPage({
         </div>
         <button className="button button--secondary" type="button" onClick={onRefresh}>Refresh</button>
       </section>
+
+      {error && <p className="network-page__alert" role="alert">{error}</p>}
 
       <div className="network-page__grid">
         <div className="network-page__main">

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -838,6 +838,7 @@ button {
   color: var(--accent-strong);
 }
 
+.network-page__alert,
 .network-config-editor__alert,
 .network-config-editor__success {
   margin: 0;
@@ -845,6 +846,7 @@ button {
   border-radius: 0.9rem;
 }
 
+.network-page__alert,
 .network-config-editor__alert {
   border: 1px solid rgba(255, 126, 126, 0.32);
   background: rgba(255, 126, 126, 0.1);

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -655,6 +655,26 @@ describe('ChatShell', () => {
     });
   });
 
+  it('surfaces initial network status load failures before config settles', async () => {
+    window.location.hash = '#/network';
+    const slowConfig = deferred<{ network: { mode: 'secure'; secureBackend: 'local-encrypted' }; chat: { model: string; enabled: boolean; host: string; port: number } }>();
+    mockNetworkGetStatus.mockRejectedValueOnce(new Error('status endpoint unavailable'));
+    mockNetworkGetConfig.mockReturnValueOnce(slowConfig.promise);
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('Unable to load network status: status endpoint unavailable');
+    });
+
+    act(() => {
+      slowConfig.resolve({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
+      });
+    });
+  });
+
   it('fetches network logs when a service is selected on the Network page', async () => {
     window.location.hash = '#/network';
     render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -187,6 +187,16 @@ const mockDashboardToggleSkill = vi.fn().mockResolvedValue(undefined);
 const mockDashboardUpdateSecurityProfile = vi.fn().mockResolvedValue(undefined);
 const mockDashboardSubscribe = vi.fn().mockResolvedValue(vi.fn());
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 vi.mock('../../src/hooks/use-chat-session.js', () => ({
   useChatSession: () => ({
     messages: [
@@ -803,6 +813,87 @@ describe('ChatShell', () => {
       expect(screen.getByRole('alert').textContent).toContain('Unable to restart chat-server: status endpoint unavailable');
     });
     await waitFor(() => expect(mockNetworkGetStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it('waits for a superseding manual refresh before resolving stale service actions', async () => {
+    window.location.hash = '#/network';
+    const actionStatus = deferred<{ mode: 'secure'; secureBackend: 'local-encrypted'; services: Array<{ id: string; status: string }> }>();
+    const manualStatus = deferred<{ mode: 'secure'; secureBackend: 'local-encrypted'; services: Array<{ id: string; status: string }> }>();
+    mockNetworkGetStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      })
+      .mockReturnValueOnce(actionStatus.promise)
+      .mockReturnValueOnce(manualStatus.promise);
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    act(() => {
+      actionStatus.resolve({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Restarting chat-server…')).toBeDefined();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    act(() => {
+      manualStatus.resolve({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Restarted chat-server.')).toBeDefined();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+  });
+
+  it('surfaces network status refresh failures before selected service logs settle', async () => {
+    window.location.hash = '#/network';
+    const slowLogs = deferred<{ logs: string[] }>();
+    mockNetworkGetStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      })
+      .mockRejectedValueOnce(new Error('status endpoint unavailable'));
+    mockNetworkGetLogs
+      .mockResolvedValueOnce({ logs: ['current log line'] })
+      .mockReturnValueOnce(slowLogs.promise);
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    await screen.findByLabelText('Service logs');
+    fireEvent.change(screen.getByLabelText('Service logs'), { target: { value: 'chat-server' } });
+    await screen.findByText('current log line');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('Unable to refresh network status: status endpoint unavailable');
+    });
+    expect(screen.getByText('Loading logs for the selected service...')).toBeDefined();
+
+    act(() => {
+      slowLogs.resolve({ logs: ['slow refreshed log line'] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('slow refreshed log line')).toBeDefined();
+    });
   });
 
   it('shows connection and session status in the top bar', () => {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -853,14 +853,6 @@ describe('ChatShell', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
-    act(() => {
-      actionStatus.resolve({
-        mode: 'secure',
-        secureBackend: 'local-encrypted',
-        services: [{ id: 'chat-server', status: 'running' }],
-      });
-    });
-
     await waitFor(() => {
       expect(screen.getByText('Restarting chat-server…')).toBeDefined();
       expect(screen.queryByRole('alert')).toBeNull();
@@ -877,6 +869,14 @@ describe('ChatShell', () => {
     await waitFor(() => {
       expect(screen.getByText('Restarted chat-server.')).toBeDefined();
       expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    act(() => {
+      actionStatus.resolve({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      });
     });
   });
 

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -880,6 +880,40 @@ describe('ChatShell', () => {
     });
   });
 
+  it('resolves stale service actions as soon as a superseding manual refresh succeeds', async () => {
+    window.location.hash = '#/network';
+    const actionStatus = deferred<{ mode: 'secure'; secureBackend: 'local-encrypted'; services: Array<{ id: string; status: string }> }>();
+    const manualStatus = deferred<{ mode: 'secure'; secureBackend: 'local-encrypted'; services: Array<{ id: string; status: string }> }>();
+    mockNetworkGetStatus
+      .mockResolvedValueOnce({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      })
+      .mockReturnValueOnce(actionStatus.promise)
+      .mockReturnValueOnce(manualStatus.promise);
+
+    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    act(() => {
+      manualStatus.resolve({
+        mode: 'secure',
+        secureBackend: 'local-encrypted',
+        services: [{ id: 'chat-server', status: 'running' }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Restarted chat-server.')).toBeDefined();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    expect(screen.queryByText('Restarting chat-server…')).toBeNull();
+  });
+
   it('surfaces network status refresh failures before selected service logs settle', async () => {
     window.location.hash = '#/network';
     const slowLogs = deferred<{ logs: string[] }>();

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -784,7 +784,7 @@ describe('ChatShell', () => {
     });
   });
 
-  it('keeps service action success feedback when the follow-up status refresh fails', async () => {
+  it('shows service action error feedback when the follow-up status refresh fails', async () => {
     window.location.hash = '#/network';
     mockNetworkGetStatus
       .mockResolvedValueOnce({
@@ -800,8 +800,7 @@ describe('ChatShell', () => {
 
     await waitFor(() => {
       expect(mockNetworkRestart).toHaveBeenCalledWith('chat-server');
-      expect(screen.getByText('Restarted chat-server.')).toBeDefined();
-      expect(screen.queryByRole('alert')).toBeNull();
+      expect(screen.getByRole('alert').textContent).toContain('Unable to restart chat-server: status endpoint unavailable');
     });
     await waitFor(() => expect(mockNetworkGetStatus).toHaveBeenCalledTimes(2));
   });

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -84,5 +84,5 @@
 - For SDK-backed stdio MCP servers, send newline-delimited JSON initialize requests while still accepting framed responses; on explicit initialize error responses, kill the still-running probe child instead of treating generic error status as a reason to skip cleanup.
 
 ## 2026-07-10 — Network page stale refresh races
-- Network action/status refresh fixes need promise-order regressions: cover a superseded action refresh settling before the newer manual refresh, and keep the action pending until the newer status request succeeds or fails.
+- Network action/status refresh fixes need promise-order regressions: cover a superseded action refresh settling before the newer manual refresh, and a hung superseded action refresh where the newer manual refresh settles first.
 - Surface Network status refresh failures independently from selected-service log refreshes and initial config loads; slow/hung independent requests must not delay operator-facing status alerts.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -82,3 +82,7 @@
 ## 2026-07-10 — MCP stdio health probes
 - MCP stdio probes need stream-level `stdin` error handlers that defer EPIPE to the process close/timeout path, and Content-Length parsing must buffer bytes rather than UTF-16 strings. Add regressions for clean-exit EPIPE races, explicit initialize error responses before close(0), non-ASCII framed JSON bodies, and split `Content-Length` headers before retriggering Codex.
 - For SDK-backed stdio MCP servers, send newline-delimited JSON initialize requests while still accepting framed responses; on explicit initialize error responses, kill the still-running probe child instead of treating generic error status as a reason to skip cleanup.
+
+## 2026-07-10 — Network page stale refresh races
+- Network action/status refresh fixes need promise-order regressions: cover a superseded action refresh settling before the newer manual refresh, and keep the action pending until the newer status request succeeds or fails.
+- Surface Network status refresh failures independently from selected-service log refreshes; a slow/hung log request must not delay the operator-facing status alert.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -85,4 +85,4 @@
 
 ## 2026-07-10 — Network page stale refresh races
 - Network action/status refresh fixes need promise-order regressions: cover a superseded action refresh settling before the newer manual refresh, and keep the action pending until the newer status request succeeds or fails.
-- Surface Network status refresh failures independently from selected-service log refreshes; a slow/hung log request must not delay the operator-facing status alert.
+- Surface Network status refresh failures independently from selected-service log refreshes and initial config loads; slow/hung independent requests must not delay operator-facing status alerts.


### PR DESCRIPTION
## Summary
- surface Network status refresh/load failures as a visible alert on the Network page
- propagate follow-up status refresh failures from service start/stop/restart actions instead of silently swallowing them
- add regression coverage for failed manual refresh and rejected post-action status refresh

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- --run src/components/chat-shell.test.tsx
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #990
