### PR TITLE
fix(orchestrator): reject repo-local provider command trust

### DIFF
--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -113,15 +113,11 @@ function isRepositoryLocalConfig(configPath: string, defaultConfigPath: string |
 
   const resolvedConfig = resolve(configPath);
   const resolvedDefault = resolve(defaultConfigPath);
-  if (resolvedConfig === resolvedDefault) {
-    return true;
-  }
-
   const defaultConfigDir = dirname(resolvedDefault);
   const hasRepositoryLocalDefaultShape = basename(defaultConfigDir) === '.fbeast'
     && basename(resolvedDefault) === 'config.json';
   if (!hasRepositoryLocalDefaultShape) {
-    return safeRealpath(resolvedConfig) === safeRealpath(resolvedDefault);
+    return false;
   }
 
   const repositoryRoot = dirname(defaultConfigDir);

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
 import type { CliArgs } from './args.js';
@@ -68,6 +69,29 @@ function removeTrustFields(value: unknown): void {
   delete value['trustedCommandPaths'];
 }
 
+function hasCommandTrustFields(value: unknown): boolean {
+  return isRecord(value)
+    && ('trustCommandOverride' in value || 'trustedCommandPaths' in value);
+}
+
+function repositoryLocalConfigHasCommandTrust(fileConfig: Partial<OrchestratorConfig>): boolean {
+  const root = fileConfig as Record<string, unknown>;
+
+  const providers = root['providers'];
+  if (isRecord(providers) && isRecord(providers['overrides'])) {
+    if (Object.values(providers['overrides']).some(hasCommandTrustFields)) {
+      return true;
+    }
+  }
+
+  const consolidatedProviders = root['consolidatedProviders'];
+  return Array.isArray(consolidatedProviders) && consolidatedProviders.some(hasCommandTrustFields);
+}
+
+function isRepositoryLocalConfig(configPath: string, defaultConfigPath: string | undefined): boolean {
+  return defaultConfigPath !== undefined && resolve(configPath) === resolve(defaultConfigPath);
+}
+
 function isJsonSyntaxError(error: unknown): error is SyntaxError {
   return error instanceof SyntaxError;
 }
@@ -124,7 +148,15 @@ export async function loadConfig(args: CliArgs, defaultConfigPath?: string): Pro
   if (configPath) {
     try {
       fileConfig = await fromFile(configPath);
-      if (!args.config && !args.trustProviderCommandOverrides) {
+      const repositoryLocal = isRepositoryLocalConfig(configPath, defaultConfigPath);
+      if (repositoryLocal) {
+        if (args.trustProviderCommandOverrides && repositoryLocalConfigHasCommandTrust(fileConfig)) {
+          throw new Error(
+            'Refusing repo-configured command override trust fields; '
+              + 'repository-local config cannot define trustCommandOverride or trustedCommandPaths. '
+              + 'Use an explicit operator-owned config file for trusted provider command overrides.',
+          );
+        }
         fileConfig = stripRepositoryLocalCommandTrust(fileConfig);
       }
     } catch (error) {

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
 import type { CliArgs } from './args.js';
@@ -113,7 +113,18 @@ function isRepositoryLocalConfig(configPath: string, defaultConfigPath: string |
 
   const resolvedConfig = resolve(configPath);
   const resolvedDefault = resolve(defaultConfigPath);
-  const repositoryRoot = dirname(dirname(resolvedDefault));
+  if (resolvedConfig === resolvedDefault) {
+    return true;
+  }
+
+  const defaultConfigDir = dirname(resolvedDefault);
+  const hasRepositoryLocalDefaultShape = basename(defaultConfigDir) === '.fbeast'
+    && basename(resolvedDefault) === 'config.json';
+  if (!hasRepositoryLocalDefaultShape) {
+    return safeRealpath(resolvedConfig) === safeRealpath(resolvedDefault);
+  }
+
+  const repositoryRoot = dirname(defaultConfigDir);
   if (isPathInsideOrEqual(resolvedConfig, repositoryRoot)) {
     return true;
   }

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -1,5 +1,6 @@
+import { realpathSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
 import type { CliArgs } from './args.js';
@@ -88,8 +89,38 @@ function repositoryLocalConfigHasCommandTrust(fileConfig: Partial<OrchestratorCo
   return Array.isArray(consolidatedProviders) && consolidatedProviders.some(hasCommandTrustFields);
 }
 
+function safeRealpath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function isPathInsideOrEqual(candidate: string, container: string): boolean {
+  const rel = relative(container, candidate);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sepForPath()}`) && !isAbsolute(rel));
+}
+
+function sepForPath(): string {
+  return process.platform === 'win32' ? '\\' : '/';
+}
+
 function isRepositoryLocalConfig(configPath: string, defaultConfigPath: string | undefined): boolean {
-  return defaultConfigPath !== undefined && resolve(configPath) === resolve(defaultConfigPath);
+  if (defaultConfigPath === undefined) {
+    return false;
+  }
+
+  const resolvedConfig = resolve(configPath);
+  const resolvedDefault = resolve(defaultConfigPath);
+  const repositoryRoot = dirname(dirname(resolvedDefault));
+  if (isPathInsideOrEqual(resolvedConfig, repositoryRoot)) {
+    return true;
+  }
+
+  const realConfig = safeRealpath(resolvedConfig);
+  const realRepositoryRoot = safeRealpath(repositoryRoot);
+  return isPathInsideOrEqual(realConfig, realRepositoryRoot);
 }
 
 function isJsonSyntaxError(error: unknown): error is SyntaxError {

--- a/packages/franken-orchestrator/test/cli/config-loading.test.ts
+++ b/packages/franken-orchestrator/test/cli/config-loading.test.ts
@@ -105,6 +105,28 @@ describe('Config file loading', () => {
 
     await expect(loadConfig(baseArgs({ config: configPath }))).rejects.toThrow();
   });
+
+  it('does not let an explicit repository-local config path self-approve provider command overrides', async () => {
+    const configPath = join(tmpDir, '.fbeast', 'config.json');
+    mkdirSync(join(tmpDir, '.fbeast'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      maxDurationMs: 60000,
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/repo-controlled/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/repo-controlled'],
+          },
+        },
+      },
+    }));
+
+    await expect(loadConfig(
+      baseArgs({ config: configPath, trustProviderCommandOverrides: true }),
+      configPath,
+    )).rejects.toThrow(/repo-configured command override/);
+  });
 });
 
 describe('SessionConfig includes config fields', () => {

--- a/packages/franken-orchestrator/test/cli/config-loading.test.ts
+++ b/packages/franken-orchestrator/test/cli/config-loading.test.ts
@@ -198,6 +198,30 @@ describe('Config file loading', () => {
 
     expect(config.providers.overrides['claude']?.command).toBe('/tmp/operator-controlled/claude-wrapper');
   });
+
+  it('does not derive a repository boundary from non-standard default config paths', async () => {
+    const defaultConfigPath = join(tmpDir, 'default.json');
+    const configPath = join(tmpDir, 'operator-config.json');
+    writeFileSync(configPath, JSON.stringify({
+      maxDurationMs: 60000,
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/operator-controlled/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/operator-controlled'],
+          },
+        },
+      },
+    }));
+
+    const config = await loadConfig(
+      baseArgs({ config: configPath, trustProviderCommandOverrides: true }),
+      defaultConfigPath,
+    );
+
+    expect(config.providers.overrides['claude']?.command).toBe('/tmp/operator-controlled/claude-wrapper');
+  });
 });
 
 describe('SessionConfig includes config fields', () => {

--- a/packages/franken-orchestrator/test/cli/config-loading.test.ts
+++ b/packages/franken-orchestrator/test/cli/config-loading.test.ts
@@ -222,6 +222,29 @@ describe('Config file loading', () => {
 
     expect(config.providers.overrides['claude']?.command).toBe('/tmp/operator-controlled/claude-wrapper');
   });
+
+  it('preserves trusted command overrides from non-standard operator-owned default configs', async () => {
+    const defaultConfigPath = join(tmpDir, 'operator-default.json');
+    writeFileSync(defaultConfigPath, JSON.stringify({
+      maxDurationMs: 60000,
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/operator-controlled/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/operator-controlled'],
+          },
+        },
+      },
+    }));
+
+    const config = await loadConfig(
+      baseArgs({ trustProviderCommandOverrides: true }),
+      defaultConfigPath,
+    );
+
+    expect(config.providers.overrides['claude']?.command).toBe('/tmp/operator-controlled/claude-wrapper');
+  });
 });
 
 describe('SessionConfig includes config fields', () => {

--- a/packages/franken-orchestrator/test/cli/config-loading.test.ts
+++ b/packages/franken-orchestrator/test/cli/config-loading.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { writeFileSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { loadConfig } from '../../src/cli/config-loader.js';
@@ -126,6 +126,77 @@ describe('Config file loading', () => {
       baseArgs({ config: configPath, trustProviderCommandOverrides: true }),
       configPath,
     )).rejects.toThrow(/repo-configured command override/);
+  });
+
+  it('treats alternate config files inside the repository as repo-local for provider command trust', async () => {
+    const defaultConfigPath = join(tmpDir, '.fbeast', 'config.json');
+    const configPath = join(tmpDir, '.fbeast', 'ci.json');
+    mkdirSync(join(tmpDir, '.fbeast'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      maxDurationMs: 60000,
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/repo-controlled/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/repo-controlled'],
+          },
+        },
+      },
+    }));
+
+    await expect(loadConfig(
+      baseArgs({ config: configPath, trustProviderCommandOverrides: true }),
+      defaultConfigPath,
+    )).rejects.toThrow(/repo-configured command override/);
+  });
+
+  it('treats symlink aliases to repository config as repo-local for provider command trust', async () => {
+    const defaultConfigPath = join(tmpDir, '.fbeast', 'config.json');
+    const aliasedConfigPath = join(tmpDir, '.fbeast', 'trusted.json');
+    mkdirSync(join(tmpDir, '.fbeast'), { recursive: true });
+    writeFileSync(defaultConfigPath, JSON.stringify({
+      maxDurationMs: 60000,
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/repo-controlled/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/repo-controlled'],
+          },
+        },
+      },
+    }));
+    symlinkSync(defaultConfigPath, aliasedConfigPath);
+
+    await expect(loadConfig(
+      baseArgs({ config: aliasedConfigPath, trustProviderCommandOverrides: true }),
+      defaultConfigPath,
+    )).rejects.toThrow(/repo-configured command override/);
+  });
+
+  it('allows explicit operator-owned configs outside the repository to approve provider command overrides', async () => {
+    const defaultConfigPath = join(tmpDir, 'repo', '.fbeast', 'config.json');
+    const configPath = join(tmpDir, 'operator-config.json');
+    writeFileSync(configPath, JSON.stringify({
+      maxDurationMs: 60000,
+      providers: {
+        overrides: {
+          claude: {
+            command: '/tmp/operator-controlled/claude-wrapper',
+            trustCommandOverride: true,
+            trustedCommandPaths: ['/tmp/operator-controlled'],
+          },
+        },
+      },
+    }));
+
+    const config = await loadConfig(
+      baseArgs({ config: configPath, trustProviderCommandOverrides: true }),
+      defaultConfigPath,
+    );
+
+    expect(config.providers.overrides['claude']?.command).toBe('/tmp/operator-controlled/claude-wrapper');
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
@@ -101,7 +101,7 @@ describe('Config loader providers passthrough', () => {
       },
     }));
 
-    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/requires explicit CLI approval/);
   });
 
   it('requires CLI approval before a repository-local config can trust an allowed provider binary', async () => {
@@ -119,7 +119,7 @@ describe('Config loader providers passthrough', () => {
       },
     }));
 
-    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/requires explicit CLI approval/);
 
     const approved = await loadConfig(makeArgs({ trustProviderCommandOverrides: true }), filePath);
     expect(approved.providers.overrides['claude']).toEqual({
@@ -164,7 +164,7 @@ describe('Config loader providers passthrough', () => {
       }],
     }));
 
-    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/trustCommandOverride: true/);
+    await expect(loadConfig(makeArgs(), filePath)).rejects.toThrow(/requires explicit CLI approval/);
   });
 
   it('merges providers with other config fields from file', async () => {


### PR DESCRIPTION
## Summary
- Reject repository-local .fbeast config files that try to provide provider command trust fields, even when the operator passes the trust flag against that repo-local path.
- Continue stripping repo-local trust fields before config validation so repository contents cannot whitelist their own provider binaries.
- Add a regression test covering explicit repository-local config paths.

## Test Plan
- npm test --workspace @franken/orchestrator -- test/cli/config-loading.test.ts tests/unit/config/orchestrator-config-providers.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1039