### PR TITLE
fix(observer): validate rate limit sampler windows

### DIFF
--- a/packages/franken-observer/src/sampling/TraceSampler.test.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.test.ts
@@ -97,6 +97,19 @@ describe('RateLimitedSampler', () => {
     expect(results.slice(0, 5).every(Boolean)).toBe(true)
     expect(results[5]).toBe(false)
   })
+
+  it('throws RangeError when windowMs is zero', () => {
+    expect(() => new RateLimitedSampler({ maxPerWindow: 1, windowMs: 0 })).toThrow(RangeError)
+  })
+
+  it('throws RangeError when windowMs is negative', () => {
+    expect(() => new RateLimitedSampler({ maxPerWindow: 1, windowMs: -1 })).toThrow(RangeError)
+  })
+
+  it('throws RangeError when windowMs is not finite', () => {
+    expect(() => new RateLimitedSampler({ maxPerWindow: 1, windowMs: Number.NaN })).toThrow(RangeError)
+    expect(() => new RateLimitedSampler({ maxPerWindow: 1, windowMs: Number.POSITIVE_INFINITY })).toThrow(RangeError)
+  })
 })
 
 // ── SamplingAdapter ──────────────────────────────────────────────────────────

--- a/packages/franken-observer/src/sampling/TraceSampler.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.ts
@@ -75,6 +75,9 @@ export class RateLimitedSampler implements SamplerStrategy {
   private windowStart: number
 
   constructor(options: RateLimitedSamplerOptions) {
+    if (!Number.isFinite(options.windowMs) || options.windowMs <= 0) {
+      throw new RangeError(`windowMs must be greater than 0, got ${options.windowMs}`)
+    }
     this.maxPerWindow = options.maxPerWindow
     this.windowMs = options.windowMs
     this.now = options.now ?? Date.now


### PR DESCRIPTION
## Summary
- Validate RateLimitedSampler windowMs is finite and greater than zero
- Add regression coverage for zero, negative, and non-finite windows

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/observer -- --run src/sampling/TraceSampler.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint:any

Closes #1126