### PR TITLE
fix(observer): tighten W3C traceparent validation

### DIFF
--- a/packages/franken-observer/src/propagation/W3CTraceContext.test.ts
+++ b/packages/franken-observer/src/propagation/W3CTraceContext.test.ts
@@ -40,11 +40,23 @@ describe('parseTraceparent', () => {
     expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-02`)?.sampled).toBe(false)
   })
 
-  it('accepts future version bytes (forwards compatibility)', () => {
-    const result = parseTraceparent(`ff-${TRACE_ID}-${SPAN_ID}-01`)
+  it('accepts non-ff future version bytes with extra fields for forwards compatibility', () => {
+    const result = parseTraceparent(`01-${TRACE_ID}-${SPAN_ID}-01-extra`)
     expect(result).not.toBeNull()
     expect(result?.traceId).toBe(TRACE_ID)
     expect(result?.parentSpanId).toBe(SPAN_ID)
+  })
+
+  it('returns null for forbidden ff version bytes', () => {
+    expect(parseTraceparent(`ff-${TRACE_ID}-${SPAN_ID}-01`)).toBeNull()
+  })
+
+  it('returns null for version 00 headers with extra fields', () => {
+    expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-extra`)).toBeNull()
+  })
+
+  it('returns null for malformed version bytes', () => {
+    expect(parseTraceparent(`0g-${TRACE_ID}-${SPAN_ID}-01`)).toBeNull()
   })
 
   it('returns null for null input', () => {
@@ -115,8 +127,16 @@ describe('formatTraceparent', () => {
     expect(() => formatTraceparent({ traceId: 'short', parentSpanId: SPAN_ID, sampled: true })).toThrow()
   })
 
+  it('throws for an all-zeros traceId', () => {
+    expect(() => formatTraceparent({ traceId: ZEROS_32, parentSpanId: SPAN_ID, sampled: true })).toThrow()
+  })
+
   it('throws for a parentSpanId that is not 16 hex chars', () => {
     expect(() => formatTraceparent({ traceId: TRACE_ID, parentSpanId: 'short', sampled: true })).toThrow()
+  })
+
+  it('throws for an all-zeros parentSpanId', () => {
+    expect(() => formatTraceparent({ traceId: TRACE_ID, parentSpanId: ZEROS_16, sampled: true })).toThrow()
   })
 
   it('roundtrips cleanly with parseTraceparent', () => {

--- a/packages/franken-observer/src/propagation/W3CTraceContext.ts
+++ b/packages/franken-observer/src/propagation/W3CTraceContext.ts
@@ -33,6 +33,8 @@ const RE_HEX_16 = /^[0-9a-f]{16}$/
 const RE_HEX_02 = /^[0-9a-f]{2}$/
 const ZEROS_32  = '0'.repeat(32)
 const ZEROS_16  = '0'.repeat(16)
+const TRACEPARENT_VERSION_00 = '00'
+const TRACEPARENT_VERSION_FORBIDDEN = 'ff'
 
 // ── parseTraceparent ──────────────────────────────────────────────────────────
 
@@ -40,8 +42,9 @@ const ZEROS_16  = '0'.repeat(16)
  * Parses a W3C `traceparent` header value.
  *
  * Returns `null` for any input that does not conform to the spec:
- * unknown version bytes are accepted (forwards compatibility), but
- * all-zeros IDs and non-hex characters are rejected.
+ * unknown version bytes other than `ff` are accepted (forwards compatibility),
+ * but version `00` must have exactly four fields and all-zeros IDs and
+ * non-hex characters are rejected.
  *
  * ```ts
  * const ctx = parseTraceparent(req.headers['traceparent'])
@@ -58,7 +61,10 @@ export function parseTraceparent(header: string | null | undefined): Traceparent
   // Spec mandates exactly 4 fields for version 00; future versions may add more.
   if (parts.length < 4) return null
 
-  const [, traceId, parentSpanId, flags] = parts
+  const [version, traceId, parentSpanId, flags] = parts
+
+  if (!RE_HEX_02.test(version) || version === TRACEPARENT_VERSION_FORBIDDEN) return null
+  if (version === TRACEPARENT_VERSION_00 && parts.length !== 4) return null
 
   if (!RE_HEX_32.test(traceId)    || traceId    === ZEROS_32) return null
   if (!RE_HEX_16.test(parentSpanId) || parentSpanId === ZEROS_16) return null
@@ -78,16 +84,16 @@ export function parseTraceparent(header: string | null | undefined): Traceparent
  * fetch(url, { headers: { traceparent: header } })
  * ```
  *
- * @throws {Error} if `traceId` is not 32 lowercase hex chars, or
- *                 if `parentSpanId` is not 16 lowercase hex chars.
+ * @throws {Error} if `traceId` is not 32 lowercase non-zero hex chars, or
+ *                 if `parentSpanId` is not 16 lowercase non-zero hex chars.
  */
 export function formatTraceparent(fields: TraceparentFields): string {
   const { traceId, parentSpanId, sampled } = fields
-  if (!RE_HEX_32.test(traceId)) {
-    throw new Error(`traceId must be 32 lowercase hex characters, got: "${traceId}"`)
+  if (!RE_HEX_32.test(traceId) || traceId === ZEROS_32) {
+    throw new Error(`traceId must be 32 lowercase non-zero hex characters, got: "${traceId}"`)
   }
-  if (!RE_HEX_16.test(parentSpanId)) {
-    throw new Error(`parentSpanId must be 16 lowercase hex characters, got: "${parentSpanId}"`)
+  if (!RE_HEX_16.test(parentSpanId) || parentSpanId === ZEROS_16) {
+    throw new Error(`parentSpanId must be 16 lowercase non-zero hex characters, got: "${parentSpanId}"`)
   }
   return `00-${traceId}-${parentSpanId}-${sampled ? '01' : '00'}`
 }


### PR DESCRIPTION
## Summary
- Reject malformed W3C traceparent versions, including forbidden `ff`.
- Require version `00` traceparent headers to have exactly four fields.
- Reject all-zero trace IDs and parent span IDs when formatting traceparent headers.

## Test Plan
- `npm run test --workspace @franken/observer -- src/propagation/W3CTraceContext.test.ts`
- `npm run test --workspace @franken/observer`
- `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (passes with 6 existing warnings outside touched files)
- `npm run build --workspace @franken/observer`

Closes #1073
