### PR TITLE
fix(web): block invalid create-agent wizard launches

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -30,6 +30,17 @@ const CATALOG: BeastCatalogEntry[] = [
       { key: 'outputDir', prompt: 'Where should the chunk plan be written?', kind: 'directory', required: true },
     ],
   },
+  {
+    id: 'martin-loop',
+    label: 'Martin Loop',
+    description: 'Run MartinLoop against an existing chunk directory',
+    executionModeDefault: 'process',
+    interviewPrompts: [
+      { key: 'provider', prompt: 'Which provider should run the martin loop?', kind: 'string', required: true, options: ['claude', 'codex'] },
+      { key: 'objective', prompt: 'What should the martin loop accomplish?', kind: 'string', required: true },
+      { key: 'chunkDirectory', prompt: 'Which chunk directory should MartinLoop execute from?', kind: 'directory', required: true },
+    ],
+  },
 ];
 
 function renderWizard(props: WizardDialogTestProps = {}) {
@@ -100,11 +111,36 @@ describe('WizardDialog validation', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle form mode' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Launch Agent' }));
+    const launchButton = screen.getByRole('button', { name: 'Launch Agent' });
+    expect(launchButton).toHaveProperty('disabled', true);
+    fireEvent.click(launchButton);
 
     expect(onLaunch).not.toHaveBeenCalled();
     expect(screen.getByRole('alert').textContent).toContain('Identity: Agent name is required');
     expect(screen.getByRole('alert').textContent).toContain('Workflow: Workflow type is required');
+  });
+
+  it('keeps review-step launch disabled when martin-loop is missing its required chunk directory', () => {
+    const onLaunch = vi.fn();
+    const store = useBeastStore.getState();
+    store.setStepValues(0, { name: 'Martin Agent' });
+    store.setStepValues(1, {
+      workflowType: 'martin-loop',
+      provider: 'codex',
+      objective: 'Implement chunks',
+    });
+    store.markStepCompleted(6);
+    store.setWizardStep(7);
+
+    renderWizard({ onLaunch });
+
+    const launchButton = screen.getByRole('button', { name: 'Launch Agent' });
+    expect(launchButton).toHaveProperty('disabled', true);
+    fireEvent.click(launchButton);
+
+    expect(onLaunch).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert').textContent).toContain('Workflow: Chunk directory path is required');
+    expect(screen.getByText('Required workflow fields are missing:')).toBeTruthy();
   });
 
   it('includes the review summary in form view before the launch action', () => {

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -238,7 +238,7 @@ export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRunt
                   <button
                     type="button"
                     onClick={buildAndLaunch}
-                    disabled={Boolean(launching) || promptFilesLoading}
+                    disabled={Boolean(launching) || promptFilesLoading || !formIsValid}
                     className="px-6 py-2.5 rounded-lg text-sm font-semibold transition-colors
                       bg-beast-accent text-beast-bg hover:bg-beast-accent-strong disabled:opacity-50"
                   >

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildInitAction, ChatShell } from './chat-shell';
+import { buildInitAction, ChatShell, resolveWizardDefinitionId } from './chat-shell';
 
 const mocks = vi.hoisted(() => ({
   createAgent: vi.fn(),
@@ -406,5 +406,11 @@ describe('ChatShell route heading', () => {
       }));
     }
 
+  });
+
+  it('rejects Create Agent wizard launch configs without an explicit workflow type', () => {
+    expect(() => resolveWizardDefinitionId({})).toThrow('Workflow type is required before launching a Beast agent.');
+    expect(() => resolveWizardDefinitionId({ workflow: { workflowType: '   ' } })).toThrow('Workflow type is required before launching a Beast agent.');
+    expect(resolveWizardDefinitionId({ workflow: { workflowType: ' martin-loop ' } })).toBe('martin-loop');
   });
 });

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -269,6 +269,15 @@ export function buildInitAction(
   throw new Error(`Unsupported Beast workflow definition: ${definitionId}`);
 }
 
+export function resolveWizardDefinitionId(config: Record<string, unknown>): string {
+  const workflow = config.workflow as Record<string, unknown> | undefined;
+  const workflowType = workflow?.workflowType;
+  if (typeof workflowType !== 'string' || workflowType.trim().length === 0) {
+    throw new Error('Workflow type is required before launching a Beast agent.');
+  }
+  return workflowType.trim();
+}
+
 export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellProps) {
   const [route, setRoute] = useState<RouteId>(() => routeFromHash(window.location.hash));
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -1152,8 +1161,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               setBeastAgentDetail(null);
             }}
             onLaunch={async (config) => {
-              const workflow = config.workflow as Record<string, unknown> | undefined;
-              const definitionId = String(workflow?.workflowType ?? 'martin-loop');
+              const definitionId = resolveWizardDefinitionId(config);
               const executionMode = config.executionMode === 'container' ? 'container' : 'process';
               const launchChatSessionId = selectedSessionId ?? activeSessionId ?? undefined;
               const initAction = buildInitAction(definitionId, config, launchChatSessionId);


### PR DESCRIPTION
## Summary
- disable form-view Create Agent launch when required wizard fields are incomplete
- require explicit workflowType before ChatShell creates a tracked Beast agent instead of defaulting missing configs to martin-loop
- add regressions for empty form launch, missing martin-loop chunkDirectory at review, and missing workflow launch config

## Test Plan
- npm --prefix packages/franken-web test -- wizard-dialog.test.tsx chat-shell.test.tsx
- npm --prefix packages/franken-web test
- npm --prefix packages/franken-web run lint (passes with existing warnings)
- npm run build --workspace @franken/types
- npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run build

Closes #1012