### PR TITLE
fix(web): summarize disabled module overrides in agent rows

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-row.tsx
+++ b/packages/franken-web/src/components/beasts/agent-row.tsx
@@ -15,6 +15,26 @@ function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
+function pluralizeModule(count: number): string {
+  return count === 1 ? 'module' : 'modules';
+}
+
+function formatModuleConfigSummary(moduleConfig: NonNullable<TrackedAgentSummary['moduleConfig']>): string {
+  const values = Object.values(moduleConfig);
+  const disabledCount = values.filter((enabled) => enabled === false).length;
+  const enabledCount = values.filter((enabled) => enabled === true).length;
+
+  if (disabledCount > 0 && enabledCount > 0) {
+    return `${disabledCount} disabled, ${enabledCount} enabled ${pluralizeModule(enabledCount)}`;
+  }
+
+  if (disabledCount > 0) {
+    return `${disabledCount} disabled ${pluralizeModule(disabledCount)}`;
+  }
+
+  return `${enabledCount} enabled ${pluralizeModule(enabledCount)}`;
+}
+
 export function AgentRow({ agent, run, density, selected, onClick }: AgentRowProps) {
   const selectedClass = selected ? 'bg-beast-accent-soft border-beast-accent' : 'border-beast-border';
   const executionMode = run?.executionMode ?? agent.executionMode;
@@ -39,7 +59,7 @@ export function AgentRow({ agent, run, density, selected, onClick }: AgentRowPro
           </span>
           {agent.moduleConfig && (
             <span className="text-xs px-2.5 py-1 rounded-full bg-beast-control text-beast-muted border border-beast-border">
-              {Object.values(agent.moduleConfig).filter(Boolean).length} modules
+              {formatModuleConfigSummary(agent.moduleConfig)}
             </span>
           )}
           {executionMode && (

--- a/packages/franken-web/tests/components/beasts/agent-row.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-row.test.tsx
@@ -30,6 +30,20 @@ describe('AgentRow', () => {
     expect(screen.getByText('design-interview')).toBeTruthy();
   });
 
+  it('summarizes disabled module overrides instead of counting them as zero modules', () => {
+    render(
+      <AgentRow
+        agent={{ ...agent, moduleConfig: { firewall: false } }}
+        density="comfortable"
+        selected={false}
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('1 disabled module')).toBeTruthy();
+    expect(screen.queryByText('0 modules')).toBeNull();
+  });
+
   it('shows execution mode from linked run', () => {
     render(<AgentRow agent={agent} run={{
       id: 'run-1',


### PR DESCRIPTION
## Summary
- replace the AgentRow truthy module badge count with enabled/disabled module override summaries
- add a regression test for partial moduleConfig objects containing disabled modules

## Test Plan
- npm test -- tests/components/beasts/agent-row.test.tsx
- npm run build --workspace=@franken/types
- npm run typecheck
- npm run build
- npm test

Closes #984
