### PR TITLE
test(planner): cover fix-it dependency deduplication

### DIFF
--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -395,12 +395,21 @@ describe('PlanGraph — insertFixItTask', () => {
       createTaskId('a'),
       createTaskId('setup'),
     ]);
-    expect(g2.topoSort().map((task) => task.id)).toEqual([
-      createTaskId('a'),
-      createTaskId('setup'),
-      createTaskId('fix-b'),
-      createTaskId('b'),
-    ]);
+    const sorted = g2.topoSort().map((task) => task.id);
+    const fixIndex = sorted.indexOf(createTaskId('fix-b'));
+    const failedIndex = sorted.indexOf(createTaskId('b'));
+
+    expect(sorted).toEqual(
+      expect.arrayContaining([
+        createTaskId('a'),
+        createTaskId('setup'),
+        createTaskId('fix-b'),
+        createTaskId('b'),
+      ])
+    );
+    expect(sorted.indexOf(createTaskId('a'))).toBeLessThan(fixIndex);
+    expect(sorted.indexOf(createTaskId('setup'))).toBeLessThan(fixIndex);
+    expect(fixIndex).toBeLessThan(failedIndex);
   });
 
   it('is immutable and increments the recovery version', () => {

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -378,6 +378,31 @@ describe('PlanGraph — insertFixItTask', () => {
     expect(g2.getTask(createTaskId('b'))?.dependsOn).toEqual([createTaskId('fix-b')]);
   });
 
+  it('deduplicates failed task and explicit fix task dependencies', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('setup'))
+      .addTask(makeTask('b'), [createTaskId('a')]);
+    const fix = makeTask('fix-b', { dependsOn: [createTaskId('a'), createTaskId('setup')] });
+
+    const g2 = g.insertFixItTask(createTaskId('b'), fix);
+
+    expect(g2.getDependencies(createTaskId('fix-b'))).toEqual([
+      createTaskId('a'),
+      createTaskId('setup'),
+    ]);
+    expect(g2.getTask(createTaskId('fix-b'))?.dependsOn).toEqual([
+      createTaskId('a'),
+      createTaskId('setup'),
+    ]);
+    expect(g2.topoSort().map((task) => task.id)).toEqual([
+      createTaskId('a'),
+      createTaskId('setup'),
+      createTaskId('fix-b'),
+      createTaskId('b'),
+    ]);
+  });
+
   it('is immutable and increments the recovery version', () => {
     const g = PlanGraph.empty().addTask(makeTask('a'));
 


### PR DESCRIPTION
## Summary
- Adds a targeted PlanGraph regression for fix-it tasks whose explicit dependencies overlap the failed task dependencies.
- Verifies insertFixItTask keeps the merged dependency list deduplicated and still sorts the fix task before the failed task.

## Test Plan
- npm run test --workspace @franken/planner -- tests/unit/core/dag.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/planner
- npm run build --workspace @franken/planner
- npm run lint --workspace @franken/planner
- npx turbo run test --filter=@franken/planner

Closes #1042
