### PR TITLE
fix(observer): fail audit verification for missing hashed content

### DIFF
--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -149,6 +149,47 @@ describe('AuditTrail', () => {
     expect(result.mismatches).toHaveLength(1);
   });
 
+  it('verify() fails when hashed input content is missing', () => {
+    const trail = new AuditTrail();
+    const event = createAuditEvent('test', {}, { phase: 'p', provider: 'pr', input: 'hello' });
+    trail.append(event);
+
+    expect(trail.verify(new Map())).toEqual({
+      valid: false,
+      mismatches: [`${event.eventId}: input content missing`],
+    });
+  });
+
+  it('verify() fails when hashed output content is missing', () => {
+    const trail = new AuditTrail();
+    const event = createAuditEvent('test', {}, { phase: 'p', provider: 'pr', output: 'result' });
+    trail.append(event);
+
+    expect(trail.verify(new Map())).toEqual({
+      valid: false,
+      mismatches: [`${event.eventId}: output content missing`],
+    });
+  });
+
+  it('verify() reports only the missing side when one hashed content entry is absent', () => {
+    const trail = new AuditTrail();
+    const event = createAuditEvent('test', {}, {
+      phase: 'p',
+      provider: 'pr',
+      input: 'hello',
+      output: 'result',
+    });
+    trail.append(event);
+
+    const contentMap = new Map<string, string>();
+    contentMap.set(`${event.eventId}:input`, 'hello');
+
+    expect(trail.verify(contentMap)).toEqual({
+      valid: false,
+      mismatches: [`${event.eventId}: output content missing`],
+    });
+  });
+
   it('verify() checks empty string content against hash', () => {
     const trail = new AuditTrail();
     const event = createAuditEvent('test', {}, { phase: 'p', provider: 'pr', input: '' });

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -166,13 +166,17 @@ export class AuditTrail {
     for (const event of this.events) {
       if (event.inputHash) {
         const content = contentMap.get(`${event.eventId}:input`);
-        if (content !== undefined && hashContent(content) !== event.inputHash) {
+        if (content === undefined) {
+          mismatches.push(`${event.eventId}: input content missing`);
+        } else if (hashContent(content) !== event.inputHash) {
           mismatches.push(`${event.eventId}: input hash mismatch`);
         }
       }
       if (event.outputHash) {
         const content = contentMap.get(`${event.eventId}:output`);
-        if (content !== undefined && hashContent(content) !== event.outputHash) {
+        if (content === undefined) {
+          mismatches.push(`${event.eventId}: output content missing`);
+        } else if (hashContent(content) !== event.outputHash) {
           mismatches.push(`${event.eventId}: output hash mismatch`);
         }
       }


### PR DESCRIPTION
## Summary
- Make `AuditTrail.verify()` fail when an event declares an input/output hash but the caller omits that content from the verification map.
- Add regression coverage for missing input content, missing output content, one-sided maps, and existing match/mismatch behavior.

## Test Plan
- `npm test --workspace @franken/observer -- --run src/audit-event.test.ts`
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (passes with 6 pre-existing warnings)
- `npm run build --workspace @franken/observer`
- `npm test --workspace @franken/observer`

Closes #1014
