### PR TITLE
fix(brain): clone working memory reads

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -35,6 +35,13 @@ export class WorkingMemoryLimitError extends Error {
   }
 }
 
+function cloneStoredWorkingMemoryValue(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as unknown;
+}
+
 class SqliteWorkingMemory implements IWorkingMemory {
   private store = new Map<string, unknown>();
   private sizes = new Map<string, number>();
@@ -85,7 +92,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   get(key: string): unknown {
-    return this.store.get(key);
+    return cloneStoredWorkingMemoryValue(this.store.get(key));
   }
 
   /**
@@ -155,7 +162,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     const result: Record<string, unknown> = {};
     for (const [key, value] of this.store) {
       Object.defineProperty(result, key, {
-        value,
+        value: cloneStoredWorkingMemoryValue(value),
         enumerable: true,
         configurable: true,
         writable: true,

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -189,6 +189,47 @@ describe('SqliteBrain', () => {
       brain.working.set('complex', complex);
       expect(brain.working.get('complex')).toEqual(complex);
     });
+
+    it('returns defensive clones from get() so callers cannot mutate accounted state', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
+      const dbPath = join(dir, 'brain.db');
+      const persistent = new SqliteBrain(dbPath);
+      const validated = { nested: { steps: ['validated'] } };
+
+      try {
+        persistent.working.set('rules', validated);
+        const accountedBytes = persistent.working.usage().totalBytes;
+        const returned = persistent.working.get('rules') as { nested: { steps: string[] } };
+
+        returned.nested.steps.push('unvalidated'.repeat(100));
+
+        expect(persistent.working.get('rules')).toEqual(validated);
+        expect(persistent.working.usage().totalBytes).toBe(accountedBytes);
+
+        persistent.serialize();
+        persistent.close();
+
+        const reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.get('rules')).toEqual(validated);
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns defensive clones from snapshot() so callers cannot mutate accounted state', () => {
+      const validated = { nested: { items: [{ name: 'validated' }] } };
+      brain.working.set('rules', validated);
+      const accountedBytes = brain.working.usage().totalBytes;
+
+      const snap = brain.working.snapshot() as { rules: { nested: { items: Array<{ name: string }> } } };
+      snap.rules.nested.items[0].name = 'unvalidated';
+      snap.rules.nested.items.push({ name: 'oversized'.repeat(100) });
+
+      expect(brain.working.snapshot()).toEqual({ rules: validated });
+      expect(brain.working.get('rules')).toEqual(validated);
+      expect(brain.working.usage().totalBytes).toBe(accountedBytes);
+    });
   });
 
   describe('flush()', () => {


### PR DESCRIPTION
## Summary
- return defensive JSON clones from WorkingMemory get() and snapshot()
- add regression coverage for nested returned-value mutation, byte accounting, and SQLite flush/reopen persistence

## Test Plan
- npm test -- sqlite-brain.test.ts -t 'defensive clones' --workspace @franken/brain
- npm test --workspace @franken/brain
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/brain
- npm run build --workspace @franken/brain
- npm run lint --workspace @franken/brain

Closes #1119