### PR TITLE
fix(observer): clone redacted spans before export

### DIFF
--- a/packages/franken-observer/src/redaction/SpanRedactor.test.ts
+++ b/packages/franken-observer/src/redaction/SpanRedactor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { SpanRedactor } from './SpanRedactor.js'
 import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
 import type { Trace, Span } from '../core/types.js'
+import type { ExportAdapter } from '../export/ExportAdapter.js'
 
 function makeSpan(overrides: Partial<Span> = {}): Span {
   return {
@@ -18,6 +19,25 @@ function makeSpan(overrides: Partial<Span> = {}): Span {
 
 function makeTrace(spans: Span[] = [], id = 'trace-1'): Trace {
   return { id, goal: 'test', status: 'completed', startedAt: Date.now(), spans }
+}
+
+class MutatingAdapter implements ExportAdapter {
+  lastTrace: Trace | null = null
+
+  async flush(trace: Trace): Promise<void> {
+    this.lastTrace = trace
+    const span = trace.spans[0]
+    span.metadata.downstream = 'mutated'
+    span.thoughtBlocks.push('downstream thought')
+  }
+
+  async queryByTraceId(): Promise<Trace | null> {
+    return this.lastTrace
+  }
+
+  async listTraceIds(): Promise<string[]> {
+    return this.lastTrace ? [this.lastTrace.id] : []
+  }
 }
 
 // ── metadata key redaction ────────────────────────────────────────────────────
@@ -197,6 +217,58 @@ describe('SpanRedactor — immutability', () => {
     const trace = makeTrace([span])
     await redactor.flush(trace)
     expect(thoughts).toEqual(['private'])
+  })
+
+  it('defensively clones spans before downstream export when no rules are configured', async () => {
+    const inner = new MutatingAdapter()
+    const span = makeSpan({ metadata: { safe: 'visible' }, thoughtBlocks: ['private'] })
+    const trace = makeTrace([span])
+    const redactor = new SpanRedactor({ adapter: inner, rules: [] })
+
+    await redactor.flush(trace)
+
+    expect(inner.lastTrace!.spans[0]).not.toBe(span)
+    expect(inner.lastTrace!.spans[0].metadata).not.toBe(span.metadata)
+    expect(inner.lastTrace!.spans[0].thoughtBlocks).not.toBe(span.thoughtBlocks)
+    expect(trace.spans[0].metadata).toEqual({ safe: 'visible' })
+    expect(trace.spans[0].thoughtBlocks).toEqual(['private'])
+  })
+
+  it('defensively clones spans before downstream export when rules do not match', async () => {
+    const inner = new MutatingAdapter()
+    const span = makeSpan({ metadata: { safe: 'visible' }, thoughtBlocks: ['private'] })
+    const trace = makeTrace([span])
+    const redactor = new SpanRedactor({
+      adapter: inner,
+      rules: [{ key: 'credential', action: 'remove' }],
+    })
+
+    await redactor.flush(trace)
+
+    expect(inner.lastTrace!.spans[0]).not.toBe(span)
+    expect(inner.lastTrace!.spans[0].metadata).not.toBe(span.metadata)
+    expect(inner.lastTrace!.spans[0].thoughtBlocks).not.toBe(span.thoughtBlocks)
+    expect(trace.spans[0].metadata).toEqual({ safe: 'visible' })
+    expect(trace.spans[0].thoughtBlocks).toEqual(['private'])
+  })
+
+  it('defensively clones unchanged spans when another span in the trace is redacted', async () => {
+    const inner = new MutatingAdapter()
+    const unchanged = makeSpan({ id: 's1', metadata: { safe: 'visible' }, thoughtBlocks: ['private'] })
+    const redacted = makeSpan({ id: 's2', metadata: { credential: 'secret' }, thoughtBlocks: [] })
+    const trace = makeTrace([unchanged, redacted])
+    const redactor = new SpanRedactor({
+      adapter: inner,
+      rules: [{ key: 'credential', action: 'remove' }],
+    })
+
+    await redactor.flush(trace)
+
+    expect(inner.lastTrace!.spans[0]).not.toBe(unchanged)
+    expect(inner.lastTrace!.spans[0].metadata).not.toBe(unchanged.metadata)
+    expect(inner.lastTrace!.spans[0].thoughtBlocks).not.toBe(unchanged.thoughtBlocks)
+    expect(trace.spans[0].metadata).toEqual({ safe: 'visible' })
+    expect(trace.spans[0].thoughtBlocks).toEqual(['private'])
   })
 })
 

--- a/packages/franken-observer/src/redaction/SpanRedactor.ts
+++ b/packages/franken-observer/src/redaction/SpanRedactor.ts
@@ -92,15 +92,14 @@ export class SpanRedactor implements ExportAdapter {
 
   private redactSpan(span: Span): Span {
     const metadata = this.redactMetadata(span.metadata)
-    const thoughtBlocks = this.redactThoughtBlocks ? [] : span.thoughtBlocks
-    if (metadata === span.metadata && thoughtBlocks === span.thoughtBlocks) return span
+    const thoughtBlocks = this.redactThoughtBlocks ? [] : [...span.thoughtBlocks]
     return { ...span, metadata, thoughtBlocks }
   }
 
   private redactMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
-    if (this.rules.length === 0) return metadata
-
     const result: Record<string, unknown> = { ...metadata }
+    if (this.rules.length === 0) return result
+
     for (const [key] of Object.entries(metadata)) {
       for (const rule of this.rules) {
         const matches =


### PR DESCRIPTION
## Summary
- Always clone SpanRedactor span wrappers before passing traces to downstream adapters
- Copy metadata and thought block arrays even when no redaction rule matches
- Add regression coverage for downstream adapter mutation in no-rule, no-match, and partial-redaction cases

## Test Plan
- npm run test --workspace @franken/observer -- src/redaction/SpanRedactor.test.ts
- npm run build --workspace @franken/types
- npm run test --workspace @franken/observer
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer
- git diff --check

Closes #1021