### PR TITLE
test(docs): guard local workspace link guidance

### DIFF
--- a/tests/docs-issue-961.test.ts
+++ b/tests/docs-issue-961.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const readText = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+const readJson = <T>(relativePath: string): T => JSON.parse(readText(relativePath)) as T;
+
+const LOCAL_LINK_DOCS = [
+  'docs/guides/quickstart.md',
+  'docs/guides/run-cli-beast.md',
+  'docs/guides/wrap-external-agent.md',
+];
+
+const PATH_STYLE_WORKSPACE_LINKS = [
+  'npm link --workspace=packages/franken-mcp-suite',
+  'npm link --workspace packages/franken-mcp-suite',
+  'npm link --workspace=packages/franken-orchestrator',
+  'npm link --workspace packages/franken-orchestrator',
+];
+
+describe('issue #961 local CLI linking docs', () => {
+  it('uses the canonical local:link script for local checkout setup docs', () => {
+    const packageJson = readJson<{ scripts?: Record<string, string> }>('package.json');
+
+    expect(packageJson.scripts?.['local:link']).toBe(
+      'npm run build && npm link --workspace=@franken/mcp-suite --workspace=@franken/orchestrator',
+    );
+
+    for (const docPath of LOCAL_LINK_DOCS) {
+      expect(readText(docPath), `${docPath} should point readers at the repo-root local link helper`).toContain(
+        'npm run local:link',
+      );
+    }
+  });
+
+  it('does not document path-style npm link workspace selectors for package workspaces', () => {
+    for (const docPath of LOCAL_LINK_DOCS) {
+      const doc = readText(docPath);
+
+      for (const staleCommand of PATH_STYLE_WORKSPACE_LINKS) {
+        expect(doc, `${docPath} should not include ${staleCommand}`).not.toContain(staleCommand);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add root documentation coverage for issue #961 local CLI linking guidance.
- Guard the quickstart, CLI Beast, and external-agent docs against stale path-style `npm link --workspace=packages/...` selectors.
- Verify the root `local:link` helper continues to use package-name workspace selectors.

## Test Plan
- `npx vitest run tests/docs-issue-961.test.ts`
- `npm run test:root -- tests/docs-issue-961.test.ts`
- `npm run typecheck`
- `npm run build`

Closes #961