### PR TITLE
fix(brain): tolerate corrupt persisted JSON rows

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -412,7 +412,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
 
     if (keywords.length <= MAX_RECALL_KEYWORDS_PER_QUERY) {
-      return this.recallKeywordChunk(keywords, limit).map(row => rowToEvent(row));
+      return rowsToEvents(this.recallKeywordChunk(keywords), limit);
     }
 
     const rowsById = new Map<number, EpisodicRow & { relevance_score: number }>();
@@ -433,7 +433,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       || b.id - a.id,
     );
 
-    return (limit < 0 ? sortedRows : sortedRows.slice(0, limit)).map(rowToEvent);
+    return rowsToEvents(sortedRows, limit);
   }
 
   private recallKeywordChunk(
@@ -472,17 +472,17 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     const rows = this.db
       .prepare(
         `SELECT * FROM episodic_events WHERE type = 'failure'
-         ORDER BY created_at DESC LIMIT ?`,
+         ORDER BY created_at DESC`,
       )
-      .all(n) as EpisodicRow[];
-    return rows.map(rowToEvent);
+      .all() as EpisodicRow[];
+    return rowsToEvents(rows, n);
   }
 
   recent(n = 10): EpisodicEvent[] {
     const rows = this.db
-      .prepare(`SELECT * FROM episodic_events ORDER BY created_at DESC LIMIT ?`)
-      .all(n) as EpisodicRow[];
-    return rows.map(rowToEvent);
+      .prepare(`SELECT * FROM episodic_events ORDER BY created_at DESC`)
+      .all() as EpisodicRow[];
+    return rowsToEvents(rows, n);
   }
 
   count(): number {
@@ -523,11 +523,16 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
   }
 
   lastCheckpoint(): ExecutionState | null {
-    const row = this.db
-      .prepare(`SELECT * FROM checkpoints ORDER BY id DESC LIMIT 1`)
-      .get() as CheckpointRow | undefined;
-    if (!row) return null;
-    return JSON.parse(row.state) as ExecutionState;
+    const rows = this.db
+      .prepare(`SELECT * FROM checkpoints ORDER BY id DESC`)
+      .all() as CheckpointRow[];
+    for (const row of rows) {
+      const state = parseCheckpointState(row);
+      if (state !== null) {
+        return state;
+      }
+    }
+    return null;
   }
 
   listCheckpoints(): Array<{ id: string; timestamp: string }> {
@@ -702,7 +707,29 @@ function parseStoredWorkingMemoryValue(value: string): unknown {
   }
 }
 
-function rowToEvent(row: EpisodicRow): EpisodicEvent {
+function rowsToEvents(rows: EpisodicRow[], limit: number): EpisodicEvent[] {
+  const events: EpisodicEvent[] = [];
+  for (const row of rows) {
+    const event = rowToEvent(row);
+    if (event) {
+      events.push(event);
+      if (limit >= 0 && events.length >= limit) {
+        break;
+      }
+    }
+  }
+  return events;
+}
+
+function parseCheckpointState(row: CheckpointRow): ExecutionState | null {
+  try {
+    return JSON.parse(row.state) as ExecutionState;
+  } catch {
+    return null;
+  }
+}
+
+function rowToEvent(row: EpisodicRow): EpisodicEvent | null {
   const event: EpisodicEvent = {
     id: row.id,
     type: row.type as EpisodicEventType,
@@ -710,6 +737,12 @@ function rowToEvent(row: EpisodicRow): EpisodicEvent {
     createdAt: row.created_at,
   };
   if (row.step) event.step = row.step;
-  if (row.details) event.details = JSON.parse(row.details) as Record<string, unknown>;
+  if (row.details) {
+    try {
+      event.details = JSON.parse(row.details) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
   return event;
 }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -368,6 +368,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
 
 const SQLITE_VARIABLE_LIMIT = 999;
 const RECALL_VARIABLES_PER_KEYWORD = 4;
+const CORRUPT_JSON_SCAN_BATCH_SIZE = 100;
 const RECALL_LIMIT_VARIABLES = 1;
 const MAX_RECALL_KEYWORDS_PER_QUERY = Math.floor(
   (SQLITE_VARIABLE_LIMIT - RECALL_LIMIT_VARIABLES) / RECALL_VARIABLES_PER_KEYWORD,
@@ -412,7 +413,10 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
 
     if (keywords.length <= MAX_RECALL_KEYWORDS_PER_QUERY) {
-      return rowsToEvents(this.recallKeywordChunk(keywords), limit);
+      return collectRowsToEvents(
+        (batchLimit, offset) => this.recallKeywordChunk(keywords, batchLimit, offset),
+        limit,
+      );
     }
 
     const rowsById = new Map<number, EpisodicRow & { relevance_score: number }>();
@@ -439,6 +443,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
   private recallKeywordChunk(
     keywords: string[],
     limit?: number,
+    offset = 0,
   ): Array<EpisodicRow & { relevance_score: number }> {
     // Build scoring SQL: count keyword matches across summary + details
     const scoringCases = keywords.map(() =>
@@ -454,7 +459,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       FROM episodic_events
       WHERE ${whereClauses}
       ORDER BY relevance_score DESC, created_at DESC
-      ${limit === undefined ? '' : 'LIMIT ?'}
+      ${limit === undefined ? '' : 'LIMIT ? OFFSET ?'}
     `;
 
     const likeParams = keywords.flatMap(k => {
@@ -463,26 +468,30 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     });
     const allParams = limit === undefined
       ? [...likeParams, ...likeParams]
-      : [...likeParams, ...likeParams, limit];
+      : [...likeParams, ...likeParams, limit, offset];
 
     return this.db.prepare(sql).all(...allParams) as Array<EpisodicRow & { relevance_score: number }>;
   }
 
   recentFailures(n = 10): EpisodicEvent[] {
-    const rows = this.db
-      .prepare(
-        `SELECT * FROM episodic_events WHERE type = 'failure'
-         ORDER BY created_at DESC`,
-      )
-      .all() as EpisodicRow[];
-    return rowsToEvents(rows, n);
+    const stmt = this.db.prepare(
+      `SELECT * FROM episodic_events WHERE type = 'failure'
+       ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+    );
+    return collectRowsToEvents(
+      (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
+      n,
+    );
   }
 
   recent(n = 10): EpisodicEvent[] {
-    const rows = this.db
-      .prepare(`SELECT * FROM episodic_events ORDER BY created_at DESC`)
-      .all() as EpisodicRow[];
-    return rowsToEvents(rows, n);
+    const stmt = this.db.prepare(
+      `SELECT * FROM episodic_events ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+    );
+    return collectRowsToEvents(
+      (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
+      n,
+    );
   }
 
   count(): number {
@@ -523,16 +532,19 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
   }
 
   lastCheckpoint(): ExecutionState | null {
-    const rows = this.db
-      .prepare(`SELECT * FROM checkpoints ORDER BY id DESC`)
-      .all() as CheckpointRow[];
-    for (const row of rows) {
-      const state = parseCheckpointState(row);
-      if (state !== null) {
-        return state;
+    const stmt = this.db.prepare(`SELECT * FROM checkpoints ORDER BY id DESC LIMIT ? OFFSET ?`);
+    for (let offset = 0; ; offset += CORRUPT_JSON_SCAN_BATCH_SIZE) {
+      const rows = stmt.all(CORRUPT_JSON_SCAN_BATCH_SIZE, offset) as CheckpointRow[];
+      for (const row of rows) {
+        const state = parseCheckpointState(row);
+        if (state !== null) {
+          return state;
+        }
+      }
+      if (rows.length < CORRUPT_JSON_SCAN_BATCH_SIZE) {
+        return null;
       }
     }
-    return null;
   }
 
   listCheckpoints(): Array<{ id: string; timestamp: string }> {
@@ -708,6 +720,10 @@ function parseStoredWorkingMemoryValue(value: string): unknown {
 }
 
 function rowsToEvents(rows: EpisodicRow[], limit: number): EpisodicEvent[] {
+  if (limit === 0) {
+    return [];
+  }
+
   const events: EpisodicEvent[] = [];
   for (const row of rows) {
     const event = rowToEvent(row);
@@ -718,6 +734,39 @@ function rowsToEvents(rows: EpisodicRow[], limit: number): EpisodicEvent[] {
       }
     }
   }
+  return events;
+}
+
+function collectRowsToEvents(
+  fetchRows: (limit: number, offset: number) => EpisodicRow[],
+  limit: number,
+): EpisodicEvent[] {
+  if (limit === 0) {
+    return [];
+  }
+
+  const events: EpisodicEvent[] = [];
+  const target = limit < 0 ? Number.POSITIVE_INFINITY : limit;
+  const batchSize = limit < 0
+    ? CORRUPT_JSON_SCAN_BATCH_SIZE
+    : Math.max(CORRUPT_JSON_SCAN_BATCH_SIZE, limit * 2);
+
+  for (let offset = 0; events.length < target; offset += batchSize) {
+    const rows = fetchRows(batchSize, offset);
+    for (const row of rows) {
+      const event = rowToEvent(row);
+      if (event) {
+        events.push(event);
+        if (events.length >= target) {
+          break;
+        }
+      }
+    }
+    if (rows.length < batchSize) {
+      break;
+    }
+  }
+
   return events;
 }
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -499,6 +499,9 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recall('searchable', 10).map(event => event.summary)).toEqual([
         'healthy searchable event',
       ]);
+      expect(brain.episodic.recall('searchable', 0)).toEqual([]);
+      expect(brain.episodic.recent(0)).toEqual([]);
+      expect(brain.episodic.recentFailures(0)).toEqual([]);
     });
   });
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -444,6 +444,62 @@ describe('SqliteBrain', () => {
         'early match kw0000',
       ]);
     });
+
+    it('skips corrupt persisted details while keeping healthy recent and failure rows available', () => {
+      brain.episodic.record(makeEvent({
+        type: 'failure',
+        summary: 'older healthy failure',
+        createdAt: '2026-07-10T00:00:00.000Z',
+        details: { marker: 'healthy' },
+      }));
+      brain.episodic.record(makeEvent({
+        type: 'failure',
+        summary: 'newer corrupt failure',
+        createdAt: '2026-07-10T00:01:00.000Z',
+        details: { marker: 'corrupt-me' },
+      }));
+      brain.episodic.record(makeEvent({
+        type: 'success',
+        summary: 'newest healthy success',
+        createdAt: '2026-07-10T00:02:00.000Z',
+        details: { marker: 'healthy' },
+      }));
+
+      const db = (brain as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE summary = ?`).run('{', 'newer corrupt failure');
+
+      expect(() => brain.episodic.recent(2)).not.toThrow();
+      expect(brain.episodic.recent(2).map(event => event.summary)).toEqual([
+        'newest healthy success',
+        'older healthy failure',
+      ]);
+
+      expect(() => brain.episodic.recentFailures(1)).not.toThrow();
+      expect(brain.episodic.recentFailures(1).map(event => event.summary)).toEqual([
+        'older healthy failure',
+      ]);
+    });
+
+    it('skips corrupt persisted details during recall', () => {
+      brain.episodic.record(makeEvent({
+        summary: 'healthy searchable event',
+        createdAt: '2026-07-10T00:00:00.000Z',
+        details: { marker: 'searchable' },
+      }));
+      brain.episodic.record(makeEvent({
+        summary: 'corrupt searchable event',
+        createdAt: '2026-07-10T00:01:00.000Z',
+        details: { marker: 'searchable' },
+      }));
+
+      const db = (brain as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE summary = ?`).run('{', 'corrupt searchable event');
+
+      expect(() => brain.episodic.recall('searchable', 10)).not.toThrow();
+      expect(brain.episodic.recall('searchable', 10).map(event => event.summary)).toEqual([
+        'healthy searchable event',
+      ]);
+    });
   });
 
   describe('recovery memory', () => {
@@ -513,6 +569,19 @@ describe('SqliteBrain', () => {
       const last = brain.recovery.lastCheckpoint();
       expect(last).not.toBeNull();
       expect(last!.step).toBe(3);
+    });
+
+    it('falls back to the newest valid checkpoint when later persisted state is corrupt', () => {
+      brain.recovery.checkpoint(makeState({ step: 1, timestamp: '2026-07-10T00:00:00.000Z' }));
+      brain.recovery.checkpoint(makeState({ step: 2, timestamp: '2026-07-10T00:01:00.000Z' }));
+
+      const db = (brain as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db;
+      db.prepare(`UPDATE checkpoints SET state = ? WHERE id = (SELECT MAX(id) FROM checkpoints)`).run('{');
+
+      expect(() => brain.recovery.lastCheckpoint()).not.toThrow();
+      expect(brain.recovery.lastCheckpoint()?.step).toBe(1);
+      expect(() => brain.serialize()).not.toThrow();
+      expect(brain.serialize().checkpoint?.step).toBe(1);
     });
 
     it('lastCheckpoint() returns null when empty', () => {


### PR DESCRIPTION
## Summary
- Skip malformed persisted episodic details rows during recent, recentFailures, and recall reads so healthy rows stay available.
- Fall back to the newest valid checkpoint when newer persisted checkpoint JSON is corrupt.
- Add regression coverage for corrupt episodic details and corrupt latest checkpoint state.

## Test Plan
- npm --prefix packages/franken-brain test -- --run tests/unit/sqlite-brain.test.ts
- npm --workspace @franken/types run build
- npm --prefix packages/franken-brain run typecheck
- npm --prefix packages/franken-brain run lint
- npm --prefix packages/franken-brain run build
- npm --prefix packages/franken-brain test

Closes #1034