### PR TITLE
test: derive workspace package fixtures

### DIFF
--- a/tests/helpers/workspaces.ts
+++ b/tests/helpers/workspaces.ts
@@ -1,0 +1,103 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, posix } from "node:path";
+
+export const ROOT = join(import.meta.dirname, "..", "..");
+
+export type PackageJson = {
+  name?: string;
+  version?: string;
+  workspaces?: string[];
+  scripts?: Record<string, string>;
+  license?: string;
+  description?: string;
+  keywords?: string[];
+  author?: string;
+  private?: boolean;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
+};
+
+export type WorkspacePackage = {
+  dir: string;
+  manifestPath: string;
+  name: string;
+  packageDirName: string;
+  packageJson: PackageJson;
+};
+
+// Preserve the historical loose JSON fixture typing used by root tests while
+// allowing callers to opt into a narrower manifest shape when useful.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LooseJson = Record<string, any>;
+
+export const readJson = <T = LooseJson>(rel: string): T =>
+  JSON.parse(readFileSync(join(ROOT, rel), "utf8")) as T;
+
+const expandWorkspacePackageDirs = (workspaces: string[]): string[] => {
+  const packageDirs = new Set<string>();
+
+  for (const workspace of workspaces) {
+    if (
+      workspace.endsWith("/*") &&
+      workspace.indexOf("*") === workspace.length - 1
+    ) {
+      const parentDir = workspace.slice(0, -2);
+      for (const entry of readdirSync(join(ROOT, parentDir), {
+        withFileTypes: true,
+      })) {
+        if (!entry.isDirectory()) continue;
+        const manifestPath = join(parentDir, entry.name, "package.json");
+        if (existsSync(join(ROOT, manifestPath))) {
+          packageDirs.add(posix.join(parentDir, entry.name));
+        }
+      }
+      continue;
+    }
+
+    if (
+      !workspace.includes("*") &&
+      existsSync(join(ROOT, workspace, "package.json"))
+    ) {
+      packageDirs.add(workspace);
+      continue;
+    }
+
+    throw new Error(
+      `Unsupported workspace glob in root package.json: ${workspace}`,
+    );
+  }
+
+  return [...packageDirs].sort();
+};
+
+export const getWorkspacePackages = (): WorkspacePackage[] => {
+  const rootPkg = readJson<PackageJson>("package.json");
+  return expandWorkspacePackageDirs(rootPkg.workspaces ?? []).map((dir) => {
+    const manifestPath = `${dir}/package.json`;
+    const packageJson = readJson<PackageJson>(manifestPath);
+    if (typeof packageJson.name !== "string" || packageJson.name.length === 0) {
+      throw new Error(`${manifestPath} must declare a package name`);
+    }
+
+    return {
+      dir,
+      manifestPath,
+      name: packageJson.name,
+      packageDirName: dir.slice("packages/".length),
+      packageJson,
+    };
+  });
+};
+
+export const getWorkspacePackageDirNames = (): string[] =>
+  getWorkspacePackages().map(
+    (workspacePackage) => workspacePackage.packageDirName,
+  );
+
+export const getWorkspacePackageManifestPaths = (): string[] =>
+  getWorkspacePackages().map(
+    (workspacePackage) => workspacePackage.manifestPath,
+  );

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -1,48 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, posix } from 'node:path';
-
-const ROOT = join(import.meta.dirname, '..');
-const readJson = (rel: string) =>
-  JSON.parse(readFileSync(join(ROOT, rel), 'utf8'));
-
-type PackageJson = {
-  name?: string;
-  workspaces?: string[];
-};
-
-type WorkspacePackage = {
-  dir: string;
-  manifestPath: string;
-  name: string;
-};
-
-const expandWorkspacePackageDirs = (workspaces: string[]): string[] => {
-  const packageDirs = new Set<string>();
-
-  for (const workspace of workspaces) {
-    if (workspace.endsWith('/*') && workspace.indexOf('*') === workspace.length - 1) {
-      const parentDir = workspace.slice(0, -2);
-      for (const entry of readdirSync(join(ROOT, parentDir), { withFileTypes: true })) {
-        if (!entry.isDirectory()) continue;
-        const manifestPath = join(parentDir, entry.name, 'package.json');
-        if (existsSync(join(ROOT, manifestPath))) {
-          packageDirs.add(posix.join(parentDir, entry.name));
-        }
-      }
-      continue;
-    }
-
-    if (!workspace.includes('*') && existsSync(join(ROOT, workspace, 'package.json'))) {
-      packageDirs.add(workspace);
-      continue;
-    }
-
-    throw new Error(`Unsupported workspace glob in tsconfig path test: ${workspace}`);
-  }
-
-  return [...packageDirs].sort();
-};
+import { describe, it, expect } from "vitest";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ROOT, readJson, getWorkspacePackages } from "./helpers/workspaces.js";
 
 const hasTypeScriptSource = (relDir: string): boolean => {
   const absDir = join(ROOT, relDir);
@@ -51,7 +10,7 @@ const hasTypeScriptSource = (relDir: string): boolean => {
   for (const entry of readdirSync(absDir, { withFileTypes: true })) {
     const relPath = `${relDir}/${entry.name}`;
     if (entry.isDirectory()) {
-      if (entry.name === 'dist' || entry.name === 'node_modules') continue;
+      if (entry.name === "dist" || entry.name === "node_modules") continue;
       if (hasTypeScriptSource(relPath)) return true;
       continue;
     }
@@ -64,64 +23,61 @@ const hasTypeScriptSource = (relDir: string): boolean => {
   return false;
 };
 
-const getWorkspacePackages = (): WorkspacePackage[] => {
-  const rootPkg = readJson('package.json') as PackageJson;
-  return expandWorkspacePackageDirs(rootPkg.workspaces ?? []).map((dir) => {
-    const manifestPath = `${dir}/package.json`;
-    const pkg = readJson(manifestPath) as PackageJson;
-    if (typeof pkg.name !== 'string' || pkg.name.length === 0) {
-      throw new Error(`${manifestPath} must declare a package name`);
-    }
-
-    return { dir, manifestPath, name: pkg.name };
-  });
-};
-
 const workspacePackages = getWorkspacePackages();
 
 const EXPECTED_ALIASES: Record<string, string> = {
-  '@franken/brain': './packages/franken-brain/src/index.ts',
-  '@franken/planner': './packages/franken-planner/src/index.ts',
-  '@franken/observer': './packages/franken-observer/src/index.ts',
-  '@franken/critique': './packages/franken-critique/src/index.ts',
-  '@franken/governor': './packages/franken-governor/src/index.ts',
-  '@franken/types/path-containment': './packages/franken-types/src/path-containment.ts',
-  '@franken/types/utils': './packages/franken-types/src/utils/index.ts',
-  '@franken/types': './packages/franken-types/src/index.ts',
-  '@franken/orchestrator': './packages/franken-orchestrator/src/index.ts',
+  "@franken/brain": "./packages/franken-brain/src/index.ts",
+  "@franken/planner": "./packages/franken-planner/src/index.ts",
+  "@franken/observer": "./packages/franken-observer/src/index.ts",
+  "@franken/critique": "./packages/franken-critique/src/index.ts",
+  "@franken/governor": "./packages/franken-governor/src/index.ts",
+  "@franken/types/path-containment":
+    "./packages/franken-types/src/path-containment.ts",
+  "@franken/types/utils": "./packages/franken-types/src/utils/index.ts",
+  "@franken/types": "./packages/franken-types/src/index.ts",
+  "@franken/orchestrator": "./packages/franken-orchestrator/src/index.ts",
 };
 
 const ALIASED_WORKSPACE_PACKAGES = new Set(
   workspacePackages
     .filter((workspacePackage) =>
       Object.keys(EXPECTED_ALIASES).some(
-        (alias) => alias === workspacePackage.name || alias.startsWith(`${workspacePackage.name}/`),
+        (alias) =>
+          alias === workspacePackage.name ||
+          alias.startsWith(`${workspacePackage.name}/`),
       ),
     )
     .map((workspacePackage) => workspacePackage.name),
 );
 
 const PATH_ALIAS_ALLOWLIST: Record<string, string> = {
-  '@franken/live-bench': 'CLI-only benchmark workspace; consumers should use the package build/bin instead of a root source alias.',
-  '@franken/mcp-suite': 'CLI/server package with package-level Vitest aliases; no root @franken source alias is exported intentionally.',
-  '@franken/web': 'Vite application workspace, not an importable library entrypoint.',
+  "@franken/live-bench":
+    "CLI-only benchmark workspace; consumers should use the package build/bin instead of a root source alias.",
+  "@franken/mcp-suite":
+    "CLI/server package with package-level Vitest aliases; no root @franken source alias is exported intentionally.",
+  "@franken/web":
+    "Vite application workspace, not an importable library entrypoint.",
 };
 
 const TSCONFIG_TEST_INCLUDE_ALLOWLIST: Record<string, string> = {
-  '@franken/live-bench': 'Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI package settings.',
-  '@franken/mcp-suite': 'Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI/server package settings.',
+  "@franken/live-bench":
+    "Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI package settings.",
+  "@franken/mcp-suite":
+    "Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI/server package settings.",
 };
 
-describe('tsconfig.json path aliases', () => {
-  const tsconfig = readJson('tsconfig.json');
+describe("tsconfig.json path aliases", () => {
+  const tsconfig = readJson("tsconfig.json");
   const paths = tsconfig.compilerOptions?.paths;
 
-  it('has paths defined', () => {
+  it("has paths defined", () => {
     expect(paths).toBeDefined();
   });
 
-  it('has the expected aliases', () => {
-    expect(Object.keys(paths)).toHaveLength(Object.keys(EXPECTED_ALIASES).length);
+  it("has the expected aliases", () => {
+    expect(Object.keys(paths)).toHaveLength(
+      Object.keys(EXPECTED_ALIASES).length,
+    );
   });
 
   for (const [alias, expectedPath] of Object.entries(EXPECTED_ALIASES)) {
@@ -130,14 +86,18 @@ describe('tsconfig.json path aliases', () => {
     });
   }
 
-  it('exposes only @franken-scoped first-party aliases', () => {
-    expect(Object.keys(paths).sort()).toEqual(Object.keys(EXPECTED_ALIASES).sort());
+  it("exposes only @franken-scoped first-party aliases", () => {
+    expect(Object.keys(paths).sort()).toEqual(
+      Object.keys(EXPECTED_ALIASES).sort(),
+    );
     for (const alias of Object.keys(paths)) {
-      expect(alias, `${alias} must use the canonical @franken scope`).toMatch(/^@franken\//);
+      expect(alias, `${alias} must use the canonical @franken scope`).toMatch(
+        /^@franken\//,
+      );
     }
   });
 
-  it('keeps every source workspace either aliased or explicitly allowlisted', () => {
+  it("keeps every source workspace either aliased or explicitly allowlisted", () => {
     for (const workspacePackage of workspacePackages) {
       if (!hasTypeScriptSource(`${workspacePackage.dir}/src`)) continue;
       const isAliased = ALIASED_WORKSPACE_PACKAGES.has(workspacePackage.name);
@@ -150,77 +110,119 @@ describe('tsconfig.json path aliases', () => {
     }
   });
 
-  it('has no stale path alias allowlist entries', () => {
-    const workspacePackageNames = new Set(workspacePackages.map((workspacePackage) => workspacePackage.name));
+  it("has no stale path alias allowlist entries", () => {
+    const workspacePackageNames = new Set(
+      workspacePackages.map((workspacePackage) => workspacePackage.name),
+    );
     for (const [packageName, reason] of Object.entries(PATH_ALIAS_ALLOWLIST)) {
-      expect(workspacePackageNames.has(packageName), `${packageName} is no longer a workspace package`).toBe(true);
-      expect(ALIASED_WORKSPACE_PACKAGES.has(packageName), `${packageName} now has a root alias; remove it from PATH_ALIAS_ALLOWLIST`).toBe(false);
-      expect(reason.trim(), `${packageName} allowlist entry must explain why no root alias is expected`).not.toBe('');
+      expect(
+        workspacePackageNames.has(packageName),
+        `${packageName} is no longer a workspace package`,
+      ).toBe(true);
+      expect(
+        ALIASED_WORKSPACE_PACKAGES.has(packageName),
+        `${packageName} now has a root alias; remove it from PATH_ALIAS_ALLOWLIST`,
+      ).toBe(false);
+      expect(
+        reason.trim(),
+        `${packageName} allowlist entry must explain why no root alias is expected`,
+      ).not.toBe("");
     }
   });
 
-  it('has no root-level module paths (no ./franken-* or ./frankenfirewall/)', () => {
-    const raw = readFileSync(join(ROOT, 'tsconfig.json'), 'utf8');
+  it("has no root-level module paths (no ./franken-* or ./frankenfirewall/)", () => {
+    const raw = readFileSync(join(ROOT, "tsconfig.json"), "utf8");
     // Should not match paths like "./franken-brain/" or "./frankenfirewall/"
     // but should match "./packages/franken-brain/" etc.
     expect(raw).not.toMatch(/"\.\/franken-[^"]*\/src/);
     expect(raw).not.toMatch(/"\.\/frankenfirewall\/src/);
   });
 
-  it('keeps include as empty array', () => {
+  it("keeps include as empty array", () => {
     expect(tsconfig.include).toEqual([]);
   });
 });
 
-describe('tsconfig.test.json includes', () => {
-  const tsconfigTest = readJson('tsconfig.test.json');
+describe("tsconfig.test.json includes", () => {
+  const tsconfigTest = readJson("tsconfig.test.json");
   const includes = tsconfigTest.include;
 
-  it('has include array', () => {
+  it("has include array", () => {
     expect(includes).toBeDefined();
     expect(Array.isArray(includes)).toBe(true);
   });
 
-  it('includes tests/**/*', () => {
-    expect(includes).toContain('tests/**/*');
+  it("includes tests/**/*", () => {
+    expect(includes).toContain("tests/**/*");
   });
 
-  it('includes or explicitly allowlists every workspace package with TypeScript source in src/', () => {
+  it("includes or explicitly allowlists every workspace package with TypeScript source in src/", () => {
     const missingPackages = workspacePackages
-      .filter((workspacePackage) => hasTypeScriptSource(`${workspacePackage.dir}/src`))
-      .filter((workspacePackage) => !includes.includes(`${workspacePackage.dir}/src/**/*`))
-      .filter((workspacePackage) => TSCONFIG_TEST_INCLUDE_ALLOWLIST[workspacePackage.name] === undefined);
+      .filter((workspacePackage) =>
+        hasTypeScriptSource(`${workspacePackage.dir}/src`),
+      )
+      .filter(
+        (workspacePackage) =>
+          !includes.includes(`${workspacePackage.dir}/src/**/*`),
+      )
+      .filter(
+        (workspacePackage) =>
+          TSCONFIG_TEST_INCLUDE_ALLOWLIST[workspacePackage.name] === undefined,
+      );
 
     expect(
       missingPackages.map((workspacePackage) => workspacePackage.name),
-      'Workspace packages with TypeScript source must be included in tsconfig.test.json or intentionally allowlisted by this test',
+      "Workspace packages with TypeScript source must be included in tsconfig.test.json or intentionally allowlisted by this test",
     ).toEqual([]);
   });
 
-  it('has no stale tsconfig.test include allowlist entries', () => {
-    const workspacePackageNames = new Set(workspacePackages.map((workspacePackage) => workspacePackage.name));
-    for (const [packageName, reason] of Object.entries(TSCONFIG_TEST_INCLUDE_ALLOWLIST)) {
-      expect(workspacePackageNames.has(packageName), `${packageName} is no longer a workspace package`).toBe(true);
-      const workspacePackage = workspacePackages.find((candidate) => candidate.name === packageName);
+  it("has no stale tsconfig.test include allowlist entries", () => {
+    const workspacePackageNames = new Set(
+      workspacePackages.map((workspacePackage) => workspacePackage.name),
+    );
+    for (const [packageName, reason] of Object.entries(
+      TSCONFIG_TEST_INCLUDE_ALLOWLIST,
+    )) {
+      expect(
+        workspacePackageNames.has(packageName),
+        `${packageName} is no longer a workspace package`,
+      ).toBe(true);
+      const workspacePackage = workspacePackages.find(
+        (candidate) => candidate.name === packageName,
+      );
       expect(
         includes.includes(`${workspacePackage?.dir}/src/**/*`),
         `${packageName} is now included in tsconfig.test.json; remove it from TSCONFIG_TEST_INCLUDE_ALLOWLIST`,
       ).toBe(false);
-      expect(reason.trim(), `${packageName} tsconfig.test include allowlist entry must explain the exclusion`).not.toBe('');
+      expect(
+        reason.trim(),
+        `${packageName} tsconfig.test include allowlist entry must explain the exclusion`,
+      ).not.toBe("");
     }
   });
 
-  it('has no stale workspace package src includes', () => {
-    const workspacePackageDirs = new Set(workspacePackages.map((workspacePackage) => workspacePackage.dir));
+  it("has no stale workspace package src includes", () => {
+    const workspacePackageDirs = new Set(
+      workspacePackages.map((workspacePackage) => workspacePackage.dir),
+    );
     const staleIncludes = includes
-      .filter((include: string) => include.startsWith('packages/') && include.endsWith('/src/**/*'))
-      .filter((include: string) => !workspacePackageDirs.has(include.slice(0, -'/src/**/*'.length)));
+      .filter(
+        (include: string) =>
+          include.startsWith("packages/") && include.endsWith("/src/**/*"),
+      )
+      .filter(
+        (include: string) =>
+          !workspacePackageDirs.has(include.slice(0, -"/src/**/*".length)),
+      );
 
-    expect(staleIncludes, 'tsconfig.test.json contains includes for packages that are no longer workspaces').toEqual([]);
+    expect(
+      staleIncludes,
+      "tsconfig.test.json contains includes for packages that are no longer workspaces",
+    ).toEqual([]);
   });
 
-  it('has no root-level module paths (no franken-*/src or frankenfirewall/src)', () => {
-    const raw = readFileSync(join(ROOT, 'tsconfig.test.json'), 'utf8');
+  it("has no root-level module paths (no franken-*/src or frankenfirewall/src)", () => {
+    const raw = readFileSync(join(ROOT, "tsconfig.test.json"), "utf8");
     // Should not match bare module paths like "franken-brain/src"
     // but should match "packages/franken-brain/src"
     expect(raw).not.toMatch(/"franken-[^"]*\/src/);

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -1,15 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { ROOT, readJson, getWorkspacePackages } from "./helpers/workspaces.js";
 
-const ROOT = join(import.meta.dirname, '..');
-const readJson = (rel: string) =>
-  JSON.parse(readFileSync(join(ROOT, rel), 'utf8'));
 const readPackageScripts = () =>
-  readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+  readdirSync(join(ROOT, "packages"), { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .flatMap((entry) => {
-      const manifestPath = join('packages', entry.name, 'package.json');
+      const manifestPath = join("packages", entry.name, "package.json");
       if (!existsSync(join(ROOT, manifestPath))) {
         return [];
       }
@@ -17,57 +15,57 @@ const readPackageScripts = () =>
       return [manifest.scripts ?? {}];
     });
 
-describe('Turborepo configuration', () => {
-  describe('turbo.json', () => {
-    it('exists at project root', () => {
-      expect(existsSync(join(ROOT, 'turbo.json'))).toBe(true);
+describe("Turborepo configuration", () => {
+  describe("turbo.json", () => {
+    it("exists at project root", () => {
+      expect(existsSync(join(ROOT, "turbo.json"))).toBe(true);
     });
 
-    it('defines build task with ^build dependency and dist outputs', () => {
-      const turbo = readJson('turbo.json');
+    it("defines build task with ^build dependency and dist outputs", () => {
+      const turbo = readJson("turbo.json");
       const buildTask = turbo.tasks?.build;
       expect(buildTask).toBeDefined();
-      expect(buildTask.dependsOn).toContain('^build');
-      expect(buildTask.outputs).toContain('dist/**');
+      expect(buildTask.dependsOn).toContain("^build");
+      expect(buildTask.outputs).toContain("dist/**");
     });
 
-    it('defines test task without a build dependency for source-alias watch mode', () => {
-      const turbo = readJson('turbo.json');
+    it("defines test task without a build dependency for source-alias watch mode", () => {
+      const turbo = readJson("turbo.json");
       const testTask = turbo.tasks?.test;
       expect(testTask).toBeDefined();
       expect(testTask.dependsOn).toBeUndefined();
     });
 
-    it('hashes cross-package Vitest source aliases and root setup scripts for cached test tasks', () => {
-      const turbo = readJson('turbo.json');
+    it("hashes cross-package Vitest source aliases and root setup scripts for cached test tasks", () => {
+      const turbo = readJson("turbo.json");
       const testTask = turbo.tasks?.test;
       expect(testTask).toBeDefined();
       expect(testTask.inputs).toEqual(
         expect.arrayContaining([
-          '$TURBO_DEFAULT$',
-          '$TURBO_ROOT$/scripts/vitest-*.ts',
-          '$TURBO_ROOT$/packages/*/src/**',
+          "$TURBO_DEFAULT$",
+          "$TURBO_ROOT$/scripts/vitest-*.ts",
+          "$TURBO_ROOT$/packages/*/src/**",
         ]),
       );
     });
 
-    it('hashes suite-selection environment variables for cached test tasks', () => {
-      const turbo = readJson('turbo.json');
+    it("hashes suite-selection environment variables for cached test tasks", () => {
+      const turbo = readJson("turbo.json");
       const testTask = turbo.tasks?.test;
       expect(testTask).toBeDefined();
       expect(testTask.env).toEqual(
-        expect.arrayContaining(['INTEGRATION', 'E2E', 'EVAL', 'DOCKER_BUILD']),
+        expect.arrayContaining(["INTEGRATION", "E2E", "EVAL", "DOCKER_BUILD"]),
       );
     });
 
-    it('does not define a stale test:ci Turbo task', () => {
-      const turbo = readJson('turbo.json');
-      expect(turbo.tasks?.['test:ci']).toBeUndefined();
+    it("does not define a stale test:ci Turbo task", () => {
+      const turbo = readJson("turbo.json");
+      expect(turbo.tasks?.["test:ci"]).toBeUndefined();
     });
 
-    it('keeps every Turbo task discoverable from root or package scripts', () => {
-      const turbo = readJson('turbo.json');
-      const rootPkg = readJson('package.json');
+    it("keeps every Turbo task discoverable from root or package scripts", () => {
+      const turbo = readJson("turbo.json");
+      const rootPkg = readJson("package.json");
       const packageScripts = readPackageScripts();
 
       for (const taskName of Object.keys(turbo.tasks ?? {})) {
@@ -79,7 +77,7 @@ describe('Turborepo configuration', () => {
           rootPkg.scripts ?? {},
         ).some(
           (script) =>
-            typeof script === 'string' &&
+            typeof script === "string" &&
             script.includes(`turbo run ${taskName}`),
         );
 
@@ -89,45 +87,45 @@ describe('Turborepo configuration', () => {
       }
     });
 
-    it('defines an explicit live-bench live test task', () => {
-      const turbo = readJson('turbo.json');
-      const liveBenchTask = turbo.tasks?.['test:live'];
+    it("defines an explicit live-bench live test task", () => {
+      const turbo = readJson("turbo.json");
+      const liveBenchTask = turbo.tasks?.["test:live"];
       expect(liveBenchTask).toBeDefined();
       expect(liveBenchTask.cache).toBe(false);
-      expect(liveBenchTask.dependsOn).toContain('build');
-      expect(liveBenchTask.env).toContain('FBEAST_LIVE_BENCH_E2E');
+      expect(liveBenchTask.dependsOn).toContain("build");
+      expect(liveBenchTask.env).toContain("FBEAST_LIVE_BENCH_E2E");
     });
 
-    it('defines typecheck task', () => {
-      const turbo = readJson('turbo.json');
+    it("defines typecheck task", () => {
+      const turbo = readJson("turbo.json");
       expect(turbo.tasks?.typecheck).toBeDefined();
     });
 
-    it('defines lint task with no dependencies (runs in parallel)', () => {
-      const turbo = readJson('turbo.json');
+    it("defines lint task with no dependencies (runs in parallel)", () => {
+      const turbo = readJson("turbo.json");
       const lintTask = turbo.tasks?.lint;
       expect(lintTask).toBeDefined();
       expect(lintTask.dependsOn).toBeUndefined();
       expect(lintTask.inputs).toEqual(
         expect.arrayContaining([
-          '$TURBO_DEFAULT$',
-          '$TURBO_ROOT$/eslint.workspace.config.js',
+          "$TURBO_DEFAULT$",
+          "$TURBO_ROOT$/eslint.workspace.config.js",
         ]),
       );
     });
   });
 
-  describe('franken-web package turbo.json', () => {
-    it('hashes the root manifest for cached web builds and tests that read the root version', () => {
-      const turbo = readJson('packages/franken-web/turbo.json');
-      expect(turbo.extends).toEqual(['//']);
+  describe("franken-web package turbo.json", () => {
+    it("hashes the root manifest for cached web builds and tests that read the root version", () => {
+      const turbo = readJson("packages/franken-web/turbo.json");
+      expect(turbo.extends).toEqual(["//"]);
 
       const buildTask = turbo.tasks?.build;
       expect(buildTask).toBeDefined();
       expect(buildTask.inputs).toEqual(
         expect.arrayContaining([
-          '$TURBO_DEFAULT$',
-          '$TURBO_ROOT$/package.json',
+          "$TURBO_DEFAULT$",
+          "$TURBO_ROOT$/package.json",
         ]),
       );
 
@@ -135,134 +133,135 @@ describe('Turborepo configuration', () => {
       expect(testTask).toBeDefined();
       expect(testTask.inputs).toEqual(
         expect.arrayContaining([
-          '$TURBO_DEFAULT$',
-          '$TURBO_ROOT$/package.json',
-          '$TURBO_ROOT$/scripts/vitest-*.ts',
-          '$TURBO_ROOT$/packages/*/src/**',
+          "$TURBO_DEFAULT$",
+          "$TURBO_ROOT$/package.json",
+          "$TURBO_ROOT$/scripts/vitest-*.ts",
+          "$TURBO_ROOT$/packages/*/src/**",
         ]),
       );
     });
   });
 
-  describe('root package.json scripts', () => {
-    const rootPkg = readJson('package.json');
+  describe("root package.json scripts", () => {
+    const rootPkg = readJson("package.json");
 
-    it('build script uses turbo run build', () => {
-      expect(rootPkg.scripts.build).toBe('turbo run build');
+    it("build script uses turbo run build", () => {
+      expect(rootPkg.scripts.build).toBe("turbo run build");
     });
 
-    it('test script uses turbo run test', () => {
-      expect(rootPkg.scripts.test).toBe('turbo run test');
+    it("test script uses turbo run test", () => {
+      expect(rootPkg.scripts.test).toBe("turbo run test");
     });
 
-    it('test:ci script runs the same root-plus-package test target as CI', () => {
-      expect(rootPkg.scripts['test:ci']).toBe(
-        'npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages && npm run ci:test:planner-integration',
+    it("test:ci script runs the same root-plus-package test target as CI", () => {
+      expect(rootPkg.scripts["test:ci"]).toBe(
+        "npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages && npm run ci:test:planner-integration",
       );
-      expect(rootPkg.scripts['ci:test:planner-integration']).toBe(
-        'node scripts/retry-ci-command.mjs -- npm run test:integration --workspace @franken/planner',
+      expect(rootPkg.scripts["ci:test:planner-integration"]).toBe(
+        "node scripts/retry-ci-command.mjs -- npm run test:integration --workspace @franken/planner",
       );
 
       const ciWorkflow = readFileSync(
-        join(ROOT, '.github/workflows/ci.yml'),
-        'utf8',
+        join(ROOT, ".github/workflows/ci.yml"),
+        "utf8",
       );
-      expect(ciWorkflow).toContain('run: npm run test:ci');
+      expect(ciWorkflow).toContain("run: npm run test:ci");
     });
 
-    it('typecheck script uses turbo run typecheck', () => {
-      expect(rootPkg.scripts.typecheck).toBe('turbo run typecheck');
+    it("typecheck script uses turbo run typecheck", () => {
+      expect(rootPkg.scripts.typecheck).toBe("turbo run typecheck");
     });
 
-    it('lint script checks workspace coverage before running Turbo lint', () => {
+    it("lint script checks workspace coverage before running Turbo lint", () => {
       expect(rootPkg.scripts.lint).toBe(
-        'node scripts/check-workspace-lint-coverage.mjs && turbo run lint',
+        "node scripts/check-workspace-lint-coverage.mjs && turbo run lint",
       );
 
       const ciWorkflow = readFileSync(
-        join(ROOT, '.github/workflows/ci.yml'),
-        'utf8',
+        join(ROOT, ".github/workflows/ci.yml"),
+        "utf8",
       );
-      expect(ciWorkflow).toContain('run: npm run lint');
+      expect(ciWorkflow).toContain("run: npm run lint");
     });
 
-    it('CI runs the root typecheck Turbo task explicitly', () => {
+    it("CI runs the root typecheck Turbo task explicitly", () => {
       const ciWorkflow = readFileSync(
-        join(ROOT, '.github/workflows/ci.yml'),
-        'utf8',
+        join(ROOT, ".github/workflows/ci.yml"),
+        "utf8",
       );
 
-      expect(rootPkg.scripts.typecheck).toBe('turbo run typecheck');
-      expect(ciWorkflow).toContain('run: npx turbo run build typecheck');
-      expect(ciWorkflow).not.toContain('run: npx turbo run build lint');
-      expect(ciWorkflow).not.toContain('run: npx turbo run build typecheck lint');
+      expect(rootPkg.scripts.typecheck).toBe("turbo run typecheck");
+      expect(ciWorkflow).toContain("run: npx turbo run build typecheck");
+      expect(ciWorkflow).not.toContain("run: npx turbo run build lint");
+      expect(ciWorkflow).not.toContain(
+        "run: npx turbo run build typecheck lint",
+      );
     });
 
-    it('does not have test:all (redundant with turbo)', () => {
-      expect(rootPkg.scripts['test:all']).toBeUndefined();
+    it("does not have test:all (redundant with turbo)", () => {
+      expect(rootPkg.scripts["test:all"]).toBeUndefined();
     });
 
-    it('keeps test:root as vitest run for root-level integration tests', () => {
-      expect(rootPkg.scripts['test:root']).toBe('vitest run');
+    it("keeps test:root as vitest run for root-level integration tests", () => {
+      expect(rootPkg.scripts["test:root"]).toBe("vitest run");
     });
 
-    it('exposes orchestrator E2E tests through a root script', () => {
-      const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
+    it("exposes orchestrator E2E tests through a root script", () => {
+      const readme = readFileSync(join(ROOT, "README.md"), "utf8");
 
-      expect(rootPkg.scripts['test:e2e']).toBe('npm run test:e2e --workspace @franken/orchestrator --');
-      expect(readme).toContain('npm run test:e2e');
-      expect(readme).toContain('E2E=true');
-      expect(readme).toContain('npm run build');
-      expect(readme).not.toContain('npm run build --workspace @franken/orchestrator');
-      expect(readme).toContain('real `claude` CLI on');
-      expect(readme).toContain('provide a valid');
-      expect(readme).toContain('`ANTHROPIC_API_KEY` in the environment');
+      expect(rootPkg.scripts["test:e2e"]).toBe(
+        "npm run test:e2e --workspace @franken/orchestrator --",
+      );
+      expect(readme).toContain("npm run test:e2e");
+      expect(readme).toContain("E2E=true");
+      expect(readme).toContain("npm run build");
+      expect(readme).not.toContain(
+        "npm run build --workspace @franken/orchestrator",
+      );
+      expect(readme).toContain("real `claude` CLI on");
+      expect(readme).toContain("provide a valid");
+      expect(readme).toContain("`ANTHROPIC_API_KEY` in the environment");
     });
 
-    it('keeps test:root:watch as vitest for dev', () => {
-      expect(rootPkg.scripts['test:root:watch']).toBe('vitest');
+    it("keeps test:root:watch as vitest for dev", () => {
+      expect(rootPkg.scripts["test:root:watch"]).toBe("vitest");
     });
 
-    it('exposes the live-bench live suite through an explicit root script', () => {
-      expect(rootPkg.scripts['test:live:bench']).toBe('turbo run test:live --filter=@franken/live-bench');
+    it("exposes the live-bench live suite through an explicit root script", () => {
+      expect(rootPkg.scripts["test:live:bench"]).toBe(
+        "turbo run test:live --filter=@franken/live-bench",
+      );
     });
   });
 
-  describe('turbo devDependency', () => {
-    const rootPkg = readJson('package.json');
+  describe("turbo devDependency", () => {
+    const rootPkg = readJson("package.json");
 
-    it('turbo is in root devDependencies', () => {
+    it("turbo is in root devDependencies", () => {
       expect(rootPkg.devDependencies.turbo).toBeDefined();
     });
   });
 
-  describe('.gitignore includes generated workspace artifacts', () => {
-    it('has .turbo entry', () => {
-      const gitignore = readFileSync(join(ROOT, '.gitignore'), 'utf8');
+  describe(".gitignore includes generated workspace artifacts", () => {
+    it("has .turbo entry", () => {
+      const gitignore = readFileSync(join(ROOT, ".gitignore"), "utf8");
       expect(gitignore).toMatch(/^\.turbo$/m);
     });
 
-    it('ignores the root .tmp directory used by package test scripts', () => {
-      const gitignore = readFileSync(join(ROOT, '.gitignore'), 'utf8');
+    it("ignores the root .tmp directory used by package test scripts", () => {
+      const gitignore = readFileSync(join(ROOT, ".gitignore"), "utf8");
       expect(gitignore).toMatch(/^\.tmp\/$/m);
     });
   });
 
-  describe('all modules use vitest run (not bare vitest) for test script', () => {
-    const allPackages = [
-      'franken-brain',
-      'franken-critique',
-      'franken-governor',
-      'franken-observer',
-      'franken-orchestrator',
-      'franken-planner',
-      'franken-types',
-      'franken-web',
-    ];
+  describe("all modules use vitest run (not bare vitest) for test script", () => {
+    const workspacePackages = getWorkspacePackages();
 
-    for (const module of allPackages) {
-      it(`packages/${module} test script uses "vitest run"`, () => {
-        const pkg = readJson(`packages/${module}/package.json`);
+    for (const workspacePackage of workspacePackages) {
+      it(`${workspacePackage.manifestPath} test script uses "vitest run"`, () => {
+        const pkg = readJson<{ scripts?: Record<string, string> }>(
+          workspacePackage.manifestPath,
+        );
         const testScript = pkg.scripts?.test;
         expect(testScript).toBeDefined();
         expect(testScript).toMatch(/vitest run/);

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -1,57 +1,57 @@
-import { describe, it, expect } from 'vitest';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { describe, it, expect } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { getWorkspacePackageDirNames } from "./helpers/workspaces.js";
 
-const ROOT = resolve(import.meta.dirname, '..');
+const ROOT = resolve(import.meta.dirname, "..");
 const exec = (command: string, args: string[]) =>
-  execFileSync(command, args, { cwd: ROOT, encoding: 'utf8' }).trim();
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  execFileSync(command, args, { cwd: ROOT, encoding: "utf8" }).trim();
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
-const ALL_PACKAGES = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
-  .filter((entry) => entry.isDirectory() && existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')))
-  .map((entry) => entry.name)
-  .sort();
+const ALL_PACKAGES = getWorkspacePackageDirNames();
 
-describe('Chunk 10: full verification pass', () => {
-  describe('verification command portability', () => {
-    it('does not rely on shell pipeline parsing in the default suite', () => {
-      const source = readFileSync(import.meta.filename, 'utf8');
+describe("Chunk 10: full verification pass", () => {
+  describe("verification command portability", () => {
+    it("does not rely on shell pipeline parsing in the default suite", () => {
+      const source = readFileSync(import.meta.filename, "utf8");
       const pipe = String.fromCharCode(124);
 
       expect(source).not.toContain(`${pipe} wc -l`);
       expect(source).not.toContain(`${pipe} head`);
-      expect(source).not.toContain(['git', 'log'].join(' '));
-      expect(source).toContain("process.platform === 'win32' ? 'npm.cmd' : 'npm'");
+      expect(source).not.toContain(["git", "log"].join(" "));
+      expect(source).toContain(
+        "process.platform === 'win32' ? 'npm.cmd' : 'npm'",
+      );
     });
   });
 
-  describe('workspace resolution', () => {
-    it('npm ls @franken/types resolves without errors', () => {
-      const result = spawnSync(npmCommand, ['ls', '@franken/types'], {
+  describe("workspace resolution", () => {
+    it("npm ls @franken/types resolves without errors", () => {
+      const result = spawnSync(npmCommand, ["ls", "@franken/types"], {
         cwd: ROOT,
-        encoding: 'utf8',
+        encoding: "utf8",
       });
       const output = `${result.stdout}\n${result.stderr}`;
 
       expect(result.status).toBe(0);
-      expect(output).not.toContain('ERR!');
-      expect(output).not.toContain('WARN');
-      expect(output).toContain('@franken/types');
+      expect(output).not.toContain("ERR!");
+      expect(output).not.toContain("WARN");
+      expect(output).toContain("@franken/types");
     });
   });
 
-  describe('no gitlinks in index', () => {
-    it('git ls-tree HEAD contains no mode-160000 entries', () => {
-      const output = exec('git', ['ls-tree', 'HEAD']);
+  describe("no gitlinks in index", () => {
+    it("git ls-tree HEAD contains no mode-160000 entries", () => {
+      const output = exec("git", ["ls-tree", "HEAD"]);
       const gitlinks = output
-        .split('\n')
-        .filter((line: string) => line.includes('160000'));
+        .split("\n")
+        .filter((line: string) => line.includes("160000"));
       expect(gitlinks).toHaveLength(0);
     });
   });
 
-  describe('no root-level module directories', () => {
+  describe("no root-level module directories", () => {
     for (const dir of ALL_PACKAGES) {
       it(`${dir}/ should not exist at root level`, () => {
         expect(existsSync(resolve(ROOT, dir))).toBe(false);
@@ -59,10 +59,10 @@ describe('Chunk 10: full verification pass', () => {
     }
   });
 
-  describe('no .git dirs inside packages', () => {
+  describe("no .git dirs inside packages", () => {
     for (const dir of ALL_PACKAGES) {
       it(`packages/${dir}/.git should not exist`, () => {
-        expect(existsSync(resolve(ROOT, 'packages', dir, '.git'))).toBe(false);
+        expect(existsSync(resolve(ROOT, "packages", dir, ".git"))).toBe(false);
       });
     }
   });

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -20,8 +20,8 @@ describe("Chunk 10: full verification pass", () => {
       expect(source).not.toContain(`${pipe} wc -l`);
       expect(source).not.toContain(`${pipe} head`);
       expect(source).not.toContain(["git", "log"].join(" "));
-      expect(source).toContain(
-        "process.platform === 'win32' ? 'npm.cmd' : 'npm'",
+      expect(source).toMatch(
+        /process\.platform\s*===\s*['"]win32['"]\s*\?\s*['"]npm\.cmd['"]\s*:\s*['"]npm['"]/,
       );
     });
   });

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  ROOT,
+  getWorkspacePackageManifestPaths,
+  getWorkspacePackages,
+  readJson,
+} from "./helpers/workspaces.js";
 
-const ROOT = join(import.meta.dirname, "..");
-const readJson = (rel: string) =>
-  JSON.parse(readFileSync(join(ROOT, rel), "utf8"));
 const readPkg = readJson;
 
 const majorMinorPatch = (version: string) => {
@@ -31,6 +34,22 @@ describe("npm workspaces configuration", () => {
 
     it("has workspaces field set to packages/*", () => {
       expect(rootPkg.workspaces).toEqual(["packages/*"]);
+    });
+
+    it("derives the complete package inventory from the workspace glob", () => {
+      const packageDirs = readdirSync(join(ROOT, "packages"), {
+        withFileTypes: true,
+      })
+        .filter((entry) => entry.isDirectory())
+        .filter((entry) =>
+          existsSync(join(ROOT, "packages", entry.name, "package.json")),
+        )
+        .map((entry) => `packages/${entry.name}`)
+        .sort();
+
+      expect(
+        getWorkspacePackages().map((workspacePackage) => workspacePackage.dir),
+      ).toEqual(packageDirs);
     });
 
     it("remains private (required for workspaces)", () => {
@@ -95,11 +114,7 @@ describe("npm workspaces configuration", () => {
   });
 
   describe("workspace coverage scripts", () => {
-    const packageJsonPaths = readdirSync(join(ROOT, "packages"), {
-      withFileTypes: true,
-    })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => `packages/${entry.name}/package.json`);
+    const packageJsonPaths = getWorkspacePackageManifestPaths();
 
     it("registers a Turbo coverage task for package workspaces", () => {
       const turbo = readJson("turbo.json");
@@ -127,9 +142,7 @@ describe("npm workspaces configuration", () => {
     const minimumVitest = "4.1.9";
     const packageJsonPaths = [
       "package.json",
-      ...readdirSync(join(ROOT, "packages"), { withFileTypes: true })
-        .filter((entry) => entry.isDirectory())
-        .map((entry) => `packages/${entry.name}/package.json`),
+      ...getWorkspacePackageManifestPaths(),
     ];
     const dependencySections = [
       "dependencies",
@@ -367,11 +380,7 @@ describe("npm workspaces configuration", () => {
   });
 
   describe("cross-module dependencies use coherent internal versions", () => {
-    const packageJsonPaths = readdirSync(join(ROOT, "packages"), {
-      withFileTypes: true,
-    })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => `packages/${entry.name}/package.json`);
+    const packageJsonPaths = getWorkspacePackageManifestPaths();
     const packageManifests = packageJsonPaths.map((path) => ({
       path,
       pkg: readPkg(path),
@@ -405,11 +414,7 @@ describe("npm workspaces configuration", () => {
   });
 
   describe("publishable package manifests", () => {
-    const packageJsonPaths = readdirSync(join(ROOT, "packages"), {
-      withFileTypes: true,
-    })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => `packages/${entry.name}/package.json`);
+    const packageJsonPaths = getWorkspacePackageManifestPaths();
 
     it("declares the shared MIT license on every publishable package and the top-level README", () => {
       for (const path of packageJsonPaths) {
@@ -482,11 +487,7 @@ describe("npm workspaces configuration", () => {
   });
 
   describe("workspace lint coverage", () => {
-    const packageJsonPaths = readdirSync(join(ROOT, "packages"), {
-      withFileTypes: true,
-    })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => `packages/${entry.name}/package.json`);
+    const packageJsonPaths = getWorkspacePackageManifestPaths();
 
     it("gives every workspace an explicit lint script and ESLint config", () => {
       for (const path of packageJsonPaths) {
@@ -529,8 +530,12 @@ describe("npm workspaces configuration", () => {
       );
 
       expect(auditScript).toContain("fileURLToPath");
-      expect(auditScript).toContain("fileURLToPath(new URL('..', import.meta.url))");
-      expect(auditScript).not.toContain("new URL('..', import.meta.url).pathname");
+      expect(auditScript).toContain(
+        "fileURLToPath(new URL('..', import.meta.url))",
+      );
+      expect(auditScript).not.toContain(
+        "new URL('..', import.meta.url).pathname",
+      );
     });
   });
 
@@ -558,11 +563,7 @@ describe("npm workspaces configuration", () => {
         })),
       );
 
-    const allPackages = readdirSync(join(ROOT, "packages"), {
-      withFileTypes: true,
-    })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
+    const workspacePackages = getWorkspacePackages();
 
     it("scans every dependency bucket that can carry package specifiers", () => {
       const entries = collectDependencyEntries({
@@ -588,13 +589,15 @@ describe("npm workspaces configuration", () => {
       );
     });
 
-    for (const module of allPackages) {
-      it(`packages/${module}/package.json has no file: dependencies`, () => {
-        const pkg = readPkg(`packages/${module}/package.json`);
-        for (const { section, name, version } of collectDependencyEntries(pkg)) {
+    for (const workspacePackage of workspacePackages) {
+      it(`${workspacePackage.manifestPath} has no file: dependencies`, () => {
+        const pkg = readPkg(workspacePackage.manifestPath);
+        for (const { section, name, version } of collectDependencyEntries(
+          pkg,
+        )) {
           expect(
             version,
-            `${name} in ${module} ${section} uses file: path`,
+            `${name} in ${workspacePackage.packageDirName} ${section} uses file: path`,
           ).not.toMatch(/^file:/);
         }
       });
@@ -602,34 +605,20 @@ describe("npm workspaces configuration", () => {
   });
 
   describe("canonical package namespace strategy", () => {
-    const expectedNames: Record<string, string> = {
-      "franken-brain": "@franken/brain",
-      "franken-critique": "@franken/critique",
-      "franken-governor": "@franken/governor",
-      "franken-mcp-suite": "@franken/mcp-suite",
-      "franken-observer": "@franken/observer",
-      "franken-orchestrator": "@franken/orchestrator",
-      "franken-planner": "@franken/planner",
-      "franken-types": "@franken/types",
-      "franken-web": "@franken/web",
-      "live-bench": "@franken/live-bench",
-    };
+    const workspacePackages = getWorkspacePackages();
+    const canonicalNameForPackageDir = (dir: string) =>
+      `@franken/${dir.replace(/^franken-/, "")}`;
 
-    for (const [dir, name] of Object.entries(expectedNames)) {
-      it(`packages/${dir}/package.json uses canonical name "${name}"`, () => {
-        const pkg = readPkg(`packages/${dir}/package.json`);
-        expect(pkg.name).toBe(name);
+    for (const workspacePackage of workspacePackages) {
+      it(`${workspacePackage.manifestPath} uses the canonical @franken package name`, () => {
+        expect(workspacePackage.name).toBe(
+          canonicalNameForPackageDir(workspacePackage.packageDirName),
+        );
       });
     }
 
     it("keeps every publishable package under the @franken npm scope", () => {
-      const allPackageJsonPaths = readdirSync(join(ROOT, "packages"), {
-        withFileTypes: true,
-      })
-        .filter((entry) => entry.isDirectory())
-        .map((entry) => `packages/${entry.name}/package.json`);
-
-      for (const path of allPackageJsonPaths) {
+      for (const path of getWorkspacePackageManifestPaths()) {
         const pkg = readPkg(path);
         if (pkg.private === true) continue;
         expect(


### PR DESCRIPTION
## Summary
- add a shared root test helper that derives workspace packages from the root package.json workspaces glob
- update workspace/package-boundary tests to use derived package manifests instead of stale hard-coded package lists
- add coverage that the derived package inventory matches packages/* manifests

## Test Plan
- npm run test:root -- tests/turborepo.test.ts tests/workspaces.test.ts tests/verify-everything.test.ts tests/tsconfig-paths.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #1035