### PR TITLE
test(web): cover prompt file attachment flow

### DIFF
--- a/packages/franken-web/tests/components/beasts/shared/file-picker.test.tsx
+++ b/packages/franken-web/tests/components/beasts/shared/file-picker.test.tsx
@@ -102,6 +102,36 @@ describe('FilePicker', () => {
     ]);
   });
 
+  it('shows a read failure and keeps successfully read selected files attached', async () => {
+    const onFilesChange = vi.fn();
+    const unreadableFile = new File(['secret'], 'unreadable.md', { type: 'text/markdown' });
+    Object.defineProperty(unreadableFile, 'text', {
+      value: () => Promise.reject(new Error('permission denied')),
+    });
+
+    render(<FilePicker files={[]} onFilesChange={onFilesChange} onRemoveFile={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('Attach files'), {
+      target: {
+        files: [
+          new File(['attached context'], 'context.md', { type: 'text/markdown' }),
+          unreadableFile,
+        ],
+      },
+    });
+
+    await waitFor(() => expect(onFilesChange).toHaveBeenCalledTimes(1));
+    expect(onFilesChange).toHaveBeenCalledWith([
+      {
+        name: 'context.md',
+        content: 'attached context',
+        tokens: 4,
+        health: 'good',
+      },
+    ]);
+    expect((await screen.findByRole('alert')).textContent).toContain('1 file could not be read and were skipped.');
+  });
+
   it('shows critical health indicator for large files', () => {
     const files = [
       { name: 'big.md', content: 'x'.repeat(80000), tokens: 20000, health: 'critical' as const },

--- a/packages/franken-web/tests/components/beasts/steps/step-prompts.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-prompts.test.tsx
@@ -47,4 +47,27 @@ describe('StepPrompts', () => {
     });
     expect(useBeastStore.getState().stepValues[5]?.promptText).toBe('Typed while loading');
   });
+
+  it('stores selected prompt files and removes them from Zustand state', async () => {
+    render(<StepPrompts />);
+
+    fireEvent.change(screen.getByLabelText('Attach files'), {
+      target: { files: [new File(['agent context'], 'context.md', { type: 'text/markdown' })] },
+    });
+
+    await waitFor(() => {
+      expect(useBeastStore.getState().stepValues[5]?.files).toEqual([
+        {
+          name: 'context.md',
+          content: 'agent context',
+          tokens: 4,
+          health: 'good',
+        },
+      ]);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove context.md' }));
+
+    expect(useBeastStore.getState().stepValues[5]?.files).toEqual([]);
+  });
 });

--- a/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-review.test.tsx
@@ -97,4 +97,18 @@ describe('StepReview', () => {
     expect(screen.getByText('Design Doc -> Chunk Creation')).toBeTruthy();
     expect(screen.getByText('codex / gpt-5.1')).toBeTruthy();
   });
+
+  it('shows selected prompt file counts on the review step', () => {
+    useBeastStore.getState().setStepValues(5, {
+      files: [
+        { name: 'context.md', content: 'agent context' },
+        { name: 'notes.md', content: 'notes' },
+      ],
+    });
+
+    render(<StepReview />);
+
+    expect(screen.getByText('2 file(s)')).toBeTruthy();
+    expect(screen.queryByText('No prompt frontloading')).toBeNull();
+  });
 });

--- a/packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-launch-config.test.ts
@@ -54,4 +54,21 @@ describe('buildWizardLaunchConfig', () => {
       heartbeatConfig: { reflectionInterval: 10 },
     });
   });
+
+  it('includes selected prompt files in the launch prompt frontload text', () => {
+    const config = buildWizardLaunchConfig({
+      5: {
+        promptText: 'Use the attached context.',
+        files: [
+          { name: 'context.md', content: 'Project context' },
+          { name: 'empty.md', content: '' },
+        ],
+      },
+    });
+
+    expect(config.prompts).toBeUndefined();
+    expect(config.promptConfig).toEqual({
+      text: 'Use the attached context.\n\n---\n\nAttached file: context.md\n\nProject context',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds regression coverage that selected prompt files are read, stored, removable, and represented in review/launch config.
- Covers the read-failure path so unreadable files surface an alert while successfully read files remain attached.
- Verifies prompt file content is included in the launch prompt frontload text.

## Test Plan
- npm ci
- npm test -- --run tests/components/beasts/shared/file-picker.test.tsx tests/components/beasts/steps/step-prompts.test.tsx tests/components/beasts/steps/step-review.test.tsx tests/components/beasts/wizard-launch-config.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web (passes with existing warnings)
- npm run build --workspace @franken/web

Closes #1011