### PR TITLE
fix(governor): prune expired session tokens on write

### DIFF
--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -63,12 +63,12 @@ export class SessionTokenStore {
     }
 
     return this.withFileLock(() => {
-      this.loadPersistedTokens();
+      const expiredPersisted = this.loadPersistedTokens();
       const pruned = this.pruneExpiredTokens();
-      if (pruned > 0) {
+      if (expiredPersisted + pruned > 0) {
         this.persist();
       }
-      return pruned;
+      return expiredPersisted + pruned;
     });
   }
 
@@ -115,8 +115,8 @@ export class SessionTokenStore {
     return pruned;
   }
 
-  private loadPersistedTokens(): void {
-    if (!this.persistenceFile) return;
+  private loadPersistedTokens(): number {
+    if (!this.persistenceFile) return 0;
 
     let raw: string;
     try {
@@ -125,7 +125,7 @@ export class SessionTokenStore {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === 'ENOENT') {
         this.tokens.clear();
-        return;
+        return 0;
       }
       throw err;
     }
@@ -142,14 +142,18 @@ export class SessionTokenStore {
     }
 
     this.tokens.clear();
+    let expiredPersisted = 0;
     for (const value of parsed) {
       const token = this.deserialize(value);
       if (token && !this.isExpired(token)) {
         this.tokens.set(token.tokenId, token);
+      } else if (token) {
+        expiredPersisted += 1;
       }
     }
 
     // Expired entries are ignored on read and pruned on the next write.
+    return expiredPersisted;
   }
 
   private deserialize(value: unknown): SessionToken | null {

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -44,14 +44,31 @@ export class SessionTokenStore {
 
   store(token: SessionToken): void {
     if (!this.persistenceFile) {
+      this.pruneExpiredTokens();
       this.tokens.set(token.tokenId, token);
       return;
     }
 
     this.withFileLock(() => {
       this.loadPersistedTokens();
+      this.pruneExpiredTokens();
       this.tokens.set(token.tokenId, token);
       this.persist();
+    });
+  }
+
+  cleanupExpired(): number {
+    if (!this.persistenceFile) {
+      return this.pruneExpiredTokens();
+    }
+
+    return this.withFileLock(() => {
+      this.loadPersistedTokens();
+      const pruned = this.pruneExpiredTokens();
+      if (pruned > 0) {
+        this.persist();
+      }
+      return pruned;
     });
   }
 
@@ -85,6 +102,17 @@ export class SessionTokenStore {
     const token = this.get(tokenId);
     if (!token) return false;
     return scope === undefined || token.scope === scope;
+  }
+
+  private pruneExpiredTokens(): number {
+    let pruned = 0;
+    for (const [tokenId, token] of this.tokens) {
+      if (this.isExpired(token)) {
+        this.tokens.delete(tokenId);
+        pruned += 1;
+      }
+    }
+    return pruned;
   }
 
   private loadPersistedTokens(): void {

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -202,21 +202,22 @@ describe('SessionTokenStore', () => {
     }
   });
 
-  it('prunes unqueried expired persisted tokens on the next write', () => {
+  it('cleanupExpired() rewrites persisted stores with unqueried expired tokens', () => {
     const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
     const persistenceFile = join(dir, 'tokens.json');
     try {
       const store = new SessionTokenStore({ persistenceFile });
-      const token = makeToken(1000);
-      store.store(token);
+      const expired = makeToken(1000);
+      const fresh = makeToken(10_000);
+      store.store(expired);
+      store.store(fresh);
 
       vi.advanceTimersByTime(2000);
 
-      const beforeWrite = JSON.parse(readFileSync(persistenceFile, 'utf8'));
-      expect(beforeWrite).toHaveLength(1);
+      const beforeCleanup = JSON.parse(readFileSync(persistenceFile, 'utf8'));
+      expect(beforeCleanup).toHaveLength(2);
 
-      const fresh = makeToken(10_000);
-      store.store(fresh);
+      expect(store.cleanupExpired()).toBe(1);
 
       const persisted = JSON.parse(readFileSync(persistenceFile, 'utf8'));
       expect(persisted).toHaveLength(1);

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -48,6 +48,20 @@ describe('SessionTokenStore', () => {
     expect(store.get(token.tokenId)).toBeUndefined();
   });
 
+  it('cleanupExpired() prunes expired in-memory tokens that were never queried', () => {
+    const store = new SessionTokenStore();
+    const expired = makeToken(1000);
+    const fresh = makeToken(10_000);
+
+    store.store(expired);
+    vi.advanceTimersByTime(2000);
+    store.store(fresh);
+
+    expect(store.cleanupExpired()).toBe(0);
+    expect(store.get(expired.tokenId)).toBeUndefined();
+    expect(store.get(fresh.tokenId)).toEqual(fresh);
+  });
+
   it('revoke() removes a token', () => {
     const store = new SessionTokenStore();
     const token = makeToken();
@@ -188,7 +202,7 @@ describe('SessionTokenStore', () => {
     }
   });
 
-  it('ignores expired tokens on read and prunes them on the next write', () => {
+  it('prunes unqueried expired persisted tokens on the next write', () => {
     const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
     const persistenceFile = join(dir, 'tokens.json');
     try {
@@ -198,7 +212,6 @@ describe('SessionTokenStore', () => {
 
       vi.advanceTimersByTime(2000);
 
-      expect(store.get(token.tokenId)).toBeUndefined();
       const beforeWrite = JSON.parse(readFileSync(persistenceFile, 'utf8'));
       expect(beforeWrite).toHaveLength(1);
 


### PR DESCRIPTION
## Summary
- Prune expired in-memory SessionTokenStore entries before accepting new tokens
- Add an explicit cleanupExpired() path for deterministic cleanup
- Update regression coverage for unqueried expired memory and persisted tokens

## Test Plan
- npm run test --workspace @franken/governor -- session-token-store.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/governor
- npm run build --workspace @franken/governor
- npm run lint --workspace @franken/governor
- npm run test --workspace @franken/governor

Closes #1109