### PR TITLE
fix(observer): clamp webhook retry jitter delay

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { seededRandom } from '@franken/types'
 import { WebhookNotifier } from './WebhookNotifier.js'
 import { CircuitBreaker } from '../cost/CircuitBreaker.js'
 import { LoopDetector } from '../incident/LoopDetector.js'
@@ -181,7 +182,7 @@ describe('WebhookNotifier', () => {
         sleep: sleepFn,
       })
       await expect(notifier.send({ type: 'test' })).rejects.toThrow()
-      const delays = sleepFn.mock.calls.map(args => args[0] as number)
+      const delays = sleepFn.mock.calls.map((args: unknown[]) => args[0] as number)
       expect(delays[0]).toBe(100)  // 100 * 2^0
       expect(delays[1]).toBe(200)  // 100 * 2^1
       expect(delays[2]).toBe(400)  // 100 * 2^2
@@ -197,7 +198,7 @@ describe('WebhookNotifier', () => {
         sleep: sleepFn,
       })
       await expect(notifier.send({ type: 'test' })).rejects.toThrow()
-      const delays = sleepFn.mock.calls.map(args => args[0] as number)
+      const delays = sleepFn.mock.calls.map((args: unknown[]) => args[0] as number)
       expect(delays[0]).toBe(100)
       expect(delays[1]).toBe(200)
       expect(delays[2]).toBe(250) // capped
@@ -207,18 +208,18 @@ describe('WebhookNotifier', () => {
     it('clamps jittered delay at maxDelayMs', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9)
+      const randomSpy = vi.spyOn(seededRandom, 'random').mockReturnValue(0.99)
       const notifier = new WebhookNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
-        retry: { maxRetries: 1, baseDelayMs: 100, maxDelayMs: 100, jitter: true },
+        retry: { maxRetries: 1, baseDelayMs: 200, maxDelayMs: 200, jitter: true },
         sleep: sleepFn,
       })
 
       try {
         await expect(notifier.send({ type: 'test' })).rejects.toThrow()
 
-        expect(sleepFn).toHaveBeenCalledWith(100)
+        expect(sleepFn).toHaveBeenCalledWith(200)
       } finally {
         randomSpy.mockRestore()
       }
@@ -300,7 +301,7 @@ describe('WebhookNotifier', () => {
         sleep: sleepFn,
       })
       await expect(notifier.send({ type: 'test' })).rejects.toThrow()
-      const delays = sleepFn.mock.calls.map(args => args[0] as number)
+      const delays = sleepFn.mock.calls.map((args: unknown[]) => args[0] as number)
       // With jitter each delay is base*2^i + random(0..base), so >= base*2^i and < 2*base*2^i
       expect(delays[0]).toBeGreaterThanOrEqual(100)
       expect(delays[0]).toBeLessThan(200)

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -93,6 +93,7 @@ export class WebhookNotifier {
         const { baseDelayMs, maxDelayMs, jitter } = this.retry
         const base = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs)
         const jittered = jitter ? base + seededRandom.random() * baseDelayMs : base
+        // Clamp after adding jitter so maxDelayMs remains a true upper bound.
         const delay = Math.min(jittered, maxDelayMs)
         await this.sleepFn(delay)
       }


### PR DESCRIPTION
## Summary
- documents that WebhookNotifier clamps after retry jitter so `maxDelayMs` remains the true upper bound
- updates the WebhookNotifier jitter regression to stub the actual deterministic random source and reproduce the max-delay case from issue #977

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/observer -- --run src/notify/WebhookNotifier.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run test --workspace @franken/observer

Closes #977