### PR TITLE
test(orchestrator): cover chat websocket peer cleanup

### DIFF
--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -102,6 +102,39 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('removes only the real websocket peer after a successful upgrade closes', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const httpServer = createServer();
+    const chatSocketServer = attachChatWebSocketServer({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+      server: httpServer,
+    });
+    const port = await listen(httpServer);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${port}/v1/chat/ws?sessionId=${encodeURIComponent(session.id)}`,
+      [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${token}`],
+    );
+
+    await expect(onceSocket(socket, 'open')).resolves.toEqual([]);
+    expect(chatSocketServer.controller.connections).toHaveLength(1);
+
+    const closed = onceSocket(socket, 'close');
+    socket.close();
+    await closed;
+
+    expect(chatSocketServer.controller.connections).toHaveLength(0);
+
+    chatSocketServer.close();
+    httpServer.close();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('rejects replayed socket tokens after the first successful upgrade', async () => {
     mkdirSync(TMP, { recursive: true });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -122,13 +122,13 @@ describe('ws chat server', () => {
     );
 
     await expect(onceSocket(socket, 'open')).resolves.toEqual([]);
-    expect(chatSocketServer.controller.connections).toHaveLength(1);
+    expect(chatSocketServer.controller.connections.size).toBe(1);
 
     const closed = onceSocket(socket, 'close');
     socket.close();
     await closed;
 
-    expect(chatSocketServer.controller.connections).toHaveLength(0);
+    expect(chatSocketServer.controller.connections.size).toBe(0);
 
     chatSocketServer.close();
     httpServer.close();


### PR DESCRIPTION
## Summary
- Add a regression test proving a successful chat websocket upgrade registers exactly the real websocket peer
- Assert closing the websocket removes the peer entry so preflight/auth bookkeeping cannot leak stale peers

## Test Plan
- npm run test -- tests/integration/chat/ws-chat-server.test.ts (packages/franken-orchestrator)
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor && npm run typecheck --workspace @franken/orchestrator && npm run build --workspace @franken/orchestrator

Closes #975