### PR TITLE
fix(orchestrator): align 1Password key encoding

### DIFF
--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -7,16 +7,7 @@ const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
 
 function titleForKey(key: string): string {
-  return `${TITLE_PREFIX}${encodeURIComponent(key)}`;
-}
-
-function keyFromTitle(title: string): string {
-  const encodedKey = title.slice(TITLE_PREFIX.length);
-  try {
-    return decodeURIComponent(encodedKey);
-  } catch {
-    return encodedKey;
-  }
+  return `${TITLE_PREFIX}${key}`;
 }
 
 export class OnePasswordStore implements ISecretStore {
@@ -64,8 +55,15 @@ export class OnePasswordStore implements ISecretStore {
   }
 
   async resolve(key: string): Promise<string | undefined> {
-    const ref = `op://${VAULT}/${titleForKey(key)}/password`;
-    const result = await this.runner('op', ['read', ref]);
+    const title = titleForKey(key);
+    const result = await this.runner('op', [
+      'item',
+      'get',
+      title,
+      `--vault=${VAULT}`,
+      '--fields=password',
+      '--reveal',
+    ]);
     if (result.exitCode !== 0) {
       return undefined;
     }
@@ -91,6 +89,6 @@ export class OnePasswordStore implements ISecretStore {
     return items
       .map(item => item.title)
       .filter(title => title.startsWith(TITLE_PREFIX))
-      .map(keyFromTitle);
+      .map(title => title.slice(TITLE_PREFIX.length));
   }
 }

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -6,6 +6,19 @@ type CliRunner = (command: string, args: string[]) => Promise<CliResult>;
 const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
 
+function titleForKey(key: string): string {
+  return `${TITLE_PREFIX}${encodeURIComponent(key)}`;
+}
+
+function keyFromTitle(title: string): string {
+  const encodedKey = title.slice(TITLE_PREFIX.length);
+  try {
+    return decodeURIComponent(encodedKey);
+  } catch {
+    return encodedKey;
+  }
+}
+
 export class OnePasswordStore implements ISecretStore {
   readonly id = '1password';
 
@@ -25,7 +38,7 @@ export class OnePasswordStore implements ISecretStore {
   }
 
   async store(key: string, value: string): Promise<void> {
-    const title = `${TITLE_PREFIX}${key}`;
+    const title = titleForKey(key);
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`]);
 
     if (getResult.exitCode === 0) {
@@ -51,8 +64,7 @@ export class OnePasswordStore implements ISecretStore {
   }
 
   async resolve(key: string): Promise<string | undefined> {
-    const encodedKey = encodeURIComponent(key);
-    const ref = `op://${VAULT}/${TITLE_PREFIX}${encodedKey}/password`;
+    const ref = `op://${VAULT}/${titleForKey(key)}/password`;
     const result = await this.runner('op', ['read', ref]);
     if (result.exitCode !== 0) {
       return undefined;
@@ -61,7 +73,7 @@ export class OnePasswordStore implements ISecretStore {
   }
 
   async delete(key: string): Promise<void> {
-    const title = `${TITLE_PREFIX}${key}`;
+    const title = titleForKey(key);
     await this.runner('op', ['item', 'delete', title, `--vault=${VAULT}`]);
   }
 
@@ -79,6 +91,6 @@ export class OnePasswordStore implements ISecretStore {
     return items
       .map(item => item.title)
       .filter(title => title.startsWith(TITLE_PREFIX))
-      .map(title => title.slice(TITLE_PREFIX.length));
+      .map(keyFromTitle);
   }
 }

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -10,6 +10,15 @@ function titleForKey(key: string): string {
   return `${TITLE_PREFIX}${key}`;
 }
 
+function itemIdFromJson(stdout: string): string | undefined {
+  try {
+    const item = JSON.parse(stdout) as { id?: unknown };
+    return typeof item.id === 'string' && item.id.length > 0 ? item.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export class OnePasswordStore implements ISecretStore {
   readonly id = '1password';
 
@@ -56,14 +65,24 @@ export class OnePasswordStore implements ISecretStore {
 
   async resolve(key: string): Promise<string | undefined> {
     const title = titleForKey(key);
-    const result = await this.runner('op', [
+    const itemResult = await this.runner('op', [
       'item',
       'get',
       title,
       `--vault=${VAULT}`,
-      '--fields=password',
-      '--reveal',
+      '--format=json',
     ]);
+
+    if (itemResult.exitCode !== 0) {
+      return undefined;
+    }
+
+    const itemId = itemIdFromJson(itemResult.stdout);
+    if (!itemId) {
+      return undefined;
+    }
+
+    const result = await this.runner('op', ['read', `op://${VAULT}/${itemId}/password`]);
     if (result.exitCode !== 0) {
       return undefined;
     }

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -71,6 +71,38 @@ describe('OnePasswordStore', () => {
       expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
     });
 
+    it('uses the same encoded item title for URL-unsafe keys across store and resolve', async () => {
+      const key = 'comms/slack@workspace.botTokenRef';
+      const encodedTitle = 'frankenbeast/comms%2Fslack%40workspace.botTokenRef';
+      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
+      mock.responses.set('read', { stdout: RESOLVED_SLACK_BOT_TOKEN, stderr: '', exitCode: 0 });
+
+      await store.store(key, TEST_SLACK_BOT_TOKEN);
+      const value = await store.resolve(key);
+
+      expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: ['item', 'get', encodedTitle, '--vault=frankenbeast'],
+      });
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: [
+          'item',
+          'create',
+          '--category=Login',
+          `--title=${encodedTitle}`,
+          '--vault=frankenbeast',
+          `password=${TEST_SLACK_BOT_TOKEN}`,
+        ],
+      });
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: ['read', `op://frankenbeast/${encodedTitle}/password`],
+      });
+    });
+
     it('returns undefined when secret not found', async () => {
       mock.responses.set('read', { stdout: '', stderr: 'not found', exitCode: 1 });
       const value = await store.resolve('nonexistent');
@@ -83,6 +115,20 @@ describe('OnePasswordStore', () => {
       mock.responses.set('item delete', { stdout: '', stderr: '', exitCode: 0 });
       await expect(store.delete('comms.slack.botTokenRef')).resolves.not.toThrow();
     });
+
+    it('deletes URL-unsafe keys using the encoded item title', async () => {
+      mock.responses.set('item delete', { stdout: '', stderr: '', exitCode: 0 });
+      await store.delete('comms/slack@workspace.botTokenRef');
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: [
+          'item',
+          'delete',
+          'frankenbeast/comms%2Fslack%40workspace.botTokenRef',
+          '--vault=frankenbeast',
+        ],
+      });
+    });
   });
 
   describe('keys', () => {
@@ -91,12 +137,17 @@ describe('OnePasswordStore', () => {
         stdout: JSON.stringify([
           { title: 'frankenbeast/comms.slack.botTokenRef' },
           { title: 'frankenbeast/network.operatorTokenRef' },
+          { title: 'frankenbeast/comms%2Fslack%40workspace.botTokenRef' },
         ]),
         stderr: '',
         exitCode: 0,
       });
       const allKeys = await store.keys();
-      expect(allKeys).toEqual(['comms.slack.botTokenRef', 'network.operatorTokenRef']);
+      expect(allKeys).toEqual([
+        'comms.slack.botTokenRef',
+        'network.operatorTokenRef',
+        'comms/slack@workspace.botTokenRef',
+      ]);
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -65,18 +65,26 @@ describe('OnePasswordStore', () => {
       expect(editCall).toBeDefined();
     });
 
-    it('resolves a stored secret via op read', async () => {
-      mock.responses.set('read', { stdout: RESOLVED_SLACK_BOT_TOKEN, stderr: '', exitCode: 0 });
+    it('resolves a stored secret via op item get', async () => {
+      mock.responses.set('--fields=password', {
+        stdout: RESOLVED_SLACK_BOT_TOKEN,
+        stderr: '',
+        exitCode: 0,
+      });
       const value = await store.resolve('comms.slack.botTokenRef');
       expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
     });
 
-    it('uses the same encoded item title for URL-unsafe keys across store and resolve', async () => {
+    it('uses the same raw item title for URL-unsafe keys across store and resolve', async () => {
       const key = 'comms/slack@workspace.botTokenRef';
-      const encodedTitle = 'frankenbeast/comms%2Fslack%40workspace.botTokenRef';
+      const title = 'frankenbeast/comms/slack@workspace.botTokenRef';
+      mock.responses.set('--fields=password', {
+        stdout: RESOLVED_SLACK_BOT_TOKEN,
+        stderr: '',
+        exitCode: 0,
+      });
       mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
       mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
-      mock.responses.set('read', { stdout: RESOLVED_SLACK_BOT_TOKEN, stderr: '', exitCode: 0 });
 
       await store.store(key, TEST_SLACK_BOT_TOKEN);
       const value = await store.resolve(key);
@@ -84,7 +92,7 @@ describe('OnePasswordStore', () => {
       expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
       expect(mock.calls).toContainEqual({
         command: 'op',
-        args: ['item', 'get', encodedTitle, '--vault=frankenbeast'],
+        args: ['item', 'get', title, '--vault=frankenbeast'],
       });
       expect(mock.calls).toContainEqual({
         command: 'op',
@@ -92,19 +100,26 @@ describe('OnePasswordStore', () => {
           'item',
           'create',
           '--category=Login',
-          `--title=${encodedTitle}`,
+          `--title=${title}`,
           '--vault=frankenbeast',
           `password=${TEST_SLACK_BOT_TOKEN}`,
         ],
       });
       expect(mock.calls).toContainEqual({
         command: 'op',
-        args: ['read', `op://frankenbeast/${encodedTitle}/password`],
+        args: [
+          'item',
+          'get',
+          title,
+          '--vault=frankenbeast',
+          '--fields=password',
+          '--reveal',
+        ],
       });
     });
 
     it('returns undefined when secret not found', async () => {
-      mock.responses.set('read', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('--fields=password', { stdout: '', stderr: 'not found', exitCode: 1 });
       const value = await store.resolve('nonexistent');
       expect(value).toBeUndefined();
     });
@@ -116,7 +131,7 @@ describe('OnePasswordStore', () => {
       await expect(store.delete('comms.slack.botTokenRef')).resolves.not.toThrow();
     });
 
-    it('deletes URL-unsafe keys using the encoded item title', async () => {
+    it('deletes URL-unsafe keys using the raw item title', async () => {
       mock.responses.set('item delete', { stdout: '', stderr: '', exitCode: 0 });
       await store.delete('comms/slack@workspace.botTokenRef');
       expect(mock.calls).toContainEqual({
@@ -124,7 +139,7 @@ describe('OnePasswordStore', () => {
         args: [
           'item',
           'delete',
-          'frankenbeast/comms%2Fslack%40workspace.botTokenRef',
+          'frankenbeast/comms/slack@workspace.botTokenRef',
           '--vault=frankenbeast',
         ],
       });
@@ -137,7 +152,7 @@ describe('OnePasswordStore', () => {
         stdout: JSON.stringify([
           { title: 'frankenbeast/comms.slack.botTokenRef' },
           { title: 'frankenbeast/network.operatorTokenRef' },
-          { title: 'frankenbeast/comms%2Fslack%40workspace.botTokenRef' },
+          { title: 'frankenbeast/comms/slack@workspace.botTokenRef' },
         ]),
         stderr: '',
         exitCode: 0,

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -66,7 +66,12 @@ describe('OnePasswordStore', () => {
     });
 
     it('resolves a stored secret via op item get', async () => {
-      mock.responses.set('--fields=password', {
+      mock.responses.set('--format=json', {
+        stdout: JSON.stringify({ id: 'item-id-123' }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('read', {
         stdout: RESOLVED_SLACK_BOT_TOKEN,
         stderr: '',
         exitCode: 0,
@@ -78,7 +83,12 @@ describe('OnePasswordStore', () => {
     it('uses the same raw item title for URL-unsafe keys across store and resolve', async () => {
       const key = 'comms/slack@workspace.botTokenRef';
       const title = 'frankenbeast/comms/slack@workspace.botTokenRef';
-      mock.responses.set('--fields=password', {
+      mock.responses.set('--format=json', {
+        stdout: JSON.stringify({ id: 'unsafe-item-id' }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('read', {
         stdout: RESOLVED_SLACK_BOT_TOKEN,
         stderr: '',
         exitCode: 0,
@@ -112,15 +122,24 @@ describe('OnePasswordStore', () => {
           'get',
           title,
           '--vault=frankenbeast',
-          '--fields=password',
-          '--reveal',
+          '--format=json',
         ],
+      });
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: ['read', 'op://frankenbeast/unsafe-item-id/password'],
       });
     });
 
     it('returns undefined when secret not found', async () => {
-      mock.responses.set('--fields=password', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('--format=json', { stdout: '', stderr: 'not found', exitCode: 1 });
       const value = await store.resolve('nonexistent');
+      expect(value).toBeUndefined();
+    });
+
+    it('returns undefined when op item metadata is malformed', async () => {
+      mock.responses.set('--format=json', { stdout: 'not json', stderr: '', exitCode: 0 });
+      const value = await store.resolve('comms.slack.botTokenRef');
       expect(value).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary
- Encode OnePasswordStore item titles using the same key encoding used in op references.
- Decode listed 1Password titles back to caller-facing secret keys.
- Add regressions for URL-unsafe keys across store/resolve/delete/keys.

## Test Plan
- npm run test -- tests/unit/network/secret-backends/one-password-store.test.ts (from packages/franken-orchestrator)
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #677