### PR TITLE
test(orchestrator): cover issues limit validation

### DIFF
--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -324,6 +324,17 @@ describe('parseArgs', () => {
       expect(args.subcommand).toBe('issues');
       expect(args.issueLimit).toBe(50);
     });
+
+    it('rejects malformed --limit values before issue selection', () => {
+      for (const value of ['abc', '10abc', '1.5', 'Infinity']) {
+        expect(() => parseArgs(['issues', '--limit', value])).toThrow(/Invalid --limit/);
+      }
+    });
+
+    it('rejects non-positive --limit values', () => {
+      expect(() => parseArgs(['issues', '--limit', '0'])).toThrow(/Invalid --limit/);
+      expect(() => parseArgs(['issues', '--limit=-1'])).toThrow(/Invalid --limit/);
+    });
     it('parses --repo', () => {
       const args = parseArgs(['issues', '--repo', 'djm204/frankenbeast']);
       expect(args.subcommand).toBe('issues');


### PR DESCRIPTION
## Summary
- add issue-subcommand regression coverage for malformed and non-positive --limit values
- assert invalid values fail during CLI parsing before issue selection can receive NaN or partial parses

## Test Plan
- npm run test -- tests/unit/cli/args.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck
- npm run build
- npm run lint (passes with existing warnings)

Closes #974