### PR TITLE
feat(learning): add PM handoff quality rubric

### DIFF
--- a/docs/pm-handoff-quality-rubric.md
+++ b/docs/pm-handoff-quality-rubric.md
@@ -1,0 +1,32 @@
+# PM handoff quality rubric
+
+Provider brain-state handoffs now include a deterministic PM handoff rubric so workers and operators can produce handoffs that are easy to review, resume, and promote into future learning.
+
+Use `formatPmHandoffQualityRubric()` when a human-facing worker retrospective or PM handoff needs the rubric text. Use `scorePmHandoffQuality(summary)` when tooling needs a structured pass/fail report.
+
+## Criteria
+
+- `issue-and-outcome`: name the issue number and the shipped or intentionally-not-shipped outcome.
+- `scope-control`: list changed files or scope notes so PM can distinguish intended work from drift.
+- `verification-evidence`: include exact commands or deterministic verifier output, not just “tested”.
+- `blocker-disclosure`: state blockers explicitly; use an empty blockers list only when there were none.
+- `operator-continuity`: include PR URL, next steps, or handoff notes plus disk/resource status when relevant.
+
+## Structured scoring
+
+A complete handoff should provide at least:
+
+```ts
+scorePmHandoffQuality({
+  issueNumber: 1862,
+  branch: 'pfkborg/issue-1862-feat-learning-add-pm-handoff-quality',
+  prUrl: 'https://github.com/djm204/frankenbeast/pull/<id>',
+  changedFiles: ['packages/franken-orchestrator/src/providers/format-handoff.ts'],
+  verificationCommands: ['npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts'],
+  blockers: [],
+  scopeNotes: ['Added PM handoff quality rubric and scorer.'],
+  diskFree: '24G',
+});
+```
+
+The scorer returns a normalized `score`, an overall `passed` boolean, per-criterion results, and `failedCriteria` IDs. Missing verification, omitted blocker disclosure, or absent continuity notes are explicit failures instead of silent drift.

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -1,4 +1,132 @@
-import type { BrainSnapshot, EpisodicEvent } from '@franken/types';
+import type { BrainSnapshot } from '@franken/types';
+
+export type PmHandoffRubricCriterionId =
+  | 'issue-and-outcome'
+  | 'scope-control'
+  | 'verification-evidence'
+  | 'blocker-disclosure'
+  | 'operator-continuity';
+
+export interface PmHandoffRubricCriterion {
+  readonly id: PmHandoffRubricCriterionId;
+  readonly label: string;
+  readonly guidance: string;
+}
+
+export interface PmHandoffSummary {
+  readonly issueNumber?: number;
+  readonly branch?: string;
+  readonly prUrl?: string | null;
+  readonly changedFiles?: readonly string[];
+  readonly verificationCommands?: readonly string[];
+  readonly blockers?: readonly string[];
+  readonly scopeNotes?: readonly string[];
+  readonly nextSteps?: readonly string[];
+  readonly diskFree?: string;
+}
+
+export interface PmHandoffQualityCriterionResult extends PmHandoffRubricCriterion {
+  readonly passed: boolean;
+}
+
+export interface PmHandoffQualityReport {
+  readonly score: number;
+  readonly passed: boolean;
+  readonly criteria: readonly PmHandoffQualityCriterionResult[];
+  readonly failedCriteria: readonly PmHandoffRubricCriterionId[];
+}
+
+export const PM_HANDOFF_QUALITY_RUBRIC: readonly PmHandoffRubricCriterion[] = [
+  {
+    id: 'issue-and-outcome',
+    label: 'Issue and outcome are explicit',
+    guidance: 'Name the issue number and the shipped or intentionally-not-shipped outcome.',
+  },
+  {
+    id: 'scope-control',
+    label: 'Scope is bounded',
+    guidance: 'List changed files or scope notes so PM can distinguish intended work from drift.',
+  },
+  {
+    id: 'verification-evidence',
+    label: 'Verification evidence is concrete',
+    guidance: 'Include exact commands or deterministic verifier output, not just “tested”.',
+  },
+  {
+    id: 'blocker-disclosure',
+    label: 'Blockers are disclosed',
+    guidance: 'State blockers explicitly; use an empty blockers list only when there were none.',
+  },
+  {
+    id: 'operator-continuity',
+    label: 'Operator continuity is preserved',
+    guidance: 'Include PR URL, next steps, or handoff notes plus disk/resource status when relevant.',
+  },
+];
+
+export function formatPmHandoffQualityRubric(): string {
+  return [
+    'PM handoff quality rubric:',
+    ...PM_HANDOFF_QUALITY_RUBRIC.map(
+      (criterion) => `  - ${criterion.id}: ${criterion.guidance}`,
+    ),
+  ].join('\n');
+}
+
+export function scorePmHandoffQuality(summary: PmHandoffSummary): PmHandoffQualityReport {
+  const criteria: readonly PmHandoffQualityCriterionResult[] = PM_HANDOFF_QUALITY_RUBRIC.map(
+    (criterion) => ({
+      ...criterion,
+      passed: evaluatePmHandoffCriterion(criterion.id, summary),
+    }),
+  );
+  const failedCriteria = criteria
+    .filter((criterion) => !criterion.passed)
+    .map((criterion) => criterion.id);
+
+  return {
+    score: criteria.filter((criterion) => criterion.passed).length / criteria.length,
+    passed: failedCriteria.length === 0,
+    criteria,
+    failedCriteria,
+  };
+}
+
+function evaluatePmHandoffCriterion(
+  criterionId: PmHandoffRubricCriterionId,
+  summary: PmHandoffSummary,
+): boolean {
+  switch (criterionId) {
+    case 'issue-and-outcome':
+      return isPositiveInteger(summary.issueNumber) && hasAnyText(summary.scopeNotes);
+    case 'scope-control':
+      return hasText(summary.branch) && (hasAnyText(summary.changedFiles) || hasAnyText(summary.scopeNotes));
+    case 'verification-evidence':
+      return hasAnyText(summary.verificationCommands);
+    case 'blocker-disclosure':
+      return Array.isArray(summary.blockers);
+    case 'operator-continuity':
+      return hasText(summary.prUrl ?? undefined) || hasAnyText(summary.nextSteps) || hasText(summary.diskFree);
+  }
+
+  const exhaustive: never = criterionId;
+  return exhaustive;
+}
+
+function isPositiveInteger(value: number | undefined): value is number {
+  if (typeof value !== 'number') {
+    return false;
+  }
+  return Number.isInteger(value) && value > 0;
+}
+
+function hasText(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasAnyText(values: readonly string[] | undefined): boolean {
+  return Array.isArray(values) && values.some((value) => hasText(value));
+}
 
 /** Rough char-to-token ratio (1 token ≈ 4 chars) */
 const CHARS_PER_TOKEN = 4;
@@ -61,6 +189,9 @@ function estimateChars(snapshot: BrainSnapshot): number {
  * (CLI flag, system prompt, GEMINI.md, etc.).
  */
 export function formatHandoff(snapshot: BrainSnapshot): string {
+  const recentEvents = snapshot.episodic
+    .slice(-10)
+    .map((event: BrainSnapshot['episodic'][number]) => `  [${event.type}] ${event.summary}`);
   const lines = [
     '--- BRAIN STATE HANDOFF ---',
     `Previous provider: ${snapshot.metadata.lastProvider}`,
@@ -71,9 +202,9 @@ export function formatHandoff(snapshot: BrainSnapshot): string {
     JSON.stringify(snapshot.working, null, 2),
     '',
     `Recent events (${snapshot.episodic.length}):`,
-    ...snapshot.episodic.slice(-10).map(
-      (e) => `  [${e.type}] ${e.summary}`,
-    ),
+    ...recentEvents,
+    '',
+    formatPmHandoffQualityRubric(),
   ];
 
   if (snapshot.checkpoint) {

--- a/packages/franken-orchestrator/src/providers/index.ts
+++ b/packages/franken-orchestrator/src/providers/index.ts
@@ -2,7 +2,20 @@ export { ProviderRegistry } from './provider-registry.js';
 export type { ProviderRegistryOptions } from './provider-registry.js';
 export { TokenAggregator } from './token-aggregator.js';
 export type { AggregatedTokenUsage } from './token-aggregator.js';
-export { formatHandoff, truncateSnapshot } from './format-handoff.js';
+export {
+  PM_HANDOFF_QUALITY_RUBRIC,
+  formatHandoff,
+  formatPmHandoffQualityRubric,
+  scorePmHandoffQuality,
+  truncateSnapshot,
+} from './format-handoff.js';
+export type {
+  PmHandoffQualityCriterionResult,
+  PmHandoffQualityReport,
+  PmHandoffRubricCriterion,
+  PmHandoffRubricCriterionId,
+  PmHandoffSummary,
+} from './format-handoff.js';
 export { ClaudeCliAdapter } from './claude-cli-adapter.js';
 export type { ClaudeCliOptions } from './claude-cli-adapter.js';
 export { CodexCliAdapter } from './codex-cli-adapter.js';

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { BrainSnapshot } from '@franken/types';
-import { formatHandoff, truncateSnapshot } from '../../../src/providers/format-handoff.js';
+import {
+  PM_HANDOFF_QUALITY_RUBRIC,
+  formatHandoff,
+  formatPmHandoffQualityRubric,
+  scorePmHandoffQuality,
+  truncateSnapshot,
+} from '../../../src/providers/format-handoff.js';
 
 function makeSnapshot(overrides: Partial<BrainSnapshot> = {}): BrainSnapshot {
   return {
@@ -70,6 +76,54 @@ describe('formatHandoff', () => {
     const text = formatHandoff(makeSnapshot());
     expect(text).toMatch(/^--- BRAIN STATE HANDOFF ---/);
     expect(text).toMatch(/--- END HANDOFF ---$/);
+  });
+
+  it('includes the PM handoff quality rubric for worker continuity', () => {
+    const text = formatHandoff(makeSnapshot());
+    expect(text).toContain('PM handoff quality rubric:');
+    expect(text).toContain('issue-and-outcome: Name the issue number');
+    expect(text).toContain('verification-evidence: Include exact commands');
+    expect(text).toContain('blocker-disclosure: State blockers explicitly');
+  });
+});
+
+describe('PM handoff quality rubric', () => {
+  it('formats deterministic rubric guidance for operator-facing handoffs', () => {
+    const text = formatPmHandoffQualityRubric();
+    for (const criterion of PM_HANDOFF_QUALITY_RUBRIC) {
+      expect(text).toContain(criterion.id);
+      expect(text).toContain(criterion.guidance);
+    }
+  });
+
+  it('scores a complete handoff as passing', () => {
+    const report = scorePmHandoffQuality({
+      issueNumber: 1862,
+      branch: 'pfkborg/issue-1862-feat-learning-add-pm-handoff-quality',
+      prUrl: 'https://github.com/djm204/frankenbeast/pull/1',
+      changedFiles: ['packages/franken-orchestrator/src/providers/format-handoff.ts'],
+      verificationCommands: ['npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts'],
+      blockers: [],
+      scopeNotes: ['Added PM handoff quality rubric and scorer.'],
+      diskFree: '24G',
+    });
+
+    expect(report.passed).toBe(true);
+    expect(report.score).toBe(1);
+    expect(report.failedCriteria).toEqual([]);
+  });
+
+  it('reports explicit failures for incomplete handoffs', () => {
+    const report = scorePmHandoffQuality({
+      issueNumber: 1862,
+      branch: 'pfkborg/issue-1862-feat-learning-add-pm-handoff-quality',
+      scopeNotes: ['Missing verification and blocker disclosure.'],
+    });
+
+    expect(report.passed).toBe(false);
+    expect(report.failedCriteria).toContain('verification-evidence');
+    expect(report.failedCriteria).toContain('blocker-disclosure');
+    expect(report.failedCriteria).toContain('operator-continuity');
   });
 });
 


### PR DESCRIPTION
## Summary\n- Adds a deterministic PM handoff quality rubric and structured scorer for operator/learning handoffs.\n- Includes the rubric in provider brain-state handoffs so future workers see concrete PM handoff expectations.\n- Documents the rubric and scoring shape in docs/pm-handoff-quality-rubric.md.\n\nCloses #1862\n\n## Verification\n- npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts (17 tests passed)\n- npm run build --workspace @franken/types\n- npm run build --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner\n- npm run typecheck --workspace @franken/orchestrator\n\n## Notes\n- fbeast MCP tools were unavailable in this Hermes tool schema, so I followed AGENTS.md with normal git/gh/terminal verification.