### PR TITLE
test(observer): fail on empty test discovery

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -760,6 +760,8 @@ EVAL=true npm run test:eval
 npm run test:watch
 ```
 
+All observer test commands fail when their selected glob discovers zero tests. This is intentional: unit, integration, and eval suites should surface renamed or drifted test files instead of reporting a successful empty run.
+
 The package ships an extensive unit test suite. All adapters and integrations are tested with injectable `fetch` functions — no network calls in CI.
 
 ---

--- a/packages/franken-observer/src/vitest-discovery.test.ts
+++ b/packages/franken-observer/src/vitest-discovery.test.ts
@@ -1,0 +1,47 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function runObserverVitestWithNoMatches(env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(
+    'npm',
+    ['exec', '--', 'vitest', 'run', '--config', 'vitest.config.ts', 'src/__empty__/**/*.test.ts'],
+    {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CI: '1',
+        INTEGRATION: undefined,
+        EVAL: undefined,
+        ...env,
+      },
+    },
+  );
+}
+
+describe('observer Vitest discovery', () => {
+  it('does not mask empty default unit test discovery', () => {
+    const config = readFileSync(resolve(packageRoot, 'vitest.config.ts'), 'utf8');
+
+    expect(config).not.toContain('passWithNoTests');
+
+    const result = runObserverVitestWithNoMatches();
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(/No test files found|No test files matched/u);
+  });
+
+  it('does not mask empty integration or eval discovery', () => {
+    for (const env of [{ INTEGRATION: 'true' }, { EVAL: 'true' }]) {
+      const result = runObserverVitestWithNoMatches(env);
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/No test files found|No test files matched/u);
+    }
+  });
+});

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -24,6 +24,5 @@ export default defineConfig({
       ? []
       : ['src/**/*.integration.test.ts', 'src/**/*.eval.test.ts'],
     reporters: ['verbose'],
-    passWithNoTests: true,
   },
 })


### PR DESCRIPTION
## Summary
- remove the observer Vitest passWithNoTests override so unit/integration/eval discovery fails loudly when empty
- add observer regression coverage that exercises intentionally empty unit, integration, and eval discovery paths
- document that empty observer test discovery is an intentional failure mode

## Test plan
- npm test -- src/vitest-discovery.test.ts
- npm test
- npm run test:integration
- npm run build --workspace=@franken/types && npm run typecheck --workspace=@franken/observer && npm run build --workspace=@franken/observer
- npm run lint:any
- expected-failure check: npm run test:eval exits 1 with "No test files found"

Closes #966