### PR TITLE
test(orchestrator): assert CLI provider boundary failure

### DIFF
--- a/packages/franken-orchestrator/tests/e2e/cli-e2e.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/cli-e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -19,6 +20,13 @@ function mockIO(answers: string[] = ['yes']): InterviewIO {
     ask: async () => answers[idx++] ?? 'yes',
     display: (_msg: string) => { /* noop in tests */ },
   };
+}
+
+function initializeGitRepository(root: string): void {
+  execFileSync('git', ['init', '-b', 'main'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Frankenbeast Test'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'frankenbeast-test@example.com'], { cwd: root });
+  execFileSync('git', ['commit', '--allow-empty', '-m', 'test: initialize e2e fixture repository'], { cwd: root });
 }
 
 describeE2E('CLI E2E', () => {
@@ -43,12 +51,24 @@ describeE2E('CLI E2E', () => {
   it('Session detects execute phase with --plan-dir', async () => {
     const paths = getProjectPaths(testDir);
     scaffoldFrankenbeast(paths);
+    initializeGitRepository(testDir);
+    const trustedBinDir = resolve(testDir, '.fbeast/bin');
+    const missingClaudeCli = resolve(trustedBinDir, 'missing-claude');
 
     const session = new Session({
       paths,
       baseBranch: 'main',
       budget: 1,
       provider: 'claude',
+      providers: ['claude'],
+      providersConfig: {
+        claude: {
+          command: missingClaudeCli,
+          trustCommandOverride: true,
+          trustedCommandPaths: [trustedBinDir],
+        },
+      },
+      trustProviderCommandOverrides: true,
       noPr: true,
       verbose: false,
       reset: false,
@@ -57,14 +77,17 @@ describeE2E('CLI E2E', () => {
       planDirOverride: fixtureChunks,
     });
 
-    // This will fail at Martin loop execution (no real CLI provider)
-    // but it proves the wiring works up to that point
-    try {
-      await session.start();
-    } catch (err) {
-      // Expected — no real claude/codex available in test
-      expect(err).toBeDefined();
-    }
+    // This should fail only after the session reaches execute-phase provider
+    // dispatch. Earlier fixture/config/scaffolding regressions should not satisfy
+    // this assertion.
+    const result = await session.start();
+
+    expect(result?.status).toBe('failed');
+    expect(result?.phase).toBe('closure');
+    expect(result?.taskResults[0]?.error).toMatch(
+      /MartinLoop failed for chunk "01_hello": No configured LLM provider CLI is available\..*Last error: llm spawn failed: claude \(ENOENT\)/s,
+    );
+    expect(result?.taskResults[0]?.error).not.toMatch(/Git isolation failed|fixture path|bad config parsing/i);
   });
 
   it('project paths are correctly derived', () => {


### PR DESCRIPTION
## Summary
- tighten the CLI E2E execute-phase test so it asserts the expected provider-boundary failure instead of accepting any error
- initialize the temporary fixture as a git repo so earlier git isolation/setup regressions fail the assertion
- force the test provider to a trusted missing CLI path so the failure is deterministic and does not depend on local claude/codex availability

## Test Plan
- npm run test:e2e --workspace @franken/orchestrator -- tests/e2e/cli-e2e.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #1033