### PR TITLE
fix(orchestrator): isolate beast event replay state

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
@@ -25,18 +25,29 @@ function reportDefaultListenerError({ event, error }: BeastEventBusListenerError
   });
 }
 
-function cloneValue(value: unknown): unknown {
+function cloneJsonCompatibleValue(value: unknown): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => cloneValue(item));
+    return value.map((item) => cloneJsonCompatibleValue(item));
   }
 
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [key, cloneValue(nestedValue)]),
+      Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+        key,
+        cloneJsonCompatibleValue(nestedValue),
+      ]),
     );
   }
 
   return value;
+}
+
+function cloneValue(value: unknown): unknown {
+  try {
+    return structuredClone(value);
+  } catch {
+    return cloneJsonCompatibleValue(value);
+  }
 }
 
 function cloneEvent(event: BeastSseEvent): BeastSseEvent {

--- a/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-event-bus.ts
@@ -25,6 +25,27 @@ function reportDefaultListenerError({ event, error }: BeastEventBusListenerError
   });
 }
 
+function cloneValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [key, cloneValue(nestedValue)]),
+    );
+  }
+
+  return value;
+}
+
+function cloneEvent(event: BeastSseEvent): BeastSseEvent {
+  return {
+    ...event,
+    data: cloneValue(event.data) as Record<string, unknown>,
+  };
+}
+
 export class BeastEventBus {
   private sequence = 0;
   private readonly listeners = new Set<EventListener>();
@@ -43,7 +64,7 @@ export class BeastEventBus {
 
   publish(event: Omit<BeastSseEvent, 'id'>): void {
     this.sequence += 1;
-    const stamped: BeastSseEvent = { ...event, id: this.sequence };
+    const stamped: BeastSseEvent = cloneEvent({ ...event, id: this.sequence });
 
     this.buffer.push(stamped);
     if (this.buffer.length > this.maxBufferSize) {
@@ -51,13 +72,14 @@ export class BeastEventBus {
     }
 
     for (const listener of this.listeners) {
+      const listenerEvent = cloneEvent(stamped);
       try {
-        const result = listener(stamped);
+        const result = listener(listenerEvent);
         if (result && typeof result.catch === 'function') {
-          result.catch((error: unknown) => this.reportListenerError(stamped, error, listener));
+          result.catch((error: unknown) => this.reportListenerError(listenerEvent, error, listener));
         }
       } catch (error) {
-        this.reportListenerError(stamped, error, listener);
+        this.reportListenerError(listenerEvent, error, listener);
       }
     }
   }
@@ -70,7 +92,7 @@ export class BeastEventBus {
   }
 
   replaySince(lastEventId: number): BeastSseEvent[] {
-    return this.buffer.filter((e) => e.id !== undefined && e.id > lastEventId);
+    return this.buffer.filter((e) => e.id !== undefined && e.id > lastEventId).map((event) => cloneEvent(event));
   }
 
   private reportListenerError(event: BeastSseEvent, error: unknown, listener: EventListener): void {

--- a/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
@@ -174,6 +174,19 @@ describe('BeastEventBus', () => {
     ]);
   });
 
+  it('preserves structured-cloneable payload values while isolating mutations', () => {
+    const bus = new BeastEventBus();
+    const observed: BeastSseEvent[] = [];
+    const startedAt = new Date('2026-03-17T00:00:00.000Z');
+
+    bus.subscribe((event) => observed.push(event));
+    bus.publish({ type: 'agent.status', data: { agentId: 'a1', startedAt } });
+
+    expect(observed[0].data.startedAt).toEqual(startedAt);
+    expect(observed[0].data.startedAt).not.toBe(startedAt);
+    expect(bus.replaySince(0)[0].data.startedAt).toEqual(startedAt);
+  });
+
   it('evicts oldest events when buffer exceeds maxBufferSize', () => {
     const bus = new BeastEventBus(3); // buffer limited to 3
     bus.publish({ type: 'e', data: { n: 1 } });

--- a/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/beast-event-bus.test.ts
@@ -125,6 +125,55 @@ describe('BeastEventBus', () => {
     expect(missed[1].id).toBe(3);
   });
 
+  it('isolates listener mutations from later listeners and replay state', () => {
+    const bus = new BeastEventBus();
+    const received: BeastSseEvent[] = [];
+
+    bus.subscribe((event) => {
+      event.id = 999;
+      event.type = 'corrupted';
+      event.data.status = 'debug';
+      event.data.extra = 'listener-only';
+    });
+    bus.subscribe((event) => received.push(event));
+
+    bus.publish({
+      type: 'agent.status',
+      data: { agentId: 'a1', status: 'running', nested: { phase: 'boot' } },
+    });
+
+    expect(received).toEqual([
+      {
+        id: 1,
+        type: 'agent.status',
+        data: { agentId: 'a1', status: 'running', nested: { phase: 'boot' } },
+      },
+    ]);
+    expect(bus.replaySince(0)).toEqual([
+      {
+        id: 1,
+        type: 'agent.status',
+        data: { agentId: 'a1', status: 'running', nested: { phase: 'boot' } },
+      },
+    ]);
+  });
+
+  it('returns replay copies so callers cannot mutate retained buffered events', () => {
+    const bus = new BeastEventBus();
+
+    bus.publish({ type: 'run.log', data: { runId: 'r1', line: 'original', meta: { level: 'info' } } });
+
+    const firstReplay = bus.replaySince(0);
+    firstReplay[0].id = 42;
+    firstReplay[0].type = 'corrupted';
+    firstReplay[0].data.line = 'mutated';
+    (firstReplay[0].data.meta as Record<string, unknown>).level = 'debug';
+
+    expect(bus.replaySince(0)).toEqual([
+      { id: 1, type: 'run.log', data: { runId: 'r1', line: 'original', meta: { level: 'info' } } },
+    ]);
+  });
+
   it('evicts oldest events when buffer exceeds maxBufferSize', () => {
     const bus = new BeastEventBus(3); // buffer limited to 3
     bus.publish({ type: 'e', data: { n: 1 } });


### PR DESCRIPTION
## Summary
- Store BeastEventBus events as defensive snapshots before buffering.
- Deliver per-listener event copies so one subscriber cannot mutate later subscribers' payloads.
- Return cloned replay events so callers cannot corrupt retained buffer state.

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/beasts/events/beast-event-bus.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)
- npm test --workspace @franken/orchestrator

Closes #1101