### PR TITLE
fix(observer): isolate LoopDetector handler failures

### DIFF
--- a/packages/franken-observer/src/core/SpanLifecycle.test.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.test.ts
@@ -164,5 +164,26 @@ describe('SpanLifecycle', () => {
       }
       expect(handler).toHaveBeenCalledOnce()
     })
+
+    it('does not let a loop-detected handler failure make endSpan throw', () => {
+      const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 2 })
+      const throwingHandler = vi.fn(() => {
+        throw new Error('handler failed')
+      })
+      const laterHandler = vi.fn()
+      detector.on('loop-detected', throwingHandler)
+      detector.on('loop-detected', laterHandler)
+
+      const trace = TraceContext.createTrace('goal')
+      for (const name of ['a', 'b', 'a']) {
+        const span = TraceContext.startSpan(trace, { name })
+        TraceContext.endSpan(span, {}, detector)
+      }
+
+      const triggeringSpan = TraceContext.startSpan(trace, { name: 'b' })
+      expect(() => TraceContext.endSpan(triggeringSpan, {}, detector)).not.toThrow()
+      expect(throwingHandler).toHaveBeenCalledOnce()
+      expect(laterHandler).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/packages/franken-observer/src/incident/LoopDetector.test.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.test.ts
@@ -223,6 +223,28 @@ describe('LoopDetector', () => {
       for (const n of ['a', 'b', 'a', 'b']) detector.check(n)
       expect(handler).not.toHaveBeenCalled()
     })
+
+    it('isolates throwing handlers and continues notifying later listeners', () => {
+      const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 2 })
+      const throwingHandler = vi.fn(() => {
+        throw new Error('webhook failed')
+      })
+      const laterHandler = vi.fn()
+
+      detector.on('loop-detected', throwingHandler)
+      detector.on('loop-detected', laterHandler)
+
+      detector.check('a')
+      detector.check('b')
+      detector.check('a')
+
+      expect(() => detector.check('b')).not.toThrow()
+      expect(throwingHandler).toHaveBeenCalledOnce()
+      expect(laterHandler).toHaveBeenCalledOnce()
+      expect(laterHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ detected: true, detectedPattern: ['a', 'b'], repetitions: 2 }),
+      )
+    })
   })
 
   describe('reset()', () => {

--- a/packages/franken-observer/src/incident/LoopDetector.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.ts
@@ -86,7 +86,11 @@ export class LoopDetector {
     }
 
     for (const handler of this.handlers) {
-      handler(result)
+      try {
+        handler(result)
+      } catch {
+        // Isolate handler failures; other handlers still receive the signal.
+      }
     }
 
     return result


### PR DESCRIPTION
## Summary
- Isolate exceptions thrown by `LoopDetector` loop-detected handlers so `check()` keeps its non-throwing contract.
- Continue notifying later loop listeners after an earlier handler fails.
- Add regression coverage for direct `LoopDetector.check()` calls and `TraceContext.endSpan()` integration.

## Test Plan
- [x] `npm test --workspace @franken/observer -- --run src/incident/LoopDetector.test.ts src/core/SpanLifecycle.test.ts` (red before fix, green after)
- [x] `npm test --workspace @franken/observer`
- [x] `npm run lint --workspace @franken/observer` (passes with pre-existing warnings)
- [x] `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/observer`
- [x] `npm run build --workspace @franken/types && npm run build --workspace @franken/observer`

Closes #1020
