### PR TITLE
docs(orchestrator): document generic warning output

### DIFF
--- a/packages/franken-orchestrator/src/logger.ts
+++ b/packages/franken-orchestrator/src/logger.ts
@@ -37,6 +37,8 @@ export class ConsoleLogger implements ILogger {
   }
 
   warn(msg: string, _data?: unknown): void {
+    // Keep generic orchestrator warnings on the shared info stream so routine
+    // status messages stay visible without triggering noisy stderr/console.warn alerts.
     printLine(formatLine('[beast:warn]', msg));
   }
 


### PR DESCRIPTION
## Summary
- Documents why generic orchestrator warnings use the shared info output path instead of `console.warn`/stderr noise.

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/logger.test.ts`
- `npm run build`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- `npm run build --workspace @franken/orchestrator`

Closes #1078