### PR TITLE
fix(planner): handle domain errors before execution

### DIFF
--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -47,8 +47,28 @@ export class Planner {
   ) {}
 
   async plan(rawInput: string): Promise<PlanResult> {
+    return this.executePlan(rawInput);
+  }
+
+  private async executePlan(rawInput: string): Promise<PlanResult> {
+    let graph: PlanGraph;
     try {
-      return await this.executePlan(rawInput);
+      // 1. Sanitize via MOD-01
+      const intent = await this.guardrails.getSanitizedIntent(rawInput);
+
+      // 2. Build task graph
+      graph = await this.graphBuilder.build(intent);
+
+      // 3. HITL approval gate
+      const markdown = this.planExporter.toMarkdown(graph);
+      const approval = await this.hitlGate.requestApproval(markdown);
+
+      if (approval.decision === 'aborted') {
+        return { status: 'aborted', reason: approval.reason };
+      }
+      if (approval.decision === 'modified') {
+        graph = applyModifications(graph, approval.changes);
+      }
     } catch (err) {
       if (err instanceof RationaleRejectedError) {
         return { status: 'rationale_rejected', taskId: createTaskId(err.taskId) };
@@ -57,25 +77,6 @@ export class Planner {
         return Planner.toStrategyDomainFailure(err);
       }
       throw err;
-    }
-  }
-
-  private async executePlan(rawInput: string): Promise<PlanResult> {
-    // 1. Sanitize via MOD-01
-    const intent = await this.guardrails.getSanitizedIntent(rawInput);
-
-    // 2. Build task graph
-    let graph = await this.graphBuilder.build(intent);
-
-    // 3. HITL approval gate
-    const markdown = this.planExporter.toMarkdown(graph);
-    const approval = await this.hitlGate.requestApproval(markdown);
-
-    if (approval.decision === 'aborted') {
-      return { status: 'aborted', reason: approval.reason };
-    }
-    if (approval.decision === 'modified') {
-      graph = applyModifications(graph, approval.changes);
     }
 
     // 4. Optionally wrap executor with CoT gate (MOD-07)

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -47,6 +47,20 @@ export class Planner {
   ) {}
 
   async plan(rawInput: string): Promise<PlanResult> {
+    try {
+      return await this.executePlan(rawInput);
+    } catch (err) {
+      if (err instanceof RationaleRejectedError) {
+        return { status: 'rationale_rejected', taskId: createTaskId(err.taskId) };
+      }
+      if (Planner.isStrategyDomainError(err)) {
+        return Planner.toStrategyDomainFailure(err);
+      }
+      throw err;
+    }
+  }
+
+  private async executePlan(rawInput: string): Promise<PlanResult> {
     // 1. Sanitize via MOD-01
     const intent = await this.guardrails.getSanitizedIntent(rawInput);
 

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -7,6 +7,7 @@ import { RecoveryController } from '../../src/recovery/recovery-controller';
 import { PlanGraph } from '../../src/core/dag';
 import {
   CyclicDependencyError,
+  DuplicateTaskError,
   MaxRecoveryAttemptsError,
   RecursionDepthExceededError,
   TaskNotFoundError,
@@ -355,6 +356,17 @@ describe('Planner — self-correction loop', () => {
       { failedTaskId: createTaskId('t-1'), attempt: 1 },
       { failedTaskId: createTaskId('fix-t-1-attempt-1'), attempt: 2 },
     ]);
+  });
+
+  it('does not convert recovery graph domain errors into synthetic planner failures', async () => {
+    const graph = PlanGraph.empty().addTask(makeTask('t-1'));
+    const error = new DuplicateTaskError('fix-t-1-attempt-1');
+    const executor = vi.fn().mockResolvedValue(failure('t-1', 'disk full'));
+    const recovery = { recover: vi.fn().mockRejectedValue(error) };
+
+    const { planner } = buildPlanner({ graph, executor, recovery });
+
+    await expect(planner.plan('do something')).rejects.toBe(error);
   });
 
   it('returns failed when error is unknown (no known fix)', async () => {

--- a/packages/franken-planner/tests/unit/planner.test.ts
+++ b/packages/franken-planner/tests/unit/planner.test.ts
@@ -427,7 +427,56 @@ describe('Planner — self-correction loop', () => {
   });
 });
 
-describe('Planner — strategy domain exceptions', () => {
+describe('Planner — domain exceptions', () => {
+  it('converts cyclic graph export errors before HITL into failed plan results', async () => {
+    const a = makeTask('a');
+    const b = makeTask('b');
+    const graph = PlanGraph.createWithRawEdges(
+      new Map([
+        [a.id, a],
+        [b.id, b],
+      ]),
+      new Map([
+        [a.id, new Set([b.id])],
+        [b.id, new Set([a.id])],
+      ])
+    );
+    const hitlGate: HITLGate = { requestApproval: vi.fn().mockResolvedValue({ decision: 'approved' }) };
+    const recovery = { recover: vi.fn() };
+
+    const { planner } = buildPlanner({ graph, hitlGate, recovery });
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
+    expect(result.error).toBeInstanceOf(CyclicDependencyError);
+    expect(hitlGate.requestApproval).not.toHaveBeenCalled();
+    expect(recovery.recover).not.toHaveBeenCalled();
+  });
+
+  it('converts graph builder recursion depth errors into failed plan results', async () => {
+    const error = new RecursionDepthExceededError(11);
+    const graphBuilder: GraphBuilder = { build: vi.fn().mockRejectedValue(error) };
+    const recovery = { recover: vi.fn() };
+    const planner = new Planner(
+      makeGuardrails(),
+      graphBuilder,
+      vi.fn().mockResolvedValue(success('t-1')),
+      new StubHITLGate(),
+      new LinearPlanner(),
+      recovery
+    );
+
+    const result = await planner.plan('do something');
+
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') throw new Error('unexpected');
+    expect(result.failedTaskId).toBe(createTaskId('planner-domain-error'));
+    expect(result.error).toBe(error);
+    expect(recovery.recover).not.toHaveBeenCalled();
+  });
+
   it('converts cyclic dependency errors from strategies into failed plan results', async () => {
     const graph = PlanGraph.empty().addTask(makeTask('t-1'));
     const error = new CyclicDependencyError('Graph contains a cycle');


### PR DESCRIPTION
## Summary
- Converts planner-domain exceptions raised before strategy execution into failed plan results
- Adds regression coverage for cyclic graph export failures and graph-builder recursion-depth failures

## Test Plan
- npm run test --workspace @franken/planner -- tests/unit/planner.test.ts
- npm run test --workspace @franken/planner
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/planner
- npm run lint --workspace @franken/planner
- npm run build --workspace @franken/planner
- npx turbo run test --filter=@franken/planner

Closes #1041