### PR TITLE
fix(web): preserve transcript code wrapping

### DIFF
--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -587,6 +587,7 @@ button {
 
 .message-card__content {
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .message-card__error {

--- a/packages/franken-web/tests/components/transcript-pane.test.tsx
+++ b/packages/franken-web/tests/components/transcript-pane.test.tsx
@@ -32,6 +32,20 @@ describe('TranscriptPane', () => {
     expect(screen.getByText('Hi there!')).toBeDefined();
   });
 
+  it('renders multiline and indented transcript text without normalizing the content', () => {
+    const multilineContent = 'run this:\n  npm test -- --runInBand\n\n```ts\nconst value = 1;\n```';
+    const { container } = render(
+      <TranscriptPane
+        messages={[{ id: 'a1', role: 'assistant' as const, content: multilineContent, timestamp: new Date().toISOString() }]}
+        showTypingIndicator={false}
+      />,
+    );
+
+    const content = container.querySelector('.message-card__content');
+    expect(content).toBeTruthy();
+    expect(content?.textContent).toBe(multilineContent);
+  });
+
   it('renders role labels for each message', () => {
     const messages = [
       { id: 'u1', role: 'user' as const, content: 'Test msg', timestamp: new Date().toISOString() },

--- a/packages/franken-web/tests/styles/app-css.test.ts
+++ b/packages/franken-web/tests/styles/app-css.test.ts
@@ -11,3 +11,9 @@ describe('app.css sidebar controls', () => {
     expect(appCss).toMatch(/@media\s*\(min-width:\s*921px\)\s*\{[\s\S]*?\.sidebar__close\s*\{\s*display:\s*none;\s*\}/m);
   });
 });
+
+describe('app.css transcript message formatting', () => {
+  it('preserves transcript newlines and wraps long unbroken output', () => {
+    expect(appCss).toMatch(/\.message-card__content\s*\{[\s\S]*?white-space:\s*pre-wrap;[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?\}/m);
+  });
+});


### PR DESCRIPTION
## Summary
- keeps transcript message text newline-preserving and adds long-token wrapping for code/stack traces
- adds component coverage for multiline/indented message text
- adds CSS contract coverage for transcript formatting and long-line wrapping

## Test Plan
- npm run test --workspace @franken/web -- --run tests/components/transcript-pane.test.tsx tests/styles/app-css.test.ts
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #1005
