### PR TITLE
fix(observer): validate BatchAdapter numeric options

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -36,6 +36,62 @@ function deferred<T = void>(): {
   return { promise, resolve, reject }
 }
 
+// ── options ───────────────────────────────────────────────────────────────────
+
+describe('BatchAdapter — options', () => {
+  it.each([
+    Number.NaN,
+    Infinity,
+    0,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid maxBatchSize: %s', maxBatchSize => {
+    expect(() => new BatchAdapter({
+      adapter: new InMemoryAdapter(),
+      maxBatchSize,
+    })).toThrow(RangeError)
+  })
+
+  it.each([
+    Number.NaN,
+    Infinity,
+    0,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid flushIntervalMs: %s', flushIntervalMs => {
+    const setIntervalFn = vi.fn()
+
+    expect(() => new BatchAdapter({
+      adapter: new InMemoryAdapter(),
+      flushIntervalMs,
+      setInterval: setIntervalFn,
+    })).toThrow(RangeError)
+    expect(setIntervalFn).not.toHaveBeenCalled()
+  })
+
+  it('accepts valid integer boundaries for batch size and timer options', async () => {
+    const inner = new InMemoryAdapter()
+    const setIntervalFn = vi.fn().mockReturnValue(42 as unknown as ReturnType<typeof globalThis.setInterval>)
+    const clearIntervalFn = vi.fn()
+    const batch = new BatchAdapter({
+      adapter: inner,
+      maxBatchSize: 1,
+      flushIntervalMs: 1,
+      setInterval: setIntervalFn,
+      clearInterval: clearIntervalFn,
+    })
+
+    await batch.flush(makeTrace('valid-boundary'))
+    expect(await inner.listTraceIds()).toEqual(['valid-boundary'])
+    expect(setIntervalFn).toHaveBeenCalledWith(expect.any(Function), 1)
+
+    await batch.stop()
+    expect(clearIntervalFn).toHaveBeenCalledWith(42)
+  })
+})
+
 // ── buffering ─────────────────────────────────────────────────────────────────
 
 describe('BatchAdapter — buffering', () => {

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -18,9 +18,16 @@ export interface BatchAdapterOptions {
    */
   flushIntervalMs?: number
   /** Injectable for testing. Defaults to `globalThis.setInterval`. */
-  setInterval?: (fn: () => void, ms: number) => ReturnType<typeof setInterval>
+  setInterval?: (fn: () => void, ms: number) => ReturnType<typeof globalThis.setInterval>
   /** Injectable for testing. Defaults to `globalThis.clearInterval`. */
-  clearInterval?: (id: ReturnType<typeof setInterval>) => void
+  clearInterval?: (id: ReturnType<typeof globalThis.setInterval>) => void
+}
+
+function validatePositiveSafeInteger(value: number, optionName: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`${optionName} must be a positive safe integer`)
+  }
+  return value
 }
 
 /**
@@ -50,18 +57,19 @@ export class BatchAdapter implements ExportAdapter {
   private readonly inner: ExportAdapter
   private readonly maxBatchSize: number
   private readonly buffer: Trace[] = []
-  private timer: ReturnType<typeof setInterval> | null = null
-  private readonly clearIntervalFn: (id: ReturnType<typeof setInterval>) => void
+  private timer: ReturnType<typeof globalThis.setInterval> | null = null
+  private readonly clearIntervalFn: (id: ReturnType<typeof globalThis.setInterval>) => void
   private drainPromise: Promise<void> | null = null
 
   constructor(options: BatchAdapterOptions) {
     this.inner = options.adapter
-    this.maxBatchSize = options.maxBatchSize ?? 10
-    this.clearIntervalFn = options.clearInterval ?? clearInterval
+    this.maxBatchSize = validatePositiveSafeInteger(options.maxBatchSize ?? 10, 'maxBatchSize')
+    this.clearIntervalFn = options.clearInterval ?? globalThis.clearInterval
 
-    if (options.flushIntervalMs && options.flushIntervalMs > 0) {
-      const si = options.setInterval ?? setInterval
-      this.timer = si(() => { void this.drain().catch(() => undefined) }, options.flushIntervalMs)
+    if (options.flushIntervalMs !== undefined) {
+      const flushIntervalMs = validatePositiveSafeInteger(options.flushIntervalMs, 'flushIntervalMs')
+      const si = options.setInterval ?? globalThis.setInterval
+      this.timer = si(() => { void this.drain().catch(() => undefined) }, flushIntervalMs)
     }
   }
 


### PR DESCRIPTION
## Summary
- validates BatchAdapter maxBatchSize as a positive safe integer before buffering
- validates provided flushIntervalMs before starting the safety-net timer
- adds regression coverage for invalid numeric options and valid integer boundaries

## Test Plan
- npm run test --workspace @franken/observer -- BatchAdapter.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run test --workspace @franken/observer
- npm run lint:any

Closes #1227