### PR TITLE
fix(orchestrator): evict expired beast rate-limit counters

### DIFF
--- a/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
+++ b/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
@@ -5,12 +5,15 @@ import { wallClockNow } from '@franken/types';
 export interface BeastRateLimitOptions {
   max: number;
   windowMs: number;
+  cleanupBatchSize?: number;
 }
 
 interface CounterState {
   count: number;
   resetAt: number;
 }
+
+const DEFAULT_CLEANUP_BATCH_SIZE = 128;
 
 export class InMemoryRateLimiter {
   private readonly counters = new Map<string, CounterState>();
@@ -22,6 +25,7 @@ export class InMemoryRateLimiter {
       return { allowed: false, remaining: 0 };
     }
     const now = wallClockNow();
+    this.evictExpiredCounters(now);
     const current = this.counters.get(key);
     if (!current || current.resetAt <= now) {
       this.counters.set(key, {
@@ -37,6 +41,26 @@ export class InMemoryRateLimiter {
 
     current.count += 1;
     return { allowed: true, remaining: this.options.max - current.count };
+  }
+
+  private evictExpiredCounters(now: number): void {
+    const cleanupBatchSize = this.options.cleanupBatchSize ?? DEFAULT_CLEANUP_BATCH_SIZE;
+    if (cleanupBatchSize <= 0) {
+      return;
+    }
+
+    let checked = 0;
+    for (const [key, counter] of this.counters) {
+      if (checked >= cleanupBatchSize) {
+        break;
+      }
+      checked += 1;
+      this.counters.delete(key);
+      if (counter.resetAt <= now) {
+        continue;
+      }
+      this.counters.set(key, counter);
+    }
   }
 }
 

--- a/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
+++ b/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
@@ -49,9 +49,10 @@ export class InMemoryRateLimiter {
       return;
     }
 
+    const maxChecks = Math.min(cleanupBatchSize, this.counters.size);
     let checked = 0;
     for (const [key, counter] of this.counters) {
-      if (checked >= cleanupBatchSize) {
+      if (checked >= maxChecks) {
         break;
       }
       checked += 1;

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-rate-limit.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-rate-limit.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InMemoryRateLimiter } from '../../../src/beasts/http/beast-rate-limit.js';
+
+function limiterCounterCount(limiter: InMemoryRateLimiter): number {
+  return (limiter as unknown as { counters: Map<string, unknown> }).counters.size;
+}
+
+describe('InMemoryRateLimiter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('evicts expired one-shot counters when a different key is used later', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T00:00:00.000Z'));
+
+    const limiter = new InMemoryRateLimiter({ max: 2, windowMs: 1_000 });
+
+    expect(limiter.take('operator-a:/beasts')).toEqual({ allowed: true, remaining: 1 });
+    expect(limiter.take('operator-b:/beasts')).toEqual({ allowed: true, remaining: 1 });
+    expect(limiter.take('operator-c:/beasts')).toEqual({ allowed: true, remaining: 1 });
+    expect(limiterCounterCount(limiter)).toBe(3);
+
+    vi.setSystemTime(new Date('2026-07-11T00:00:01.001Z'));
+
+    expect(limiter.take('operator-d:/beasts')).toEqual({ allowed: true, remaining: 1 });
+
+    expect(limiterCounterCount(limiter)).toBe(1);
+  });
+
+  it('preserves active-key limiting semantics while counters are inside the window', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T00:00:00.000Z'));
+
+    const limiter = new InMemoryRateLimiter({ max: 2, windowMs: 1_000 });
+
+    expect(limiter.take('operator-a:/beasts')).toEqual({ allowed: true, remaining: 1 });
+    expect(limiter.take('operator-a:/beasts')).toEqual({ allowed: true, remaining: 0 });
+    expect(limiter.take('operator-a:/beasts')).toEqual({ allowed: false, remaining: 0 });
+    expect(limiterCounterCount(limiter)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- evicts expired Beast rate-limit counters opportunistically during limiter access
- rotates active entries through a bounded cleanup batch to avoid unbounded per-call scans
- adds unit coverage for one-shot expired keys and active-key limit semantics

## Test Plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)
- npm test --workspace @franken/orchestrator -- --run tests/unit/beasts/beast-rate-limit.test.ts

Closes #1009
