### PR TITLE
fix(brain): handle circular working-memory serialization

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -42,6 +42,23 @@ function cloneStoredWorkingMemoryValue(value: unknown): unknown {
   return JSON.parse(JSON.stringify(value)) as unknown;
 }
 
+function stringifyWorkingMemoryValue(key: string, value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized !== undefined) {
+      return serialized;
+    }
+  } catch (error) {
+    throw new WorkingMemoryLimitError(
+      `Working memory value for "${key}" is not JSON-serializable and could not be persisted: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  throw new WorkingMemoryLimitError(
+    `Working memory value for "${key}" is not JSON-serializable and could not be persisted`,
+  );
+}
+
 class SqliteWorkingMemory implements IWorkingMemory {
   private store = new Map<string, unknown>();
   private sizes = new Map<string, number>();
@@ -219,12 +236,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     key: string,
     value: unknown,
   ): { normalized: unknown; serialized: string; size: number } {
-    const serialized = JSON.stringify(value);
-    if (serialized === undefined) {
-      throw new WorkingMemoryLimitError(
-        `Working memory value for "${key}" is not JSON-serializable and could not be persisted`,
-      );
-    }
+    const serialized = stringifyWorkingMemoryValue(key, value);
     const valueBytes = Buffer.byteLength(serialized, 'utf8');
     if (valueBytes > this.limits.maxValueBytes) {
       throw new WorkingMemoryLimitError(

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -149,6 +149,17 @@ describe('SqliteBrain', () => {
       );
     });
 
+    it('rejects circular values with a working-memory error and keeps prior state', () => {
+      const circular: Record<string, unknown> = { label: 'loop' };
+      circular.self = circular;
+      brain.working.set('safe', { status: 'persisted' });
+
+      expect(() => brain.working.set('cycle', circular)).toThrow(WorkingMemoryLimitError);
+      expect(() => brain.working.restore({ cycle: circular })).toThrow(WorkingMemoryLimitError);
+      expect(brain.working.snapshot()).toEqual({ safe: { status: 'persisted' } });
+      expect(brain.working.has('cycle')).toBe(false);
+    });
+
     it('accounts for the serialized form, not a deceptive small JSON facade', () => {
       // A Map stringifies to '{}' but would retain its full contents if stored
       // by reference. The store normalizes to the JSON round-trip, so what is


### PR DESCRIPTION
## Summary
- wrap WorkingMemory JSON serialization failures in WorkingMemoryLimitError
- preserve existing state when set/restore receives circular object graphs
- add regression coverage for circular working-memory values

## Test Plan
- npm --prefix packages/franken-brain test -- tests/unit/sqlite-brain.test.ts -t 'rejects circular values' (RED: failed before fix with raw TypeError)
- npm --prefix packages/franken-brain test -- tests/unit/sqlite-brain.test.ts
- npm run build --workspace @franken/types
- npm --prefix packages/franken-brain run typecheck
- npm --prefix packages/franken-brain run build
- npm --prefix packages/franken-brain run lint
- npm --prefix packages/franken-brain test

Closes #1050