### PR TITLE
fix(orchestrator): report corrupt chat session files

### DIFF
--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync, renameSync } from 'node:fs';
+import { chmodSync, readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync, renameSync, statSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { join, resolve, sep } from 'node:path';
 import { ChatSessionSchema, type ChatSession } from './types.js';
@@ -6,6 +6,7 @@ import { isoNow, now as deterministicNow } from '@franken/types';
 
 export interface CorruptChatSessionFile {
   id: string;
+  projectId?: string;
   path: string;
   quarantinePath: string;
   reason: string;
@@ -17,7 +18,7 @@ export interface ISessionStore {
   save(session: ChatSession): void;
   list(): string[];
   listSessions(projectId?: string): ChatSession[];
-  listCorruptions?(): CorruptChatSessionFile[];
+  listCorruptions?(projectId?: string): CorruptChatSessionFile[];
   delete(id: string): void;
 }
 
@@ -62,7 +63,7 @@ export class FileSessionStore implements ISessionStore {
     try {
       return ChatSessionSchema.parse(JSON.parse(raw));
     } catch (error) {
-      this.quarantineCorruptSession(id, path, error);
+      this.quarantineCorruptSession(id, path, raw, error);
       return undefined;
     }
   }
@@ -89,13 +90,15 @@ export class FileSessionStore implements ISessionStore {
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   }
 
-  listCorruptions(): CorruptChatSessionFile[] {
+  listCorruptions(projectId?: string): CorruptChatSessionFile[] {
     for (const diagnostic of this.listQuarantinedFiles()) {
       if (!this.corruptions.has(diagnostic.id)) {
         this.corruptions.set(diagnostic.id, diagnostic);
       }
     }
-    return Array.from(this.corruptions.values()).sort((left, right) => left.id.localeCompare(right.id));
+    return Array.from(this.corruptions.values())
+      .filter((diagnostic) => projectId === undefined || diagnostic.projectId === projectId)
+      .sort((left, right) => left.id.localeCompare(right.id));
   }
 
   delete(id: string): void {
@@ -128,7 +131,11 @@ export class FileSessionStore implements ISessionStore {
     }
     const tmpPath = `${destination}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
     try {
+      const existingMode = this.existingFileMode(destination);
       writeFileSync(tmpPath, JSON.stringify(session, null, 2), 'utf-8');
+      if (existingMode !== undefined) {
+        chmodSync(tmpPath, existingMode);
+      }
       renameSync(tmpPath, destination);
       this.corruptions.delete(session.id);
     } catch (error) {
@@ -141,10 +148,25 @@ export class FileSessionStore implements ISessionStore {
     }
   }
 
-  private quarantineCorruptSession(id: string, path: string, error: unknown): void {
+  private existingFileMode(path: string): number | undefined {
+    try {
+      return statSync(path).mode & 0o777;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private quarantineCorruptSession(id: string, path: string, raw: string, error: unknown): void {
     const quarantinePath = `${path}.corrupt-${deterministicNow()}-${randomBytes(3).toString('hex')}`;
     const reason = error instanceof Error ? error.message : String(error);
-    const diagnostic: CorruptChatSessionFile = { id, path, quarantinePath, reason };
+    const projectId = this.extractProjectId(raw);
+    const diagnostic: CorruptChatSessionFile = {
+      id,
+      ...(projectId === undefined ? {} : { projectId }),
+      path,
+      quarantinePath,
+      reason,
+    };
     this.corruptions.set(id, diagnostic);
 
     try {
@@ -164,15 +186,35 @@ export class FileSessionStore implements ISessionStore {
         .filter((file) => file.includes('.json.corrupt-'))
         .map((file) => {
           const id = file.slice(0, file.indexOf('.json.corrupt-'));
+          const quarantinePath = join(this.storeDir, file);
+          const projectId = this.extractProjectIdFromFile(quarantinePath);
           return {
             id,
+            ...(projectId === undefined ? {} : { projectId }),
             path: this.filePath(id),
-            quarantinePath: join(this.storeDir, file),
+            quarantinePath,
             reason: 'previously quarantined corrupt chat session file',
           };
         });
     } catch {
       return [];
+    }
+  }
+
+  private extractProjectIdFromFile(path: string): string | undefined {
+    try {
+      return this.extractProjectId(readFileSync(path, 'utf-8'));
+    } catch {
+      return undefined;
+    }
+  }
+
+  private extractProjectId(raw: string): string | undefined {
+    try {
+      const parsed = JSON.parse(raw) as { projectId?: unknown };
+      return typeof parsed.projectId === 'string' ? parsed.projectId : undefined;
+    } catch {
+      return undefined;
     }
   }
 }

--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -142,7 +142,7 @@ export class FileSessionStore implements ISessionStore {
   }
 
   private quarantineCorruptSession(id: string, path: string, error: unknown): void {
-    const quarantinePath = `${path}.corrupt-${deterministicNow()}`;
+    const quarantinePath = `${path}.corrupt-${deterministicNow()}-${randomBytes(3).toString('hex')}`;
     const reason = error instanceof Error ? error.message : String(error);
     const diagnostic: CorruptChatSessionFile = { id, path, quarantinePath, reason };
     this.corruptions.set(id, diagnostic);

--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -1,8 +1,15 @@
-import { readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync, renameSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import { ChatSessionSchema, type ChatSession } from './types.js';
 import { isoNow, now as deterministicNow } from '@franken/types';
+
+export interface CorruptChatSessionFile {
+  id: string;
+  path: string;
+  quarantinePath: string;
+  reason: string;
+}
 
 export interface ISessionStore {
   create(projectId: string): ChatSession;
@@ -10,11 +17,13 @@ export interface ISessionStore {
   save(session: ChatSession): void;
   list(): string[];
   listSessions(projectId?: string): ChatSession[];
+  listCorruptions?(): CorruptChatSessionFile[];
   delete(id: string): void;
 }
 
 export class FileSessionStore implements ISessionStore {
   private readonly storeDir: string;
+  private readonly corruptions = new Map<string, CorruptChatSessionFile>();
 
   constructor(storeDir: string) {
     this.storeDir = storeDir;
@@ -41,7 +50,10 @@ export class FileSessionStore implements ISessionStore {
     try {
       const raw = readFileSync(this.filePath(id), 'utf-8');
       return ChatSessionSchema.parse(JSON.parse(raw));
-    } catch {
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        this.quarantineCorruptSession(id, error);
+      }
       return undefined;
     }
   }
@@ -68,6 +80,10 @@ export class FileSessionStore implements ISessionStore {
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   }
 
+  listCorruptions(): CorruptChatSessionFile[] {
+    return Array.from(this.corruptions.values()).sort((left, right) => left.id.localeCompare(right.id));
+  }
+
   delete(id: string): void {
     try {
       unlinkSync(this.filePath(id));
@@ -82,6 +98,41 @@ export class FileSessionStore implements ISessionStore {
 
   private writeToDisk(session: ChatSession): void {
     mkdirSync(this.storeDir, { recursive: true });
-    writeFileSync(this.filePath(session.id), JSON.stringify(session, null, 2), 'utf-8');
+    const destination = this.filePath(session.id);
+    const tmpPath = `${destination}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+    try {
+      writeFileSync(tmpPath, JSON.stringify(session, null, 2), 'utf-8');
+      renameSync(tmpPath, destination);
+      this.corruptions.delete(session.id);
+    } catch (error) {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // Best-effort cleanup only; preserve the original write failure.
+      }
+      throw error;
+    }
   }
+
+  private quarantineCorruptSession(id: string, error: unknown): void {
+    const path = this.filePath(id);
+    const quarantinePath = `${path}.corrupt-${deterministicNow()}`;
+    const reason = error instanceof Error ? error.message : String(error);
+    const diagnostic: CorruptChatSessionFile = { id, path, quarantinePath, reason };
+    this.corruptions.set(id, diagnostic);
+
+    try {
+      renameSync(path, quarantinePath);
+    } catch (renameError) {
+      diagnostic.reason = `${reason}; failed to quarantine: ${renameError instanceof Error ? renameError.message : String(renameError)}`;
+    }
+
+    console.warn(
+      `[chat-session-store] corrupt chat session ${id} quarantined at ${diagnostic.quarantinePath}: ${diagnostic.reason}`,
+    );
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }

--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -97,7 +97,7 @@ export class FileSessionStore implements ISessionStore {
       }
     }
     return Array.from(this.corruptions.values())
-      .filter((diagnostic) => projectId === undefined || diagnostic.projectId === projectId)
+      .filter((diagnostic) => projectId === undefined || diagnostic.projectId === undefined || diagnostic.projectId === projectId)
       .sort((left, right) => left.id.localeCompare(right.id));
   }
 
@@ -132,7 +132,7 @@ export class FileSessionStore implements ISessionStore {
     const tmpPath = `${destination}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
     try {
       const existingMode = this.existingFileMode(destination);
-      writeFileSync(tmpPath, JSON.stringify(session, null, 2), 'utf-8');
+      writeFileSync(tmpPath, JSON.stringify(session, null, 2), { encoding: 'utf-8', mode: existingMode ?? 0o600 });
       if (existingMode !== undefined) {
         chmodSync(tmpPath, existingMode);
       }

--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync, renameSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { ChatSessionSchema, type ChatSession } from './types.js';
 import { isoNow, now as deterministicNow } from '@franken/types';
 
@@ -47,13 +47,22 @@ export class FileSessionStore implements ISessionStore {
   }
 
   get(id: string): ChatSession | undefined {
+    const path = this.safeFilePath(id);
+    if (path === undefined) {
+      return undefined;
+    }
+
+    let raw: string;
     try {
-      const raw = readFileSync(this.filePath(id), 'utf-8');
+      raw = readFileSync(path, 'utf-8');
+    } catch {
+      return undefined;
+    }
+
+    try {
       return ChatSessionSchema.parse(JSON.parse(raw));
     } catch (error) {
-      if (!isNotFoundError(error)) {
-        this.quarantineCorruptSession(id, error);
-      }
+      this.quarantineCorruptSession(id, path, error);
       return undefined;
     }
   }
@@ -81,6 +90,11 @@ export class FileSessionStore implements ISessionStore {
   }
 
   listCorruptions(): CorruptChatSessionFile[] {
+    for (const diagnostic of this.listQuarantinedFiles()) {
+      if (!this.corruptions.has(diagnostic.id)) {
+        this.corruptions.set(diagnostic.id, diagnostic);
+      }
+    }
     return Array.from(this.corruptions.values()).sort((left, right) => left.id.localeCompare(right.id));
   }
 
@@ -96,9 +110,22 @@ export class FileSessionStore implements ISessionStore {
     return join(this.storeDir, `${id}.json`);
   }
 
+  private safeFilePath(id: string): string | undefined {
+    const resolvedStoreDir = resolve(this.storeDir);
+    const resolvedPath = resolve(this.storeDir, `${id}.json`);
+    if (resolvedPath === resolvedStoreDir || !resolvedPath.startsWith(`${resolvedStoreDir}${sep}`)) {
+      console.warn(`[chat-session-store] ignoring invalid chat session id ${JSON.stringify(id)}`);
+      return undefined;
+    }
+    return resolvedPath;
+  }
+
   private writeToDisk(session: ChatSession): void {
     mkdirSync(this.storeDir, { recursive: true });
-    const destination = this.filePath(session.id);
+    const destination = this.safeFilePath(session.id);
+    if (destination === undefined) {
+      throw new Error(`Invalid chat session id: ${JSON.stringify(session.id)}`);
+    }
     const tmpPath = `${destination}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
     try {
       writeFileSync(tmpPath, JSON.stringify(session, null, 2), 'utf-8');
@@ -114,8 +141,7 @@ export class FileSessionStore implements ISessionStore {
     }
   }
 
-  private quarantineCorruptSession(id: string, error: unknown): void {
-    const path = this.filePath(id);
+  private quarantineCorruptSession(id: string, path: string, error: unknown): void {
     const quarantinePath = `${path}.corrupt-${deterministicNow()}`;
     const reason = error instanceof Error ? error.message : String(error);
     const diagnostic: CorruptChatSessionFile = { id, path, quarantinePath, reason };
@@ -131,8 +157,22 @@ export class FileSessionStore implements ISessionStore {
       `[chat-session-store] corrupt chat session ${id} quarantined at ${diagnostic.quarantinePath}: ${diagnostic.reason}`,
     );
   }
-}
 
-function isNotFoundError(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+  private listQuarantinedFiles(): CorruptChatSessionFile[] {
+    try {
+      return readdirSync(this.storeDir)
+        .filter((file) => file.includes('.json.corrupt-'))
+        .map((file) => {
+          const id = file.slice(0, file.indexOf('.json.corrupt-'));
+          return {
+            id,
+            path: this.filePath(id),
+            quarantinePath: join(this.storeDir, file),
+            reason: 'previously quarantined corrupt chat session file',
+          };
+        });
+    } catch {
+      return [];
+    }
+  }
 }

--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -92,6 +92,10 @@ export class FileSessionStore implements ISessionStore {
 
   listCorruptions(projectId?: string): CorruptChatSessionFile[] {
     for (const diagnostic of this.listQuarantinedFiles()) {
+      if (this.hasValidCurrentSessionFile(diagnostic.id)) {
+        this.corruptions.delete(diagnostic.id);
+        continue;
+      }
       if (!this.corruptions.has(diagnostic.id)) {
         this.corruptions.set(diagnostic.id, diagnostic);
       }
@@ -153,6 +157,20 @@ export class FileSessionStore implements ISessionStore {
       return statSync(path).mode & 0o777;
     } catch {
       return undefined;
+    }
+  }
+
+  private hasValidCurrentSessionFile(id: string): boolean {
+    const path = this.safeFilePath(id);
+    if (path === undefined) {
+      return false;
+    }
+
+    try {
+      ChatSessionSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -134,7 +134,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
     }));
-    const corruptSessions = sessionStore.listCorruptions?.() ?? [];
+    const corruptSessions = sessionStore.listCorruptions?.(projectId) ?? [];
     return c.json({
       data: { sessions, corruptSessions },
     } satisfies ApiDataEnvelope<{ sessions: ChatSessionSummary[]; corruptSessions: CorruptChatSessionFile[] }>);

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -134,10 +134,17 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
     }));
-    const corruptSessions = sessionStore.listCorruptions?.(projectId) ?? [];
+    const corruptSessions = (sessionStore.listCorruptions?.(projectId) ?? []).map(({ id, projectId, reason }) => ({
+      id,
+      ...(projectId === undefined ? {} : { projectId }),
+      reason,
+    }));
     return c.json({
       data: { sessions, corruptSessions },
-    } satisfies ApiDataEnvelope<{ sessions: ChatSessionSummary[]; corruptSessions: CorruptChatSessionFile[] }>);
+    } satisfies ApiDataEnvelope<{
+      sessions: ChatSessionSummary[];
+      corruptSessions: Pick<CorruptChatSessionFile, 'id' | 'projectId' | 'reason'>[];
+    }>);
   });
 
   // Get session

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { approvalRuntimeInput } from '../../chat/approval-input.js';
-import type { ISessionStore } from '../../chat/session-store.js';
+import type { CorruptChatSessionFile, ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
 import { ChatRuntime, pendingApprovalRuntimeState } from '../../chat/runtime.js';
 import type { TurnRunner } from '../../chat/turn-runner.js';
@@ -134,7 +134,10 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
     }));
-    return c.json({ data: { sessions } } satisfies ApiDataEnvelope<{ sessions: ChatSessionSummary[] }>);
+    const corruptSessions = sessionStore.listCorruptions?.() ?? [];
+    return c.json({
+      data: { sessions, corruptSessions },
+    } satisfies ApiDataEnvelope<{ sessions: ChatSessionSummary[]; corruptSessions: CorruptChatSessionFile[] }>);
   });
 
   // Get session

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { FileSessionStore } from '../../../src/chat/session-store.js';
 
@@ -109,6 +109,26 @@ describe('FileSessionStore', () => {
     warn.mockRestore();
   });
 
+  it('filters corrupt-session diagnostics by project id when available', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const firstId = 'chat-corrupt-first-project';
+    const secondId = 'chat-corrupt-second-project';
+    writeFileSync(join(TMP, `${firstId}.json`), JSON.stringify({ id: firstId, projectId: 'first' }), 'utf-8');
+    writeFileSync(join(TMP, `${secondId}.json`), JSON.stringify({ id: secondId, projectId: 'second' }), 'utf-8');
+
+    expect(store.get(firstId)).toBeUndefined();
+    expect(store.get(secondId)).toBeUndefined();
+
+    expect(store.listCorruptions('first')).toEqual([
+      expect.objectContaining({ id: firstId, projectId: 'first' }),
+    ]);
+    expect(store.listCorruptions('second')).toEqual([
+      expect.objectContaining({ id: secondId, projectId: 'second' }),
+    ]);
+
+    warn.mockRestore();
+  });
+
   it('does not quarantine unreadable session paths', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const unreadableId = 'chat-directory-entry';
@@ -168,6 +188,18 @@ describe('FileSessionStore', () => {
 
     expect(store.get(session.id)!.transcript).toHaveLength(1);
     expect(readdirSync(TMP).filter((entry) => entry.includes('.tmp'))).toEqual([]);
+  });
+
+  it('preserves existing session file permissions during atomic saves', () => {
+    const session = store.create('proj');
+    const sessionPath = join(TMP, `${session.id}.json`);
+    chmodSync(sessionPath, 0o600);
+
+    session.transcript.push({ role: 'user', content: 'private', timestamp: new Date().toISOString() });
+    store.save(session);
+
+    expect(statSync(sessionPath).mode & 0o777).toBe(0o600);
+    expect(store.get(session.id)!.transcript).toHaveLength(1);
   });
 
   it('uses unique quarantine paths for repeated corrupt writes with the same id', () => {

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -89,6 +89,54 @@ describe('FileSessionStore', () => {
     warn.mockRestore();
   });
 
+  it('keeps corrupt-session diagnostics visible after a store restart', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corruptId = 'chat-corrupt-before-restart';
+    const corruptPath = join(TMP, `${corruptId}.json`);
+    writeFileSync(corruptPath, '{"id":', 'utf-8');
+
+    expect(store.get(corruptId)).toBeUndefined();
+    const restartedStore = new FileSessionStore(TMP);
+
+    expect(restartedStore.listCorruptions()).toEqual([
+      expect.objectContaining({
+        id: corruptId,
+        path: corruptPath,
+        reason: 'previously quarantined corrupt chat session file',
+      }),
+    ]);
+
+    warn.mockRestore();
+  });
+
+  it('does not quarantine unreadable session paths', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const unreadableId = 'chat-directory-entry';
+    const unreadablePath = join(TMP, `${unreadableId}.json`);
+    mkdirSync(unreadablePath, { recursive: true });
+
+    expect(store.get(unreadableId)).toBeUndefined();
+
+    expect(existsSync(unreadablePath)).toBe(true);
+    expect(store.listCorruptions()).toEqual([]);
+
+    warn.mockRestore();
+  });
+
+  it('rejects path-traversal session ids without moving files outside the store', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const outsidePath = join(TMP, '..', 'config.json');
+    writeFileSync(outsidePath, JSON.stringify({ ok: true }), 'utf-8');
+
+    expect(store.get('../config')).toBeUndefined();
+
+    expect(existsSync(outsidePath)).toBe(true);
+    expect(store.listCorruptions()).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ignoring invalid chat session id'));
+
+    warn.mockRestore();
+  });
+
   it('quarantines schema-invalid session files separately from missing files', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const corruptId = 'chat-invalid-schema';

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -125,13 +125,16 @@ describe('FileSessionStore', () => {
 
   it('rejects path-traversal session ids without moving files outside the store', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const outsidePath = join(TMP, '..', 'config.json');
+    const nestedStoreDir = join(TMP, 'nested-store');
+    const nestedStore = new FileSessionStore(nestedStoreDir);
+    mkdirSync(nestedStoreDir, { recursive: true });
+    const outsidePath = join(TMP, 'config.json');
     writeFileSync(outsidePath, JSON.stringify({ ok: true }), 'utf-8');
 
-    expect(store.get('../config')).toBeUndefined();
+    expect(nestedStore.get('../config')).toBeUndefined();
 
     expect(existsSync(outsidePath)).toBe(true);
-    expect(store.listCorruptions()).toEqual([]);
+    expect(nestedStore.listCorruptions()).toEqual([]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('ignoring invalid chat session id'));
 
     warn.mockRestore();
@@ -165,5 +168,24 @@ describe('FileSessionStore', () => {
 
     expect(store.get(session.id)!.transcript).toHaveLength(1);
     expect(readdirSync(TMP).filter((entry) => entry.includes('.tmp'))).toEqual([]);
+  });
+
+  it('uses unique quarantine paths for repeated corrupt writes with the same id', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corruptId = 'chat-repeat-corrupt';
+    const corruptPath = join(TMP, `${corruptId}.json`);
+    writeFileSync(corruptPath, '{"id":', 'utf-8');
+    expect(store.get(corruptId)).toBeUndefined();
+    const firstQuarantine = store.listCorruptions()[0]!.quarantinePath;
+
+    writeFileSync(corruptPath, '{"id":', 'utf-8');
+    expect(store.get(corruptId)).toBeUndefined();
+
+    const quarantinedFiles = readdirSync(TMP).filter((entry) => entry.startsWith(`${corruptId}.json.corrupt-`));
+    expect(quarantinedFiles).toHaveLength(2);
+    expect(store.listCorruptions()[0]!.quarantinePath).not.toBe(firstQuarantine);
+    expect(existsSync(corruptPath)).toBe(false);
+
+    warn.mockRestore();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -113,17 +113,22 @@ describe('FileSessionStore', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const firstId = 'chat-corrupt-first-project';
     const secondId = 'chat-corrupt-second-project';
+    const unknownId = 'chat-corrupt-unknown-project';
     writeFileSync(join(TMP, `${firstId}.json`), JSON.stringify({ id: firstId, projectId: 'first' }), 'utf-8');
     writeFileSync(join(TMP, `${secondId}.json`), JSON.stringify({ id: secondId, projectId: 'second' }), 'utf-8');
+    writeFileSync(join(TMP, `${unknownId}.json`), '{"id":', 'utf-8');
 
     expect(store.get(firstId)).toBeUndefined();
     expect(store.get(secondId)).toBeUndefined();
+    expect(store.get(unknownId)).toBeUndefined();
 
     expect(store.listCorruptions('first')).toEqual([
       expect.objectContaining({ id: firstId, projectId: 'first' }),
+      expect.objectContaining({ id: unknownId }),
     ]);
     expect(store.listCorruptions('second')).toEqual([
       expect.objectContaining({ id: secondId, projectId: 'second' }),
+      expect.objectContaining({ id: unknownId }),
     ]);
 
     warn.mockRestore();

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { FileSessionStore } from '../../../src/chat/session-store.js';
 
@@ -68,5 +68,54 @@ describe('FileSessionStore', () => {
 
   it('returns undefined for non-existent session', () => {
     expect(store.get('nonexistent')).toBeUndefined();
+    expect(store.listCorruptions()).toEqual([]);
+  });
+
+  it('quarantines malformed JSON sessions and reports them during listing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corruptId = 'chat-corrupt-json';
+    const corruptPath = join(TMP, `${corruptId}.json`);
+    writeFileSync(corruptPath, '{"id":', 'utf-8');
+
+    expect(store.listSessions()).toEqual([]);
+
+    const [diagnostic] = store.listCorruptions();
+    expect(diagnostic).toMatchObject({ id: corruptId, path: corruptPath });
+    expect(diagnostic!.reason).toContain('JSON');
+    expect(existsSync(corruptPath)).toBe(false);
+    expect(existsSync(diagnostic!.quarantinePath)).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('corrupt chat session chat-corrupt-json'));
+
+    warn.mockRestore();
+  });
+
+  it('quarantines schema-invalid session files separately from missing files', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corruptId = 'chat-invalid-schema';
+    const corruptPath = join(TMP, `${corruptId}.json`);
+    writeFileSync(corruptPath, JSON.stringify({ id: corruptId, projectId: 'proj' }), 'utf-8');
+
+    expect(store.get(corruptId)).toBeUndefined();
+
+    const corruptions = store.listCorruptions();
+    expect(corruptions).toHaveLength(1);
+    expect(corruptions[0]).toMatchObject({ id: corruptId, path: corruptPath });
+    expect(corruptions[0]!.reason).toContain('Required');
+    expect(existsSync(corruptPath)).toBe(false);
+    expect(existsSync(corruptions[0]!.quarantinePath)).toBe(true);
+    expect(store.get('nonexistent')).toBeUndefined();
+    expect(store.listCorruptions()).toHaveLength(1);
+
+    warn.mockRestore();
+  });
+
+  it('writes sessions atomically without leaving temporary files after a save', () => {
+    const session = store.create('proj');
+    session.transcript.push({ role: 'user', content: 'Hello', timestamp: new Date().toISOString() });
+
+    store.save(session);
+
+    expect(store.get(session.id)!.transcript).toHaveLength(1);
+    expect(readdirSync(TMP).filter((entry) => entry.includes('.tmp'))).toEqual([]);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -109,6 +109,36 @@ describe('FileSessionStore', () => {
     warn.mockRestore();
   });
 
+  it('does not report archived corruptions after the same session id is repaired', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const repairedId = 'chat-repaired-after-corruption';
+    const repairedPath = join(TMP, `${repairedId}.json`);
+    writeFileSync(repairedPath, '{"id":', 'utf-8');
+
+    expect(store.get(repairedId)).toBeUndefined();
+    expect(store.listCorruptions()).toEqual([
+      expect.objectContaining({ id: repairedId, path: repairedPath }),
+    ]);
+
+    store.save({
+      id: repairedId,
+      projectId: 'proj',
+      transcript: [],
+      state: 'active',
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:01.000Z',
+    });
+
+    expect(readdirSync(TMP).some((entry) => entry.startsWith(`${repairedId}.json.corrupt-`))).toBe(true);
+    expect(store.get(repairedId)).toMatchObject({ id: repairedId, projectId: 'proj' });
+    expect(store.listCorruptions()).toEqual([]);
+    expect(new FileSessionStore(TMP).listCorruptions()).toEqual([]);
+
+    warn.mockRestore();
+  });
+
   it('filters corrupt-session diagnostics by project id when available', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const firstId = 'chat-corrupt-first-project';

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../hooks/use-chat-session', () => ({
 vi.mock('../lib/api', () => ({
   ChatApiClient: class {
     listSessions = vi.fn().mockResolvedValue([]);
+    listSessionsWithDiagnostics = vi.fn().mockResolvedValue({ sessions: [], corruptSessions: [] });
   },
 }));
 

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -18,7 +18,7 @@ import {
   type TrackedAgentInitAction,
   type TrackedAgentSummary,
 } from '../lib/beast-api';
-import { ChatApiClient, type ChatSessionSummary } from '../lib/api';
+import { ChatApiClient, type ChatSessionSummary, type CorruptChatSessionFile } from '../lib/api';
 import { NetworkApiClient, type NetworkConfigResponse, type NetworkStatusResponse } from '../lib/network-api';
 import { BeastsPage } from '../pages/beasts-page';
 import type { AgentLifecycleAction } from './beasts/agent-action-bar';
@@ -281,6 +281,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [preserveComposerDraft, setPreserveComposerDraft] = useState(!sessionId);
   const [clearedFailedDraft, setClearedFailedDraft] = useState<{ content: string; nonce: number } | undefined>(undefined);
   const [chatSessions, setChatSessions] = useState<ChatSessionSummary[]>([]);
+  const [corruptChatSessions, setCorruptChatSessions] = useState<CorruptChatSessionFile[]>([]);
   const [chatSessionsLoading, setChatSessionsLoading] = useState(true);
   const [chatSessionsError, setChatSessionsError] = useState<string | null>(null);
   const [chatSessionsRefreshNonce, setChatSessionsRefreshNonce] = useState(0);
@@ -468,15 +469,17 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     setChatSessionsLoading(true);
     setChatSessionsError(null);
 
-    void chatClient.listSessions(projectId)
-      .then((sessions) => {
+    void chatClient.listSessionsWithDiagnostics(projectId)
+      .then(({ sessions, corruptSessions }) => {
         if (!cancelled) {
           setChatSessions(sessions);
+          setCorruptChatSessions(corruptSessions);
         }
       })
       .catch((error: unknown) => {
         if (!cancelled) {
           setChatSessions([]);
+          setCorruptChatSessions([]);
           setChatSessionsError(error instanceof Error ? error.message : 'Unable to load conversations.');
         }
       })
@@ -1032,6 +1035,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                         {chatSessions.length} saved {chatSessions.length === 1 ? 'conversation' : 'conversations'} available.
                       </small>
                     )}
+                    {!chatSessionsLoading && !chatSessionsError && corruptChatSessions.length > 0 ? (
+                      <small className="field-error" role="alert">
+                        {corruptChatSessions.length} corrupted saved {corruptChatSessions.length === 1 ? 'conversation was' : 'conversations were'} quarantined and omitted.
+                      </small>
+                    ) : null}
                   </label>
                   {chatSessionsError ? (
                     <button

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -23,6 +23,18 @@ export type {
 } from '@franken/types';
 export type { ChatSessionResponse as ChatSession } from '@franken/types';
 
+export interface CorruptChatSessionFile {
+  id: string;
+  path: string;
+  quarantinePath: string;
+  reason: string;
+}
+
+export interface ChatSessionListResponse {
+  sessions: ChatSessionSummary[];
+  corruptSessions: CorruptChatSessionFile[];
+}
+
 export const CHAT_SOCKET_PROTOCOL = 'franken.chat.v1';
 export const CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX = 'franken.chat.token.';
 
@@ -107,15 +119,20 @@ export class ChatApiClient {
   }
 
   async listSessions(projectId?: string): Promise<ChatSessionSummary[]> {
+    const body = await this.listSessionsWithDiagnostics(projectId);
+    return body.sessions;
+  }
+
+  async listSessionsWithDiagnostics(projectId?: string): Promise<ChatSessionListResponse> {
     const url = new URL('/v1/chat/sessions', this.requestBaseUrl);
     if (projectId) {
       url.searchParams.set('projectId', projectId);
     }
-    const body = await this.request<{ sessions: ChatSessionSummary[] }>(
+    const body = await this.request<ChatSessionListResponse>(
       `${url.pathname}${url.search}`,
       { method: 'GET' },
     );
-    return body.sessions;
+    return { sessions: body.sessions, corruptSessions: body.corruptSessions ?? [] };
   }
 
   async sendMessage(sessionId: string, content: string): Promise<MessageResult> {

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -26,8 +26,6 @@ export type { ChatSessionResponse as ChatSession } from '@franken/types';
 export interface CorruptChatSessionFile {
   id: string;
   projectId?: string;
-  path: string;
-  quarantinePath: string;
   reason: string;
 }
 

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -25,6 +25,7 @@ export type { ChatSessionResponse as ChatSession } from '@franken/types';
 
 export interface CorruptChatSessionFile {
   id: string;
+  projectId?: string;
   path: string;
   quarantinePath: string;
   reason: string;

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -244,8 +244,15 @@ vi.mock('../../src/hooks/use-chat-session.js', () => ({
 }));
 
 vi.mock('../../src/lib/api.js', () => ({
-  ChatApiClient: vi.fn(function (this: { listSessions: typeof mockListSessions }) {
+  ChatApiClient: vi.fn(function (this: {
+    listSessions: typeof mockListSessions;
+    listSessionsWithDiagnostics: (projectId?: string) => Promise<{ sessions: Awaited<ReturnType<typeof mockListSessions>>; corruptSessions: [] }>;
+  }) {
     this.listSessions = mockListSessions;
+    this.listSessionsWithDiagnostics = async (projectId?: string) => ({
+      sessions: await mockListSessions(projectId),
+      corruptSessions: [],
+    });
   }),
 }));
 

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -86,3 +86,7 @@
 ## 2026-07-10 — Network page stale refresh races
 - Network action/status refresh fixes need promise-order regressions: cover a superseded action refresh settling before the newer manual refresh, and a hung superseded action refresh where the newer manual refresh settles first.
 - Surface Network status refresh failures independently from selected-service log refreshes and initial config loads; slow/hung independent requests must not delay operator-facing status alerts.
+
+## 2026-07-11 — Session-store corruption diagnostics
+- Atomic session writes for private transcripts should create temp files with the final restrictive mode up front, not chmod only after writing; preserve existing destination mode and default new session files to restrictive permissions.
+- Corrupt-session API diagnostics should expose only operator-useful summaries, not local server paths. When project-filtering diagnostics, keep unknown-project corruptions visible so malformed JSON does not disappear silently after quarantine.


### PR DESCRIPTION
## Summary
- quarantine malformed/schema-invalid chat session JSON files instead of silently swallowing them
- expose corrupted session diagnostics from the chat sessions listing response
- write session files via temporary file + rename to reduce partial-write corruption

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/chat/session-store.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings)
- npm run build --workspace @franken/orchestrator

Closes #998