### PR TITLE
fix(beasts): return 404 for unknown interview sessions

### DIFF
--- a/packages/franken-orchestrator/src/beasts/services/beast-interview-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-interview-service.ts
@@ -14,6 +14,13 @@ export interface BeastInterviewProgress {
   readonly config?: Readonly<Record<string, unknown>> | undefined;
 }
 
+export class UnknownBeastInterviewSessionError extends Error {
+  constructor(public readonly sessionId: string) {
+    super(`Unknown Beast interview session: ${sessionId}`);
+    this.name = 'UnknownBeastInterviewSessionError';
+  }
+}
+
 export class BeastInterviewService {
   constructor(
     private readonly repository: SQLiteBeastRepository,
@@ -37,7 +44,7 @@ export class BeastInterviewService {
   resume(sessionId: string): BeastInterviewProgress {
     const session = this.repository.getInterviewSession(sessionId);
     if (!session) {
-      throw new Error(`Unknown Beast interview session: ${sessionId}`);
+      throw new UnknownBeastInterviewSessionError(sessionId);
     }
 
     const definition = this.getDefinitionOrThrow(session.definitionId);
@@ -60,7 +67,7 @@ export class BeastInterviewService {
   answer(sessionId: string, answer: string): BeastInterviewProgress {
     const session = this.repository.getInterviewSession(sessionId);
     if (!session) {
-      throw new Error(`Unknown Beast interview session: ${sessionId}`);
+      throw new UnknownBeastInterviewSessionError(sessionId);
     }
 
     const definition = this.getDefinitionOrThrow(session.definitionId);

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -7,7 +7,10 @@ import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions 
 import { UnknownTrackedAgentError } from '../../beasts/errors.js';
 import { BeastCatalogService } from '../../beasts/services/beast-catalog-service.js';
 import { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
-import { BeastInterviewService } from '../../beasts/services/beast-interview-service.js';
+import {
+  BeastInterviewService,
+  UnknownBeastInterviewSessionError,
+} from '../../beasts/services/beast-interview-service.js';
 import { BeastRunService, UnknownBeastRunError } from '../../beasts/services/beast-run-service.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
@@ -74,6 +77,12 @@ function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRun
 
 function beastRunNotFound(runId: string): HttpError {
   return new HttpError(404, 'BEAST_RUN_NOT_FOUND', `Beast run '${runId}' was not found`);
+}
+
+class InterviewSessionNotFoundHttpError extends HttpError {
+  constructor(sessionId: string) {
+    super(404, 'INTERVIEW_SESSION_NOT_FOUND', `Beast interview session '${sessionId}' was not found`);
+  }
 }
 
 function throwKnownRunError(runId: string, error: unknown): never {
@@ -271,7 +280,16 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
 
   app.post('/v1/beasts/interviews/:sessionId/answer', async (c) => {
     const body = validateBody(InterviewAnswerBody, await parseJsonBody(c));
-    const progress = deps.interviews.answer(c.req.param('sessionId'), body.answer);
+    const sessionId = c.req.param('sessionId');
+    let progress;
+    try {
+      progress = deps.interviews.answer(sessionId, body.answer);
+    } catch (error) {
+      if (error instanceof UnknownBeastInterviewSessionError) {
+        throw new InterviewSessionNotFoundHttpError(sessionId);
+      }
+      throw error;
+    }
     return c.json({ data: progress });
   });
 

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -415,6 +415,27 @@ describe('beast routes', () => {
     expect(answered.data.session.currentPrompt.key).toBe('objective');
   });
 
+  it('returns a structured 404 when answering an unknown interview session', async () => {
+    const { app, operatorToken } = createBeastApp();
+
+    const response = await app.request('/v1/beasts/interviews/missing-session/answer', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${operatorToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ answer: 'claude' }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'INTERVIEW_SESSION_NOT_FOUND',
+        message: "Beast interview session 'missing-session' was not found",
+      },
+    });
+  });
+
   it('returns 404 and does not persist a run when trackedAgentId is unknown', async () => {
     const { app, operatorToken } = createBeastApp();
     const headers = {


### PR DESCRIPTION
## Summary
- Add a typed unknown Beast interview session error from the interview service.
- Map unknown interview answer requests to 404 `INTERVIEW_SESSION_NOT_FOUND`.
- Add integration coverage for answering a missing interview session.

## Test Plan
- `npm test -- --run tests/integration/beasts/beast-routes.test.ts -t "unknown interview session"`
- `npm test -- --run tests/integration/beasts/beast-routes.test.ts`
- `npm test -- --run tests/unit/beasts/interview-service.test.ts tests/integration/beasts/beast-routes.test.ts`
- `npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run typecheck --workspace @franken/orchestrator && npm run lint --workspace @franken/orchestrator && npm run build --workspace @franken/orchestrator`

Closes #1434