### PR TITLE
fix(observer): isolate circuit breaker handler failures

### DIFF
--- a/packages/franken-observer/src/cost/CircuitBreaker.test.ts
+++ b/packages/franken-observer/src/cost/CircuitBreaker.test.ts
@@ -102,6 +102,32 @@ describe('CircuitBreaker', () => {
       expect(() => breaker.check(999)).not.toThrow()
     })
 
+    it('isolates handler failures and still returns the trip result', () => {
+      breaker.on('limit-reached', () => {
+        throw new Error('webhook failed')
+      })
+
+      expect(() => breaker.check(0.51)).not.toThrow()
+      expect(breaker.check(0.60)).toEqual({ tripped: true, limitUsd: 0.50, spendUsd: 0.60 })
+    })
+
+    it('attempts later handlers after an earlier limit-reached handler throws', () => {
+      const throwingHandler = vi.fn(() => {
+        throw new Error('webhook failed')
+      })
+      const laterHandler = vi.fn()
+
+      breaker.on('limit-reached', throwingHandler)
+      breaker.on('limit-reached', laterHandler)
+
+      expect(() => breaker.check(0.51)).not.toThrow()
+      expect(throwingHandler).toHaveBeenCalledOnce()
+      expect(laterHandler).toHaveBeenCalledOnce()
+      expect(laterHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ tripped: true, limitUsd: 0.50, spendUsd: 0.51 }),
+      )
+    })
+
     it('continues returning results after trip', () => {
       breaker.check(1.00)
       const result = breaker.check(2.00)

--- a/packages/franken-observer/src/cost/CircuitBreaker.ts
+++ b/packages/franken-observer/src/cost/CircuitBreaker.ts
@@ -38,7 +38,12 @@ export class CircuitBreaker {
       if (!this.tripped) {
         this.tripped = true
         for (const handler of this.handlers) {
-          handler(result)
+          try {
+            handler(result)
+          } catch {
+            // Preserve the circuit breaker's non-blocking contract: listener
+            // failures are isolated so every registered handler is attempted.
+          }
         }
       }
     } else {


### PR DESCRIPTION
## Summary
- isolate CircuitBreaker limit-reached listener failures so check() remains non-blocking
- continue attempting later handlers after one listener throws
- add regression coverage for handler exception isolation

## Test Plan
- npm test -- CircuitBreaker.test.ts (from packages/franken-observer)
- npm run build --workspace @franken/types && npm run typecheck && npm run lint && npm run build

Closes #1180