### PR TITLE
fix(orchestrator): preserve child spawn error details

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -69,6 +69,7 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
     let exitInfo: { code: number | null; signal: string | null } | undefined;
     let exitFired = false;
     let cleanupStarted = false;
+    let setupError: Error | undefined;
     const forceClose = {
       stdout: undefined as (() => void) | undefined,
       stderr: undefined as (() => void) | undefined,
@@ -102,6 +103,7 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
     let maybeFireExit: () => void = () => undefined;
 
     const onError = (error: Error) => {
+      setupError ??= error;
       callbacks.onStderr(`Process spawn failed for ${spec.command}: ${error.message}`);
       if (!exitInfo) {
         exitInfo = { code: 1, signal: null };
@@ -138,7 +140,9 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
     child.once('error', onError);
 
     if (!child.pid) {
-      throw new Error(
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      cleanupProcess();
+      throw setupError ?? new Error(
         `Failed to spawn Beast process for command: ${spec.command}`,
       );
     }

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -71,7 +71,7 @@ describe('ProcessSupervisor', () => {
       const callbacks = makeCallbacks();
       const spec = makeSpec({ command: '/definitely/not-a-real-command-franken-698', args: [] });
 
-      await expect(supervisor.spawn(spec, callbacks)).rejects.toThrow(/Failed to spawn Beast process/);
+      await expect(supervisor.spawn(spec, callbacks)).rejects.toMatchObject({ code: 'ENOENT' });
 
       await vi.waitFor(() => {
         expect(callbacks.onStderr).toHaveBeenCalledWith(expect.stringContaining('Process spawn failed'));

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -8,7 +8,7 @@ import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { martinLoopDefinition } from '../../../src/beasts/definitions/martin-loop-definition.js';
 import { ProcessBeastExecutor } from '../../../src/beasts/execution/process-beast-executor.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
-import type { ProcessCallbacks } from '../../../src/beasts/execution/process-supervisor.js';
+import { ProcessSupervisor, type ProcessCallbacks } from '../../../src/beasts/execution/process-supervisor.js';
 import type { BeastDefinition } from '../../../src/beasts/types.js';
 
 function createTestRun(repo: SQLiteBeastRepository) {
@@ -1739,6 +1739,39 @@ describe('ProcessBeastExecutor', () => {
         stopReason: 'spawn_failed',
       });
       expect(updatedRun!.finishedAt).toBeDefined();
+    });
+
+    it('records real ProcessSupervisor missing-command error events as run.spawn_failed', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const executor = new ProcessBeastExecutor(repo, logs, new ProcessSupervisor());
+      const run = createTestRun(repo);
+      const missingCommandDefinition = {
+        ...martinLoopDefinition,
+        buildProcessSpec: () => ({
+          command: '/definitely/not-a-real-command-franken-1013',
+          args: [],
+          cwd: workDir,
+          env: {},
+        }),
+      } satisfies BeastDefinition;
+
+      await expect(executor.start(run, missingCommandDefinition)).rejects.toMatchObject({ code: 'ENOENT' });
+
+      const updatedRun = repo.getRun(run.id);
+      expect(updatedRun).toMatchObject({
+        status: 'failed',
+        stopReason: 'spawn_failed',
+      });
+
+      const spawnEvent = repo.listEvents(run.id).find((e) => e.type === 'run.spawn_failed');
+      expect(spawnEvent?.payload).toMatchObject({
+        code: 'ENOENT',
+        command: '/definitely/not-a-real-command-franken-1013',
+        args: [],
+      });
+      expect(String(spawnEvent?.payload.error)).toContain('ENOENT');
     });
 
     it('appends run.spawn_failed event with error details', async () => {


### PR DESCRIPTION
## Summary
- preserves the original child-process spawn error when ProcessSupervisor receives ENOENT/EACCES before a pid is available
- adds real ProcessSupervisor + ProcessBeastExecutor coverage that missing commands become `run.spawn_failed` with useful error details

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint
- npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator run test -- tests/unit/beasts/execution/process-supervisor.test.ts tests/unit/beasts/process-beast-executor.test.ts

Closes #1013
