### PR TITLE
fix(web): guard analytics detail drawer updates

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -407,6 +407,105 @@ describe('AnalyticsPage', () => {
     });
   });
 
+  it('keeps the latest selected event detail when earlier detail requests resolve later', async () => {
+    const client = mockClient();
+    let resolveAuditDetail!: (event: Awaited<ReturnType<AnalyticsApiClient['fetchEventDetail']>>) => void;
+    let resolveGovernorDetail!: (event: Awaited<ReturnType<AnalyticsApiClient['fetchEventDetail']>>) => void;
+    vi.mocked(client.fetchEventDetail)
+      .mockReturnValueOnce(new Promise((resolve) => {
+        resolveAuditDetail = resolve;
+      }))
+      .mockReturnValueOnce(new Promise((resolve) => {
+        resolveGovernorDetail = resolve;
+      }));
+
+    render(<AnalyticsPage client={client} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'View details for Logged audit event' }));
+    const governorDetailButton = document.querySelector<HTMLElement>('[data-analytics-event-id="governor:1"]');
+    expect(governorDetailButton).toBeTruthy();
+    fireEvent.click(governorDetailButton!);
+
+    resolveGovernorDetail({
+      id: 'governor:1',
+      timestamp: '2026-04-28T12:01:00.000Z',
+      sessionId: 'session-a',
+      toolName: 'exec_command',
+      source: 'governor',
+      category: 'decision',
+      outcome: 'denied',
+      summary: 'Denied destructive command',
+      severity: 'error',
+      raw: { decision: 'denied', current: true },
+      links: {},
+    });
+
+    expect(await screen.findByText('"current": true')).toBeTruthy();
+
+    resolveAuditDetail({
+      id: 'audit:1',
+      timestamp: '2026-04-28T12:00:00.000Z',
+      sessionId: 'session-a',
+      toolName: 'fbeast_observer_log',
+      source: 'observer',
+      category: 'tool_call',
+      outcome: 'approved',
+      summary: 'Logged audit event',
+      severity: 'info',
+      raw: { event: 'tool_call', stale: true },
+      links: {},
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Denied destructive command' })).toBeTruthy();
+      expect(screen.getByText('"current": true')).toBeTruthy();
+      expect(screen.queryByText('"stale": true')).toBeNull();
+    });
+    expect(client.fetchEventDetail).toHaveBeenNthCalledWith(1, 'audit:1');
+    expect(client.fetchEventDetail).toHaveBeenNthCalledWith(2, 'governor:1');
+  });
+
+  it('ignores stale detail errors from an earlier selection', async () => {
+    const client = mockClient();
+    let rejectAuditDetail!: (error: Error) => void;
+    let resolveGovernorDetail!: (event: Awaited<ReturnType<AnalyticsApiClient['fetchEventDetail']>>) => void;
+    vi.mocked(client.fetchEventDetail)
+      .mockReturnValueOnce(new Promise((_, reject) => {
+        rejectAuditDetail = reject;
+      }))
+      .mockReturnValueOnce(new Promise((resolve) => {
+        resolveGovernorDetail = resolve;
+      }));
+
+    render(<AnalyticsPage client={client} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'View details for Logged audit event' }));
+    const governorDetailButton = document.querySelector<HTMLElement>('[data-analytics-event-id="governor:1"]');
+    expect(governorDetailButton).toBeTruthy();
+    fireEvent.click(governorDetailButton!);
+
+    rejectAuditDetail(new Error('audit detail timeout'));
+    await waitFor(() => {
+      expect(screen.queryByText('audit detail timeout')).toBeNull();
+      expect(screen.getByRole('dialog', { name: 'Denied destructive command' })).toBeTruthy();
+    });
+
+    resolveGovernorDetail({
+      id: 'governor:1',
+      timestamp: '2026-04-28T12:01:00.000Z',
+      sessionId: 'session-a',
+      toolName: 'exec_command',
+      source: 'governor',
+      category: 'decision',
+      outcome: 'denied',
+      summary: 'Denied destructive command',
+      severity: 'error',
+      raw: { decision: 'denied', current: true },
+      links: {},
+    });
+
+    expect(await screen.findByText('"current": true')).toBeTruthy();
+    expect(screen.queryByText('audit detail timeout')).toBeNull();
+  });
+
   it('opens event details in a labelled modal dialog and focuses the close button', async () => {
     const client = mockClient();
 

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -56,6 +56,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   const [pendingFocusEventId, setPendingFocusEventId] = useState<string | null>(null);
   const detailTriggerRef = useRef<HTMLElement | null>(null);
   const detailTriggerEventIdRef = useRef<string | null>(null);
+  const activeDetailEventIdRef = useRef<string | null>(null);
   const detailRequestSeqRef = useRef(0);
   const deferDetailFocusUntilEventsLoadRef = useRef(false);
   const sawDeferredEventsLoadRef = useRef(false);
@@ -173,27 +174,33 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   async function openDetail(event: AnalyticsEvent, trigger?: HTMLElement) {
     detailTriggerRef.current = trigger ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
     detailTriggerEventIdRef.current = event.id;
+    activeDetailEventIdRef.current = event.id;
     setSelectedEvent(event);
     setHasFullDetail(false);
     await loadEventDetail(event.id);
   }
 
+  function isCurrentDetailRequest(requestSeq: number, eventId: string) {
+    return detailRequestSeqRef.current === requestSeq && activeDetailEventIdRef.current === eventId;
+  }
+
   async function loadEventDetail(eventId: string) {
     const requestSeq = detailRequestSeqRef.current + 1;
     detailRequestSeqRef.current = requestSeq;
+    activeDetailEventIdRef.current = eventId;
     setIsDetailLoading(true);
     setDetailError(null);
     try {
       const detail = await client.fetchEventDetail(eventId);
-      if (detailRequestSeqRef.current !== requestSeq) return;
+      if (!isCurrentDetailRequest(requestSeq, eventId)) return;
       setSelectedEvent(detail);
       setHasFullDetail(true);
     } catch (error) {
-      if (detailRequestSeqRef.current !== requestSeq) return;
+      if (!isCurrentDetailRequest(requestSeq, eventId)) return;
       setHasFullDetail(false);
       setDetailError(error instanceof Error ? error.message : 'Unable to load event detail.');
     } finally {
-      if (detailRequestSeqRef.current === requestSeq) {
+      if (isCurrentDetailRequest(requestSeq, eventId)) {
         setIsDetailLoading(false);
       }
     }
@@ -215,6 +222,7 @@ export function AnalyticsPage({ client }: AnalyticsPageProps) {
   function closeDetail() {
     const triggerEventId = detailTriggerEventIdRef.current;
     detailRequestSeqRef.current += 1;
+    activeDetailEventIdRef.current = null;
     setSelectedEvent(null);
     setIsDetailLoading(false);
     setHasFullDetail(false);


### PR DESCRIPTION
## Summary
- Track the active analytics detail event id alongside the detail request sequence so stale responses cannot update the open drawer.
- Ignore stale detail fetch failures from previous selections.
- Add regression coverage for out-of-order successful and failed detail requests.

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- src/pages/analytics-page.test.tsx
- npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1016
