### PR TITLE
feat(learning): add lesson-to-test traceability map

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -80,6 +80,18 @@ if (result.verdict !== 'pass') {
 
 Use `createReviewer` when a caller has the required guardrails, memory, observability, and known-package dependencies and wants the package's pre-wired reviewer facade instead of assembling a pipeline directly.
 
+## Lesson-to-test traceability
+
+When the critique loop recovers from one or more failing iterations and ends in `pass` or `warn`, `LessonRecorder` records each learned critique lesson with a `testTraceability` map. Each entry includes:
+
+- `lessonId`: a stable identifier derived from task id, evaluator name, and failing iteration.
+- `failingIteration` and `resolvedIteration`: the retry path that produced the lesson.
+- `sourceFindingMessages`: the evaluator findings that motivated the lesson.
+- `testId`: the deterministic regression-test identifier PM handoffs can require before promoting or retiring the lesson.
+- `verificationCommand`: the targeted command that verifies the traceability-map contract.
+
+Infrastructure-only evaluator exceptions are intentionally excluded from the map so operator dashboards do not promote broken tooling as product lessons. PM handoffs should treat lessons without a matching regression `testId` as unverified learning that is not ready for promotion.
+
 ## Package scripts
 
 Run these from the package directory with `npm run <script>`, or from the repository root with `npm run <script> --workspace @franken/critique`.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -21,6 +21,7 @@ export type {
   SandboxResult,
   ADRMatch,
   EpisodicTrace,
+  LessonTestTraceabilityEntry,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -4,6 +4,9 @@ import type { TaskId } from '../types/common.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
 import { isoNow } from '@franken/types';
 
+const LESSON_TRACEABILITY_VERIFICATION_COMMAND =
+  'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts';
+
 export class LessonRecorder {
   private readonly memory: MemoryPort;
 
@@ -49,18 +52,45 @@ export class LessonRecorder {
       );
 
       if (evalResult.verdict === 'fail' && critiqueFindings.length > 0) {
+        const resolvedIteration = passingIteration?.index ?? failingIteration.index;
+        const lessonId = createLessonId(taskId, evalResult.evaluatorName, failingIteration.index);
+        const findingMessages = critiqueFindings.map((f) => f.message);
+
         lessons.push({
           evaluatorName: evalResult.evaluatorName,
-          failureDescription: critiqueFindings.map((f) => f.message).join('; '),
+          failureDescription: findingMessages.join('; '),
           correctionApplied: passingIteration
             ? `Corrected in iteration ${passingIteration.index}`
             : 'Unknown correction',
           taskId,
           timestamp: isoNow(),
+          testTraceability: [
+            {
+              lessonId,
+              taskId,
+              evaluatorName: evalResult.evaluatorName,
+              failingIteration: failingIteration.index,
+              resolvedIteration,
+              sourceFindingMessages: findingMessages,
+              testId: `${lessonId}:regression`,
+              verificationCommand: LESSON_TRACEABILITY_VERIFICATION_COMMAND,
+            },
+          ],
         });
       }
     }
 
     return lessons;
   }
+}
+
+function createLessonId(taskId: TaskId, evaluatorName: string, iterationIndex: number): string {
+  return [taskId, evaluatorName, `iteration-${iterationIndex}`]
+    .map((part) => sanitizeLessonIdPart(part))
+    .join(':');
+}
+
+function sanitizeLessonIdPart(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, '-');
+  return normalized.replace(/^-+|-+$/g, '') || 'unknown';
 }

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -35,6 +35,21 @@ export interface EpisodicTrace {
   readonly timestamp: string;
 }
 
+/** A traceable link from a learned critique lesson to the regression test expected to guard it. */
+export interface LessonTestTraceabilityEntry {
+  /** Stable identifier that PM handoffs can use to connect the lesson to its regression test. */
+  readonly lessonId: string;
+  readonly taskId: TaskId;
+  readonly evaluatorName: string;
+  readonly failingIteration: number;
+  readonly resolvedIteration: number;
+  readonly sourceFindingMessages: readonly string[];
+  /** Deterministic regression-test identifier expected to cover this lesson before promotion. */
+  readonly testId: string;
+  /** Targeted command that verifies the traceability-map contract itself. */
+  readonly verificationCommand: string;
+}
+
 /** A lesson learned from a successful critique cycle. */
 export interface CritiqueLesson {
   readonly evaluatorName: string;
@@ -42,6 +57,8 @@ export interface CritiqueLesson {
   readonly correctionApplied: string;
   readonly taskId: TaskId;
   readonly timestamp: string;
+  /** Present for lessons recorded by LessonRecorder; absent legacy lessons are unverified. */
+  readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -81,6 +81,61 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('adds a deterministic lesson-to-test traceability map to recorded lessons', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'Safety Gate', [
+          { message: 'plain HTTP endpoint needs HTTPS', severity: 'critical' },
+        ]),
+        createIteration(2, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'Task 123');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.testTraceability).toEqual([
+      {
+        lessonId: 'task-123:safety-gate:iteration-0',
+        taskId: 'Task 123',
+        evaluatorName: 'Safety Gate',
+        failingIteration: 0,
+        resolvedIteration: 2,
+        sourceFindingMessages: ['plain HTTP endpoint needs HTTPS'],
+        testId: 'task-123:safety-gate:iteration-0:regression',
+        verificationCommand:
+          'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts',
+      },
+    ]);
+  });
+
+  it('does not create traceability entries for infrastructure-only evaluator exceptions', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'adr-compliance', [
+          {
+            message: 'internal evaluator error occurred',
+            severity: 'critical',
+            location: EVALUATOR_EXCEPTION_LOCATION,
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-123');
+
+    expect(port.recordLesson).not.toHaveBeenCalled();
+  });
+
   it('includes correction info from the failing iteration', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);

--- a/tasks/issue-1864-lesson-test-traceability-progress.md
+++ b/tasks/issue-1864-lesson-test-traceability-progress.md
@@ -1,0 +1,11 @@
+# Issue 1864 lesson-to-test traceability progress
+
+- [x] Inspect issue #1864 and repository instructions.
+- [x] Locate current lesson capture/recording implementation and tests.
+- [x] Add the smallest lesson-to-test traceability behavior.
+- [x] Add focused success and edge-case tests.
+- [x] Update operator-facing docs/help guidance.
+- [x] Run targeted verification.
+  - `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` passed (10 tests).
+  - `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique` passed after installing workspace dependencies because the isolated worktree had no node_modules.
+- [ ] Commit, push, open PR, and request Codex review.

--- a/tasks/issue-1864-lesson-test-traceability-progress.md
+++ b/tasks/issue-1864-lesson-test-traceability-progress.md
@@ -8,4 +8,7 @@
 - [x] Run targeted verification.
   - `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` passed (10 tests).
   - `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique` passed after installing workspace dependencies because the isolated worktree had no node_modules.
-- [ ] Commit, push, open PR, and request Codex review.
+- [x] Commit, push, open PR, and request Codex review.
+  - Commit: `290400e7 feat(learning): add lesson test traceability`.
+  - PR: https://github.com/djm204/frankenbeast/pull/1872.
+  - Posted `@codex review` on the PR.


### PR DESCRIPTION
## Summary
- add structured lesson-to-test traceability metadata to recorded critique lessons
- document how PM/operator handoffs should interpret lesson traceability
- cover deterministic map generation and infrastructure-exception exclusion in LessonRecorder tests

Closes #1864

## Test plan
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique

Note: fbeast MCP tools were not available in this worker tool schema, so I followed AGENTS.md with normal terminal/file/git/gh verification.