### PR TITLE
fix(orchestrator): reject malformed analytics pagination

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
@@ -18,7 +18,10 @@ const TIME_WINDOWS = ['24h', '7d', '30d', 'all'] as const;
 const TIME_WINDOW_SET = new Set<string>(TIME_WINDOWS);
 
 type FiltersResult = { ok: true; filters: AnalyticsFilters } | { ok: false };
-type PageRequestResult = { ok: true; request: AnalyticsPageRequest } | { ok: false };
+type PageRequestResult =
+  | { ok: true; request: AnalyticsPageRequest }
+  | { ok: false; reason: 'invalid_time_window' }
+  | { ok: false; reason: 'invalid_pagination'; parameter: 'page' | 'pageSize' };
 
 export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
   const app = new Hono();
@@ -37,7 +40,9 @@ export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
 
   app.get('/events', async (c) => {
     const result = readPageRequest(c.req.query());
-    if (!result.ok) return invalidTimeWindow(c);
+    if (!result.ok) {
+      return result.reason === 'invalid_pagination' ? invalidPagination(c, result.parameter) : invalidTimeWindow(c);
+    }
     return c.json(await deps.analytics.listEvents(result.request));
   });
 
@@ -55,17 +60,23 @@ export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
 function readPageRequest(query: Record<string, string>): PageRequestResult {
   const filters = readFilters(query);
   if (!filters.ok) {
-    return filters;
+    return { ok: false, reason: 'invalid_time_window' };
   }
   const page = readPositiveInteger(query['page']);
+  if (!page.ok) {
+    return { ok: false, reason: 'invalid_pagination', parameter: 'page' };
+  }
   const pageSize = readPositiveInteger(query['pageSize']);
+  if (!pageSize.ok) {
+    return { ok: false, reason: 'invalid_pagination', parameter: 'pageSize' };
+  }
 
   return {
     ok: true,
     request: {
       ...filters.filters,
-      ...(page ? { page } : {}),
-      ...(pageSize ? { pageSize } : {}),
+      ...(page.value ? { page: page.value } : {}),
+      ...(pageSize.value ? { pageSize: pageSize.value } : {}),
     },
   };
 }
@@ -97,10 +108,25 @@ function invalidTimeWindow(c: Context) {
   }, 400);
 }
 
-function readPositiveInteger(value: string | undefined): number | undefined {
-  if (!value) {
-    return undefined;
+function invalidPagination(c: Context, parameter: 'page' | 'pageSize') {
+  return c.json({
+    error: {
+      message: 'Invalid Analytics pagination parameter',
+      code: 'invalid_pagination',
+      parameter,
+      expected: 'positive integer',
+    },
+  }, 400);
+}
+
+type PositiveIntegerResult = { ok: true; value?: number } | { ok: false };
+
+function readPositiveInteger(value: string | undefined): PositiveIntegerResult {
+  if (value === undefined || value === '') {
+    return { ok: true };
   }
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  if (!/^[1-9]\d*$/.test(value)) {
+    return { ok: false };
+  }
+  return { ok: true, value: Number(value) };
 }

--- a/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
@@ -128,5 +128,6 @@ function readPositiveInteger(value: string | undefined): PositiveIntegerResult {
   if (!/^[1-9]\d*$/.test(value)) {
     return { ok: false };
   }
-  return { ok: true, value: Number(value) };
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? { ok: true, value: parsed } : { ok: false };
 }

--- a/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
@@ -81,6 +81,31 @@ describe('analytics routes', () => {
     expect(service.listEvents).toHaveBeenCalledWith({ page: 2, pageSize: 25 });
   });
 
+  it.each([
+    ['/events?page=2abc', 'page'],
+    ['/events?pageSize=25junk', 'pageSize'],
+    ['/events?page=1.5', 'page'],
+    ['/events?page=-1', 'page'],
+    ['/events?page=0', 'page'],
+    ['/events?page=abc', 'page'],
+  ])('rejects malformed pagination value %s before reading analytics data', async (path, parameter) => {
+    const service = mockAnalyticsService();
+    const app = createAnalyticsRoutes({ analytics: service });
+
+    const res = await app.request(path);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: {
+        message: 'Invalid Analytics pagination parameter',
+        code: 'invalid_pagination',
+        parameter,
+        expected: 'positive integer',
+      },
+    });
+    expect(service.listEvents).not.toHaveBeenCalled();
+  });
+
   it('rejects unsupported timeWindow query values before reading analytics data', async () => {
     const service = mockAnalyticsService();
     const app = createAnalyticsRoutes({ analytics: service });

--- a/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
@@ -88,6 +88,7 @@ describe('analytics routes', () => {
     ['/events?page=-1', 'page'],
     ['/events?page=0', 'page'],
     ['/events?page=abc', 'page'],
+    [`/events?page=${'9'.repeat(400)}`, 'page'],
   ])('rejects malformed pagination value %s before reading analytics data', async (path, parameter) => {
     const service = mockAnalyticsService();
     const app = createAnalyticsRoutes({ analytics: service });


### PR DESCRIPTION
## Summary
- reject malformed analytics events pagination query values instead of partially parsing numeric prefixes
- return a structured invalid_pagination error before querying analytics data
- cover numeric prefixes, decimals, zero, negative, and non-numeric pagination values

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/http/analytics-routes.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm test --workspace @franken/orchestrator

Closes #987