### PR TITLE
test: expose root e2e test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,11 +562,11 @@ npm run test:e2e
 ```
 
 The E2E suites are opt-in and remain outside the regular `npm test` path. Before
-running them, build the orchestrator artifacts with
-`npm run build --workspace @franken/orchestrator`, install a real `claude` CLI on
-`PATH`, and provide a valid `ANTHROPIC_API_KEY` in the environment. The root
-`test:e2e` script delegates to the workspace script, which sets `E2E=true` for
-the gated suites.
+running them from a clean checkout, run the dependency-aware root build with
+`npm run build`, install a real `claude` CLI on `PATH`, and provide a valid
+`ANTHROPIC_API_KEY` in the environment. The root `test:e2e` script delegates to
+the workspace script, which sets `E2E=true` for the gated suites and forwards
+Vitest arguments after `--`.
 
 ## Local Dev Environment
 

--- a/README.md
+++ b/README.md
@@ -557,9 +557,16 @@ npm test
 # Per-package tests via Turborepo
 npx turbo run test --filter=franken-brain
 
-# Orchestrator E2E tests
-cd packages/franken-orchestrator && npm run test:e2e
+# Orchestrator E2E tests (sets E2E=true and delegates to @franken/orchestrator)
+npm run test:e2e
 ```
+
+The E2E suites are opt-in and remain outside the regular `npm test` path. Before
+running them, build the orchestrator artifacts with
+`npm run build --workspace @franken/orchestrator`, install a real `claude` CLI on
+`PATH`, and provide a valid `ANTHROPIC_API_KEY` in the environment. The root
+`test:e2e` script delegates to the workspace script, which sets `E2E=true` for
+the gated suites.
 
 ## Local Dev Environment
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "test": "turbo run test",
     "test:ci": "npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages",
+    "test:e2e": "npm run test:e2e --workspace @franken/orchestrator",
     "test:live:bench": "turbo run test:live --filter=@franken/live-bench",
     "ci:test:root": "node scripts/retry-ci-command.mjs -- npm run test:root",
     "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "test": "turbo run test",
     "test:ci": "npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages",
-    "test:e2e": "npm run test:e2e --workspace @franken/orchestrator",
+    "test:e2e": "npm run test:e2e --workspace @franken/orchestrator --",
     "test:live:bench": "turbo run test:live --filter=@franken/live-bench",
     "ci:test:root": "node scripts/retry-ci-command.mjs -- npm run test:root",
     "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -173,6 +173,17 @@ describe('Turborepo configuration', () => {
       expect(rootPkg.scripts['test:root']).toBe('vitest run');
     });
 
+    it('exposes orchestrator E2E tests through a root script', () => {
+      const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
+
+      expect(rootPkg.scripts['test:e2e']).toBe('npm run test:e2e --workspace @franken/orchestrator');
+      expect(readme).toContain('npm run test:e2e');
+      expect(readme).toContain('E2E=true');
+      expect(readme).toContain('npm run build --workspace @franken/orchestrator');
+      expect(readme).toContain('real `claude` CLI on');
+      expect(readme).toContain('valid `ANTHROPIC_API_KEY` in the environment');
+    });
+
     it('keeps test:root:watch as vitest for dev', () => {
       expect(rootPkg.scripts['test:root:watch']).toBe('vitest');
     });

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -176,12 +176,14 @@ describe('Turborepo configuration', () => {
     it('exposes orchestrator E2E tests through a root script', () => {
       const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
 
-      expect(rootPkg.scripts['test:e2e']).toBe('npm run test:e2e --workspace @franken/orchestrator');
+      expect(rootPkg.scripts['test:e2e']).toBe('npm run test:e2e --workspace @franken/orchestrator --');
       expect(readme).toContain('npm run test:e2e');
       expect(readme).toContain('E2E=true');
-      expect(readme).toContain('npm run build --workspace @franken/orchestrator');
+      expect(readme).toContain('npm run build');
+      expect(readme).not.toContain('npm run build --workspace @franken/orchestrator');
       expect(readme).toContain('real `claude` CLI on');
-      expect(readme).toContain('valid `ANTHROPIC_API_KEY` in the environment');
+      expect(readme).toContain('provide a valid');
+      expect(readme).toContain('`ANTHROPIC_API_KEY` in the environment');
     });
 
     it('keeps test:root:watch as vitest for dev', () => {


### PR DESCRIPTION
## Summary
- add root npm run test:e2e script delegating to @franken/orchestrator
- document E2E opt-in behavior and required build/CLI/API-key prerequisites
- add regression coverage for script/docs discoverability

## Test Plan
- npm run test:root -- tests/turborepo.test.ts tests/vitest-env.test.ts
- npm run typecheck
- npm run lint:any
- npm run build

Closes #928