### PR TITLE
fix(critique): count inline unresolved comments

### DIFF
--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -17,6 +17,10 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
   'gi',
 );
+const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
+  `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
+  'i',
+);
 const MAX_COMMENT_RATIO = 0.5;
 
 export class ConcisenessEvaluator implements Evaluator {
@@ -56,8 +60,11 @@ export class ConcisenessEvaluator implements Evaluator {
     const totalLines = lines.filter((l) => l.trim().length > 0).length;
     if (totalLines === 0) return;
 
-    // Count single-line comments
-    let commentLines = lines.filter((l) => COMMENT_LINE_PATTERN.test(l)).length;
+    // Count single-line comments and inline unresolved comment markers.
+    let commentLines = lines.filter(
+      (l) =>
+        COMMENT_LINE_PATTERN.test(l) || UNRESOLVED_COMMENT_LINE_PATTERN.test(l),
+    ).length;
 
     // Count block comment lines
     for (const match of content.matchAll(BLOCK_COMMENT_PATTERN)) {
@@ -85,7 +92,8 @@ export class ConcisenessEvaluator implements Evaluator {
       findings.push({
         message: `Found ${matches.length} unresolved marker comment(s): ${labels}. Address or track these as issues.`,
         severity: 'info',
-        suggestion: 'Resolve deferred-work items or convert them to tracked issues',
+        suggestion:
+          'Resolve deferred-work items or convert them to tracked issues',
       });
     }
   }

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -42,6 +42,26 @@ describe('ConcisenessEvaluator', () => {
     );
   });
 
+  it('counts inline unresolved comments toward the comment ratio', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const lines = [
+      `const first = 1; // ${pendingMarker}: replace placeholder`,
+      `const second = 2; // ${trackedMarker}: remove duplication`,
+      `const third = 3; // ${hackMarker}: temporary fallback`,
+      'const fourth = 4;',
+    ];
+    const result = await evaluator.evaluate(createInput(lines.join('\n')));
+
+    expect(
+      result.findings.some((f) =>
+        f.message.startsWith('Excessive comment ratio:'),
+      ),
+    ).toBe(true);
+  });
+
   it('flags unresolved marker comments', async () => {
     const evaluator = new ConcisenessEvaluator();
     const pendingMarker = ['TO', 'DO'].join('');


### PR DESCRIPTION
## Summary
- Count inline unresolved comment markers toward the conciseness comment ratio.
- Add a regression test covering inline TODO/FIXME/HACK markers.

## Test Plan
- npm test --workspace @franken/critique -- --run tests/unit/evaluators/conciseness.test.ts (red before fix, green after fix)
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/critique
- npm test --workspace @franken/critique

Note: package-wide `npm run format:check --workspace @franken/critique` currently fails on pre-existing formatting drift across many files, so I verified Prettier only on the two touched files with `npx prettier --check ...`.

Closes #1070