### PR TITLE
fix(ci): update release-please action guard

### DIFF
--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -291,10 +291,10 @@ describe('release-please.yml publishes released npm packages', () => {
     releasePlease = expectRecord(jobs['release-please'], 'jobs.release-please');
     publishNpm = expectRecord(jobs['publish-npm'], 'jobs.publish-npm');
     const matchingReleaseStep = expectSteps(releasePlease).find(
-      (step) => step.uses === 'googleapis/release-please-action@v4',
+      (step) => step.uses === 'googleapis/release-please-action@v5',
     );
     if (!matchingReleaseStep) {
-      throw new Error('release-please action step should be present');
+      throw new Error('release-please action v5 step should be present');
     }
     releaseStep = matchingReleaseStep;
   });
@@ -312,7 +312,7 @@ on:
 jobs:
   release-please:
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
 `),
     ).toThrow(/YAML/);
   });


### PR DESCRIPTION
## Summary
- update the release-please workflow guard to expect googleapis/release-please-action@v5
- refresh the malformed-YAML fixture so release workflow guard coverage matches the current action major

## Test Plan
- npm run test:root -- tests/unit/ci-workflow.test.ts -t "release-please.yml publishes released npm packages"
- npm run test:root -- tests/unit/ci-workflow.test.ts
- npm run test:root -- tests/workspaces.test.ts tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/web-dev-server-dependency-policy.test.ts

Closes #1648