### PR TITLE
fix(web): guard dashboard SSE snapshot parsing

### DIFF
--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -202,6 +202,48 @@ describe('DashboardApiClient', () => {
       }
     });
 
+    it('reports malformed snapshot payloads without throwing out of the EventSource listener', async () => {
+      const listeners: Record<string, (event: { data: string }) => void> = {};
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data: string }) => void) => void;
+        close?: () => void;
+      }) {
+        this.addEventListener = vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          listeners[type] = handler;
+        });
+        this.close = vi.fn();
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ticket: 'dashboard-ticket' }),
+      });
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const onSnapshot = vi.fn();
+        const onError = vi.fn();
+        const unsub = await client.subscribeToDashboard(onSnapshot, onError);
+
+        expect(() => listeners['snapshot']!({ data: '{not-json' })).not.toThrow();
+        expect(onSnapshot).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+
+        unsub();
+      } finally {
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
     it('mints a fresh one-shot ticket after EventSource errors', async () => {
       vi.useFakeTimers();
       const closeFns = [vi.fn(), vi.fn()];

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -57,7 +57,10 @@ export class DashboardApiClient {
   // NOTE: EventSource cannot attach an Authorization header. Browser clients
   // first mint a short-lived, one-shot stream ticket with normal authenticated
   // fetch, then put only that ticket in the EventSource URL.
-  async subscribeToDashboard(onSnapshot: (snapshot: DashboardSnapshot) => void): Promise<() => void> {
+  async subscribeToDashboard(
+    onSnapshot: (snapshot: DashboardSnapshot) => void,
+    onError?: (error: Error) => void,
+  ): Promise<() => void> {
     let eventSource: EventSource | undefined;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let closed = false;
@@ -99,8 +102,12 @@ export class DashboardApiClient {
       }
       eventSource = nextEventSource;
       nextEventSource.addEventListener('snapshot', (event: any) => {
-        const snapshot = JSON.parse(event.data) as DashboardSnapshot;
-        onSnapshot(snapshot);
+        try {
+          const snapshot = JSON.parse(event.data) as DashboardSnapshot;
+          onSnapshot(snapshot);
+        } catch (error) {
+          onError?.(toError(error));
+        }
       });
       nextEventSource.addEventListener('error', () => {
         closeActiveSource();
@@ -116,4 +123,8 @@ export class DashboardApiClient {
     };
   }
 
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -173,13 +173,21 @@ export function DashboardPage({ client }: DashboardPageProps) {
     loadSnapshot();
     let unsub: (() => void) | undefined;
     let streamActive = true;
-    client.subscribeToDashboard((snap) => {
-      if (!mountedRef.current) return;
-      if (!streamActive) return;
-      if (clientGenerationRef.current !== subscriptionGeneration) return;
-      setLoadError(null);
-      applyServerSnapshot(snap);
-    })
+    client.subscribeToDashboard(
+      (snap) => {
+        if (!mountedRef.current) return;
+        if (!streamActive) return;
+        if (clientGenerationRef.current !== subscriptionGeneration) return;
+        setLoadError(null);
+        applyServerSnapshot(snap);
+      },
+      (error) => {
+        if (!mountedRef.current) return;
+        if (!streamActive) return;
+        if (clientGenerationRef.current !== subscriptionGeneration) return;
+        setLoadError(`Unable to process dashboard stream update. ${describeError(error)}`);
+      },
+    )
       .then((nextUnsub) => {
         if (!mountedRef.current || !streamActive || clientGenerationRef.current !== subscriptionGeneration) {
           nextUnsub();


### PR DESCRIPTION
## Summary
- guard dashboard SSE snapshot JSON parsing so malformed snapshot events do not throw out of the listener
- expose an optional stream parse error callback and surface parse failures on the dashboard page
- add a regression test for malformed snapshot payloads

## Test Plan
- npm test -- src/lib/dashboard-api.test.ts --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1081