### PR TITLE
test(observer): run eval suite from eval script

### DIFF
--- a/packages/franken-observer/src/vitest-discovery.test.ts
+++ b/packages/franken-observer/src/vitest-discovery.test.ts
@@ -24,6 +24,19 @@ function runObserverVitestWithNoMatches(env: NodeJS.ProcessEnv = {}) {
   );
 }
 
+function runObserverPackageScript(script: string) {
+  return spawnSync('npm', ['run', script], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CI: '1',
+      INTEGRATION: undefined,
+      EVAL: undefined,
+    },
+  });
+}
+
 describe('observer Vitest discovery', () => {
   it('does not mask empty default unit test discovery', () => {
     const config = readFileSync(resolve(packageRoot, 'vitest.config.ts'), 'utf8');
@@ -43,5 +56,14 @@ describe('observer Vitest discovery', () => {
       expect(result.status).not.toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/No test files found|No test files matched/u);
     }
+  });
+
+  it('runs the advertised observer eval suite instead of a zero-test placeholder', () => {
+    const result = runObserverPackageScript('test:eval');
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status, output).toBe(0);
+    expect(output).toMatch(/src\/evals\/.+\.test\.ts/u);
+    expect(output).toMatch(/Test Files[\s\S]*[1-9]\d*\s+passed/u);
   });
 });

--- a/packages/franken-observer/vitest.config.ts
+++ b/packages/franken-observer/vitest.config.ts
@@ -14,11 +14,11 @@ export default defineConfig({
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     // Default: unit tests only.
     // INTEGRATION=true → integration tests only.
-    // EVAL=true        → eval (LLM-judge) tests only.
+    // EVAL=true        → observer evaluation tests only.
     include: isIntegration
       ? ['src/**/*.integration.test.ts']
       : isEval
-        ? ['src/**/*.eval.test.ts']
+        ? ['src/evals/**/*.test.ts', 'src/**/*.eval.test.ts']
         : ['src/**/*.test.ts'],
     exclude: isIntegration || isEval
       ? []


### PR DESCRIPTION
## Summary
- Updates the observer eval Vitest lane so `test:eval` collects the existing `src/evals/**/*.test.ts` suite instead of only the currently-empty `*.eval.test.ts` pattern.
- Adds a regression check proving `npm run test:eval` runs real eval tests while zero-match discovery still fails closed.

## Test Plan
- npm run test:eval --workspace=@franken/observer
- npm exec --workspace=@franken/observer -- vitest run --config vitest.config.ts src/vitest-discovery.test.ts
- npm test --workspace=@franken/observer
- npm run build --workspace=@franken/types
- npm run typecheck --workspace=@franken/observer
- npm run lint --workspace=@franken/observer (passes with existing warnings)
- npm run build --workspace=@franken/observer

Closes #1185
