### PR TITLE
feat(learning): add per-agent improvement scorecard

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -92,6 +92,17 @@ When the critique loop recovers from one or more failing iterations and ends in 
 
 Infrastructure-only evaluator exceptions are intentionally excluded from the map so operator dashboards do not promote broken tooling as product lessons. PM handoffs should treat lessons without a matching regression `testId` as unverified learning that is not ready for promotion.
 
+## Per-agent improvement scorecard
+
+Every recorded critique lesson also includes an `improvementScorecard` object so PM handoff summaries, liveness views, and learning telemetry can compare recovery behavior per agent without parsing prose. The scorecard records:
+
+- `agentId`: read from `EvaluationInput.metadata.agentId` when available; otherwise `unknown-agent` with `agentIdSource: "fallback"` so missing attribution is explicit.
+- `baselineScore`, `resolvedScore`, and `improvementDelta`: deterministic rounded score values for the failed evaluator and resolved critique outcome.
+- `failedIteration`, `resolvedIteration`, and `retryCount`: the retry path that produced the improvement.
+- `summary`: a compact operator-facing sentence suitable for PM handoffs.
+
+Scorecards are only emitted for product critique findings that become lessons. Infrastructure-only evaluator exceptions are excluded, matching the traceability-map behavior, so dashboards do not reward agents for recovering from broken evaluation tooling.
+
 ## Package scripts
 
 Run these from the package directory with `npm run <script>`, or from the repository root with `npm run <script> --workspace @franken/critique`.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ADRMatch,
   EpisodicTrace,
   LessonTestTraceabilityEntry,
+  AgentImprovementScorecard,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1,4 +1,4 @@
-import type { MemoryPort, CritiqueLesson } from '../types/contracts.js';
+import type { MemoryPort, CritiqueLesson, AgentImprovementScorecard } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
@@ -64,6 +64,14 @@ export class LessonRecorder {
             : 'Unknown correction',
           taskId,
           timestamp: isoNow(),
+          improvementScorecard: createImprovementScorecard({
+            taskId,
+            evaluatorName: evalResult.evaluatorName,
+            failingIteration,
+            resolvedIteration,
+            baselineScore: evalResult.score,
+            resolvedScore: passingIteration?.result.overallScore ?? failingIteration.result.overallScore,
+          }),
           testTraceability: [
             {
               lessonId,
@@ -82,6 +90,51 @@ export class LessonRecorder {
 
     return lessons;
   }
+}
+
+function createImprovementScorecard(input: {
+  taskId: TaskId;
+  evaluatorName: string;
+  failingIteration: CritiqueIteration;
+  resolvedIteration: number;
+  baselineScore: number;
+  resolvedScore: number;
+}): AgentImprovementScorecard {
+  const agentId = getAgentId(input.failingIteration);
+  const baselineScore = stableScore(input.baselineScore);
+  const resolvedScore = stableScore(input.resolvedScore);
+  const improvementDelta = stableScore(resolvedScore - baselineScore);
+  const retryCount = Math.max(0, input.resolvedIteration - input.failingIteration.index);
+
+  return {
+    agentId: agentId.value,
+    taskId: input.taskId,
+    evaluatorName: input.evaluatorName,
+    failedIteration: input.failingIteration.index,
+    resolvedIteration: input.resolvedIteration,
+    baselineScore,
+    resolvedScore,
+    improvementDelta,
+    retryCount,
+    agentIdSource: agentId.source,
+    summary: `${agentId.value} improved ${input.evaluatorName} from ${baselineScore} to ${resolvedScore} after ${retryCount} ${retryCount === 1 ? 'retry' : 'retries'}.`,
+  };
+}
+
+function getAgentId(iteration: CritiqueIteration): {
+  value: string;
+  source: AgentImprovementScorecard['agentIdSource'];
+} {
+  const rawAgentId = iteration.input.metadata['agentId'];
+  if (typeof rawAgentId === 'string' && rawAgentId.trim().length > 0) {
+    return { value: rawAgentId.trim(), source: 'metadata' };
+  }
+
+  return { value: 'unknown-agent', source: 'fallback' };
+}
+
+function stableScore(value: number): number {
+  return Math.round(value * 10_000) / 10_000;
 }
 
 function createLessonId(taskId: TaskId, evaluatorName: string, iterationIndex: number): string {

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -50,6 +50,28 @@ export interface LessonTestTraceabilityEntry {
   readonly verificationCommand: string;
 }
 
+/** Deterministic scorecard that lets PM/liveness tooling compare learning recovery by agent. */
+export interface AgentImprovementScorecard {
+  /** Agent identity from evaluation metadata; falls back to `unknown-agent` when callers omit it. */
+  readonly agentId: string;
+  readonly taskId: TaskId;
+  readonly evaluatorName: string;
+  readonly failedIteration: number;
+  readonly resolvedIteration: number;
+  /** Score before correction, rounded to four decimal places for stable structured output. */
+  readonly baselineScore: number;
+  /** Score after correction, rounded to four decimal places for stable structured output. */
+  readonly resolvedScore: number;
+  /** Positive, zero, or negative score delta after correction. */
+  readonly improvementDelta: number;
+  /** How many critique retries were needed before the lesson was resolved. */
+  readonly retryCount: number;
+  /** Whether the source provided an explicit agent id or the scorecard used the fallback. */
+  readonly agentIdSource: 'metadata' | 'fallback';
+  /** Operator-facing interpretation for handoffs and dashboards. */
+  readonly summary: string;
+}
+
 /** A lesson learned from a successful critique cycle. */
 export interface CritiqueLesson {
   readonly evaluatorName: string;
@@ -59,6 +81,8 @@ export interface CritiqueLesson {
   readonly timestamp: string;
   /** Present for lessons recorded by LessonRecorder; absent legacy lessons are unverified. */
   readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
+  /** Present for per-agent learning telemetry produced by LessonRecorder. */
+  readonly improvementScorecard?: AgentImprovementScorecard;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -18,6 +18,7 @@ function createIteration(
   verdict: 'pass' | 'warn' | 'fail',
   evaluatorName = 'mock',
   findings: EvaluationFinding[] = [],
+  metadata: Readonly<Record<string, unknown>> = {},
 ): CritiqueIteration {
   const result: CritiqueResult = {
     verdict,
@@ -34,7 +35,7 @@ function createIteration(
   };
   return {
     index,
-    input: { content: `iteration ${index}`, metadata: {} },
+    input: { content: `iteration ${index}`, metadata },
     result,
     completedAt: new Date().toISOString(),
   };
@@ -113,7 +114,68 @@ describe('LessonRecorder', () => {
     ]);
   });
 
-  it('does not create traceability entries for infrastructure-only evaluator exceptions', async () => {
+  it('adds a per-agent improvement scorecard to recorded lessons', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(
+          0,
+          'fail',
+          'complexity',
+          [{ message: 'too many params', severity: 'warning' }],
+          { agentId: 'worker-alpha' },
+        ),
+        createIteration(2, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-1858');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.improvementScorecard).toEqual({
+      agentId: 'worker-alpha',
+      taskId: 'task-1858',
+      evaluatorName: 'complexity',
+      failedIteration: 0,
+      resolvedIteration: 2,
+      baselineScore: 0.3,
+      resolvedScore: 1,
+      improvementDelta: 0.7,
+      retryCount: 2,
+      agentIdSource: 'metadata',
+      summary: 'worker-alpha improved complexity from 0.3 to 1 after 2 retries.',
+    });
+  });
+
+  it('uses an explicit fallback agent id when scorecard metadata is missing', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'safety', [{ message: 'plain HTTP endpoint', severity: 'critical' }]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-1858');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.improvementScorecard).toEqual(
+      expect.objectContaining({
+        agentId: 'unknown-agent',
+        agentIdSource: 'fallback',
+        improvementDelta: 0.7,
+        summary: 'unknown-agent improved safety from 0.3 to 1 after 1 retry.',
+      }),
+    );
+  });
+
+  it('does not create scorecards for infrastructure-only evaluator exceptions', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);
 

--- a/tasks/issue-1858-agent-improvement-scorecard-progress.md
+++ b/tasks/issue-1858-agent-improvement-scorecard-progress.md
@@ -1,0 +1,9 @@
+# Issue 1858 — per-agent improvement scorecard progress
+
+- [x] Inspect issue #1858 and repository instructions.
+- [x] Inventory existing lesson capture and traceability code paths.
+- [x] Add a narrow per-agent improvement scorecard model/runtime surface.
+- [x] Cover scorecard success and edge cases with targeted tests.
+- [x] Update operator-facing documentation for interpreting the scorecard.
+- [x] Run targeted verification.
+- [ ] Commit, push branch, open PR, and request Codex review.

--- a/tasks/issue-1858-agent-improvement-scorecard-progress.md
+++ b/tasks/issue-1858-agent-improvement-scorecard-progress.md
@@ -6,4 +6,4 @@
 - [x] Cover scorecard success and edge cases with targeted tests.
 - [x] Update operator-facing documentation for interpreting the scorecard.
 - [x] Run targeted verification.
-- [ ] Commit, push branch, open PR, and request Codex review.
+- [x] Commit, push branch, open PR, and request Codex review.


### PR DESCRIPTION
## Summary
- Closes #1858
- Adds a structured AgentImprovementScorecard to recorded critique lessons with per-agent attribution, retry counts, score deltas, and operator summary text.
- Documents scorecard interpretation for PM handoffs and learning telemetry.
- Covers metadata attribution, fallback attribution, and infrastructure-exception exclusion in LessonRecorder tests.

## Test plan
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/critique
- git diff --check

## Notes
- fbeast MCP tools were not available in this worker tool schema, so verification used normal git/terminal/GitHub tooling.