### PR TITLE
docs: remove stale todo marker wording

### DIFF
--- a/docs/plans/consolidation/phase5-skill-loading.md
+++ b/docs/plans/consolidation/phase5-skill-loading.md
@@ -69,7 +69,7 @@ This keeps dashboard toggles durable without rewriting user-authored YAML on eve
 
 ## Current implementation status
 
-The Phase 5 SkillManager work is not a TODO placeholder. The live code now has
+The Phase 5 SkillManager work is not a generic placeholder. The live code now has
 these supported surfaces:
 
 - `packages/franken-orchestrator/src/skills/skill-manager.ts` owns the


### PR DESCRIPTION
## Summary
- removes the final tracked TODO/FIXME/HACK marker wording from the Phase 5 skill-loading plan
- verifies the repository marker scan is clean after the documentation wording change

## Test Plan
- `git diff --check`
- `npm run audit:todos`
- `npm run lint:security`
- tracked-file Python marker scan reports `TOTAL_TRACKED_MARKER_HITS=0`

Closes #981