### PR TITLE
test(governor): isolate integration suite

### DIFF
--- a/packages/franken-governor/package.json
+++ b/packages/franken-governor/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "INTEGRATION=true vitest run",
+    "test:integration": "INTEGRATION=true vitest run --config vitest.integration.config.ts",
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [

--- a/packages/franken-governor/vitest.integration.config.ts
+++ b/packages/franken-governor/vitest.integration.config.ts
@@ -9,15 +9,6 @@ export default defineConfig({
   test: {
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
-    include: ['tests/unit/**/*.test.ts'],
-    coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/index.ts'],
-      thresholds: {
-        lines: 80,
-        branches: 80,
-      },
-    },
+    include: ['tests/integration/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- restrict the governor default Vitest config to `tests/unit/**/*.test.ts`
- add a dedicated integration Vitest config for `tests/integration/**/*.test.ts`
- point `test:integration` at the integration config so the suite remains intentionally runnable

## Test Plan
- npm test --workspace=@franken/governor -- --reporter verbose
- npm run test:integration --workspace=@franken/governor -- --reporter verbose
- npm run build --workspace=@franken/types && npm run typecheck --workspace=@franken/governor
- npm run lint --workspace=@franken/governor
- npm run build --workspace=@franken/governor

Closes #1117
