### PR TITLE
fix(web): surface Dashboard initial load failures

### DIFF
--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -56,6 +56,7 @@ describe('DashboardPage', () => {
     render(<DashboardPage client={client} />);
 
     expect((await screen.findByRole('alert')).textContent).toContain('Unable to load dashboard. HTTP 503');
+    expect(useDashboardStore.getState().loading).toBe(false);
     expect(screen.getByRole('button', { name: 'Retry loading dashboard' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry loading dashboard' }));


### PR DESCRIPTION
## Summary
- Adds an explicit regression assertion that rejected Dashboard initial snapshot loads clear the Zustand loading flag.
- Verifies the visible retryable Dashboard error state does not leave operators stuck at `Loading dashboard...`.

## Test Plan
- npm --prefix packages/franken-web test -- dashboard-page.test.tsx
- npm --prefix packages/franken-types run build && npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build

Closes #1196
