### PR TITLE
docs(ramp-up): refresh package safety status

### DIFF
--- a/packages/franken-critique/docs/RAMP_UP.md
+++ b/packages/franken-critique/docs/RAMP_UP.md
@@ -1,20 +1,30 @@
 # franken-critique (MOD-06) Ramp-Up
 
-**Status**: **GHOST** — This module is currently **unwired** from the primary `@franken/orchestrator` production path. The orchestrator uses a `stubCritique` adapter in `dep-factory.ts`.
+**Status**: **Integrated safety module** — The primary `@franken/orchestrator` CLI dependency path loads `@franken/critique` when the critique module is enabled. The orchestrator falls back to the local all-pass critique only when the module is explicitly disabled, or when an enabled package is missing and `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opts into unsafe degraded mode. The canonical integration status lives in [`../../../docs/RAMP_UP.md`](../../../docs/RAMP_UP.md).
 
 ## Module Overview
 `franken-critique` implements the Reflexion pattern for the Beast Loop. It scores agent output (plans or code) using a pipeline of deterministic and heuristic evaluators, forcing a correction loop on failures.
 
-## Current Functionality (Implemented but Unused)
+## Current Functionality
 - **Critique Loop**: A while-loop that retries generation until a minimum score is met or a circuit breaker trips.
 - **Evaluators**:
     - `SafetyEvaluator`: Checks for guardrail violations.
     - `GhostDependencyEvaluator`: Detects undeclared imports.
     - `ADRComplianceEvaluator`: Checks against stored Architecture Decision Records.
+    - `ReflectionEvaluator`: Produces reflection findings from an LLM-backed adapter.
 - **Circuit Breakers**: Prevents infinite critique spirals.
+- **Reviewer Facade**: `createReviewer` wires package evaluators behind the interface consumed by the orchestrator adapter.
 
-## Integration Gap
-The `@franken/orchestrator` currently skips the reflection phase by using a stub that returns a perfect score (1.0) for every plan. **Phase 8 Focus**: Implement the real critique loop in the `runPlanning` phase to improve plan quality and safety.
+## Current Orchestrator Wiring
+- `packages/franken-orchestrator/src/cli/dep-factory.ts` imports `@franken/critique` lazily when `modules.critique` is enabled.
+- `createCritiqueDeps()` builds a package reviewer with guardrail, memory, observability, and known-package ports, then wraps it in `CritiquePortAdapter` for the Beast loop.
+- `packages/franken-orchestrator/src/cli/create-beast-deps.ts` also wires `ReflectionEvaluator` into heartbeat reflection when reflection is enabled.
+- Missing enabled critique packages fail closed by default. Unsafe all-pass fallback requires the explicit `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opt-out documented in the root ramp-up guide.
+
+## Narrow Integration Notes
+- The critique module depends on caller-provided ports for guardrails, memory, observability, known package metadata, and LLM-backed reflection.
+- The orchestrator can still use the local all-pass critique stub when critique is deliberately disabled by config or environment.
+- Keep this package-level note aligned with the canonical root integration story in [`../../../docs/RAMP_UP.md`](../../../docs/RAMP_UP.md), especially the `dep-factory.ts` / `createBeastDeps()` section.
 
 ## Key API
 - `CritiquePipeline`: Executes a sequence of evaluators.

--- a/packages/franken-governor/docs/RAMP_UP.md
+++ b/packages/franken-governor/docs/RAMP_UP.md
@@ -1,11 +1,11 @@
 # franken-governor (MOD-07) Ramp-Up
 
-**Status**: **GHOST** — This module is currently **unwired** from the primary `@franken/orchestrator` production path. The orchestrator uses a `stubGovernor` adapter in `dep-factory.ts`.
+**Status**: **Integrated safety module** — The primary `@franken/orchestrator` CLI dependency path loads `@franken/governor` when the governor module is enabled. The orchestrator falls back to the local passthrough governor only when the module is explicitly disabled, or when an enabled package is missing and `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opts into unsafe degraded mode. The canonical integration status lives in [`../../../docs/RAMP_UP.md`](../../../docs/RAMP_UP.md).
 
 ## Module Overview
 `franken-governor` is the Human-in-the-loop (HITL) gateway. It pauses agent execution for human approval on high-stakes actions, such as budget breaches, destructive commands, or low-confidence plans.
 
-## Current Functionality (Implemented but Unused)
+## Current Functionality
 - **Approval Gateway**: Manages the lifecycle of an approval request across multiple channels.
 - **Triggers**:
     - `BudgetTrigger`: Fires when token spend exceeds limits.
@@ -14,10 +14,18 @@
 - **Channels**:
     - `CliChannel`: Interacts with the user via terminal prompt.
     - `SlackChannel`: Sends requests to a Slack webhook and awaits callback.
-- **Security**: HMCS-SHA256 signing for secure approval responses.
+- **Security**: HMAC-SHA256 signing for secure approval responses.
 
-## Integration Gap
-The `@franken/orchestrator` currently auto-approves all tasks and budget increases because it uses a no-op governor stub. **Phase 8 Focus**: Wire the `CliChannel` and `BudgetTrigger` into the orchestrator's `runExecution` phase.
+## Current Orchestrator Wiring
+- `packages/franken-orchestrator/src/cli/dep-factory.ts` imports `@franken/governor` lazily when `modules.governor` is enabled.
+- TTY CLI runs use `CliChannel` through `ApprovalGateway` and `GovernorPortAdapter`.
+- Non-TTY CLI runs use the orchestrator adapter's configured default decision path instead of prompting on stdin.
+- Missing enabled governor packages fail closed by default. Unsafe all-approve fallback requires the explicit `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opt-out documented in the root ramp-up guide.
+
+## Narrow Integration Notes
+- The package supplies trigger, approval, audit, signing, and session-token primitives; callers remain responsible for supplying live context sources and enforcing approval results at execution boundaries.
+- Budget and skill triggers only fire when the caller provides the relevant budget state or skill metadata.
+- Keep this package-level note aligned with the canonical root integration story in [`../../../docs/RAMP_UP.md`](../../../docs/RAMP_UP.md), especially the `dep-factory.ts` / `createBeastDeps()` section.
 
 ## Key API
 - `ApprovalGateway`: Central point for requesting approvals.

--- a/tests/docs-issue-949.test.ts
+++ b/tests/docs-issue-949.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readText = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+const PACKAGE_RAMP_UP_DOCS = [
+  'packages/franken-governor/docs/RAMP_UP.md',
+  'packages/franken-critique/docs/RAMP_UP.md',
+] as const;
+
+describe('issue #949 package ramp-up status docs', () => {
+  it('keeps governor and critique package docs aligned with the consolidated root status', () => {
+    const rootRampUp = readText('docs/RAMP_UP.md');
+
+    expect(rootRampUp).toContain('does **not** synthesize permissive passthrough success deps');
+    expect(rootRampUp).toContain('FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1');
+
+    for (const docPath of PACKAGE_RAMP_UP_DOCS) {
+      const rampUp = readText(docPath);
+
+      expect(rampUp, `${docPath} should link the canonical root ramp-up guide`).toContain('../../../docs/RAMP_UP.md');
+      expect(rampUp, `${docPath} should describe the enabled-module integration path`).toMatch(
+        /when the (governor|critique) module is enabled/u,
+      );
+      expect(rampUp, `${docPath} should mention fail-closed unsafe opt-out semantics`).toContain(
+        'FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1',
+      );
+      expect(rampUp, `${docPath} should not claim the package is globally ghosted`).not.toMatch(
+        /Status\*\*: \*\*GHOST\*\*/u,
+      );
+      expect(rampUp, `${docPath} should not claim the package is globally unwired`).not.toContain(
+        'currently **unwired**',
+      );
+    }
+  });
+
+  it('phrases remaining governor and critique gaps as narrow current limitations', () => {
+    const governorRampUp = readText('packages/franken-governor/docs/RAMP_UP.md');
+    const critiqueRampUp = readText('packages/franken-critique/docs/RAMP_UP.md');
+
+    expect(governorRampUp).toContain('## Narrow Integration Notes');
+    expect(governorRampUp).toContain('callers remain responsible for supplying live context sources');
+    expect(governorRampUp).not.toContain('auto-approves all tasks and budget increases because it uses a no-op governor stub');
+
+    expect(critiqueRampUp).toContain('## Narrow Integration Notes');
+    expect(critiqueRampUp).toContain('depends on caller-provided ports');
+    expect(critiqueRampUp).not.toContain('skips the reflection phase by using a stub that returns a perfect score');
+  });
+});


### PR DESCRIPTION
## Summary
- update governor and critique package ramp-up docs to match the consolidated root status
- document narrow remaining integration limitations instead of global ghost/unwired status
- add a root docs regression for issue #949

## Test Plan
- npm run test:root -- tests/docs-issue-949.test.ts tests/docs-issue-511.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/governor
- npm run typecheck --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/critique

Closes #949