### PR TITLE
fix(mcp): tolerate skills adapter filesystem races

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/skills-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/skills-adapter.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsMockState = vi.hoisted(() => ({
+  readdirFailures: new Set<string>(),
+  readFailures: new Set<string>(),
+  statFailures: new Set<string>(),
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+
+  return {
+    ...actual,
+    readdirSync: (path: Parameters<typeof actual.readdirSync>[0], options?: Parameters<typeof actual.readdirSync>[1]) => {
+      if (fsMockState.readdirFailures.has(String(path))) {
+        throw Object.assign(new Error(`simulated readdir failure for ${String(path)}`), { code: 'ENOENT' });
+      }
+      return actual.readdirSync(path, options as never);
+    },
+    readFileSync: (path: Parameters<typeof actual.readFileSync>[0], options?: Parameters<typeof actual.readFileSync>[1]) => {
+      if (fsMockState.readFailures.has(String(path))) {
+        throw Object.assign(new Error(`simulated read failure for ${String(path)}`), { code: 'EACCES' });
+      }
+      return actual.readFileSync(path, options as never);
+    },
+    statSync: (path: Parameters<typeof actual.statSync>[0], options?: Parameters<typeof actual.statSync>[1]) => {
+      if (fsMockState.statFailures.has(String(path))) {
+        throw Object.assign(new Error(`simulated stat failure for ${String(path)}`), { code: 'ENOENT' });
+      }
+      return actual.statSync(path, options as never);
+    },
+  };
+});
+
+const { createSkillsAdapter } = await import('./skills-adapter.js');
+
+describe('SkillsAdapter filesystem race handling', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    fsMockState.readdirFailures.clear();
+    fsMockState.readFailures.clear();
+    fsMockState.statFailures.clear();
+    root = await mkdtemp(join(tmpdir(), 'skills-adapter-'));
+    await mkdir(join(root, 'skills'), { recursive: true });
+    await writeFile(join(root, 'config.json'), JSON.stringify({ skills: { enabled: ['stable', 'flaky'] } }));
+  });
+
+  afterEach(async () => {
+    fsMockState.readdirFailures.clear();
+    fsMockState.readFailures.clear();
+    fsMockState.statFailures.clear();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns an empty skill list when the skills directory disappears after the existence check', async () => {
+    const skillsDir = join(root, 'skills');
+    fsMockState.readdirFailures.add(skillsDir);
+
+    await expect(createSkillsAdapter(join(root, 'beast.db')).list({})).resolves.toEqual([]);
+  });
+
+  it('skips a skill whose directory disappears between discovery and stat', async () => {
+    await createSkill('stable', { context: '# Stable skill\nUseful.' });
+    await createSkill('flaky');
+    fsMockState.statFailures.add(join(root, 'skills', 'flaky'));
+
+    const rows = await createSkillsAdapter(join(root, 'beast.db')).list({});
+
+    expect(rows.map((row) => row.name)).toEqual(['stable']);
+  });
+
+  it('loads skill info without throwing when context.md becomes unreadable after existsSync', async () => {
+    const contextPath = await createSkill('flaky', { context: '# Flaky skill\nUseful.' });
+    fsMockState.readFailures.add(contextPath);
+
+    const info = await createSkillsAdapter(join(root, 'beast.db')).info('flaky');
+
+    expect(info).toMatchObject({
+      name: 'flaky',
+      enabled: true,
+      hasContext: true,
+      context: undefined,
+      tools: [],
+    });
+  });
+
+  async function createSkill(name: string, options: { context?: string; mcp?: unknown } = {}): Promise<string> {
+    const skillDir = join(root, 'skills', name);
+    const contextPath = join(skillDir, 'context.md');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'mcp.json'),
+      JSON.stringify(options.mcp ?? { mcpServers: { [`${name}-server`]: { command: name } } }),
+    );
+    if (options.context !== undefined) {
+      await writeFile(contextPath, options.context);
+    }
+    return contextPath;
+  }
+});

--- a/packages/franken-mcp-suite/src/adapters/skills-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/skills-adapter.ts
@@ -49,10 +49,12 @@ export function createSkillsAdapter(dbPathOrDeps: string | SkillsAdapterDeps): S
       const toolsPath = join(skillDir, 'tools.json');
       const mcpPath = join(skillDir, 'mcp.json');
 
+      const context = readOptionalTextFile(contextPath);
+
       return {
         ...summary,
         hasContext: existsSync(contextPath),
-        context: existsSync(contextPath) ? readFileSync(contextPath, 'utf8') : undefined,
+        context,
         mcpConfig: readJsonFile(mcpPath),
         tools: readJsonFile(toolsPath) ?? [],
       };
@@ -65,7 +67,14 @@ function listInstalledSkills(skillsDir: string, enabledSkills: Set<string>): Ski
     return [];
   }
 
-  return readdirSync(skillsDir, { withFileTypes: true })
+  let entries;
+  try {
+    entries = readdirSync(skillsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => readSkillSummary(skillsDir, entry.name, enabledSkills))
     .filter((entry): entry is SkillsListEntry => entry !== undefined)
@@ -84,7 +93,13 @@ function readSkillSummary(
     return undefined;
   }
 
-  const stat = statSync(skillDir);
+  let stat;
+  try {
+    stat = statSync(skillDir);
+  } catch {
+    return undefined;
+  }
+
   return {
     name,
     enabled: enabledSkills.has(name),
@@ -95,8 +110,9 @@ function readSkillSummary(
 
 function inferDescription(skillDir: string, name: string): string {
   const contextPath = join(skillDir, 'context.md');
-  if (existsSync(contextPath)) {
-    const firstMeaningfulLine = readFileSync(contextPath, 'utf8')
+  const context = readOptionalTextFile(contextPath);
+  if (context !== undefined) {
+    const firstMeaningfulLine = context
       .split('\n')
       .map((line) => line.trim())
       .find((line) => line.length > 0);
@@ -134,6 +150,18 @@ function readJsonFile(path: string): unknown {
 
   try {
     return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalTextFile(path: string): string | undefined {
+  if (!existsSync(path)) {
+    return undefined;
+  }
+
+  try {
+    return readFileSync(path, 'utf8');
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- Wrap SkillsAdapter directory enumeration, per-skill stat, and context reads so transient filesystem TOCTOU failures do not crash skill list/discover/load calls.
- Skip entries that disappear during discovery and treat unreadable optional context as absent while keeping skill metadata available.
- Add regression coverage for readdir/stat/read races around the skills adapter.

## Test Plan
- npm ci
- npm test --workspace @franken/mcp-suite -- --run src/adapters/skills-adapter.test.ts src/servers/skills.test.ts
- npm run build --workspace @franken/types --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/observer --workspace @franken/orchestrator --workspace @franken/planner (first orchestrator pass failed before planner dist existed; reran orchestrator after planner build)
- npm run build --workspace @franken/orchestrator
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite
- npm test --workspace @franken/mcp-suite

Closes #935