### PR TITLE
fix(orchestrator): validate beast SSE replay cursors

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -12,6 +12,15 @@ function safeTokenCompare(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
+function parseLastEventId(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!/^\d+$/.test(value)) return undefined;
+
+  const id = Number(value);
+  if (!Number.isSafeInteger(id)) return undefined;
+  return id;
+}
+
 export interface BeastSseRouteDeps {
   bus: BeastEventBus;
   ticketStore: SseConnectionTicketStore;
@@ -61,11 +70,20 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }
 
-    const lastEventId = c.req.header('Last-Event-ID') ?? c.req.query('lastEventId');
+    const lastEventIdValue = c.req.header('Last-Event-ID') ?? c.req.query('lastEventId');
+    const lastEventId = parseLastEventId(lastEventIdValue);
+    if (lastEventIdValue !== undefined && lastEventId === undefined) {
+      return c.json({
+        error: {
+          code: 'INVALID_LAST_EVENT_ID',
+          message: 'Last-Event-ID must be a non-negative safe integer',
+        },
+      }, 400);
+    }
 
     return streamSSE(c, async (stream) => {
       // Send initial snapshot if no Last-Event-ID (fresh connect, not reconnect)
-      if (!lastEventId && deps.getSnapshot) {
+      if (lastEventId === undefined && deps.getSnapshot) {
         await stream.writeSSE({
           id: '0',
           event: 'snapshot',
@@ -73,17 +91,14 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
         });
       }
 
-      if (lastEventId) {
-        const id = parseInt(lastEventId, 10);
-        if (!isNaN(id)) {
-          const missed = bus.replaySince(id);
-          for (const event of missed) {
-            await stream.writeSSE({
-              id: String(event.id),
-              event: event.type,
-              data: JSON.stringify(event.data),
-            });
-          }
+      if (lastEventId !== undefined) {
+        const missed = bus.replaySince(lastEventId);
+        for (const event of missed) {
+          await stream.writeSSE({
+            id: String(event.id),
+            event: event.type,
+            data: JSON.stringify(event.data),
+          });
         }
       }
 

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Hono } from 'hono';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
@@ -237,6 +237,49 @@ describe('Beast SSE routes', () => {
 
     expect(events.find((e) => e.id === '1')).toBeUndefined();
     expect(events.find((e) => e.id === '2')).toBeDefined();
+  });
+
+  it.each([
+    ['partial numeric Last-Event-ID header', { headers: { 'Last-Event-ID': '10abc' } }],
+    ['non-numeric lastEventId query', { query: 'lastEventId=abc' }],
+    ['negative lastEventId query', { query: 'lastEventId=-1' }],
+    ['unsafe integer Last-Event-ID header', { headers: { 'Last-Event-ID': '9007199254740992' } }],
+  ])('rejects malformed reconnect cursor: %s', async (_label, options) => {
+    const getSnapshot = vi.fn(() => ({ agents: [{ id: 'a1', status: 'idle' }] }));
+    const ctx = createSseApp({ getSnapshot });
+    ticketStore = ctx.ticketStore;
+
+    ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
+
+    const ticket = await issueTicket(ctx.app);
+    const query = options.query ? `&${options.query}` : '';
+    const req = new Request(`http://localhost/v1/beasts/events/stream?ticket=${ticket}${query}`, {
+      headers: options.headers,
+    });
+    const res = await ctx.app.request(req);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: {
+        code: 'INVALID_LAST_EVENT_ID',
+        message: 'Last-Event-ID must be a non-negative safe integer',
+      },
+    });
+    expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid Last-Event-ID header even when lastEventId query is valid', async () => {
+    const ctx = createSseApp();
+    ticketStore = ctx.ticketStore;
+
+    const ticket = await issueTicket(ctx.app);
+    const req = new Request(`http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`, {
+      headers: { 'Last-Event-ID': '1abc' },
+    });
+    const res = await ctx.app.request(req);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: { code: 'INVALID_LAST_EVENT_ID' } });
   });
 
   it('does not send snapshot on reconnect with Last-Event-ID', async () => {


### PR DESCRIPTION
## Summary
- Validates Beast SSE `Last-Event-ID` / `lastEventId` reconnect cursors with a strict non-negative safe-integer parser before entering the stream replay path.
- Rejects malformed, partial numeric, negative, and unsafe cursors with a structured 400 instead of suppressing snapshots or replaying the wrong range.
- Adds integration coverage for valid replay, malformed header/query cursors, and header precedence over query fallback.

## Test Plan
- `npm test -- tests/integration/beasts/sse-stream.test.ts`
- `npm run typecheck` (`packages/franken-orchestrator`)
- `npm run build` (`packages/franken-orchestrator`)
- `npm run lint` (`packages/franken-orchestrator`; passes with existing warnings)
- `npm run build` (repo root)

Closes #988
