### PR TITLE
fix(web): reject fake directory picker paths

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -24,11 +24,24 @@ function isBlank(value: unknown): boolean {
   return typeof value !== 'string' || value.trim().length === 0;
 }
 
+function hasUnsafeRepoPathSegments(value: string): boolean {
+  if (value.includes('\0')) return true;
+  if (value.startsWith('/') || value.startsWith('\\') || /^[a-zA-Z]:/.test(value)) return true;
+  return value.split(/[\\/]+/).includes('..');
+}
+
+function isBrowserFakePath(value: string): boolean {
+  return /^(?:[a-zA-Z]:)?[\\/]*fakepath[\\/]/i.test(value);
+}
+
 function isRepoRelativeMarkdownDesignDocPath(value: string): boolean {
-  if (value.includes('\0')) return false;
-  if (value.startsWith('/') || value.startsWith('\\') || /^[a-zA-Z]:/.test(value)) return false;
-  if (value.split(/[\\/]+/).includes('..')) return false;
+  if (hasUnsafeRepoPathSegments(value)) return false;
   return /\.(?:md|mdx|markdown)$/i.test(value);
+}
+
+function isDirectoryPathPrompt(prompt: BeastInterviewPrompt): boolean {
+  const key = prompt.key.toLowerCase();
+  return prompt.kind === 'directory' || key.includes('dir') || key.includes('directory');
 }
 
 function requiredMessage(prompt: BeastInterviewPrompt): string {
@@ -55,6 +68,11 @@ function validateCatalogPrompt(
   }
   if (prompt.key === 'designDocPath' && typeof value === 'string' && !isRepoRelativeMarkdownDesignDocPath(value)) {
     errors.designDocPath = 'Design doc path must be a repo-relative Markdown file without traversal.';
+  }
+  if (isDirectoryPathPrompt(prompt) && typeof value === 'string' && (isBrowserFakePath(value) || hasUnsafeRepoPathSegments(value))) {
+    errors[errorKey] = isBrowserFakePath(value)
+      ? 'Directory path must be a repo-relative path, not a browser fake path.'
+      : 'Directory path must be a repo-relative path without traversal.';
   }
 }
 

--- a/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
@@ -60,6 +60,15 @@ describe('wizard validation', () => {
     expect(errors).toEqual({});
   });
 
+  it.each([
+    ['chunk-plan output directory', { workflowType: 'chunk-plan', designDocPath: 'docs/design.md', outputDir: 'C:\\fakepath\\chunks' }, 'outputDir'],
+    ['martin-loop chunk directory', { workflowType: 'martin-loop', provider: 'codex', objective: 'Implement chunks', chunkDirectory: 'C:\\fakepath\\chunks' }, 'chunkDir'],
+  ])('rejects browser fakepath values for %s', (_label, workflowValues, errorKey) => {
+    const errors = validateWizardStep(1, { 1: workflowValues });
+
+    expect(errors[errorKey]).toBe('Directory path must be a repo-relative path, not a browser fake path.');
+  });
+
   it('rejects martin-loop when backend-required fields are missing', () => {
     const errors = validateWizardStep(1, {
       1: { workflowType: 'martin-loop', provider: '', objective: '   ' },


### PR DESCRIPTION
## Summary
- reject browser fakepath values for Beast directory/path prompts
- keep directory prompt validation constrained to repo-relative paths
- add wizard validation regression coverage for directory fakepath inputs

## Test Plan
- npm test --workspace @franken/web -- tests/components/beasts/wizard-validation.test.ts tests/components/beasts/steps/step-workflow.test.ts
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #985