### PR TITLE
docs(packages): add remaining workspace READMEs

### DIFF
--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -1,0 +1,89 @@
+# @franken/orchestrator
+
+The Beast Loop product package for Frankenbeast: core orchestration, the `frankenbeast` CLI, issue-to-PR workflows, chat/network serving surfaces, Beast run management, and provider-backed execution.
+
+## Requirements
+
+- Node.js `>=22.13.0 <23 || >=24.0.0 <26`
+- Install dependencies from the repository root with `npm install`
+- CLI features that call external models require the corresponding provider credentials and local CLI/API configuration
+
+## Public entrypoints
+
+```ts
+import { BeastLoop } from '@franken/orchestrator';
+```
+
+The package's main public API is its compiled `dist/index.js` export. Most day-to-day usage goes through the CLI binaries.
+
+## CLI binaries
+
+This package publishes three aliases that resolve to the same CLI entrypoint:
+
+| Binary | Purpose |
+| --- | --- |
+| `frankenbeast` | Canonical CLI. |
+| `franken` | Short alias. |
+| `frkn` | Compact alias. |
+
+Common commands and modes include:
+
+```bash
+frankenbeast --help
+frankenbeast interview
+frankenbeast plan --design-doc <file>
+frankenbeast run --plan-dir <dir>
+frankenbeast issues
+frankenbeast chat-server
+frankenbeast beasts-daemon
+```
+
+For local development from the monorepo, build and link the CLI from the root:
+
+```bash
+npm run local:link
+frankenbeast --help
+```
+
+## Development scripts
+
+Run commands from the repository root with the workspace selector:
+
+```bash
+npm run build --workspace=@franken/orchestrator
+npm run typecheck --workspace=@franken/orchestrator
+npm test --workspace=@franken/orchestrator
+npm run lint --workspace=@franken/orchestrator
+```
+
+Additional package scripts:
+
+```bash
+npm run chat-server --workspace=@franken/orchestrator
+npm run beasts-daemon --workspace=@franken/orchestrator
+npm run test:integration --workspace=@franken/orchestrator
+npm run test:e2e --workspace=@franken/orchestrator
+npm run test:coverage --workspace=@franken/orchestrator
+```
+
+Integration and E2E scripts enable broader runtime paths with `INTEGRATION=true` or `E2E=true`; use them when the needed local services, credentials, and fixtures are available.
+
+## Package areas
+
+| Area | Paths | Responsibility |
+| --- | --- | --- |
+| Core Beast Loop | `src/beast-loop.ts`, `src/phases/`, `src/context/` | Ingestion, hydration, planning, execution, and closure pipeline. |
+| CLI/session workflow | `src/cli/`, `src/planning/`, `src/session/` | Interview, plan generation, chunk execution, resume, and local project flows. |
+| Issue workflows | `src/issues/` | GitHub issue triage, planning, PR creation, and resolve-issues orchestration. |
+| Provider adapters | `src/providers/`, `src/skills/providers/`, `src/adapters/` | Claude, Codex, Gemini, Aider, and API/CLI provider integration. |
+| HTTP/chat/network | `src/http/`, `src/chat/`, `src/network/` | Chat server, managed network services, logs, secrets, and local attachment flows. |
+| Beast management | `src/beasts/` | Beast catalog, run persistence, and daemon-backed run services. |
+| Skills | `src/skills/` | CLI skill discovery, translation, execution, and auth/config stores. |
+
+## Related docs
+
+- [Ramp-up notes](./docs/RAMP_UP.md)
+- [LLM caching architecture](./docs/architecture/llm-caching.md)
+- [ADR 0001: hybrid intelligent LLM caching](./docs/adr/0001-hybrid-intelligent-llm-caching.md)
+- [ADR 0002: work-scoped LLM cache isolation](./docs/adr/0002-work-scoped-llm-cache-isolation.md)
+- [Changelog](./CHANGELOG.md)

--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -82,8 +82,8 @@ Integration and E2E scripts enable broader runtime paths with `INTEGRATION=true`
 
 ## Related docs
 
-- [Ramp-up notes](./docs/RAMP_UP.md)
-- [LLM caching architecture](./docs/architecture/llm-caching.md)
-- [ADR 0001: hybrid intelligent LLM caching](./docs/adr/0001-hybrid-intelligent-llm-caching.md)
-- [ADR 0002: work-scoped LLM cache isolation](./docs/adr/0002-work-scoped-llm-cache-isolation.md)
-- [Changelog](./CHANGELOG.md)
+- [Ramp-up notes](https://github.com/djm204/frankenbeast/blob/main/packages/franken-orchestrator/docs/RAMP_UP.md)
+- [LLM caching architecture](https://github.com/djm204/frankenbeast/blob/main/packages/franken-orchestrator/docs/architecture/llm-caching.md)
+- [ADR 0001: hybrid intelligent LLM caching](https://github.com/djm204/frankenbeast/blob/main/packages/franken-orchestrator/docs/adr/0001-hybrid-intelligent-llm-caching.md)
+- [ADR 0002: work-scoped LLM cache isolation](https://github.com/djm204/frankenbeast/blob/main/packages/franken-orchestrator/docs/adr/0002-work-scoped-llm-cache-isolation.md)
+- [Changelog](https://github.com/djm204/frankenbeast/blob/main/packages/franken-orchestrator/CHANGELOG.md)

--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -1,0 +1,77 @@
+# @franken/types
+
+Shared TypeScript contracts, runtime schemas, branded IDs, deterministic utilities, and common DTOs for Frankenbeast packages.
+
+Use this package when two packages need to agree on core domain shapes without depending on each other's runtime implementations.
+
+## Requirements
+
+- Node.js `>=22.13.0 <23 || >=24.0.0 <26`
+- Install dependencies from the repository root with `npm install`
+
+Runtime dependency: `zod` for exported validation schemas.
+
+## Public entrypoints
+
+```ts
+import {
+  createProjectId,
+  createSessionId,
+  createTaskId,
+  makeTokenSpend,
+  McpConfigSchema,
+  SkillInfoSchema,
+  ToolDefinitionSchema,
+  type Result,
+  type FrankenContext,
+  type ILlmClient,
+  type ProviderCritiqueFinding,
+} from '@franken/types';
+```
+
+Subpath exports are available for focused imports:
+
+```ts
+import { assertInsideRoot } from '@franken/types/path-containment';
+import { seededRandom, deterministicUuid } from '@franken/types/utils';
+```
+
+## Export groups
+
+| Area | Files | Purpose |
+| --- | --- | --- |
+| Branded IDs | `src/ids.ts` | `ProjectId`, `SessionId`, `TaskId`, `RequestId`, `SpanId`, and `TraceId` factories. |
+| Result and verdicts | `src/result.ts`, `src/verdict.ts` | Shared success/error and verdict shapes. |
+| Core context | `src/context.ts`, `src/orchestration.ts`, `src/token.ts` | Shared `FrankenContext`, task outcomes, phases, and token-spend contracts. |
+| Provider contracts | `src/provider.ts`, `src/llm.ts` | LLM provider interfaces, stream events, tool schemas, MCP server config, and critique finding shapes. |
+| Skills and comms | `src/skill.ts`, `src/comms.ts` | Skill metadata schemas and communication payload contracts. |
+| Deterministic helpers | `src/deterministic.ts`, `src/utils/` | Seeded random, deterministic UUIDs, and clock helpers used by tests and reproducible runs. |
+| API DTOs | `src/api-contracts.ts` | Shared web/API contract data transfer objects. |
+
+## Development scripts
+
+Run commands from the repository root with the workspace selector:
+
+```bash
+npm run build --workspace=@franken/types
+npm run typecheck --workspace=@franken/types
+npm test --workspace=@franken/types
+npm run test:watch --workspace=@franken/types
+```
+
+The package test script writes temporary files under `../../.tmp/franken-types` so path-containment and filesystem tests do not collide with other workspaces.
+
+## Package layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/index.ts` | Main package export barrel. |
+| `src/path-containment.ts` | Root containment helpers exported as a subpath. |
+| `src/utils/` | Utility subpath exports. |
+| `docs/RAMP_UP.md` | Deeper architecture and contributor ramp-up notes. |
+| `CHANGELOG.md` | Package release history. |
+
+## Related docs
+
+- [Ramp-up notes](./docs/RAMP_UP.md)
+- [Changelog](./CHANGELOG.md)

--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -32,8 +32,8 @@ import {
 Subpath exports are available for focused imports:
 
 ```ts
-import { assertInsideRoot } from '@franken/types/path-containment';
-import { seededRandom, deterministicUuid } from '@franken/types/utils';
+import { resolveContainedPath } from '@franken/types/path-containment';
+import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 ```
 
 ## Export groups
@@ -73,5 +73,5 @@ The package test script writes temporary files under `../../.tmp/franken-types` 
 
 ## Related docs
 
-- [Ramp-up notes](./docs/RAMP_UP.md)
-- [Changelog](./CHANGELOG.md)
+- [Ramp-up notes](https://github.com/djm204/frankenbeast/blob/main/packages/franken-types/docs/RAMP_UP.md)
+- [Changelog](https://github.com/djm204/frankenbeast/blob/main/packages/franken-types/CHANGELOG.md)

--- a/packages/live-bench/README.md
+++ b/packages/live-bench/README.md
@@ -1,0 +1,81 @@
+# @franken/live-bench
+
+Live benchmark runner for comparing Codex, Gemini, and Frankenbeast MCP-suite behavior against repeatable corpora.
+
+The package exposes reusable corpus/workspace helpers and the `fbeast-live-bench` CLI so contributors can inspect benchmark task sets before running live client comparisons.
+
+## Requirements
+
+- Node.js `>=22.13.0 <23 || >=24.0.0 <26`
+- Install dependencies from the repository root with `npm install`
+- Live runs require any provider CLI credentials needed by the benchmark client under test
+
+## Public entrypoints
+
+```ts
+import {
+  loadCorpus,
+  loadTaskFile,
+  BenchmarkTaskSchema,
+  FixtureStore,
+  WorkspaceProvisioner,
+  type BenchmarkTask,
+  type BenchmarkMatrixRow,
+  type ClientRunResult,
+} from '@franken/live-bench';
+```
+
+Key exports:
+
+| Export | Purpose |
+| --- | --- |
+| `loadCorpus`, `loadTaskFile` | Load benchmark task definitions from a corpus root. |
+| `BenchmarkTaskSchema` | Validate benchmark task JSON with Zod. |
+| `ToolCallEvidenceSchema`, `serializeToolCallEvidence` | Validate and serialize tool-call evidence artifacts. |
+| `FixtureStore` | Manage fixture files used by benchmark workspaces. |
+| `WorkspaceProvisioner` | Create isolated workspaces and capture environment snapshots for benchmark runs. |
+
+## CLI
+
+The package publishes `fbeast-live-bench`.
+
+```bash
+npm run build --workspace=@franken/live-bench
+fbeast-live-bench --help
+fbeast-live-bench list <corpus-root>
+```
+
+`list` loads the corpus root and prints the benchmark task ids, one per line. Use it as a lightweight sanity check before a live benchmark run.
+
+## Development scripts
+
+Run commands from the repository root with the workspace selector:
+
+```bash
+npm run build --workspace=@franken/live-bench
+npm run typecheck --workspace=@franken/live-bench
+npm test --workspace=@franken/live-bench
+```
+
+Additional script:
+
+```bash
+npm run test:live --workspace=@franken/live-bench
+```
+
+`test:live` builds the package and runs `tests/live` with `FBEAST_LIVE_BENCH_E2E=1`; only use it when the required live provider credentials and local tooling are available.
+
+## Package layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/cli/main.ts` | `fbeast-live-bench` command entrypoint. |
+| `src/corpus/` | Corpus schemas and loaders. |
+| `src/evidence/` | Tool-call evidence schemas and serializers. |
+| `src/workspace/` | Fixture and workspace provisioning helpers. |
+| `corpus/` | Packaged benchmark corpus assets. |
+| `fixtures/` | Packaged benchmark fixtures. |
+
+## Related docs
+
+This package currently keeps its package-specific onboarding in this README. See the repository root docs and package scripts for broader Frankenbeast setup and release guidance.

--- a/packages/live-bench/README.md
+++ b/packages/live-bench/README.md
@@ -1,8 +1,8 @@
 # @franken/live-bench
 
-Live benchmark runner for comparing Codex, Gemini, and Frankenbeast MCP-suite behavior against repeatable corpora.
+Corpus, fixture, workspace, and evidence helpers for live Codex/Gemini/Frankenbeast MCP-suite benchmark work.
 
-The package exposes reusable corpus/workspace helpers and the `fbeast-live-bench` CLI so contributors can inspect benchmark task sets before running live client comparisons.
+The package exposes reusable primitives plus the `fbeast-live-bench` CLI so contributors can inspect benchmark task sets before wiring or running live client comparison workflows.
 
 ## Requirements
 
@@ -31,7 +31,8 @@ Key exports:
 | --- | --- |
 | `loadCorpus`, `loadTaskFile` | Load benchmark task definitions from a corpus root. |
 | `BenchmarkTaskSchema` | Validate benchmark task JSON with Zod. |
-| `ToolCallEvidenceSchema`, `serializeToolCallEvidence` | Validate and serialize tool-call evidence artifacts. |
+| `ToolCallEvidenceSchema` | Validate a single tool-call evidence record. |
+| `ToolCallEvidenceManifestSchema`, `serializeToolCallEvidence` | Validate and serialize the full tool-call evidence artifact array. |
 | `FixtureStore` | Manage fixture files used by benchmark workspaces. |
 | `WorkspaceProvisioner` | Create isolated workspaces and capture environment snapshots for benchmark runs. |
 
@@ -41,8 +42,8 @@ The package publishes `fbeast-live-bench`.
 
 ```bash
 npm run build --workspace=@franken/live-bench
-fbeast-live-bench --help
-fbeast-live-bench list <corpus-root>
+npm exec --workspace=@franken/live-bench -- fbeast-live-bench --help
+npm exec --workspace=@franken/live-bench -- fbeast-live-bench list <corpus-root>
 ```
 
 `list` loads the corpus root and prints the benchmark task ids, one per line. Use it as a lightweight sanity check before a live benchmark run.


### PR DESCRIPTION
## Summary
- Add package-root README docs for @franken/live-bench, @franken/types, and @franken/orchestrator
- Document each package purpose, public entrypoints/CLI, package scripts, requirements, and related deeper docs
- Keep issue #955 scoped separately to franken-critique

## Test Plan
- npm run typecheck --workspace=@franken/types
- npm run build --workspace=@franken/types
- npm test --workspace=@franken/types
- npm run typecheck --workspace=@franken/live-bench
- npm run build --workspace=@franken/live-bench
- npm test --workspace=@franken/live-bench
- npx turbo run build --filter=@franken/orchestrator...
- npm run typecheck --workspace=@franken/orchestrator
- npm run build --workspace=@franken/orchestrator
- npm test --workspace=@franken/orchestrator

Closes #956