### PR TITLE
fix(web): refresh network config editor state

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -321,6 +321,62 @@ describe('ChatShell route heading', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network config: HTTP 503');
   });
 
+  it('keeps config refresh failures visible after status refresh succeeds', async () => {
+    let resolveStatus!: (value: unknown) => void;
+    networkApiMocks.getStatus
+      .mockResolvedValueOnce({ mode: 'secure', secureBackend: 'local-encrypted', services: [] })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStatus = resolve; }));
+    networkApiMocks.getConfig
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      })
+      .mockRejectedValueOnce(new Error('HTTP 503'));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network config: HTTP 503');
+
+    resolveStatus({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('alert').textContent).toContain('Unable to refresh network config: HTTP 503');
+  });
+
+  it('prevents stale config refreshes from overwriting a saved config response', async () => {
+    let resolveStaleConfig!: (value: unknown) => void;
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleConfig = resolve; }));
+    networkApiMocks.updateConfig.mockResolvedValue({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'saved-model', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(2));
+    fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'saved-model' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
+
+    await waitFor(() => expect(screen.getByDisplayValue('saved-model')).toBeDefined());
+    resolveStaleConfig({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'stale-model', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
+
+    expect(screen.getByDisplayValue('saved-model')).toBeDefined();
+    expect(screen.queryByDisplayValue('stale-model')).toBeNull();
+  });
+
   it('ignores stale refresh failures after a newer network refresh succeeds', async () => {
     let rejectStaleRefresh!: (error: Error) => void;
     networkApiMocks.getStatus

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -272,6 +272,55 @@ describe('ChatShell route heading', () => {
     expect(screen.getByDisplayValue('refreshed-model')).toBeDefined();
   });
 
+  it('ignores stale config refresh responses after a newer refresh succeeds', async () => {
+    let resolveStaleConfig!: (value: unknown) => void;
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleConfig = resolve; }))
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'newer-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      });
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => expect(screen.getByDisplayValue('newer-model')).toBeDefined());
+    resolveStaleConfig({
+      network: { mode: 'secure', secureBackend: 'local-encrypted' },
+      chat: { model: 'stale-model', enabled: true, host: '127.0.0.1', port: 3737 },
+    });
+
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(3));
+    expect(screen.getByDisplayValue('newer-model')).toBeDefined();
+    expect(screen.queryByDisplayValue('stale-model')).toBeNull();
+  });
+
+  it('surfaces failed config refreshes from the Network page', async () => {
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      })
+      .mockRejectedValueOnce(new Error('HTTP 503'));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network config: HTTP 503');
+  });
+
   it('ignores stale refresh failures after a newer network refresh succeeds', async () => {
     let rejectStaleRefresh!: (error: Error) => void;
     networkApiMocks.getStatus

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -249,6 +249,29 @@ describe('ChatShell route heading', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network status: HTTP 503');
   });
 
+  it('refreshes both network status and config from the Network page', async () => {
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      })
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'refreshed-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      });
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
+    expect(screen.getByDisplayValue('initial-model')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(2));
+    expect(screen.getByDisplayValue('refreshed-model')).toBeDefined();
+  });
+
   it('ignores stale refresh failures after a newer network refresh succeeds', async () => {
     let rejectStaleRefresh!: (error: Error) => void;
     networkApiMocks.getStatus

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -377,6 +377,46 @@ describe('ChatShell route heading', () => {
     expect(screen.queryByDisplayValue('stale-model')).toBeNull();
   });
 
+  it('applies save responses even when a newer manual refresh resolves first', async () => {
+    let resolveSave!: (value: unknown) => void;
+    let resolveRefresh!: (value: unknown) => void;
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig
+      .mockResolvedValueOnce({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveRefresh = resolve; }));
+    networkApiMocks.updateConfig.mockImplementationOnce(() => new Promise((resolve) => { resolveSave = resolve; }));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'saved-model' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolveRefresh({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'initial-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      });
+    });
+
+    await act(async () => {
+      resolveSave({
+        network: { mode: 'secure', secureBackend: 'local-encrypted' },
+        chat: { model: 'saved-model', enabled: true, host: '127.0.0.1', port: 3737 },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText('Saved network config changes.')).toBeTruthy());
+    expect(screen.getByDisplayValue('saved-model')).toBeDefined();
+    expect(screen.queryByDisplayValue('initial-model')).toBeNull();
+    expect((screen.getByRole('button', { name: 'Save config' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it('ignores stale refresh failures after a newer network refresh succeeds', async () => {
     let rejectStaleRefresh!: (error: Error) => void;
     networkApiMocks.getStatus

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1327,12 +1327,10 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             }}
             onSaveConfig={(assignments) => {
               const client = new NetworkApiClient(baseUrl);
-              const configRequestId = ++networkConfigRequestIdRef.current;
               return client.updateConfig(assignments).then((nextConfig) => {
-                if (configRequestId === networkConfigRequestIdRef.current) {
-                  setNetworkConfig(nextConfig);
-                  setNetworkConfigError(null);
-                }
+                networkConfigRequestIdRef.current += 1;
+                setNetworkConfig(nextConfig);
+                setNetworkConfigError(null);
               });
             }}
             onSelectLogService={(serviceId) => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -314,6 +314,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const [networkLogsLoading, setNetworkLogsLoading] = useState(false);
   const [networkLogsError, setNetworkLogsError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
+  const [networkConfigError, setNetworkConfigError] = useState<string | null>(null);
   const networkStatusRequestIdRef = useRef(0);
   const networkStatusSuccessRequestIdRef = useRef(0);
   const networkStatusSettledRequestIdRef = useRef(0);
@@ -1254,7 +1255,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         ) : route === 'network' ? (
           <NetworkPage
             config={networkConfig}
-            error={networkError}
+            error={networkError ?? networkConfigError}
             logs={networkLogs}
             logsError={networkLogsError}
             logsLoading={networkLogsLoading}
@@ -1287,11 +1288,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 .then((nextConfig) => {
                   if (configRequestId === networkConfigRequestIdRef.current) {
                     setNetworkConfig(nextConfig);
+                    setNetworkConfigError(null);
                   }
                 })
                 .catch((error: unknown) => {
                   if (configRequestId === networkConfigRequestIdRef.current) {
-                    setNetworkError(`Unable to refresh network config: ${networkErrorMessage(error, 'Request failed.')}`);
+                    setNetworkConfigError(`Unable to refresh network config: ${networkErrorMessage(error, 'Request failed.')}`);
                   }
                 });
               if (!logServiceId) {
@@ -1325,8 +1327,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             }}
             onSaveConfig={(assignments) => {
               const client = new NetworkApiClient(baseUrl);
+              const configRequestId = ++networkConfigRequestIdRef.current;
               return client.updateConfig(assignments).then((nextConfig) => {
-                setNetworkConfig(nextConfig);
+                if (configRequestId === networkConfigRequestIdRef.current) {
+                  setNetworkConfig(nextConfig);
+                  setNetworkConfigError(null);
+                }
               });
             }}
             onSelectLogService={(serviceId) => {

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1278,6 +1278,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                     setNetworkError(`Unable to refresh network status: ${networkErrorMessage(error, 'Request failed.')}`);
                   }
                 });
+              void client.getConfig()
+                .then((nextConfig) => {
+                  setNetworkConfig(nextConfig);
+                })
+                .catch(() => undefined);
               if (!logServiceId) {
                 return;
               }

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -317,6 +317,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const networkStatusRequestIdRef = useRef(0);
   const networkStatusSuccessRequestIdRef = useRef(0);
   const networkStatusSettledRequestIdRef = useRef(0);
+  const networkConfigRequestIdRef = useRef(0);
   const networkLogsRequestIdRef = useRef(0);
   const {
     activity,
@@ -394,9 +395,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           setNetworkError(`Unable to load network status: ${networkErrorMessage(error, 'Request failed.')}`);
         }
       });
+    const configRequestId = ++networkConfigRequestIdRef.current;
     void client.getConfig()
       .then((nextConfig) => {
-        setNetworkConfig(nextConfig);
+        if (configRequestId === networkConfigRequestIdRef.current) {
+          setNetworkConfig(nextConfig);
+        }
       })
       .catch(() => undefined);
   }, [baseUrl]);
@@ -1278,11 +1282,18 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                     setNetworkError(`Unable to refresh network status: ${networkErrorMessage(error, 'Request failed.')}`);
                   }
                 });
+              const configRequestId = ++networkConfigRequestIdRef.current;
               void client.getConfig()
                 .then((nextConfig) => {
-                  setNetworkConfig(nextConfig);
+                  if (configRequestId === networkConfigRequestIdRef.current) {
+                    setNetworkConfig(nextConfig);
+                  }
                 })
-                .catch(() => undefined);
+                .catch((error: unknown) => {
+                  if (configRequestId === networkConfigRequestIdRef.current) {
+                    setNetworkError(`Unable to refresh network config: ${networkErrorMessage(error, 'Request failed.')}`);
+                  }
+                });
               if (!logServiceId) {
                 return;
               }

--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { NetworkConfigResponse } from '../lib/network-api';
 
 interface NetworkConfigEditorProps {
@@ -132,6 +132,7 @@ function validateForm(state: NetworkConfigFormState): string[] {
 
 export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps) {
   const initialState = useMemo(() => formStateFromConfig(config), [config]);
+  const previousInitialStateRef = useRef<NetworkConfigFormState>(initialState);
   const [formState, setFormState] = useState<NetworkConfigFormState>(initialState);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -141,7 +142,17 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
   const canSave = assignments.length > 0 && validationErrors.length === 0 && !isSaving;
 
   useEffect(() => {
-    setFormState(initialState);
+    const previousInitialState = previousInitialStateRef.current;
+    setFormState((current) => {
+      const next: NetworkConfigFormState = { ...initialState };
+      for (const key of Object.keys(current) as Array<keyof NetworkConfigFormState>) {
+        if (current[key] !== previousInitialState[key]) {
+          next[key] = current[key] as never;
+        }
+      }
+      return next;
+    });
+    previousInitialStateRef.current = initialState;
     setError(null);
   }, [initialState]);
 

--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -133,6 +133,7 @@ function validateForm(state: NetworkConfigFormState): string[] {
 export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps) {
   const initialState = useMemo(() => formStateFromConfig(config), [config]);
   const previousInitialStateRef = useRef<NetworkConfigFormState>(initialState);
+  const shouldAcceptNextConfigRef = useRef(false);
   const [formState, setFormState] = useState<NetworkConfigFormState>(initialState);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -142,6 +143,13 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
   const canSave = assignments.length > 0 && validationErrors.length === 0 && !isSaving;
 
   useEffect(() => {
+    if (shouldAcceptNextConfigRef.current) {
+      setFormState(initialState);
+      previousInitialStateRef.current = initialState;
+      shouldAcceptNextConfigRef.current = false;
+      setError(null);
+      return;
+    }
     const previousInitialState = previousInitialStateRef.current;
     setFormState((current) => {
       const next: NetworkConfigFormState = { ...initialState };
@@ -171,6 +179,7 @@ export function NetworkConfigEditor({ config, onSave }: NetworkConfigEditorProps
     setSuccess(null);
     try {
       await onSave(assignments);
+      shouldAcceptNextConfigRef.current = true;
       setSuccess('Saved network config changes.');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to save network config.');

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -299,6 +299,48 @@ describe('NetworkPage', () => {
     expect((screen.getByLabelText('Comms enabled') as HTMLInputElement).checked).toBe(true);
   });
 
+  it('syncs refreshed config into untouched fields without clobbering unsaved edits', () => {
+    const { rerender } = render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });
+
+    rerender(
+      <NetworkPage
+        config={{
+          ...baseConfig,
+          chat: { ...baseConfig.chat, model: 'fresh-backend-model', host: '192.168.1.10' },
+        }}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('fresh-backend-model')).toBeDefined();
+    expect(screen.getByDisplayValue('0.0.0.0')).toBeDefined();
+    expect(screen.getByText('chat.host=0.0.0.0')).toBeDefined();
+    expect(screen.queryByText('chat.model=fresh-backend-model')).toBeNull();
+  });
+
   it('surfaces save errors from the network config API', async () => {
     const onSaveConfig = vi.fn().mockRejectedValue(new Error('HTTP 400'));
 

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -341,6 +341,51 @@ describe('NetworkPage', () => {
     expect(screen.queryByText('chat.model=fresh-backend-model')).toBeNull();
   });
 
+  it('accepts normalized config returned after a successful save', async () => {
+    const onSaveConfig = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Chat port'), { target: { value: '03737' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save config' }));
+
+    await waitFor(() => expect(onSaveConfig).toHaveBeenCalledWith(['chat.port=03737']));
+
+    rerender(
+      <NetworkPage
+        config={{
+          ...baseConfig,
+          chat: { ...baseConfig.chat, port: 3737 },
+        }}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('3737')).toBeDefined();
+    expect(screen.getByText('No pending config changes.')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Save config' })).toHaveProperty('disabled', true);
+  });
+
   it('surfaces save errors from the network config API', async () => {
     const onSaveConfig = vi.fn().mockRejectedValue(new Error('HTTP 400'));
 


### PR DESCRIPTION
## Summary
- refreshes network config alongside manual Network page refreshes so the editor no longer keeps stale config values
- preserves operator edits when refreshed backend config updates untouched fields
- adds regression coverage for stale chat model/config refresh behavior

## Test Plan
- npm test -- --run tests/components/network-page.test.tsx src/components/chat-shell.test.tsx
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm test --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1018