### PR TITLE
feat(learning): add lesson rollback workflow

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -92,6 +92,18 @@ When the critique loop recovers from one or more failing iterations and ends in 
 
 Infrastructure-only evaluator exceptions are intentionally excluded from the map so operator dashboards do not promote broken tooling as product lessons. PM handoffs should treat lessons without a matching regression `testId` as unverified learning that is not ready for promotion.
 
+## Lesson rollback workflow
+
+Every traceable `LessonRecorder` lesson also includes a `rollbackWorkflow` object so PM handoffs and dashboards can demote bad learning without deleting audit history. The workflow includes:
+
+- `rollbackId`: a stable `<lessonId>:rollback` identifier.
+- `state`: `active` for newly recorded lessons; downstream memory stores can mark their retained copy as rolled back or superseded after execution.
+- `requiredEvidence`: the minimum evidence keys (`rollbackReason` and `supersedingFindingOrRegression`) operators must attach before rollback.
+- `rollbackSteps`: ordered actions for handoffs: document the reason/evidence, mark the retained memory record as rolled back or superseded instead of deleting it, then run the verification command before promoting a replacement lesson.
+- `verificationCommand`: the targeted regression command that must pass before replacement learning is promoted.
+
+Infrastructure-only evaluator exceptions do not record lessons, traceability, or rollback workflows. This prevents operators from rolling back or promoting lessons that came from broken evaluator tooling instead of product behavior.
+
 ## Package scripts
 
 Run these from the package directory with `npm run <script>`, or from the repository root with `npm run <script> --workspace @franken/critique`.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ADRMatch,
   EpisodicTrace,
   LessonTestTraceabilityEntry,
+  LessonRollbackWorkflow,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,
@@ -61,7 +62,7 @@ export type { CritiqueErrorOptions } from './errors/index.js';
 // Core components
 export { CritiquePipeline } from './pipeline/critique-pipeline.js';
 export { CritiqueLoop } from './loop/critique-loop.js';
-export { LessonRecorder } from './memory/lesson-recorder.js';
+export { LessonRecorder, createLessonRollbackWorkflow } from './memory/lesson-recorder.js';
 
 // Evaluators
 export { SafetyEvaluator } from './evaluators/safety.js';

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1,4 +1,9 @@
-import type { MemoryPort, CritiqueLesson } from '../types/contracts.js';
+import type {
+  MemoryPort,
+  CritiqueLesson,
+  LessonRollbackWorkflow,
+  LessonTestTraceabilityEntry,
+} from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
@@ -6,6 +11,35 @@ import { isoNow } from '@franken/types';
 
 const LESSON_TRACEABILITY_VERIFICATION_COMMAND =
   'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts';
+
+const LESSON_ROLLBACK_REQUIRED_EVIDENCE = [
+  'rollbackReason',
+  'supersedingFindingOrRegression',
+] as const;
+
+const LESSON_ROLLBACK_STEPS = [
+  'Attach the rollback reason and superseding evidence to the PM handoff.',
+  'Mark the lesson as rolled back or superseded in the memory store; do not delete the original audit record.',
+  'Run the lesson verification command before promoting a replacement lesson.',
+] as const;
+
+export function createLessonRollbackWorkflow(
+  traceability: LessonTestTraceabilityEntry,
+): LessonRollbackWorkflow {
+  return {
+    rollbackId: `${traceability.lessonId}:rollback`,
+    lessonId: traceability.lessonId,
+    taskId: traceability.taskId,
+    evaluatorName: traceability.evaluatorName,
+    state: 'active',
+    requiredEvidence: LESSON_ROLLBACK_REQUIRED_EVIDENCE,
+    rollbackSteps: LESSON_ROLLBACK_STEPS,
+    verificationCommand: traceability.verificationCommand,
+    operatorMessage:
+      `Rollback ${traceability.lessonId} only with a concrete reason and superseding evidence; ` +
+      'preserve the original lesson for audit history.',
+  };
+}
 
 export class LessonRecorder {
   private readonly memory: MemoryPort;
@@ -55,6 +89,16 @@ export class LessonRecorder {
         const resolvedIteration = passingIteration?.index ?? failingIteration.index;
         const lessonId = createLessonId(taskId, evalResult.evaluatorName, failingIteration.index);
         const findingMessages = critiqueFindings.map((f) => f.message);
+        const traceability: LessonTestTraceabilityEntry = {
+          lessonId,
+          taskId,
+          evaluatorName: evalResult.evaluatorName,
+          failingIteration: failingIteration.index,
+          resolvedIteration,
+          sourceFindingMessages: findingMessages,
+          testId: `${lessonId}:regression`,
+          verificationCommand: LESSON_TRACEABILITY_VERIFICATION_COMMAND,
+        };
 
         lessons.push({
           evaluatorName: evalResult.evaluatorName,
@@ -64,18 +108,8 @@ export class LessonRecorder {
             : 'Unknown correction',
           taskId,
           timestamp: isoNow(),
-          testTraceability: [
-            {
-              lessonId,
-              taskId,
-              evaluatorName: evalResult.evaluatorName,
-              failingIteration: failingIteration.index,
-              resolvedIteration,
-              sourceFindingMessages: findingMessages,
-              testId: `${lessonId}:regression`,
-              verificationCommand: LESSON_TRACEABILITY_VERIFICATION_COMMAND,
-            },
-          ],
+          testTraceability: [traceability],
+          rollbackWorkflow: createLessonRollbackWorkflow(traceability),
         });
       }
     }

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -50,6 +50,25 @@ export interface LessonTestTraceabilityEntry {
   readonly verificationCommand: string;
 }
 
+/** Structured operator workflow for rolling back a learned lesson without deleting audit history. */
+export interface LessonRollbackWorkflow {
+  /** Stable identifier PM handoffs can reference when requesting a rollback. */
+  readonly rollbackId: string;
+  readonly lessonId: string;
+  readonly taskId: TaskId;
+  readonly evaluatorName: string;
+  /** LessonRecorder emits active workflows; downstream stores may mark them rolled_back after execution. */
+  readonly state: 'active';
+  /** Evidence operators must provide before the lesson can be demoted or superseded. */
+  readonly requiredEvidence: readonly string[];
+  /** Deterministic, ordered actions for PM/worker handoffs. */
+  readonly rollbackSteps: readonly string[];
+  /** Command that should pass before a replacement lesson is promoted. */
+  readonly verificationCommand: string;
+  /** Human-readable guidance for dashboards or retrospective summaries. */
+  readonly operatorMessage: string;
+}
+
 /** A lesson learned from a successful critique cycle. */
 export interface CritiqueLesson {
   readonly evaluatorName: string;
@@ -59,6 +78,8 @@ export interface CritiqueLesson {
   readonly timestamp: string;
   /** Present for lessons recorded by LessonRecorder; absent legacy lessons are unverified. */
   readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
+  /** Structured rollback workflow for lessons that are traceable enough to safely demote. */
+  readonly rollbackWorkflow?: LessonRollbackWorkflow;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { LessonRecorder } from '../../../src/memory/lesson-recorder.js';
+import { LessonRecorder, createLessonRollbackWorkflow } from '../../../src/memory/lesson-recorder.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
 import type { MemoryPort } from '../../../src/types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../../../src/types/loop.js';
@@ -111,6 +111,86 @@ describe('LessonRecorder', () => {
           'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts',
       },
     ]);
+  });
+
+  it('adds an active lesson rollback workflow for traceable recorded lessons', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'Safety Gate', [
+          { message: 'plain HTTP endpoint needs HTTPS', severity: 'critical' },
+        ]),
+        createIteration(2, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'Task 123');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.rollbackWorkflow).toEqual({
+      rollbackId: 'task-123:safety-gate:iteration-0:rollback',
+      lessonId: 'task-123:safety-gate:iteration-0',
+      taskId: 'Task 123',
+      evaluatorName: 'Safety Gate',
+      state: 'active',
+      requiredEvidence: ['rollbackReason', 'supersedingFindingOrRegression'],
+      rollbackSteps: [
+        'Attach the rollback reason and superseding evidence to the PM handoff.',
+        'Mark the lesson as rolled back or superseded in the memory store; do not delete the original audit record.',
+        'Run the lesson verification command before promoting a replacement lesson.',
+      ],
+      verificationCommand:
+        'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts',
+      operatorMessage:
+        'Rollback task-123:safety-gate:iteration-0 only with a concrete reason and superseding evidence; preserve the original lesson for audit history.',
+    });
+  });
+
+  it('builds rollback workflow metadata from a traceability entry without recording a lesson', () => {
+    expect(
+      createLessonRollbackWorkflow({
+        lessonId: 'task-123:safety-gate:iteration-0',
+        taskId: 'Task 123',
+        evaluatorName: 'Safety Gate',
+        failingIteration: 0,
+        resolvedIteration: 2,
+        sourceFindingMessages: ['plain HTTP endpoint needs HTTPS'],
+        testId: 'task-123:safety-gate:iteration-0:regression',
+        verificationCommand: 'npm run test --workspace @franken/critique -- --run lesson-recorder',
+      }),
+    ).toMatchObject({
+      rollbackId: 'task-123:safety-gate:iteration-0:rollback',
+      lessonId: 'task-123:safety-gate:iteration-0',
+      state: 'active',
+      requiredEvidence: ['rollbackReason', 'supersedingFindingOrRegression'],
+      verificationCommand: 'npm run test --workspace @franken/critique -- --run lesson-recorder',
+    });
+  });
+
+  it('does not create rollback workflow entries for infrastructure-only evaluator exceptions', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'adr-compliance', [
+          {
+            message: 'internal evaluator error occurred',
+            severity: 'critical',
+            location: EVALUATOR_EXCEPTION_LOCATION,
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-123');
+
+    expect(port.recordLesson).not.toHaveBeenCalled();
   });
 
   it('does not create traceability entries for infrastructure-only evaluator exceptions', async () => {

--- a/tasks/issue-1860-lesson-rollback-workflow-progress.md
+++ b/tasks/issue-1860-lesson-rollback-workflow-progress.md
@@ -8,4 +8,7 @@
 - [x] Run targeted verification.
   - `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` passed (13 tests).
   - `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique` passed.
-- [ ] Commit, push, open PR, and request Codex review.
+- [x] Commit, push, open PR, and request Codex review.
+  - Commit: `369ae6ed feat(learning): add lesson rollback workflow`.
+  - PR: https://github.com/djm204/frankenbeast/pull/1881.
+  - Codex review requested: https://github.com/djm204/frankenbeast/pull/1881#issuecomment-4948580894.

--- a/tasks/issue-1860-lesson-rollback-workflow-progress.md
+++ b/tasks/issue-1860-lesson-rollback-workflow-progress.md
@@ -1,0 +1,11 @@
+# Issue 1860 lesson rollback workflow progress
+
+- [x] Inspect issue #1860 and repository instructions.
+- [x] Locate current lesson capture and traceability implementation.
+- [x] Add the smallest structured lesson rollback workflow.
+- [x] Add focused success and edge-case tests.
+- [x] Update operator-facing docs/help text.
+- [x] Run targeted verification.
+  - `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` passed (13 tests).
+  - `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique` passed.
+- [ ] Commit, push, open PR, and request Codex review.


### PR DESCRIPTION
## Summary
- Adds structured rollbackWorkflow metadata for traceable LessonRecorder lessons.
- Exports the rollback workflow type/helper for PM handoffs and dashboard consumers.
- Documents operator rollback evidence and non-deletion guidance.

Closes #1860

## Test plan
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique