### PR TITLE
fix(observer): harden SQLite adapter database opens

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { unlinkSync, existsSync } from 'node:fs'
+import { unlinkSync, existsSync, rmSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import Database from 'better-sqlite3'
 import { TraceContext } from '../../core/TraceContext.js'
@@ -31,6 +31,26 @@ describe('SQLiteAdapter', () => {
   afterEach(() => {
     adapter.close()
     cleanup(dbPath)
+  })
+
+  describe('database open hardening', () => {
+    it('creates nested database directories and configures durability pragmas', () => {
+      const root = join(tmpdir(), `franken-observer-nested-${randomUUID()}`)
+      const nestedDbPath = join(root, 'missing', 'observer.db')
+      const nestedAdapter = new SQLiteAdapter(nestedDbPath)
+
+      try {
+        expect(existsSync(dirname(nestedDbPath))).toBe(true)
+
+        const handle = (nestedAdapter as unknown as { db: Database.Database }).db
+        expect(handle.pragma('busy_timeout', { simple: true })).toBe(5000)
+        expect(String(handle.pragma('journal_mode', { simple: true })).toLowerCase()).toBe('wal')
+        expect(handle.pragma('foreign_keys', { simple: true })).toBe(1)
+      } finally {
+        nestedAdapter.close()
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
   })
 
   describe('flush() + queryByTraceId()', () => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -30,11 +30,15 @@ describe('SQLiteAdapter', () => {
     vi.clearAllMocks()
   })
 
-  it('configures a busy timeout so concurrent writers wait for locks', () => {
+  it('configures WAL, foreign keys, and a busy timeout so concurrent writers wait for locks', () => {
     const adapter = new SQLiteAdapter('/tmp/traces.db')
 
     expect(Database).toHaveBeenCalledWith('/tmp/traces.db')
-    expect(pragmaMock).toHaveBeenCalledWith('busy_timeout = 5000')
+    expect(pragmaMock.mock.calls.map(call => call[0])).toEqual([
+      'busy_timeout = 5000',
+      'journal_mode = WAL',
+      'foreign_keys = ON',
+    ])
 
     adapter.close()
   })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -1,4 +1,6 @@
 import Database from 'better-sqlite3'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 import type { Trace, Span } from '../../core/types.js'
 import type { ExportAdapter, TraceSummary } from '../../export/ExportAdapter.js'
 import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
@@ -102,6 +104,7 @@ export class SQLiteAdapter implements ExportAdapter {
   private flushedSpanSnapshotCount = 0
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
+    mkdirSync(dirname(filePath), { recursive: true })
     this.db = new Database(filePath)
     this.maxFlushedSpanSnapshots = Math.max(
       0,


### PR DESCRIPTION
## Summary
- Create the SQLite database parent directory before opening the observer DB file.
- Keep WAL/foreign-key setup and assert busy_timeout/WAL/foreign_keys pragmas in regression coverage.
- Add an integration regression for nested missing database directories.

## Test Plan
- npm run test --workspace @franken/observer -- SQLiteAdapter.test.ts SQLiteAdapter.integration.test.ts
- INTEGRATION=true npm run test --workspace @franken/observer -- SQLiteAdapter.integration.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer
- npm run test --workspace @franken/observer

Closes #1025