### PR TITLE
feat(learning): add post-pr lesson extraction template

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -103,6 +103,20 @@ Recorded critique lessons also carry a `reviewerFeedback` object so worker retro
 
 Infrastructure-only evaluator exceptions and failed iterations without actionable findings do not create reviewer-feedback captures. This keeps broken tooling noise from being promoted as durable agent-learning guidance.
 
+## Post-PR lesson extraction template
+
+Recorded critique lessons include `postPrLessonExtractionTemplate`, a deterministic prompt/template for the post-PR moment after review or merge evidence exists. PM/liveness tooling can hand the template to an LLM or worker to extract one reusable lesson without inventing missing evidence.
+
+The template requires these evidence inputs before promotion:
+
+- linked issue or task identifier;
+- PR URL or merge/review artifact;
+- reviewer finding or failure mode that motivated the correction;
+- correction applied in the final PR head;
+- regression test, verifier, or explicit reason no code-level regression applies.
+
+Its output schema is intentionally narrow: `issueNumber`, `prUrl`, `sourceFinding`, `correctionApplied`, `reusableLesson`, `regressionEvidence`, and `followUpNeeded`. If any required evidence is missing, tooling should set `followUpNeeded: true` and surface the template's `insufficientEvidenceGuidance` instead of promoting a guessed lesson. Infrastructure-only evaluator exceptions and failed iterations without actionable findings do not create the template.
+
 ## Lesson experiment sandbox
 
 New lessons recorded by `LessonRecorder` also include an `experimentSandbox` object. The sandbox marks the lesson as `state: "experimental"`, sets `promotionBlocked: true`, and carries operator-facing exit criteria plus the verification command. PM and liveness tooling should surface these lessons for review, but must not promote or retire them as durable guidance until the traceability entry is present, the listed verification command has been run, and a reviewer confirms the regression covers the source finding.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -25,6 +25,7 @@ export type {
   LessonExperimentSandbox,
   ReviewerFeedbackLessonEntry,
   ReviewerFeedbackLessonCapture,
+  PostPrLessonExtractionTemplate,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1,4 +1,9 @@
-import type { MemoryPort, CritiqueLesson, ReviewerFeedbackLessonCapture } from '../types/contracts.js';
+import type {
+  MemoryPort,
+  CritiqueLesson,
+  ReviewerFeedbackLessonCapture,
+  PostPrLessonExtractionTemplate,
+} from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
@@ -12,6 +17,34 @@ const LESSON_EXPERIMENT_SANDBOX_REASON =
 
 const MISSING_REVIEWER_SUGGESTION_GUIDANCE =
   'Reviewer feedback did not include suggestions for every finding; PM handoffs should preserve the original message and ask a reviewer to attach remediation guidance before promotion.';
+
+const POST_PR_LESSON_EXTRACTION_TEMPLATE: PostPrLessonExtractionTemplate = {
+  templateId: 'post-pr-lesson-extraction-v1',
+  trigger: 'after-pr-review-or-merge',
+  instructions: [
+    'Inspect the linked issue, PR description, final diff, reviewer feedback, and verification evidence before extracting a durable lesson.',
+    'Extract only lessons that are reusable for future workers; do not restate one-off implementation details as policy.',
+    'If required evidence is missing, set followUpNeeded to true and use insufficientEvidenceGuidance instead of inventing a lesson.',
+  ],
+  requiredEvidence: [
+    'Linked issue or task identifier',
+    'PR URL or merge/review artifact',
+    'Reviewer finding or failure mode that motivated the correction',
+    'Correction applied in the final PR head',
+    'Regression test, verifier, or explicit reason no code-level regression applies',
+  ],
+  outputSchema: {
+    issueNumber: 'number-or-null',
+    prUrl: 'string-or-null',
+    sourceFinding: 'string',
+    correctionApplied: 'string',
+    reusableLesson: 'string',
+    regressionEvidence: 'string',
+    followUpNeeded: 'boolean',
+  },
+  insufficientEvidenceGuidance:
+    'Do not promote a post-PR lesson until the issue/PR, source finding, correction, and verification evidence are all available.',
+};
 
 export class LessonRecorder {
   private readonly memory: MemoryPort;
@@ -98,12 +131,22 @@ export class LessonRecorder {
             evalResult.evaluatorName,
             critiqueFindings,
           ),
+          postPrLessonExtractionTemplate: createPostPrLessonExtractionTemplate(),
         });
       }
     }
 
     return lessons;
   }
+}
+
+function createPostPrLessonExtractionTemplate(): PostPrLessonExtractionTemplate {
+  return {
+    ...POST_PR_LESSON_EXTRACTION_TEMPLATE,
+    instructions: [...POST_PR_LESSON_EXTRACTION_TEMPLATE.instructions],
+    requiredEvidence: [...POST_PR_LESSON_EXTRACTION_TEMPLATE.requiredEvidence],
+    outputSchema: { ...POST_PR_LESSON_EXTRACTION_TEMPLATE.outputSchema },
+  };
 }
 
 function createReviewerFeedbackCapture(

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -97,6 +97,30 @@ export interface ReviewerFeedbackLessonCapture {
   readonly missingSuggestionGuidance?: string;
 }
 
+/** LLM-friendly template PM/worker handoffs can use after a PR closes to extract reusable lessons. */
+export interface PostPrLessonExtractionTemplate {
+  /** Stable template identifier for downstream liveness tooling and prompt selection. */
+  readonly templateId: 'post-pr-lesson-extraction-v1';
+  /** Operator-facing moment when this template should be run. */
+  readonly trigger: 'after-pr-review-or-merge';
+  /** Prompt instructions for the LLM or worker producing the post-PR lesson. */
+  readonly instructions: readonly string[];
+  /** Evidence that must be present before a lesson can be promoted from this template. */
+  readonly requiredEvidence: readonly string[];
+  /** JSON object shape expected from the extraction step. */
+  readonly outputSchema: {
+    readonly issueNumber: 'number-or-null';
+    readonly prUrl: 'string-or-null';
+    readonly sourceFinding: 'string';
+    readonly correctionApplied: 'string';
+    readonly reusableLesson: 'string';
+    readonly regressionEvidence: 'string';
+    readonly followUpNeeded: 'boolean';
+  };
+  /** Explicit failure guidance when the PR lacks enough evidence to extract a lesson. */
+  readonly insufficientEvidenceGuidance: string;
+}
+
 /** A lesson learned from a successful critique cycle. */
 export interface CritiqueLesson {
   readonly evaluatorName: string;
@@ -110,6 +134,8 @@ export interface CritiqueLesson {
   readonly experimentSandbox?: LessonExperimentSandbox;
   /** Structured reviewer feedback that produced the lesson and should be reusable in PM handoffs. */
   readonly reviewerFeedback?: ReviewerFeedbackLessonCapture;
+  /** Structured template for extracting reusable lessons from post-PR review/merge evidence. */
+  readonly postPrLessonExtractionTemplate?: PostPrLessonExtractionTemplate;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -184,6 +184,79 @@ describe('LessonRecorder', () => {
     });
   });
 
+  it('attaches an LLM-friendly post-PR lesson extraction template to recorded lessons', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'reviewer', [
+          {
+            message: 'PR omitted the regression evidence from the handoff',
+            severity: 'warning',
+            suggestion: 'Add the exact verifier command and result before requesting promotion.',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'post-pr-template-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(lesson.postPrLessonExtractionTemplate).toEqual({
+      templateId: 'post-pr-lesson-extraction-v1',
+      trigger: 'after-pr-review-or-merge',
+      instructions: [
+        'Inspect the linked issue, PR description, final diff, reviewer feedback, and verification evidence before extracting a durable lesson.',
+        'Extract only lessons that are reusable for future workers; do not restate one-off implementation details as policy.',
+        'If required evidence is missing, set followUpNeeded to true and use insufficientEvidenceGuidance instead of inventing a lesson.',
+      ],
+      requiredEvidence: [
+        'Linked issue or task identifier',
+        'PR URL or merge/review artifact',
+        'Reviewer finding or failure mode that motivated the correction',
+        'Correction applied in the final PR head',
+        'Regression test, verifier, or explicit reason no code-level regression applies',
+      ],
+      outputSchema: {
+        issueNumber: 'number-or-null',
+        prUrl: 'string-or-null',
+        sourceFinding: 'string',
+        correctionApplied: 'string',
+        reusableLesson: 'string',
+        regressionEvidence: 'string',
+        followUpNeeded: 'boolean',
+      },
+      insufficientEvidenceGuidance:
+        'Do not promote a post-PR lesson until the issue/PR, source finding, correction, and verification evidence are all available.',
+    });
+  });
+
+  it('does not attach a post-PR extraction template when no actionable lesson is recorded', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'reviewer', [
+          {
+            message: 'internal evaluator error occurred',
+            severity: 'critical',
+            location: EVALUATOR_EXCEPTION_LOCATION,
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'post-pr-template-task');
+
+    expect(port.recordLesson).not.toHaveBeenCalled();
+  });
+
   it('sandboxes new lessons as experimental and blocks promotion until verified', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);


### PR DESCRIPTION
## Summary
- Closes #1853
- Adds a typed post-PR lesson extraction template to recorded critique lessons for PM/liveness handoffs
- Documents required evidence, output schema, and insufficient-evidence handling
- Covers success and infrastructure-exception edge cases in LessonRecorder tests

## Test plan
- `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts`
- `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique`

## Notes
- fbeast MCP tools were not available in this runtime, so I used normal git/GitHub/terminal verification.
