### PR TITLE
feat(learning): sandbox new critique lessons

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -92,6 +92,12 @@ When the critique loop recovers from one or more failing iterations and ends in 
 
 Infrastructure-only evaluator exceptions are intentionally excluded from the map so operator dashboards do not promote broken tooling as product lessons. PM handoffs should treat lessons without a matching regression `testId` as unverified learning that is not ready for promotion.
 
+## Lesson experiment sandbox
+
+New lessons recorded by `LessonRecorder` also include an `experimentSandbox` object. The sandbox marks the lesson as `state: "experimental"`, sets `promotionBlocked: true`, and carries operator-facing exit criteria plus the verification command. PM and liveness tooling should surface these lessons for review, but must not promote or retire them as durable guidance until the traceability entry is present, the listed verification command has been run, and a reviewer confirms the regression covers the source finding.
+
+Failing iterations without actionable findings, and infrastructure-only evaluator exceptions, do not create sandboxed lessons. This keeps broken evaluator/tooling noise from entering the learning pipeline as experimental guidance.
+
 ## Package scripts
 
 Run these from the package directory with `npm run <script>`, or from the repository root with `npm run <script> --workspace @franken/critique`.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ADRMatch,
   EpisodicTrace,
   LessonTestTraceabilityEntry,
+  LessonExperimentSandbox,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -7,6 +7,9 @@ import { isoNow } from '@franken/types';
 const LESSON_TRACEABILITY_VERIFICATION_COMMAND =
   'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts';
 
+const LESSON_EXPERIMENT_SANDBOX_REASON =
+  'New critique lessons are experimental until their traceability map and regression evidence are independently verified.';
+
 export class LessonRecorder {
   private readonly memory: MemoryPort;
 
@@ -64,6 +67,17 @@ export class LessonRecorder {
             : 'Unknown correction',
           taskId,
           timestamp: isoNow(),
+          experimentSandbox: {
+            state: 'experimental',
+            promotionBlocked: true,
+            reason: LESSON_EXPERIMENT_SANDBOX_REASON,
+            exitCriteria: [
+              'Confirm at least one lesson-to-test traceability entry is present.',
+              'Run the listed verification command and attach the evidence to the PM handoff.',
+              'Promote or retire the lesson only after review confirms the regression covers the source finding.',
+            ],
+            verificationCommand: LESSON_TRACEABILITY_VERIFICATION_COMMAND,
+          },
           testTraceability: [
             {
               lessonId,

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -50,6 +50,25 @@ export interface LessonTestTraceabilityEntry {
   readonly verificationCommand: string;
 }
 
+/**
+ * Safety metadata for newly learned critique lessons.
+ *
+ * New lessons are recorded as experimental so PM and liveness tooling can inspect them without
+ * treating one recovered critique loop as enough evidence to promote or retire production guidance.
+ */
+export interface LessonExperimentSandbox {
+  /** New lessons start in the experiment sandbox until a human or promotion job verifies them. */
+  readonly state: 'experimental';
+  /** Promotion is intentionally blocked while the lesson is still in the sandbox. */
+  readonly promotionBlocked: true;
+  /** Operator-facing reason explaining why this lesson is quarantined. */
+  readonly reason: string;
+  /** Deterministic criteria required before PM handoffs can promote or retire the lesson. */
+  readonly exitCriteria: readonly string[];
+  /** Targeted command that verifies the sandbox metadata contract itself. */
+  readonly verificationCommand: string;
+}
+
 /** A lesson learned from a successful critique cycle. */
 export interface CritiqueLesson {
   readonly evaluatorName: string;
@@ -59,6 +78,8 @@ export interface CritiqueLesson {
   readonly timestamp: string;
   /** Present for lessons recorded by LessonRecorder; absent legacy lessons are unverified. */
   readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
+  /** Present for new lessons that must remain quarantined until independently verified. */
+  readonly experimentSandbox?: LessonExperimentSandbox;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -113,6 +113,52 @@ describe('LessonRecorder', () => {
     ]);
   });
 
+  it('sandboxes new lessons as experimental and blocks promotion until verified', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'factuality', [
+          { message: 'handoff cited an unverified file path', severity: 'critical' },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'sandbox-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.experimentSandbox).toEqual({
+      state: 'experimental',
+      promotionBlocked: true,
+      reason:
+        'New critique lessons are experimental until their traceability map and regression evidence are independently verified.',
+      exitCriteria: [
+        'Confirm at least one lesson-to-test traceability entry is present.',
+        'Run the listed verification command and attach the evidence to the PM handoff.',
+        'Promote or retire the lesson only after review confirms the regression covers the source finding.',
+      ],
+      verificationCommand:
+        'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts',
+    });
+  });
+
+  it('does not create an experimental sandbox entry for failing iterations with no actionable finding', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [createIteration(0, 'fail', 'empty-failure'), createIteration(1, 'pass')],
+    };
+
+    await recorder.record(result, 'sandbox-task');
+
+    expect(port.recordLesson).not.toHaveBeenCalled();
+  });
+
   it('does not create traceability entries for infrastructure-only evaluator exceptions', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);


### PR DESCRIPTION
## Summary
- add structured experimentSandbox metadata to new critique lessons so they remain experimental and promotion-blocked until verified
- export the sandbox contract for PM/liveness consumers
- document operator guidance and cover success plus no-actionable-finding edge cases

Closes #1859

## Test plan
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique

## Notes
- fbeast MCP tools were not available in this Hermes tool schema, so I followed AGENTS.md with normal git/GitHub/terminal verification.
- Initial targeted test/typecheck attempts failed before dependency installation because node_modules was absent; I installed dependencies with npm install --ignore-scripts --no-audit --no-fund --package-lock=false after confirming disk headroom.