### PR TITLE
feat(learning): add episodic learning cooldown

### DIFF
--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -49,6 +49,23 @@ brain.episodic.record({
 });
 const related = brain.episodic.recall('package inventory', 5);
 
+// Agent learning capture can opt into a cooldown so retrospectives or PM
+// handoffs do not churn the same lesson repeatedly. The key is stored in
+// details.learningKey; duplicate attempts return a structured cooldown result
+// instead of silently inserting another episodic row.
+const learningResult = brain.episodic.recordLearning({
+  type: 'observation',
+  step: 'worker-retrospective',
+  summary: 'Run targeted package tests before broad verification',
+  createdAt: new Date().toISOString(),
+}, {
+  key: 'targeted-package-tests',
+  cooldownMs: 24 * 60 * 60 * 1000,
+});
+if (!learningResult.recorded) {
+  console.log(`Learning still cooling down until ${learningResult.cooldownUntil}`);
+}
+
 // Recovery memory stores execution checkpoints and flushes working memory.
 const checkpoint = brain.recovery.checkpoint({
   runId: 'run-001',

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -413,6 +413,8 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       throw new Error(`Learning event createdAt must be a valid ISO timestamp: ${event.createdAt}`);
     }
 
+    const normalizedCreatedAt = new Date(eventTimeMs).toISOString();
+
     if (cooldownMs > 0) {
       const existingEvent = this.findLearningCooldownEvent(key, eventTimeMs, cooldownMs);
       if (existingEvent) {
@@ -429,6 +431,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
 
     this.insertEvent({
       ...event,
+      createdAt: normalizedCreatedAt,
       details: {
         ...(event.details ?? {}),
         learningKey: key,
@@ -459,19 +462,26 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     eventTimeMs: number,
     cooldownMs: number,
   ): EpisodicEvent | null {
-    const cooldownStart = new Date(eventTimeMs - cooldownMs).toISOString();
-    const eventTime = new Date(eventTimeMs).toISOString();
     const rows = this.db
       .prepare(
         `SELECT * FROM episodic_events
-         WHERE created_at >= ? AND created_at <= ?
-         ORDER BY created_at DESC, id DESC`,
+         WHERE details IS NOT NULL
+         ORDER BY id DESC`,
       )
-      .all(cooldownStart, eventTime) as EpisodicRow[];
+      .all() as EpisodicRow[];
 
     for (const row of rows) {
       const existingEvent = rowToEvent(row);
-      if (existingEvent && learningKeyForEvent(existingEvent) === key) {
+      if (!existingEvent || normalizeLearningKey(readLearningKey(existingEvent) ?? '') !== key) {
+        continue;
+      }
+
+      const existingTimeMs = Date.parse(existingEvent.createdAt);
+      if (
+        Number.isFinite(existingTimeMs)
+        && existingTimeMs <= eventTimeMs
+        && eventTimeMs - existingTimeMs <= cooldownMs
+      ) {
         return existingEvent;
       }
     }
@@ -788,12 +798,6 @@ function normalizeLearningKey(value: string): string {
 function readLearningKey(event: EpisodicEvent): string | undefined {
   const key = event.details?.learningKey;
   return typeof key === 'string' ? key : undefined;
-}
-
-function learningKeyForEvent(event: EpisodicEvent): string {
-  return normalizeLearningKey(
-    readLearningKey(event) ?? `${event.step ?? ''}:${event.summary}`,
-  );
 }
 
 function chunkArray<T>(values: T[], size: number): T[][] {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -427,7 +427,9 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
             key,
             cooldownMs,
             existingEvent,
-            cooldownUntil: new Date(Date.parse(existingEvent.createdAt) + cooldownMs).toISOString(),
+            cooldownUntil: new Date(
+              Date.parse(existingEvent.createdAt) + (readLearningCooldownMs(existingEvent) ?? cooldownMs),
+            ).toISOString(),
           };
         }
       }
@@ -473,10 +475,10 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     const rows = this.db
       .prepare(
         `SELECT * FROM episodic_events
-         WHERE details IS NOT NULL
+         WHERE details LIKE ? ESCAPE '\\'
          ORDER BY id DESC`,
       )
-      .all() as EpisodicRow[];
+      .all(learningKeyDetailsPattern(key)) as EpisodicRow[];
 
     for (const row of rows) {
       const existingEvent = rowToEvent(row);
@@ -485,10 +487,13 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       }
 
       const existingTimeMs = Date.parse(existingEvent.createdAt);
+      const existingCooldownMs = readLearningCooldownMs(existingEvent) ?? cooldownMs;
       if (
         Number.isFinite(existingTimeMs)
+        && Number.isInteger(existingCooldownMs)
+        && existingCooldownMs > 0
         && existingTimeMs <= eventTimeMs
-        && eventTimeMs - existingTimeMs < cooldownMs
+        && eventTimeMs - existingTimeMs < existingCooldownMs
       ) {
         return existingEvent;
       }
@@ -600,20 +605,22 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     const activeLearningRows = this.db
       .prepare(
         `SELECT * FROM episodic_events
-         WHERE details IS NOT NULL
+         WHERE details LIKE ? ESCAPE '\\'
          ORDER BY id DESC`,
       )
-      .all() as EpisodicRow[];
-    const activeSinceMs = nowMs - DEFAULT_LEARNING_COOLDOWN_MS;
+      .all(learningKeyDetailsPattern()) as EpisodicRow[];
 
     for (const row of activeLearningRows) {
       const event = rowToEvent(row);
       const eventTimeMs = event ? Date.parse(event.createdAt) : NaN;
+      const eventCooldownMs = event ? readLearningCooldownMs(event) ?? DEFAULT_LEARNING_COOLDOWN_MS : NaN;
       if (
         event
         && readLearningKey(event) !== undefined
         && Number.isFinite(eventTimeMs)
-        && eventTimeMs >= activeSinceMs
+        && Number.isInteger(eventCooldownMs)
+        && eventCooldownMs > 0
+        && nowMs - eventTimeMs < eventCooldownMs
       ) {
         eventsById.set(event.id ?? `${event.createdAt}:${event.summary}`, event);
       }
@@ -838,6 +845,16 @@ function normalizeLearningKey(value: string): string {
 function readLearningKey(event: EpisodicEvent): string | undefined {
   const key = event.details?.learningKey;
   return typeof key === 'string' ? key : undefined;
+}
+
+function readLearningCooldownMs(event: EpisodicEvent): number | undefined {
+  const cooldownMs = event.details?.learningCooldownMs;
+  return typeof cooldownMs === 'number' ? cooldownMs : undefined;
+}
+
+function learningKeyDetailsPattern(key?: string): string {
+  const keyPattern = key === undefined ? '' : JSON.stringify(key);
+  return `%${escapeLike(`"learningKey":${keyPattern}`)}%`;
 }
 
 function compareEventsNewestFirst(a: EpisodicEvent, b: EpisodicEvent): number {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -8,6 +8,8 @@ import type {
   EpisodicEvent,
   ExecutionState,
   EpisodicEventType,
+  LearningCooldownOptions,
+  LearningRecordResult,
 } from '@franken/types';
 import { isoNow } from '@franken/types';
 
@@ -369,6 +371,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
 const SQLITE_VARIABLE_LIMIT = 999;
 const RECALL_VARIABLES_PER_KEYWORD = 4;
 const CORRUPT_JSON_SCAN_BATCH_SIZE = 100;
+const DEFAULT_LEARNING_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const RECALL_LIMIT_VARIABLES = 1;
 const MAX_RECALL_KEYWORDS_PER_QUERY = Math.floor(
   (SQLITE_VARIABLE_LIMIT - RECALL_LIMIT_VARIABLES) / RECALL_VARIABLES_PER_KEYWORD,
@@ -387,6 +390,56 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
   constructor(private db: Database.Database) {}
 
   record(event: EpisodicEvent): void {
+    this.insertEvent(event);
+  }
+
+  recordLearning(
+    event: EpisodicEvent,
+    options: LearningCooldownOptions = {},
+  ): LearningRecordResult {
+    const key = normalizeLearningKey(
+      options.key ?? readLearningKey(event) ?? `${event.step ?? ''}:${event.summary}`,
+    );
+    const cooldownMs = options.cooldownMs ?? DEFAULT_LEARNING_COOLDOWN_MS;
+    const eventTimeMs = Date.parse(event.createdAt);
+
+    if (!key) {
+      throw new Error('Learning cooldown key must not be empty');
+    }
+    if (!Number.isInteger(cooldownMs) || cooldownMs < 0) {
+      throw new RangeError('Learning cooldown must be a non-negative integer number of milliseconds');
+    }
+    if (!Number.isFinite(eventTimeMs)) {
+      throw new Error(`Learning event createdAt must be a valid ISO timestamp: ${event.createdAt}`);
+    }
+
+    if (cooldownMs > 0) {
+      const existingEvent = this.findLearningCooldownEvent(key, eventTimeMs, cooldownMs);
+      if (existingEvent) {
+        return {
+          recorded: false,
+          reason: 'cooldown',
+          key,
+          cooldownMs,
+          existingEvent,
+          cooldownUntil: new Date(Date.parse(existingEvent.createdAt) + cooldownMs).toISOString(),
+        };
+      }
+    }
+
+    this.insertEvent({
+      ...event,
+      details: {
+        ...(event.details ?? {}),
+        learningKey: key,
+        learningCooldownMs: cooldownMs,
+      },
+    });
+
+    return { recorded: true, key, cooldownMs };
+  }
+
+  private insertEvent(event: EpisodicEvent): void {
     this.db
       .prepare(
         `INSERT INTO episodic_events (type, step, summary, details, created_at)
@@ -399,6 +452,31 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         event.details ? JSON.stringify(event.details) : null,
         event.createdAt,
       );
+  }
+
+  private findLearningCooldownEvent(
+    key: string,
+    eventTimeMs: number,
+    cooldownMs: number,
+  ): EpisodicEvent | null {
+    const cooldownStart = new Date(eventTimeMs - cooldownMs).toISOString();
+    const eventTime = new Date(eventTimeMs).toISOString();
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM episodic_events
+         WHERE created_at >= ? AND created_at <= ?
+         ORDER BY created_at DESC, id DESC`,
+      )
+      .all(cooldownStart, eventTime) as EpisodicRow[];
+
+    for (const row of rows) {
+      const existingEvent = rowToEvent(row);
+      if (existingEvent && learningKeyForEvent(existingEvent) === key) {
+        return existingEvent;
+      }
+    }
+
+    return null;
   }
 
   recall(query: string, limit = 10): EpisodicEvent[] {
@@ -701,6 +779,21 @@ const STOPWORDS = new Set([
 
 function escapeLike(s: string): string {
   return s.replace(/[%_\\]/g, '\\$&');
+}
+
+function normalizeLearningKey(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function readLearningKey(event: EpisodicEvent): string | undefined {
+  const key = event.details?.learningKey;
+  return typeof key === 'string' ? key : undefined;
+}
+
+function learningKeyForEvent(event: EpisodicEvent): string {
+  return normalizeLearningKey(
+    readLearningKey(event) ?? `${event.step ?? ''}:${event.summary}`,
+  );
 }
 
 function chunkArray<T>(values: T[], size: number): T[][] {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -415,31 +415,39 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
 
     const normalizedCreatedAt = new Date(eventTimeMs).toISOString();
 
-    if (cooldownMs > 0) {
-      const existingEvent = this.findLearningCooldownEvent(key, eventTimeMs, cooldownMs);
-      if (existingEvent) {
-        return {
-          recorded: false,
-          reason: 'cooldown',
-          key,
-          cooldownMs,
-          existingEvent,
-          cooldownUntil: new Date(Date.parse(existingEvent.createdAt) + cooldownMs).toISOString(),
-        };
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      if (cooldownMs > 0) {
+        const existingEvent = this.findLearningCooldownEvent(key, eventTimeMs, cooldownMs);
+        if (existingEvent) {
+          this.db.exec('COMMIT');
+          return {
+            recorded: false,
+            reason: 'cooldown',
+            key,
+            cooldownMs,
+            existingEvent,
+            cooldownUntil: new Date(Date.parse(existingEvent.createdAt) + cooldownMs).toISOString(),
+          };
+        }
       }
+
+      this.insertEvent({
+        ...event,
+        createdAt: normalizedCreatedAt,
+        details: {
+          ...(event.details ?? {}),
+          learningKey: key,
+          learningCooldownMs: cooldownMs,
+        },
+      });
+
+      this.db.exec('COMMIT');
+      return { recorded: true, key, cooldownMs };
+    } catch (error) {
+      this.db.exec('ROLLBACK');
+      throw error;
     }
-
-    this.insertEvent({
-      ...event,
-      createdAt: normalizedCreatedAt,
-      details: {
-        ...(event.details ?? {}),
-        learningKey: key,
-        learningCooldownMs: cooldownMs,
-      },
-    });
-
-    return { recorded: true, key, cooldownMs };
   }
 
   private insertEvent(event: EpisodicEvent): void {
@@ -480,7 +488,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       if (
         Number.isFinite(existingTimeMs)
         && existingTimeMs <= eventTimeMs
-        && eventTimeMs - existingTimeMs <= cooldownMs
+        && eventTimeMs - existingTimeMs < cooldownMs
       ) {
         return existingEvent;
       }
@@ -580,6 +588,38 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
       n,
     );
+  }
+
+  snapshotForHandoff(n = 100, nowMs = Date.now()): EpisodicEvent[] {
+    const recentEvents = this.recent(n);
+    const eventsById = new Map<number | string, EpisodicEvent>();
+    for (const event of recentEvents) {
+      eventsById.set(event.id ?? `${event.createdAt}:${event.summary}`, event);
+    }
+
+    const activeLearningRows = this.db
+      .prepare(
+        `SELECT * FROM episodic_events
+         WHERE details IS NOT NULL
+         ORDER BY id DESC`,
+      )
+      .all() as EpisodicRow[];
+    const activeSinceMs = nowMs - DEFAULT_LEARNING_COOLDOWN_MS;
+
+    for (const row of activeLearningRows) {
+      const event = rowToEvent(row);
+      const eventTimeMs = event ? Date.parse(event.createdAt) : NaN;
+      if (
+        event
+        && readLearningKey(event) !== undefined
+        && Number.isFinite(eventTimeMs)
+        && eventTimeMs >= activeSinceMs
+      ) {
+        eventsById.set(event.id ?? `${event.createdAt}:${event.summary}`, event);
+      }
+    }
+
+    return [...eventsById.values()].sort(compareEventsNewestFirst);
   }
 
   count(): number {
@@ -708,7 +748,7 @@ export class SqliteBrain implements IBrain {
       version: 1,
       timestamp: isoNow(),
       working: this.working.snapshot(),
-      episodic: this.episodic.recent(100),
+      episodic: this.episodic.snapshotForHandoff(100),
       checkpoint: this.recovery.lastCheckpoint(),
       metadata: {
         lastProvider: '',
@@ -798,6 +838,11 @@ function normalizeLearningKey(value: string): string {
 function readLearningKey(event: EpisodicEvent): string | undefined {
   const key = event.details?.learningKey;
   return typeof key === 'string' ? key : undefined;
+}
+
+function compareEventsNewestFirst(a: EpisodicEvent, b: EpisodicEvent): number {
+  return Date.parse(b.createdAt) - Date.parse(a.createdAt)
+    || (b.id ?? 0) - (a.id ?? 0);
 }
 
 function chunkArray<T>(values: T[], size: number): T[][] {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -528,8 +528,8 @@ describe('SqliteBrain', () => {
       const now = Date.now();
       brain.episodic.recordLearning(makeEvent({
         summary: 'Keep cooldown metadata across handoffs',
-        createdAt: new Date(now - 1_000).toISOString(),
-      }), { key: 'handoff-cooldown', cooldownMs: 86_400_000 });
+        createdAt: new Date(now - 25 * 60 * 60 * 1_000).toISOString(),
+      }), { key: 'handoff-cooldown', cooldownMs: 7 * 24 * 60 * 60 * 1_000 });
 
       for (let i = 0; i < 101; i++) {
         brain.episodic.record(makeEvent({
@@ -540,6 +540,24 @@ describe('SqliteBrain', () => {
 
       const snapshot = brain.serialize();
       expect(snapshot.episodic.some(event => event.details?.learningKey === 'handoff-cooldown')).toBe(true);
+    });
+
+    it('uses the stored learning cooldown duration for duplicate detection', () => {
+      brain.episodic.recordLearning(makeEvent({
+        summary: 'Respect stored cooldowns',
+        createdAt: '2026-07-11T12:00:00.000Z',
+      }), { key: 'stored-cooldown', cooldownMs: 7 * 24 * 60 * 60 * 1_000 });
+
+      const duplicate = brain.episodic.recordLearning(makeEvent({
+        summary: 'Respect stored cooldowns',
+        createdAt: '2026-07-12T12:00:00.000Z',
+      }), { key: 'stored-cooldown' });
+
+      expect(duplicate).toMatchObject({
+        recorded: false,
+        reason: 'cooldown',
+        cooldownUntil: '2026-07-18T12:00:00.000Z',
+      });
     });
 
     it('recall() finds matching events by keyword', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -484,6 +484,46 @@ describe('SqliteBrain', () => {
       )).toThrow(RangeError);
     });
 
+    it('does not let non-learning events satisfy the learning cooldown', () => {
+      brain.episodic.record(makeEvent({
+        type: 'success',
+        step: 'retro',
+        summary: 'Prefer targeted verification for touched packages',
+        createdAt: '2026-07-11T12:00:00.000Z',
+      }));
+
+      const result = brain.episodic.recordLearning(makeEvent({
+        step: 'retro',
+        summary: 'Prefer targeted verification for touched packages',
+        createdAt: '2026-07-11T12:00:30.000Z',
+      }), { cooldownMs: 60_000 });
+
+      expect(result.recorded).toBe(true);
+      expect(brain.episodic.count()).toBe(2);
+    });
+
+    it('compares learning cooldown timestamps as instants', () => {
+      brain.episodic.recordLearning(makeEvent({
+        summary: 'Normalize timestamps before comparing cooldowns',
+        createdAt: '2026-07-11T08:00:00-04:00',
+      }), { key: 'timestamp-normalization', cooldownMs: 60_000 });
+
+      const duplicate = brain.episodic.recordLearning(makeEvent({
+        summary: 'Normalize timestamps before comparing cooldowns',
+        createdAt: '2026-07-11T12:00:30.000Z',
+      }), { key: 'timestamp-normalization', cooldownMs: 60_000 });
+
+      expect(duplicate).toMatchObject({
+        recorded: false,
+        reason: 'cooldown',
+        cooldownUntil: '2026-07-11T12:01:00.000Z',
+      });
+      expect(duplicate.recorded === false ? duplicate.existingEvent.createdAt : '').toBe(
+        '2026-07-11T12:00:00.000Z',
+      );
+      expect(brain.episodic.count()).toBe(1);
+    });
+
     it('recall() finds matching events by keyword', () => {
       brain.episodic.record(makeEvent({ summary: 'first test event' }));
       brain.episodic.record(makeEvent({ summary: 'second test event' }));

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -473,7 +473,7 @@ describe('SqliteBrain', () => {
       brain.episodic.recordLearning(base, { key: 'handoff-receipts', cooldownMs: 60_000 });
       const afterCooldown = brain.episodic.recordLearning({
         ...base,
-        createdAt: '2026-07-11T12:01:01.000Z',
+        createdAt: '2026-07-11T12:01:00.000Z',
       }, { key: 'handoff-receipts', cooldownMs: 60_000 });
 
       expect(afterCooldown.recorded).toBe(true);
@@ -522,6 +522,24 @@ describe('SqliteBrain', () => {
         '2026-07-11T12:00:00.000Z',
       );
       expect(brain.episodic.count()).toBe(1);
+    });
+
+    it('keeps active learning cooldown rows in handoff snapshots beyond the recent limit', () => {
+      const now = Date.now();
+      brain.episodic.recordLearning(makeEvent({
+        summary: 'Keep cooldown metadata across handoffs',
+        createdAt: new Date(now - 1_000).toISOString(),
+      }), { key: 'handoff-cooldown', cooldownMs: 86_400_000 });
+
+      for (let i = 0; i < 101; i++) {
+        brain.episodic.record(makeEvent({
+          summary: `newer event ${i}`,
+          createdAt: new Date(now + i).toISOString(),
+        }));
+      }
+
+      const snapshot = brain.serialize();
+      expect(snapshot.episodic.some(event => event.details?.learningKey === 'handoff-cooldown')).toBe(true);
     });
 
     it('recall() finds matching events by keyword', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -419,6 +419,71 @@ describe('SqliteBrain', () => {
       expect(events[0]!.details).toEqual({ file: 'auth.ts', line: 42 });
     });
 
+    it('records a learning once during its cooldown window to prevent churn', () => {
+      const first = brain.episodic.recordLearning(makeEvent({
+        step: 'retro',
+        summary: 'Prefer targeted verification for touched packages',
+        createdAt: '2026-07-11T12:00:00.000Z',
+      }), { cooldownMs: 60_000 });
+      const second = brain.episodic.recordLearning(makeEvent({
+        step: 'handoff',
+        summary: 'Prefer targeted verification for touched packages',
+        createdAt: '2026-07-11T12:00:30.000Z',
+      }), {
+        key: 'targeted-verification',
+        cooldownMs: 60_000,
+      });
+
+      expect(first).toEqual({
+        recorded: true,
+        key: 'retro:prefer targeted verification for touched packages',
+        cooldownMs: 60_000,
+      });
+      expect(second.recorded).toBe(true);
+      expect(brain.episodic.count()).toBe(2);
+
+      const duplicate = brain.episodic.recordLearning(makeEvent({
+        step: 'handoff',
+        summary: 'Same lesson in a different wording',
+        createdAt: '2026-07-11T12:00:45.000Z',
+      }), {
+        key: ' TARGETED-VERIFICATION ',
+        cooldownMs: 60_000,
+      });
+
+      expect(duplicate).toMatchObject({
+        recorded: false,
+        reason: 'cooldown',
+        key: 'targeted-verification',
+        cooldownMs: 60_000,
+        cooldownUntil: '2026-07-11T12:01:30.000Z',
+      });
+      expect(duplicate.recorded === false ? duplicate.existingEvent.summary : '').toBe(
+        'Prefer targeted verification for touched packages',
+      );
+      expect(brain.episodic.count()).toBe(2);
+    });
+
+    it('records a learning again after cooldown and rejects invalid cooldown input', () => {
+      const base = makeEvent({
+        summary: 'Use structured handoff receipts',
+        createdAt: '2026-07-11T12:00:00.000Z',
+      });
+
+      brain.episodic.recordLearning(base, { key: 'handoff-receipts', cooldownMs: 60_000 });
+      const afterCooldown = brain.episodic.recordLearning({
+        ...base,
+        createdAt: '2026-07-11T12:01:01.000Z',
+      }, { key: 'handoff-receipts', cooldownMs: 60_000 });
+
+      expect(afterCooldown.recorded).toBe(true);
+      expect(brain.episodic.count()).toBe(2);
+      expect(() => brain.episodic.recordLearning(
+        base,
+        { key: 'handoff-receipts', cooldownMs: -1 },
+      )).toThrow(RangeError);
+    });
+
     it('recall() finds matching events by keyword', () => {
       brain.episodic.record(makeEvent({ summary: 'first test event' }));
       brain.episodic.record(makeEvent({ summary: 'second test event' }));

--- a/packages/franken-types/src/brain.ts
+++ b/packages/franken-types/src/brain.ts
@@ -102,7 +102,7 @@ export const EpisodicEventSchema = z.object({
 });
 
 export const LearningCooldownOptionsSchema = z.object({
-  key: z.string().min(1).optional(),
+  key: z.string().trim().min(1).optional(),
   cooldownMs: z.number().int().nonnegative().optional(),
 });
 

--- a/packages/franken-types/src/brain.ts
+++ b/packages/franken-types/src/brain.ts
@@ -22,6 +22,7 @@ export interface IWorkingMemory {
 
 export interface IEpisodicMemory {
   record(event: EpisodicEvent): void;
+  recordLearning(event: EpisodicEvent, options?: LearningCooldownOptions): LearningRecordResult;
   recall(query: string, limit?: number): EpisodicEvent[];
   recentFailures(n?: number): EpisodicEvent[];
   recent(n?: number): EpisodicEvent[];
@@ -47,6 +48,24 @@ export interface EpisodicEvent {
   details?: Record<string, unknown>;
   createdAt: string;
 }
+
+export interface LearningCooldownOptions {
+  /** Stable identity for the lesson. Defaults to details.learningKey or a normalized step+summary key. */
+  key?: string;
+  /** Cooldown window in milliseconds. Defaults to 24 hours. */
+  cooldownMs?: number;
+}
+
+export type LearningRecordResult =
+  | { recorded: true; key: string; cooldownMs: number }
+  | {
+      recorded: false;
+      reason: 'cooldown';
+      key: string;
+      cooldownMs: number;
+      existingEvent: EpisodicEvent;
+      cooldownUntil: string;
+    };
 
 export interface ExecutionState {
   runId: string;
@@ -80,6 +99,11 @@ export const EpisodicEventSchema = z.object({
   summary: z.string().min(1),
   details: z.record(z.unknown()).optional(),
   createdAt: z.string().datetime(),
+});
+
+export const LearningCooldownOptionsSchema = z.object({
+  key: z.string().min(1).optional(),
+  cooldownMs: z.number().int().nonnegative().optional(),
 });
 
 export const ExecutionStateSchema = z.object({

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -67,11 +67,14 @@ export type {
   IRecoveryMemory,
   EpisodicEventType,
   EpisodicEvent,
+  LearningCooldownOptions,
+  LearningRecordResult,
   ExecutionState,
   BrainSnapshot,
 } from './brain.js';
 export {
   EpisodicEventSchema,
+  LearningCooldownOptionsSchema,
   ExecutionStateSchema,
   BrainSnapshotSchema,
 } from './brain.js';

--- a/packages/franken-types/tests/brain.test.ts
+++ b/packages/franken-types/tests/brain.test.ts
@@ -210,6 +210,11 @@ describe('Brain interfaces (type-level)', () => {
   it('IEpisodicMemory has required methods', () => {
     const em: IEpisodicMemory = {
       record: (_event: EpisodicEvent) => {},
+      recordLearning: (_event: EpisodicEvent) => ({
+        recorded: true,
+        key: 'lesson',
+        cooldownMs: 86_400_000,
+      }),
       recall: (_query: string, _limit?: number) => [],
       recentFailures: (_n?: number) => [],
       recent: (_n?: number) => [],

--- a/packages/franken-types/tests/brain.test.ts
+++ b/packages/franken-types/tests/brain.test.ts
@@ -3,6 +3,7 @@ import {
   BrainSnapshotSchema,
   EpisodicEventSchema,
   ExecutionStateSchema,
+  LearningCooldownOptionsSchema,
   type BrainSnapshot,
   type EpisodicEvent,
   type ExecutionState,
@@ -179,6 +180,16 @@ describe('ExecutionState schema', () => {
         timestamp: new Date().toISOString(),
       }),
     ).toThrow();
+  });
+});
+
+describe('LearningCooldownOptions schema', () => {
+  it('trims cooldown keys and rejects whitespace-only values', () => {
+    expect(LearningCooldownOptionsSchema.parse({ key: ' Lesson Key ', cooldownMs: 1 })).toEqual({
+      key: 'Lesson Key',
+      cooldownMs: 1,
+    });
+    expect(() => LearningCooldownOptionsSchema.parse({ key: '   ' })).toThrow();
   });
 });
 


### PR DESCRIPTION
Resolves #1863

## Summary
- add `recordLearning()` to episodic memory with a stable learning key and 24h default cooldown
- return structured cooldown results when duplicate lessons are skipped
- document operator usage and update type exports/tests

## Test plan
- `npm test --workspace @franken/brain`
- `npm test --workspace @franken/types`
- `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/types && npm run typecheck --workspace @franken/brain`

Note: fbeast MCP tools were not available in this worker tool schema, so I followed AGENTS.md using normal git/GitHub/tool verification.