### PR TITLE
fix(critique): handle late typed complexity edge cases

### DIFF
--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -151,7 +151,9 @@ function findBodyOpenAfterSignature(content: string, startIndex: number): number
     if (char === '{' && typeDepth === 0) {
       const returnTypeObjectLikely =
         expectTypeOperand ||
-        ['keyof', 'is', 'asserts'].includes(previousIdentifier(content, i - 1));
+        ['keyof', 'is', 'asserts', 'extends', 'infer'].includes(
+          previousIdentifier(content, i - 1),
+        );
       const closeIndex = findMatchingDelimiter(content, i, '{', '}');
       if (closeIndex === -1) return returnTypeObjectLikely ? -1 : i;
       let nextIndex = closeIndex + 1;

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -81,6 +81,9 @@ function startsWithDeclarationKeyword(content: string, index: number): boolean {
 
   return declarationKeywords.some((keyword) => {
     if (!content.startsWith(keyword, index)) return false;
+    if (/[A-Za-z0-9_$]/.test(content[index - 1] ?? '')) {
+      return false;
+    }
     if (/[A-Za-z0-9_$]/.test(content[index + keyword.length] ?? '')) {
       return false;
     }
@@ -146,13 +149,15 @@ function findBodyOpenAfterSignature(content: string, startIndex: number): number
     }
 
     if (char === '{' && typeDepth === 0) {
+      const returnTypeObjectLikely =
+        expectTypeOperand ||
+        ['keyof', 'is', 'asserts'].includes(previousIdentifier(content, i - 1));
       const closeIndex = findMatchingDelimiter(content, i, '{', '}');
-      if (closeIndex === -1) return -1;
+      if (closeIndex === -1) return returnTypeObjectLikely ? -1 : i;
       let nextIndex = closeIndex + 1;
       nextIndex = skipWhitespace(content, nextIndex);
       if (
-        expectTypeOperand ||
-        ['keyof', 'is', 'asserts'].includes(previousIdentifier(content, i - 1)) ||
+        returnTypeObjectLikely ||
         content[nextIndex] === '{' ||
         content[nextIndex] === '|' ||
         content[nextIndex] === '&' ||

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -662,9 +662,32 @@ describe('ComplexityEvaluator', () => {
     expect(result.findings.some((finding) => finding.message.includes('parameter'))).toBe(true);
   });
 
+  it('keeps keyword suffixes in multiline return annotations from hiding implementation bodies', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const lines = Array.from({ length: 60 }, (_, i) => `  const x${i}: number = ${i};`);
+    const content = [
+      'function longFn():',
+      '  Myinterface {',
+      ...lines,
+      '  return undefined;',
+      '}',
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((finding) => finding.message.includes('long'))).toBe(true);
+  });
+
   it('flags parameter count even when a parsed function body is unclosed', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function complex(a, b, c, d, e, f) { if (a) { return b; }`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((finding) => finding.message.includes('parameter'))).toBe(true);
+  });
+
+  it('flags typed parameter count even when a parsed function body is unclosed', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function complex(a, b, c, d, e, f): void { if (a) { return b; }`;
     const result = await evaluator.evaluate(createInput(content));
 
     expect(result.findings.some((finding) => finding.message.includes('parameter'))).toBe(true);

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -693,6 +693,14 @@ describe('ComplexityEvaluator', () => {
     expect(result.findings.some((finding) => finding.message.includes('parameter'))).toBe(true);
   });
 
+  it('keeps unclosed conditional return types from becoming function bodies', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = `function external(a, b, c, d, e, f): T extends { id: string`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.findings.some((finding) => finding.message.includes('parameter'))).toBe(false);
+  });
+
   it('flags deeply nested code', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `if (a) { if (b) { if (c) { if (d) { if (e) { doThing(); } } } } }`;


### PR DESCRIPTION
## Summary
- follow up on late Codex findings from PR #1406 / issue #1243
- require declaration keyword matches to have a left identifier boundary
- preserve typed function bodies with unmatched implementation braces so parameter complexity still runs

## Test Plan
- [x] `npm test --workspace @franken/critique -- tests/unit/evaluators/complexity.test.ts` (red before fix: 2 new tests failed; green after fix: 72/72 pass)
- [x] `npm run lint --workspace @franken/critique`
- [x] `npm run build --workspace @franken/types`
- [x] `npm run build --workspace @franken/critique`
- [x] `npm run typecheck --workspace @franken/critique`
- [x] `TMPDIR=$PWD/.tmp npm test --workspace @franken/critique -- --maxWorkers=2` (395/395 pass)

Follow-up to #1243 and #1406.
