### PR TITLE
fix(planner): dedupe recursive expansion tasks

### DIFF
--- a/packages/franken-planner/src/planners/recursive.ts
+++ b/packages/franken-planner/src/planners/recursive.ts
@@ -1,5 +1,4 @@
 import {
-  DuplicateTaskError,
   RationaleRejectedError,
   RecursionDepthExceededError,
   TaskNotFoundError,
@@ -97,16 +96,18 @@ export class RecursivePlanner implements PlanningStrategy {
 
   private _buildSubGraph(tasks: Task[], completedTaskIds: ReadonlySet<TaskId>): PlanGraph {
     const nodes = new Map<Task['id'], Task>();
+    const uniqueTasks: Task[] = [];
 
     for (const task of tasks) {
       if (nodes.has(task.id)) {
-        throw new DuplicateTaskError(task.id);
+        continue;
       }
       nodes.set(task.id, task);
+      uniqueTasks.push(task);
     }
 
     const edges = new Map<Task['id'], Set<Task['id']>>();
-    const tasksWithInternalDependencies = tasks.map((task) => {
+    const tasksWithInternalDependencies = uniqueTasks.map((task) => {
       const internalDependencies: TaskId[] = [];
       for (const dependencyId of task.dependsOn) {
         if (nodes.has(dependencyId)) {

--- a/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-recursive.integration.test.ts
@@ -83,6 +83,27 @@ describe('Integration — RecursivePlanner', () => {
     expect(executor).toHaveBeenCalledTimes(3);
   });
 
+  it('deduplicates expanded tasks by id before building the subgraph', async () => {
+    const sub = makeTask('sub');
+    const duplicateSub = makeTask('sub');
+    const parent = makeTask('parent');
+    const graph = PlanGraph.empty().addTask(parent);
+
+    const executor = vi.fn()
+      .mockResolvedValueOnce(expand('parent', [sub, duplicateSub]))
+      .mockResolvedValueOnce(ok('sub'));
+
+    const result = await buildRecursivePlanner(graph, executor).plan('...');
+
+    expect(result.status).toBe('completed');
+    expect(executor).toHaveBeenCalledTimes(2);
+    if (result.status !== 'completed') throw new Error('unexpected');
+    expect(result.taskResults.map((taskResult) => taskResult.taskId)).toEqual([
+      createTaskId('parent'),
+      createTaskId('sub'),
+    ]);
+  });
+
   it('collects results for parent and all sub-tasks', async () => {
     const sub = makeTask('sub');
     const parent = makeTask('parent');


### PR DESCRIPTION
## Summary
- de-duplicates duplicate task IDs produced by recursive dynamic expansions before building the subgraph
- preserves the first expanded task for each ID and executes each unique expanded task once
- adds an integration regression for duplicate expanded task IDs

## Test Plan
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/planner
- npm run lint --workspace @franken/planner
- npm run test --workspace @franken/planner
- npm run test:integration --workspace @franken/planner
- npm run build --workspace @franken/planner
- npx turbo run test --filter=@franken/planner

Note: the issue text's `npx turbo run test --filter=franken-planner` command fails because the workspace package is named `@franken/planner`; the equivalent package filter above passes.

Closes #1049
