### PR TITLE
fix(observer): isolate multi adapter read failures

### DIFF
--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.test.ts
@@ -108,6 +108,43 @@ describe('MultiAdapter', () => {
       expect(await multi.queryByTraceId(trace.id)).toEqual(trace)
     })
 
+    it('continues to a later adapter when an earlier adapter rejects', async () => {
+      const failingQuery: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+        listTraceIds: vi.fn().mockResolvedValue([]),
+      }
+      const healthy = new InMemoryAdapter()
+      const trace = makeTrace()
+      await healthy.flush(trace)
+      const multi = new MultiAdapter({ adapters: [failingQuery, healthy] })
+
+      await expect(multi.queryByTraceId(trace.id)).resolves.toEqual(trace)
+      expect(failingQuery.queryByTraceId).toHaveBeenCalledWith(trace.id)
+    })
+
+    it('throws an aggregate error when adapters fail and no trace is found', async () => {
+      const failingQuery: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+        listTraceIds: vi.fn().mockResolvedValue([]),
+      }
+      const multi = new MultiAdapter({ adapters: [failingQuery, new InMemoryAdapter()] })
+
+      await expect(multi.queryByTraceId('missing')).rejects.toThrow('queryByTraceId')
+    })
+
+    it('returns null for query failures when throwOnError is false', async () => {
+      const failingQuery: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+        listTraceIds: vi.fn().mockResolvedValue([]),
+      }
+      const multi = new MultiAdapter({ adapters: [failingQuery], throwOnError: false })
+
+      await expect(multi.queryByTraceId('missing')).resolves.toBeNull()
+    })
+
     it('returns null when no adapter has the trace', async () => {
       const multi = new MultiAdapter({ adapters: [new InMemoryAdapter(), new InMemoryAdapter()] })
       expect(await multi.queryByTraceId('missing')).toBeNull()
@@ -140,6 +177,42 @@ describe('MultiAdapter', () => {
       const multi = new MultiAdapter({ adapters: [a, b] })
       const ids = await multi.listTraceIds()
       expect(ids).toEqual(['shared'])
+    })
+
+    it('returns ids from healthy adapters when another adapter rejects', async () => {
+      const failingList: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockResolvedValue(null),
+        listTraceIds: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+      }
+      const healthy = new InMemoryAdapter()
+      await healthy.flush(makeTrace('healthy'))
+      const multi = new MultiAdapter({ adapters: [failingList, healthy] })
+
+      await expect(multi.listTraceIds()).resolves.toEqual(['healthy'])
+      expect(failingList.listTraceIds).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws an aggregate error when every list adapter rejects', async () => {
+      const failingList: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockResolvedValue(null),
+        listTraceIds: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+      }
+      const multi = new MultiAdapter({ adapters: [failingList] })
+
+      await expect(multi.listTraceIds()).rejects.toThrow('listTraceIds')
+    })
+
+    it('returns an empty list when every list adapter rejects and throwOnError is false', async () => {
+      const failingList: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockResolvedValue(null),
+        listTraceIds: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+      }
+      const multi = new MultiAdapter({ adapters: [failingList], throwOnError: false })
+
+      await expect(multi.listTraceIds()).resolves.toEqual([])
     })
 
     it('returns an empty array with empty adapters list', async () => {

--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.test.ts
@@ -204,6 +204,18 @@ describe('MultiAdapter', () => {
       await expect(multi.listTraceIds()).rejects.toThrow('listTraceIds')
     })
 
+    it('throws an aggregate error when failures leave only empty list results', async () => {
+      const failingList: ExportAdapter = {
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockResolvedValue(null),
+        listTraceIds: vi.fn().mockRejectedValue(new Error('remote unavailable')),
+      }
+      const emptyFallback = new InMemoryAdapter()
+      const multi = new MultiAdapter({ adapters: [failingList, emptyFallback] })
+
+      await expect(multi.listTraceIds()).rejects.toThrow('listTraceIds')
+    })
+
     it('returns an empty list when every list adapter rejects and throwOnError is false', async () => {
       const failingList: ExportAdapter = {
         flush: vi.fn().mockResolvedValue(undefined),

--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
@@ -56,15 +56,45 @@ export class MultiAdapter implements ExportAdapter {
   }
 
   async queryByTraceId(traceId: string): Promise<Trace | null> {
+    const errors: unknown[] = []
+
     for (const adapter of this.adapters) {
-      const result = await adapter.queryByTraceId(traceId)
-      if (result !== null) return result
+      try {
+        const result = await adapter.queryByTraceId(traceId)
+        if (result !== null) return result
+      } catch (error) {
+        errors.push(error)
+      }
     }
+
+    if (this.throwOnError && errors.length > 0) {
+      throw this.createReadAggregateError('queryByTraceId', errors)
+    }
+
     return null
   }
 
   async listTraceIds(): Promise<string[]> {
-    const sets = await Promise.all(this.adapters.map(a => a.listTraceIds()))
+    const results = await Promise.allSettled(this.adapters.map(a => a.listTraceIds()))
+    const sets = results.filter((r): r is PromiseFulfilledResult<string[]> => r.status === 'fulfilled').map(r => r.value)
+    const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+
+    if (this.throwOnError && sets.length === 0 && failed.length > 0) {
+      throw this.createReadAggregateError(
+        'listTraceIds',
+        failed.map(f => f.reason),
+      )
+    }
+
     return [...new Set(sets.flat())]
+  }
+
+  private createReadAggregateError(operation: string, errors: unknown[]): AggregateError {
+    return new AggregateError(
+      errors,
+      `MultiAdapter: ${errors.length} adapter(s) failed during ${operation}: ${errors
+        .map(e => (e instanceof Error ? e.message : String(e)))
+        .join('; ')}`,
+    )
   }
 }

--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
@@ -79,14 +79,16 @@ export class MultiAdapter implements ExportAdapter {
     const sets = results.filter((r): r is PromiseFulfilledResult<string[]> => r.status === 'fulfilled').map(r => r.value)
     const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
 
-    if (this.throwOnError && sets.length === 0 && failed.length > 0) {
+    const traceIds = sets.flat()
+
+    if (this.throwOnError && traceIds.length === 0 && failed.length > 0) {
       throw this.createReadAggregateError(
         'listTraceIds',
         failed.map(f => f.reason),
       )
     }
 
-    return [...new Set(sets.flat())]
+    return [...new Set(traceIds)]
   }
 
   private createReadAggregateError(operation: string, errors: unknown[]): AggregateError {


### PR DESCRIPTION
## Summary
- isolate `MultiAdapter.queryByTraceId()` failures per backend so later healthy adapters can still return traces
- switch `listTraceIds()` to settled fan-in so healthy adapters still contribute IDs when another backend rejects
- add regression coverage for throwing read adapters and `throwOnError: false`

## Test Plan
- `npm run build --workspace @franken/types`
- `npm --workspace @franken/observer test -- --run src/adapters/multi/MultiAdapter.test.ts`
- `npm --workspace @franken/observer run typecheck`
- `npm --workspace @franken/observer run lint` (passes with pre-existing warnings)
- `npm --workspace @franken/observer run build`
- `npm --workspace @franken/observer test`

Closes #1188
