### PR TITLE
docs(readme): clarify checkpoint resume behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ frankenbeast --design-doc docs/my-feature-design.md
 frankenbeast --plan-dir ./my-chunks/
 ```
 
-Cold `frankenbeast run` clears checkpoint/chunk-session state before execution. Use `--resume` to preserve existing checkpoint data and continue an interrupted run; when no checkpoint exists, `--resume` fails fast instead of silently behaving like a cold run.
+Cold `frankenbeast run` clears checkpoint/chunk-session state before execution. Use `frankenbeast run --resume` when a previous run was interrupted and you want to continue from the saved checkpoint/chunk-session data. If the checkpoint is missing, the resume command fails fast with a missing-checkpoint error instead of silently starting a cold run.
 
 ### Subcommands
 


### PR DESCRIPTION
## Summary
- Clarifies that `frankenbeast run --resume` now resumes interrupted runs from checkpoint/chunk-session data.
- Documents the missing-checkpoint failure behavior instead of implying resume is unwired or silently cold-started.

## Test Plan
- npm run check:package-manager

Closes #942