### PR TITLE
fix(orchestrator): return 404 for missing beast run reads

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -72,14 +72,22 @@ function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRun
   return runWithContainerFields(run, attemptsForContainerRun(run, deps));
 }
 
+function beastRunNotFound(runId: string): HttpError {
+  return new HttpError(404, 'BEAST_RUN_NOT_FOUND', `Beast run '${runId}' was not found`);
+}
+
+function throwKnownRunError(runId: string, error: unknown): never {
+  if (error instanceof UnknownBeastRunError) {
+    throw beastRunNotFound(runId);
+  }
+  throw error;
+}
+
 async function requireKnownRunAction(runId: string, action: () => Promise<BeastRun>): Promise<BeastRun> {
   try {
     return await action();
   } catch (error) {
-    if (error instanceof UnknownBeastRunError) {
-      throw new HttpError(404, 'BEAST_RUN_NOT_FOUND', `Beast run '${runId}' was not found`);
-    }
-    throw error;
+    throwKnownRunError(runId, error);
   }
 }
 
@@ -193,6 +201,9 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   app.get('/v1/beasts/runs/:runId', (c) => {
     const runId = c.req.param('runId');
     const run = deps.runs.getRun(runId);
+    if (!run) {
+      throw beastRunNotFound(runId);
+    }
     const attempts = deps.runs.listAttempts(runId);
     return c.json({
       data: {
@@ -204,19 +215,29 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   });
 
   app.get('/v1/beasts/runs/:runId/events', (c) => {
-    return c.json({
-      data: {
-        events: deps.runs.listEvents(c.req.param('runId')),
-      },
-    });
+    const runId = c.req.param('runId');
+    try {
+      return c.json({
+        data: {
+          events: deps.runs.listEvents(runId),
+        },
+      });
+    } catch (error) {
+      throwKnownRunError(runId, error);
+    }
   });
 
   app.get('/v1/beasts/runs/:runId/logs', async (c) => {
-    return c.json({
-      data: {
-        logs: await deps.runs.readLogs(c.req.param('runId')),
-      },
-    });
+    const runId = c.req.param('runId');
+    try {
+      return c.json({
+        data: {
+          logs: await deps.runs.readLogs(runId),
+        },
+      });
+    } catch (error) {
+      throwKnownRunError(runId, error);
+    }
   });
 
   app.post('/v1/beasts/runs/:runId/start', async (c) => {

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -198,6 +198,26 @@ describe('beast routes', () => {
     expect(logsBody.data.logs.some((line) => line.includes('started'))).toBe(true);
   });
 
+  it.each([
+    ['/v1/beasts/runs/missing-run-id'],
+    ['/v1/beasts/runs/missing-run-id/events'],
+    ['/v1/beasts/runs/missing-run-id/logs'],
+  ])('returns a structured 404 when reading unknown run path %s', async (path) => {
+    const { app, operatorToken } = createBeastApp();
+
+    const response = await app.request(path, {
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'BEAST_RUN_NOT_FOUND',
+        message: "Beast run 'missing-run-id' was not found",
+      },
+    });
+  });
+
   it('dispatches a real container executor through the API and exposes container fields', async () => {
     const { app, operatorToken, fakeContainerSupervisor } = createBeastApp({ realContainer: true });
     const headers = {


### PR DESCRIPTION
## Summary
- maps unknown Beast run read endpoints to structured BEAST_RUN_NOT_FOUND 404 responses
- keeps valid run detail/events/log behavior unchanged
- adds integration coverage for missing run detail, events, and logs

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- tests/integration/beasts/beast-routes.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #989