### PR TITLE
fix(planner): protect graph task immutability

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -25,15 +25,27 @@ function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
     return value;
   }
 
-  try {
-    return structuredClone(value);
-  } catch {
-    // Fall back to targeted cloning for runtimes/values not covered by structuredClone.
-  }
-
   const existing = seen.get(value);
   if (existing !== undefined) {
     return existing as T;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0) as T;
+  }
+
+  if (typeof SharedArrayBuffer !== 'undefined' && value instanceof SharedArrayBuffer) {
+    throw new TypeError('Task metadata cannot contain SharedArrayBuffer values');
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    const copiedBuffer = bytes.slice().buffer;
+    if (value instanceof DataView) {
+      return new DataView(copiedBuffer) as T;
+    }
+    const TypedArray = value.constructor as new (buffer: ArrayBuffer) => ArrayBufferView;
+    return new TypedArray(copiedBuffer) as T;
   }
 
   if (Array.isArray(value)) {
@@ -47,10 +59,6 @@ function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
 
   if (value instanceof Date) {
     return new Date(value.getTime()) as T;
-  }
-
-  if (value instanceof URL) {
-    return new URL(value.href) as T;
   }
 
   if (value instanceof RegExp) {

--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -16,13 +16,101 @@ export interface PlanGraphFromTasksOptions {
   reason?: string;
 }
 
+function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const existing = seen.get(value);
+  if (existing !== undefined) {
+    return existing as T;
+  }
+
+  if (Array.isArray(value)) {
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    for (const item of value) {
+      clone.push(cloneUnknown(item, seen));
+    }
+    return clone as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Set) {
+    const clone = new Set<unknown>();
+    seen.set(value, clone);
+    for (const item of value) {
+      clone.add(cloneUnknown(item, seen));
+    }
+    return clone as T;
+  }
+
+  if (value instanceof Map) {
+    const clone = new Map<unknown, unknown>();
+    seen.set(value, clone);
+    for (const [key, mapValue] of value) {
+      clone.set(cloneUnknown(key, seen), cloneUnknown(mapValue, seen));
+    }
+    return clone as T;
+  }
+
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  if (prototype !== Object.prototype && prototype !== null) {
+    return value;
+  }
+
+  const clone: Record<string, unknown> = {};
+  seen.set(value, clone);
+  for (const [key, objectValue] of Object.entries(value as Record<string, unknown>)) {
+    clone[key] = cloneUnknown(objectValue, seen);
+  }
+  return clone as T;
+}
+
+function cloneTask(task: Task): Task {
+  const cloned: Task = {
+    ...task,
+    requiredSkills: [...task.requiredSkills],
+    dependsOn: [...task.dependsOn],
+  };
+  if (task.metadata !== undefined) {
+    cloned.metadata = cloneUnknown(task.metadata);
+  }
+  return cloned;
+}
+
+function cloneTaskMap(nodes: ReadonlyMap<TaskId, Task>): Map<TaskId, Task> {
+  const cloned = new Map<TaskId, Task>();
+  for (const [id, task] of nodes) {
+    cloned.set(id, cloneTask(task));
+  }
+  return cloned;
+}
+
+function cloneEdgeMap(edges: ReadonlyMap<TaskId, ReadonlySet<TaskId>>): Map<TaskId, Set<TaskId>> {
+  const cloned = new Map<TaskId, Set<TaskId>>();
+  for (const [id, deps] of edges) {
+    cloned.set(id, new Set(deps));
+  }
+  return cloned;
+}
+
 export class PlanGraph {
+  private readonly _nodes: ReadonlyMap<TaskId, Task>;
+  private readonly _edges: ReadonlyMap<TaskId, ReadonlySet<TaskId>>;
+
   private constructor(
-    private readonly _nodes: ReadonlyMap<TaskId, Task>,
-    private readonly _edges: ReadonlyMap<TaskId, ReadonlySet<TaskId>>,
+    nodes: ReadonlyMap<TaskId, Task>,
+    edges: ReadonlyMap<TaskId, ReadonlySet<TaskId>>,
     readonly version: number,
     readonly reason: string
-  ) {}
+  ) {
+    this._nodes = cloneTaskMap(nodes);
+    this._edges = cloneEdgeMap(edges);
+  }
 
   // ─── Factories ─────────────────────────────────────────────────────────────
 
@@ -96,11 +184,12 @@ export class PlanGraph {
   // ─── Queries ───────────────────────────────────────────────────────────────
 
   getTask(taskId: TaskId): Task | undefined {
-    return this._nodes.get(taskId);
+    const task = this._nodes.get(taskId);
+    return task === undefined ? undefined : cloneTask(task);
   }
 
   getTasks(): Task[] {
-    return Array.from(this._nodes.values());
+    return Array.from(this._nodes.values(), cloneTask);
   }
 
   getDependencies(taskId: TaskId): TaskId[] {
@@ -130,7 +219,7 @@ export class PlanGraph {
         `Graph contains a cycle — ${this._nodes.size - sorted.length} task(s) unresolvable`
       );
     }
-    return sorted.map((id) => this._nodes.get(id) as Task);
+    return sorted.map((id) => cloneTask(this._nodes.get(id) as Task));
   }
 
   // ─── Mutations (all return new PlanGraph — immutable) ──────────────────────

--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -62,7 +62,9 @@ function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
   }
 
   if (value instanceof RegExp) {
-    return new RegExp(value.source, value.flags) as T;
+    const clone = new RegExp(value.source, value.flags);
+    clone.lastIndex = value.lastIndex;
+    return clone as T;
   }
 
   if (value instanceof Set) {

--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -17,8 +17,18 @@ export interface PlanGraphFromTasksOptions {
 }
 
 function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (typeof value === 'function') {
+    throw new TypeError('Task metadata cannot contain functions because they cannot be cloned safely');
+  }
+
   if (value === null || typeof value !== 'object') {
     return value;
+  }
+
+  try {
+    return structuredClone(value);
+  } catch {
+    // Fall back to targeted cloning for runtimes/values not covered by structuredClone.
   }
 
   const existing = seen.get(value);
@@ -37,6 +47,14 @@ function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
 
   if (value instanceof Date) {
     return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof URL) {
+    return new URL(value.href) as T;
+  }
+
+  if (value instanceof RegExp) {
+    return new RegExp(value.source, value.flags) as T;
   }
 
   if (value instanceof Set) {
@@ -59,13 +77,18 @@ function cloneUnknown<T>(value: T, seen = new WeakMap<object, unknown>()): T {
 
   const prototype = Object.getPrototypeOf(value) as unknown;
   if (prototype !== Object.prototype && prototype !== null) {
-    return value;
+    throw new TypeError('Task metadata contains an unsupported mutable object');
   }
 
-  const clone: Record<string, unknown> = {};
+  const clone: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   seen.set(value, clone);
   for (const [key, objectValue] of Object.entries(value as Record<string, unknown>)) {
-    clone[key] = cloneUnknown(objectValue, seen);
+    Object.defineProperty(clone, key, {
+      value: cloneUnknown(objectValue, seen),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
   }
   return clone as T;
 }

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -138,6 +138,20 @@ describe('PlanGraph — construction', () => {
     }
   });
 
+  it('preserves stateful RegExp metadata when cloning task snapshots', () => {
+    const pattern = /work/g;
+    pattern.lastIndex = 2;
+    const graph = PlanGraph.empty().addTask(makeTask('regexp', { metadata: { pattern } }));
+    pattern.lastIndex = 0;
+
+    const snapshot = graph.getTask(createTaskId('regexp')) as Task;
+    expect((snapshot.metadata?.pattern as RegExp).lastIndex).toBe(2);
+
+    (snapshot.metadata?.pattern as RegExp).lastIndex = 0;
+    const stored = graph.getTask(createTaskId('regexp')) as Task;
+    expect((stored.metadata?.pattern as RegExp).lastIndex).toBe(2);
+  });
+
   it('isolates stored tasks from mutations to getTask, getTasks, and topoSort results', () => {
     const g = PlanGraph.empty()
       .addTask(makeTask('a', { requiredSkills: ['setup'] }))

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -115,6 +115,29 @@ describe('PlanGraph — construction', () => {
     expect((stored.metadata as { polluted?: boolean }).polluted).toBeUndefined();
   });
 
+  it('rejects metadata objects that cannot be cloned without aliasing or semantic loss', () => {
+    class CustomMetadata {
+      readonly value = 'custom';
+    }
+
+    expect(() =>
+      PlanGraph.empty().addTask(makeTask('custom', { metadata: { value: new CustomMetadata() } }))
+    ).toThrow(/unsupported mutable object/);
+
+    if (typeof SharedArrayBuffer !== 'undefined') {
+      const shared = new Uint8Array(new SharedArrayBuffer(4));
+      shared[0] = 1;
+      const graph = PlanGraph.empty().addTask(makeTask('shared', { metadata: { bytes: shared } }));
+      shared[0] = 9;
+      const snapshot = graph.getTask(createTaskId('shared')) as Task;
+      (snapshot.metadata?.bytes as Uint8Array)[0] = 8;
+
+      const stored = graph.getTask(createTaskId('shared')) as Task;
+      expect(Array.from(stored.metadata?.bytes as Uint8Array)).toEqual([1, 0, 0, 0]);
+      expect((stored.metadata?.bytes as Uint8Array).buffer).toBeInstanceOf(ArrayBuffer);
+    }
+  });
+
   it('isolates stored tasks from mutations to getTask, getTasks, and topoSort results', () => {
     const g = PlanGraph.empty()
       .addTask(makeTask('a', { requiredSkills: ['setup'] }))

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -77,6 +77,46 @@ describe('PlanGraph — construction', () => {
     const g = PlanGraph.empty().addTask(a).addTask(b);
     expect(g.getTasks()).toEqual([a, b]);
   });
+
+  it('isolates stored tasks from mutations to the original task object', () => {
+    const task = makeTask('t-1', {
+      requiredSkills: ['planner'],
+      metadata: { nested: { priority: 'low' } },
+    });
+    const g = PlanGraph.empty().addTask(task);
+
+    task.status = 'completed';
+    task.requiredSkills.push('unexpected');
+    (task.metadata as { nested: { priority: string } }).nested.priority = 'high';
+
+    expect(g.getTask(createTaskId('t-1'))).toMatchObject({
+      status: 'pending',
+      requiredSkills: ['planner'],
+      metadata: { nested: { priority: 'low' } },
+    });
+  });
+
+  it('isolates stored tasks from mutations to getTask, getTasks, and topoSort results', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a', { requiredSkills: ['setup'] }))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+
+    const fromGetTask = g.getTask(createTaskId('b')) as Task;
+    fromGetTask.status = 'completed';
+    fromGetTask.dependsOn.push(createTaskId('ghost'));
+
+    const fromGetTasks = g.getTasks().find((task) => task.id === createTaskId('a')) as Task;
+    fromGetTasks.requiredSkills.push('mutated');
+
+    const fromTopoSort = g.topoSort().find((task) => task.id === createTaskId('b')) as Task;
+    fromTopoSort.dependsOn.length = 0;
+
+    expect(g.getTask(createTaskId('b'))?.status).toBe('pending');
+    expect(g.getTask(createTaskId('a'))?.requiredSkills).toEqual(['setup']);
+    expect(g.getTask(createTaskId('b'))?.dependsOn).toEqual([createTaskId('a')]);
+    expect(g.getDependencies(createTaskId('b'))).toEqual([createTaskId('a')]);
+    expect(g.topoSort().map((task) => task.id)).toEqual([createTaskId('a'), createTaskId('b')]);
+  });
 });
 
 // ─── Topological Sort ────────────────────────────────────────────────────────

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -96,6 +96,25 @@ describe('PlanGraph — construction', () => {
     });
   });
 
+  it('clones mutable metadata values and preserves __proto__ as data', () => {
+    const task = makeTask('t-1', {
+      metadata: {
+        bytes: new Uint8Array([1, 2, 3]),
+        ...JSON.parse('{"__proto__":{"polluted":true}}'),
+      },
+    });
+    const g = PlanGraph.empty().addTask(task);
+
+    (task.metadata?.bytes as Uint8Array)[0] = 9;
+    const snapshot = g.getTask(createTaskId('t-1')) as Task;
+    (snapshot.metadata?.bytes as Uint8Array)[1] = 8;
+
+    const stored = g.getTask(createTaskId('t-1')) as Task;
+    expect(Array.from(stored.metadata?.bytes as Uint8Array)).toEqual([1, 2, 3]);
+    expect(Object.hasOwn(stored.metadata as object, '__proto__')).toBe(true);
+    expect((stored.metadata as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
   it('isolates stored tasks from mutations to getTask, getTasks, and topoSort results', () => {
     const g = PlanGraph.empty()
       .addTask(makeTask('a', { requiredSkills: ['setup'] }))


### PR DESCRIPTION
## Summary
- defensively clone PlanGraph task nodes and dependency edges on construction
- return cloned task snapshots from getTask(), getTasks(), and topoSort()
- add regressions for post-insert and post-read Task mutation aliases

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/planner
- npm run typecheck --workspace @franken/planner
- npm run lint --workspace @franken/planner
- npm run build --workspace @franken/planner

Closes #1103