### PR TITLE
fix(beasts): reject malformed daemon pid files

### DIFF
--- a/packages/franken-orchestrator/src/http/beast-daemon-server.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-server.ts
@@ -49,6 +49,7 @@ function errorMessage(error: unknown): string {
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 4050;
 const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'stopped']);
+const PID_FILE_DECIMAL_PATTERN = /^\d+$/;
 
 export function defaultBeastDaemonPidFile(root: string): string {
   return join(root, '.frankenbeast', 'beasts-daemon.pid');
@@ -149,8 +150,8 @@ async function claimPidFile(pidFile: string): Promise<void> {
 async function readExistingPidFile(pidFile: string): Promise<number | undefined> {
   try {
     const raw = await readFile(pidFile, 'utf8');
-    const pid = Number.parseInt(raw.trim(), 10);
-    if (Number.isFinite(pid) && pid > 0) {
+    const pid = parsePidFileContents(raw);
+    if (pid !== undefined) {
       return pid;
     }
     await rm(pidFile, { force: true });
@@ -166,14 +167,22 @@ async function readExistingPidFile(pidFile: string): Promise<number | undefined>
 async function readPidFile(pidFile: string): Promise<number | undefined> {
   try {
     const raw = await readFile(pidFile, 'utf8');
-    const pid = Number.parseInt(raw.trim(), 10);
-    return Number.isFinite(pid) && pid > 0 ? pid : undefined;
+    return parsePidFileContents(raw);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return undefined;
     }
     throw error;
   }
+}
+
+function parsePidFileContents(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  if (!PID_FILE_DECIMAL_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+  const pid = Number(trimmed);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -363,6 +363,46 @@ describe('beast daemon', () => {
     expect(existsSync(corrupt.pidFile)).toBe(false);
   });
 
+  it('rejects partially numeric and otherwise malformed pid files before claiming', async () => {
+    const malformedPidFileContents = [
+      `${process.pid}abc\n`,
+      `${process.pid}\n456`,
+      '   \n',
+      `-${process.pid}\n`,
+      `${process.pid}.5\n`,
+    ];
+
+    for (const contents of malformedPidFileContents) {
+      const paths = await makePaths();
+      await mkdir(join(paths.root, '.frankenbeast'), { recursive: true });
+      await writeFile(paths.pidFile, contents, { flag: 'wx' });
+
+      const daemon = await startBeastDaemon({
+        ...paths,
+        operatorToken,
+        port: 0,
+      });
+
+      expect(await readFile(paths.pidFile, 'utf8')).toBe(`${process.pid}\n`);
+      await daemon.close();
+      expect(existsSync(paths.pidFile)).toBe(false);
+    }
+  });
+
+  it('removes malformed pid files during release checks', async () => {
+    const paths = await makePaths();
+    const daemon = await startBeastDaemon({
+      ...paths,
+      operatorToken,
+      port: 0,
+    });
+
+    await writeFile(paths.pidFile, `${process.pid}abc\n`);
+    await daemon.close();
+
+    expect(existsSync(paths.pidFile)).toBe(false);
+  });
+
   it('releases the pid file when service construction fails', async () => {
     const paths = await makePaths();
     const badDbParent = join(paths.root, 'not-a-directory');


### PR DESCRIPTION
## Summary
- Add strict full-decimal validation for beasts daemon pid-file contents before converting to a number
- Treat malformed existing pid files as stale so daemon startup can reclaim them
- Treat malformed release-time pid files as absent so shutdown removes them

## Test Plan
- npm --workspace @franken/orchestrator test -- tests/integration/beasts/beast-daemon.test.ts
- npm --workspace @franken/orchestrator run lint
- npm run build
- npm --workspace @franken/orchestrator run typecheck

Closes #995
