### PR TITLE
test(vitest): parse suite env flags strictly

### DIFF
--- a/packages/franken-observer/src/vitest-discovery.test.ts
+++ b/packages/franken-observer/src/vitest-discovery.test.ts
@@ -2,7 +2,14 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+type VitestConfig = {
+  test?: {
+    include?: string[];
+    exclude?: string[];
+  };
+};
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const discoverySmokeTimeoutMs = 20_000;
@@ -58,6 +65,42 @@ describe('observer Vitest discovery', () => {
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/No test files found|No test files matched/u);
     }
   }, discoverySmokeTimeoutMs);
+
+  it('treats false-like suite flags as default unit test selection', async () => {
+    const originalEnv = {
+      INTEGRATION: process.env['INTEGRATION'],
+      EVAL: process.env['EVAL'],
+    };
+
+    try {
+      for (const env of [{ INTEGRATION: 'false' }, { INTEGRATION: '0' }, { EVAL: 'false' }]) {
+        vi.resetModules();
+        for (const name of ['INTEGRATION', 'EVAL'] as const) {
+          const value = env[name];
+          if (value === undefined) {
+            delete process.env[name];
+          } else {
+            process.env[name] = value;
+          }
+        }
+
+        const module = await import('../vitest.config.ts');
+        const config = module.default as VitestConfig;
+
+        expect(config.test?.include).toEqual(['src/**/*.test.ts']);
+        expect(config.test?.exclude).toEqual(['src/**/*.integration.test.ts', 'src/**/*.eval.test.ts']);
+      }
+    } finally {
+      for (const [name, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      }
+      vi.resetModules();
+    }
+  });
 
   it('runs the advertised observer eval suite instead of a zero-test placeholder', () => {
     const result = runObserverPackageScript('test:eval');

--- a/packages/franken-orchestrator/test/e2e/e2e-pipeline.test.ts
+++ b/packages/franken-orchestrator/test/e2e/e2e-pipeline.test.ts
@@ -32,6 +32,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { readVitestFlag } from '../../../../scripts/vitest-env.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -39,7 +40,7 @@ const hasE2eProviderCredentials = (): boolean => Boolean(
   process.env['ANTHROPIC_API_KEY'] || process.env['OPENAI_API_KEY'],
 );
 
-describe.skipIf(!process.env['E2E'] || !hasE2eProviderCredentials())('E2E Pipeline', () => {
+describe.skipIf(!readVitestFlag(process.env, 'E2E') || !hasE2eProviderCredentials())('E2E Pipeline', () => {
   let tmpDir: string;
   const designDoc = resolve(__dirname, 'test-design-doc.md');
   const cliBin = resolve(__dirname, '../../dist/cli/run.js');

--- a/packages/franken-orchestrator/tests/e2e/chunk-pipeline.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/chunk-pipeline.test.ts
@@ -13,6 +13,7 @@ import type { GitBranchIsolator } from '../../src/skills/git-branch-isolator.js'
 import { ChunkFileGraphBuilder } from '../../src/planning/chunk-file-graph-builder.js';
 import { FileCheckpointStore } from '../../src/checkpoint/file-checkpoint-store.js';
 import type { PrCreator } from '../../src/closure/pr-creator.js';
+import { readVitestFlag } from '../../../../scripts/vitest-env.js';
 import {
   InMemoryFirewall,
   InMemorySkills,
@@ -24,7 +25,7 @@ import {
   InMemoryHeartbeat,
 } from '../helpers/in-memory-ports.js';
 
-describe.skipIf(!process.env['E2E'])('E2E: Chunk Pipeline', () => {
+describe.skipIf(!readVitestFlag(process.env, 'E2E'))('E2E: Chunk Pipeline', () => {
   let tmpDir: string;
 
   afterEach(() => {

--- a/packages/franken-orchestrator/tests/e2e/cli-e2e.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/cli-e2e.test.ts
@@ -6,11 +6,12 @@ import { fileURLToPath } from 'node:url';
 import { Session } from '../../src/cli/session.js';
 import { getProjectPaths, scaffoldFrankenbeast } from '../../src/cli/project-root.js';
 import type { InterviewIO } from '../../src/planning/interview-loop.js';
+import { readVitestFlag } from '../../../../scripts/vitest-env.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Only run in E2E mode
-const describeE2E = process.env['E2E'] === 'true' ? describe : describe.skip;
+const describeE2E = readVitestFlag(process.env, 'E2E') ? describe : describe.skip;
 
 function mockIO(answers: string[] = ['yes']): InterviewIO {
   let idx = 0;

--- a/packages/franken-orchestrator/tests/e2e/cli-skill-execution.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/cli-skill-execution.test.ts
@@ -25,8 +25,9 @@ import {
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { readVitestFlag } from '../../../../scripts/vitest-env.js';
 
-describe.skipIf(!process.env['E2E'])('E2E: CLI Skill Execution', () => {
+describe.skipIf(!readVitestFlag(process.env, 'E2E'))('E2E: CLI Skill Execution', () => {
   const PROMISE_TAG = 'IMPL_test-chunk_DONE';
   const PROMISE_OUTPUT = `Implementation complete\n<promise>${PROMISE_TAG}</promise>`;
 

--- a/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
+++ b/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
@@ -1,8 +1,53 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { readVitestFlag } from '../../../../scripts/vitest-env.js';
+
+type VitestConfig = {
+  test?: {
+    include?: string[];
+    exclude?: string[];
+  };
+};
+
+async function loadPackageVitestConfig(
+  env: Record<string, string | undefined>,
+  argv: string[] = ['node', 'vitest', 'run'],
+): Promise<VitestConfig> {
+  const originalArgv = process.argv;
+  const originalEnv = {
+    E2E: process.env['E2E'],
+    INTEGRATION: process.env['INTEGRATION'],
+  };
+
+  try {
+    vi.resetModules();
+    process.argv = argv;
+
+    for (const name of ['E2E', 'INTEGRATION'] as const) {
+      const value = env[name];
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+
+    const module = await import('../../vitest.config.ts');
+    return module.default as VitestConfig;
+  } finally {
+    process.argv = originalArgv;
+    for (const [name, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+    vi.resetModules();
+  }
+}
 
 function listTestFiles(dir: string): string[] {
   if (!existsSync(dir)) {
@@ -50,6 +95,33 @@ describe('Vitest environment flags', () => {
     expect(config).toContain("arg.includes('test/e2e/')");
     expect(config).toContain("'tests/e2e/**/*.test.ts'");
     expect(config).toContain("'test/e2e/**/*.test.ts'");
+  });
+
+  it('treats false-like suite flags as default unit test selection', async () => {
+    for (const env of [{ E2E: 'false' }, { E2E: '0' }, { INTEGRATION: 'false' }]) {
+      const config = await loadPackageVitestConfig(env);
+
+      expect(config.test?.include).toEqual(['tests/unit/**/*.test.ts', 'test/**/*.test.ts']);
+      expect(config.test?.exclude).toContain('tests/integration/**/*.test.ts');
+      expect(config.test?.exclude).toContain('tests/e2e/**/*.test.ts');
+      expect(config.test?.exclude).toContain('test/e2e/**/*.test.ts');
+    }
+  });
+
+  it('uses strict E2E parsing in direct-path E2E guards', () => {
+    const packageRoot = resolve(import.meta.dirname, '../..');
+    const directE2eGuards = [
+      'tests/e2e/cli-skill-execution.test.ts',
+      'tests/e2e/chunk-pipeline.test.ts',
+      'tests/e2e/cli-e2e.test.ts',
+      'test/e2e/e2e-pipeline.test.ts',
+    ].map((file) => readFileSync(resolve(packageRoot, file), 'utf8'));
+
+    for (const guard of directE2eGuards) {
+      expect(guard).toContain("readVitestFlag(process.env, 'E2E')");
+      expect(guard).not.toContain("!process.env['E2E']");
+      expect(guard).not.toContain("process.env['E2E'] === 'true'");
+    }
   });
 
   it('keeps every package E2E test tree covered by the E2E include globs', () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-11 — Vitest config env-flag regression tests
+- For Vitest suite-flag fixes, assert false-like env values (`0`, `false`, `no`, blank) preserve the default unit-test include set in package configs, not just helper return values.
+- In Vitest tests, avoid cache-busting variable dynamic imports such as `import(`../vitest.config.ts?case=${...}`)`: Vite cannot statically analyze them. Use a static config import and reset env/argv around each assertion instead.
+
 ## 2026-07-10 — Codex usage-limit handling in issue-to-PR flow
 - If `@codex review` immediately responds with usage-limit, treat it as a hard blocker for the merge gate and stop extra polling. Resume review only after credits are restored and a fresh trigger can produce a current-head clean response.
 


### PR DESCRIPTION
## Summary
- route E2E suite gating through `readVitestFlag` instead of direct `process.env.E2E` checks
- add regression coverage that false-like suite flags keep default unit test discovery active
- strengthen orchestrator and observer Vitest config/discovery tests around strict suite flag parsing

## Test Plan
- [x] `npm exec -- vitest run tests/unit/vitest-env.test.ts` (from `packages/franken-orchestrator`)
- [x] `npm exec -- vitest run src/vitest-discovery.test.ts` (from `packages/franken-observer`)
- [x] dependency builds + typecheck/lint for orchestrator/observer related packages
- [x] `npm run test --workspace @franken/orchestrator`
- [x] `npm run test --workspace @franken/observer`

Closes #1038
