### PR TITLE
fix(brain): replace hydrated sqlite snapshot rows

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -456,8 +456,8 @@ export class SqliteBrain implements IBrain {
 
     try {
       const insertEvent = brain.db.prepare(
-        `INSERT INTO episodic_events (type, step, summary, details, created_at)
-         VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO episodic_events (id, type, step, summary, details, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
       );
       const insertCheckpoint = brain.db.prepare(
         `INSERT INTO checkpoints (state, created_at) VALUES (?, ?)`,
@@ -472,6 +472,7 @@ export class SqliteBrain implements IBrain {
 
         for (const event of snapshot.episodic) {
           insertEvent.run(
+            event.id ?? null,
             event.type,
             event.step ?? null,
             event.summary,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -467,6 +467,9 @@ export class SqliteBrain implements IBrain {
         brain.working.restore(snapshot.working);
         brain.working.flushToDb();
 
+        brain.db.prepare(`DELETE FROM episodic_events`).run();
+        brain.db.prepare(`DELETE FROM checkpoints`).run();
+
         for (const event of snapshot.episodic) {
           insertEvent.run(
             event.type,

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -416,6 +416,43 @@ describe('SqliteBrain', () => {
       brain2.close();
     });
 
+    it('hydrate() replaces existing persistent database rows without duplicating snapshot data', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        brain.working.set('task', 'snapshot');
+        brain.episodic.record({
+          type: 'success',
+          summary: 'hydrated once only',
+          createdAt: '2026-07-10T00:00:00Z',
+        });
+        brain.recovery.checkpoint({
+          runId: 'run-1',
+          phase: 'execution',
+          step: 1,
+          context: {},
+          timestamp: '2026-07-10T00:01:00Z',
+        });
+        const snapshot = brain.serialize();
+
+        const first = SqliteBrain.hydrate(snapshot, dbPath);
+        first.close();
+        const second = SqliteBrain.hydrate(snapshot, dbPath);
+
+        expect(second.working.snapshot()).toEqual({ task: 'snapshot' });
+        expect(second.episodic.count()).toBe(1);
+        expect(second.episodic.recent(10).map(event => event.summary)).toEqual([
+          'hydrated once only',
+        ]);
+        expect(second.recovery.listCheckpoints()).toHaveLength(1);
+        expect(second.recovery.lastCheckpoint()?.runId).toBe('run-1');
+        second.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('round-trips with null checkpoint', () => {
       brain.working.set('key', 'val');
       const snapshot = brain.serialize();

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -442,9 +442,8 @@ describe('SqliteBrain', () => {
 
         expect(second.working.snapshot()).toEqual({ task: 'snapshot' });
         expect(second.episodic.count()).toBe(1);
-        expect(second.episodic.recent(10).map(event => event.summary)).toEqual([
-          'hydrated once only',
-        ]);
+        expect(second.episodic.recent(10)).toEqual(snapshot.episodic);
+        expect(second.serialize().episodic).toEqual(snapshot.episodic);
         expect(second.recovery.listCheckpoints()).toHaveLength(1);
         expect(second.recovery.lastCheckpoint()?.runId).toBe('run-1');
         second.close();


### PR DESCRIPTION
## Summary
- Clear persisted episodic events and checkpoints inside SqliteBrain.hydrate's restore transaction before replaying a snapshot
- Keep working memory replacement behavior atomic with the snapshot restore
- Add a persistent SQLite regression that hydrates the same snapshot twice and verifies rows do not duplicate

## Test Plan
- npm test --workspace @franken/brain
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/brain && npm run build --workspace @franken/brain
- npm run lint --workspace @franken/brain
- npx turbo run test --filter=@franken/brain
- npx turbo run typecheck --filter=@franken/brain
- npx turbo run build --filter=@franken/brain
- npx turbo run lint --filter=@franken/brain
- npx turbo run test --filter=@franken/orchestrator

Closes #920