### PR TITLE
docs: link CLI before quickstart commands

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -73,21 +73,30 @@ Root scripts currently include `build`, `typecheck`, `test`, `test:ci`, `test:li
 
 ## 5. Try the orchestrator CLI
 
+The repository root is private and does not publish a root `frankenbeast` binary
+for `npx` to resolve. Link the local workspace CLIs first; the `local:link`
+script builds the packages and links both `@franken/orchestrator` and
+`@franken/mcp-suite` so `frankenbeast`, `franken`, `frkn`, and `fbeast` are on
+your PATH.
+
 ```bash
+# Build and link the local workspace binaries once from the repo root
+npm run local:link
+
 # Show supported commands and flags
-npx frankenbeast --help
+frankenbeast --help
 
 # Interview only — generates a design doc under .fbeast/plans/
-npx frankenbeast interview
+frankenbeast interview
 
 # Plan from an existing design doc
-npx frankenbeast plan --design-doc docs/my-feature-design.md
+frankenbeast plan --design-doc docs/my-feature-design.md
 
 # Execute chunks from .fbeast/plans/ or a supplied plan directory
-npx frankenbeast run --plan-dir .fbeast/plans/my-plan/
+frankenbeast run --plan-dir .fbeast/plans/my-plan/
 
 # Preview GitHub issue triage without executing fixes
-npx frankenbeast issues --repo owner/repo --dry-run
+frankenbeast issues --repo owner/repo --dry-run
 ```
 
 `--dry-run` is an issue-workflow flag; it is not a global CLI dry-run flag.

--- a/tests/docs-issue-961.test.ts
+++ b/tests/docs-issue-961.test.ts
@@ -46,3 +46,18 @@ describe('issue #961 local CLI linking docs', () => {
     }
   });
 });
+
+describe('issue #1022 quickstart orchestrator CLI docs', () => {
+  it('links local workspace binaries before invoking frankenbeast', () => {
+    const quickstart = readText('docs/guides/quickstart.md');
+
+    expect(quickstart).toContain('The repository root is private');
+    expect(quickstart).toContain('npm run local:link');
+    expect(quickstart.indexOf('npm run local:link')).toBeLessThan(quickstart.indexOf('frankenbeast --help'));
+    expect(quickstart).toContain('frankenbeast interview');
+    expect(quickstart).toContain('frankenbeast plan --design-doc docs/my-feature-design.md');
+    expect(quickstart).toContain('frankenbeast run --plan-dir .fbeast/plans/my-plan/');
+    expect(quickstart).toContain('frankenbeast issues --repo owner/repo --dry-run');
+    expect(quickstart).not.toContain('npx frankenbeast');
+  });
+});


### PR DESCRIPTION
## Summary
- document that fresh local checkouts must run `npm run local:link` before using the `frankenbeast` binary
- replace stale quickstart `npx frankenbeast` examples with linked `frankenbeast` invocations
- add a regression test so quickstart docs do not reintroduce the unlinked `npx frankenbeast` path

## Test Plan
- [x] `npm run test:root -- tests/docs-issue-961.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`

Closes #1022
