### PR TITLE
chore(package): normalize workspace metadata

### DIFF
--- a/packages/franken-brain/package.json
+++ b/packages/franken-brain/package.json
@@ -18,8 +18,12 @@
     "lint": "eslint src/ tests/",
     "prepublishOnly": "npm --prefix ../.. run build"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "frankenbeast",
+    "memory",
+    "agent-memory",
+    "sqlite"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -56,5 +56,12 @@
   "engines": {
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "frankenbeast",
+    "mcp",
+    "model-context-protocol",
+    "claude-code",
+    "agent-tools"
+  ]
 }

--- a/packages/franken-observer/package.json
+++ b/packages/franken-observer/package.json
@@ -36,5 +36,12 @@
   "engines": {
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "frankenbeast",
+    "observability",
+    "evaluation",
+    "tracing",
+    "metrics"
+  ]
 }

--- a/packages/franken-planner/package.json
+++ b/packages/franken-planner/package.json
@@ -40,5 +40,11 @@
   "engines": {
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "frankenbeast",
+    "planning",
+    "decomposition",
+    "agent"
+  ]
 }

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -39,5 +39,12 @@
   "engines": {
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "description": "Shared TypeScript contracts, schemas, and utility types for Frankenbeast packages",
+  "keywords": [
+    "frankenbeast",
+    "types",
+    "schemas",
+    "utilities"
+  ]
 }

--- a/packages/franken-web/package.json
+++ b/packages/franken-web/package.json
@@ -54,5 +54,11 @@
   },
   "engines": {
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
-  }
+  },
+  "keywords": [
+    "frankenbeast",
+    "dashboard",
+    "operator-ui",
+    "agent"
+  ]
 }

--- a/packages/live-bench/package.json
+++ b/packages/live-bench/package.json
@@ -38,5 +38,12 @@
   "engines": {
     "node": ">=22.13.0 <23 || >=24.0.0 <26"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "frankenbeast",
+    "benchmark",
+    "codex",
+    "gemini",
+    "mcp"
+  ]
 }

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -300,6 +300,23 @@ describe('npm workspaces configuration', () => {
       expect(readme).toMatch(/## License\n\nMIT\n?$/);
     });
 
+    it('keeps publishable package discovery metadata intentional', () => {
+      for (const path of packageJsonPaths) {
+        const pkg = readPkg(path);
+        if (pkg.private === true) continue;
+
+        expect(typeof pkg.description, `${path} must describe the package for npm discovery`).toBe('string');
+        expect(pkg.description.trim().length, `${path} must use a non-empty package description`).toBeGreaterThan(0);
+        expect(Array.isArray(pkg.keywords), `${path} must declare npm keywords`).toBe(true);
+        expect(pkg.keywords.length, `${path} must include at least one npm keyword`).toBeGreaterThan(0);
+        expect(pkg.keywords, `${path} must include the shared frankenbeast discovery keyword`).toContain('frankenbeast');
+        if (pkg.author !== undefined) {
+          expect(typeof pkg.author, `${path} author must be a string when declared`).toBe('string');
+          expect(pkg.author.trim().length, `${path} must not declare an empty author`).toBeGreaterThan(0);
+        }
+      }
+    });
+
     it('builds dist artifacts before publishing publishable packages', () => {
       for (const path of packageJsonPaths) {
         const pkg = readPkg(path);


### PR DESCRIPTION
## Summary
- add npm discovery keywords to workspace package manifests missing them
- add the missing @franken/types package description
- remove the empty @franken/brain author field and cover metadata hygiene in workspace tests

## Test Plan
- npm run test:root -- tests/workspaces.test.ts
- npm run typecheck
- npm run build
- git diff --check

Closes #960