### PR TITLE
chore(docs): keep audit artifacts out of repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,15 @@ dist
 # Build runner artifacts (logs, traces, checkpoint) — must be invisible to git/codex/rg
 **/.build/
 
+# Generated audit/scan artifacts belong in issues, PR attachments, or docs/audits/ after review.
+/audit.json
+/eval_findings.json
+/npm-audit*.json
+/*audit_findings*.md
+/packages_*_audit.md
+/packages_audit_findings.md
+/security_audit_findings.md
+
 # Root-level module directories (legacy gitlinks, pending cleanup)
 /franken-brain
 /franken-critique

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,19 @@
+# Audit documents
+
+This directory is the canonical home for retained human-readable audit records.
+Audit notes kept here must use repository-relative paths, identify their freshness,
+and point actionable findings to canonical GitHub issues when they are still live.
+
+Do not commit transient scanner output or raw generated reports at the repository root.
+Generated files such as `audit.json`, `eval_findings.json`, `npm-audit*.json`,
+`*_audit_findings*.md`, or package-specific one-off audit reports should either be
+reproduced on demand, attached to the relevant issue/PR, or converted into a
+reviewed document in this directory with historical/non-actionable findings marked
+explicitly.
+
+Current retained audit records:
+
+- `agent-systems-audit-2026-04-28.md` — historical system audit with dated addenda
+  that identify resolved, partially fixed, and residual findings.
+- `test-suite-audit.md` — historical test-suite audit; actions should be validated
+  against current code before filing or fixing follow-up issues.

--- a/tests/unit/repo-audit-artifacts.test.ts
+++ b/tests/unit/repo-audit-artifacts.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const DOCS_AUDITS_README = resolve(ROOT, 'docs', 'audits', 'README.md');
+
+const staleRootAuditArtifacts = new Set([
+  'audit.json',
+  'eval_findings.json',
+  'npm-audit.json',
+  'npm-audit-report.json',
+  'npm-audit-full.json',
+  'packages_audit_findings.md',
+  'packages_governor_mcp_audit.md',
+  'packages_security_audit.md',
+  'security_audit_findings.md',
+]);
+
+const adHocRootAuditPattern = /(?:^|_)(?:audit_findings|audit)(?:_|\.|$)|^npm-audit.*\.json$/u;
+const allowedRootDocs = new Set(['SECURITY.md']);
+
+describe('repository audit artifact hygiene', () => {
+  it('keeps known stale generated audit artifacts out of the repository root', () => {
+    const rootEntries = readdirSync(ROOT);
+
+    expect(rootEntries.filter((entry) => staleRootAuditArtifacts.has(entry))).toEqual([]);
+  });
+
+  it('does not add new ad hoc audit output files at the repository root', () => {
+    const unexpectedRootArtifacts = readdirSync(ROOT)
+      .filter((entry) => adHocRootAuditPattern.test(entry))
+      .filter((entry) => !allowedRootDocs.has(entry));
+
+    expect(unexpectedRootArtifacts).toEqual([]);
+  });
+
+  it('documents the canonical location and freshness rules for retained audits', () => {
+    const readme = readFileSync(DOCS_AUDITS_README, 'utf8');
+
+    expect(readme).toContain('canonical home for retained human-readable audit records');
+    expect(readme).toContain('repository-relative paths');
+    expect(readme).toContain('historical/non-actionable findings');
+  });
+});


### PR DESCRIPTION
## Summary
- document docs/audits as the canonical home for retained audit records
- ignore generated root audit/report artifacts so stale machine output does not reappear
- add a root hygiene regression that keeps known stale audit artifacts out of the repo root

## Test Plan
- npm run test:root -- tests/unit/repo-audit-artifacts.test.ts
- npm run typecheck

Closes #959