### PR TITLE
fix(orchestrator): harden managed chat websocket parsing

### DIFF
--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -74,6 +74,20 @@ interface RemoteChatSession {
   socket: WebSocket;
 }
 
+const REMOTE_CHAT_TIMEOUT_MS = 30_000;
+
+function parseManagedChatMessage(data: string, phase: string): Record<string, unknown> {
+  try {
+    const payload = JSON.parse(data) as unknown;
+    if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+      return payload as Record<string, unknown>;
+    }
+  } catch {
+    // Fall through to the uniform managed-chat diagnostic below.
+  }
+  throw new Error(`Invalid managed chat websocket message during ${phase}`);
+}
+
 async function createRemoteSession(target: ManagedChatAttachment, projectId: string): Promise<RemoteChatSession> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (target.operatorToken) {
@@ -112,19 +126,57 @@ async function createRemoteSession(target: ManagedChatAttachment, projectId: str
     [CHAT_SOCKET_PROTOCOL, `${CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX}${ticketBody.data.ticket}`],
   );
   await new Promise<void>((resolve, reject) => {
-    socket.addEventListener('open', () => resolve(), { once: true });
-    socket.addEventListener('error', () => reject(new Error('Managed chat websocket failed to connect')), { once: true });
+    const cleanup = (): void => {
+      socket.removeEventListener('open', onOpen);
+      socket.removeEventListener('error', onError);
+    };
+    const onOpen = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onError = (): void => {
+      cleanup();
+      reject(new Error('Managed chat websocket failed to connect'));
+    };
+    socket.addEventListener('open', onOpen, { once: true });
+    socket.addEventListener('error', onError, { once: true });
   });
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.close();
+      reject(new Error('Timed out waiting for managed chat session readiness'));
+    }, REMOTE_CHAT_TIMEOUT_MS);
+
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      socket.removeEventListener('message', onMessage);
+      socket.removeEventListener('error', onError);
+    };
+
+    const onError = (): void => {
+      cleanup();
+      reject(new Error('Managed chat websocket error while waiting for session readiness'));
+    };
+
     const onMessage = (event: MessageEvent<string>) => {
-      const payload = JSON.parse(event.data) as { type?: string };
+      let payload: Record<string, unknown>;
+      try {
+        payload = parseManagedChatMessage(event.data, 'session readiness');
+      } catch (error) {
+        cleanup();
+        socket.close();
+        reject(error);
+        return;
+      }
       if (payload.type === 'session.ready') {
-        socket.removeEventListener('message', onMessage);
+        cleanup();
         resolve();
       }
     };
     socket.addEventListener('message', onMessage);
+    socket.addEventListener('error', onError, { once: true });
   });
 
   return {
@@ -152,7 +204,7 @@ async function awaitRemoteReply(socket: WebSocket, verbose: boolean): Promise<vo
     const timeout = setTimeout(() => {
       cleanup();
       reject(new Error('Timed out waiting for managed chat reply'));
-    }, 30_000);
+    }, REMOTE_CHAT_TIMEOUT_MS);
 
     const cleanup = (): void => {
       clearTimeout(timeout);
@@ -166,7 +218,14 @@ async function awaitRemoteReply(socket: WebSocket, verbose: boolean): Promise<vo
     };
 
     const onMessage = (event: MessageEvent<string>): void => {
-      const payload = JSON.parse(event.data) as Record<string, unknown>;
+      let payload: Record<string, unknown>;
+      try {
+        payload = parseManagedChatMessage(event.data, 'reply handling');
+      } catch (error) {
+        cleanup();
+        reject(error);
+        return;
+      }
       switch (payload.type) {
         case 'assistant.message.delta':
           process.stdout.write(String(payload.chunk ?? ''));
@@ -206,6 +265,12 @@ async function awaitRemoteReply(socket: WebSocket, verbose: boolean): Promise<vo
     socket.addEventListener('error', onError, { once: true });
   });
 }
+
+export const __chatAttachTestHooks = {
+  awaitRemoteReply,
+  createRemoteSession,
+  parseManagedChatMessage,
+};
 
 export async function runManagedChatRepl(options: {
   attachment: ManagedChatAttachment;

--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -1,14 +1,88 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
-import { resolveManagedChatAttachment } from '../../../src/network/chat-attach.js';
+import {
+  __chatAttachTestHooks,
+  resolveManagedChatAttachment,
+  type ManagedChatAttachment,
+} from '../../../src/network/chat-attach.js';
+
+class MockManagedChatWebSocket extends EventTarget {
+  static instances: MockManagedChatWebSocket[] = [];
+
+  readonly send = vi.fn();
+  readonly close = vi.fn();
+  readonly url: string;
+  readonly protocols?: string | string[];
+  readonly listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+
+  constructor(url: string | URL, protocols?: string | string[]) {
+    super();
+    this.url = String(url);
+    this.protocols = protocols;
+    MockManagedChatWebSocket.instances.push(this);
+    queueMicrotask(() => this.dispatchEvent(new Event('open')));
+  }
+
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    if (callback) {
+      const callbacks = this.listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>();
+      callbacks.add(callback);
+      this.listeners.set(type, callbacks);
+    }
+    super.addEventListener(type, callback, options);
+  }
+
+  override removeEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean,
+  ): void {
+    if (callback) {
+      this.listeners.get(type)?.delete(callback);
+    }
+    super.removeEventListener(type, callback, options);
+  }
+
+  emitMessage(data: string): void {
+    this.dispatchEvent(new MessageEvent('message', { data }));
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+function stubRemoteSessionFetch(): void {
+  vi.stubGlobal('fetch', vi.fn()
+    .mockResolvedValueOnce(Response.json({ data: { id: 'session-1' } }))
+    .mockResolvedValueOnce(Response.json({ data: { ticket: 'ticket-1' } })));
+}
+
+function stubManagedChatWebSocket(): void {
+  MockManagedChatWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', MockManagedChatWebSocket);
+}
+
+function managedChatAttachment(): ManagedChatAttachment {
+  return {
+    baseUrl: 'http://127.0.0.1:4242',
+    wsUrl: 'ws://127.0.0.1:4242/v1/chat/ws',
+  };
+}
 
 describe('resolveManagedChatAttachment', () => {
   let workDir: string | undefined;
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     if (workDir) {
       await rm(workDir, { recursive: true, force: true });
     }
@@ -118,5 +192,55 @@ describe('resolveManagedChatAttachment', () => {
     const directConsoleCall = ['console', 'log'].join('.');
 
     expect(source).not.toContain(directConsoleCall);
+  });
+
+  it('rejects malformed websocket frames while waiting for session readiness', async () => {
+    stubRemoteSessionFetch();
+    stubManagedChatWebSocket();
+
+    const session = __chatAttachTestHooks.createRemoteSession(managedChatAttachment(), 'project-1');
+    await vi.waitFor(() => expect(MockManagedChatWebSocket.instances).toHaveLength(1));
+    const socket = MockManagedChatWebSocket.instances[0];
+    expect(socket?.listenerCount('message')).toBe(1);
+
+    const rejection = expect(session).rejects.toThrow('Invalid managed chat websocket message during session readiness');
+    socket?.emitMessage('{not-json');
+
+    await rejection;
+    expect(socket?.listenerCount('message')).toBe(0);
+    expect(socket?.listenerCount('error')).toBe(0);
+    expect(socket?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out instead of waiting indefinitely for session readiness', async () => {
+    vi.useFakeTimers();
+    stubRemoteSessionFetch();
+    stubManagedChatWebSocket();
+
+    const session = __chatAttachTestHooks.createRemoteSession(managedChatAttachment(), 'project-1');
+    await vi.waitFor(() => expect(MockManagedChatWebSocket.instances).toHaveLength(1));
+    const socket = MockManagedChatWebSocket.instances[0];
+
+    const rejection = expect(session).rejects.toThrow('Timed out waiting for managed chat session readiness');
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await rejection;
+    expect(socket?.listenerCount('message')).toBe(0);
+    expect(socket?.listenerCount('error')).toBe(0);
+    expect(socket?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed websocket frames while waiting for a reply', async () => {
+    stubManagedChatWebSocket();
+    const socket = new MockManagedChatWebSocket('ws://127.0.0.1:4242/v1/chat/ws');
+
+    const reply = __chatAttachTestHooks.awaitRemoteReply(socket as unknown as WebSocket, false);
+    expect(socket.listenerCount('message')).toBe(1);
+
+    socket.emitMessage('{not-json');
+
+    await expect(reply).rejects.toThrow('Invalid managed chat websocket message during reply handling');
+    expect(socket.listenerCount('message')).toBe(0);
+    expect(socket.listenerCount('error')).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- validate managed chat WebSocket frames before acting on them
- add timeout/error cleanup for the initial session.ready wait
- reject malformed reply frames through the existing managed-chat error path

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/cli/chat-attach.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1082