### PR TITLE
test(mcp-suite): cover observer log edge cases

### DIFF
--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -89,6 +89,48 @@ describe('Observer Server', () => {
     expect(verifyResult.content[0]!.text).toContain('verified');
   });
 
+  it('rejects invalid observer log inputs before calling the observer adapter', async () => {
+    const observer = {
+      log: vi.fn().mockResolvedValue({ id: 42, hash: 'abc123' }),
+      logCost: vi.fn(),
+      cost: vi.fn(),
+      trail: vi.fn(),
+      verify: vi.fn(),
+    };
+    const logTool = createObserverServer({ observer }).tools.find((t) => t.name === 'fbeast_observer_log')!;
+
+    const invalidCases = [
+      { event: '', metadata: '{"ok":true}', sessionId: 'sess-1' },
+      { event: '   ', metadata: '{"ok":true}', sessionId: 'sess-1' },
+      { event: 'file_edit', metadata: '{"ok":true}', sessionId: '' },
+      { event: 'file_edit', metadata: '{"ok":true}', sessionId: '   ' },
+      { event: 'file_edit', metadata: { ok: true }, sessionId: 'sess-1' },
+      { event: 'file_edit', metadata: ['not', 'json'], sessionId: 'sess-1' },
+    ];
+
+    for (const args of invalidCases) {
+      const result = await logTool.handler(args);
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Error: fbeast_observer_log');
+      expect(result.content[0]!.text).not.toContain('Logged event');
+    }
+
+    expect(observer.log).not.toHaveBeenCalled();
+
+    const malformedJsonResult = await logTool.handler({
+      event: 'file_edit',
+      metadata: '{not-json',
+      sessionId: 'sess-1',
+    });
+
+    expect(malformedJsonResult.isError).toBeUndefined();
+    expect(observer.log).toHaveBeenCalledWith({
+      event: 'file_edit',
+      metadata: '{not-json',
+      sessionId: 'sess-1',
+    });
+  });
+
   it('rejects invalid cost inputs before calling the observer adapter', async () => {
     const observer = {
       log: vi.fn(),

--- a/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
@@ -44,6 +44,48 @@ describe('TOOL_REGISTRY', () => {
     expect(stubNames.size).toBe(EXPECTED_COUNT);
   });
 
+  it('rejects invalid observer log arguments before invoking the registry adapter handler', async () => {
+    const observer = {
+      log: vi.fn().mockResolvedValue({ id: 42, hash: 'abc123' }),
+      logCost: vi.fn(),
+      cost: vi.fn(),
+      trail: vi.fn(),
+      verify: vi.fn(),
+    };
+    const handler = TOOL_REGISTRY.get('fbeast_observer_log')!.makeHandler({ observer } as unknown as AdapterSet);
+
+    const invalidCases = [
+      { event: '', metadata: '{"ok":true}', sessionId: 'sess-1' },
+      { event: '   ', metadata: '{"ok":true}', sessionId: 'sess-1' },
+      { event: 'file_edit', metadata: '{"ok":true}', sessionId: '' },
+      { event: 'file_edit', metadata: '{"ok":true}', sessionId: '   ' },
+      { event: 'file_edit', metadata: { ok: true }, sessionId: 'sess-1' },
+      { event: 'file_edit', metadata: ['not', 'json'], sessionId: 'sess-1' },
+    ];
+
+    for (const args of invalidCases) {
+      const result = await handler(args);
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Error: fbeast_observer_log');
+      expect(result.content[0]!.text).not.toContain('Logged event');
+    }
+
+    expect(observer.log).not.toHaveBeenCalled();
+
+    const malformedJsonResult = await handler({
+      event: 'file_edit',
+      metadata: '{not-json',
+      sessionId: 'sess-1',
+    });
+
+    expect(malformedJsonResult.isError).toBeUndefined();
+    expect(observer.log).toHaveBeenCalledWith({
+      event: 'file_edit',
+      metadata: '{not-json',
+      sessionId: 'sess-1',
+    });
+  });
+
   it('rejects invalid observer log cost arguments before invoking the registry adapter handler', async () => {
     const observer = {
       log: vi.fn(),

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -90,6 +90,20 @@ function parseOptionalNonNegativeNumberArg(name: string, value: unknown): { ok: 
   return { ok: true, value: parsed };
 }
 
+function parseNonEmptyStringArg(name: string, value: unknown): { ok: true; value: string } | { ok: false; message: string } {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return { ok: false, message: `${name} must be a non-empty string` };
+  }
+  return { ok: true, value };
+}
+
+function parseStringArg(name: string, value: unknown): { ok: true; value: string } | { ok: false; message: string } {
+  if (typeof value !== 'string') {
+    return { ok: false, message: `${name} must be a string` };
+  }
+  return { ok: true, value };
+}
+
 export function createAdapterSet(dbPath: string, options: { root?: string | undefined; configPath?: string | undefined } = {}): AdapterSet {
   return {
     brain: createBrainAdapter(dbPath),
@@ -386,11 +400,20 @@ const TOOLS: ToolFull[] = [
       required: ['event', 'metadata', 'sessionId'],
     },
     makeHandler: ({ observer }) => async (args) => {
-      const event = String(args['event']);
-      const metadata = String(args['metadata']);
-      const sessionId = String(args['sessionId']);
-      const result = await observer.log({ event, metadata, sessionId });
-      return { content: [{ type: 'text', text: `Logged event: ${event} (id: ${result.id}, hash: ${result.hash})` }] };
+      const eventArg = parseNonEmptyStringArg('event', args['event']);
+      if (!eventArg.ok) {
+        return { content: [{ type: 'text', text: `Error: fbeast_observer_log ${eventArg.message}` }], isError: true };
+      }
+      const metadataArg = parseStringArg('metadata', args['metadata']);
+      if (!metadataArg.ok) {
+        return { content: [{ type: 'text', text: `Error: fbeast_observer_log ${metadataArg.message}` }], isError: true };
+      }
+      const sessionIdArg = parseNonEmptyStringArg('sessionId', args['sessionId']);
+      if (!sessionIdArg.ok) {
+        return { content: [{ type: 'text', text: `Error: fbeast_observer_log ${sessionIdArg.message}` }], isError: true };
+      }
+      const result = await observer.log({ event: eventArg.value, metadata: metadataArg.value, sessionId: sessionIdArg.value });
+      return { content: [{ type: 'text', text: `Logged event: ${eventArg.value} (id: ${result.id}, hash: ${result.hash})` }] };
     },
   },
   {


### PR DESCRIPTION
## Summary
- add standalone observer server coverage for invalid observer log event/session/metadata inputs
- add matching shared registry coverage for the observer log handler path
- reject blank event/session IDs and non-string metadata before invoking the observer adapter while preserving exact metadata strings for downstream audit hashing

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/servers/observer.test.ts src/shared/tool-registry.test.ts
- npm run build
- npm --prefix packages/franken-mcp-suite run typecheck
- npm --prefix packages/franken-mcp-suite run lint
- npm --prefix packages/franken-mcp-suite test

Closes #1191