### PR TITLE
fix(orchestrator): report corrupt Beast JSON hydration

### DIFF
--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -181,6 +181,24 @@ function prefixedId(prefix: string): string {
   return `${prefix}_${randomUUID()}`;
 }
 
+export interface BeastRepositoryJsonCorruptionContext {
+  readonly table: string;
+  readonly column: string;
+  readonly rowId: string;
+  readonly valueSnippet: string;
+}
+
+export class BeastRepositoryJsonCorruptionError extends Error {
+  constructor(
+    public readonly context: BeastRepositoryJsonCorruptionContext,
+    public override readonly cause: unknown,
+  ) {
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    super(`Corrupt Beast JSON in ${context.table}.${context.column} for row ${context.rowId}: ${causeMessage}`);
+    this.name = 'BeastRepositoryJsonCorruptionError';
+  }
+}
+
 export class SQLiteBeastRepository {
   private readonly db: Database.Database;
 
@@ -748,7 +766,11 @@ function mapRun(row: BeastRunRow): BeastRun {
     definitionVersion: row.definition_version,
     status: row.status,
     executionMode: row.execution_mode,
-    configSnapshot: JSON.parse(row.config_snapshot) as Readonly<Record<string, unknown>>,
+    configSnapshot: parseJsonColumn(row.config_snapshot, {
+      table: 'beast_runs',
+      column: 'config_snapshot',
+      rowId: row.id,
+    }) as Readonly<Record<string, unknown>>,
     dispatchedBy: row.dispatched_by,
     dispatchedByUser: row.dispatched_by_user,
     createdAt: row.created_at,
@@ -774,7 +796,13 @@ function mapAttempt(row: BeastAttemptRow): BeastRunAttempt {
     ...(row.exit_code !== null ? { exitCode: row.exit_code } : {}),
     ...(row.stop_reason ? { stopReason: row.stop_reason } : {}),
     ...(row.executor_metadata
-      ? { executorMetadata: JSON.parse(row.executor_metadata) as Readonly<Record<string, unknown>> }
+      ? {
+          executorMetadata: parseJsonColumn(row.executor_metadata, {
+            table: 'beast_run_attempts',
+            column: 'executor_metadata',
+            rowId: row.id,
+          }) as Readonly<Record<string, unknown>>,
+        }
       : {}),
   };
 }
@@ -786,7 +814,11 @@ function mapEvent(row: BeastEventRow): BeastRunEvent {
     ...(row.attempt_id ? { attemptId: row.attempt_id } : {}),
     sequence: row.sequence,
     type: row.type,
-    payload: JSON.parse(row.payload) as Readonly<Record<string, unknown>>,
+    payload: parseJsonColumn(row.payload, {
+      table: 'beast_run_events',
+      column: 'payload',
+      rowId: row.id,
+    }) as Readonly<Record<string, unknown>>,
     createdAt: row.created_at,
   };
 }
@@ -796,14 +828,22 @@ function mapInterviewSession(row: BeastInterviewSessionRow): BeastInterviewSessi
     id: row.id,
     definitionId: row.definition_id,
     status: row.status,
-    answers: JSON.parse(row.answers) as Readonly<Record<string, unknown>>,
+    answers: parseJsonColumn(row.answers, {
+      table: 'beast_interview_sessions',
+      column: 'answers',
+      rowId: row.id,
+    }) as Readonly<Record<string, unknown>>,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
 }
 
 function mapTrackedAgent(row: TrackedAgentRow): TrackedAgent {
-  const initConfig = JSON.parse(row.init_config) as Readonly<Record<string, unknown>>;
+  const initConfig = parseJsonColumn(row.init_config, {
+    table: 'tracked_agents',
+    column: 'init_config',
+    rowId: row.id,
+  }) as Readonly<Record<string, unknown>>;
   return {
     id: row.id,
     ...trackedAgentIdentityPatch(initConfig),
@@ -811,12 +851,24 @@ function mapTrackedAgent(row: TrackedAgentRow): TrackedAgent {
     source: row.source,
     status: row.status,
     createdByUser: row.created_by_user,
-    initAction: JSON.parse(row.init_action) as TrackedAgentInitAction,
+    initAction: parseJsonColumn(row.init_action, {
+      table: 'tracked_agents',
+      column: 'init_action',
+      rowId: row.id,
+    }) as TrackedAgentInitAction,
     initConfig,
     ...(row.chat_session_id ? { chatSessionId: row.chat_session_id } : {}),
     ...(row.dispatch_run_id ? { dispatchRunId: row.dispatch_run_id } : {}),
     ...(row.execution_mode ? { executionMode: row.execution_mode } : {}),
-    ...(row.module_config ? { moduleConfig: JSON.parse(row.module_config) as ModuleConfig } : {}),
+    ...(row.module_config
+      ? {
+          moduleConfig: parseJsonColumn(row.module_config, {
+            table: 'tracked_agents',
+            column: 'module_config',
+            rowId: row.id,
+          }) as ModuleConfig,
+        }
+      : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -832,6 +884,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function parseJsonColumn(
+  value: string,
+  context: Omit<BeastRepositoryJsonCorruptionContext, 'valueSnippet'>,
+): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch (error) {
+    throw new BeastRepositoryJsonCorruptionError({
+      ...context,
+      valueSnippet: value.slice(0, 120),
+    }, error);
+  }
+}
+
 function mapTrackedAgentEvent(row: TrackedAgentEventRow): TrackedAgentEvent {
   return {
     id: row.id,
@@ -840,7 +906,11 @@ function mapTrackedAgentEvent(row: TrackedAgentEventRow): TrackedAgentEvent {
     level: row.level,
     type: row.type,
     message: row.message,
-    payload: JSON.parse(row.payload) as Readonly<Record<string, unknown>>,
+    payload: parseJsonColumn(row.payload, {
+      table: 'tracked_agent_events',
+      column: 'payload',
+      rowId: row.id,
+    }) as Readonly<Record<string, unknown>>,
     createdAt: row.created_at,
   };
 }

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -4,8 +4,122 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import Database from 'better-sqlite3';
 import { UnknownTrackedAgentError } from '../../../src/beasts/errors.js';
-import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
+import {
+  BeastRepositoryJsonCorruptionError,
+  SQLiteBeastRepository,
+} from '../../../src/beasts/repository/sqlite-beast-repository.js';
 
+type CorruptJsonTable =
+  | 'beast_runs'
+  | 'beast_run_attempts'
+  | 'beast_run_events'
+  | 'beast_interview_sessions'
+  | 'tracked_agents'
+  | 'tracked_agent_events';
+
+interface CorruptJsonFixtureIds {
+  readonly runId: string;
+  readonly healthyRunId: string;
+  readonly attemptId: string;
+  readonly eventId: string;
+  readonly interviewId: string;
+  readonly agentId: string;
+  readonly agentEventId: string;
+  rowIdFor(table: string): string;
+}
+
+function seedCorruptJsonFixture(repo: SQLiteBeastRepository): CorruptJsonFixtureIds {
+  const run = repo.createRun({
+    definitionId: 'martin-loop',
+    definitionVersion: 1,
+    executionMode: 'process',
+    configSnapshot: { provider: 'claude' },
+    dispatchedBy: 'dashboard',
+    dispatchedByUser: 'pfk',
+    createdAt: '2026-03-10T00:00:00.000Z',
+  });
+  const healthyRun = repo.createRun({
+    definitionId: 'martin-loop',
+    definitionVersion: 1,
+    executionMode: 'process',
+    configSnapshot: { healthy: true },
+    dispatchedBy: 'dashboard',
+    dispatchedByUser: 'pfk',
+    createdAt: '2026-03-10T00:00:01.000Z',
+  });
+  const attempt = repo.createAttempt(run.id, {
+    status: 'running',
+    executorMetadata: { backend: 'process' },
+    startedAt: '2026-03-10T00:01:00.000Z',
+  });
+  const event = repo.appendEvent(run.id, {
+    attemptId: attempt.id,
+    type: 'attempt.started',
+    payload: { pid: 101 },
+    createdAt: '2026-03-10T00:01:01.000Z',
+  });
+  const interview = repo.createInterviewSession({
+    definitionId: 'martin-loop',
+    status: 'active',
+    answers: { goal: 'hydrate safely' },
+    createdAt: '2026-03-10T00:02:00.000Z',
+    updatedAt: '2026-03-10T00:02:00.000Z',
+  });
+  const agent = repo.createTrackedAgent({
+    definitionId: 'martin-loop',
+    source: 'dashboard',
+    status: 'initializing',
+    createdByUser: 'operator',
+    initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+    initConfig: { identity: { name: 'Corruption test agent' } },
+    moduleConfig: { firewall: true },
+    createdAt: '2026-03-10T00:03:00.000Z',
+    updatedAt: '2026-03-10T00:03:00.000Z',
+  });
+  const agentEvent = repo.appendTrackedAgentEvent(agent.id, {
+    level: 'info',
+    type: 'agent.command.sent',
+    message: 'Sent martin-loop command',
+    payload: { command: 'martin-loop' },
+    createdAt: '2026-03-10T00:03:01.000Z',
+  });
+
+  return {
+    runId: run.id,
+    healthyRunId: healthyRun.id,
+    attemptId: attempt.id,
+    eventId: event.id,
+    interviewId: interview.id,
+    agentId: agent.id,
+    agentEventId: agentEvent.id,
+    rowIdFor(table: string): string {
+      switch (table as CorruptJsonTable) {
+        case 'beast_runs':
+          return run.id;
+        case 'beast_run_attempts':
+          return attempt.id;
+        case 'beast_run_events':
+          return event.id;
+        case 'beast_interview_sessions':
+          return interview.id;
+        case 'tracked_agents':
+          return agent.id;
+        case 'tracked_agent_events':
+          return agentEvent.id;
+      }
+    },
+  };
+}
+
+function corruptJsonColumn(dbPath: string, table: string, column: string, rowId: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.prepare(`UPDATE ${table} SET ${column} = ? WHERE id = ?`).run('{malformed json', rowId);
+  } finally {
+    db.close();
+  }
+}
+ 
 describe('SQLiteBeastRepository', () => {
   let workDir: string | undefined;
 
@@ -280,6 +394,83 @@ describe('SQLiteBeastRepository', () => {
     })).toThrow('Unknown tracked agent: agent-missing');
 
     expect(repo.listRuns()).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: 'beast_runs.config_snapshot',
+      table: 'beast_runs',
+      column: 'config_snapshot',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.getRun(ids.runId),
+    },
+    {
+      name: 'beast_run_attempts.executor_metadata',
+      table: 'beast_run_attempts',
+      column: 'executor_metadata',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listAttempts(ids.runId),
+    },
+    {
+      name: 'beast_run_events.payload',
+      table: 'beast_run_events',
+      column: 'payload',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listEvents(ids.runId),
+    },
+    {
+      name: 'beast_interview_sessions.answers',
+      table: 'beast_interview_sessions',
+      column: 'answers',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.getInterviewSession(ids.interviewId),
+    },
+    {
+      name: 'tracked_agents.init_action',
+      table: 'tracked_agents',
+      column: 'init_action',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.getTrackedAgent(ids.agentId),
+    },
+    {
+      name: 'tracked_agents.init_config',
+      table: 'tracked_agents',
+      column: 'init_config',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.getTrackedAgent(ids.agentId),
+    },
+    {
+      name: 'tracked_agents.module_config',
+      table: 'tracked_agents',
+      column: 'module_config',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.getTrackedAgent(ids.agentId),
+    },
+    {
+      name: 'tracked_agent_events.payload',
+      table: 'tracked_agent_events',
+      column: 'payload',
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listTrackedAgentEvents(ids.agentId),
+    },
+  ])('reports structured data-corruption details for corrupt $name JSON', async ({ table, column, exercise }) => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(dbPath);
+    const ids = seedCorruptJsonFixture(repo);
+    corruptJsonColumn(dbPath, table, column, ids.rowIdFor(table));
+
+    expect(exercise(repo, ids)).toThrow(BeastRepositoryJsonCorruptionError);
+
+    try {
+      exercise(repo, ids)();
+      throw new Error('expected corrupt JSON read to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BeastRepositoryJsonCorruptionError);
+      const corruption = error as BeastRepositoryJsonCorruptionError;
+      expect(corruption.context).toMatchObject({
+        table,
+        column,
+        rowId: ids.rowIdFor(table),
+        valueSnippet: '{malformed json',
+      });
+      expect(corruption.message).toContain(`${table}.${column}`);
+      expect(corruption.message).toContain(ids.rowIdFor(table));
+    }
+
+    expect(repo.getRun(ids.healthyRunId)?.configSnapshot).toEqual({ healthy: true });
   });
 
   it('migrates legacy beast_runs tables that predate tracked_agent_id', async () => {


### PR DESCRIPTION
## Summary
- add structured BeastRepositoryJsonCorruptionError diagnostics for malformed Beast SQLite JSON columns
- route run, attempt, event, interview, tracked-agent, and tracked-agent-event hydration through contextual JSON parsing
- add regression coverage for each persisted Beast JSON column while keeping healthy rows readable

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/beasts/sqlite-beast-repository.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1008