### PR TITLE
docs(web): document Quick Start scripts

### DIFF
--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -11,9 +11,19 @@ The dashboard is the primary Beast operator UI. CLI users can perform the same c
 ```bash
 npm run dev          # Start Vite dev server (default: http://localhost:5173)
 npm run dev:chat     # Start with API proxy pointing to chat-server on :3737
+npm run dev:network  # Start the network-management dashboard dev server
 npm run build        # Production build (tsc + vite build)
 npm run preview      # Preview production build locally
 npm test             # Run tests
+npm run typecheck    # Run the web package TypeScript check (tsc --noEmit)
+```
+
+Use `npm run dev:network` when working on the Network tab or local network-service flows. It serves the web dashboard in local Vite dev mode; keep API calls behind the same-origin proxy and set `VITE_API_PROXY_TARGET` when `/v1/network/*` should talk to a non-default local orchestrator/daemon. Set `VITE_BEAST_API_PROXY_TARGET` only when Beast controls under `/v1/beasts/*` should use a different target.
+
+From the repo root, run the same focused TypeScript check with:
+
+```bash
+npm --workspace @franken/web run typecheck
 ```
 
 ## Run with MCP Mode

--- a/tests/unit/web-readme-scripts.test.ts
+++ b/tests/unit/web-readme-scripts.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const README = readFileSync(resolve(ROOT, 'packages/franken-web/README.md'), 'utf8');
+const WEB_PACKAGE = JSON.parse(
+  readFileSync(resolve(ROOT, 'packages/franken-web/package.json'), 'utf8'),
+) as { scripts?: Record<string, string> };
+
+const userFacingScripts = ['dev', 'dev:chat', 'dev:network', 'build', 'preview', 'test', 'typecheck'];
+
+function quickStartCommandLines(): string[] {
+  const quickStart = README.slice(
+    README.indexOf('## Quick Start'),
+    README.indexOf('## Run with MCP Mode'),
+  );
+  const commandBlock = quickStart.match(/```bash\n(?<body>[\s\S]*?)\n```/)?.groups?.body;
+  expect(commandBlock, 'Quick Start must include a bash command block').toBeDefined();
+
+  return commandBlock!.split('\n').map((line) => line.trim());
+}
+
+describe('@franken/web README scripts', () => {
+  it('documents each user-facing package script in Quick Start', () => {
+    const commandLines = quickStartCommandLines();
+
+    for (const script of userFacingScripts) {
+      expect(WEB_PACKAGE.scripts?.[script], `package script ${script} must exist`).toBeDefined();
+      const command = script === 'test' ? 'npm test' : `npm run ${script}`;
+      expect(commandLines.some((line) => line.startsWith(`${command} `)), `Quick Start must document ${command}`).toBe(true);
+    }
+  });
+
+  it('explains network dev mode and web package typechecking', () => {
+    expect(README).toContain('Use `npm run dev:network` when working on the Network tab');
+    expect(README).toContain('set `VITE_API_PROXY_TARGET` when `/v1/network/*`');
+    expect(README).toContain('VITE_BEAST_API_PROXY_TARGET');
+    expect(README).toContain('npm --workspace @franken/web run typecheck');
+    expect(README).toContain('tsc --noEmit');
+  });
+});


### PR DESCRIPTION
## Summary
- document the web package dev:network and typecheck scripts in the Quick Start block
- add guidance for network dashboard development and repo-root web typecheck usage
- add a root docs regression test that keeps user-facing web scripts documented

## Test Plan
- npm run test:root -- --run tests/unit/web-readme-scripts.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm test --workspace @franken/web

Closes #951