### PR TITLE
fix(observer): reject traces with active spans

### DIFF
--- a/packages/franken-observer/src/core/TraceContext.test.ts
+++ b/packages/franken-observer/src/core/TraceContext.test.ts
@@ -120,6 +120,19 @@ describe('TraceContext', () => {
       TraceContext.endTrace(trace)
       expect(() => TraceContext.endTrace(trace)).toThrow()
     })
+
+    it('throws without completing the trace if any span is still active', () => {
+      const trace = TraceContext.createTrace('goal')
+      const active = TraceContext.startSpan(trace, { name: 'active-step' })
+      const closed = TraceContext.startSpan(trace, { name: 'closed-step' })
+      TraceContext.endSpan(closed)
+
+      expect(() => TraceContext.endTrace(trace)).toThrow(/Cannot end trace with 1 active span/)
+      expect(trace.status).toBe('active')
+      expect(trace.endedAt).toBeUndefined()
+      expect(active.status).toBe('active')
+      expect(active.endedAt).toBeUndefined()
+    })
   })
 
   describe('validateTrace()', () => {

--- a/packages/franken-observer/src/core/TraceContext.ts
+++ b/packages/franken-observer/src/core/TraceContext.ts
@@ -43,8 +43,9 @@ export const TraceContext = {
     if (span.status !== 'active') {
       throw new Error(`Cannot end span that is already ${span.status} (id: ${span.id})`)
     }
-    span.endedAt = wallClockNow()
-    span.durationMs = span.endedAt - span.startedAt
+    const endedAt = wallClockNow()
+    span.endedAt = endedAt
+    span.durationMs = endedAt - span.startedAt
     span.status = options.status ?? 'completed'
     if (options.errorMessage !== undefined) {
       span.errorMessage = options.errorMessage
@@ -55,6 +56,15 @@ export const TraceContext = {
   endTrace(trace: Trace): void {
     if (trace.status !== 'active') {
       throw new Error(`Cannot end trace that is already ${trace.status} (id: ${trace.id})`)
+    }
+    const activeSpans = trace.spans.filter(span => span.status === 'active')
+    if (activeSpans.length > 0) {
+      const activeSpanSummary = activeSpans
+        .map(span => `"${span.name}" (${span.id})`)
+        .join(', ')
+      throw new Error(
+        `Cannot end trace with ${activeSpans.length} active span(s): ${activeSpanSummary} (trace id: ${trace.id})`,
+      )
     }
     trace.endedAt = wallClockNow()
     trace.status = 'completed'


### PR DESCRIPTION
## Summary
- Reject TraceContext.endTrace() while child spans are still active
- Preserve the trace/span active state on rejected end attempts
- Add regression coverage for completed-trace/active-span invariant

## Test Plan
- npm run build --workspace @franken/types
- npm --prefix packages/franken-observer test -- TraceContext.test.ts
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run build

Closes #1074