### PR TITLE
fix(observer): repair corrupt replay blobs atomically

### DIFF
--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReplayContentStore } from './replay-content-store.js';
@@ -31,6 +31,19 @@ describe('ReplayContentStore', () => {
     corruptReplayBlob(root, ref, 'tampered');
 
     expect(() => store.get(ref)).toThrow(/hash mismatch/i);
+  });
+
+  it('repairs a corrupt existing blob before returning its content ref', () => {
+    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const store = new ReplayContentStore(root);
+    const content = 'original';
+    const ref = store.put(content);
+    const blobPath = join(root, 'blobs', ref);
+    corruptReplayBlob(root, ref, 'partial write');
+
+    expect(store.put(content)).toBe(ref);
+    expect(readFileSync(blobPath, 'utf8')).toBe(content);
+    expect(store.get(ref)).toBe(content);
   });
 
   it('rejects refs that are not exact lowercase sha256 hex before reading', () => {

--- a/packages/franken-observer/src/replay/replay-content-store.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.ts
@@ -1,4 +1,5 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { resolveContainedExistingPath, resolveContainedPath } from '@franken/types/path-containment';
 import { contentHashMatches } from '../utils/crypto.js';
 import { hashContent } from './replay-record.js';
@@ -18,9 +19,11 @@ export class ReplayContentStore {
   put(content: string): string {
     const ref = hashContent(content);
     const path = this.blobPath(ref);
-    if (!existsSync(path)) {
-      writeFileSync(path, content, 'utf8');
+    if (existsSync(path) && contentHashMatches(readFileSync(path, 'utf8'), ref)) {
+      return ref;
     }
+
+    this.writeBlobAtomically(ref, content, path);
     return ref;
   }
 
@@ -30,6 +33,19 @@ export class ReplayContentStore {
       throw new Error(`Replay blob hash mismatch for ${ref}`);
     }
     return content;
+  }
+
+  private writeBlobAtomically(ref: string, content: string, finalPath: string): void {
+    const tempName = `.${ref}.${process.pid}.${randomUUID()}.tmp`;
+    const tempPath = resolveContainedPath(this.dir, tempName, 'replayBlobTempPath');
+
+    try {
+      writeFileSync(tempPath, content, 'utf8');
+      renameSync(tempPath, finalPath);
+    } catch (err) {
+      rmSync(tempPath, { force: true });
+      throw err;
+    }
   }
 
   private blobPath(ref: string): string {


### PR DESCRIPTION
## Summary
- verifies existing replay blobs before returning content refs
- rewrites missing/corrupt replay blobs via same-directory temp files and atomic rename
- adds regression coverage for repairing a corrupt existing blob

## Test Plan
- npm test --workspace @franken/observer -- --run src/replay/replay-content-store.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer
- npm test --workspace @franken/observer

Closes #1027