### PR TITLE
chore(workspaces): enforce root lockfile policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist
 # Build runner artifacts (logs, traces, checkpoint) — must be invisible to git/codex/rg
 **/.build/
 
+# npm workspaces use the root package-lock.json as the single dependency lockfile.
+/packages/*/package-lock.json
+
 # Generated audit/scan artifacts belong in issues, PR attachments, or docs/audits/ after review.
 /audit.json
 /eval_findings.json

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -22,6 +22,8 @@ For CI-style validation without mutating files or installing dependencies, run:
 
 If Corepack is not available yet, install it first with `npm install -g corepack`; the bootstrap script then activates and verifies the root `packageManager` pin.
 
+Dependency locking is centralized at the workspace root: commit updates to the root `package-lock.json` only. Package workspaces under `packages/*` must not carry their own nested `package-lock.json` files; run installs from the repository root so npm records workspace dependency changes in the root lockfile. Standalone example projects under `examples/` may keep their own lockfiles because they are scaffolded outside the monorepo workspace.
+
 Run reproducible dependency audits through the guarded script so the live npm
 binary still matches the root `packageManager` pin before `npm audit` runs:
 

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = join(import.meta.dirname, '..');
@@ -40,6 +40,20 @@ describe('npm workspaces configuration', () => {
     it('pins ws to a security-fixed version for all workspace consumers', () => {
       expect(rootPkg.overrides?.ws).toBeDefined();
       expect(isAtLeast(rootPkg.overrides.ws, '8.21.0')).toBe(true);
+    });
+
+    it('uses the root package-lock.json as the only package workspace lockfile', () => {
+      expect(existsSync(join(ROOT, 'package-lock.json')), 'root package-lock.json must govern workspace installs').toBe(true);
+
+      const nestedWorkspaceLockfiles = readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => `packages/${entry.name}/package-lock.json`)
+        .filter((path) => existsSync(join(ROOT, path)));
+
+      expect(
+        nestedWorkspaceLockfiles,
+        'npm workspaces under packages/* must not commit nested lockfiles; use the root package-lock.json instead',
+      ).toEqual([]);
     });
 
     it('pins Vite to a security-fixed version for Vitest consumers', () => {


### PR DESCRIPTION
## Summary
- documents the root-lockfile-only policy for npm workspaces
- ignores new nested `packages/*/package-lock.json` files
- adds a root workspace regression that fails if package workspaces regain nested lockfiles

## Test Plan
- `npm run test:root -- tests/workspaces.test.ts tests/local-setup-scripts.test.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run build`

Closes #954
