### PR TITLE
fix(orchestrator): reject invalid analytics outcomes

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
@@ -17,10 +17,11 @@ const OUTCOMES = new Set<AnalyticsOutcome>([
 const TIME_WINDOWS = ['24h', '7d', '30d', 'all'] as const;
 const TIME_WINDOW_SET = new Set<string>(TIME_WINDOWS);
 
-type FiltersResult = { ok: true; filters: AnalyticsFilters } | { ok: false };
+type FilterValidationError = 'invalid_time_window' | 'invalid_outcome';
+type FiltersResult = { ok: true; filters: AnalyticsFilters } | { ok: false; reason: FilterValidationError };
 type PageRequestResult =
   | { ok: true; request: AnalyticsPageRequest }
-  | { ok: false; reason: 'invalid_time_window' }
+  | { ok: false; reason: FilterValidationError }
   | { ok: false; reason: 'invalid_pagination'; parameter: 'page' | 'pageSize' };
 
 export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
@@ -28,20 +29,20 @@ export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
 
   app.get('/summary', async (c) => {
     const result = readFilters(c.req.query());
-    if (!result.ok) return invalidTimeWindow(c);
+    if (!result.ok) return invalidFilter(c, result.reason);
     return c.json(await deps.analytics.getSummary(result.filters));
   });
 
   app.get('/sessions', async (c) => {
     const result = readFilters(c.req.query());
-    if (!result.ok) return invalidTimeWindow(c);
+    if (!result.ok) return invalidFilter(c, result.reason);
     return c.json({ sessions: await deps.analytics.listSessions(result.filters) });
   });
 
   app.get('/events', async (c) => {
     const result = readPageRequest(c.req.query());
     if (!result.ok) {
-      return result.reason === 'invalid_pagination' ? invalidPagination(c, result.parameter) : invalidTimeWindow(c);
+      return result.reason === 'invalid_pagination' ? invalidPagination(c, result.parameter) : invalidFilter(c, result.reason);
     }
     return c.json(await deps.analytics.listEvents(result.request));
   });
@@ -60,7 +61,7 @@ export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
 function readPageRequest(query: Record<string, string>): PageRequestResult {
   const filters = readFilters(query);
   if (!filters.ok) {
-    return { ok: false, reason: 'invalid_time_window' };
+    return { ok: false, reason: filters.reason };
   }
   const page = readPositiveInteger(query['page']);
   if (!page.ok) {
@@ -85,17 +86,24 @@ function readFilters(query: Record<string, string>): FiltersResult {
   const outcome = query['outcome'];
   const timeWindow = query['timeWindow'];
   if (timeWindow && !TIME_WINDOW_SET.has(timeWindow)) {
-    return { ok: false };
+    return { ok: false, reason: 'invalid_time_window' };
+  }
+  if (outcome && !OUTCOMES.has(outcome as AnalyticsOutcome)) {
+    return { ok: false, reason: 'invalid_outcome' };
   }
   return {
     ok: true,
     filters: {
       ...(query['sessionId'] ? { sessionId: query['sessionId'] } : {}),
       ...(query['toolQuery'] ? { toolQuery: query['toolQuery'] } : {}),
-      ...(outcome && OUTCOMES.has(outcome as AnalyticsOutcome) ? { outcome: outcome as AnalyticsOutcome } : {}),
+      ...(outcome ? { outcome: outcome as AnalyticsOutcome } : {}),
       ...(timeWindow ? { timeWindow } : {}),
     },
   };
+}
+
+function invalidFilter(c: Context, reason: FilterValidationError) {
+  return reason === 'invalid_outcome' ? invalidOutcome(c) : invalidTimeWindow(c);
 }
 
 function invalidTimeWindow(c: Context) {
@@ -104,6 +112,16 @@ function invalidTimeWindow(c: Context) {
       message: 'Unsupported Analytics timeWindow filter',
       code: 'invalid_time_window',
       allowedValues: TIME_WINDOWS,
+    },
+  }, 400);
+}
+
+function invalidOutcome(c: Context) {
+  return c.json({
+    error: {
+      message: 'Unsupported Analytics outcome filter',
+      code: 'invalid_outcome',
+      allowedValues: [...OUTCOMES],
     },
   }, 400);
 }

--- a/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
@@ -124,6 +124,27 @@ describe('analytics routes', () => {
     expect(service.listEvents).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['/summary?outcome=faild', 'getSummary'],
+    ['/sessions?outcome=blocked', 'listSessions'],
+    ['/events?outcome=unknown', 'listEvents'],
+  ] as const)('rejects unsupported outcome query values for %s before reading analytics data', async (path, serviceMethod) => {
+    const service = mockAnalyticsService();
+    const app = createAnalyticsRoutes({ analytics: service });
+
+    const res = await app.request(path);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: {
+        message: 'Unsupported Analytics outcome filter',
+        code: 'invalid_outcome',
+        allowedValues: ['approved', 'denied', 'review_recommended', 'failed', 'error', 'detected'],
+      },
+    });
+    expect(service[serviceMethod]).not.toHaveBeenCalled();
+  });
+
   it('returns event details or a 404', async () => {
     const service = mockAnalyticsService();
     const app = createAnalyticsRoutes({ analytics: service });


### PR DESCRIPTION
## Summary
- Reject unsupported Analytics `outcome` query values at the route boundary.
- Return a structured `invalid_outcome` 400 response instead of silently widening to all outcomes.
- Add regression coverage across summary, sessions, and events routes.

## Test Plan
- `npm test --workspace @franken/orchestrator -- tests/unit/http/analytics-routes.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)
- `npm run build --workspace @franken/orchestrator`
- `npm test --workspace @franken/orchestrator`

Closes #1226
