### PR TITLE
fix(orchestrator): harden init JSON persistence

### DIFF
--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -68,6 +68,10 @@ function removeTrustFields(value: unknown): void {
   delete value['trustedCommandPaths'];
 }
 
+function isJsonSyntaxError(error: unknown): error is SyntaxError {
+  return error instanceof SyntaxError;
+}
+
 /**
  * Repository-local config is an untrusted input from the checked-out project.
  * It may request provider command overrides, but it must not be able to
@@ -124,7 +128,9 @@ export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Pro
         fileConfig = stripRepositoryLocalCommandTrust(fileConfig);
       }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT' || args.config) {
+      const missingDefaultConfig = (error as NodeJS.ErrnoException).code === 'ENOENT' && !args.config;
+      const malformedDefaultInitConfig = isJsonSyntaxError(error) && args.subcommand === 'init' && !args.config;
+      if (!missingDefaultConfig && !malformedDefaultInitConfig) {
         throw error;
       }
     }

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -2,7 +2,8 @@ import type { InterviewIO } from '../planning/interview-loop.js';
 import { parseOrchestratorConfig, defaultConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { FileInitStateStore } from './init-state-store.js';
 import { runInitWizard } from './init-wizard.js';
-import type { InitState } from './init-types.js';
+import type { InitState, InitModuleId, SupportedCommsTransportId } from './init-types.js';
+import { createEmptyInitState } from './init-types.js';
 import { verifyInit } from './init-verify.js';
 import type { ISecretStore } from '../network/secret-store.js';
 import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from './init-json-file.js';
@@ -57,9 +58,45 @@ async function saveConfig(configFile: string, config: OrchestratorConfig): Promi
   await writeJsonFileAtomic(configFile, config);
 }
 
+function initStateFromConfig(configPath: string, config: OrchestratorConfig): InitState {
+  const selectedModules: InitModuleId[] = [];
+  if (config.chat.enabled) selectedModules.push('chat');
+  if (config.dashboard.enabled) selectedModules.push('dashboard');
+  if (config.comms.enabled) selectedModules.push('comms');
+
+  const selectedCommsTransports: SupportedCommsTransportId[] = [];
+  if (config.comms.slack.enabled) selectedCommsTransports.push('slack');
+  if (config.comms.discord.enabled) selectedCommsTransports.push('discord');
+  if (config.comms.telegram.enabled) selectedCommsTransports.push('telegram');
+  if (config.comms.whatsapp.enabled) selectedCommsTransports.push('whatsapp');
+
+  return {
+    ...createEmptyInitState(configPath),
+    selectedModules,
+    selectedCommsTransports,
+    securityMode: config.network.mode,
+    answers: {
+      'providers.default': config.providers.default,
+      'network.operatorTokenRef': config.network.operatorTokenRef,
+      'comms.slack.appId': config.comms.slack.appId,
+      'comms.slack.botTokenRef': config.comms.slack.botTokenRef,
+      'comms.slack.signingSecretRef': config.comms.slack.signingSecretRef,
+      'comms.discord.applicationId': config.comms.discord.applicationId,
+      'comms.discord.botTokenRef': config.comms.discord.botTokenRef,
+      'comms.discord.publicKeyRef': config.comms.discord.publicKeyRef,
+      'comms.telegram.botTokenRef': config.comms.telegram.botTokenRef,
+      'comms.telegram.webhookSecretTokenRef': config.comms.telegram.webhookSecretTokenRef,
+      'comms.whatsapp.accessTokenRef': config.comms.whatsapp.accessTokenRef,
+      'comms.whatsapp.phoneNumberIdRef': config.comms.whatsapp.phoneNumberIdRef,
+      'comms.whatsapp.appSecretRef': config.comms.whatsapp.appSecretRef,
+      'comms.whatsapp.verifyTokenRef': config.comms.whatsapp.verifyTokenRef,
+    },
+  };
+}
+
 export async function runInteractiveInit(options: RunInteractiveInitOptions): Promise<InitEngineResult> {
-  const initialState = await options.stateStore.load(options.configFile);
   const baseConfig = await resolveBaseConfig(options);
+  const initialState = await options.stateStore.load(options.configFile, () => initStateFromConfig(options.configFile, baseConfig));
   const result = await runInitWizard({
     io: options.io,
     initialState,

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -62,13 +62,13 @@ function initStateFromConfig(configPath: string, config: OrchestratorConfig): In
   const selectedModules: InitModuleId[] = [];
   if (config.chat.enabled) selectedModules.push('chat');
   if (config.dashboard.enabled) selectedModules.push('dashboard');
-  if (config.comms.enabled) selectedModules.push('comms');
 
   const selectedCommsTransports: SupportedCommsTransportId[] = [];
   if (config.comms.slack.enabled) selectedCommsTransports.push('slack');
   if (config.comms.discord.enabled) selectedCommsTransports.push('discord');
   if (config.comms.telegram.enabled) selectedCommsTransports.push('telegram');
   if (config.comms.whatsapp.enabled) selectedCommsTransports.push('whatsapp');
+  if (config.comms.enabled || selectedCommsTransports.length > 0) selectedModules.push('comms');
 
   return {
     ...createEmptyInitState(configPath),

--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -1,5 +1,3 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
 import type { InterviewIO } from '../planning/interview-loop.js';
 import { parseOrchestratorConfig, defaultConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { FileInitStateStore } from './init-state-store.js';
@@ -7,6 +5,7 @@ import { runInitWizard } from './init-wizard.js';
 import type { InitState } from './init-types.js';
 import { verifyInit } from './init-verify.js';
 import type { ISecretStore } from '../network/secret-store.js';
+import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from './init-json-file.js';
 
 export interface InitEngineResult {
   config: OrchestratorConfig;
@@ -29,17 +28,13 @@ async function loadExistingConfig(
   configFile: string,
   options: { allowTrustedProviderCommandOverrides?: boolean | undefined } = {},
 ): Promise<OrchestratorConfig> {
-  try {
-    const raw = await readFile(configFile, 'utf-8');
-    return parseOrchestratorConfig(JSON.parse(raw), {
+  const rawConfig = await readJsonFileOrDefault(configFile, defaultConfig, {
+    description: 'orchestrator config',
+    onCorrupt: warnJsonQuarantined,
+  });
+  return parseOrchestratorConfig(rawConfig, {
       allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
-    });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return defaultConfig();
-    }
-    throw error;
-  }
+  });
 }
 
 async function resolveBaseConfig(options: RunInteractiveInitOptions): Promise<OrchestratorConfig> {
@@ -59,8 +54,7 @@ async function resolveBaseConfig(options: RunInteractiveInitOptions): Promise<Or
 }
 
 async function saveConfig(configFile: string, config: OrchestratorConfig): Promise<void> {
-  await mkdir(dirname(configFile), { recursive: true });
-  await writeFile(configFile, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  await writeJsonFileAtomic(configFile, config);
 }
 
 export async function runInteractiveInit(options: RunInteractiveInitOptions): Promise<InitEngineResult> {

--- a/packages/franken-orchestrator/src/init/init-json-file.ts
+++ b/packages/franken-orchestrator/src/init/init-json-file.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { chmod, lstat, mkdir, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 export interface JsonCorruptionRecovery {
@@ -48,12 +48,30 @@ export async function readJsonFileOrDefault<T>(
   }
 }
 
-export async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
-  await mkdir(dirname(filePath), { recursive: true });
-  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${randomUUID()}`;
+async function resolveAtomicWriteTarget(filePath: string): Promise<{ targetPath: string; mode?: number | undefined }> {
   try {
-    await writeFile(tempPath, JSON.stringify(value, null, 2) + '\n', 'utf-8');
-    await rename(tempPath, filePath);
+    const linkInfo = await lstat(filePath);
+    const targetPath = linkInfo.isSymbolicLink() ? await realpath(filePath) : filePath;
+    const targetInfo = await stat(targetPath);
+    return { targetPath, mode: targetInfo.mode & 0o777 };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { targetPath: filePath };
+    }
+    throw error;
+  }
+}
+
+export async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
+  const { targetPath, mode } = await resolveAtomicWriteTarget(filePath);
+  await mkdir(dirname(targetPath), { recursive: true });
+  const tempPath = join(dirname(targetPath), `.${basename(targetPath)}.tmp-${process.pid}-${Date.now()}-${randomUUID()}`);
+  try {
+    await writeFile(tempPath, JSON.stringify(value, null, 2) + '\n', { encoding: 'utf-8', mode });
+    if (mode !== undefined) {
+      await chmod(tempPath, mode);
+    }
+    await rename(tempPath, targetPath);
   } catch (error) {
     await rm(tempPath, { force: true }).catch(() => undefined);
     throw error;

--- a/packages/franken-orchestrator/src/init/init-json-file.ts
+++ b/packages/franken-orchestrator/src/init/init-json-file.ts
@@ -1,5 +1,5 @@
-import { chmod, lstat, mkdir, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, basename } from 'node:path';
+import { chmod, lstat, mkdir, readFile, readlink, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, basename, isAbsolute, resolve as resolvePath } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 export interface JsonCorruptionRecovery {
@@ -15,6 +15,26 @@ function isJsonSyntaxError(error: unknown): error is SyntaxError {
 
 function quarantinePathFor(filePath: string): string {
   return `${filePath}.corrupt-${Date.now()}-${process.pid}-${randomUUID()}`;
+}
+
+async function resolveSymlinkTargetPath(filePath: string): Promise<string> {
+  const info = await lstat(filePath);
+  if (!info.isSymbolicLink()) {
+    return filePath;
+  }
+  const linkTarget = await readlink(filePath);
+  return isAbsolute(linkTarget) ? linkTarget : resolvePath(dirname(filePath), linkTarget);
+}
+
+async function resolveExistingOrSymlinkTarget(filePath: string): Promise<string> {
+  try {
+    return await resolveSymlinkTargetPath(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return filePath;
+    }
+    throw error;
+  }
 }
 
 export async function readJsonFileOrDefault<T>(
@@ -41,22 +61,22 @@ export async function readJsonFileOrDefault<T>(
     if (!isJsonSyntaxError(error)) {
       throw error;
     }
-    const quarantinePath = quarantinePathFor(filePath);
-    await rename(filePath, quarantinePath);
+    const targetPath = await resolveExistingOrSymlinkTarget(filePath);
+    const quarantinePath = quarantinePathFor(targetPath);
+    await rename(targetPath, quarantinePath);
     options.onCorrupt?.({ description: options.description, filePath, quarantinePath, error });
     return fallback();
   }
 }
 
 async function resolveAtomicWriteTarget(filePath: string): Promise<{ targetPath: string; mode?: number | undefined }> {
+  const targetPath = await resolveExistingOrSymlinkTarget(filePath);
   try {
-    const linkInfo = await lstat(filePath);
-    const targetPath = linkInfo.isSymbolicLink() ? await realpath(filePath) : filePath;
     const targetInfo = await stat(targetPath);
     return { targetPath, mode: targetInfo.mode & 0o777 };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { targetPath: filePath };
+      return { targetPath };
     }
     throw error;
   }

--- a/packages/franken-orchestrator/src/init/init-json-file.ts
+++ b/packages/franken-orchestrator/src/init/init-json-file.ts
@@ -1,0 +1,67 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export interface JsonCorruptionRecovery {
+  description: string;
+  filePath: string;
+  quarantinePath: string;
+  error: unknown;
+}
+
+function isJsonSyntaxError(error: unknown): error is SyntaxError {
+  return error instanceof SyntaxError;
+}
+
+function quarantinePathFor(filePath: string): string {
+  return `${filePath}.corrupt-${Date.now()}-${process.pid}-${randomUUID()}`;
+}
+
+export async function readJsonFileOrDefault<T>(
+  filePath: string,
+  fallback: () => T,
+  options: {
+    description: string;
+    onCorrupt?: (recovery: JsonCorruptionRecovery) => void;
+  },
+): Promise<T> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return fallback();
+    }
+    throw error;
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    if (!isJsonSyntaxError(error)) {
+      throw error;
+    }
+    const quarantinePath = quarantinePathFor(filePath);
+    await rename(filePath, quarantinePath);
+    options.onCorrupt?.({ description: options.description, filePath, quarantinePath, error });
+    return fallback();
+  }
+}
+
+export async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${randomUUID()}`;
+  try {
+    await writeFile(tempPath, JSON.stringify(value, null, 2) + '\n', 'utf-8');
+    await rename(tempPath, filePath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export function warnJsonQuarantined({ description, filePath, quarantinePath, error }: JsonCorruptionRecovery): void {
+  console.warn(
+    `Malformed ${description} JSON in ${filePath}; quarantined original at ${quarantinePath} and continuing with defaults. ${error instanceof Error ? error.message : String(error)}`,
+  );
+}

--- a/packages/franken-orchestrator/src/init/init-json-file.ts
+++ b/packages/franken-orchestrator/src/init/init-json-file.ts
@@ -1,5 +1,5 @@
 import { chmod, lstat, mkdir, readFile, readlink, rename, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, basename, isAbsolute, resolve as resolvePath } from 'node:path';
+import { dirname, join, basename, isAbsolute, resolve as resolvePath, relative, sep } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 export interface JsonCorruptionRecovery {
@@ -17,18 +17,26 @@ function quarantinePathFor(filePath: string): string {
   return `${filePath}.corrupt-${Date.now()}-${process.pid}-${randomUUID()}`;
 }
 
-async function resolveSymlinkTargetPath(filePath: string): Promise<string> {
+const recoveredFileModes = new Map<string, number>();
+
+function isInsideDirectory(filePath: string, directory: string): boolean {
+  const rel = relative(resolvePath(directory), resolvePath(filePath));
+  return rel.length === 0 || (!rel.startsWith('..') && !rel.includes(`..${sep}`) && !isAbsolute(rel));
+}
+
+async function resolveSafeSymlinkTargetPath(filePath: string): Promise<string> {
   const info = await lstat(filePath);
   if (!info.isSymbolicLink()) {
     return filePath;
   }
   const linkTarget = await readlink(filePath);
-  return isAbsolute(linkTarget) ? linkTarget : resolvePath(dirname(filePath), linkTarget);
+  const targetPath = isAbsolute(linkTarget) ? linkTarget : resolvePath(dirname(filePath), linkTarget);
+  return isInsideDirectory(targetPath, dirname(filePath)) ? targetPath : filePath;
 }
 
 async function resolveExistingOrSymlinkTarget(filePath: string): Promise<string> {
   try {
-    return await resolveSymlinkTargetPath(filePath);
+    return await resolveSafeSymlinkTargetPath(filePath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return filePath;
@@ -63,7 +71,12 @@ export async function readJsonFileOrDefault<T>(
     }
     const targetPath = await resolveExistingOrSymlinkTarget(filePath);
     const quarantinePath = quarantinePathFor(targetPath);
+    const targetMode = await stat(targetPath).then((info) => info.mode & 0o777).catch(() => undefined);
     await rename(targetPath, quarantinePath);
+    if (targetMode !== undefined) {
+      recoveredFileModes.set(filePath, targetMode);
+      recoveredFileModes.set(targetPath, targetMode);
+    }
     options.onCorrupt?.({ description: options.description, filePath, quarantinePath, error });
     return fallback();
   }
@@ -76,7 +89,7 @@ async function resolveAtomicWriteTarget(filePath: string): Promise<{ targetPath:
     return { targetPath, mode: targetInfo.mode & 0o777 };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { targetPath };
+      return { targetPath, mode: recoveredFileModes.get(targetPath) ?? recoveredFileModes.get(filePath) };
     }
     throw error;
   }

--- a/packages/franken-orchestrator/src/init/init-state-store.ts
+++ b/packages/franken-orchestrator/src/init/init-state-store.ts
@@ -5,8 +5,8 @@ import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from 
 export class FileInitStateStore {
   constructor(readonly filePath: string) {}
 
-  async load(configPath: string): Promise<InitState> {
-    return readJsonFileOrDefault(this.filePath, () => createEmptyInitState(configPath), {
+  async load(configPath: string, fallback: () => InitState = () => createEmptyInitState(configPath)): Promise<InitState> {
+    return readJsonFileOrDefault(this.filePath, fallback, {
       description: 'init state',
       onCorrupt: warnJsonQuarantined,
     });

--- a/packages/franken-orchestrator/src/init/init-state-store.ts
+++ b/packages/franken-orchestrator/src/init/init-state-store.ts
@@ -1,26 +1,19 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
 import type { InitState } from './init-types.js';
 import { createEmptyInitState } from './init-types.js';
+import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from './init-json-file.js';
 
 export class FileInitStateStore {
   constructor(readonly filePath: string) {}
 
   async load(configPath: string): Promise<InitState> {
-    try {
-      const raw = await readFile(this.filePath, 'utf-8');
-      return JSON.parse(raw) as InitState;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return createEmptyInitState(configPath);
-      }
-      throw error;
-    }
+    return readJsonFileOrDefault(this.filePath, () => createEmptyInitState(configPath), {
+      description: 'init state',
+      onCorrupt: warnJsonQuarantined,
+    });
   }
 
   async save(state: InitState): Promise<InitState> {
-    await mkdir(dirname(this.filePath), { recursive: true });
-    await writeFile(this.filePath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
+    await writeJsonFileAtomic(this.filePath, state);
     return state;
   }
 }

--- a/packages/franken-orchestrator/src/init/init-verify.ts
+++ b/packages/franken-orchestrator/src/init/init-verify.ts
@@ -1,7 +1,7 @@
-import { readFile } from 'node:fs/promises';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import type { FileInitStateStore } from './init-state-store.js';
 import type { ISecretStore } from '../network/secret-store.js';
+import { readJsonFileOrDefault, warnJsonQuarantined } from './init-json-file.js';
 
 export type InitIssueCode =
   | 'missing-config'
@@ -25,15 +25,10 @@ export interface InitVerificationResult {
 }
 
 async function tryReadJson<T>(filePath: string): Promise<T | undefined> {
-  try {
-    const raw = await readFile(filePath, 'utf-8');
-    return JSON.parse(raw) as T;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return undefined;
-    }
-    throw error;
-  }
+  return readJsonFileOrDefault<T | undefined>(filePath, () => undefined, {
+    description: 'init verification JSON',
+    onCorrupt: warnJsonQuarantined,
+  });
 }
 
 export async function verifyInit(options: {

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -74,6 +74,23 @@ describe('Config loader', () => {
     expect(config.chat.model).toBe('claude-sonnet-4-6');
   });
 
+  it('ignores a malformed default operator config file for init commands', async () => {
+    const filePath = join(tmpdir(), `beast-default-config-malformed-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, '{"chat": {', 'utf-8');
+
+    const config = await loadConfig(makeArgs({ subcommand: 'init' }), filePath);
+    expect(config.chat.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('throws on a malformed explicit config file for init commands', async () => {
+    const filePath = join(tmpdir(), `beast-explicit-config-malformed-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, '{"chat": {', 'utf-8');
+
+    await expect(loadConfig(makeArgs({ subcommand: 'init', config: filePath }))).rejects.toThrow(SyntaxError);
+  });
+
   it('deep merges nested network config from file', async () => {
     const filePath = join(tmpdir(), `beast-network-config-${Date.now()}.json`);
     tmpFiles.push(filePath);

--- a/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
@@ -200,4 +200,55 @@ describe('runInteractiveInit', () => {
     await expect(readFile(configFile, 'utf-8')).resolves.toContain('"dashboard"');
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed orchestrator config JSON'));
   });
+
+  it('preserves config-backed comms answers when malformed init state is quarantined', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-engine-'));
+    const configFile = join(tempDir, '.fbeast', 'config.json');
+    const stateFile = join(tempDir, '.fbeast', 'init-state.json');
+    const stateStore = new FileInitStateStore(stateFile);
+    const config = defaultConfig();
+    await mkdir(join(tempDir, '.fbeast'), { recursive: true });
+    await writeFile(configFile, JSON.stringify({
+      ...config,
+      chat: { ...config.chat, enabled: true },
+      comms: {
+        ...config.comms,
+        enabled: true,
+        slack: {
+          ...config.comms.slack,
+          enabled: true,
+          appId: 'existing-app',
+          botTokenRef: 'op://existing/slack-bot-token',
+          signingSecretRef: 'op://existing/slack-signing-secret',
+        },
+      },
+      providers: { ...config.providers, default: 'codex' },
+    }), 'utf-8');
+    await writeFile(stateFile, '{"answers": {', 'utf-8');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { io } = scriptedIo(
+      '', // keep chat enabled from config
+      '', // keep dashboard from config
+      '', // keep comms enabled from config
+      '', // keep provider from config
+      '', // keep security mode from config
+      '', // keep slack enabled from config
+      '', // keep app id from config
+      '', // keep bot token ref from config
+      '', // keep signing secret ref from config
+      'n', // discord disabled
+    );
+
+    const result = await runInteractiveInit({
+      configFile,
+      stateStore,
+      io,
+    });
+
+    expect(result.config.providers.default).toBe('codex');
+    expect(result.config.comms.slack.appId).toBe('existing-app');
+    expect(result.config.comms.slack.botTokenRef).toBe('op://existing/slack-bot-token');
+    expect(result.config.comms.slack.signingSecretRef).toBe('op://existing/slack-signing-secret');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed init state JSON'));
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
@@ -213,7 +213,7 @@ describe('runInteractiveInit', () => {
       chat: { ...config.chat, enabled: true },
       comms: {
         ...config.comms,
-        enabled: true,
+        enabled: false,
         slack: {
           ...config.comms.slack,
           enabled: true,

--- a/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-engine.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runInteractiveInit } from '../../../src/init/init-engine.js';
@@ -26,6 +26,7 @@ describe('runInteractiveInit', () => {
   let tempDir: string | undefined;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true });
       tempDir = undefined;
@@ -166,5 +167,37 @@ describe('runInteractiveInit', () => {
     expect(result.config.comms.slack.signingSecretRef).toBe('op://existing/slack-signing-secret');
     expect(result.state.selectedModules).toEqual(['chat', 'comms']);
     expect(result.state.selectedCommsTransports).toEqual(['slack']);
+  });
+
+  it('quarantines malformed existing config and continues with defaults', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-engine-'));
+    const configFile = join(tempDir, '.fbeast', 'config.json');
+    const stateStore = new FileInitStateStore(join(tempDir, '.fbeast', 'init-state.json'));
+    await mkdir(join(tempDir, '.fbeast'), { recursive: true });
+    await writeFile(configFile, '{"chat": {', 'utf-8');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { io } = scriptedIo(
+      'n', // chat default false after corrupt config fallback
+      'y', // dashboard
+      'n', // comms
+      'claude', // provider
+      'secure', // security mode
+    );
+
+    const result = await runInteractiveInit({
+      configFile,
+      stateStore,
+      io,
+    });
+    const files = await readdir(join(tempDir, '.fbeast'));
+    const quarantine = files.find((file) => file.startsWith('config.json.corrupt-'));
+
+    expect(result.config.chat.enabled).toBe(false);
+    expect(result.config.dashboard.enabled).toBe(true);
+    expect(result.config.comms.enabled).toBe(false);
+    expect(quarantine).toBeTruthy();
+    await expect(readFile(join(tempDir, '.fbeast', quarantine ?? ''), 'utf-8')).resolves.toBe('{"chat": {');
+    await expect(readFile(configFile, 'utf-8')).resolves.toContain('"dashboard"');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed orchestrator config JSON'));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { FileInitStateStore } from '../../../src/init/init-state-store.js';
@@ -9,6 +9,7 @@ describe('FileInitStateStore', () => {
   let tempDir: string | undefined;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true });
       tempDir = undefined;
@@ -39,5 +40,34 @@ describe('FileInitStateStore', () => {
     const loaded = await store.load('/tmp/project/.fbeast/config.json');
 
     expect(loaded).toEqual(saved);
+  });
+
+  it('quarantines malformed JSON and returns a clean initial state', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
+    const stateFile = join(tempDir, 'init-state.json');
+    const store = new FileInitStateStore(stateFile);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await writeFile(stateFile, '{"selectedModules": [', 'utf-8');
+
+    const state = await store.load('/tmp/project/.fbeast/config.json');
+    const files = await readdir(tempDir);
+    const quarantine = files.find((file) => file.startsWith('init-state.json.corrupt-'));
+
+    expect(state).toEqual(createEmptyInitState('/tmp/project/.fbeast/config.json'));
+    expect(quarantine).toBeTruthy();
+    await expect(readFile(join(tempDir, quarantine ?? ''), 'utf-8')).resolves.toBe('{"selectedModules": [');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed init state JSON'));
+  });
+
+  it('saves state through a temporary file rename without leaving temp files behind', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
+    const stateFile = join(tempDir, 'nested', 'init-state.json');
+    const store = new FileInitStateStore(stateFile);
+
+    await store.save(createEmptyInitState('/tmp/project/.fbeast/config.json'));
+
+    const files = await readdir(join(tempDir, 'nested'));
+    expect(files).toEqual(['init-state.json']);
+    await expect(readFile(stateFile, 'utf-8')).resolves.toContain('/tmp/project/.fbeast/config.json');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { chmod, lstat, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { FileInitStateStore } from '../../../src/init/init-state-store.js';
@@ -103,18 +103,43 @@ describe('FileInitStateStore', () => {
     const targetFile = join(tempDir, 'shared-init-state.json');
     const stateFile = join(tempDir, 'init-state.json');
     await writeFile(targetFile, '{"selectedModules": [', 'utf-8');
+    await chmod(targetFile, 0o600);
     await symlink(targetFile, stateFile);
     const store = new FileInitStateStore(stateFile);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     await store.load('/tmp/project/.fbeast/config.json');
+    await store.save(createEmptyInitState('/tmp/project/.fbeast/config.json'));
 
     const linkInfo = await lstat(stateFile);
+    const targetInfo = await stat(targetFile);
     const files = await readdir(tempDir);
     const quarantine = files.find((file) => file.startsWith('shared-init-state.json.corrupt-'));
     expect(linkInfo.isSymbolicLink()).toBe(true);
+    expect(targetInfo.mode & 0o777).toBe(0o600);
     expect(quarantine).toBeTruthy();
     await expect(readFile(join(tempDir, quarantine ?? ''), 'utf-8')).resolves.toBe('{"selectedModules": [');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed init state JSON'));
+  });
+
+  it('quarantines unsafe external symlinks without moving their targets', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
+    const projectDir = join(tempDir, 'project');
+    await mkdir(projectDir);
+    const externalTarget = join(tempDir, 'outside-init-state.json');
+    const stateFile = join(projectDir, 'init-state.json');
+    await writeFile(externalTarget, '{"selectedModules": [', 'utf-8');
+    await symlink(externalTarget, stateFile);
+    const store = new FileInitStateStore(stateFile);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await store.load('/tmp/project/.fbeast/config.json');
+
+    const files = await readdir(projectDir);
+    const quarantine = files.find((file) => file.startsWith('init-state.json.corrupt-'));
+    expect(quarantine).toBeTruthy();
+    await expect(readFile(externalTarget, 'utf-8')).resolves.toBe('{"selectedModules": [');
+    await expect(readFile(join(projectDir, quarantine ?? ''), 'utf-8')).resolves.toBe('{"selectedModules": [');
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed init state JSON'));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
@@ -84,11 +84,10 @@ describe('FileInitStateStore', () => {
     expect(fileInfo.mode & 0o777).toBe(0o600);
   });
 
-  it('updates a symlink target instead of replacing the symlink', async () => {
+  it('updates a dangling symlink target instead of replacing the symlink', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
     const targetFile = join(tempDir, 'shared-init-state.json');
     const stateFile = join(tempDir, 'init-state.json');
-    await writeFile(targetFile, '{}', 'utf-8');
     await symlink(targetFile, stateFile);
     const store = new FileInitStateStore(stateFile);
 
@@ -97,5 +96,25 @@ describe('FileInitStateStore', () => {
     const linkInfo = await lstat(stateFile);
     expect(linkInfo.isSymbolicLink()).toBe(true);
     await expect(readFile(targetFile, 'utf-8')).resolves.toContain('/tmp/project/.fbeast/config.json');
+  });
+
+  it('quarantines malformed JSON from a symlink target without replacing the symlink', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
+    const targetFile = join(tempDir, 'shared-init-state.json');
+    const stateFile = join(tempDir, 'init-state.json');
+    await writeFile(targetFile, '{"selectedModules": [', 'utf-8');
+    await symlink(targetFile, stateFile);
+    const store = new FileInitStateStore(stateFile);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await store.load('/tmp/project/.fbeast/config.json');
+
+    const linkInfo = await lstat(stateFile);
+    const files = await readdir(tempDir);
+    const quarantine = files.find((file) => file.startsWith('shared-init-state.json.corrupt-'));
+    expect(linkInfo.isSymbolicLink()).toBe(true);
+    expect(quarantine).toBeTruthy();
+    await expect(readFile(join(tempDir, quarantine ?? ''), 'utf-8')).resolves.toBe('{"selectedModules": [');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed init state JSON'));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-state-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { FileInitStateStore } from '../../../src/init/init-state-store.js';
@@ -69,5 +69,33 @@ describe('FileInitStateStore', () => {
     const files = await readdir(join(tempDir, 'nested'));
     expect(files).toEqual(['init-state.json']);
     await expect(readFile(stateFile, 'utf-8')).resolves.toContain('/tmp/project/.fbeast/config.json');
+  });
+
+  it('preserves existing file permissions when saving atomically', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
+    const stateFile = join(tempDir, 'init-state.json');
+    await writeFile(stateFile, '{}', 'utf-8');
+    await chmod(stateFile, 0o600);
+    const store = new FileInitStateStore(stateFile);
+
+    await store.save(createEmptyInitState('/tmp/project/.fbeast/config.json'));
+
+    const fileInfo = await lstat(stateFile);
+    expect(fileInfo.mode & 0o777).toBe(0o600);
+  });
+
+  it('updates a symlink target instead of replacing the symlink', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-state-'));
+    const targetFile = join(tempDir, 'shared-init-state.json');
+    const stateFile = join(tempDir, 'init-state.json');
+    await writeFile(targetFile, '{}', 'utf-8');
+    await symlink(targetFile, stateFile);
+    const store = new FileInitStateStore(stateFile);
+
+    await store.save(createEmptyInitState('/tmp/project/.fbeast/config.json'));
+
+    const linkInfo = await lstat(stateFile);
+    expect(linkInfo.isSymbolicLink()).toBe(true);
+    await expect(readFile(targetFile, 'utf-8')).resolves.toContain('/tmp/project/.fbeast/config.json');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-verify.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
@@ -27,6 +27,7 @@ describe('verifyInit', () => {
   let tempDir: string | undefined;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true });
       tempDir = undefined;
@@ -46,6 +47,33 @@ describe('verifyInit', () => {
     expect(result.ok).toBe(false);
     expect(result.messages.join('\n')).toContain('Config file is missing');
     expect(result.messages.join('\n')).toContain('Init state is missing');
+  });
+
+  it('quarantines malformed verification JSON and reports it as missing', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-verify-'));
+    const fbeastDir = join(tempDir, '.fbeast');
+    const configFile = join(fbeastDir, 'config.json');
+    const stateFile = join(fbeastDir, 'init-state.json');
+    const stateStore = new FileInitStateStore(stateFile);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await mkdir(fbeastDir, { recursive: true });
+    await writeFile(configFile, '{"comms": {', 'utf-8');
+    await writeFile(stateFile, '{"completedSteps": [', 'utf-8');
+
+    const result = await verifyInit({
+      configFile,
+      stateStore,
+    });
+    const files = await readdir(fbeastDir);
+
+    expect(result.ok).toBe(false);
+    expect(result.messages.join('\n')).toContain('Config file is missing');
+    expect(result.messages.join('\n')).toContain('Init state is missing');
+    expect(files.some((file) => file.startsWith('config.json.corrupt-'))).toBe(true);
+    const stateQuarantine = files.find((file) => file.startsWith('init-state.json.corrupt-'));
+    expect(stateQuarantine).toBeTruthy();
+    await expect(readFile(join(fbeastDir, stateQuarantine ?? ''), 'utf-8')).resolves.toBe('{"completedSteps": [');
+    expect(warn).toHaveBeenCalledTimes(2);
   });
 
   it('checks only enabled comms transports', async () => {


### PR DESCRIPTION
## Summary
- adds init JSON read/write helpers that quarantine malformed JSON and continue with defaults
- switches init config/state saves to temp-file + rename persistence
- covers malformed config/state, verify repair handling, and temp-file cleanup regressions

## Test Plan
- npm --workspace packages/franken-orchestrator test -- tests/unit/init/init-state-store.test.ts tests/unit/init/init-engine.test.ts tests/unit/init/init-verify.test.ts
- npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/planner --workspace @franken/critique --workspace @franken/governor
- npm --workspace packages/franken-orchestrator run typecheck
- npm --workspace packages/franken-orchestrator run lint
- npm --workspace packages/franken-orchestrator run build

Closes #1000
