### PR TITLE
fix(orchestrator): clear stop exit telemetry

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -10,7 +10,7 @@ import {
   type BeastWorktreeAllocation,
   type GitWorktreeIsolationConfig,
 } from './git-worktree-isolation.js';
-import { isoNow, wallClockNow } from '@franken/types';
+import { wallClockNow } from '@franken/types';
 import type { ProcessSupervisorLike } from './process-supervisor.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
@@ -753,6 +753,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       status,
       finishedAt,
       stopReason,
+      latestExitCode: null,
     });
     const finishEvent = {
       attemptId: attempt.id,

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -761,6 +761,40 @@ describe('ProcessBeastExecutor', () => {
     });
   });
 
+  it('clears stale failure telemetry when an operator-stopped process exits by signal', async () => {
+    workDir = await createTempWorkDir();
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    let capturedCallbacks: ProcessCallbacks | undefined;
+    const supervisor = {
+      spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+        capturedCallbacks = callbacks as ProcessCallbacks;
+        return { pid: 777 };
+      }),
+      stop: vi.fn(async () => {
+        capturedCallbacks?.onExit(null, 'SIGTERM');
+      }),
+      kill: vi.fn(async () => {}),
+    };
+    const executor = new ProcessBeastExecutor(repo, logs, supervisor, { defaultStopTimeoutMs: 100 });
+    const run = createTestRun(repo);
+    repo.updateRun(run.id, {
+      status: 'failed',
+      stopReason: 'signal_SIGTERM',
+      latestExitCode: 143,
+      finishedAt: '2026-03-10T00:00:01.000Z',
+    });
+
+    const attempt = await executor.start(run, martinLoopDefinition);
+    await executor.stop(run.id, attempt.id);
+
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'stopped',
+      stopReason: 'operator_stop',
+    });
+    expect(repo.getRun(run.id)?.latestExitCode).toBeUndefined();
+  });
+
   it('clears operator-stop bookkeeping when stop dispatch fails', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));


### PR DESCRIPTION
## Summary
- clear stale run-level latestExitCode when an operator stop finishes an attempt
- add a regression for SIGTERM exits during operator stop after stale failure telemetry exists
- remove an unused ProcessBeastExecutor import while touching the file

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/process-beast-executor.test.ts
- npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner && npm --prefix packages/franken-orchestrator run typecheck && npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator run lint (passes with pre-existing warnings)

Closes #1452