### PR TITLE
fix(web): clear typing indicator on chat turn errors

### DIFF
--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -214,6 +214,76 @@ describe('useChatSession error banners', () => {
     });
   });
 
+  it('clears the typing indicator when a socket turn errors before completion', async () => {
+    vi.stubGlobal('fetch', chatFetch());
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'assistant.typing.start',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.showTypingIndicator).toBe(true);
+
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'turn.error',
+          code: 'TOOL_DENIED',
+          message: 'Approval denied by policy.',
+          timestamp: '2026-07-05T00:00:01.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.showTypingIndicator).toBe(false);
+    expect(result.current.activity[0]).toMatchObject({
+      type: 'turn.error',
+      data: { code: 'TOOL_DENIED', message: 'Approval denied by policy.' },
+    });
+  });
+
+  it('clears the typing indicator when the websocket errors mid-turn', async () => {
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockWebSocket.instances[0]!.onmessage?.({
+        data: JSON.stringify({
+          type: 'assistant.typing.start',
+          timestamp: '2026-07-05T00:00:00.000Z',
+        }),
+      });
+    });
+
+    expect(result.current.showTypingIndicator).toBe(true);
+
+    act(() => {
+      MockWebSocket.instances[0]!.onerror?.();
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.showTypingIndicator).toBe(false);
+  });
+
   it('preserves approval metadata on activity events for readable timeline chips', async () => {
     vi.stubGlobal('fetch', chatFetch());
     vi.stubGlobal('WebSocket', MockWebSocket);

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -419,6 +419,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
     clearTimeout(pending.timeoutId);
     pendingSendsRef.current.delete(messageId);
+    setShowTypingIndicator(false);
     setMessages((current) => markMessageFailed(current, messageId, error.message, canRetry));
     setStatus('error');
     pending.reject(error);
@@ -615,6 +616,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       } catch {
         // Ignore close failures; the protocol-error banner already tells the user how to recover.
       }
+      setShowTypingIndicator(false);
       setStatus('error');
       setConnectionStatus('error');
       failAllPendingSends(new Error(message));
@@ -780,6 +782,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           if (payload.code === 'APPROVAL_PENDING') {
             void refreshSession();
           }
+          setShowTypingIndicator(false);
           updateApprovalResolving(false);
           setApprovalError(payload.message);
           setActivity((current) => [
@@ -818,6 +821,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         return;
       }
       const hadPendingSends = pendingSendsRef.current.size > 0;
+      setShowTypingIndicator(false);
       failAllPendingSends(new Error('WebSocket send failed before the server acknowledged the message.'));
       if (approvalResolvingRef.current) {
         updateApprovalResolving(false);
@@ -848,6 +852,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         return;
       }
       socketRef.current = null;
+      setShowTypingIndicator(false);
       failAllPendingSends(new Error('Connection closed before the server acknowledged the message.'));
       if (approvalResolvingRef.current) {
         updateApprovalResolving(false);
@@ -978,6 +983,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           'Retry last message',
           'message_send_failed',
         ));
+        setShowTypingIndicator(false);
         setStatus('error');
         throw sendError;
       }


### PR DESCRIPTION
## Summary
- Clear the chat typing indicator when `turn.error` arrives before assistant completion.
- Also clear the stale indicator on websocket/protocol/send failure paths.
- Add hook regression coverage for typing-start followed by turn.error and websocket error.

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- --run src/hooks/use-chat-session.test.tsx
- npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/web
- npm test --workspace @franken/web

Closes #1006
