### PR TITLE
fix(observer): validate rate limit sampler maximum

### DIFF
--- a/packages/franken-observer/src/sampling/TraceSampler.test.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.test.ts
@@ -110,6 +110,20 @@ describe('RateLimitedSampler', () => {
     expect(() => new RateLimitedSampler({ maxPerWindow: 1, windowMs: Number.NaN })).toThrow(RangeError)
     expect(() => new RateLimitedSampler({ maxPerWindow: 1, windowMs: Number.POSITIVE_INFINITY })).toThrow(RangeError)
   })
+
+  it('throws RangeError when maxPerWindow is not greater than zero', () => {
+    expect(() => new RateLimitedSampler({ maxPerWindow: 0, windowMs: 1000 })).toThrow(RangeError)
+    expect(() => new RateLimitedSampler({ maxPerWindow: -1, windowMs: 1000 })).toThrow(RangeError)
+  })
+
+  it('throws RangeError when maxPerWindow is not finite', () => {
+    expect(() => new RateLimitedSampler({ maxPerWindow: Number.NaN, windowMs: 1000 })).toThrow(
+      RangeError,
+    )
+    expect(() =>
+      new RateLimitedSampler({ maxPerWindow: Number.POSITIVE_INFINITY, windowMs: 1000 }),
+    ).toThrow(RangeError)
+  })
 })
 
 // ── SamplingAdapter ──────────────────────────────────────────────────────────

--- a/packages/franken-observer/src/sampling/TraceSampler.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.ts
@@ -78,6 +78,9 @@ export class RateLimitedSampler implements SamplerStrategy {
     if (!Number.isFinite(options.windowMs) || options.windowMs <= 0) {
       throw new RangeError(`windowMs must be greater than 0, got ${options.windowMs}`)
     }
+    if (!Number.isFinite(options.maxPerWindow) || options.maxPerWindow <= 0) {
+      throw new RangeError(`maxPerWindow must be greater than 0, got ${options.maxPerWindow}`)
+    }
     this.maxPerWindow = options.maxPerWindow
     this.windowMs = options.windowMs
     this.now = options.now ?? Date.now


### PR DESCRIPTION
## Summary
- validate RateLimitedSampler maxPerWindow before storing it
- add regression coverage for zero, negative, NaN, and infinite maxPerWindow values

## Test Plan
- npm --prefix packages/franken-observer test -- src/sampling/TraceSampler.test.ts
- npm --prefix packages/franken-observer test
- npm --prefix packages/franken-types run build && npm --prefix packages/franken-observer run typecheck && npm --prefix packages/franken-observer run build

Closes #1121