### PR TITLE
fix(planner): preserve fix task dependencies

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -190,8 +190,12 @@ export class PlanGraph {
       return { ...task, dependsOn: this.getDependencies(task.id) };
     });
 
+    const fixTaskDependencies = [
+      ...new Set([...this.getDependencies(failedTaskId), ...fixTask.dependsOn]),
+    ];
+
     return PlanGraph.fromTasks(
-      [...tasks, { ...fixTask, dependsOn: this.getDependencies(failedTaskId) }],
+      [...tasks, { ...fixTask, dependsOn: fixTaskDependencies }],
       {
         version: this.version + 1,
         reason: `recovery: fix-it injected before '${failedTaskId}'`,

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -246,6 +246,81 @@ describe('PlanGraph — removeTask', () => {
   });
 });
 
+describe('PlanGraph — insertFixItTask', () => {
+  it('inserts a fix task before the failed task', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+
+    const g2 = g.insertFixItTask(createTaskId('b'), makeTask('fix-b'));
+
+    expect(g2.size()).toBe(3);
+    expect(g2.getDependencies(createTaskId('fix-b'))).toEqual([createTaskId('a')]);
+    expect(g2.getDependencies(createTaskId('b'))).toEqual([createTaskId('fix-b')]);
+    expect(g2.getTask(createTaskId('fix-b'))?.dependsOn).toEqual([createTaskId('a')]);
+    expect(g2.getTask(createTaskId('b'))?.dependsOn).toEqual([createTaskId('fix-b')]);
+  });
+
+  it('preserves explicit fix task dependencies when inserting before a failed task', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('setup'))
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+    const fix = makeTask('fix-b', { dependsOn: [createTaskId('setup')] });
+
+    const g2 = g.insertFixItTask(createTaskId('b'), fix);
+
+    expect(g2.getDependencies(createTaskId('fix-b'))).toEqual([
+      createTaskId('a'),
+      createTaskId('setup'),
+    ]);
+    expect(g2.getTask(createTaskId('fix-b'))?.dependsOn).toEqual([
+      createTaskId('a'),
+      createTaskId('setup'),
+    ]);
+    expect(g2.getDependencies(createTaskId('b'))).toEqual([createTaskId('fix-b')]);
+    expect(g2.getTask(createTaskId('b'))?.dependsOn).toEqual([createTaskId('fix-b')]);
+  });
+
+  it('is immutable and increments the recovery version', () => {
+    const g = PlanGraph.empty().addTask(makeTask('a'));
+
+    const g2 = g.insertFixItTask(createTaskId('a'), makeTask('fix-a'));
+
+    expect(g.size()).toBe(1);
+    expect(g2.version).toBe(g.version + 1);
+    expect(g2.reason).toMatch(/recovery/i);
+  });
+
+  it('throws when the target task is missing or the fix task id already exists', () => {
+    expect(() =>
+      PlanGraph.empty().insertFixItTask(createTaskId('missing'), makeTask('fix'))
+    ).toThrowError(TaskNotFoundError);
+
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+    expect(() => g.insertFixItTask(createTaskId('b'), makeTask('a'))).toThrowError(
+      DuplicateTaskError
+    );
+  });
+
+  it('sorts the fix task before the failed task', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+
+    const sorted = g
+      .insertFixItTask(createTaskId('b'), makeTask('fix-b'))
+      .topoSort()
+      .map((t) => t.id);
+
+    expect(sorted.indexOf(createTaskId('fix-b'))).toBeLessThan(
+      sorted.indexOf(createTaskId('b'))
+    );
+  });
+});
+
 
 describe('PlanGraph — fromTasks', () => {
   it('builds a graph from tasks supplied in dependency-last order', () => {


### PR DESCRIPTION
## Summary
- Merge incoming fix task dependencies with the failed task's existing dependencies in PlanGraph.insertFixItTask
- Add PlanGraph regression coverage for preserved fix task prerequisites and insertion behavior

## Test Plan
- npm run test --workspace @franken/planner -- tests/unit/core/dag.test.ts
- npm run test --workspace @franken/planner
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/planner && npm run build --workspace @franken/planner
- npm run lint --workspace @franken/planner

Closes #938