### PR TITLE
fix(web): add network service log actions

### DIFF
--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -6,11 +6,13 @@ interface NetworkServiceItem {
   explanation?: string;
   url?: string;
   inProcess?: boolean;
+  hostServiceId?: string;
   channels?: Record<string, boolean>;
 }
 
 interface NetworkServiceListProps {
   services: NetworkServiceItem[];
+  onSelectLogs(serviceId: string): void;
   onStart(serviceId: string): Promise<void> | void;
   onStop(serviceId: string): Promise<void> | void;
   onRestart(serviceId: string): Promise<void> | void;
@@ -43,8 +45,13 @@ function canStopOrRestartService(service: NetworkServiceItem): boolean {
   return !service.inProcess && (status === 'running' || status === 'stale');
 }
 
+function canViewServiceLogs(service: NetworkServiceItem): boolean {
+  return !service.inProcess || Boolean(service.hostServiceId);
+}
+
 export function NetworkServiceList({
   services,
+  onSelectLogs,
   onStart,
   onStop,
   onRestart,
@@ -123,6 +130,16 @@ export function NetworkServiceList({
               )}
             </div>
             <div className="network-services__actions">
+              {canViewServiceLogs(service) ? (
+                <button
+                  aria-label={`View logs for ${service.id}`}
+                  className="button button--secondary button--small"
+                  onClick={() => onSelectLogs(service.id)}
+                  type="button"
+                >
+                  View logs
+                </button>
+              ) : null}
               <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'start', onStart)} aria-label={`Start ${service.id}`} disabled={startDisabled}>Start</button>
               <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'stop', onStop)} aria-label={`Stop ${service.id}`} disabled={stopOrRestartDisabled}>Stop</button>
               <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'restart', onRestart)} aria-label={`Restart ${service.id}`} disabled={stopOrRestartDisabled}>Restart</button>

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -54,6 +54,7 @@ export function NetworkPage({
           <NetworkStatusGrid mode={status.mode} secureBackend={status.secureBackend} />
           <NetworkServiceList
             services={services}
+            onSelectLogs={onSelectLogService}
             onRestart={onRestart}
             onStart={onStart}
             onStop={onStop}

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -400,6 +400,13 @@ describe('NetworkPage', () => {
     expect(onSelectLogService).toHaveBeenCalledWith('chat-server');
     expect(screen.queryByRole('option', { name: 'orphan-in-process (running)' })).toBeNull();
     expect(screen.getByRole('option', { name: 'comms-gateway (running)' })).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View logs for dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'View logs for comms-gateway' }));
+
+    expect(onSelectLogService).toHaveBeenCalledWith('dashboard');
+    expect(onSelectLogService).toHaveBeenCalledWith('comms-gateway');
+    expect(screen.queryByRole('button', { name: 'View logs for orphan-in-process' })).toBeNull();
   });
 
   it('upgrades network logs into a searchable operational viewer', () => {


### PR DESCRIPTION
## Summary
- adds per-service View logs actions in the Network services rail
- wires those actions to the existing Network logs selection/fetch flow
- extends Network page coverage for selectable log actions and unsupported in-process services

## Test Plan
- npm run test --workspace @franken/web -- tests/components/network-page.test.tsx tests/components/chat-shell.test.tsx
- npm run lint --workspace @franken/web
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/types
- npm run build --workspace @franken/web

Closes #1017