### PR TITLE
docs(readme): align issue workflow flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,8 +495,11 @@ frankenbeast issues --label bug --repo owner/repo
 --assignee <user>       Filter by assignee
 --limit <n>             Max issues to fetch (default: 30)
 --repo <owner/repo>     Target repository (auto-inferred if omitted)
+--target-upstream       Use the checkout's upstream remote as the target repo
 --dry-run               Preview triage without executing
 ```
+
+Execution controls such as `--budget`, `--provider`, `--providers`, and `--no-pr` are global options that also affect `frankenbeast issues` runs; see [Fix GitHub Issues](docs/guides/fix-github-issues.md#all-flags) for the complete issue workflow flag table.
 
 **Chat server flags:**
 

--- a/tests/unit/readme-issue-flags.test.ts
+++ b/tests/unit/readme-issue-flags.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
+const ISSUE_GUIDE = readFileSync(resolve(ROOT, 'docs/guides/fix-github-issues.md'), 'utf-8');
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}
+
+describe('README issue workflow flags', () => {
+  it('keeps the quick-reference aligned with the dedicated issue guide', () => {
+    const readmeIssueFlags = sectionBetween(
+      README,
+      '**Issues-specific flags:**',
+      '**Chat server flags:**',
+    );
+
+    for (const flag of [
+      '--label <labels>',
+      '--search <query>',
+      '--milestone <name>',
+      '--assignee <user>',
+      '--limit <n>',
+      '--repo <owner/repo>',
+      '--target-upstream',
+      '--dry-run',
+    ]) {
+      expect(ISSUE_GUIDE).toContain(flag);
+      expect(readmeIssueFlags).toContain(flag);
+    }
+
+    for (const flag of ['--budget', '--provider', '--providers', '--no-pr']) {
+      expect(readmeIssueFlags).toContain(flag);
+    }
+
+    expect(readmeIssueFlags).toContain('docs/guides/fix-github-issues.md');
+  });
+});

--- a/tests/unit/readme-issue-flags.test.ts
+++ b/tests/unit/readme-issue-flags.test.ts
@@ -16,6 +16,14 @@ function sectionBetween(source: string, start: string, end: string): string {
   return source.slice(startIndex, endIndex);
 }
 
+function escapeRegex(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function expectFlagToken(source: string, flag: string): void {
+  expect(source).toMatch(new RegExp(`(^|[^\\w-])${escapeRegex(flag)}([^\\w-]|$)`));
+}
+
 describe('README issue workflow flags', () => {
   it('keeps the quick-reference aligned with the dedicated issue guide', () => {
     const readmeIssueFlags = sectionBetween(
@@ -35,11 +43,11 @@ describe('README issue workflow flags', () => {
       '--dry-run',
     ]) {
       expect(ISSUE_GUIDE).toContain(flag);
-      expect(readmeIssueFlags).toContain(flag);
+      expectFlagToken(readmeIssueFlags, flag);
     }
 
     for (const flag of ['--budget', '--provider', '--providers', '--no-pr']) {
-      expect(readmeIssueFlags).toContain(flag);
+      expectFlagToken(readmeIssueFlags, flag);
     }
 
     expect(readmeIssueFlags).toContain('docs/guides/fix-github-issues.md');


### PR DESCRIPTION
## Summary
- add `--target-upstream` to the root README issues-specific flags quick-reference
- cross-reference the dedicated fix-github-issues guide for global issue execution controls
- add a root Vitest regression that keeps README issue flags aligned with the guide

## Test Plan
- [x] `npx vitest run tests/unit/readme-issue-flags.test.ts`
- [x] `npm run test:root`
- [x] `npm run typecheck`
- [x] `npm run build`

Closes #962
