### PR TITLE
fix(orchestrator): return 404 for unknown Beast definition

### DIFF
--- a/packages/franken-orchestrator/src/beasts/errors.ts
+++ b/packages/franken-orchestrator/src/beasts/errors.ts
@@ -6,6 +6,14 @@ export class UnknownTrackedAgentError extends Error {
   }
 }
 
+export class UnknownBeastDefinitionError extends Error {
+  constructor(
+    public readonly definitionId: string,
+  ) {
+    super(`Unknown Beast definition: ${definitionId}`);
+  }
+}
+
 export class DeletedTrackedAgentError extends Error {
   constructor(
     public readonly agentId: string,

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -6,6 +6,7 @@ import type { BeastExecutor } from '../execution/beast-executor.js';
 import type { BeastMetrics } from '../telemetry/beast-metrics.js';
 import { BeastCatalogService } from './beast-catalog-service.js';
 import { wallClockNow } from '@franken/types';
+import { UnknownBeastDefinitionError } from '../errors.js';
 
 export interface BeastDispatchServiceOptions {
   eventBus?: BeastEventBus;
@@ -213,7 +214,7 @@ export class BeastDispatchService {
   private getDefinitionOrThrow(definitionId: string): BeastDefinition {
     const definition = this.catalog.getDefinition(definitionId);
     if (!definition) {
-      throw new Error(`Unknown Beast definition: ${definitionId}`);
+      throw new UnknownBeastDefinitionError(definitionId);
     }
     return definition;
   }

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -4,7 +4,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
-import { UnknownTrackedAgentError } from '../../beasts/errors.js';
+import { UnknownBeastDefinitionError, UnknownTrackedAgentError } from '../../beasts/errors.js';
 import { BeastCatalogService } from '../../beasts/services/beast-catalog-service.js';
 import { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
 import { BeastInterviewService } from '../../beasts/services/beast-interview-service.js';
@@ -178,6 +178,13 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
         ...(body.moduleConfig ? { moduleConfig: body.moduleConfig } : {}),
       });
     } catch (error) {
+      if (error instanceof UnknownBeastDefinitionError) {
+        throw new HttpError(
+          404,
+          'BEAST_DEFINITION_NOT_FOUND',
+          `Beast definition '${body.definitionId}' was not found`,
+        );
+      }
       if (error instanceof UnknownTrackedAgentError && body.trackedAgentId) {
         throw new HttpError(
           404,

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -453,6 +453,40 @@ describe('beast routes', () => {
     expect(runsBody.data.runs).toEqual([]);
   });
 
+  it('returns 404 and does not persist a run when definitionId is unknown', async () => {
+    const { app, operatorToken } = createBeastApp();
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+
+    const createResponse = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        definitionId: 'does-not-exist',
+        config: {},
+        startNow: true,
+      }),
+    });
+
+    expect(createResponse.status).toBe(404);
+    expect(await createResponse.json()).toEqual({
+      error: {
+        code: 'BEAST_DEFINITION_NOT_FOUND',
+        message: "Beast definition 'does-not-exist' was not found",
+      },
+    });
+
+    const runsResponse = await app.request('/v1/beasts/runs', {
+      headers: {
+        authorization: `Bearer ${operatorToken}`,
+      },
+    });
+    const runsBody = await runsResponse.json() as { data: { runs: Array<unknown> } };
+    expect(runsBody.data.runs).toEqual([]);
+  });
+
   it('persists a failed run instead of returning 500 when startNow startup fails', async () => {
     const { app, operatorToken } = createBeastApp({ failStart: true });
     const headers = {


### PR DESCRIPTION
## Summary
- Add an explicit `UnknownBeastDefinitionError` domain error for missing Beast definitions.
- Map missing `definitionId` dispatch failures from `POST /v1/beasts/runs` to 404 `BEAST_DEFINITION_NOT_FOUND`.
- Cover the unknown-definition API path and assert no run is persisted.

## Test Plan
- `npm ci`
- `npm run build --workspace @franken/types`
- `npm run test --workspace @franken/orchestrator -- tests/integration/beasts/beast-routes.test.ts`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)

Closes #1432
