### PR TITLE
fix(orchestrator): harden network state persistence

### DIFF
--- a/packages/franken-orchestrator/src/network/network-state-store.ts
+++ b/packages/franken-orchestrator/src/network/network-state-store.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { atomicWriteFileSync, readJsonFileOrQuarantine } from '../session/atomic-file.js';
 
 export interface ManagedNetworkServiceState {
   id: string;
@@ -29,20 +30,12 @@ export class NetworkStateStore {
   constructor(private readonly filePath: string) {}
 
   async load(): Promise<NetworkOperatorState | undefined> {
-    try {
-      const raw = await readFile(this.filePath, 'utf-8');
-      return JSON.parse(raw) as NetworkOperatorState;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return undefined;
-      }
-      throw error;
-    }
+    return readJsonFileOrQuarantine<NetworkOperatorState>(this.filePath);
   }
 
   async save(state: NetworkOperatorState): Promise<void> {
     await mkdir(dirname(this.filePath), { recursive: true });
-    await writeFile(this.filePath, JSON.stringify(state, null, 2), 'utf-8');
+    atomicWriteFileSync(this.filePath, JSON.stringify(state, null, 2));
   }
 
   async clear(): Promise<void> {

--- a/packages/franken-orchestrator/tests/unit/network/network-state-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-state-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { NetworkStateStore, type NetworkOperatorState } from '../../../src/network/network-state-store.js';
@@ -37,6 +37,42 @@ describe('NetworkStateStore', () => {
     await store.save(state);
 
     await expect(store.load()).resolves.toEqual(state);
+  });
+
+  it('uses atomic temp-file replacement without leaving partial write artifacts', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-state-atomic-'));
+    const statePath = join(workDir, 'network-state.json');
+    const store = new NetworkStateStore(statePath);
+
+    await writeFile(statePath, '{"mode":"old"}', 'utf-8');
+    await store.save({
+      mode: 'secure',
+      secureBackend: 'local-encrypted',
+      detached: false,
+      startedAt: '2026-03-09T00:00:00.000Z',
+      services: [],
+    });
+
+    const entries = await readdir(workDir);
+    expect(entries).toEqual(['network-state.json']);
+    await expect(readFile(statePath, 'utf-8')).resolves.toContain('"mode": "secure"');
+  });
+
+  it('quarantines truncated state JSON and degrades to absent state', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-network-state-corrupt-'));
+    const statePath = join(workDir, 'network-state.json');
+    const store = new NetworkStateStore(statePath);
+    await writeFile(statePath, '{"mode":"secure","services":[', 'utf-8');
+
+    await expect(store.load()).resolves.toBeUndefined();
+
+    const entries = await readdir(workDir);
+    expect(entries.some((entry) => entry === 'network-state.json')).toBe(false);
+    const quarantined = entries.filter((entry) => entry.startsWith('network-state.json.corrupt.'));
+    expect(quarantined).toHaveLength(1);
+    await expect(readFile(join(workDir, quarantined[0]!), 'utf-8')).resolves.toBe(
+      '{"mode":"secure","services":[',
+    );
   });
 
   it('clears persisted state', async () => {


### PR DESCRIPTION
## Summary
- Reuse the atomic temp-file/fsync/rename JSON helper for network operator state saves
- Quarantine truncated/corrupt network state JSON during load so network commands degrade to absent state
- Add regression coverage for corrupt state recovery and atomic save artifacts

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/network/network-state-store.test.ts
- npm run build -- --filter=@franken/orchestrator...
- npm run typecheck -- --filter=@franken/orchestrator...
- npm --prefix packages/franken-orchestrator run lint -- src/network/network-state-store.ts tests/unit/network/network-state-store.test.ts

Closes #967