### PR TITLE
docs: align documented node requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.34.4
           corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.34.4
           corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
+          npm install -g corepack@latest
           corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 
@@ -98,6 +99,7 @@ jobs:
 
       - name: Enable packageManager-pinned npm
         run: |
+          npm install -g corepack@latest
           corepack enable npm
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Enable packageManager-pinned npm
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Enable packageManager-pinned npm

--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ Community announcement target: share this release summary in the Frankenbeast Di
 
 Both modes share `.fbeast/beast.db`.
 
-## Prerequisites
-
-- Node.js `>=22.13.0 <23 || >=24.0.0 <26`; the local default is pinned in [.nvmrc](.nvmrc), enforced by the root `engines.node` field with `engine-strict=true`, and exercised by CI.
-- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`).
-
 ## Why This Exists
 
 LLM-based agents routinely lose safety constraints when context windows compress, hallucinate tool calls that violate architectural rules, and take destructive actions without human oversight. Frankenbeast solves this by placing safety enforcement in a deterministic pipeline that the LLM cannot bypass, forget, or summarise away.
@@ -341,8 +336,8 @@ The shipped Hono HTTP surface is integrated in `@franken/orchestrator`'s chat se
 
 ## Prerequisites
 
-- **Node.js** `>=22.13.0 <23 || >=24.0.0 <26` (see `.nvmrc` for the pinned local default; npm enforces this with `engine-strict=true`)
-- **npm** >= 10.0.0
+- **Node.js** `>=22.13.0 <23 || >=24.0.0 <26` (the local default is pinned in [.nvmrc](.nvmrc); npm enforces this with `engine-strict=true`, and CI exercises the same pinned baseline)
+- **npm** 11.5.1 via the root `packageManager` pin
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Community announcement target: share this release summary in the Frankenbeast Di
 
 Both modes share `.fbeast/beast.db`.
 
+## Prerequisites
+
+- Node.js `>=22.13.0 <23 || >=24.0.0 <26`; the local default is pinned in [.nvmrc](.nvmrc), enforced by the root `engines.node` field with `engine-strict=true`, and exercised by CI.
+- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`).
+
 ## Why This Exists
 
 LLM-based agents routinely lose safety constraints when context windows compress, hallucinate tool calls that violate architectural rules, and take destructive actions without human oversight. Frankenbeast solves this by placing safety enforcement in a deterministic pipeline that the LLM cannot bypass, forget, or summarise away.

--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -7,7 +7,7 @@ Current public API: `SqliteBrain`, `WorkingMemoryLimitError`, `DEFAULT_WORKING_M
 ## Requirements
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26` for the current package/runtime workflow
-- npm 10+
+- npm 11.5.1 via the repository `packageManager` setting
 - `better-sqlite3` (runtime dependency)
 
 ## Installation

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -19,6 +19,8 @@ describe('local setup scripts', () => {
 
     expect(read('.nvmrc').trim()).toBe('22.13.0');
     expect(read('.npmrc')).toContain('engine-strict=true');
+    expect(read('README.md')).toContain('Node.js `>=22.13.0 <23 || >=24.0.0 <26`');
+    expect(read('README.md')).toContain('local default is pinned in [.nvmrc](.nvmrc)');
     expect(read('docs/guides/quickstart.md')).toContain('npm run bootstrap -- --no-docker');
     expect(read('docs/guides/quickstart.md')).toContain('npm install -g corepack');
     expect(read('scripts/bootstrap.sh')).toContain('command -v corepack');

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -19,8 +19,10 @@ describe('local setup scripts', () => {
 
     expect(read('.nvmrc').trim()).toBe('22.13.0');
     expect(read('.npmrc')).toContain('engine-strict=true');
-    expect(read('README.md')).toContain('Node.js `>=22.13.0 <23 || >=24.0.0 <26`');
+    expect(read('README.md')).toContain('Node.js** `>=22.13.0 <23 || >=24.0.0 <26`');
     expect(read('README.md')).toContain('local default is pinned in [.nvmrc](.nvmrc)');
+    expect(read('README.md')).toContain('**npm** 11.5.1 via the root `packageManager` pin');
+    expect(read('packages/franken-brain/README.md')).toContain('npm 11.5.1 via the repository `packageManager` setting');
     expect(read('docs/guides/quickstart.md')).toContain('npm run bootstrap -- --no-docker');
     expect(read('docs/guides/quickstart.md')).toContain('npm install -g corepack');
     expect(read('scripts/bootstrap.sh')).toContain('command -v corepack');

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -103,9 +103,11 @@ on:
     });
 
     it('enables Corepack and verifies the packageManager-pinned npm before installing', () => {
+      expect(content).toContain('npm install -g corepack@latest');
       expect(content).toContain('corepack enable npm');
       expect(content).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
       expect(content).toContain('node scripts/check-package-manager.mjs');
+      expect(content.indexOf('npm install -g corepack@latest')).toBeLessThan(content.indexOf('corepack enable npm'));
       expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     });
 

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -81,13 +81,14 @@ on:
       expect(pullRequest.branches).toEqual(['main']);
     });
 
-    it('uses Node.js 22', () => {
+    it('uses the repository-pinned minimum supported Node.js version', () => {
       const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
       const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
       const setupNode = expectSteps(buildTestLint).find((step) => step.uses === 'actions/setup-node@v4');
       expect(setupNode).toBeTruthy();
       const setupNodeWith = expectRecord(setupNode?.with, 'actions/setup-node.with');
-      expect(setupNodeWith['node-version']).toBe('22');
+      expect(setupNodeWith['node-version-file']).toBe('.nvmrc');
+      expect(setupNodeWith['node-version']).toBeUndefined();
     });
 
     it('runs npm ci for deterministic installs', () => {
@@ -175,6 +176,22 @@ on:
       expect(setupNode).toBeTruthy();
       const setupNodeWith = expectRecord(setupNode?.with, 'actions/setup-node.with');
       expect(setupNodeWith.cache).toBe('npm');
+    });
+
+    it('uses the pinned minimum Node.js version in every CI setup-node step', () => {
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const nvmrc = readFileSync(resolve(ROOT, '.nvmrc'), 'utf-8').trim();
+
+      for (const [jobName, jobConfig] of Object.entries(jobs)) {
+        const job = expectRecord(jobConfig, `jobs.${jobName}`);
+        for (const step of expectSteps(job).filter((candidate) => candidate.uses === 'actions/setup-node@v4')) {
+          const setupNodeWith = expectRecord(step.with, `${jobName}.actions/setup-node.with`);
+          expect(setupNodeWith['node-version-file']).toBe('.nvmrc');
+          expect(setupNodeWith['node-version']).toBeUndefined();
+        }
+      }
+
+      expect(nvmrc).toBe('22.13.0');
     });
 
     it('uses actions/checkout with full history for root verification tests', () => {

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -103,11 +103,11 @@ on:
     });
 
     it('enables Corepack and verifies the packageManager-pinned npm before installing', () => {
-      expect(content).toContain('npm install -g corepack@latest');
+      expect(content).toContain('npm install -g corepack@0.34.4');
       expect(content).toContain('corepack enable npm');
       expect(content).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
       expect(content).toContain('node scripts/check-package-manager.mjs');
-      expect(content.indexOf('npm install -g corepack@latest')).toBeLessThan(content.indexOf('corepack enable npm'));
+      expect(content.indexOf('npm install -g corepack@0.34.4')).toBeLessThan(content.indexOf('corepack enable npm'));
       expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     });
 


### PR DESCRIPTION
## Summary
- documents the supported Node.js engine range in the root README
- switches CI setup-node steps to use `.nvmrc` so the documented lower bound is exercised
- adds regressions that keep README, package engines, `.nvmrc`, and CI aligned

## Test Plan
- npm ci
- npx vitest run tests/local-setup-scripts.test.ts tests/unit/ci-workflow.test.ts
- npm run test:root
- npm run typecheck
- npx turbo run build lint

Closes #952
