### PR TITLE
feat(learning): capture reviewer-feedback lessons

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -92,6 +92,17 @@ When the critique loop recovers from one or more failing iterations and ends in 
 
 Infrastructure-only evaluator exceptions are intentionally excluded from the map so operator dashboards do not promote broken tooling as product lessons. PM handoffs should treat lessons without a matching regression `testId` as unverified learning that is not ready for promotion.
 
+## Reviewer-feedback lesson capture
+
+Recorded critique lessons also carry a `reviewerFeedback` object so worker retrospectives and PM handoff summaries can reuse the reviewer feedback that created the lesson without parsing prose. The capture includes:
+
+- `summary`: a concise concatenation of the reviewer finding messages.
+- `findings`: normalized feedback entries with source iteration, evaluator name, message, severity, and any reviewer-provided source location or suggestion.
+- `suggestionsComplete`: `true` only when every captured feedback item includes a reviewer suggestion.
+- `missingSuggestionGuidance`: present when at least one feedback item lacks a suggestion; PM/liveness tooling should surface the original message and ask for remediation guidance before promotion.
+
+Infrastructure-only evaluator exceptions and failed iterations without actionable findings do not create reviewer-feedback captures. This keeps broken tooling noise from being promoted as durable agent-learning guidance.
+
 ## Lesson experiment sandbox
 
 New lessons recorded by `LessonRecorder` also include an `experimentSandbox` object. The sandbox marks the lesson as `state: "experimental"`, sets `promotionBlocked: true`, and carries operator-facing exit criteria plus the verification command. PM and liveness tooling should surface these lessons for review, but must not promote or retire them as durable guidance until the traceability entry is present, the listed verification command has been run, and a reviewer confirms the regression covers the source finding.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -23,6 +23,8 @@ export type {
   EpisodicTrace,
   LessonTestTraceabilityEntry,
   LessonExperimentSandbox,
+  ReviewerFeedbackLessonEntry,
+  ReviewerFeedbackLessonCapture,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1,4 +1,4 @@
-import type { MemoryPort, CritiqueLesson } from '../types/contracts.js';
+import type { MemoryPort, CritiqueLesson, ReviewerFeedbackLessonCapture } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
@@ -9,6 +9,9 @@ const LESSON_TRACEABILITY_VERIFICATION_COMMAND =
 
 const LESSON_EXPERIMENT_SANDBOX_REASON =
   'New critique lessons are experimental until their traceability map and regression evidence are independently verified.';
+
+const MISSING_REVIEWER_SUGGESTION_GUIDANCE =
+  'Reviewer feedback did not include suggestions for every finding; PM handoffs should preserve the original message and ask a reviewer to attach remediation guidance before promotion.';
 
 export class LessonRecorder {
   private readonly memory: MemoryPort;
@@ -90,12 +93,45 @@ export class LessonRecorder {
               verificationCommand: LESSON_TRACEABILITY_VERIFICATION_COMMAND,
             },
           ],
+          reviewerFeedback: createReviewerFeedbackCapture(
+            failingIteration.index,
+            evalResult.evaluatorName,
+            critiqueFindings,
+          ),
         });
       }
     }
 
     return lessons;
   }
+}
+
+function createReviewerFeedbackCapture(
+  sourceIteration: number,
+  evaluatorName: string,
+  findings: readonly {
+    readonly message: string;
+    readonly severity: string;
+    readonly location?: string | undefined;
+    readonly suggestion?: string | undefined;
+  }[],
+): ReviewerFeedbackLessonCapture {
+  const capturedFindings = findings.map((finding) => ({
+    sourceIteration,
+    evaluatorName,
+    message: finding.message,
+    severity: finding.severity,
+    ...(finding.location ? { location: finding.location } : {}),
+    ...(finding.suggestion ? { suggestion: finding.suggestion } : {}),
+  }));
+  const suggestionsComplete = capturedFindings.every((finding) => Boolean(finding.suggestion));
+
+  return {
+    summary: capturedFindings.map((finding) => finding.message).join('; '),
+    findings: capturedFindings,
+    suggestionsComplete,
+    ...(suggestionsComplete ? {} : { missingSuggestionGuidance: MISSING_REVIEWER_SUGGESTION_GUIDANCE }),
+  };
 }
 
 function createLessonId(taskId: TaskId, evaluatorName: string, iterationIndex: number): string {

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -69,6 +69,34 @@ export interface LessonExperimentSandbox {
   readonly verificationCommand: string;
 }
 
+/** A normalized reviewer finding captured alongside a learned critique lesson. */
+export interface ReviewerFeedbackLessonEntry {
+  /** Iteration where the reviewer feedback was emitted. */
+  readonly sourceIteration: number;
+  /** Evaluator/reviewer that emitted the feedback. */
+  readonly evaluatorName: string;
+  /** Original reviewer finding message. */
+  readonly message: string;
+  /** Severity assigned by the reviewer. */
+  readonly severity: string;
+  /** Optional source location supplied by the reviewer. */
+  readonly location?: string;
+  /** Optional reviewer suggestion captured for future workers. */
+  readonly suggestion?: string;
+}
+
+/** Structured reviewer feedback attached to a learned critique lesson. */
+export interface ReviewerFeedbackLessonCapture {
+  /** Operator-facing summary of the feedback that produced the lesson. */
+  readonly summary: string;
+  /** Findings from the failed reviewer pass that should guide future workers. */
+  readonly findings: readonly ReviewerFeedbackLessonEntry[];
+  /** Whether every captured feedback item included an actionable suggestion. */
+  readonly suggestionsComplete: boolean;
+  /** Deterministic guidance for PM handoffs when suggestions are missing. */
+  readonly missingSuggestionGuidance?: string;
+}
+
 /** A lesson learned from a successful critique cycle. */
 export interface CritiqueLesson {
   readonly evaluatorName: string;
@@ -80,6 +108,8 @@ export interface CritiqueLesson {
   readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
   /** Present for new lessons that must remain quarantined until independently verified. */
   readonly experimentSandbox?: LessonExperimentSandbox;
+  /** Structured reviewer feedback that produced the lesson and should be reusable in PM handoffs. */
+  readonly reviewerFeedback?: ReviewerFeedbackLessonCapture;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -113,6 +113,77 @@ describe('LessonRecorder', () => {
     ]);
   });
 
+  it('captures reviewer feedback messages, suggestions, severities, and source locations with the lesson', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'reviewer', [
+          {
+            message: 'PR summary omits the verification command',
+            severity: 'warning',
+            location: 'pull-request-body',
+            suggestion: 'Add the exact targeted test command and result to the PR description.',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'review-feedback-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.reviewerFeedback).toEqual({
+      summary: 'PR summary omits the verification command',
+      findings: [
+        {
+          sourceIteration: 0,
+          evaluatorName: 'reviewer',
+          message: 'PR summary omits the verification command',
+          severity: 'warning',
+          location: 'pull-request-body',
+          suggestion: 'Add the exact targeted test command and result to the PR description.',
+        },
+      ],
+      suggestionsComplete: true,
+    });
+  });
+
+  it('marks reviewer-feedback lessons with missing suggestions for PM follow-up', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'reviewer', [
+          { message: 'Review identified a handoff gap without remediation guidance', severity: 'critical' },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'missing-suggestion-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.reviewerFeedback).toEqual({
+      summary: 'Review identified a handoff gap without remediation guidance',
+      findings: [
+        {
+          sourceIteration: 0,
+          evaluatorName: 'reviewer',
+          message: 'Review identified a handoff gap without remediation guidance',
+          severity: 'critical',
+        },
+      ],
+      suggestionsComplete: false,
+      missingSuggestionGuidance:
+        'Reviewer feedback did not include suggestions for every finding; PM handoffs should preserve the original message and ask a reviewer to attach remediation guidance before promotion.',
+    });
+  });
+
   it('sandboxes new lessons as experimental and blocks promotion until verified', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);

--- a/tasks/issue-1855-reviewer-feedback-lesson-capture-progress.md
+++ b/tasks/issue-1855-reviewer-feedback-lesson-capture-progress.md
@@ -9,4 +9,7 @@
   - Initial `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` failed because dependencies were absent (`Cannot find package 'vitest'`).
   - Installed repo dependencies with `npm install --ignore-scripts --no-audit --no-fund --package-lock=false` after disk preflight.
   - `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique && npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` passed.
-- [ ] Commit, push, open PR, and request Codex review.
+- [x] Commit, push, open PR, and request Codex review.
+  - Commit: `0f5ae756 feat(learning): capture reviewer-feedback lessons`.
+  - PR: https://github.com/djm204/frankenbeast/pull/1887.
+  - Posted `@codex review` on the PR.

--- a/tasks/issue-1855-reviewer-feedback-lesson-capture-progress.md
+++ b/tasks/issue-1855-reviewer-feedback-lesson-capture-progress.md
@@ -1,0 +1,12 @@
+# Issue 1855 reviewer-feedback lesson capture progress
+
+- [x] Inspect issue #1855 and repository instructions.
+- [x] Locate current lesson recording implementation and tests.
+- [x] Add structured reviewer-feedback capture to recorded critique lessons.
+- [x] Cover success and edge cases with targeted tests.
+- [x] Update operator-facing package docs.
+- [x] Run targeted verification.
+  - Initial `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` failed because dependencies were absent (`Cannot find package 'vitest'`).
+  - Installed repo dependencies with `npm install --ignore-scripts --no-audit --no-fund --package-lock=false` after disk preflight.
+  - `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique && npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` passed.
+- [ ] Commit, push, open PR, and request Codex review.


### PR DESCRIPTION
## Summary
- Closes #1855
- Adds structured reviewerFeedback lesson metadata for recovered critique lessons
- Captures reviewer message, severity, source iteration, location, suggestion completeness, and PM follow-up guidance for missing suggestions
- Documents how PM/liveness tooling should interpret reviewer-feedback lesson captures

## Test plan
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique && npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts

## Notes
- fbeast MCP tools were not available in this worker tool schema, so I used normal git/terminal/gh verification.