### PR TITLE
fix(orchestrator): validate SSE ticket durations

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -21,12 +21,21 @@ export type SseTicketStatus = 'valid' | 'invalid' | 'reused';
 
 const DEFAULT_TICKET_TTL_MS = 30_000;
 const DEFAULT_CLEANUP_INTERVAL_MS = 60_000;
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
 const MIN_CONSUMED_RETENTION_MS = 600_000;
 
-function resolvePositiveDurationMs(name: string, value: number | undefined, defaultValue: number): number {
+function resolvePositiveDurationMs(
+  name: string,
+  value: number | undefined,
+  defaultValue: number,
+  maxValue?: number,
+): number {
   const resolved = value ?? defaultValue;
   if (!Number.isSafeInteger(resolved) || resolved <= 0) {
     throw new RangeError(`${name} must be a finite positive integer number of milliseconds`);
+  }
+  if (maxValue !== undefined && resolved > maxValue) {
+    throw new RangeError(`${name} must be at most ${maxValue} milliseconds`);
   }
   return resolved;
 }
@@ -56,6 +65,7 @@ export class SseConnectionTicketStore {
       'cleanupIntervalMs',
       options?.cleanupIntervalMs,
       DEFAULT_CLEANUP_INTERVAL_MS,
+      MAX_NODE_TIMER_DELAY_MS,
     );
     this.cleanupInterval = setInterval(() => this.cleanup(), cleanupMs);
     this.cleanupInterval.unref?.();

--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -19,6 +19,18 @@ export interface SseConnectionTicketStoreOptions {
 
 export type SseTicketStatus = 'valid' | 'invalid' | 'reused';
 
+const DEFAULT_TICKET_TTL_MS = 30_000;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60_000;
+const MIN_CONSUMED_RETENTION_MS = 600_000;
+
+function resolvePositiveDurationMs(name: string, value: number | undefined, defaultValue: number): number {
+  const resolved = value ?? defaultValue;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError(`${name} must be a finite positive integer number of milliseconds`);
+  }
+  return resolved;
+}
+
 export class SseConnectionTicketStore {
   private readonly tickets = new Map<string, TicketEntry>();
   // Consumed tickets are remembered past the issue TTL so that an EventSource
@@ -32,11 +44,19 @@ export class SseConnectionTicketStore {
   private readonly cleanupInterval: ReturnType<typeof setInterval>;
 
   constructor(options?: SseConnectionTicketStoreOptions) {
-    this.ttlMs = options?.ttlMs ?? 30_000;
+    this.ttlMs = resolvePositiveDurationMs('ttlMs', options?.ttlMs, DEFAULT_TICKET_TTL_MS);
     // Cover EventSource's reconnect behaviour comfortably (>> ttl) while still
     // bounding memory: at least 10 minutes, or 20× the issue TTL if larger.
-    this.consumedRetentionMs = options?.consumedRetentionMs ?? Math.max(this.ttlMs * 20, 600_000);
-    const cleanupMs = options?.cleanupIntervalMs ?? 60_000;
+    this.consumedRetentionMs = resolvePositiveDurationMs(
+      'consumedRetentionMs',
+      options?.consumedRetentionMs,
+      Math.max(this.ttlMs * 20, MIN_CONSUMED_RETENTION_MS),
+    );
+    const cleanupMs = resolvePositiveDurationMs(
+      'cleanupIntervalMs',
+      options?.cleanupIntervalMs,
+      DEFAULT_CLEANUP_INTERVAL_MS,
+    );
     this.cleanupInterval = setInterval(() => this.cleanup(), cleanupMs);
     this.cleanupInterval.unref?.();
   }

--- a/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
@@ -92,6 +92,18 @@ describe('SseConnectionTicketStore', () => {
     },
   );
 
+  it('rejects cleanupIntervalMs values above Node timer delay limits before scheduling cleanup', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    try {
+      expect(() => new SseConnectionTicketStore({ cleanupIntervalMs: 2_147_483_648 })).toThrow(
+        /cleanupIntervalMs must be at most 2147483647 milliseconds/,
+      );
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
   it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
     'rejects invalid consumedRetentionMs value %s',
     (consumedRetentionMs) => {

--- a/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SseConnectionTicketStore } from '../../../../src/beasts/events/sse-connection-ticket.js';
 
 describe('SseConnectionTicketStore', () => {
@@ -67,6 +67,39 @@ describe('SseConnectionTicketStore', () => {
     expect(shortStore.validate(ticket, 'operator-token-123')).toBe(false);
     shortStore.destroy();
   });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    'rejects invalid ticket ttlMs value %s',
+    (ttlMs) => {
+      expect(() => new SseConnectionTicketStore({ ttlMs })).toThrow(
+        /ttlMs must be a finite positive integer number of milliseconds/,
+      );
+    },
+  );
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    'rejects invalid cleanupIntervalMs value %s before scheduling cleanup',
+    (cleanupIntervalMs) => {
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      try {
+        expect(() => new SseConnectionTicketStore({ cleanupIntervalMs })).toThrow(
+          /cleanupIntervalMs must be a finite positive integer number of milliseconds/,
+        );
+        expect(setIntervalSpy).not.toHaveBeenCalled();
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    'rejects invalid consumedRetentionMs value %s',
+    (consumedRetentionMs) => {
+      expect(() => new SseConnectionTicketStore({ consumedRetentionMs })).toThrow(
+        /consumedRetentionMs must be a finite positive integer number of milliseconds/,
+      );
+    },
+  );
 
   it('rejects unknown tickets', () => {
     expect(store.validate('nonexistent-uuid', 'operator-token-123')).toBe(false);


### PR DESCRIPTION
## Summary
- Validate SSE ticket `ttlMs`, `cleanupIntervalMs`, and consumed-ticket retention as finite positive integer millisecond durations.
- Reject invalid cleanup intervals before `setInterval` can schedule a tight or malformed cleanup loop.
- Add regression coverage for zero, negative, NaN, Infinity, and fractional duration options.

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/beasts/events/sse-connection-ticket.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- `npm run build --workspace @franken/orchestrator`

Closes #1231
