### PR TITLE
fix(web): preserve SSE cursor on parse failure

### DIFF
--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -184,8 +184,17 @@ export class BeastApiClient {
       const parsed = parse<T>(event);
       return event.lastEventId ? { ...parsed, eventId: event.lastEventId } : parsed;
     };
-    const rememberEventId = (event: MessageEvent): void => {
+    const rememberProcessedEventId = (event: MessageEvent): void => {
       if (event.lastEventId) lastEventId = event.lastEventId;
+    };
+    const handleEvent = <T>(
+      event: MessageEvent,
+      parsePayload: (event: MessageEvent) => T,
+      handler: ((payload: T) => void) | undefined,
+    ): void => {
+      const payload = parsePayload(event);
+      handler?.(payload);
+      rememberProcessedEventId(event);
     };
     const scheduleReconnect = () => {
       if (closed || reconnectTimer) return;
@@ -212,28 +221,46 @@ export class BeastApiClient {
       eventSource = nextSource;
 
       nextSource.addEventListener('snapshot', (event) => {
-        rememberEventId(event as MessageEvent);
-        try { handlers.snapshot?.(parse<BeastSseSnapshot>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try {
+          handleEvent(event as MessageEvent, parse<BeastSseSnapshot>, handlers.snapshot);
+        } catch (error) {
+          handlers.error?.(toError(error));
+        }
       });
       nextSource.addEventListener('agent.status', (event) => {
-        rememberEventId(event as MessageEvent);
-        try { handlers.agentStatus?.(parse<BeastSseAgentStatusEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try {
+          handleEvent(event as MessageEvent, parse<BeastSseAgentStatusEvent>, handlers.agentStatus);
+        } catch (error) {
+          handlers.error?.(toError(error));
+        }
       });
       nextSource.addEventListener('agent.event', (event) => {
-        rememberEventId(event as MessageEvent);
-        try { handlers.agentEvent?.(parse<BeastSseAgentEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try {
+          handleEvent(event as MessageEvent, parse<BeastSseAgentEvent>, handlers.agentEvent);
+        } catch (error) {
+          handlers.error?.(toError(error));
+        }
       });
       nextSource.addEventListener('run.status', (event) => {
-        rememberEventId(event as MessageEvent);
-        try { handlers.runStatus?.(parse<BeastSseRunStatusEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try {
+          handleEvent(event as MessageEvent, parse<BeastSseRunStatusEvent>, handlers.runStatus);
+        } catch (error) {
+          handlers.error?.(toError(error));
+        }
       });
       nextSource.addEventListener('run.log', (event) => {
-        rememberEventId(event as MessageEvent);
-        try { handlers.runLog?.(parseWithEventId<BeastSseRunLogEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try {
+          handleEvent(event as MessageEvent, parseWithEventId<BeastSseRunLogEvent>, handlers.runLog);
+        } catch (error) {
+          handlers.error?.(toError(error));
+        }
       });
       nextSource.addEventListener('run.event', (event) => {
-        rememberEventId(event as MessageEvent);
-        try { handlers.runEvent?.(parse<BeastSseRunEvent>(event as MessageEvent)); } catch (error) { handlers.error?.(toError(error)); }
+        try {
+          handleEvent(event as MessageEvent, parse<BeastSseRunEvent>, handlers.runEvent);
+        } catch (error) {
+          handlers.error?.(toError(error));
+        }
       });
       nextSource.addEventListener('error', () => {
         if (closed) return;

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -179,22 +179,40 @@ export class BeastApiClient {
     let eventSource: EventSource | undefined;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let lastEventId: string | undefined;
+    let failedEventId: string | undefined;
     const parse = <T>(event: MessageEvent): T => JSON.parse(event.data) as T;
     const parseWithEventId = <T extends object>(event: MessageEvent): T & { eventId?: string } => {
       const parsed = parse<T>(event);
       return event.lastEventId ? { ...parsed, eventId: event.lastEventId } : parsed;
     };
     const rememberProcessedEventId = (event: MessageEvent): void => {
-      if (event.lastEventId) lastEventId = event.lastEventId;
+      if (!event.lastEventId) return;
+      if (failedEventId && event.lastEventId !== failedEventId) return;
+      lastEventId = event.lastEventId;
+      if (event.lastEventId === failedEventId) failedEventId = undefined;
+    };
+    const rememberFailedEventId = (event: MessageEvent): void => {
+      if (event.lastEventId && !failedEventId) failedEventId = event.lastEventId;
     };
     const handleEvent = <T>(
       event: MessageEvent,
       parsePayload: (event: MessageEvent) => T,
       handler: ((payload: T) => void) | undefined,
     ): void => {
-      const payload = parsePayload(event);
+      if (!handler) {
+        rememberProcessedEventId(event);
+        return;
+      }
+
+      let payload: T;
+      try {
+        payload = parsePayload(event);
+      } catch (error) {
+        rememberFailedEventId(event);
+        throw error;
+      }
       rememberProcessedEventId(event);
-      handler?.(payload);
+      handler(payload);
     };
     const scheduleReconnect = () => {
       if (closed || reconnectTimer) return;

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -193,8 +193,8 @@ export class BeastApiClient {
       handler: ((payload: T) => void) | undefined,
     ): void => {
       const payload = parsePayload(event);
-      handler?.(payload);
       rememberProcessedEventId(event);
+      handler?.(payload);
     };
     const scheduleReconnect = () => {
       if (closed || reconnectTimer) return;

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -471,7 +471,7 @@ describe('BeastApiClient', () => {
     }
   });
 
-  it('passes the last received SSE event id when reconnecting with a fresh ticket', async () => {
+  it('passes the last successfully parsed SSE event id when reconnecting with a fresh ticket', async () => {
     vi.useFakeTimers();
     const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];
     const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
@@ -493,15 +493,21 @@ describe('BeastApiClient', () => {
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
 
     try {
-      const unsubscribe = await client.subscribeToEvents({ runStatus: vi.fn(), error: vi.fn() });
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ runStatus: vi.fn(), runLog: vi.fn(), error: onError });
 
       listeners[0]?.['run.status']?.({
         data: JSON.stringify({ runId: 'run-1', status: 'running' }),
         lastEventId: '42',
       });
+      listeners[0]?.['run.log']?.({
+        data: '{malformed-json',
+        lastEventId: '43',
+      });
       listeners[0]?.error?.({ data: '' });
       await vi.advanceTimersByTimeAsync(1_000);
 
+      expect(onError).toHaveBeenCalledWith(expect.any(SyntaxError));
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
         'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=42',

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -504,6 +504,10 @@ describe('BeastApiClient', () => {
         data: '{malformed-json',
         lastEventId: '43',
       });
+      listeners[0]?.['run.status']?.({
+        data: JSON.stringify({ runId: 'run-1', status: 'completed' }),
+        lastEventId: '44',
+      });
       listeners[0]?.error?.({ data: '' });
       await vi.advanceTimersByTimeAsync(1_000);
 
@@ -511,6 +515,56 @@ describe('BeastApiClient', () => {
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
         'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=42',
+      );
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('acknowledges unhandled SSE events without parsing their payloads', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string; lastEventId?: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string; lastEventId?: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ runStatus: vi.fn(), error: onError });
+
+      listeners[0]?.['agent.status']?.({
+        data: '{malformed-json-for-unhandled-event',
+        lastEventId: '45',
+      });
+      listeners[0]?.error?.({ data: '' });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('reconnecting') }));
+      expect(MockEventSource).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=45',
       );
 
       unsubscribe();

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -525,6 +525,60 @@ describe('BeastApiClient', () => {
     }
   });
 
+  it('retains a parsed SSE event id when its handler throws', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string; lastEventId?: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string; lastEventId?: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const handlerError = new Error('consumer failed');
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({
+        runStatus: vi.fn(() => { throw handlerError; }),
+        error: onError,
+      });
+
+      listeners[0]?.['run.status']?.({
+        data: JSON.stringify({ runId: 'run-1', status: 'running' }),
+        lastEventId: '44',
+      });
+      listeners[0]?.error?.({ data: '' });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(onError).toHaveBeenCalledWith(handlerError);
+      expect(MockEventSource).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=44',
+      );
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
   it('keeps retrying when a reconnect ticket request fails once', async () => {
     vi.useFakeTimers();
     const listeners: Array<Record<string, (event: { data: string }) => void>> = [];


### PR DESCRIPTION
## Summary
- Commit Beast SSE resume cursor only after an event payload parses and its handler returns successfully.
- Keep malformed SSE payloads reporting through `handlers.error` without advancing reconnect `lastEventId`.
- Add regression coverage for a malformed `run.log` followed by reconnect.

## Test Plan
- `npm run build --workspace @franken/types`
- `npm run test --workspace @franken/web -- --run tests/lib/beast-api.test.ts`
- `npm run typecheck --workspace @franken/web`
- `npm run lint --workspace @franken/web` (passes with existing warnings)
- `npm run build --workspace @franken/web`

Closes #1087
