### PR TITLE
fix(observer): protect AuditTrail immutable state

### DIFF
--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { createAuditEvent, AuditTrail, hashContent } from './audit-event.js';
+import { createAuditEvent, AuditTrail, hashContent, type AuditEvent } from './audit-event.js';
+
+function ignoreMutation(mutate: () => void): void {
+  try {
+    mutate();
+  } catch {
+    // Frozen runtime values may throw in strict mode; the invariant under test is
+    // that mutation attempts never alter the trail's stored history.
+  }
+}
 
 describe('createAuditEvent', () => {
   it('generates unique eventId', () => {
@@ -102,6 +111,76 @@ describe('AuditTrail', () => {
 
     expect(trail.toJSON()[0]!.payload).toBeNull();
     expect(AuditTrail.fromJSON(trail.toJSON()).getAll()[0]!.payload).toBeNull();
+  });
+
+  it('does not retain mutable aliases to appended events', () => {
+    const trail = new AuditTrail();
+    const event = createAuditEvent('append.alias', { nested: { count: 1 } }, { phase: 'p', provider: 'pr' });
+    trail.append(event);
+
+    event.type = 'tampered';
+    (event.payload as { nested: { count: number } }).nested.count = 99;
+
+    expect(trail.getAll()[0]).toMatchObject({
+      type: 'append.alias',
+      payload: { nested: { count: 1 } },
+    });
+  });
+
+  it('returns defensive copies from getAll()', () => {
+    const trail = new AuditTrail();
+    const event = createAuditEvent('get.alias', { nested: { count: 1 } }, { phase: 'p', provider: 'pr' });
+    trail.append(event);
+
+    const returned = trail.getAll() as AuditEvent[];
+    ignoreMutation(() => returned.push(createAuditEvent('extra', {}, { phase: 'p', provider: 'pr' })));
+    ignoreMutation(() => {
+      returned[0]!.type = 'tampered';
+    });
+    ignoreMutation(() => {
+      (returned[0]!.payload as { nested: { count: number } }).nested.count = 99;
+    });
+
+    expect(trail.getAll()).toHaveLength(1);
+    expect(trail.getAll()[0]).toMatchObject({
+      type: 'get.alias',
+      payload: { nested: { count: 1 } },
+    });
+  });
+
+  it('returns defensive copies from toJSON()', () => {
+    const trail = new AuditTrail();
+    trail.append(createAuditEvent('json.alias', { nested: { count: 1 } }, { phase: 'p', provider: 'pr' }));
+
+    const json = trail.toJSON();
+    ignoreMutation(() => json.push(createAuditEvent('extra', {}, { phase: 'p', provider: 'pr' })));
+    ignoreMutation(() => {
+      json[0]!.type = 'tampered';
+    });
+    ignoreMutation(() => {
+      (json[0]!.payload as { nested: { count: number } }).nested.count = 99;
+    });
+
+    expect(trail.getAll()).toHaveLength(1);
+    expect(trail.getAll()[0]).toMatchObject({
+      type: 'json.alias',
+      payload: { nested: { count: 1 } },
+    });
+  });
+
+  it('fromJSON does not retain aliases to caller-owned JSON data', () => {
+    const json = [createAuditEvent('restore.alias', { nested: { count: 1 } }, { phase: 'p', provider: 'pr' })];
+    const trail = AuditTrail.fromJSON(json);
+
+    json[0]!.type = 'tampered';
+    (json[0]!.payload as { nested: { count: number } }).nested.count = 99;
+    json.push(createAuditEvent('extra', {}, { phase: 'p', provider: 'pr' }));
+
+    expect(trail.getAll()).toHaveLength(1);
+    expect(trail.getAll()[0]).toMatchObject({
+      type: 'restore.alias',
+      payload: { nested: { count: 1 } },
+    });
   });
 
   it('fromJSON rejects non-array input', () => {

--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -183,6 +183,38 @@ describe('AuditTrail', () => {
     });
   });
 
+  it('freezes function payloads so callable objects cannot mutate stored history', () => {
+    const trail = new AuditTrail();
+    const payload = (): string => 'ok';
+    (payload as { mutable?: { count: number } }).mutable = { count: 1 };
+
+    trail.append(createAuditEvent('function.payload', payload, { phase: 'p', provider: 'pr' }));
+
+    ignoreMutation(() => {
+      (payload as { mutable?: { count: number } }).mutable = { count: 99 };
+    });
+    const returnedPayload = trail.getAll()[0]!.payload as { mutable?: { count: number } };
+    ignoreMutation(() => {
+      returnedPayload.mutable = { count: 42 };
+    });
+
+    expect((trail.getAll()[0]!.payload as { mutable?: { count: number } }).mutable).toEqual({ count: 1 });
+  });
+
+  it('preserves Buffer payloads while isolating mutable aliases', () => {
+    const trail = new AuditTrail();
+    const payload = Buffer.from('audit-bytes');
+    trail.append(createAuditEvent('buffer.payload', payload, { phase: 'p', provider: 'pr' }));
+
+    payload[0] = 0;
+    const returnedPayload = trail.getAll()[0]!.payload as Buffer;
+    expect(Buffer.isBuffer(returnedPayload)).toBe(true);
+    expect(returnedPayload.toString()).toBe('audit-bytes');
+
+    returnedPayload[0] = 0;
+    expect((trail.getAll()[0]!.payload as Buffer).toString()).toBe('audit-bytes');
+  });
+
   it('fromJSON rejects non-array input', () => {
     expect(() => AuditTrail.fromJSON({})).toThrow(/events must be an array/i);
   });

--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -193,6 +193,9 @@ describe('AuditTrail', () => {
     ignoreMutation(() => {
       (payload as { mutable?: { count: number } }).mutable = { count: 99 };
     });
+    ignoreMutation(() => {
+      (payload as { mutable?: { count: number } }).mutable!.count = 99;
+    });
     const returnedPayload = trail.getAll()[0]!.payload as { mutable?: { count: number } };
     ignoreMutation(() => {
       returnedPayload.mutable = { count: 42 };
@@ -213,6 +216,30 @@ describe('AuditTrail', () => {
 
     returnedPayload[0] = 0;
     expect((trail.getAll()[0]!.payload as Buffer).toString()).toBe('audit-bytes');
+  });
+
+  it('copies typed arrays backed by shared memory', () => {
+    const trail = new AuditTrail();
+    const shared = new SharedArrayBuffer(4);
+    const payload = new Uint8Array(shared);
+    payload.set([1, 2, 3, 4]);
+    trail.append(createAuditEvent('shared.payload', payload, { phase: 'p', provider: 'pr' }));
+
+    payload[0] = 99;
+    const returnedPayload = trail.getAll()[0]!.payload as Uint8Array;
+    expect(Array.from(returnedPayload)).toEqual([1, 2, 3, 4]);
+
+    returnedPayload[1] = 88;
+    expect(Array.from(trail.getAll()[0]!.payload as Uint8Array)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('preserves prototype-backed toJSON payload data', () => {
+    const trail = new AuditTrail();
+    const url = new URL('https://example.com/audit?event=1');
+    trail.append(createAuditEvent('url.payload', url, { phase: 'p', provider: 'pr' }));
+
+    expect(trail.getAll()[0]!.payload).toBe('https://example.com/audit?event=1');
+    expect(trail.toJSON()[0]!.payload).toBe('https://example.com/audit?event=1');
   });
 
   it('fromJSON rejects non-array input', () => {

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -116,6 +116,27 @@ export function createAuditEvent(
 
 export { hashContent };
 
+function cloneArrayBufferView<T extends ArrayBufferView>(value: T): T {
+  if (value instanceof DataView) {
+    const copy = new Uint8Array(value.byteLength);
+    copy.set(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+    return new DataView(copy.buffer) as unknown as T;
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return Buffer.from(value) as unknown as T;
+  }
+
+  const TypedArray = value.constructor as new (source: ArrayLike<number>) => T;
+  return new TypedArray(value as unknown as ArrayLike<number>);
+}
+
+function cloneArrayBuffer<T extends ArrayBuffer | SharedArrayBuffer>(value: T): ArrayBuffer {
+  const copy = new Uint8Array(value.byteLength);
+  copy.set(new Uint8Array(value));
+  return copy.buffer;
+}
+
 function cloneValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
   if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
     return value;
@@ -127,8 +148,8 @@ function cloneValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
   }
 
   if (typeof value === 'function') {
-    Object.freeze(value);
     seen.set(value, value);
+    freezeValue(value);
     return value;
   }
 
@@ -167,16 +188,39 @@ function cloneValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
     return clone as T;
   }
 
-  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
-    return structuredClone(value);
+  if (ArrayBuffer.isView(value)) {
+    return cloneArrayBufferView(value) as T;
   }
 
-  const clone: Record<string, unknown> = {};
-  seen.set(value, clone);
-  for (const [key, item] of Object.entries(value)) {
-    clone[key] = cloneValue(item, seen);
+  if (value instanceof ArrayBuffer || value instanceof SharedArrayBuffer) {
+    return cloneArrayBuffer(value) as T;
   }
-  return clone as T;
+
+  const toJSON = (value as { toJSON?: unknown }).toJSON;
+  if (typeof toJSON === 'function') {
+    return cloneValue(toJSON.call(value), seen) as T;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype === Object.prototype || prototype === null) {
+    const clone: Record<string, unknown> = {};
+    seen.set(value, clone);
+    for (const [key, item] of Object.entries(value)) {
+      clone[key] = cloneValue(item, seen);
+    }
+    return clone as T;
+  }
+
+  try {
+    return structuredClone(value);
+  } catch {
+    const clone: Record<string, unknown> = {};
+    seen.set(value, clone);
+    for (const [key, item] of Object.entries(value)) {
+      clone[key] = cloneValue(item, seen);
+    }
+    return clone as T;
+  }
 }
 
 function freezeValue<T>(value: T, seen = new WeakSet<object>()): T {

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -116,6 +116,110 @@ export function createAuditEvent(
 
 export { hashContent };
 
+function cloneValueFallback(value: unknown, seen: WeakMap<object, unknown>): unknown {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const existing = seen.get(value);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (Array.isArray(value)) {
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    for (const item of value) {
+      clone.push(cloneValue(item, seen));
+    }
+    return clone;
+  }
+
+  if (value instanceof Map) {
+    const clone = new Map<unknown, unknown>();
+    seen.set(value, clone);
+    for (const [key, item] of value) {
+      clone.set(cloneValue(key, seen), cloneValue(item, seen));
+    }
+    return clone;
+  }
+
+  if (value instanceof Set) {
+    const clone = new Set<unknown>();
+    seen.set(value, clone);
+    for (const item of value) {
+      clone.add(cloneValue(item, seen));
+    }
+    return clone;
+  }
+
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return structuredClone(value);
+  }
+
+  const clone: Record<string, unknown> = {};
+  seen.set(value, clone);
+  for (const [key, item] of Object.entries(value)) {
+    clone[key] = cloneValue(item, seen);
+  }
+  return clone;
+}
+
+function cloneValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return cloneValueFallback(value, seen) as T;
+  }
+}
+
+function freezeValue<T>(value: T, seen = new WeakSet<object>()): T {
+  if (typeof value !== 'object' || value === null || seen.has(value)) {
+    return value;
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      freezeValue(item, seen);
+    }
+  } else if (value instanceof Map) {
+    for (const [key, item] of value) {
+      freezeValue(key, seen);
+      freezeValue(item, seen);
+    }
+  } else if (value instanceof Set) {
+    for (const item of value) {
+      freezeValue(item, seen);
+    }
+  } else {
+    for (const item of Object.values(value)) {
+      freezeValue(item, seen);
+    }
+  }
+
+  if (!ArrayBuffer.isView(value)) {
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function immutableAuditEvent(event: AuditEvent): AuditEvent {
+  return freezeValue(cloneValue(event));
+}
+
+function auditEventForJson(event: AuditEvent): AuditEvent {
+  return freezeValue({
+    ...cloneValue(event),
+    payload: event.payload === undefined ? null : cloneValue(event.payload),
+  });
+}
+
 /**
  * Append-only, immutable audit trail.
  * Records every execution decision for compliance auditing.
@@ -124,30 +228,27 @@ export class AuditTrail {
   private events: AuditEvent[] = [];
 
   append(event: AuditEvent): void {
-    this.events.push(event);
+    this.events.push(immutableAuditEvent(event));
   }
 
   getAll(): readonly AuditEvent[] {
-    return this.events;
+    return this.events.map((event) => immutableAuditEvent(event));
   }
 
   getByType(type: string): AuditEvent[] {
-    return this.events.filter((e) => e.type === type);
+    return this.events.filter((e) => e.type === type).map((event) => immutableAuditEvent(event));
   }
 
   getByPhase(phase: string): AuditEvent[] {
-    return this.events.filter((e) => e.phase === phase);
+    return this.events.filter((e) => e.phase === phase).map((event) => immutableAuditEvent(event));
   }
 
   getChildren(parentEventId: string): AuditEvent[] {
-    return this.events.filter((e) => e.parentEventId === parentEventId);
+    return this.events.filter((e) => e.parentEventId === parentEventId).map((event) => immutableAuditEvent(event));
   }
 
   toJSON(): AuditEvent[] {
-    return this.events.map((event) => ({
-      ...event,
-      payload: event.payload === undefined ? null : event.payload,
-    }));
+    return this.events.map((event) => auditEventForJson(event));
   }
 
   static fromJSON(events: unknown): AuditTrail {

--- a/packages/franken-observer/src/audit-event.ts
+++ b/packages/franken-observer/src/audit-event.ts
@@ -116,18 +116,28 @@ export function createAuditEvent(
 
 export { hashContent };
 
-function cloneValueFallback(value: unknown, seen: WeakMap<object, unknown>): unknown {
-  if (typeof value !== 'object' || value === null) {
+function cloneValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
     return value;
   }
 
   const existing = seen.get(value);
   if (existing !== undefined) {
-    return existing;
+    return existing as T;
+  }
+
+  if (typeof value === 'function') {
+    Object.freeze(value);
+    seen.set(value, value);
+    return value;
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return Buffer.from(value) as T;
   }
 
   if (value instanceof Date) {
-    return new Date(value.getTime());
+    return new Date(value.getTime()) as T;
   }
 
   if (Array.isArray(value)) {
@@ -136,7 +146,7 @@ function cloneValueFallback(value: unknown, seen: WeakMap<object, unknown>): unk
     for (const item of value) {
       clone.push(cloneValue(item, seen));
     }
-    return clone;
+    return clone as T;
   }
 
   if (value instanceof Map) {
@@ -145,7 +155,7 @@ function cloneValueFallback(value: unknown, seen: WeakMap<object, unknown>): unk
     for (const [key, item] of value) {
       clone.set(cloneValue(key, seen), cloneValue(item, seen));
     }
-    return clone;
+    return clone as T;
   }
 
   if (value instanceof Set) {
@@ -154,7 +164,7 @@ function cloneValueFallback(value: unknown, seen: WeakMap<object, unknown>): unk
     for (const item of value) {
       clone.add(cloneValue(item, seen));
     }
-    return clone;
+    return clone as T;
   }
 
   if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
@@ -166,19 +176,11 @@ function cloneValueFallback(value: unknown, seen: WeakMap<object, unknown>): unk
   for (const [key, item] of Object.entries(value)) {
     clone[key] = cloneValue(item, seen);
   }
-  return clone;
-}
-
-function cloneValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
-  try {
-    return structuredClone(value);
-  } catch {
-    return cloneValueFallback(value, seen) as T;
-  }
+  return clone as T;
 }
 
 function freezeValue<T>(value: T, seen = new WeakSet<object>()): T {
-  if (typeof value !== 'object' || value === null || seen.has(value)) {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null || seen.has(value)) {
     return value;
   }
 

--- a/packages/franken-observer/src/execution-replayer.test.ts
+++ b/packages/franken-observer/src/execution-replayer.test.ts
@@ -20,8 +20,15 @@ function buildTrail(
   return trail;
 }
 
-function corruptTimestamp(trail: AuditTrail, index: number, timestamp: string): void {
-  (trail.getAll()[index] as { timestamp: string }).timestamp = timestamp;
+function corruptTimestamp(trail: AuditTrail, index: number, timestamp: string): AuditTrail {
+  const corrupted = new AuditTrail();
+  trail.getAll().forEach((event, eventIndex) => {
+    corrupted.append({
+      ...event,
+      timestamp: eventIndex === index ? timestamp : event.timestamp,
+    });
+  });
+  return corrupted;
 }
 
 describe('ExecutionReplayer', () => {
@@ -80,9 +87,9 @@ describe('ExecutionReplayer', () => {
       { type: 'run.start', phase: 'planning', provider: 'claude-cli' },
       { type: 'phase.end', phase: 'planning', provider: 'claude-cli' },
     ]);
-    corruptTimestamp(trail, 0, 'not-a-date');
+    const corrupted = corruptTimestamp(trail, 0, 'not-a-date');
 
-    expect(() => replayer.replay(trail)).toThrow(
+    expect(() => replayer.replay(corrupted)).toThrow(
       /Invalid audit event timestamp during replay \(phase planning\): eventId=.*phase=planning, type=run\.start, timestamp="not-a-date"/,
     );
   });
@@ -94,9 +101,9 @@ describe('ExecutionReplayer', () => {
       { type: 'phase.start', phase: 'execution', provider: 'codex-cli' },
       { type: 'phase.end', phase: 'execution', provider: 'codex-cli' },
     ]);
-    corruptTimestamp(trail, 3, 'still-not-a-date');
+    const corrupted = corruptTimestamp(trail, 3, 'still-not-a-date');
 
-    expect(() => replayer.replay(trail)).toThrow(
+    expect(() => replayer.replay(corrupted)).toThrow(
       /Invalid audit event timestamp during replay \(phase execution\): eventId=.*phase=execution, type=phase\.end, timestamp="still-not-a-date"/,
     );
   });
@@ -106,9 +113,9 @@ describe('ExecutionReplayer', () => {
       { type: 'phase.start', phase: 'planning', provider: 'claude-cli' },
       { type: 'phase.end', phase: 'planning', provider: 'claude-cli' },
     ]);
-    corruptTimestamp(trail, 1, '2026-02-31T00:00:00.000Z');
+    const corrupted = corruptTimestamp(trail, 1, '2026-02-31T00:00:00.000Z');
 
-    expect(() => replayer.replay(trail)).toThrow(
+    expect(() => replayer.replay(corrupted)).toThrow(
       /Invalid audit event timestamp during replay \(phase planning\): eventId=.*phase=planning, type=phase\.end, timestamp="2026-02-31T00:00:00.000Z"/,
     );
   });


### PR DESCRIPTION
## Summary
- Defensively clone and freeze AuditTrail events at append/restore and when returning snapshots.
- Ensure getAll(), filters, and toJSON() no longer expose mutable aliases to stored audit history.
- Add regression coverage for append, getAll(), toJSON(), and fromJSON alias-mutation paths.

## Test Plan
- npm test --workspace @franken/observer
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer

Closes #1114
