### PR TITLE
test: remove git history assumptions from verification

### DIFF
--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 const ROOT = resolve(import.meta.dirname, '..');
 const exec = (command: string, args: string[]) =>
   execFileSync(command, args, { cwd: ROOT, encoding: 'utf8' }).trim();
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 const ALL_PACKAGES = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
   .filter((entry) => entry.isDirectory() && existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')))
@@ -21,12 +22,13 @@ describe('Chunk 10: full verification pass', () => {
       expect(source).not.toContain(`${pipe} wc -l`);
       expect(source).not.toContain(`${pipe} head`);
       expect(source).not.toContain(['git', 'log'].join(' '));
+      expect(source).toContain("process.platform === 'win32' ? 'npm.cmd' : 'npm'");
     });
   });
 
   describe('workspace resolution', () => {
     it('npm ls @franken/types resolves without errors', () => {
-      const result = spawnSync('npm', ['ls', '@franken/types'], {
+      const result = spawnSync(npmCommand, ['ls', '@franken/types'], {
         cwd: ROOT,
         encoding: 'utf8',
       });

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { execSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dirname, '..');
-const exec = (cmd: string) =>
-  execSync(cmd, { cwd: ROOT, encoding: 'utf8' }).trim();
+const exec = (command: string, args: string[]) =>
+  execFileSync(command, args, { cwd: ROOT, encoding: 'utf8' }).trim();
 
 const ALL_PACKAGES = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
   .filter((entry) => entry.isDirectory() && existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')))
@@ -13,58 +13,38 @@ const ALL_PACKAGES = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: tru
   .sort();
 
 describe('Chunk 10: full verification pass', () => {
+  describe('verification command portability', () => {
+    it('does not rely on shell pipeline parsing in the default suite', () => {
+      const source = readFileSync(import.meta.filename, 'utf8');
+      const pipe = String.fromCharCode(124);
+
+      expect(source).not.toContain(`${pipe} wc -l`);
+      expect(source).not.toContain(`${pipe} head`);
+      expect(source).not.toContain(['git', 'log'].join(' '));
+    });
+  });
+
   describe('workspace resolution', () => {
     it('npm ls @franken/types resolves without errors', () => {
-      // npm ls exits non-zero on errors, so a successful exec means no errors
-      const output = exec('npm ls @franken/types 2>&1');
+      const result = spawnSync('npm', ['ls', '@franken/types'], {
+        cwd: ROOT,
+        encoding: 'utf8',
+      });
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.status).toBe(0);
       expect(output).not.toContain('ERR!');
       expect(output).not.toContain('WARN');
       expect(output).toContain('@franken/types');
     });
   });
 
-  describe('git history preservation', () => {
-    it('packages/franken-types/ has 3+ commits in history', () => {
-      const count = parseInt(
-        exec('git log --oneline packages/franken-types/ | wc -l'),
-        10,
-      );
-      expect(count).toBeGreaterThanOrEqual(3);
-    });
-
-    it('packages/franken-orchestrator/ has 108+ commits in history', () => {
-      const count = parseInt(
-        exec('git log --oneline packages/franken-orchestrator/ | wc -l'),
-        10,
-      );
-      expect(count).toBeGreaterThanOrEqual(108);
-    });
-
-    it('packages/franken-brain/ has commits in history', () => {
-      const count = parseInt(
-        exec('git log --oneline packages/franken-brain/ | wc -l'),
-        10,
-      );
-      expect(count).toBeGreaterThanOrEqual(1);
-    });
-
-    it('git blame shows commit hashes for planner source', () => {
-      const blame = exec(
-        'git blame packages/franken-planner/src/core/dag.ts | head -5',
-      );
-      const hashes = blame
-        .split('\n')
-        .map((line) => line.split(' ')[0])
-        .filter(Boolean);
-      // At least one valid hash should exist
-      expect(hashes.length).toBeGreaterThan(0);
-    });
-  });
-
   describe('no gitlinks in index', () => {
     it('git ls-tree HEAD contains no mode-160000 entries', () => {
-      const output = exec('git ls-tree HEAD');
-      const gitlinks = output.split('\n').filter((l) => l.includes('160000'));
+      const output = exec('git', ['ls-tree', 'HEAD']);
+      const gitlinks = output
+        .split('\n')
+        .filter((line: string) => line.includes('160000'));
       expect(gitlinks).toHaveLength(0);
     });
   });


### PR DESCRIPTION
## Summary
- remove default verify-everything git history/commit-count assertions
- replace shell-string exec usage with argv-based child-process calls
- add a portability regression guard against shell pipelines and git history parsing

## Test Plan
- npm run test:root -- tests/verify-everything.test.ts
- npm run lint
- npm run typecheck
- npm run build

Closes #1036