### PR TITLE
docs: fix frankenbeast issues CLI setup guide

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -3,7 +3,21 @@
 ## Prerequisites
 
 - `gh` CLI authenticated (`gh auth status`)
-- `frankenbeast` installed globally (`npm link` from repo root)
+- `frankenbeast` available from the current checkout. From the repo root, run:
+
+  ```bash
+  npm install
+  npm run local:link
+  npm run local:verify-cli
+  ```
+
+  `local:link` builds the repo and links the workspaces that expose the `fbeast` and `frankenbeast` binaries. If you do not want global links, run issue commands through the orchestrator workspace instead:
+
+  ```bash
+  npm --workspace @franken/orchestrator exec -- frankenbeast issues --help
+  ```
+
+  See [Running the CLI Beast Harness](./run-cli-beast.md) for the full local CLI setup, including the paired `fbeast` MCP flow.
 - A GitHub repository with open issues
 
 ## How It Works

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -18,10 +18,14 @@
   npm --workspace @franken/orchestrator exec -- frankenbeast issues --help
   ```
 
-  For real issue runs through the workspace fallback, include both `--base-dir` and `--repo`: `--base-dir` points generated branches, plans, and artifacts at the repository whose issues you want to fix, while `--repo` prevents GitHub repo inference from using the Frankenbeast checkout selected by `npm --workspace`.
+  For preview or real issue runs through the workspace fallback, include both `--base-dir` and `--repo`: `--base-dir` points generated branches, plans, and artifacts at the repository whose issues you want to fix, while `--repo` prevents GitHub repo inference from using the Frankenbeast checkout selected by `npm --workspace`. Keep `--dry-run` for triage previews, and remove it when you are ready to execute approved fixes.
 
   ```bash
+  # Preview only
   npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --dry-run
+
+  # Execute approved fixes
+  npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --label critical
   ```
 
   See [Running the CLI Beast Harness](./run-cli-beast.md) for the full local CLI setup, including the paired `fbeast` MCP flow.

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -11,10 +11,16 @@
   npm run local:verify-cli
   ```
 
-  `local:link` builds the repo and links the workspaces that expose the `fbeast` and `frankenbeast` binaries. If you do not want global links, build the checkout first and run issue commands through the orchestrator workspace. Include `--base-dir` so generated branches, plans, and artifacts target the repository whose issues you want to fix rather than the orchestrator workspace:
+  `local:link` builds the repo and links the workspaces that expose the `fbeast` and `frankenbeast` binaries. If you do not want global links, build the full checkout first and use `--help` as the setup smoke test:
 
   ```bash
-  npm run build --workspace @franken/orchestrator
+  npm run build
+  npm --workspace @franken/orchestrator exec -- frankenbeast issues --help
+  ```
+
+  For real issue runs through the workspace fallback, include both `--base-dir` and `--repo`: `--base-dir` points generated branches, plans, and artifacts at the repository whose issues you want to fix, while `--repo` prevents GitHub repo inference from using the Frankenbeast checkout selected by `npm --workspace`.
+
+  ```bash
   npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --dry-run
   ```
 

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -11,10 +11,11 @@
   npm run local:verify-cli
   ```
 
-  `local:link` builds the repo and links the workspaces that expose the `fbeast` and `frankenbeast` binaries. If you do not want global links, run issue commands through the orchestrator workspace instead:
+  `local:link` builds the repo and links the workspaces that expose the `fbeast` and `frankenbeast` binaries. If you do not want global links, build the checkout first and run issue commands through the orchestrator workspace. Include `--base-dir` so generated branches, plans, and artifacts target the repository whose issues you want to fix rather than the orchestrator workspace:
 
   ```bash
-  npm --workspace @franken/orchestrator exec -- frankenbeast issues --help
+  npm run build --workspace @franken/orchestrator
+  npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --dry-run
   ```
 
   See [Running the CLI Beast Harness](./run-cli-beast.md) for the full local CLI setup, including the paired `fbeast` MCP flow.

--- a/tests/docs-issue-1023.test.ts
+++ b/tests/docs-issue-1023.test.ts
@@ -24,8 +24,12 @@ describe('issue #1023 GitHub issues guide CLI setup docs', () => {
     expect(guide).toContain(
       'npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --dry-run',
     );
+    expect(guide).toContain(
+      'npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --label critical',
+    );
     expect(guide).toContain('./run-cli-beast.md');
     expect(guide).toContain('include both `--base-dir` and `--repo`');
+    expect(guide).toContain('remove it when you are ready to execute approved fixes');
   });
 
   it('does not recommend a bare root npm link for the frankenbeast binary', () => {

--- a/tests/docs-issue-1023.test.ts
+++ b/tests/docs-issue-1023.test.ts
@@ -19,12 +19,13 @@ describe('issue #1023 GitHub issues guide CLI setup docs', () => {
 
     expect(guide).toContain('npm run local:link');
     expect(guide).toContain('npm run local:verify-cli');
-    expect(guide).toContain('npm run build --workspace @franken/orchestrator');
+    expect(guide).toContain('npm run build');
+    expect(guide).toContain('npm --workspace @franken/orchestrator exec -- frankenbeast issues --help');
     expect(guide).toContain(
       'npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --dry-run',
     );
     expect(guide).toContain('./run-cli-beast.md');
-    expect(guide).toContain('Include `--base-dir`');
+    expect(guide).toContain('include both `--base-dir` and `--repo`');
   });
 
   it('does not recommend a bare root npm link for the frankenbeast binary', () => {

--- a/tests/docs-issue-1023.test.ts
+++ b/tests/docs-issue-1023.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const readText = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+const readJson = <T>(relativePath: string): T => JSON.parse(readText(relativePath)) as T;
+
+describe('issue #1023 GitHub issues guide CLI setup docs', () => {
+  it('points the issues guide at the supported local frankenbeast link path', () => {
+    const guide = readText('docs/guides/fix-github-issues.md');
+    const packageJson = readJson<{ scripts?: Record<string, string> }>('package.json');
+    const orchestratorPackage = readJson<{ bin?: Record<string, string> }>('packages/franken-orchestrator/package.json');
+
+    expect(packageJson.scripts?.['local:link']).toContain('--workspace=@franken/orchestrator');
+    expect(orchestratorPackage.bin).toHaveProperty('frankenbeast');
+
+    expect(guide).toContain('npm run local:link');
+    expect(guide).toContain('npm run local:verify-cli');
+    expect(guide).toContain('npm --workspace @franken/orchestrator exec -- frankenbeast issues --help');
+    expect(guide).toContain('./run-cli-beast.md');
+  });
+
+  it('does not recommend a bare root npm link for the frankenbeast binary', () => {
+    const guide = readText('docs/guides/fix-github-issues.md');
+
+    expect(guide).not.toMatch(/npm link`?\s+from repo root/i);
+    expect(guide).not.toContain('frankenbeast` installed globally (`npm link` from repo root)');
+  });
+});

--- a/tests/docs-issue-1023.test.ts
+++ b/tests/docs-issue-1023.test.ts
@@ -19,8 +19,12 @@ describe('issue #1023 GitHub issues guide CLI setup docs', () => {
 
     expect(guide).toContain('npm run local:link');
     expect(guide).toContain('npm run local:verify-cli');
-    expect(guide).toContain('npm --workspace @franken/orchestrator exec -- frankenbeast issues --help');
+    expect(guide).toContain('npm run build --workspace @franken/orchestrator');
+    expect(guide).toContain(
+      'npm --workspace @franken/orchestrator exec -- frankenbeast issues --base-dir /path/to/target-repo --repo owner/repo --dry-run',
+    );
     expect(guide).toContain('./run-cli-beast.md');
+    expect(guide).toContain('Include `--base-dir`');
   });
 
   it('does not recommend a bare root npm link for the frankenbeast binary', () => {


### PR DESCRIPTION
## Summary
- replace the stale bare root npm link prerequisite in the GitHub issues guide with the supported repo-root local:link flow
- document the unlinked orchestrator workspace exec fallback for frankenbeast issues help
- add a regression test tying the guide to the real local:link script and orchestrator bin

## Test Plan
- npx vitest run tests/docs-issue-1023.test.ts tests/unit/readme-issue-flags.test.ts
- npm --workspace @franken/orchestrator exec -- frankenbeast issues --help
- npm run typecheck
- npm run lint
- npm run build

Closes #1023