### PR TITLE
test(mcp-suite): add integration test script

### DIFF
--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -154,6 +154,21 @@ fbeast_observer_trail({ sessionId: 'fbeast-central-dispatch' })
 
 `fbeast-mcp` runs all 21 tools in a single MCP server process.
 
+## Testing
+
+```bash
+# Unit tests
+npm test
+
+# Full-cycle integration tests (real SQLite/adapters; no mocked integration seams)
+npm run test:integration
+
+# Watch mode
+npm run test:watch
+```
+
+`test:integration` targets the package's `src/**/*.integration.test.ts` files, including the full-cycle MCP suite. The suite runs deterministically without a Codex CLI installation: Codex-specific prerequisite assertions are skipped when the `codex` binary is unavailable, while the remaining database and adapter integration checks still execute.
+
 ## Hooks
 
 When installed with `--hooks`, `fbeast-hook` provides governance and audit on every tool call:

--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -31,6 +31,7 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --reporter=verbose",
+    "test:integration": "vitest run --reporter=verbose src/**/*.integration.test.ts",
     "test:watch": "vitest --reporter=verbose",
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm --prefix ../.. run build"

--- a/packages/franken-mcp-suite/src/shared/package-scripts.test.ts
+++ b/packages/franken-mcp-suite/src/shared/package-scripts.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function readPackageJson(): { scripts?: Record<string, string> } {
+  return JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as {
+    scripts?: Record<string, string>;
+  };
+}
+
+function readReadme(): string {
+  return readFileSync(join(packageRoot, 'README.md'), 'utf-8');
+}
+
+describe('package testing scripts', () => {
+  it('exposes and documents a discoverable integration test command', () => {
+    const scripts = readPackageJson().scripts ?? {};
+
+    expect(scripts['test:integration']).toBe('vitest run --reporter=verbose src/**/*.integration.test.ts');
+    expect(scripts['test:integration']).toContain('src/**/*.integration.test.ts');
+    expect(readReadme()).toContain('npm run test:integration');
+    expect(readReadme()).toContain('Codex-specific prerequisite assertions are skipped');
+  });
+});


### PR DESCRIPTION
## Summary
- add a discoverable `test:integration` package script for `@franken/mcp-suite`
- document how to run MCP suite unit/integration/watch tests and Codex skip behavior
- add a regression test that keeps the integration script and README guidance present

## Test Plan
- `npm --workspace @franken/mcp-suite test -- src/shared/package-scripts.test.ts`
- `npm --workspace @franken/mcp-suite run test:integration`
- `npm --workspace @franken/mcp-suite run typecheck`
- `npm --workspace @franken/mcp-suite run build`
- `npm --workspace @franken/mcp-suite test`
- `PATH=<temp node/npm without codex> npm --workspace @franken/mcp-suite exec -- vitest run --reporter=verbose src/integration/full-cycle.integration.test.ts`

Closes #947