### PR TITLE
fix(critique): detect block comment markers

### DIFF
--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -438,6 +438,36 @@ function collectBlockCommentLabels(
   return [extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment), commentEnd];
 }
 
+function collectJsxTagExpressionLabels(
+  content: string,
+  start: number,
+  end: number,
+): string[] {
+  const labels: string[] = [];
+  let index = start + 1;
+
+  while (index < end - 1) {
+    const current = content[index];
+    if (current === '"' || current === "'") {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+    if (current === '{') {
+      const [expressionLabels, expressionEnd] = collectCodeLabels(
+        content,
+        index + 1,
+        '}',
+      );
+      labels.push(...expressionLabels);
+      index = expressionEnd;
+      continue;
+    }
+    index += 1;
+  }
+
+  return labels;
+}
+
 function skipJsxTag(content: string, start: number, limit = content.length): number {
   let index = start + 1;
   let quote = '';
@@ -559,6 +589,59 @@ function findNextJsxTagAfter(content: string, start: number): string | undefined
   return undefined;
 }
 
+function jsxTagName(tag: string): string | undefined {
+  const match = /^<\/?\s*([A-Za-z][\w.]*)/.exec(tag);
+  return match?.[1];
+}
+
+function hasOpenJsxAncestorBefore(content: string, end: number): boolean {
+  const stack: string[] = [];
+  let index = 0;
+
+  while (index < end) {
+    const current = content[index];
+    const next = content[index + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+    if (current === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? end : lineEnd + 1;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? end : commentEnd + 2;
+      continue;
+    }
+    if (
+      current === '<' &&
+      /[A-Za-z/>]/.test(next ?? '') &&
+      content[index - 1] !== '<'
+    ) {
+      const tagEnd = skipJsxTag(content, index, end);
+      if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
+        const tag = content.slice(index, tagEnd).trim();
+        if (tag === '<>') {
+          stack.push('');
+        } else if (tag.startsWith('</')) {
+          stack.pop();
+        } else if (!/\/\s*>$/.test(tag)) {
+          const name = jsxTagName(tag);
+          if (name) stack.push(name);
+        }
+        index = tagEnd;
+        continue;
+      }
+    }
+    index += 1;
+  }
+
+  return stack.length > 0;
+}
+
 function isJsxTextBlockComment(content: string, start: number, end: number): boolean {
   const before = content.slice(0, start);
   const previousNonWhitespace = before.trimEnd().at(-1) ?? '';
@@ -575,7 +658,11 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
   }
 
   const textSinceLastTag = before.slice(previousTag.end);
-  if (/[;=]/.test(textSinceLastTag)) {
+  if (
+    /(?:^|\s)(?:const|let|var|return|function|class)\b/.test(
+      textSinceLastTag,
+    )
+  ) {
     return false;
   }
   const lastOpenBrace = textSinceLastTag.lastIndexOf('{');
@@ -598,7 +685,10 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
   }
 
   if (isSelfClosingTag || isClosingTag) {
-    return nextTag.startsWith('</');
+    return (
+      nextTag.startsWith('</') ||
+      hasOpenJsxAncestorBefore(content, previousTag.start)
+    );
   }
 
   return isOpeningTag;
@@ -679,7 +769,12 @@ function collectCodeLabels(
       continue;
     }
 
-    if (current === '`' && next === '`' && content[index + 2] === '`') {
+    if (
+      current === '`' &&
+      next === '`' &&
+      content[index + 2] === '`' &&
+      /^\s*$/.test(content.slice(content.lastIndexOf('\n', index - 1) + 1, index))
+    ) {
       while (content[index] === '`') {
         index += 1;
       }
@@ -725,6 +820,7 @@ function collectCodeLabels(
     ) {
       const tagEnd = skipJsxTag(content, index);
       if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
+        labels.push(...collectJsxTagExpressionLabels(content, index, tagEnd));
         index = tagEnd;
         continue;
       }

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -18,7 +18,7 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   'gi',
 );
 const UNRESOLVED_MARKER_PATTERN = new RegExp(
-  `\\b(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
+  `(?:^|[\\s*])(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\s*:`,
   'gi',
 );
 const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
@@ -100,9 +100,20 @@ function previousSignificantToken(content: string, index: number): string {
   return content.slice(cursor + 1, end);
 }
 
+function nextSignificantCharacter(content: string, index: number): string {
+  for (let cursor = index; cursor < content.length; cursor += 1) {
+    const current = content[cursor] ?? '';
+    if (!/\s/.test(current)) {
+      return current;
+    }
+  }
+  return '';
+}
+
 function canStartRegexLiteral(content: string, index: number): boolean {
   const previous = previousSignificantCharacter(content, index);
   const previousToken = previousSignificantToken(content, index);
+  const next = nextSignificantCharacter(content, index + 1);
   return (
     [
       'return',
@@ -113,9 +124,11 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'typeof',
       'void',
       'delete',
+      'else',
     ].includes(previousToken) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^>)'.includes(previous)
+    '([{=,:;!&|?+-*~^>'.includes(previous) ||
+    (previous === ')' && next === '[')
   );
 }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -125,9 +125,70 @@ function previousSignificantToken(content: string, index: number): string {
   return content.slice(cursor + 1, end);
 }
 
+function isOperandEndingCharacter(character: string): boolean {
+  return /[$\w)\]]/.test(character);
+}
+
+function isPostfixOperatorBefore(content: string, index: number): boolean {
+  const previousIndex = previousSignificantIndex(content, index);
+  const previous = previousIndex >= 0 ? (content[previousIndex] ?? '') : '';
+
+  if (previous === '!') {
+    const operandIndex = previousSignificantIndex(content, previousIndex);
+    const operand = operandIndex >= 0 ? (content[operandIndex] ?? '') : '';
+    return isOperandEndingCharacter(operand);
+  }
+
+  if (
+    (previous === '+' || previous === '-') &&
+    content[previousIndex - 1] === previous
+  ) {
+    const operandIndex = previousSignificantIndex(content, previousIndex - 1);
+    const operand = operandIndex >= 0 ? (content[operandIndex] ?? '') : '';
+    return isOperandEndingCharacter(operand);
+  }
+
+  return false;
+}
+
+function findMatchingOpeningParen(content: string, closeIndex: number): number {
+  let depth = 0;
+  for (let cursor = closeIndex; cursor >= 0; cursor -= 1) {
+    const current = content[cursor];
+    if (current === ')') {
+      depth += 1;
+    } else if (current === '(') {
+      depth -= 1;
+      if (depth === 0) {
+        return cursor;
+      }
+    }
+  }
+  return -1;
+}
+
+function followsControlCondition(content: string, index: number): boolean {
+  const previousIndex = previousSignificantIndex(content, index);
+  if (content[previousIndex] !== ')') {
+    return false;
+  }
+
+  const openIndex = findMatchingOpeningParen(content, previousIndex);
+  if (openIndex === -1) {
+    return false;
+  }
+
+  return ['if', 'while', 'for', 'with'].includes(
+    previousSignificantToken(content, openIndex),
+  );
+}
+
 function canStartRegexLiteral(content: string, index: number): boolean {
   const previous = previousSignificantCharacter(content, index);
   const previousToken = previousSignificantToken(content, index);
+  if (isPostfixOperatorBefore(content, index)) {
+    return false;
+  }
   return (
     [
       'return',
@@ -143,6 +204,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'in',
       'default',
     ].includes(previousToken) ||
+    followsControlCondition(content, index) ||
     previous === '' ||
     '([{=,:;!&|?+-*~^>'.includes(previous)
   );
@@ -202,6 +264,41 @@ function collectBlockCommentLabels(
     .replace(/^\/\*/, '')
     .replace(/\*\/$/, '');
   return [extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment), commentEnd];
+}
+
+function isJsxTextBlockComment(content: string, start: number, end: number): boolean {
+  const lineStart = content.lastIndexOf('\n', start) + 1;
+  const nextLineBreak = content.indexOf('\n', end);
+  const lineEnd = nextLineBreak === -1 ? content.length : nextLineBreak;
+  const before = content.slice(lineStart, start);
+  const after = content.slice(end, lineEnd);
+  const previousNonWhitespace = before.trimEnd().at(-1) ?? '';
+
+  if (previousNonWhitespace === '{') {
+    return false;
+  }
+
+  const lastOpenBrace = before.lastIndexOf('{');
+  const lastCloseBrace = before.lastIndexOf('}');
+  if (lastOpenBrace > lastCloseBrace) {
+    return false;
+  }
+
+  const lastTagEnd = before.lastIndexOf('>');
+  const lastTagStart = before.lastIndexOf('<');
+  const nextTagStart = after.indexOf('<');
+
+  if (lastTagEnd === -1 || lastTagEnd <= lastTagStart || nextTagStart === -1) {
+    return false;
+  }
+
+  const openingTagStart = before.lastIndexOf('<', lastTagEnd);
+  if (openingTagStart === -1) {
+    return false;
+  }
+
+  const openingTag = before.slice(openingTagStart, lastTagEnd + 1).trim();
+  return /^<[A-Za-z][^>]*>$/.test(openingTag) && !/\/\s*>$/.test(openingTag);
 }
 
 function collectTemplateLiteralLabels(
@@ -311,7 +408,9 @@ function collectCodeLabels(
         content,
         index,
       );
-      labels.push(...commentLabels);
+      if (!isJsxTextBlockComment(content, index, commentEnd)) {
+        labels.push(...commentLabels);
+      }
       index = commentEnd;
       continue;
     }

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -18,8 +18,8 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   'gi',
 );
 const UNRESOLVED_MARKER_PATTERN = new RegExp(
-  `(?:^|[\\s*])(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\s*:`,
-  'gi',
+  `(?:^|[\\s*])(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
+  'g',
 );
 const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
   `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
@@ -125,6 +125,8 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'void',
       'delete',
       'else',
+      'of',
+      'in',
     ].includes(previousToken) ||
     previous === '' ||
     '([{=,:;!&|?+-*~^>'.includes(previous) ||
@@ -248,6 +250,15 @@ function collectCodeLabels(
 
     if (endCharacter && endCharacter !== '}' && current === endCharacter) {
       return [labels, index + 1];
+    }
+
+    if (
+      current === "'" &&
+      /[$\w]/.test(content[index - 1] ?? '') &&
+      /[$\w]/.test(content[index + 1] ?? '')
+    ) {
+      index += 1;
+      continue;
     }
 
     if (current === '"' || current === "'") {

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -100,7 +100,39 @@ function startsRegexLiteralOnLine(
     return true;
   }
 
-  return '([{=,:;!&|?+-*~^<>/'.includes(content[cursor] ?? '');
+  let tokenStart = cursor;
+  while (tokenStart >= lineStart && /[$\w]/.test(content[tokenStart] ?? '')) {
+    tokenStart -= 1;
+  }
+
+  return (
+    isRegexPrefixToken(content.slice(tokenStart + 1, cursor + 1)) ||
+    followsForIterationKeywordOnLine(content, index) ||
+    '([{=,:;!&|?+-*~^<>/'.includes(content[cursor] ?? '')
+  );
+}
+
+function isRegexPrefixToken(token: string): boolean {
+  return [
+    'return',
+    'throw',
+    'case',
+    'yield',
+    'await',
+    'typeof',
+    'void',
+    'delete',
+    'else',
+    'do',
+    'default',
+  ].includes(token);
+}
+
+function followsForIterationKeywordOnLine(content: string, index: number): boolean {
+  const lineStart = content.lastIndexOf('\n', index - 1) + 1;
+  return /\bfor\s*\([^)]*\b(?:of|in)\s*$/.test(
+    content.slice(lineStart, index),
+  );
 }
 
 function previousSignificantIndex(content: string, index: number): number {
@@ -278,21 +310,8 @@ function canStartRegexLiteralWhileMatchingParens(
     return true;
   }
   return (
-    [
-      'return',
-      'throw',
-      'case',
-      'yield',
-      'await',
-      'typeof',
-      'void',
-      'delete',
-      'else',
-      'do',
-      'of',
-      'in',
-      'default',
-    ].includes(previousToken) ||
+    isRegexPrefixToken(previousToken) ||
+    followsForIterationKeywordOnLine(content, index) ||
     previous === '' ||
     '([{=,:;!&|?+-*~^<>/'.includes(previous)
   );
@@ -330,21 +349,8 @@ function canStartRegexLiteral(content: string, index: number): boolean {
     }
   }
   return (
-    [
-      'return',
-      'throw',
-      'case',
-      'yield',
-      'await',
-      'typeof',
-      'void',
-      'delete',
-      'else',
-      'do',
-      'of',
-      'in',
-      'default',
-    ].includes(previousToken) ||
+    isRegexPrefixToken(previousToken) ||
+    followsForIterationKeywordOnLine(content, index) ||
     followsControlCondition(content, index) ||
     previous === '' ||
     '([{=,:;!&|?+-*~^<>/'.includes(previous)
@@ -390,7 +396,11 @@ function isLikelyTypeArgumentTag(
     .slice(start, end)
     .replace(/\/\*[\s\S]*?\*\//g, ' ')
     .trim();
-  if (!/^<\s*[A-Za-z_$][\w$]*(?:\s*,\s*[A-Za-z_$][\w$]*)*\s*>$/.test(tagText)) {
+  if (
+    !/^<\s*[A-Za-z_$][\w$]*(?:\s+(?:extends|=)\s*[^,>]+)?(?:\s*,\s*[A-Za-z_$][\w$]*(?:\s+(?:extends|=)\s*[^,>]+)?)*\s*>$/.test(
+      tagText,
+    )
+  ) {
     return false;
   }
 
@@ -413,14 +423,11 @@ function isLikelyTypeArgumentTag(
 
 function isLikelyJsxTagStart(content: string, index: number): boolean {
   const next = content[index + 1];
-  if (!/[A-Za-z/>]/.test(next ?? '')) {
+  if (!/[A-Za-z_$/>]/.test(next ?? '')) {
     return false;
   }
   if (content[index - 1] === '<') {
     return false;
-  }
-  if (next === '/' || next === '>') {
-    return true;
   }
 
   const previousIndex = previousSignificantIndex(content, index);
@@ -428,9 +435,14 @@ function isLikelyJsxTagStart(content: string, index: number): boolean {
   const previousToken = previousSignificantToken(content, index);
   if (
     /[$\w)\]]/.test(previous) &&
-    !['return', 'yield', 'case', 'else', 'do'].includes(previousToken)
+    !['return', 'yield', 'case', 'else', 'do'].includes(previousToken) &&
+    !(next === '/' && hasOpenJsxAncestorBefore(content, index))
   ) {
     return false;
+  }
+
+  if (next === '/' || next === '>') {
+    return true;
   }
 
   return true;
@@ -480,6 +492,15 @@ function collectJsxTagExpressionLabels(
       index = skipQuotedLiteral(content, index);
       continue;
     }
+    if (current === '/' && content[index + 1] === '*') {
+      const [commentLabels, commentEnd] = collectBlockCommentLabels(
+        content,
+        index,
+      );
+      labels.push(...commentLabels);
+      index = commentEnd;
+      continue;
+    }
     if (current === '{') {
       const [expressionLabels, expressionEnd] = collectCodeLabels(
         content,
@@ -515,6 +536,20 @@ function skipJsxTag(content: string, start: number, limit = content.length): num
       continue;
     }
     if (braceDepth > 0) {
+      if (current === '"' || current === "'" || current === '`') {
+        index = skipQuotedLiteral(content, index);
+        continue;
+      }
+      if (current === '/' && content[index + 1] === '/') {
+        const lineEnd = content.indexOf('\n', index + 2);
+        index = lineEnd === -1 ? limit : lineEnd + 1;
+        continue;
+      }
+      if (current === '/' && content[index + 1] === '*') {
+        const commentEnd = content.indexOf('*/', index + 2);
+        index = commentEnd === -1 ? limit : commentEnd + 2;
+        continue;
+      }
       if (current === '{') {
         braceDepth += 1;
       } else if (current === '}') {
@@ -625,7 +660,9 @@ function findNextJsxTagAfter(content: string, start: number): string | undefined
 }
 
 function jsxTagName(tag: string): string | undefined {
-  const match = /^<\/?\s*([A-Za-z][\w.]*)/.exec(tag);
+  const match = /^<\/?\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)/.exec(
+    tag,
+  );
   return match?.[1];
 }
 
@@ -707,11 +744,11 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
     return nextTag.startsWith('</>');
   }
 
-  const isOpeningTag = new RegExp('^<[A-Za-z]').test(openingTag);
+  const isOpeningTag = new RegExp('^<[A-Za-z_$]').test(openingTag);
   const isSelfClosingTag = new RegExp('/\\s*>$').test(openingTag);
-  const isClosingTag = new RegExp('^</[A-Za-z]').test(openingTag);
+  const isClosingTag = new RegExp('^</[A-Za-z_$]').test(openingTag);
 
-  if (!new RegExp('^<[/A-Za-z]').test(nextTag)) {
+  if (!new RegExp('^<[/A-Za-z_$]').test(nextTag)) {
     return false;
   }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -49,6 +49,32 @@ function skipQuotedLiteral(content: string, start: number): number {
   return index;
 }
 
+function findLineCommentStart(
+  content: string,
+  lineStart: number,
+  lineEnd: number,
+): number {
+  let index = lineStart;
+
+  while (index < lineEnd) {
+    const current = content[index];
+    const next = content[index + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      return index;
+    }
+
+    index += 1;
+  }
+
+  return -1;
+}
+
 function previousSignificantIndex(content: string, index: number): number {
   let cursor = index - 1;
 
@@ -71,10 +97,9 @@ function previousSignificantIndex(content: string, index: number): number {
     }
 
     const lineStart = content.lastIndexOf('\n', cursor) + 1;
-    const linePrefix = content.slice(lineStart, cursor + 1);
-    const lineCommentStart = linePrefix.indexOf('//');
+    const lineCommentStart = findLineCommentStart(content, lineStart, cursor + 1);
     if (lineCommentStart !== -1) {
-      cursor = lineStart + lineCommentStart - 1;
+      cursor = lineCommentStart - 1;
       continue;
     }
 
@@ -100,20 +125,9 @@ function previousSignificantToken(content: string, index: number): string {
   return content.slice(cursor + 1, end);
 }
 
-function nextSignificantCharacter(content: string, index: number): string {
-  for (let cursor = index; cursor < content.length; cursor += 1) {
-    const current = content[cursor] ?? '';
-    if (!/\s/.test(current)) {
-      return current;
-    }
-  }
-  return '';
-}
-
 function canStartRegexLiteral(content: string, index: number): boolean {
   const previous = previousSignificantCharacter(content, index);
   const previousToken = previousSignificantToken(content, index);
-  const next = nextSignificantCharacter(content, index + 1);
   return (
     [
       'return',
@@ -130,8 +144,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'default',
     ].includes(previousToken) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^>'.includes(previous) ||
-    (previous === ')' && next === '[')
+    '([{=,:;!&|?+-*~^>'.includes(previous)
   );
 }
 
@@ -256,11 +269,7 @@ function collectCodeLabels(
       return [labels, index + 1];
     }
 
-    if (
-      current === "'" &&
-      /[$\w]/.test(content[index - 1] ?? '') &&
-      /[$\w]/.test(content[index + 1] ?? '')
-    ) {
+    if (current === "'" && /[$\w]/.test(content[index - 1] ?? '')) {
       index += 1;
       continue;
     }

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -71,6 +71,11 @@ function findLineCommentStart(
       continue;
     }
 
+    if (current === '/' && next !== '/' && startsRegexLiteralOnLine(content, index, lineStart)) {
+      index = skipRegexLiteral(content, index);
+      continue;
+    }
+
     if (current === '/' && next === '/') {
       return index;
     }
@@ -79,6 +84,23 @@ function findLineCommentStart(
   }
 
   return -1;
+}
+
+function startsRegexLiteralOnLine(
+  content: string,
+  index: number,
+  lineStart: number,
+): boolean {
+  let cursor = index - 1;
+  while (cursor >= lineStart && /\s/.test(content[cursor] ?? '')) {
+    cursor -= 1;
+  }
+
+  if (cursor < lineStart) {
+    return true;
+  }
+
+  return '([{=,:;!&|?+-*~^<>/'.includes(content[cursor] ?? '');
 }
 
 function previousSignificantIndex(content: string, index: number): number {
@@ -347,6 +369,33 @@ function skipRegexLiteral(content: string, start: number): number {
   return index;
 }
 
+function isLikelyTypeArgumentTag(
+  content: string,
+  start: number,
+  end: number,
+): boolean {
+  const tagText = content.slice(start, end).trim();
+  if (!/^<[A-Za-z_$][\w$]*(?:\s*,\s*[A-Za-z_$][\w$]*)*>$/.test(tagText)) {
+    return false;
+  }
+
+  let cursor = start - 1;
+  while (cursor >= 0 && /\s/.test(content[cursor] ?? '')) {
+    cursor -= 1;
+  }
+  const previous = content[cursor] ?? '';
+  if (!/[$\w)]/.test(previous)) {
+    return false;
+  }
+
+  cursor = end;
+  while (cursor < content.length && /\s/.test(content[cursor] ?? '')) {
+    cursor += 1;
+  }
+
+  return ['(', '.', ';', ','].includes(content[cursor] ?? '');
+}
+
 function extractMarkerLabels(pattern: RegExp, comment: string): string[] {
   pattern.lastIndex = 0;
   return [...comment.matchAll(pattern)].flatMap((match) =>
@@ -440,11 +489,13 @@ function findLastJsxTagBefore(
     ) {
       const tagEnd = skipJsxTag(content, index, end);
       if (tagEnd !== -1) {
-        lastTag = {
-          start: index,
-          end: tagEnd,
-          text: content.slice(index, tagEnd).trim(),
-        };
+        if (!isLikelyTypeArgumentTag(content, index, tagEnd)) {
+          lastTag = {
+            start: index,
+            end: tagEnd,
+            text: content.slice(index, tagEnd).trim(),
+          };
+        }
         index = tagEnd;
         continue;
       }
@@ -483,6 +534,10 @@ function findNextJsxTagAfter(content: string, start: number): string | undefined
     ) {
       const tagEnd = skipJsxTag(content, index);
       if (tagEnd !== -1) {
+        if (isLikelyTypeArgumentTag(content, index, tagEnd)) {
+          index = tagEnd;
+          continue;
+        }
         return content.slice(index, tagEnd).trim();
       }
     }
@@ -508,6 +563,9 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
   }
 
   const textSinceLastTag = before.slice(previousTag.end);
+  if (/[;=]/.test(textSinceLastTag)) {
+    return false;
+  }
   const lastOpenBrace = textSinceLastTag.lastIndexOf('{');
   const lastCloseBrace = textSinceLastTag.lastIndexOf('}');
   if (lastOpenBrace > lastCloseBrace) {
@@ -520,8 +578,7 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
   }
 
   return (
-    new RegExp('^<[A-Za-z][^>]*>$').test(openingTag) &&
-    !new RegExp('/\\s*>$').test(openingTag) &&
+    new RegExp('^</?[A-Za-z][^>]*>$').test(openingTag) &&
     new RegExp('^<[/A-Za-z]').test(nextTag)
   );
 }

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -152,18 +152,42 @@ function isPostfixOperatorBefore(content: string, index: number): boolean {
 }
 
 function findMatchingOpeningParen(content: string, closeIndex: number): number {
-  let depth = 0;
-  for (let cursor = closeIndex; cursor >= 0; cursor -= 1) {
+  const openParens: number[] = [];
+  let cursor = 0;
+
+  while (cursor <= closeIndex && cursor < content.length) {
     const current = content[cursor];
-    if (current === ')') {
-      depth += 1;
-    } else if (current === '(') {
-      depth -= 1;
-      if (depth === 0) {
-        return cursor;
+    const next = content[cursor + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      cursor = skipQuotedLiteral(content, cursor);
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', cursor + 2);
+      cursor = lineEnd === -1 ? content.length : lineEnd + 1;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', cursor + 2);
+      cursor = commentEnd === -1 ? content.length : commentEnd + 2;
+      continue;
+    }
+
+    if (current === '(') {
+      openParens.push(cursor);
+    } else if (current === ')') {
+      const openIndex = openParens.pop();
+      if (cursor === closeIndex) {
+        return openIndex ?? -1;
       }
     }
+
+    cursor += 1;
   }
+
   return -1;
 }
 
@@ -206,7 +230,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
     ].includes(previousToken) ||
     followsControlCondition(content, index) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^>'.includes(previous)
+    '([{=,:;!&|?+-*~^<>/'.includes(previous)
   );
 }
 
@@ -219,6 +243,9 @@ function skipRegexLiteral(content: string, start: number): number {
     if (current === '\\') {
       index += 2;
       continue;
+    }
+    if ((current === '\n' || current === '\r') && !inCharacterClass) {
+      return start + 1;
     }
     if (current === '[') {
       inCharacterClass = true;
@@ -238,6 +265,7 @@ function skipRegexLiteral(content: string, start: number): number {
 }
 
 function extractMarkerLabels(pattern: RegExp, comment: string): string[] {
+  pattern.lastIndex = 0;
   return [...comment.matchAll(pattern)].flatMap((match) =>
     match[1] ? [match[1]] : [],
   );
@@ -267,38 +295,36 @@ function collectBlockCommentLabels(
 }
 
 function isJsxTextBlockComment(content: string, start: number, end: number): boolean {
-  const lineStart = content.lastIndexOf('\n', start) + 1;
-  const nextLineBreak = content.indexOf('\n', end);
-  const lineEnd = nextLineBreak === -1 ? content.length : nextLineBreak;
-  const before = content.slice(lineStart, start);
-  const after = content.slice(end, lineEnd);
+  const before = content.slice(0, start);
+  const after = content.slice(end);
   const previousNonWhitespace = before.trimEnd().at(-1) ?? '';
 
   if (previousNonWhitespace === '{') {
     return false;
   }
 
-  const lastOpenBrace = before.lastIndexOf('{');
-  const lastCloseBrace = before.lastIndexOf('}');
+  const lastTagEnd = before.lastIndexOf('>');
+  const lastTagStart = before.lastIndexOf('<', lastTagEnd);
+  const nextTagStart = after.indexOf('<');
+
+  if (lastTagEnd === -1 || lastTagStart === -1 || nextTagStart === -1) {
+    return false;
+  }
+
+  const textSinceLastTag = before.slice(lastTagEnd + 1);
+  const lastOpenBrace = textSinceLastTag.lastIndexOf('{');
+  const lastCloseBrace = textSinceLastTag.lastIndexOf('}');
   if (lastOpenBrace > lastCloseBrace) {
     return false;
   }
 
-  const lastTagEnd = before.lastIndexOf('>');
-  const lastTagStart = before.lastIndexOf('<');
-  const nextTagStart = after.indexOf('<');
-
-  if (lastTagEnd === -1 || lastTagEnd <= lastTagStart || nextTagStart === -1) {
-    return false;
-  }
-
-  const openingTagStart = before.lastIndexOf('<', lastTagEnd);
-  if (openingTagStart === -1) {
-    return false;
-  }
-
-  const openingTag = before.slice(openingTagStart, lastTagEnd + 1).trim();
-  return /^<[A-Za-z][^>]*>$/.test(openingTag) && !/\/\s*>$/.test(openingTag);
+  const openingTag = before.slice(lastTagStart, lastTagEnd + 1).trim();
+  const nextTag = after.slice(nextTagStart).trimStart();
+  return (
+    /^<[A-Za-z][^>]*>$/.test(openingTag) &&
+    !/\/\s*>$/.test(openingTag) &&
+    /^<\/[A-Za-z]/.test(nextTag)
+  );
 }
 
 function collectTemplateLiteralLabels(

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -386,8 +386,11 @@ function isLikelyTypeArgumentTag(
   start: number,
   end: number,
 ): boolean {
-  const tagText = content.slice(start, end).trim();
-  if (!/^<[A-Za-z_$][\w$]*(?:\s*,\s*[A-Za-z_$][\w$]*)*>$/.test(tagText)) {
+  const tagText = content
+    .slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .trim();
+  if (!/^<\s*[A-Za-z_$][\w$]*(?:\s*,\s*[A-Za-z_$][\w$]*)*\s*>$/.test(tagText)) {
     return false;
   }
 
@@ -396,7 +399,7 @@ function isLikelyTypeArgumentTag(
     cursor -= 1;
   }
   const previous = content[cursor] ?? '';
-  if (!/[$\w)]/.test(previous)) {
+  if (!/[$\w)=]/.test(previous)) {
     return false;
   }
 
@@ -406,6 +409,31 @@ function isLikelyTypeArgumentTag(
   }
 
   return ['(', '.', ';', ','].includes(content[cursor] ?? '');
+}
+
+function isLikelyJsxTagStart(content: string, index: number): boolean {
+  const next = content[index + 1];
+  if (!/[A-Za-z/>]/.test(next ?? '')) {
+    return false;
+  }
+  if (content[index - 1] === '<') {
+    return false;
+  }
+  if (next === '/' || next === '>') {
+    return true;
+  }
+
+  const previousIndex = previousSignificantIndex(content, index);
+  const previous = previousIndex === -1 ? '' : content[previousIndex] ?? '';
+  const previousToken = previousSignificantToken(content, index);
+  if (
+    /[$\w)\]]/.test(previous) &&
+    !['return', 'yield', 'case', 'else', 'do'].includes(previousToken)
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function extractMarkerLabels(pattern: RegExp, comment: string): string[] {
@@ -471,6 +499,7 @@ function collectJsxTagExpressionLabels(
 function skipJsxTag(content: string, start: number, limit = content.length): number {
   let index = start + 1;
   let quote = '';
+  let braceDepth = 0;
 
   while (index < limit) {
     const current = content[index];
@@ -485,8 +514,22 @@ function skipJsxTag(content: string, start: number, limit = content.length): num
       index += 1;
       continue;
     }
+    if (braceDepth > 0) {
+      if (current === '{') {
+        braceDepth += 1;
+      } else if (current === '}') {
+        braceDepth -= 1;
+      }
+      index += 1;
+      continue;
+    }
     if (current === '"' || current === "'") {
       quote = current;
+      index += 1;
+      continue;
+    }
+    if (current === '{') {
+      braceDepth = 1;
       index += 1;
       continue;
     }
@@ -524,11 +567,7 @@ function findLastJsxTagBefore(
       index = commentEnd === -1 ? end : commentEnd + 2;
       continue;
     }
-    if (
-      current === '<' &&
-      /[A-Za-z/>]/.test(next ?? '') &&
-      content[index - 1] !== '<'
-    ) {
+    if (current === '<' && isLikelyJsxTagStart(content, index)) {
       const tagEnd = skipJsxTag(content, index, end);
       if (tagEnd !== -1) {
         if (!isLikelyTypeArgumentTag(content, index, tagEnd)) {
@@ -569,11 +608,7 @@ function findNextJsxTagAfter(content: string, start: number): string | undefined
       index = commentEnd === -1 ? content.length : commentEnd + 2;
       continue;
     }
-    if (
-      current === '<' &&
-      /[A-Za-z/>]/.test(next ?? '') &&
-      content[index - 1] !== '<'
-    ) {
+    if (current === '<' && isLikelyJsxTagStart(content, index)) {
       const tagEnd = skipJsxTag(content, index);
       if (tagEnd !== -1) {
         if (isLikelyTypeArgumentTag(content, index, tagEnd)) {
@@ -616,11 +651,7 @@ function hasOpenJsxAncestorBefore(content: string, end: number): boolean {
       index = commentEnd === -1 ? end : commentEnd + 2;
       continue;
     }
-    if (
-      current === '<' &&
-      /[A-Za-z/>]/.test(next ?? '') &&
-      content[index - 1] !== '<'
-    ) {
+    if (current === '<' && isLikelyJsxTagStart(content, index)) {
       const tagEnd = skipJsxTag(content, index, end);
       if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
         const tag = content.slice(index, tagEnd).trim();
@@ -687,7 +718,7 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
   if (isSelfClosingTag || isClosingTag) {
     return (
       nextTag.startsWith('</') ||
-      hasOpenJsxAncestorBefore(content, previousTag.start)
+      hasOpenJsxAncestorBefore(content, previousTag.end)
     );
   }
 
@@ -813,11 +844,7 @@ function collectCodeLabels(
       continue;
     }
 
-    if (
-      current === '<' &&
-      /[A-Za-z/>]/.test(next ?? '') &&
-      content[index - 1] !== '<'
-    ) {
+    if (current === '<' && isLikelyJsxTagStart(content, index)) {
       const tagEnd = skipJsxTag(content, index);
       if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
         labels.push(...collectJsxTagExpressionLabels(content, index, tagEnd));

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -37,6 +37,9 @@ function skipQuotedLiteral(content: string, start: number): number {
       index += 2;
       continue;
     }
+    if (quote !== '`' && (current === '\n' || current === '\r')) {
+      return index;
+    }
     if (current === quote) {
       return index + 1;
     }
@@ -46,21 +49,51 @@ function skipQuotedLiteral(content: string, start: number): number {
   return index;
 }
 
-function previousSignificantCharacter(content: string, index: number): string {
-  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
-    const current = content[cursor] ?? '';
-    if (!/\s/.test(current)) {
-      return current;
+function previousSignificantIndex(content: string, index: number): number {
+  let cursor = index - 1;
+
+  while (cursor >= 0) {
+    while (cursor >= 0 && /\s/.test(content[cursor] ?? '')) {
+      cursor -= 1;
     }
+
+    if (cursor <= 0) {
+      return cursor;
+    }
+
+    if (content[cursor] === '/' && content[cursor - 1] === '*') {
+      const start = content.lastIndexOf('/*', cursor - 2);
+      if (start === -1) {
+        return cursor;
+      }
+      cursor = start - 1;
+      continue;
+    }
+
+    const lineStart = content.lastIndexOf('\n', cursor) + 1;
+    const linePrefix = content.slice(lineStart, cursor + 1);
+    const lineCommentStart = linePrefix.indexOf('//');
+    if (
+      lineCommentStart !== -1 &&
+      linePrefix.slice(0, lineCommentStart).trim().length === 0
+    ) {
+      cursor = lineStart - 1;
+      continue;
+    }
+
+    return cursor;
   }
-  return '';
+
+  return cursor;
+}
+
+function previousSignificantCharacter(content: string, index: number): string {
+  const cursor = previousSignificantIndex(content, index);
+  return cursor >= 0 ? (content[cursor] ?? '') : '';
 }
 
 function previousSignificantToken(content: string, index: number): string {
-  let cursor = index - 1;
-  while (cursor >= 0 && /\s/.test(content[cursor] ?? '')) {
-    cursor -= 1;
-  }
+  let cursor = previousSignificantIndex(content, index);
 
   const end = cursor + 1;
   while (cursor >= 0 && /[$\w]/.test(content[cursor] ?? '')) {

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -18,8 +18,8 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   'gi',
 );
 const UNRESOLVED_MARKER_PATTERN = new RegExp(
-  `(?:^|[\\s*])(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
-  'g',
+  `^\\s*(?:\\*|//)?\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
+  'gim',
 );
 const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
   `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
@@ -127,6 +127,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'else',
       'of',
       'in',
+      'default',
     ].includes(previousToken) ||
     previous === '' ||
     '([{=,:;!&|?+-*~^>'.includes(previous) ||
@@ -183,7 +184,10 @@ function collectBlockCommentLabels(
 ): [string[], number] {
   const end = content.indexOf('*/', start + 2);
   const commentEnd = end === -1 ? content.length : end + 2;
-  const comment = content.slice(start, commentEnd);
+  const comment = content
+    .slice(start, commentEnd)
+    .replace(/^\/\*/, '')
+    .replace(/\*\/$/, '');
   return [extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment), commentEnd];
 }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -294,7 +294,7 @@ function canStartRegexLiteralWhileMatchingParens(
       'default',
     ].includes(previousToken) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^<>/}'.includes(previous)
+    '([{=,:;!&|?+-*~^<>/'.includes(previous)
   );
 }
 
@@ -308,6 +308,12 @@ function canStartRegexLiteral(content: string, index: number): boolean {
     return false;
   }
   if (isSpreadOperatorBefore(content, index)) {
+    return true;
+  }
+  if (
+    previous === '}' &&
+    /^\s*$/.test(content.slice(content.lastIndexOf('\n', index - 1) + 1, index))
+  ) {
     return true;
   }
   if (
@@ -341,7 +347,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
     ].includes(previousToken) ||
     followsControlCondition(content, index) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^<>/}'.includes(previous)
+    '([{=,:;!&|?+-*~^<>/'.includes(previous)
   );
 }
 
@@ -583,7 +589,7 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
     return nextTag.startsWith('</>');
   }
 
-  const isOpeningTag = new RegExp('^<[A-Za-z][^>]*>$').test(openingTag);
+  const isOpeningTag = new RegExp('^<[A-Za-z]').test(openingTag);
   const isSelfClosingTag = new RegExp('/\\s*>$').test(openingTag);
   const isClosingTag = new RegExp('^</[A-Za-z]').test(openingTag);
 
@@ -710,6 +716,18 @@ function collectCodeLabels(
       }
       index = commentEnd;
       continue;
+    }
+
+    if (
+      current === '<' &&
+      /[A-Za-z/>]/.test(next ?? '') &&
+      content[index - 1] !== '<'
+    ) {
+      const tagEnd = skipJsxTag(content, index);
+      if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
+        index = tagEnd;
+        continue;
+      }
     }
 
     if (current === '/' && canStartRegexLiteral(content, index)) {

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -27,6 +27,68 @@ const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
 );
 const MAX_COMMENT_RATIO = 0.5;
 
+function skipQuotedLiteral(content: string, start: number): number {
+  const quote = content[start];
+  let index = start + 1;
+
+  while (index < content.length) {
+    const current = content[index];
+    if (current === '\\') {
+      index += 2;
+      continue;
+    }
+    if (current === quote) {
+      return index + 1;
+    }
+    index += 1;
+  }
+
+  return index;
+}
+
+function extractMarkerLabels(pattern: RegExp, comment: string): string[] {
+  return [...comment.matchAll(pattern)].flatMap((match) =>
+    match[1] ? [match[1]] : [],
+  );
+}
+
+function collectUnresolvedCommentMarkerLabels(content: string): string[] {
+  const labels: string[] = [];
+  let index = 0;
+
+  while (index < content.length) {
+    const current = content[index];
+    const next = content[index + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      const end = content.indexOf('\n', index + 2);
+      const commentEnd = end === -1 ? content.length : end;
+      const comment = content.slice(index, commentEnd);
+      labels.push(...extractMarkerLabels(UNRESOLVED_COMMENT_PATTERN, comment));
+      index = commentEnd;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      const end = content.indexOf('*/', index + 2);
+      const commentEnd = end === -1 ? content.length : end + 2;
+      const comment = content.slice(index, commentEnd);
+      labels.push(...extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment));
+      index = commentEnd;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return labels;
+}
+
 export class ConcisenessEvaluator implements Evaluator {
   readonly name = 'conciseness';
   readonly category = 'heuristic' as const;
@@ -90,15 +152,10 @@ export class ConcisenessEvaluator implements Evaluator {
     content: string,
     findings: EvaluationFinding[],
   ): void {
-    const lineMatches = [...content.matchAll(UNRESOLVED_COMMENT_PATTERN)];
-    const blockMatches = [...content.matchAll(BLOCK_COMMENT_PATTERN)].flatMap(
-      (match) => [...match[0].matchAll(UNRESOLVED_MARKER_PATTERN)],
-    );
-    const matches = [...lineMatches, ...blockMatches];
-    if (matches.length > 0) {
-      const labels = matches.map((m) => m[1]).join(', ');
+    const labels = collectUnresolvedCommentMarkerLabels(content);
+    if (labels.length > 0) {
       findings.push({
-        message: `Found ${matches.length} unresolved marker comment(s): ${labels}. Address or track these as issues.`,
+        message: `Found ${labels.length} unresolved marker comment(s): ${labels.join(', ')}. Address or track these as issues.`,
         severity: 'info',
         suggestion:
           'Resolve deferred-work items or convert them to tracked issues',

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -17,6 +17,10 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
   'gi',
 );
+const UNRESOLVED_MARKER_PATTERN = new RegExp(
+  `\\b(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
+  'gi',
+);
 const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
   `//\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})\\b`,
   'i',
@@ -86,7 +90,11 @@ export class ConcisenessEvaluator implements Evaluator {
     content: string,
     findings: EvaluationFinding[],
   ): void {
-    const matches = [...content.matchAll(UNRESOLVED_COMMENT_PATTERN)];
+    const lineMatches = [...content.matchAll(UNRESOLVED_COMMENT_PATTERN)];
+    const blockMatches = [...content.matchAll(BLOCK_COMMENT_PATTERN)].flatMap(
+      (match) => [...match[0].matchAll(UNRESOLVED_MARKER_PATTERN)],
+    );
+    const matches = [...lineMatches, ...blockMatches];
     if (matches.length > 0) {
       const labels = matches.map((m) => m[1]).join(', ');
       findings.push({

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -18,7 +18,7 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   'gi',
 );
 const UNRESOLVED_MARKER_PATTERN = new RegExp(
-  `^\\s*(?:\\*|//)?\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
+  `^\\s*(?:\\*+|//)?\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
   'gim',
 );
 const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
@@ -62,6 +62,12 @@ function findLineCommentStart(
 
     if (current === '"' || current === "'" || current === '`') {
       index = skipQuotedLiteral(content, index);
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? lineEnd : commentEnd + 2;
       continue;
     }
 
@@ -132,7 +138,19 @@ function previousTokenIsPropertyName(content: string, index: number): boolean {
     cursor -= 1;
   }
 
-  return content[cursor] === '.';
+  return (
+    content[cursor] === '.' &&
+    !(content[cursor - 1] === '.' && content[cursor - 2] === '.')
+  );
+}
+
+function isSpreadOperatorBefore(content: string, index: number): boolean {
+  const previousIndex = previousSignificantIndex(content, index);
+  return (
+    content[previousIndex] === '.' &&
+    content[previousIndex - 1] === '.' &&
+    content[previousIndex - 2] === '.'
+  );
 }
 
 function isOperandEndingCharacter(character: string): boolean {
@@ -234,6 +252,9 @@ function canStartRegexLiteralWhileMatchingParens(
   if (previousTokenIsPropertyName(content, index)) {
     return false;
   }
+  if (isSpreadOperatorBefore(content, index)) {
+    return true;
+  }
   return (
     [
       'return',
@@ -264,7 +285,14 @@ function canStartRegexLiteral(content: string, index: number): boolean {
   if (previousTokenIsPropertyName(content, index)) {
     return false;
   }
-  if (previous === '<' && previousSignificantIndex(content, index) === index - 1) {
+  if (isSpreadOperatorBefore(content, index)) {
+    return true;
+  }
+  if (
+    previous === '<' &&
+    previousSignificantIndex(content, index) === index - 1 &&
+    /[A-Za-z>]/.test(content[index + 1] ?? '')
+  ) {
     return false;
   }
   return (
@@ -349,32 +377,144 @@ function collectBlockCommentLabels(
   return [extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment), commentEnd];
 }
 
+function skipJsxTag(content: string, start: number, limit = content.length): number {
+  let index = start + 1;
+  let quote = '';
+
+  while (index < limit) {
+    const current = content[index];
+    if (quote) {
+      if (current === '\\') {
+        index += 2;
+        continue;
+      }
+      if (current === quote) {
+        quote = '';
+      }
+      index += 1;
+      continue;
+    }
+    if (current === '"' || current === "'") {
+      quote = current;
+      index += 1;
+      continue;
+    }
+    if (current === '>') {
+      return index + 1;
+    }
+    index += 1;
+  }
+
+  return -1;
+}
+
+function findLastJsxTagBefore(
+  content: string,
+  end: number,
+): { start: number; end: number; text: string } | undefined {
+  let index = 0;
+  let lastTag: { start: number; end: number; text: string } | undefined;
+
+  while (index < end) {
+    const current = content[index];
+    const next = content[index + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+    if (current === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? end : lineEnd + 1;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? end : commentEnd + 2;
+      continue;
+    }
+    if (
+      current === '<' &&
+      /[A-Za-z/>]/.test(next ?? '') &&
+      content[index - 1] !== '<'
+    ) {
+      const tagEnd = skipJsxTag(content, index, end);
+      if (tagEnd !== -1) {
+        lastTag = {
+          start: index,
+          end: tagEnd,
+          text: content.slice(index, tagEnd).trim(),
+        };
+        index = tagEnd;
+        continue;
+      }
+    }
+    index += 1;
+  }
+
+  return lastTag;
+}
+
+function findNextJsxTagAfter(content: string, start: number): string | undefined {
+  let index = start;
+
+  while (index < content.length) {
+    const current = content[index];
+    const next = content[index + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+    if (current === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? content.length : lineEnd + 1;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? content.length : commentEnd + 2;
+      continue;
+    }
+    if (
+      current === '<' &&
+      /[A-Za-z/>]/.test(next ?? '') &&
+      content[index - 1] !== '<'
+    ) {
+      const tagEnd = skipJsxTag(content, index);
+      if (tagEnd !== -1) {
+        return content.slice(index, tagEnd).trim();
+      }
+    }
+    index += 1;
+  }
+
+  return undefined;
+}
+
 function isJsxTextBlockComment(content: string, start: number, end: number): boolean {
   const before = content.slice(0, start);
-  const after = content.slice(end);
   const previousNonWhitespace = before.trimEnd().at(-1) ?? '';
 
   if (previousNonWhitespace === '{') {
     return false;
   }
 
-  const lastTagEnd = before.lastIndexOf('>');
-  const lastTagStart = before.lastIndexOf('<', lastTagEnd);
-  const nextTagStart = after.indexOf('<');
+  const previousTag = findLastJsxTagBefore(content, start);
+  const nextTag = findNextJsxTagAfter(content, end);
 
-  if (lastTagEnd === -1 || lastTagStart === -1 || nextTagStart === -1) {
+  if (!previousTag || !nextTag) {
     return false;
   }
 
-  const textSinceLastTag = before.slice(lastTagEnd + 1);
+  const textSinceLastTag = before.slice(previousTag.end);
   const lastOpenBrace = textSinceLastTag.lastIndexOf('{');
   const lastCloseBrace = textSinceLastTag.lastIndexOf('}');
   if (lastOpenBrace > lastCloseBrace) {
     return false;
   }
 
-  const openingTag = before.slice(lastTagStart, lastTagEnd + 1).trim();
-  const nextTag = after.slice(nextTagStart).trimStart();
+  const openingTag = previousTag.text;
   if (openingTag === '<>') {
     return nextTag.startsWith('</>');
   }
@@ -382,7 +522,7 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
   return (
     new RegExp('^<[A-Za-z][^>]*>$').test(openingTag) &&
     !new RegExp('/\\s*>$').test(openingTag) &&
-    new RegExp('^</[A-Za-z]').test(nextTag)
+    new RegExp('^<[/A-Za-z]').test(nextTag)
   );
 }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -125,6 +125,16 @@ function previousSignificantToken(content: string, index: number): string {
   return content.slice(cursor + 1, end);
 }
 
+function previousTokenIsPropertyName(content: string, index: number): boolean {
+  const tokenEnd = previousSignificantIndex(content, index) + 1;
+  let cursor = tokenEnd - 1;
+  while (cursor >= 0 && /[$\w]/.test(content[cursor] ?? '')) {
+    cursor -= 1;
+  }
+
+  return content[cursor] === '.';
+}
+
 function isOperandEndingCharacter(character: string): boolean {
   return /[$\w)\]]/.test(character);
 }
@@ -176,6 +186,11 @@ function findMatchingOpeningParen(content: string, closeIndex: number): number {
       continue;
     }
 
+    if (current === '/' && canStartRegexLiteralWhileMatchingParens(content, cursor)) {
+      cursor = skipRegexLiteral(content, cursor);
+      continue;
+    }
+
     if (current === '(') {
       openParens.push(cursor);
     } else if (current === ')') {
@@ -207,10 +222,16 @@ function followsControlCondition(content: string, index: number): boolean {
   );
 }
 
-function canStartRegexLiteral(content: string, index: number): boolean {
+function canStartRegexLiteralWhileMatchingParens(
+  content: string,
+  index: number,
+): boolean {
   const previous = previousSignificantCharacter(content, index);
   const previousToken = previousSignificantToken(content, index);
   if (isPostfixOperatorBefore(content, index)) {
+    return false;
+  }
+  if (previousTokenIsPropertyName(content, index)) {
     return false;
   }
   return (
@@ -224,6 +245,40 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'void',
       'delete',
       'else',
+      'do',
+      'of',
+      'in',
+      'default',
+    ].includes(previousToken) ||
+    previous === '' ||
+    '([{=,:;!&|?+-*~^<>/'.includes(previous)
+  );
+}
+
+function canStartRegexLiteral(content: string, index: number): boolean {
+  const previous = previousSignificantCharacter(content, index);
+  const previousToken = previousSignificantToken(content, index);
+  if (isPostfixOperatorBefore(content, index)) {
+    return false;
+  }
+  if (previousTokenIsPropertyName(content, index)) {
+    return false;
+  }
+  if (previous === '<' && previousSignificantIndex(content, index) === index - 1) {
+    return false;
+  }
+  return (
+    [
+      'return',
+      'throw',
+      'case',
+      'yield',
+      'await',
+      'typeof',
+      'void',
+      'delete',
+      'else',
+      'do',
       'of',
       'in',
       'default',
@@ -320,10 +375,14 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
 
   const openingTag = before.slice(lastTagStart, lastTagEnd + 1).trim();
   const nextTag = after.slice(nextTagStart).trimStart();
+  if (openingTag === '<>') {
+    return nextTag.startsWith('</>');
+  }
+
   return (
-    /^<[A-Za-z][^>]*>$/.test(openingTag) &&
-    !/\/\s*>$/.test(openingTag) &&
-    /^<\/[A-Za-z]/.test(nextTag)
+    new RegExp('^<[A-Za-z][^>]*>$').test(openingTag) &&
+    !new RegExp('/\\s*>$').test(openingTag) &&
+    new RegExp('^</[A-Za-z]').test(nextTag)
   );
 }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -18,7 +18,7 @@ const UNRESOLVED_COMMENT_PATTERN = new RegExp(
   'gi',
 );
 const UNRESOLVED_MARKER_PATTERN = new RegExp(
-  `^\\s*(?:\\*+|//)?\\s*(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
+  `^\\s*(?:\\*+|//)?\\s*@?(${UNRESOLVED_COMMENT_MARKERS.join('|')})(?:\\b|(?=\\())`,
   'gim',
 );
 const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
@@ -294,7 +294,7 @@ function canStartRegexLiteralWhileMatchingParens(
       'default',
     ].includes(previousToken) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^<>/'.includes(previous)
+    '([{=,:;!&|?+-*~^<>/}'.includes(previous)
   );
 }
 
@@ -315,7 +315,13 @@ function canStartRegexLiteral(content: string, index: number): boolean {
     previousSignificantIndex(content, index) === index - 1 &&
     /[A-Za-z>]/.test(content[index + 1] ?? '')
   ) {
-    return false;
+    let beforeLessThan = index - 2;
+    while (beforeLessThan >= 0 && /\s/.test(content[beforeLessThan] ?? '')) {
+      beforeLessThan -= 1;
+    }
+    if (!/[$\w)\]]/.test(content[beforeLessThan] ?? '')) {
+      return false;
+    }
   }
   return (
     [
@@ -335,7 +341,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
     ].includes(previousToken) ||
     followsControlCondition(content, index) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^<>/'.includes(previous)
+    '([{=,:;!&|?+-*~^<>/}'.includes(previous)
   );
 }
 
@@ -577,10 +583,19 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
     return nextTag.startsWith('</>');
   }
 
-  return (
-    new RegExp('^</?[A-Za-z][^>]*>$').test(openingTag) &&
-    new RegExp('^<[/A-Za-z]').test(nextTag)
-  );
+  const isOpeningTag = new RegExp('^<[A-Za-z][^>]*>$').test(openingTag);
+  const isSelfClosingTag = new RegExp('/\\s*>$').test(openingTag);
+  const isClosingTag = new RegExp('^</[A-Za-z]').test(openingTag);
+
+  if (!new RegExp('^<[/A-Za-z]').test(nextTag)) {
+    return false;
+  }
+
+  if (isSelfClosingTag || isClosingTag) {
+    return nextTag.startsWith('</');
+  }
+
+  return isOpeningTag;
 }
 
 function collectTemplateLiteralLabels(

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -73,11 +73,8 @@ function previousSignificantIndex(content: string, index: number): number {
     const lineStart = content.lastIndexOf('\n', cursor) + 1;
     const linePrefix = content.slice(lineStart, cursor + 1);
     const lineCommentStart = linePrefix.indexOf('//');
-    if (
-      lineCommentStart !== -1 &&
-      linePrefix.slice(0, lineCommentStart).trim().length === 0
-    ) {
-      cursor = lineStart - 1;
+    if (lineCommentStart !== -1) {
+      cursor = lineStart + lineCommentStart - 1;
       continue;
     }
 
@@ -118,7 +115,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
       'delete',
     ].includes(previousToken) ||
     previous === '' ||
-    '([{=,:;!&|?+-*~^>'.includes(previous)
+    '([{=,:;!&|?+-*~^>)'.includes(previous)
   );
 }
 
@@ -246,7 +243,9 @@ function collectCodeLabels(
     }
 
     if (current === '`' && next === '`' && content[index + 2] === '`') {
-      index += 3;
+      while (content[index] === '`') {
+        index += 1;
+      }
       continue;
     }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -434,18 +434,21 @@ function isLikelyJsxTagStart(content: string, index: number): boolean {
     return false;
   }
 
+  if (next === '>') {
+    return true;
+  }
+
   const previousIndex = previousSignificantIndex(content, index);
   const previous = previousIndex === -1 ? '' : content[previousIndex] ?? '';
   const previousToken = previousSignificantToken(content, index);
   if (
     /[$\w)\]]/.test(previous) &&
-    !['return', 'yield', 'case', 'else', 'do'].includes(previousToken) &&
-    !(next === '/' && hasOpenJsxAncestorBefore(content, index))
+    !['return', 'yield', 'case', 'else', 'do'].includes(previousToken)
   ) {
-    return false;
+    return next === '/' && hasOpenJsxAncestorBefore(content, index);
   }
 
-  if (next === '/' || next === '>') {
+  if (next === '/') {
     return true;
   }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -46,47 +46,176 @@ function skipQuotedLiteral(content: string, start: number): number {
   return index;
 }
 
+function previousSignificantCharacter(content: string, index: number): string {
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    const current = content[cursor] ?? '';
+    if (!/\s/.test(current)) {
+      return current;
+    }
+  }
+  return '';
+}
+
+function canStartRegexLiteral(content: string, index: number): boolean {
+  const previous = previousSignificantCharacter(content, index);
+  return previous === '' || '([{=,:;!&|?+-*~^<>'.includes(previous);
+}
+
+function skipRegexLiteral(content: string, start: number): number {
+  let index = start + 1;
+  let inCharacterClass = false;
+
+  while (index < content.length) {
+    const current = content[index];
+    if (current === '\\') {
+      index += 2;
+      continue;
+    }
+    if (current === '[') {
+      inCharacterClass = true;
+    } else if (current === ']') {
+      inCharacterClass = false;
+    } else if (current === '/' && !inCharacterClass) {
+      index += 1;
+      while (/[$\w]/.test(content[index] ?? '')) {
+        index += 1;
+      }
+      return index;
+    }
+    index += 1;
+  }
+
+  return index;
+}
+
 function extractMarkerLabels(pattern: RegExp, comment: string): string[] {
   return [...comment.matchAll(pattern)].flatMap((match) =>
     match[1] ? [match[1]] : [],
   );
 }
 
-function collectUnresolvedCommentMarkerLabels(content: string): string[] {
+function collectLineCommentLabels(
+  content: string,
+  start: number,
+): [string[], number] {
+  const end = content.indexOf('\n', start + 2);
+  const commentEnd = end === -1 ? content.length : end;
+  const comment = content.slice(start, commentEnd);
+  return [extractMarkerLabels(UNRESOLVED_COMMENT_PATTERN, comment), commentEnd];
+}
+
+function collectBlockCommentLabels(
+  content: string,
+  start: number,
+): [string[], number] {
+  const end = content.indexOf('*/', start + 2);
+  const commentEnd = end === -1 ? content.length : end + 2;
+  const comment = content.slice(start, commentEnd);
+  return [extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment), commentEnd];
+}
+
+function collectTemplateLiteralLabels(
+  content: string,
+  start: number,
+): [string[], number] {
   const labels: string[] = [];
-  let index = 0;
+  let index = start + 1;
+
+  while (index < content.length) {
+    const current = content[index];
+    const next = content[index + 1];
+    if (current === '\\') {
+      index += 2;
+      continue;
+    }
+    if (current === '`') {
+      return [labels, index + 1];
+    }
+    if (current === '$' && next === '{') {
+      const [expressionLabels, expressionEnd] = collectCodeLabels(
+        content,
+        index + 2,
+        '}',
+      );
+      labels.push(...expressionLabels);
+      index = expressionEnd;
+      continue;
+    }
+    index += 1;
+  }
+
+  return [labels, index];
+}
+
+function collectCodeLabels(
+  content: string,
+  start = 0,
+  endCharacter?: string,
+): [string[], number] {
+  const labels: string[] = [];
+  let index = start;
 
   while (index < content.length) {
     const current = content[index];
     const next = content[index + 1];
 
-    if (current === '"' || current === "'" || current === '`') {
+    if (endCharacter && current === endCharacter) {
+      return [labels, index + 1];
+    }
+
+    if (current === '"' || current === "'") {
       index = skipQuotedLiteral(content, index);
       continue;
     }
 
+    if (current === '`' && next === '`' && content[index + 2] === '`') {
+      index += 3;
+      continue;
+    }
+
+    if (current === '`') {
+      const [templateLabels, templateEnd] = collectTemplateLiteralLabels(
+        content,
+        index,
+      );
+      labels.push(...templateLabels);
+      index = templateEnd;
+      continue;
+    }
+
     if (current === '/' && next === '/') {
-      const end = content.indexOf('\n', index + 2);
-      const commentEnd = end === -1 ? content.length : end;
-      const comment = content.slice(index, commentEnd);
-      labels.push(...extractMarkerLabels(UNRESOLVED_COMMENT_PATTERN, comment));
+      const [commentLabels, commentEnd] = collectLineCommentLabels(
+        content,
+        index,
+      );
+      labels.push(...commentLabels);
       index = commentEnd;
       continue;
     }
 
     if (current === '/' && next === '*') {
-      const end = content.indexOf('*/', index + 2);
-      const commentEnd = end === -1 ? content.length : end + 2;
-      const comment = content.slice(index, commentEnd);
-      labels.push(...extractMarkerLabels(UNRESOLVED_MARKER_PATTERN, comment));
+      const [commentLabels, commentEnd] = collectBlockCommentLabels(
+        content,
+        index,
+      );
+      labels.push(...commentLabels);
       index = commentEnd;
+      continue;
+    }
+
+    if (current === '/' && canStartRegexLiteral(content, index)) {
+      index = skipRegexLiteral(content, index);
       continue;
     }
 
     index += 1;
   }
 
-  return labels;
+  return [labels, index];
+}
+
+function collectUnresolvedCommentMarkerLabels(content: string): string[] {
+  return collectCodeLabels(content)[0];
 }
 
 export class ConcisenessEvaluator implements Evaluator {

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -192,6 +192,10 @@ function previousTokenIsPropertyName(content: string, index: number): boolean {
     cursor -= 1;
   }
 
+  if (content[cursor] === '#') {
+    return true;
+  }
+
   return (
     content[cursor] === '.' &&
     !(content[cursor - 1] === '.' && content[cursor - 2] === '.')
@@ -666,6 +670,15 @@ function jsxTagName(tag: string): string | undefined {
   return match?.[1];
 }
 
+function isSimpleJsxTagStart(content: string, index: number): boolean {
+  const next = content[index + 1];
+  return (
+    content[index] === '<' &&
+    /[A-Za-z_$/>]/.test(next ?? '') &&
+    content[index - 1] !== '<'
+  );
+}
+
 function hasOpenJsxAncestorBefore(content: string, end: number): boolean {
   const stack: string[] = [];
   let index = 0;
@@ -688,7 +701,7 @@ function hasOpenJsxAncestorBefore(content: string, end: number): boolean {
       index = commentEnd === -1 ? end : commentEnd + 2;
       continue;
     }
-    if (current === '<' && isLikelyJsxTagStart(content, index)) {
+    if (isSimpleJsxTagStart(content, index)) {
       const tagEnd = skipJsxTag(content, index, end);
       if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
         const tag = content.slice(index, tagEnd).trim();
@@ -710,11 +723,44 @@ function hasOpenJsxAncestorBefore(content: string, end: number): boolean {
   return stack.length > 0;
 }
 
+function hasUnclosedBraceOnCurrentLine(content: string, end: number): boolean {
+  const lineStart = content.lastIndexOf('\n', end - 1) + 1;
+  let depth = 0;
+  let index = lineStart;
+
+  while (index < end) {
+    const current = content[index];
+    const next = content[index + 1];
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+    if (current === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? end : Math.min(lineEnd + 1, end);
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? end : Math.min(commentEnd + 2, end);
+      continue;
+    }
+    if (current === '{') {
+      depth += 1;
+    } else if (current === '}' && depth > 0) {
+      depth -= 1;
+    }
+    index += 1;
+  }
+
+  return depth > 0;
+}
+
 function isJsxTextBlockComment(content: string, start: number, end: number): boolean {
   const before = content.slice(0, start);
   const previousNonWhitespace = before.trimEnd().at(-1) ?? '';
 
-  if (previousNonWhitespace === '{') {
+  if (previousNonWhitespace === '{' || hasUnclosedBraceOnCurrentLine(content, start)) {
     return false;
   }
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -56,9 +56,37 @@ function previousSignificantCharacter(content: string, index: number): string {
   return '';
 }
 
+function previousSignificantToken(content: string, index: number): string {
+  let cursor = index - 1;
+  while (cursor >= 0 && /\s/.test(content[cursor] ?? '')) {
+    cursor -= 1;
+  }
+
+  const end = cursor + 1;
+  while (cursor >= 0 && /[$\w]/.test(content[cursor] ?? '')) {
+    cursor -= 1;
+  }
+
+  return content.slice(cursor + 1, end);
+}
+
 function canStartRegexLiteral(content: string, index: number): boolean {
   const previous = previousSignificantCharacter(content, index);
-  return previous === '' || '([{=,:;!&|?+-*~^<>'.includes(previous);
+  const previousToken = previousSignificantToken(content, index);
+  return (
+    [
+      'return',
+      'throw',
+      'case',
+      'yield',
+      'await',
+      'typeof',
+      'void',
+      'delete',
+    ].includes(previousToken) ||
+    previous === '' ||
+    '([{=,:;!&|?+-*~^>'.includes(previous)
+  );
 }
 
 function skipRegexLiteral(content: string, start: number): number {
@@ -154,12 +182,28 @@ function collectCodeLabels(
 ): [string[], number] {
   const labels: string[] = [];
   let index = start;
+  let braceDepth = endCharacter === '}' ? 1 : 0;
 
   while (index < content.length) {
     const current = content[index];
     const next = content[index + 1];
 
-    if (endCharacter && current === endCharacter) {
+    if (endCharacter === '}' && current === '{') {
+      braceDepth += 1;
+      index += 1;
+      continue;
+    }
+
+    if (endCharacter === '}' && current === '}') {
+      braceDepth -= 1;
+      index += 1;
+      if (braceDepth === 0) {
+        return [labels, index];
+      }
+      continue;
+    }
+
+    if (endCharacter && endCharacter !== '}' && current === endCharacter) {
       return [labels, index + 1];
     }
 

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -526,6 +526,12 @@ const x = 1;
       `const arrow = <T /* ${hackMarker}: generic */>() => value;`,
       `const first = <p></p>; /* ${xxxMarker}: statement-level */ const second = <div />;`,
       `const comparison = a < b /* ${pendingMarker}: compare operands */ > c;`,
+      `const quoted = <Widget text={"} >"} value={/* ${trackedMarker}: later prop */ x} />;`,
+      `return /[//]/.source / total; // ${hackMarker}: real line marker`,
+      `const constrained = <T extends Foo /* ${trackedMarker}: constrained generic */>() => value;`,
+      `const attrComment = <Widget /* ${hackMarker}: tag trivia */ value={1} />;`,
+      `<_Foo>/* ${pendingMarker}: shown to users */</_Foo>`,
+      `const contextual = of / total; // ${xxxMarker}: contextual identifier division`,
       `<p>/* ${pendingMarker}: shown to users */</p>`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
@@ -533,7 +539,7 @@ const x = 1;
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('5 unresolved marker comment(s)') &&
+          f.message.includes('10 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           f.message.includes(hackMarker) &&

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -190,24 +190,29 @@ const x = 1;
     const pendingMarker = ['TO', 'DO'].join('');
     const trackedMarker = ['FIX', 'ME'].join('');
     const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
     const content = [
       "Don't skip later fenced code markers:",
       '````ts',
       `// ${pendingMarker}: fenced code follow-up`,
       '````',
+      '/** Render the todo list for this page. */',
+      'const ratio = (a + b) / c;',
+      `// ${trackedMarker}: division comment remains visible`,
       'const re = // docs before regex',
-      `  /[/* ${trackedMarker}: regex data */]/;`,
-      `if (ok) /[/* ${hackMarker}: regex data */]/.test(value);`,
+      `  /[/* ${hackMarker}: regex data */]/;`,
+      `if (ok) foo(); else /[/* ${xxxMarker}: regex data */]/.test(value);`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
 
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('1 unresolved marker comment(s)') &&
+          f.message.includes('2 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
-          !f.message.includes(trackedMarker) &&
-          !f.message.includes(hackMarker),
+          f.message.includes(trackedMarker) &&
+          !f.message.includes(hackMarker) &&
+          !f.message.includes(xxxMarker),
       ),
     ).toBe(true);
   });

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -157,6 +157,34 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('handles return regexes, nested template braces, and JSX-adjacent comments', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
+    const content = [
+      `function pattern() { return /[/* ${pendingMarker}: regex data */]/; }`,
+      `const value = \`${'${'}condition ? { nested: true } : /* ${trackedMarker}: real nested expression comment */ fallback}\`;`,
+      '<div />',
+      `// ${hackMarker}: adjacent jsx line comment`,
+      '</div>',
+      `/* ${xxxMarker}: adjacent jsx block comment */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('3 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker) &&
+          f.message.includes(xxxMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -482,8 +482,11 @@ const x = 1;
     const xxxMarker = ['X', 'XX'].join('');
     const content = [
       `<p><span />/* ${pendingMarker}: shown to users */</p>`,
+      `<Tooltip label="a > b">/* ${pendingMarker}: shown to users */</Tooltip>`,
       `const generic = make<Item>(); /* ${trackedMarker}: real block marker */ return <div />;`,
       `const cls = /[//]/; const ratio = a / b; // ${hackMarker}: normalize`,
+      `const x = <div>text</div>; // ${hackMarker}: real jsx-adjacent line marker`,
+      `const ratio = {} / total; // ${trackedMarker}: real brace division marker`,
       `if (ok) {}`,
       `/[/* ${pendingMarker}: regex data */]/.test(value);`,
       `const compact = value</a[/* ${pendingMarker}: regex data */]/.source;`,
@@ -498,7 +501,7 @@ const x = 1;
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('5 unresolved marker comment(s)') &&
+          f.message.includes('7 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           f.message.includes(hackMarker) &&

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -331,6 +331,72 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('ignores multiline JSX text that contains block-comment-shaped markers', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = [
+      '<section>',
+      '  <p>',
+      `    /* ${pendingMarker}: shown to users */`,
+      '  </p>',
+      `  <p>{/* ${trackedMarker}: real JSX comment */}</p>`,
+      '</section>',
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('skips regex statement bodies after control conditions with string parens', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = [
+      `if (label === ")") /[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `while (label !== "(") /[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `/* ${trackedMarker}: real block marker */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('skips regex literals after comparison and division operators', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = [
+      `const isPattern = value < /[/* ${pendingMarker}: regex data */]/.source;`,
+      `const ratio = total / /[/* ${pendingMarker}: regex data */]/.source.length;`,
+      `/* ${trackedMarker}: real block marker */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -445,6 +445,35 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('handles edge cases from current Codex scanner findings', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
+    const content = [
+      `const open = "<p>"; /* ${pendingMarker}: real block marker */ const close = "</p>";`,
+      `/**** ${trackedMarker}: banner block marker ****/`,
+      `<p>/* ${pendingMarker}: shown to users */<span /></p>`,
+      `const chars = [.../[/* ${pendingMarker}: regex data */]/.source];`,
+      `const compact = value</[/* ${pendingMarker}: regex data */]/.source;`,
+      `const ratio = /* // docs */ a / total; // ${hackMarker}: real line marker`,
+      `/* ${xxxMarker}: final real block marker */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('4 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker) &&
+          f.message.includes(xxxMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -132,6 +132,31 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('handles regex literals, template interpolation comments, and markdown fences', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const content = [
+      `const pattern = /[/* ${pendingMarker}: regex data */]/;`,
+      `const value = \`${'${'}answer /* ${trackedMarker}: real interpolation comment */}\`;`,
+      '```ts',
+      `// ${hackMarker}: fenced code comment`,
+      '```',
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('2 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -531,7 +531,10 @@ const x = 1;
       `const constrained = <T extends Foo /* ${trackedMarker}: constrained generic */>() => value;`,
       `const attrComment = <Widget /* ${hackMarker}: tag trivia */ value={1} />;`,
       `<_Foo>/* ${pendingMarker}: shown to users */</_Foo>`,
-      `const contextual = of / total; // ${xxxMarker}: contextual identifier division`,
+      `const ratio = of / total; // ${xxxMarker}: contextual identifier division`,
+      `class C { m(total) { return this.#default / total; // ${pendingMarker}: private field division } }`,
+      `const expr = <>{items.map((item) => <span /> /* ${trackedMarker}: jsx expression comment */)}</>;`,
+      `${Array.from({ length: 24 }, (_, index) => `<p>text ${index}</p>`).join('')}`,
       `<p>/* ${pendingMarker}: shown to users */</p>`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
@@ -539,10 +542,40 @@ const x = 1;
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('10 unresolved marker comment(s)') &&
+          f.message.includes('12 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           f.message.includes(hackMarker) &&
+          f.message.includes(xxxMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('handles recursive JSX, private fields, and JSX expression comments from Codex follow-up findings', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
+    const repeatedJsx = `<>{${Array.from({ length: 25 }, (_, index) => `<p>text ${index}</p>`).join('')}}</>`;
+    const content = [
+      repeatedJsx,
+      `class Example { #default = 1; value(total: number) { return this.#default / total; // ${pendingMarker}: private field division } }`,
+      `const fragment = <>{items.map((item) => <span key={item.id} /> /* ${trackedMarker}: expression comment */)}</>;`,
+      `<p><span />/* ${hackMarker}: shown sibling text */</p>`,
+      `/* ${xxxMarker}: final real block marker */`,
+    ].join('\n');
+    const start = Date.now();
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('3 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          !f.message.includes(hackMarker) &&
           f.message.includes(xxxMarker),
       ),
     ).toBe(true);

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -195,21 +195,23 @@ const x = 1;
       `Don't leave // ${pendingMarker}: same-line prose marker`,
       '````ts',
       `/* ${trackedMarker}(owner): block marker without colon */`,
+      `/* ${pendingMarker.toLowerCase()}: lowercase block marker */`,
       '````',
-      '/** Render the todo list for this page. */',
+      '/** Render the TODO column in this view. */',
       'const ratio = (a + b) / c;',
       `// ${trackedMarker}: division comment remains visible`,
       'const re = // docs before regex',
       `  /[/* ${hackMarker}: regex data */]/;`,
       `if (ok) foo(); else /[/* ${xxxMarker}: regex data */]/.test(value);`,
       `for (const m of /[/* ${xxxMarker}: regex data */]/g.exec(s) ?? []) {}`,
+      `export default /[/* ${hackMarker}: regex data */]/;`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
 
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('3 unresolved marker comment(s)') &&
+          f.message.includes('4 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           !f.message.includes(hackMarker) &&

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -189,14 +189,15 @@ const x = 1;
     const evaluator = new ConcisenessEvaluator();
     const pendingMarker = ['TO', 'DO'].join('');
     const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
     const content = [
       "Don't skip later fenced code markers:",
-      '```ts',
+      '````ts',
       `// ${pendingMarker}: fenced code follow-up`,
-      '```',
-      'const re =',
-      '  // docs before regex',
+      '````',
+      'const re = // docs before regex',
       `  /[/* ${trackedMarker}: regex data */]/;`,
+      `if (ok) /[/* ${hackMarker}: regex data */]/.test(value);`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
 
@@ -205,7 +206,8 @@ const x = 1;
         (f) =>
           f.message.includes('1 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
-          !f.message.includes(trackedMarker),
+          !f.message.includes(trackedMarker) &&
+          !f.message.includes(hackMarker),
       ),
     ).toBe(true);
   });

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -514,6 +514,34 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('handles JSX and TypeScript angle edge cases from Codex follow-up findings', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
+    const content = [
+      `const widget = <Widget value={a > b ? /* ${pendingMarker}: compare */ value : fallback} />;`,
+      `const generic = make<Foo /* ${trackedMarker}: type */>();`,
+      `const arrow = <T /* ${hackMarker}: generic */>() => value;`,
+      `const first = <p></p>; /* ${xxxMarker}: statement-level */ const second = <div />;`,
+      `const comparison = a < b /* ${pendingMarker}: compare operands */ > c;`,
+      `<p>/* ${pendingMarker}: shown to users */</p>`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('5 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker) &&
+          f.message.includes(xxxMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -483,6 +483,10 @@ const x = 1;
     const content = [
       `<p><span />/* ${pendingMarker}: shown to users */</p>`,
       `<Tooltip label="a > b">/* ${pendingMarker}: shown to users */</Tooltip>`,
+      `<div><span />/* ${pendingMarker}: shown sibling text */<strong /></div>`,
+      `<p>a=b; c /* ${pendingMarker}: shown punctuation */</p>`,
+      `const md = \`\`\`ts\n/* ${pendingMarker}: fenced template text */\n\`\`\`;`,
+      `const widget = <Widget value={/* ${trackedMarker}: prop expression */ value} />;`,
       `const generic = make<Item>(); /* ${trackedMarker}: real block marker */ return <div />;`,
       `const cls = /[//]/; const ratio = a / b; // ${hackMarker}: normalize`,
       `const x = <div>text</div>; // ${hackMarker}: real jsx-adjacent line marker`,
@@ -501,7 +505,7 @@ const x = 1;
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('7 unresolved marker comment(s)') &&
+          f.message.includes('8 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           f.message.includes(hackMarker) &&

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -397,6 +397,54 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('continues scanning markers after keyword property divisions and JSX closing tags', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const content = [
+      `const ratio = config.default / total; // ${pendingMarker}: normalize`,
+      `const grouped = source.in / total; /* ${trackedMarker}: normalize */`,
+      `const node = <div></div>; // ${hackMarker}: remove`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('3 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores fragment text and regex bodies after do/control conditions', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const content = [
+      `const fragment = <>/* ${pendingMarker}: shown to users */</>;`,
+      `if (/[)]/.test(value)) /[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `do /[/* ${pendingMarker}: regex data */]/.test(value); while (ok);`,
+      `/* ${trackedMarker}: real block marker */`,
+      `// ${hackMarker}: real line marker`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('2 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -474,6 +474,33 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('handles follow-up Codex scanner edge cases', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
+    const content = [
+      `<p><span />/* ${pendingMarker}: shown to users */</p>`,
+      `const generic = make<Item>(); /* ${trackedMarker}: real block marker */ return <div />;`,
+      `const cls = /[//]/; const ratio = a / b; // ${hackMarker}: normalize`,
+      `const ok = value < /a[/* ${pendingMarker}: regex data */]/.source;`,
+      `/* ${xxxMarker}: final real block marker */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('3 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker) &&
+          f.message.includes(xxxMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -220,6 +220,48 @@ const x = 1;
     ).toBe(true);
   });
 
+
+  it('keeps scanning array literals after division expressions', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const content = `const ratio = total() / [/* ${pendingMarker}: remove divisor */ divisor][0];`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not treat string slashes as line-comment trivia before regexes', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const content = `const s = "abc // def"; const re = /[/* ${pendingMarker}: regex data */]/;`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some((f) => f.message.includes('unresolved marker comment')),
+    ).toBe(false);
+  });
+
+  it('detects line-comment markers after plural possessive prose apostrophes', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const content = `Users' // ${pendingMarker}: migrate groups`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -110,6 +110,28 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('does not count comment-shaped markers inside strings or twice inside block comments', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = `
+const text = "/* ${pendingMarker}: visible to users */";
+const template = \`// ${trackedMarker}: example only\`;
+/* // ${pendingMarker}: real block marker */
+const x = 1;
+`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          !f.message.includes(trackedMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -262,6 +262,75 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('keeps scanning comments after postfix non-null and increment divisions', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const content = [
+      `const ratio = value! / denominator; // ${pendingMarker}: normalize`,
+      `const incremented = i++ / denominator; // ${trackedMarker}: normalize`,
+      `const decremented = i-- / denominator; // ${hackMarker}: normalize`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('3 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('skips regex literals used as statement bodies after control conditions', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = [
+      `if (ok) /[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `while (ok) /[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `for (const value of values) /[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `const ratio = total() / divisor; /* ${trackedMarker}: real block marker */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores block-comment-shaped markers in JSX text but not JSX comments', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const content = [
+      `<p>/* ${pendingMarker}: shown to users */</p>`,
+      `<p>prefix /* ${pendingMarker}: also shown */ suffix</p>`,
+      `<p>{/* ${trackedMarker}: real JSX comment */}</p>`,
+      `/* ${hackMarker}: real block marker */`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('2 unresolved marker comment(s)') &&
+          !f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -192,9 +192,9 @@ const x = 1;
     const hackMarker = ['HA', 'CK'].join('');
     const xxxMarker = ['X', 'XX'].join('');
     const content = [
-      "Don't skip later fenced code markers:",
+      `Don't leave // ${pendingMarker}: same-line prose marker`,
       '````ts',
-      `// ${pendingMarker}: fenced code follow-up`,
+      `/* ${trackedMarker}(owner): block marker without colon */`,
       '````',
       '/** Render the todo list for this page. */',
       'const ratio = (a + b) / c;',
@@ -202,13 +202,14 @@ const x = 1;
       'const re = // docs before regex',
       `  /[/* ${hackMarker}: regex data */]/;`,
       `if (ok) foo(); else /[/* ${xxxMarker}: regex data */]/.test(value);`,
+      `for (const m of /[/* ${xxxMarker}: regex data */]/g.exec(s) ?? []) {}`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
 
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('2 unresolved marker comment(s)') &&
+          f.message.includes('3 unresolved marker comment(s)') &&
           f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           !f.message.includes(hackMarker) &&

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -80,6 +80,36 @@ describe('ConcisenessEvaluator', () => {
     ).toBe(true);
   });
 
+  it('flags unresolved markers in block comments without matching strings', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const hackMarker = ['HA', 'CK'].join('');
+    const xxxMarker = ['X', 'XX'].join('');
+    const content = `
+const literal = "${pendingMarker}: visible to users";
+/* ${pendingMarker}: remove workaround */
+/** ${trackedMarker}: tracked follow-up */
+/*
+ * ${hackMarker}: temporary behavior
+ * ${xxxMarker}: remove temporary behavior
+ */
+const x = 1;
+`;
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('4 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          f.message.includes(trackedMarker) &&
+          f.message.includes(hackMarker) &&
+          f.message.includes(xxxMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -185,6 +185,31 @@ const x = 1;
     ).toBe(true);
   });
 
+  it('recovers from prose apostrophes and comment trivia before regex literals', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const pendingMarker = ['TO', 'DO'].join('');
+    const trackedMarker = ['FIX', 'ME'].join('');
+    const content = [
+      "Don't skip later fenced code markers:",
+      '```ts',
+      `// ${pendingMarker}: fenced code follow-up`,
+      '```',
+      'const re =',
+      '  // docs before regex',
+      `  /[/* ${trackedMarker}: regex data */]/;`,
+    ].join('\n');
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(
+      result.findings.some(
+        (f) =>
+          f.message.includes('1 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
+          !f.message.includes(trackedMarker),
+      ),
+    ).toBe(true);
+  });
+
   it('passes empty content', async () => {
     const evaluator = new ConcisenessEvaluator();
     const result = await evaluator.evaluate(createInput(''));

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -484,7 +484,13 @@ const x = 1;
       `<p><span />/* ${pendingMarker}: shown to users */</p>`,
       `const generic = make<Item>(); /* ${trackedMarker}: real block marker */ return <div />;`,
       `const cls = /[//]/; const ratio = a / b; // ${hackMarker}: normalize`,
-      `const ok = value < /a[/* ${pendingMarker}: regex data */]/.source;`,
+      `if (ok) {}`,
+      `/[/* ${pendingMarker}: regex data */]/.test(value);`,
+      `const compact = value</a[/* ${pendingMarker}: regex data */]/.source;`,
+      `const first = <div />`,
+      `/* ${pendingMarker}: ASI-separated real block marker */`,
+      `const second = <span />;`,
+      `/** @${pendingMarker.toLowerCase()} remove workaround */`,
       `/* ${xxxMarker}: final real block marker */`,
     ].join('\n');
     const result = await evaluator.evaluate(createInput(content));
@@ -492,8 +498,8 @@ const x = 1;
     expect(
       result.findings.some(
         (f) =>
-          f.message.includes('3 unresolved marker comment(s)') &&
-          !f.message.includes(pendingMarker) &&
+          f.message.includes('5 unresolved marker comment(s)') &&
+          f.message.includes(pendingMarker) &&
           f.message.includes(trackedMarker) &&
           f.message.includes(hackMarker) &&
           f.message.includes(xxxMarker),


### PR DESCRIPTION
## Summary
- detect unresolved markers inside block comments in ConcisenessEvaluator
- keep string literals from counting by scanning only comment-shaped regions
- add regression coverage for block comments, multiline blocks, and existing line-comment behavior

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/critique -- tests/unit/evaluators/conciseness.test.ts -t "flags unresolved markers in block comments" (verified RED before fix, then GREEN)
- npm run test --workspace @franken/critique -- tests/unit/evaluators/conciseness.test.ts
- npm run test --workspace @franken/critique
- npm run typecheck --workspace @franken/critique
- npm run build --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npx prettier --check packages/franken-critique/src/evaluators/conciseness.ts packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
- npm run audit:todos

Note: package-wide `npm run format:check --workspace @franken/critique` still reports pre-existing formatting warnings in 37 unrelated files; the two changed files pass Prettier directly.

Closes #1072
