### PR TITLE
docs(readme): add onboarding quick-start block

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@
 
 Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's context window. Every check that can be deterministic is deterministic — regex-based injection scanning, schema validation, dependency whitelisting, DAG cycle detection, HMAC signature verification. These do not hallucinate.
 
+## 🚀 One-click onboarding
+
+Starting from a fresh checkout? Use the [Frankenbeast onboarding checklist](ONBOARDING.md) for prerequisites, environment setup, and first-run validation, then run the repository bootstrap script:
+
+```bash
+npm run bootstrap -- --no-docker
+```
+
+The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. To preview the checks without changing files or installing packages, run:
+
+```bash
+./scripts/bootstrap.sh --dry-run
+```
+
 ## Latest release announcement
 
 [Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0) is the latest Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates.

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -145,7 +145,12 @@ describe('local setup scripts', () => {
     expect(script).toContain('GRAFANA_USER=admin');
     expect(script).toContain('npm ci');
     expect(script).toContain('docker compose up -d');
+    expect(readme).toContain('## 🚀 One-click onboarding');
+    expect(readme).toContain('[Frankenbeast onboarding checklist](ONBOARDING.md)');
+    expect(readme).toContain('[`scripts/bootstrap.sh`](scripts/bootstrap.sh)');
     expect(readme).toContain('npm run bootstrap -- --no-docker');
+    expect(readme).toContain('./scripts/bootstrap.sh --dry-run');
+    expect(onboarding).toMatch(/^---\ntitle: Frankenbeast Onboarding Checklist\ndescription: /);
     expect(onboarding).toContain('./scripts/bootstrap.sh --dry-run');
     expect(quickstart).toContain('./scripts/bootstrap.sh --dry-run');
     expect(ci).toContain('Validate bootstrap dry-run');


### PR DESCRIPTION
## Summary
- Add a top-level 🚀 One-click onboarding block to the README.
- Link the canonical onboarding checklist and executable bootstrap script from the block.
- Extend local setup docs tests to lock the README links and onboarding front matter.

## Test Plan
- [x] `npm run test:root -- tests/local-setup-scripts.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`

Closes #1411
