### PR TITLE
fix(observer): reject invalid TraceSampler numeric options

### DIFF
--- a/packages/franken-observer/src/sampling/TraceSampler.test.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.test.ts
@@ -63,6 +63,12 @@ describe('ProbabilisticSampler', () => {
   it('throws RangeError for probability > 1', () => {
     expect(() => new ProbabilisticSampler(1.1)).toThrow(RangeError)
   })
+
+  it('throws RangeError for non-finite probability values', () => {
+    expect(() => new ProbabilisticSampler(Number.NaN)).toThrow(RangeError)
+    expect(() => new ProbabilisticSampler(Number.POSITIVE_INFINITY)).toThrow(RangeError)
+    expect(() => new ProbabilisticSampler(Number.NEGATIVE_INFINITY)).toThrow(RangeError)
+  })
 })
 
 // ── RateLimitedSampler ───────────────────────────────────────────────────────
@@ -122,6 +128,16 @@ describe('RateLimitedSampler', () => {
     )
     expect(() =>
       new RateLimitedSampler({ maxPerWindow: Number.POSITIVE_INFINITY, windowMs: 1000 }),
+    ).toThrow(RangeError)
+    expect(() =>
+      new RateLimitedSampler({ maxPerWindow: Number.NEGATIVE_INFINITY, windowMs: 1000 }),
+    ).toThrow(RangeError)
+  })
+
+  it('throws RangeError when maxPerWindow is not a safe integer', () => {
+    expect(() => new RateLimitedSampler({ maxPerWindow: 1.5, windowMs: 1000 })).toThrow(RangeError)
+    expect(() =>
+      new RateLimitedSampler({ maxPerWindow: Number.MAX_SAFE_INTEGER + 1, windowMs: 1000 }),
     ).toThrow(RangeError)
   })
 })

--- a/packages/franken-observer/src/sampling/TraceSampler.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.ts
@@ -37,8 +37,8 @@ export class ProbabilisticSampler implements SamplerStrategy {
   private readonly random: () => number
 
   constructor(probability: number, random: () => number = Math.random) {
-    if (probability < 0 || probability > 1) {
-      throw new RangeError(`probability must be between 0 and 1, got ${probability}`)
+    if (!Number.isFinite(probability) || probability < 0 || probability > 1) {
+      throw new RangeError(`probability must be a finite number between 0 and 1, got ${probability}`)
     }
     this.probability = probability
     this.random = random
@@ -78,8 +78,14 @@ export class RateLimitedSampler implements SamplerStrategy {
     if (!Number.isFinite(options.windowMs) || options.windowMs <= 0) {
       throw new RangeError(`windowMs must be greater than 0, got ${options.windowMs}`)
     }
-    if (!Number.isFinite(options.maxPerWindow) || options.maxPerWindow <= 0) {
-      throw new RangeError(`maxPerWindow must be greater than 0, got ${options.maxPerWindow}`)
+    if (
+      !Number.isFinite(options.maxPerWindow) ||
+      !Number.isSafeInteger(options.maxPerWindow) ||
+      options.maxPerWindow <= 0
+    ) {
+      throw new RangeError(
+        `maxPerWindow must be a positive safe integer, got ${options.maxPerWindow}`,
+      )
     }
     this.maxPerWindow = options.maxPerWindow
     this.windowMs = options.windowMs


### PR DESCRIPTION
## Summary
- Reject non-finite probabilistic sampler probabilities before sampling starts
- Require rate-limit maxPerWindow to be a positive safe integer
- Add regression coverage for NaN/Infinity and unsafe/fractional sampler options

## Test Plan
- npm run test --workspace @franken/observer -- TraceSampler.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer (passes with existing warnings)
- npm run test --workspace @franken/observer

Closes #1118