### PR TITLE
feat(memory): add snapshot diff command

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -15,6 +15,7 @@ export type Subcommand =
   | 'chat-server'
   | 'beasts-daemon'
   | 'network'
+  | 'memory'
   | 'skill'
   | 'security'
   | undefined;
@@ -48,6 +49,7 @@ export type BeastAction =
 
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
+export type MemoryAction = 'snapshot-diff' | undefined;
 
 export interface CliArgs {
   subcommand: Subcommand;
@@ -55,6 +57,9 @@ export interface CliArgs {
   beastTarget?: string | undefined;
   networkAction?: NetworkAction;
   networkTarget?: string | undefined;
+  memoryAction?: MemoryAction;
+  memorySnapshotBefore?: string | undefined;
+  memorySnapshotAfter?: string | undefined;
   networkDetached: boolean;
   networkSet?: string[] | undefined;
   skillAction?: SkillAction;
@@ -102,8 +107,9 @@ export interface CliArgs {
   moduleConfig?: import('../beasts/types.js').ModuleConfig | undefined;
 }
 
-const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'skill', 'security']);
+const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
+const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff']);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
@@ -167,6 +173,7 @@ Subcommands:
   chat-server             Run the local HTTP+WebSocket chat server for franken-web
   beasts-daemon           Run the standalone Beast control-plane daemon
   network                 Manage Frankenbeast request-serving services
+  memory                  Inspect persisted BrainSnapshot JSON artifacts
   skill                   Manage MCP skill plugins
   security                View or change security profile
 
@@ -222,6 +229,10 @@ Network Commands:
   network config [--set a.b.c=value]  Inspect or update operator config
   network credentials                 Print scoped credential refs inventory (never secret values)
   network help                        Show network command help
+
+Memory Commands:
+  memory snapshot-diff <before> <after>
+                                  Print a structured JSON diff between two BrainSnapshot files
 
 Beast Commands:
   beasts catalog                      List fixed Beast definitions
@@ -498,6 +509,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let networkTarget: string | undefined;
   let beastAction: BeastAction;
   let beastTarget: string | undefined;
+  let memoryAction: MemoryAction;
+  let memorySnapshotBefore: string | undefined;
+  let memorySnapshotAfter: string | undefined;
   let skillAction: SkillAction;
   let skillTarget: string | undefined;
   let skillCommand: string | undefined;
@@ -525,6 +539,19 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     }
     assertNoExtraPositionals('beasts', positionals, maxBeastPositionals(beastAction));
     beastTarget = positionals[1];
+  } else if (subcommand === 'memory') {
+    const actionCandidate = positionals[0];
+    if (actionCandidate !== undefined) {
+      if (!VALID_MEMORY_ACTIONS.has(actionCandidate)) {
+        throw new TypeError(`Unknown memory action: ${actionCandidate}`);
+      }
+      memoryAction = actionCandidate as MemoryAction;
+    }
+    memorySnapshotBefore = positionals[1];
+    memorySnapshotAfter = positionals[2];
+    if (positionals.length > 3) {
+      throw new TypeError(`Unexpected argument '${positionals[3]}'. memory snapshot-diff accepts exactly two snapshot files`);
+    }
   } else if (subcommand === 'skill') {
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
@@ -657,6 +684,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     beastTarget,
     networkAction,
     networkTarget,
+    memoryAction,
+    memorySnapshotBefore,
+    memorySnapshotAfter,
     networkDetached: values.detached ?? false,
     networkSet: values.set,
     skillAction,

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -1,0 +1,167 @@
+import { readFile } from 'node:fs/promises';
+import { BrainSnapshotSchema, type BrainSnapshot, type EpisodicEvent } from '@franken/types';
+
+export interface SnapshotDiff<T = unknown> {
+  readonly added: Record<string, T>;
+  readonly removed: Record<string, T>;
+  readonly changed: Record<string, { before: T; after: T }>;
+  readonly unchanged: string[];
+}
+
+export interface MemorySnapshotDiffReport {
+  readonly ok: true;
+  readonly command: 'memory snapshot-diff';
+  readonly before: { readonly path: string; readonly timestamp: string };
+  readonly after: { readonly path: string; readonly timestamp: string };
+  readonly summary: {
+    readonly workingAdded: number;
+    readonly workingRemoved: number;
+    readonly workingChanged: number;
+    readonly episodicAdded: number;
+    readonly episodicRemoved: number;
+    readonly episodicChanged: number;
+    readonly checkpointChanged: boolean;
+    readonly metadataChanged: boolean;
+  };
+  readonly diff: {
+    readonly working: SnapshotDiff;
+    readonly episodic: SnapshotDiff<EpisodicEvent>;
+    readonly checkpoint: { readonly changed: boolean; readonly before: BrainSnapshot['checkpoint']; readonly after: BrainSnapshot['checkpoint'] };
+    readonly metadata: SnapshotDiff;
+  };
+}
+
+export interface MemoryCommandDeps {
+  readonly action: 'snapshot-diff' | undefined;
+  readonly beforePath?: string | undefined;
+  readonly afterPath?: string | undefined;
+  readonly print: (message: string) => void;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value));
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, sortJsonValue(nested)]),
+    );
+  }
+  return value;
+}
+
+function diffRecords<T>(before: Record<string, T>, after: Record<string, T>): SnapshotDiff<T> {
+  const added: Record<string, T> = {};
+  const removed: Record<string, T> = {};
+  const changed: Record<string, { before: T; after: T }> = {};
+  const unchanged: string[] = [];
+  const keys = Array.from(new Set([...Object.keys(before), ...Object.keys(after)])).sort();
+
+  for (const key of keys) {
+    const hasBefore = Object.prototype.hasOwnProperty.call(before, key);
+    const hasAfter = Object.prototype.hasOwnProperty.call(after, key);
+    if (!hasBefore && hasAfter) {
+      added[key] = after[key] as T;
+      continue;
+    }
+    if (hasBefore && !hasAfter) {
+      removed[key] = before[key] as T;
+      continue;
+    }
+    const beforeValue = before[key] as T;
+    const afterValue = after[key] as T;
+    if (stableStringify(beforeValue) === stableStringify(afterValue)) {
+      unchanged.push(key);
+      continue;
+    }
+    changed[key] = { before: beforeValue, after: afterValue };
+  }
+
+  return { added, removed, changed, unchanged };
+}
+
+function eventDiffKey(event: EpisodicEvent, index: number): string {
+  if (event.id !== undefined) {
+    return `id:${event.id}`;
+  }
+  return `event:${event.createdAt}:${event.type}:${event.step ?? ''}:${event.summary}:${index}`;
+}
+
+function indexEvents(events: EpisodicEvent[]): Record<string, EpisodicEvent> {
+  return Object.fromEntries(events.map((event, index) => [eventDiffKey(event, index), event]));
+}
+
+export function diffMemorySnapshots(
+  beforePath: string,
+  before: BrainSnapshot,
+  afterPath: string,
+  after: BrainSnapshot,
+): MemorySnapshotDiffReport {
+  const working = diffRecords(before.working, after.working);
+  const episodic = diffRecords(indexEvents(before.episodic), indexEvents(after.episodic));
+  const checkpointChanged = stableStringify(before.checkpoint) !== stableStringify(after.checkpoint);
+  const metadata = diffRecords(before.metadata, after.metadata);
+
+  return {
+    ok: true,
+    command: 'memory snapshot-diff',
+    before: { path: beforePath, timestamp: before.timestamp },
+    after: { path: afterPath, timestamp: after.timestamp },
+    summary: {
+      workingAdded: Object.keys(working.added).length,
+      workingRemoved: Object.keys(working.removed).length,
+      workingChanged: Object.keys(working.changed).length,
+      episodicAdded: Object.keys(episodic.added).length,
+      episodicRemoved: Object.keys(episodic.removed).length,
+      episodicChanged: Object.keys(episodic.changed).length,
+      checkpointChanged,
+      metadataChanged: Object.keys(metadata.added).length > 0
+        || Object.keys(metadata.removed).length > 0
+        || Object.keys(metadata.changed).length > 0,
+    },
+    diff: {
+      working,
+      episodic,
+      checkpoint: { changed: checkpointChanged, before: before.checkpoint, after: after.checkpoint },
+      metadata,
+    },
+  };
+}
+
+async function readSnapshot(path: string): Promise<BrainSnapshot> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read memory snapshot ${path}: ${message}`);
+  }
+
+  const result = BrainSnapshotSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`Invalid memory snapshot ${path}: ${result.error.issues.map((issue) => issue.path.join('.') + ' ' + issue.message).join('; ')}`);
+  }
+  return result.data as unknown as BrainSnapshot;
+}
+
+export async function handleMemoryCommand(deps: MemoryCommandDeps): Promise<void> {
+  const { action, beforePath, afterPath, print } = deps;
+  if (action !== 'snapshot-diff') {
+    throw new Error('Usage: frankenbeast memory snapshot-diff <before-snapshot.json> <after-snapshot.json>');
+  }
+  if (!beforePath || !afterPath) {
+    throw new Error('memory snapshot-diff requires two BrainSnapshot JSON files: <before> <after>');
+  }
+
+  const [before, after] = await Promise.all([
+    readSnapshot(beforePath),
+    readSnapshot(afterPath),
+  ]);
+  print(JSON.stringify(diffMemorySnapshots(beforePath, before, afterPath, after), null, 2));
+}

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -947,6 +947,21 @@ export async function main(): Promise<void> {
   }
 
   const root = resolveProjectRoot(args.baseDir);
+  if (args.subcommand === 'memory') {
+    try {
+      await handleMemoryCommand({
+        action: args.memoryAction,
+        beforePath: args.memorySnapshotBefore,
+        afterPath: args.memorySnapshotAfter,
+        print: printLine,
+      });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   const suppressBanner = args.subcommand === 'network' && args.networkAction === 'credentials';
   if (!suppressBanner && process.env.FRANKENBEAST_NETWORK_MANAGED !== '1') {
     printLine(await renderBanner(root));
@@ -1028,21 +1043,6 @@ export async function main(): Promise<void> {
 
   if (args.subcommand === 'network') {
     await runNetworkCommand(args, config, root, paths);
-    return;
-  }
-
-  if (args.subcommand === 'memory') {
-    try {
-      await handleMemoryCommand({
-        action: args.memoryAction,
-        beforePath: args.memorySnapshotBefore,
-        afterPath: args.memorySnapshotAfter,
-        print: printLine,
-      });
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exitCode = 1;
-    }
     return;
   }
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -16,6 +16,7 @@ import { handleBeastCommand } from './beast-cli.js';
 import { handleInitCommand } from './init-command.js';
 import { handleSkillCommand } from './skill-cli.js';
 import { handleSecurityCommand } from './security-cli.js';
+import { handleMemoryCommand } from './memory-snapshot-diff.js';
 import { loadConfig } from './config-loader.js';
 import { cleanupBuild } from './cleanup.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
@@ -1027,6 +1028,21 @@ export async function main(): Promise<void> {
 
   if (args.subcommand === 'network') {
     await runNetworkCommand(args, config, root, paths);
+    return;
+  }
+
+  if (args.subcommand === 'memory') {
+    try {
+      await handleMemoryCommand({
+        action: args.memoryAction,
+        beforePath: args.memorySnapshotBefore,
+        afterPath: args.memorySnapshotAfter,
+        print: printLine,
+      });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { BrainSnapshot } from '@franken/types';
+import { parseArgs } from '../../../src/cli/args.js';
+import { diffMemorySnapshots, handleMemoryCommand } from '../../../src/cli/memory-snapshot-diff.js';
+
+const baseSnapshot: BrainSnapshot = {
+  version: 1,
+  timestamp: '2026-07-11T00:00:00.000Z',
+  working: {
+    keep: { same: true },
+    remove: 'old',
+    change: { count: 1 },
+  },
+  episodic: [
+    {
+      id: 1,
+      type: 'observation',
+      summary: 'existing event',
+      createdAt: '2026-07-11T00:00:01.000Z',
+    },
+    {
+      id: 2,
+      type: 'failure',
+      summary: 'removed event',
+      createdAt: '2026-07-11T00:00:02.000Z',
+    },
+  ],
+  checkpoint: null,
+  metadata: {
+    lastProvider: 'claude',
+    switchReason: '',
+    totalTokensUsed: 10,
+  },
+};
+
+describe('memory snapshot-diff CLI args', () => {
+  it('parses the memory snapshot-diff command and snapshot paths', () => {
+    const args = parseArgs(['memory', 'snapshot-diff', 'before.json', 'after.json']);
+
+    expect(args.subcommand).toBe('memory');
+    expect(args.memoryAction).toBe('snapshot-diff');
+    expect(args.memorySnapshotBefore).toBe('before.json');
+    expect(args.memorySnapshotAfter).toBe('after.json');
+  });
+
+  it('rejects unknown memory actions explicitly', () => {
+    expect(() => parseArgs(['memory', 'unknown'])).toThrow(/Unknown memory action: unknown/);
+  });
+});
+
+describe('diffMemorySnapshots', () => {
+  it('reports deterministic structured changes across working, episodic, checkpoint, and metadata memory', () => {
+    const after: BrainSnapshot = {
+      ...baseSnapshot,
+      timestamp: '2026-07-11T00:10:00.000Z',
+      working: {
+        keep: { same: true },
+        change: { count: 2 },
+        add: 'new',
+      },
+      episodic: [
+        {
+          id: 1,
+          type: 'observation',
+          summary: 'existing event updated',
+          createdAt: '2026-07-11T00:00:01.000Z',
+        },
+        {
+          id: 3,
+          type: 'success',
+          summary: 'added event',
+          createdAt: '2026-07-11T00:00:03.000Z',
+        },
+      ],
+      checkpoint: {
+        runId: 'run-1',
+        phase: 'execute',
+        step: 1,
+        context: { task: 't1' },
+        timestamp: '2026-07-11T00:09:00.000Z',
+      },
+      metadata: {
+        lastProvider: 'codex',
+        switchReason: 'fallback',
+        totalTokensUsed: 20,
+      },
+    };
+
+    const report = diffMemorySnapshots('before.json', baseSnapshot, 'after.json', after);
+
+    expect(report.summary).toEqual({
+      workingAdded: 1,
+      workingRemoved: 1,
+      workingChanged: 1,
+      episodicAdded: 1,
+      episodicRemoved: 1,
+      episodicChanged: 1,
+      checkpointChanged: true,
+      metadataChanged: true,
+    });
+    expect(report.diff.working.added).toEqual({ add: 'new' });
+    expect(report.diff.working.removed).toEqual({ remove: 'old' });
+    expect(report.diff.working.changed.change).toEqual({ before: { count: 1 }, after: { count: 2 } });
+    expect(report.diff.working.unchanged).toEqual(['keep']);
+    expect(report.diff.episodic.changed['id:1']?.after.summary).toBe('existing event updated');
+  });
+});
+
+describe('handleMemoryCommand', () => {
+  it('prints JSON diff for valid snapshot files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-snapshot-diff-'));
+    const beforePath = join(dir, 'before.json');
+    const afterPath = join(dir, 'after.json');
+    await writeFile(beforePath, JSON.stringify(baseSnapshot));
+    await writeFile(afterPath, JSON.stringify({
+      ...baseSnapshot,
+      timestamp: '2026-07-11T00:01:00.000Z',
+      working: { ...baseSnapshot.working, add: true },
+    }));
+    const printed: string[] = [];
+
+    await handleMemoryCommand({
+      action: 'snapshot-diff',
+      beforePath,
+      afterPath,
+      print: (message) => printed.push(message),
+    });
+
+    expect(printed).toHaveLength(1);
+    expect(JSON.parse(printed[0]!)).toMatchObject({
+      ok: true,
+      command: 'memory snapshot-diff',
+      summary: { workingAdded: 1 },
+    });
+  });
+
+  it('fails with actionable guidance when a snapshot is invalid', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-snapshot-diff-invalid-'));
+    const beforePath = join(dir, 'before.json');
+    const afterPath = join(dir, 'after.json');
+    await writeFile(beforePath, JSON.stringify({ version: 1 }));
+    await writeFile(afterPath, JSON.stringify(baseSnapshot));
+
+    await expect(handleMemoryCommand({
+      action: 'snapshot-diff',
+      beforePath,
+      afterPath,
+      print: () => undefined,
+    })).rejects.toThrow(/Invalid memory snapshot/);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -984,6 +984,50 @@ describe('main() execution', () => {
     });
   });
 
+  it('prints memory snapshot diffs as parseable JSON without a banner or config log', async () => {
+    const dir = join(tmpdir(), `franken-memory-diff-${Date.now()}-${Math.random()}`);
+    tempDirs.push(dir);
+    mkdirSync(dir, { recursive: true });
+    const beforePath = join(dir, 'before.json');
+    const afterPath = join(dir, 'after.json');
+    const before = {
+      version: 1,
+      timestamp: '2026-07-11T00:00:00.000Z',
+      working: { keep: true },
+      episodic: [],
+      checkpoint: null,
+      metadata: { lastProvider: 'claude', switchReason: '', totalTokensUsed: 1 },
+    };
+    const after = {
+      ...before,
+      timestamp: '2026-07-11T00:01:00.000Z',
+      working: { keep: true, added: true },
+    };
+    writeFileSync(beforePath, JSON.stringify(before), 'utf-8');
+    writeFileSync(afterPath, JSON.stringify(after), 'utf-8');
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    mockParseArgs.mockReturnValue({
+      ...(mockParseArgs() as Record<string, unknown>),
+      subcommand: 'memory',
+      memoryAction: 'snapshot-diff',
+      memorySnapshotBefore: beforePath,
+      memorySnapshotAfter: afterPath,
+    } as ReturnType<typeof mockParseArgs>);
+
+    await main();
+
+    const stdout = info.mock.calls.map((call) => String(call[0]));
+    expect(stdout).toHaveLength(1);
+    expect(stdout[0]).not.toContain('[BANNER]');
+    expect(stdout[0]).not.toContain('Using default config');
+    expect(JSON.parse(stdout[0] ?? '{}')).toMatchObject({
+      ok: true,
+      command: 'memory snapshot-diff',
+      summary: { workingAdded: 1 },
+    });
+    expect(scaffoldFrankenbeast).not.toHaveBeenCalled();
+  });
+
   it('does not hide non-file init config loading errors behind init fallback defaults', async () => {
     const tempDir = join(tmpdir(), `franken-run-init-${Date.now()}-${Math.random()}`);
     tempDirs.push(tempDir);

--- a/tasks/issue-1852-memory-snapshot-diff-progress.md
+++ b/tasks/issue-1852-memory-snapshot-diff-progress.md
@@ -6,4 +6,4 @@
 - [x] Implement structured JSON BrainSnapshot diff output with validation errors.
 - [x] Add focused unit coverage for parsing, success output, and invalid snapshot failure.
 - [x] Run targeted test and orchestrator typecheck verification.
-- [ ] Commit, push branch, open PR, and request `@codex review`.
+- [x] Commit, push branch, open PR, and request `@codex review`.

--- a/tasks/issue-1852-memory-snapshot-diff-progress.md
+++ b/tasks/issue-1852-memory-snapshot-diff-progress.md
@@ -1,0 +1,9 @@
+# Issue 1852 — memory snapshot diff command progress
+
+- [x] Inspect issue #1852 and repository instructions.
+- [x] Locate CLI argument parsing and BrainSnapshot schema paths.
+- [x] Add `frankenbeast memory snapshot-diff <before> <after>` parsing and help text.
+- [x] Implement structured JSON BrainSnapshot diff output with validation errors.
+- [x] Add focused unit coverage for parsing, success output, and invalid snapshot failure.
+- [x] Run targeted test and orchestrator typecheck verification.
+- [ ] Commit, push branch, open PR, and request `@codex review`.


### PR DESCRIPTION
Closes #1852\n\n## Summary\n- add `frankenbeast memory snapshot-diff <before> <after>` CLI parsing and help text\n- validate both inputs as BrainSnapshot JSON and emit a deterministic structured JSON diff for working memory, episodic events, checkpoint, and metadata\n- add focused unit coverage for parsing, success output, and invalid snapshot failure modes\n\n## Test plan\n- `npm run test --workspace @franken/orchestrator -- tests/unit/cli/memory-snapshot-diff.test.ts`\n- `npm run typecheck --workspace @franken/orchestrator`\n\nNotes: fbeast MCP tools were not available in this worker, so I followed AGENTS.md with normal git/gh/terminal verification.