### PR TITLE
fix(web): persist tracked-agent detail edits

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-detail-panel.test.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TrackedAgentDetail } from '../../lib/beast-api';
+import { useBeastStore } from '../../stores/beast-store';
+import { AgentDetailPanel } from './agent-detail-panel';
+
+const baseDetail: TrackedAgentDetail = {
+  agent: {
+    id: 'agent-1',
+    name: 'Current Agent',
+    definitionId: 'agent-definition',
+    status: 'stopped',
+    source: 'dashboard',
+    createdByUser: 'operator',
+    initAction: { kind: 'design-interview', command: 'fbeast run agent', config: {} },
+    initConfig: {
+      identity: {
+        name: 'Config Agent',
+        description: 'Current description',
+      },
+    },
+    moduleConfig: {
+      firewall: true,
+      planner: false,
+    },
+    createdAt: '2026-07-11T00:00:00.000Z',
+    updatedAt: '2026-07-11T00:00:00.000Z',
+  },
+  events: [],
+};
+
+function renderPanel(overrides: Partial<ComponentProps<typeof AgentDetailPanel>> = {}) {
+  const onSaveConfig = vi.fn().mockResolvedValue(undefined);
+  const onClose = vi.fn();
+
+  render(
+    <AgentDetailPanel
+      isOpen
+      detail={baseDetail}
+      logs={[]}
+      onClose={onClose}
+      onStart={vi.fn()}
+      onStop={vi.fn()}
+      onRestart={vi.fn()}
+      onResume={vi.fn()}
+      onDelete={vi.fn()}
+      onKill={vi.fn()}
+      onSaveConfig={onSaveConfig}
+      {...overrides}
+    />,
+  );
+
+  return { onSaveConfig, onClose };
+}
+
+describe('AgentDetailPanel edit mode', () => {
+  afterEach(() => {
+    cleanup();
+    useBeastStore.getState().resetEdit();
+  });
+
+  it('seeds selected agent values and enables save after a field changes', async () => {
+    const { onSaveConfig } = renderPanel();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Edit' }));
+
+    const nameInput = await screen.findByDisplayValue('Current Agent');
+    expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe('Current description');
+    expect((screen.getByLabelText('planner') as HTMLInputElement).checked).toBe(false);
+
+    const saveButton = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    fireEvent.change(nameInput, { target: { value: 'Updated Agent' } });
+    expect(saveButton.disabled).toBe(false);
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(onSaveConfig).toHaveBeenCalledTimes(1));
+    expect(onSaveConfig).toHaveBeenCalledWith({
+      name: 'Updated Agent',
+      description: 'Current description',
+      moduleConfig: {
+        firewall: true,
+        planner: false,
+      },
+    });
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull());
+  });
+
+  it('keeps edit mode open and shows an error when save fails', async () => {
+    const onSaveConfig = vi.fn().mockRejectedValue(new Error('PATCH failed'));
+    renderPanel({ onSaveConfig });
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Edit' }));
+    fireEvent.change(await screen.findByDisplayValue('Current Agent'), { target: { value: 'Broken Agent' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('PATCH failed');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+    expect(onSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ name: 'Broken Agent' }));
+  });
+
+  it('resets the edit store when the panel is closed from edit mode', async () => {
+    const { onClose } = renderPanel();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Edit' }));
+    fireEvent.change(await screen.findByDisplayValue('Current Agent'), { target: { value: 'Unsaved Agent' } });
+    expect(useBeastStore.getState().isEditDirty).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(useBeastStore.getState().editValues).toBeNull();
+    expect(useBeastStore.getState().isEditDirty).toBe(false);
+  });
+});

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -65,9 +65,17 @@ export function AgentDetailPanel({
     }
   };
 
+  const handleClose = () => {
+    if (saving) return;
+    setSaveError(null);
+    setMode('readonly');
+    resetEdit();
+    onClose();
+  };
+
   return (
     <>
-      <SlideInPanel isOpen={isOpen} onClose={onClose}>
+      <SlideInPanel isOpen={isOpen} onClose={handleClose}>
         {/* Header */}
         <div className="flex items-center gap-3 px-4 py-3 border-b border-beast-border shrink-0">
           <StatusLight status={agent.status} />
@@ -97,7 +105,8 @@ export function AgentDetailPanel({
           </ToggleGroup.Root>
           <button
             type="button"
-            onClick={onClose}
+            onClick={handleClose}
+            disabled={saving}
             aria-label="Close panel"
             className="p-1.5 rounded-lg text-beast-subtle hover:text-beast-text hover:bg-beast-elevated transition-colors"
           >

--- a/packages/franken-web/src/stores/beast-store.test.ts
+++ b/packages/franken-web/src/stores/beast-store.test.ts
@@ -56,4 +56,20 @@ describe('beast-store agentEditSlice', () => {
     setEditValues({ name: 'Agent1-modified' });
     expect(useBeastStore.getState().isEditDirty).toBe(true);
   });
+
+  it('seeds edit values from each new snapshot and starts clean', () => {
+    const { setEditSnapshot, setEditField } = useBeastStore.getState();
+
+    setEditSnapshot({ name: 'Agent1', moduleConfig: { planner: false } });
+    setEditField('name', 'Unsaved Agent');
+    expect(useBeastStore.getState().isEditDirty).toBe(true);
+
+    setEditSnapshot({ name: 'Agent2', moduleConfig: { planner: true } });
+
+    expect(useBeastStore.getState().editValues).toEqual({
+      name: 'Agent2',
+      moduleConfig: { planner: true },
+    });
+    expect(useBeastStore.getState().isEditDirty).toBe(false);
+  });
 });

--- a/packages/franken-web/src/stores/beast-store.ts
+++ b/packages/franken-web/src/stores/beast-store.ts
@@ -111,11 +111,11 @@ export const useBeastStore = create<BeastStore>()((set, get) => ({
   isEditDirty: false,
 
   setEditSnapshot: (snapshot) =>
-    set((s) => ({
+    set({
       editSnapshot: snapshot,
-      editValues: s.editValues ?? { ...snapshot },
-      isEditDirty: computeDirty(snapshot, s.editValues ?? snapshot),
-    })),
+      editValues: { ...snapshot },
+      isEditDirty: false,
+    }),
 
   setEditValues: (values) =>
     set((s) => ({


### PR DESCRIPTION
## Summary
- Seed tracked-agent edit state from each selected agent snapshot instead of preserving stale edit values.
- Reset edit state when the detail panel closes and keep failed saves in edit mode with the existing visible error path.
- Add regression coverage for populated edit fields, dirty Save enablement, failed saves, close reset, and store snapshot reseeding.

## Test Plan
- npm run build --workspace @franken/types
- npm test --workspace @franken/web -- --run src/stores/beast-store.test.ts src/components/beasts/agent-detail-panel.test.tsx
- npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1010