### PR TITLE
fix(observer): snapshot InMemoryAdapter traces

### DIFF
--- a/packages/franken-observer/src/export/ExportAdapter.test.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.test.ts
@@ -60,6 +60,44 @@ describe('InMemoryAdapter', () => {
       expect(retrieved!.goal).toBe('updated goal')
     })
 
+    it('captures a flush-time snapshot and returns defensive query copies', async () => {
+      const trace = TraceContext.createTrace('snapshot goal')
+      const span = TraceContext.startSpan(trace, { name: 'original span' })
+      span.metadata = { nested: { count: 1 }, label: 'before' }
+      SpanLifecycle.addThoughtBlock(span, 'first thought')
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+
+      await adapter.flush(trace)
+
+      trace.goal = 'mutated original goal'
+      trace.status = 'error'
+      trace.spans[0]!.name = 'mutated original span'
+      trace.spans[0]!.metadata = { nested: { count: 2 }, label: 'after' }
+      trace.spans[0]!.thoughtBlocks.push('mutated original thought')
+
+      const firstQuery = await adapter.queryByTraceId(trace.id)
+      expect(firstQuery).not.toBeNull()
+      expect(firstQuery!.goal).toBe('snapshot goal')
+      expect(firstQuery!.status).toBe('completed')
+      expect(firstQuery!.spans[0]!.name).toBe('original span')
+      expect(firstQuery!.spans[0]!.metadata).toEqual({ nested: { count: 1 }, label: 'before' })
+      expect(firstQuery!.spans[0]!.thoughtBlocks).toEqual(['first thought'])
+
+      firstQuery!.goal = 'mutated queried goal'
+      firstQuery!.status = 'error'
+      firstQuery!.spans[0]!.name = 'mutated queried span'
+      firstQuery!.spans[0]!.metadata = { nested: { count: 3 }, label: 'queried' }
+      firstQuery!.spans[0]!.thoughtBlocks.push('mutated queried thought')
+
+      const secondQuery = await adapter.queryByTraceId(trace.id)
+      expect(secondQuery!.goal).toBe('snapshot goal')
+      expect(secondQuery!.status).toBe('completed')
+      expect(secondQuery!.spans[0]!.name).toBe('original span')
+      expect(secondQuery!.spans[0]!.metadata).toEqual({ nested: { count: 1 }, label: 'before' })
+      expect(secondQuery!.spans[0]!.thoughtBlocks).toEqual(['first thought'])
+    })
+
     it('warns when exporting a trace that still has active spans', async () => {
       const trace = TraceContext.createTrace('goal')
       TraceContext.startSpan(trace, { name: 'orphaned' })

--- a/packages/franken-observer/src/export/ExportAdapter.test.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.test.ts
@@ -98,6 +98,29 @@ describe('InMemoryAdapter', () => {
       expect(secondQuery!.spans[0]!.thoughtBlocks).toEqual(['first thought'])
     })
 
+    it('tolerates uncloneable metadata values while snapshotting traces', async () => {
+      const trace = TraceContext.createTrace('uncloneable metadata')
+      const span = TraceContext.startSpan(trace, { name: 'metadata span' })
+      const callback = () => 'value'
+      const marker = Symbol('marker')
+      SpanLifecycle.setMetadata(span, {
+        callback,
+        marker,
+        nested: { callback, marker, kept: true },
+      })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+
+      await expect(adapter.flush(trace)).resolves.toBeUndefined()
+
+      const retrieved = await adapter.queryByTraceId(trace.id)
+      expect(retrieved!.spans[0]!.metadata).toEqual({
+        callback: String(callback),
+        marker: String(marker),
+        nested: { callback: String(callback), marker: String(marker), kept: true },
+      })
+    })
+
     it('warns when exporting a trace that still has active spans', async () => {
       const trace = TraceContext.createTrace('goal')
       TraceContext.startSpan(trace, { name: 'orphaned' })

--- a/packages/franken-observer/src/export/ExportAdapter.test.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.test.ts
@@ -139,6 +139,46 @@ describe('InMemoryAdapter', () => {
       })
     })
 
+    it('preserves container, Error, and __proto__ metadata during fallback cloning', async () => {
+      const trace = TraceContext.createTrace('container metadata')
+      const span = TraceContext.startSpan(trace, { name: 'container metadata span' })
+      const callback = () => 'container'
+      const error = new Error('boom') as Error & { code?: string; details?: { retryable: boolean } }
+      error.code = 'E_BOOM'
+      error.details = { retryable: true }
+      const protoValue = { polluted: true }
+      SpanLifecycle.setMetadata(span, {
+        tools: new Map<string, unknown>([['cb', callback]]),
+        values: new Set<unknown>([callback, 'kept']),
+        error,
+        callback,
+      })
+      Object.defineProperty(span.metadata, '__proto__', {
+        value: protoValue,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+
+      await adapter.flush(trace)
+
+      const retrieved = await adapter.queryByTraceId(trace.id)
+      const metadata = retrieved!.spans[0]!.metadata
+      expect(metadata['tools']).toEqual(new Map([['cb', String(callback)]]))
+      expect(metadata['values']).toEqual(new Set([String(callback), 'kept']))
+      expect(metadata['error']).toMatchObject({
+        name: 'Error',
+        message: 'boom',
+        code: 'E_BOOM',
+        details: { retryable: true },
+      })
+      expect(Object.prototype.hasOwnProperty.call(metadata, '__proto__')).toBe(true)
+      expect(metadata['__proto__']).toEqual(protoValue)
+      expect(Object.getPrototypeOf(metadata)).toBe(Object.prototype)
+    })
+
     it('warns when exporting a trace that still has active spans', async () => {
       const trace = TraceContext.createTrace('goal')
       TraceContext.startSpan(trace, { name: 'orphaned' })

--- a/packages/franken-observer/src/export/ExportAdapter.test.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.test.ts
@@ -121,6 +121,24 @@ describe('InMemoryAdapter', () => {
       })
     })
 
+    it('preserves repeated uncloneable metadata references without treating them as cycles', async () => {
+      const trace = TraceContext.createTrace('shared metadata')
+      const span = TraceContext.startSpan(trace, { name: 'shared metadata span' })
+      const callback = () => 'shared'
+      const shared = { callback, kept: true }
+      SpanLifecycle.setMetadata(span, { a: shared, b: shared })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+
+      await adapter.flush(trace)
+
+      const retrieved = await adapter.queryByTraceId(trace.id)
+      expect(retrieved!.spans[0]!.metadata).toEqual({
+        a: { callback: String(callback), kept: true },
+        b: { callback: String(callback), kept: true },
+      })
+    })
+
     it('warns when exporting a trace that still has active spans', async () => {
       const trace = TraceContext.createTrace('goal')
       TraceContext.startSpan(trace, { name: 'orphaned' })

--- a/packages/franken-observer/src/export/ExportAdapter.test.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.test.ts
@@ -179,6 +179,35 @@ describe('InMemoryAdapter', () => {
       expect(Object.getPrototypeOf(metadata)).toBe(Object.prototype)
     })
 
+    it('preserves binary, RegExp, and cyclic Error metadata snapshots', async () => {
+      const trace = TraceContext.createTrace('complex metadata')
+      const span = TraceContext.startSpan(trace, { name: 'complex metadata span' })
+      const bytes = new Uint8Array([1, 2, 3])
+      const view = new DataView(new Uint8Array([4, 5, 6, 7]).buffer, 1, 2)
+      const regex = /ab/g
+      regex.lastIndex = 2
+      const cyclicError = new Error('cyclic') as Error & { cause?: unknown }
+      cyclicError.cause = cyclicError
+      const aggregate = new AggregateError([cyclicError], 'many')
+      SpanLifecycle.setMetadata(span, { bytes, view, regex, cyclicError, aggregate })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+
+      await adapter.flush(trace)
+      bytes[0] = 9
+      regex.lastIndex = 0
+
+      const retrieved = await adapter.queryByTraceId(trace.id)
+      const metadata = retrieved!.spans[0]!.metadata
+      expect(metadata['bytes']).toEqual(new Uint8Array([1, 2, 3]))
+      expect(Array.from(new Uint8Array((metadata['view'] as DataView).buffer))).toEqual([5, 6])
+      expect(metadata['regex']).toMatchObject({ source: 'ab', flags: 'g', lastIndex: 2 })
+      expect(metadata['cyclicError']).toMatchObject({ name: 'Error', message: 'cyclic' })
+      expect((metadata['cyclicError'] as { cause: unknown }).cause).toBe(metadata['cyclicError'])
+      expect(metadata['aggregate']).toMatchObject({ name: 'AggregateError', message: 'many' })
+      expect((metadata['aggregate'] as { errors: unknown[] }).errors).toHaveLength(1)
+    })
+
     it('warns when exporting a trace that still has active spans', async () => {
       const trace = TraceContext.createTrace('goal')
       TraceContext.startSpan(trace, { name: 'orphaned' })

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -11,14 +11,19 @@ export class InMemoryAdapter implements ExportAdapter {
 
   async flush(trace: Trace): Promise<void> {
     warnIfTraceHasActiveSpans(trace, 'InMemoryAdapter')
-    this.store.set(trace.id, trace)
+    this.store.set(trace.id, cloneTrace(trace))
   }
 
   async queryByTraceId(traceId: string): Promise<Trace | null> {
-    return this.store.get(traceId) ?? null
+    const trace = this.store.get(traceId)
+    return trace ? cloneTrace(trace) : null
   }
 
   async listTraceIds(): Promise<string[]> {
     return Array.from(this.store.keys())
   }
+}
+
+function cloneTrace(trace: Trace): Trace {
+  return structuredClone(trace)
 }

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -25,5 +25,60 @@ export class InMemoryAdapter implements ExportAdapter {
 }
 
 function cloneTrace(trace: Trace): Trace {
-  return structuredClone(trace)
+  return {
+    id: trace.id,
+    goal: trace.goal,
+    status: trace.status,
+    startedAt: trace.startedAt,
+    ...(trace.endedAt !== undefined ? { endedAt: trace.endedAt } : {}),
+    spans: trace.spans.map(span => ({
+      id: span.id,
+      traceId: span.traceId,
+      ...(span.parentSpanId !== undefined ? { parentSpanId: span.parentSpanId } : {}),
+      name: span.name,
+      status: span.status,
+      startedAt: span.startedAt,
+      ...(span.endedAt !== undefined ? { endedAt: span.endedAt } : {}),
+      ...(span.durationMs !== undefined ? { durationMs: span.durationMs } : {}),
+      ...(span.errorMessage !== undefined ? { errorMessage: span.errorMessage } : {}),
+      metadata: cloneMetadata(span.metadata),
+      thoughtBlocks: [...span.thoughtBlocks],
+    })),
+  }
+}
+
+function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  return cloneMetadataValue(metadata) as Record<string, unknown>
+}
+
+function cloneMetadataValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return String(value)
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+
+  try {
+    return structuredClone(value)
+  } catch {
+    // Fall back to a JSON-like enumerable clone for metadata containing values
+    // unsupported by the structured clone algorithm, such as functions/symbols.
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    return value.map(item => cloneMetadataValue(item, seen))
+  }
+
+  const cloned: Record<string, unknown> = {}
+  for (const [key, nestedValue] of Object.entries(value)) {
+    cloned[key] = cloneMetadataValue(nestedValue, seen)
+  }
+  return cloned
 }

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -51,7 +51,7 @@ function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknow
   return cloneMetadataValue(metadata) as Record<string, unknown>
 }
 
-function cloneMetadataValue(value: unknown, seen = new WeakSet<object>()): unknown {
+function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
   if (typeof value === 'function' || typeof value === 'symbol') {
     return String(value)
   }
@@ -68,15 +68,18 @@ function cloneMetadataValue(value: unknown, seen = new WeakSet<object>()): unkno
   }
 
   if (seen.has(value)) {
-    return '[Circular]'
+    return seen.get(value)
   }
-  seen.add(value)
 
   if (Array.isArray(value)) {
-    return value.map(item => cloneMetadataValue(item, seen))
+    const cloned: unknown[] = []
+    seen.set(value, cloned)
+    cloned.push(...value.map(item => cloneMetadataValue(item, seen)))
+    return cloned
   }
 
   const cloned: Record<string, unknown> = {}
+  seen.set(value, cloned)
   for (const [key, nestedValue] of Object.entries(value)) {
     cloned[key] = cloneMetadataValue(nestedValue, seen)
   }

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -69,7 +69,17 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
   }
 
   if (value instanceof RegExp) {
-    return new RegExp(value.source, value.flags)
+    const cloned = new RegExp(value.source, value.flags)
+    cloned.lastIndex = value.lastIndex
+    return cloned
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0)
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return cloneArrayBufferView(value)
   }
 
   if (value instanceof Map) {
@@ -102,9 +112,12 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
       name: value.name,
       message: value.message,
     }
+    seen.set(value, cloned)
     if (value.stack !== undefined) cloned['stack'] = value.stack
     if ('cause' in value) cloned['cause'] = cloneMetadataValue(value.cause, seen)
-    seen.set(value, cloned)
+    if (value instanceof AggregateError) {
+      cloned['errors'] = cloneMetadataValue(value.errors, seen)
+    }
     for (const [key, nestedValue] of Object.entries(value)) {
       defineMetadataProperty(cloned, key, cloneMetadataValue(nestedValue, seen))
     }
@@ -117,6 +130,21 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
     defineMetadataProperty(cloned, key, cloneMetadataValue(nestedValue, seen))
   }
   return cloned
+}
+
+function cloneArrayBufferView(value: ArrayBufferView): ArrayBufferView {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+    return Buffer.from(value)
+  }
+
+  const sourceBytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+  const clonedBuffer = sourceBytes.slice().buffer as ArrayBuffer
+  if (value instanceof DataView) {
+    return new DataView(clonedBuffer)
+  }
+
+  const constructor = value.constructor as new (buffer: ArrayBuffer) => ArrayBufferView
+  return new constructor(clonedBuffer)
 }
 
 function defineMetadataProperty(

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -60,15 +60,34 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
     return value
   }
 
-  try {
-    return structuredClone(value)
-  } catch {
-    // Fall back to a JSON-like enumerable clone for metadata containing values
-    // unsupported by the structured clone algorithm, such as functions/symbols.
-  }
-
   if (seen.has(value)) {
     return seen.get(value)
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime())
+  }
+
+  if (value instanceof RegExp) {
+    return new RegExp(value.source, value.flags)
+  }
+
+  if (value instanceof Map) {
+    const cloned = new Map<unknown, unknown>()
+    seen.set(value, cloned)
+    for (const [key, nestedValue] of value.entries()) {
+      cloned.set(cloneMetadataValue(key, seen), cloneMetadataValue(nestedValue, seen))
+    }
+    return cloned
+  }
+
+  if (value instanceof Set) {
+    const cloned = new Set<unknown>()
+    seen.set(value, cloned)
+    for (const nestedValue of value.values()) {
+      cloned.add(cloneMetadataValue(nestedValue, seen))
+    }
+    return cloned
   }
 
   if (Array.isArray(value)) {
@@ -78,10 +97,37 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
     return cloned
   }
 
+  if (value instanceof Error) {
+    const cloned: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+    }
+    if (value.stack !== undefined) cloned['stack'] = value.stack
+    if ('cause' in value) cloned['cause'] = cloneMetadataValue(value.cause, seen)
+    seen.set(value, cloned)
+    for (const [key, nestedValue] of Object.entries(value)) {
+      defineMetadataProperty(cloned, key, cloneMetadataValue(nestedValue, seen))
+    }
+    return cloned
+  }
+
   const cloned: Record<string, unknown> = {}
   seen.set(value, cloned)
   for (const [key, nestedValue] of Object.entries(value)) {
-    cloned[key] = cloneMetadataValue(nestedValue, seen)
+    defineMetadataProperty(cloned, key, cloneMetadataValue(nestedValue, seen))
   }
   return cloned
+}
+
+function defineMetadataProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  })
 }


### PR DESCRIPTION
## Summary
- clone traces when InMemoryAdapter flushes so stored records are flush-time snapshots
- return defensive trace copies from queryByTraceId to protect the backing store
- add regression coverage for original/queried trace mutations across trace fields, spans, metadata, and thought blocks

## Test Plan
- npm test --workspace @franken/observer -- ExportAdapter.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer (passes with pre-existing warnings)
- npm test --workspace @franken/observer

Closes #1015