### PR TITLE
test(live-bench): expose live suite from root

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -69,7 +69,7 @@ npm run typecheck
 npm test
 ```
 
-Root scripts currently include `build`, `typecheck`, `test`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts.
+Root scripts currently include `build`, `typecheck`, `test`, `test:live:bench`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts. `test:live:bench` is an explicit opt-in for the live benchmark suite and delegates to the gated `@franken/live-bench` `test:live` task, which sets `FBEAST_LIVE_BENCH_E2E=1`.
 
 ## 5. Try the orchestrator CLI
 
@@ -144,4 +144,7 @@ npm run test:root
 
 # Single package via Turbo filter
 npx turbo run test --filter=franken-brain
+
+# Explicit opt-in live benchmark suite (sets FBEAST_LIVE_BENCH_E2E=1)
+npm run test:live:bench
 ```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "test": "turbo run test",
+    "test:live:bench": "turbo run test:live --filter=@franken/live-bench",
     "ci:test:root": "node scripts/retry-ci-command.mjs -- npm run test:root",
     "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",
     "test:root": "vitest run",

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -56,6 +56,15 @@ describe('Turborepo configuration', () => {
       expect(testCiTask.dependsOn).toContain('build');
     });
 
+    it('defines an explicit live-bench live test task', () => {
+      const turbo = readJson('turbo.json');
+      const liveBenchTask = turbo.tasks?.['test:live'];
+      expect(liveBenchTask).toBeDefined();
+      expect(liveBenchTask.cache).toBe(false);
+      expect(liveBenchTask.dependsOn).toContain('build');
+      expect(liveBenchTask.env).toContain('FBEAST_LIVE_BENCH_E2E');
+    });
+
     it('defines typecheck task', () => {
       const turbo = readJson('turbo.json');
       expect(turbo.tasks?.typecheck).toBeDefined();
@@ -121,6 +130,10 @@ describe('Turborepo configuration', () => {
 
     it('keeps test:root:watch as vitest for dev', () => {
       expect(rootPkg.scripts['test:root:watch']).toBe('vitest');
+    });
+
+    it('exposes the live-bench live suite through an explicit root script', () => {
+      expect(rootPkg.scripts['test:live:bench']).toBe('turbo run test:live --filter=@franken/live-bench');
     });
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,11 @@
     "test:ci": {
       "dependsOn": ["build"]
     },
+    "test:live": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "env": ["FBEAST_LIVE_BENCH_E2E"]
+    },
     "typecheck": {
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
## Summary
- add a root `test:live:bench` script that delegates to the live-bench `test:live` workspace task
- add a discoverable Turbo `test:live` task with explicit live-bench env hashing and caching disabled
- document the opt-in live benchmark test command in the quickstart

## Test Plan
- [x] npm run test:root -- tests/turborepo.test.ts
- [x] npm run test:live:bench -- --dry=json
- [x] npx turbo run typecheck --filter=@franken/live-bench
- [x] npx turbo run test --filter=@franken/live-bench
- [x] npx turbo run build --filter=@franken/live-bench

Closes #950