### PR TITLE
fix(web): surface analytics API structured errors

### DIFF
--- a/packages/franken-web/src/lib/analytics-api.test.ts
+++ b/packages/franken-web/src/lib/analytics-api.test.ts
@@ -49,6 +49,30 @@ describe('AnalyticsApiClient', () => {
     await expect(client.fetchSummary({})).rejects.toThrow('HTTP 500');
   });
 
+  it('throws structured analytics error messages when failed responses include an envelope', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: { message: 'Analytics event not found' } }),
+    });
+
+    const client = new AnalyticsApiClient(BASE_URL);
+    await expect(client.fetchEventDetail('missing-event-id')).rejects.toThrow('Analytics event not found');
+  });
+
+  it('falls back to HTTP status when failed responses have malformed JSON', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON');
+      },
+    });
+
+    const client = new AnalyticsApiClient(BASE_URL);
+    await expect(client.fetchEvents({})).rejects.toThrow('HTTP 502');
+  });
+
   it('does not add Authorization from the browser client', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ totalEvents: 0 }) });
     globalThis.fetch = fetchMock;

--- a/packages/franken-web/src/lib/analytics-api.ts
+++ b/packages/franken-web/src/lib/analytics-api.ts
@@ -62,6 +62,12 @@ export interface AnalyticsEventPage {
   pageSize: number;
 }
 
+interface AnalyticsApiErrorEnvelope {
+  error?: {
+    message?: string;
+  };
+}
+
 export class AnalyticsApiClient {
   constructor(private readonly baseUrl: string) {}
 
@@ -84,7 +90,18 @@ export class AnalyticsApiClient {
 
   private async fetchJson<T>(path: string): Promise<T> {
     const res = await fetch(`${this.baseUrl}${path}`);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) {
+      let message = `HTTP ${res.status}`;
+      try {
+        const body = (await res.json()) as AnalyticsApiErrorEnvelope;
+        if (body.error?.message) {
+          message = body.error.message;
+        }
+      } catch {
+        // Fall through with HTTP status message.
+      }
+      throw new Error(message);
+    }
     return (await res.json()) as T;
   }
 }


### PR DESCRIPTION
## Summary
- Parse structured Analytics API error envelopes on failed responses
- Surface backend-provided error.message values before falling back to HTTP status
- Add regression coverage for analytics 404 envelopes and malformed JSON fallbacks

## Test plan
- npm --prefix packages/franken-types run build
- npm --prefix packages/franken-web test -- analytics-api.test.ts
- npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build

Closes #1194