### PR TITLE
chore(ci): expose shared test:ci target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
 
       - run: npm run audit:security
 
-      - name: Run deterministic root Vitest suite
-        run: npm run ci:test:root
-
       - name: Run Docker sandbox build smoke test
         run: npm run test:docker:sandbox
 
@@ -79,8 +76,8 @@ jobs:
       - name: Run package build and lint
         run: npx turbo run build lint
 
-      - name: Run package tests
-        run: npm run ci:test:packages
+      - name: Run CI test suite
+        run: npm run test:ci
 
       - name: Phantom dependency check (every runtime import is declared)
         run: node scripts/check-phantom-deps.mjs

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -69,7 +69,7 @@ npm run typecheck
 npm test
 ```
 
-Root scripts currently include `build`, `typecheck`, `test`, `test:live:bench`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts. `test:live:bench` is an explicit opt-in for the live benchmark suite and delegates to the gated `@franken/live-bench` `test:live` task, which sets `FBEAST_LIVE_BENCH_E2E=1`.
+Root scripts currently include `build`, `typecheck`, `test`, `test:ci`, `test:live:bench`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts. Use `test:ci` for the same root-plus-package test target that CI runs locally; it first builds the shared `@franken/types` workspace so fresh checkouts can resolve workspace package exports, and it intentionally excludes Docker smoke, security, dependency, lint, and live/e2e gates that remain separate CI steps. `test:live:bench` is an explicit opt-in for the live benchmark suite and delegates to the gated `@franken/live-bench` `test:live` task, which sets `FBEAST_LIVE_BENCH_E2E=1`.
 
 ## 5. Try the orchestrator CLI
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "test": "turbo run test",
+    "test:ci": "npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages",
     "test:live:bench": "turbo run test:live --filter=@franken/live-bench",
     "ci:test:root": "node scripts/retry-ci-command.mjs -- npm run test:root",
     "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = join(import.meta.dirname, '..');
 const readJson = (rel: string) =>
   JSON.parse(readFileSync(join(ROOT, rel), 'utf8'));
+const readPackageScripts = () =>
+  readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const manifestPath = join('packages', entry.name, 'package.json');
+      if (!existsSync(join(ROOT, manifestPath))) {
+        return [];
+      }
+      const manifest = readJson(manifestPath);
+      return [manifest.scripts ?? {}];
+    });
 
 describe('Turborepo configuration', () => {
   describe('turbo.json', () => {
@@ -49,11 +60,33 @@ describe('Turborepo configuration', () => {
       );
     });
 
-    it('defines test:ci task with package build dependency for CI ordering', () => {
+    it('does not define a stale test:ci Turbo task', () => {
       const turbo = readJson('turbo.json');
-      const testCiTask = turbo.tasks?.['test:ci'];
-      expect(testCiTask).toBeDefined();
-      expect(testCiTask.dependsOn).toContain('build');
+      expect(turbo.tasks?.['test:ci']).toBeUndefined();
+    });
+
+    it('keeps every Turbo task discoverable from root or package scripts', () => {
+      const turbo = readJson('turbo.json');
+      const rootPkg = readJson('package.json');
+      const packageScripts = readPackageScripts();
+
+      for (const taskName of Object.keys(turbo.tasks ?? {})) {
+        const hasRootScript = rootPkg.scripts?.[taskName] != null;
+        const hasPackageScript = packageScripts.some(
+          (scripts) => scripts[taskName] != null,
+        );
+        const hasRootScriptDelegatingToTask = Object.values(
+          rootPkg.scripts ?? {},
+        ).some(
+          (script) =>
+            typeof script === 'string' &&
+            script.includes(`turbo run ${taskName}`),
+        );
+
+        expect(
+          hasRootScript || hasPackageScript || hasRootScriptDelegatingToTask,
+        ).toBe(true);
+      }
     });
 
     it('defines an explicit live-bench live test task', () => {
@@ -114,6 +147,18 @@ describe('Turborepo configuration', () => {
 
     it('test script uses turbo run test', () => {
       expect(rootPkg.scripts.test).toBe('turbo run test');
+    });
+
+    it('test:ci script runs the same root-plus-package test target as CI', () => {
+      expect(rootPkg.scripts['test:ci']).toBe(
+        'npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages',
+      );
+
+      const ciWorkflow = readFileSync(
+        join(ROOT, '.github/workflows/ci.yml'),
+        'utf8',
+      );
+      expect(ciWorkflow).toContain('run: npm run test:ci');
     });
 
     it('typecheck script uses turbo run typecheck', () => {

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -108,18 +108,24 @@ on:
       expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     });
 
-    it('builds before running package tests in CI', () => {
+    it('builds before running the shared CI test target', () => {
       expect(content).toContain('turbo run');
-      expect(content).toMatch(/turbo run build lint[\s\S]*npm run ci:test:packages/);
-      expect(content.indexOf('turbo run build lint')).toBeLessThan(content.indexOf('npm run ci:test:packages'));
+      expect(content).toMatch(/turbo run build lint[\s\S]*npm run test:ci/);
+      expect(content.indexOf('turbo run build lint')).toBeLessThan(content.indexOf('npm run test:ci'));
       expect(content).not.toMatch(/turbo run.*build\s+test\s+lint/);
     });
 
-    it('runs the deterministic root Vitest suite separately from Turbo', () => {
-      expect(content).toMatch(/name:\s*Run deterministic root Vitest suite/);
-      expect(content).toContain('npm run ci:test:root');
+    it('runs the deterministic root Vitest suite through the shared CI test script', () => {
+      const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+        scripts?: Record<string, string>;
+      };
+
+      expect(content).toMatch(/name:\s*Run CI test suite/);
+      expect(packageJson.scripts?.['test:ci']).toContain('npm run ci:test:root');
       expect(content).not.toMatch(/npm run test:root --/);
-      expect(content.indexOf('npm run ci:test:root')).toBeLessThan(content.indexOf('npm run ci:test:packages'));
+      expect(packageJson.scripts?.['test:ci']?.indexOf('npm run ci:test:root')).toBeLessThan(
+        packageJson.scripts?.['test:ci']?.indexOf('npm run ci:test:packages') ?? -1,
+      );
     });
 
     it('runs a bootstrap dry-run after deterministic install and fails the workflow on prerequisite errors', () => {
@@ -134,7 +140,7 @@ on:
       expect(content).toContain('deterministic-seed');
       expect(content).toContain("deterministic-seed: ['1337']");
       expect(content).toContain('FRANKENBEAST_SEED: ${{ matrix.deterministic-seed }}');
-      expect(content.indexOf('FRANKENBEAST_SEED')).toBeLessThan(content.indexOf('npm run ci:test:root'));
+      expect(content.indexOf('FRANKENBEAST_SEED')).toBeLessThan(content.indexOf('npm run test:ci'));
     });
 
     it('runs test commands through a configurable retry wrapper', () => {
@@ -145,16 +151,19 @@ on:
       expect(content).toContain("CI_TEST_RETRIES: ${{ vars.CI_TEST_RETRIES || '2' }}");
       expect(packageJson.scripts?.['ci:test:root']).toBe('node scripts/retry-ci-command.mjs -- npm run test:root');
       expect(packageJson.scripts?.['ci:test:packages']).toBe('node scripts/retry-ci-command.mjs -- npx turbo run test');
-      expect(content).toContain('npm run ci:test:root');
-      expect(content).toContain('npm run ci:test:packages');
+      expect(packageJson.scripts?.['test:ci']).toBe(
+        'npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages',
+      );
+      expect(content).toContain('npm run test:ci');
+      expect(content).not.toContain('run: npm run ci:test:root');
+      expect(content).not.toContain('run: npm run ci:test:packages');
       expect(content).not.toContain('run: npm run test:root');
       expect(content).not.toContain('run: npx turbo run test');
     });
 
-    it('documents the root-suite and package-Turbo CI split in step names', () => {
+    it('documents the package build and shared CI test target in step names', () => {
       expect(content).toMatch(/name:\s*Run package build and lint/);
-      expect(content).toMatch(/name:\s*Run package tests/);
-      expect(content).toMatch(/name:\s*Run deterministic root Vitest suite/);
+      expect(content).toMatch(/name:\s*Run CI test suite/);
     });
 
     it('keeps workflow linting in a dedicated workflow so broken ci.yml syntax can be reported', () => {

--- a/tests/unit/todo-markers.test.ts
+++ b/tests/unit/todo-markers.test.ts
@@ -38,7 +38,8 @@ describe('code comment debt marker scanner', () => {
 
     expect(packageJson.scripts?.['audit:todos']).toBe('node scripts/audit-todo-markers.mjs');
     expect(packageJson.scripts?.['lint:security']).toContain('node scripts/audit-todo-markers.mjs');
-    expect(workflow).toContain('npm run ci:test:root');
+    expect(packageJson.scripts?.['test:ci']).toContain('npm run ci:test:root');
+    expect(workflow).toContain('npm run test:ci');
     expect(workflow).not.toMatch(/npm run test:root --/);
     expect(workflow).toContain('npm run audit:todos');
   });

--- a/turbo.json
+++ b/turbo.json
@@ -14,9 +14,6 @@
       ],
       "env": ["INTEGRATION", "E2E", "EVAL", "DOCKER_BUILD"]
     },
-    "test:ci": {
-      "dependsOn": ["build"]
-    },
     "test:live": {
       "dependsOn": ["build"],
       "cache": false,


### PR DESCRIPTION
## Summary
- add a root `test:ci` script that matches the CI root-plus-package test target
- remove the unused Turbo `test:ci` task and route CI through the root script
- update workflow/script invariant tests and quickstart docs

## Test Plan
- npm run test:root -- tests/turborepo.test.ts tests/unit/ci-workflow.test.ts tests/unit/todo-markers.test.ts
- npm run test:ci (root suite passed; package suite reached @franken/observer timeout under full Turbo load)
- npm run test --workspace @franken/observer -- src/vitest-discovery.test.ts
- npx turbo run build lint

Closes #944