### PR TITLE
test(observer): cover BatchAdapter failed drain retention

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -229,6 +229,36 @@ describe('BatchAdapter — drain()', () => {
     expect(calls).toEqual(['fast-fail', 'slow-success', 'fast-fail'])
   })
 
+  it('retains failed traces for retry without duplicating successful traces after partial drain failure', async () => {
+    const inner = new InMemoryAdapter()
+    const failedOnce = new Set<string>()
+    const calls: string[] = []
+    vi.spyOn(inner, 'flush').mockImplementation(async trace => {
+      calls.push(trace.id)
+      if (trace.id === 'retry-later' && !failedOnce.has(trace.id)) {
+        failedOnce.add(trace.id)
+        throw new Error('transient exporter failure')
+      }
+      await InMemoryAdapter.prototype.flush.call(inner, trace)
+    })
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    const alreadyPersisted = makeTrace('already-persisted')
+    const retryLater = makeTrace('retry-later')
+
+    await batch.flush(alreadyPersisted)
+    await batch.flush(retryLater)
+    await expect(batch.drain()).rejects.toThrow('transient exporter failure')
+
+    expect(await inner.listTraceIds()).toEqual(['already-persisted'])
+    expect(await batch.queryByTraceId('retry-later')).toEqual(retryLater)
+    expect((await batch.listTraceIds()).sort()).toEqual(['already-persisted', 'retry-later'])
+
+    await expect(batch.drain()).resolves.toBeUndefined()
+    expect((await inner.listTraceIds()).sort()).toEqual(['already-persisted', 'retry-later'])
+    expect(calls).toEqual(['already-persisted', 'retry-later', 'retry-later'])
+  })
+
   it('does not fail a newly queued trace because an older drain rejects', async () => {
     const oldFailure = deferred()
     const inner: ExportAdapter = {
@@ -411,6 +441,17 @@ describe('BatchAdapter — stop()', () => {
     await expect(stopPromise).rejects.toThrow('old drain failed')
     expect(received).toEqual(['old', 'old', 'appended'])
     expect(await batch.listTraceIds()).toEqual(['old'])
+  })
+
+  it('retains shutdown traces when stop fails to flush them', async () => {
+    const batch = new BatchAdapter({ adapter: new FailingFlushAdapter(), maxBatchSize: 100 })
+    const trace = makeTrace('shutdown-retry')
+
+    await batch.flush(trace)
+    await expect(batch.stop()).rejects.toThrow('database temporarily locked')
+
+    expect(await batch.queryByTraceId('shutdown-retry')).toEqual(trace)
+    expect(await batch.listTraceIds()).toEqual(['shutdown-retry'])
   })
 
   it('does not call clearInterval when no timer was started', async () => {


### PR DESCRIPTION
## Summary
- add regression coverage that partial BatchAdapter drain failures keep failed traces retryable without duplicating successful traces
- add shutdown coverage proving stop() failures leave final buffered traces visible for retry
- verify the existing BatchAdapter implementation already satisfies issue #1019 retention semantics

## Test Plan
- npm test --workspace packages/franken-observer -- BatchAdapter.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace packages/franken-observer
- npm run build --workspace packages/franken-observer
- npm run lint --workspace packages/franken-observer (passes with existing warnings)

Closes #1019