### PR TITLE
fix(security): harden dependabot internal scope updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,6 @@ updates:
           - "@franken/*"
     ignore:
       - dependency-name: "@franken/*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       npm-security-and-maintenance:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@franken/*"
+    ignore:
+      - dependency-name: "@franken/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Workspace dependency hygiene (no wildcard internal deps)
         run: node scripts/check-workspace-deps.mjs
 
+      - name: Dependabot supply-chain guard
+        run: npm run check:dependabot-supply-chain
+
       - name: Run package build and typecheck
         run: npx turbo run build typecheck
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ Frankenbeast is pre-1.0 and evolves quickly. Security fixes are applied to `main
 - Keep npm dependencies on the repository-pinned package manager (`packageManager` in `package.json`).
 - Run `npm run audit:dependencies` and `npm run audit:security` before shipping security-sensitive changes.
 - The CI workflow runs dependency vulnerability checks, major-version freshness checks, and SBOM generation on pull requests.
-- Dependabot must ignore first-party `@franken/*` workspace packages and exclude that scope from broad npm update groups; release automation owns internal package version changes so registry-driven dependency PRs cannot confuse workspace packages with public packages.
+- Dependabot must ignore first-party `@franken/*` workspace packages, including security updates, and exclude that scope from every npm update group; release automation owns internal package version changes so registry-driven dependency PRs cannot confuse workspace packages with public packages.
 - The daily deterministic security scan runs Semgrep, Gitleaks, and dependency audit jobs; treat its filed issues as active security work until closed.
 - Prefer targeted dependency upgrades with lockfile review over broad updates that mix unrelated changes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,7 @@ Frankenbeast is pre-1.0 and evolves quickly. Security fixes are applied to `main
 - Keep npm dependencies on the repository-pinned package manager (`packageManager` in `package.json`).
 - Run `npm run audit:dependencies` and `npm run audit:security` before shipping security-sensitive changes.
 - The CI workflow runs dependency vulnerability checks, major-version freshness checks, and SBOM generation on pull requests.
+- Dependabot must ignore first-party `@franken/*` workspace packages and exclude that scope from broad npm update groups; release automation owns internal package version changes so registry-driven dependency PRs cannot confuse workspace packages with public packages.
 - The daily deterministic security scan runs Semgrep, Gitleaks, and dependency audit jobs; treat its filed issues as active security work until closed.
 - Prefer targeted dependency upgrades with lockfile review over broad updates that mix unrelated changes.
 
@@ -65,6 +66,7 @@ Useful local checks before opening or merging security-sensitive changes:
 ```bash
 npm run audit:dependencies
 npm run audit:security
+npm run check:dependabot-supply-chain
 npm run lint:security
 ```
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -31,6 +31,13 @@ binary still matches the root `packageManager` pin before `npm audit` runs:
 npm run audit:security
 ```
 
+Dependency-update automation is fail-closed for first-party packages: Dependabot
+may update external npm and GitHub Actions dependencies, but it must ignore the
+internal `@franken/*` workspace scope and exclude it from broad npm update
+groups. Run `npm run check:dependabot-supply-chain` after editing
+`.github/dependabot.yml` to verify that registry-driven update PRs cannot
+confuse internal workspace packages with public packages.
+
 ## 2. Configure environment
 
 ```bash

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -33,10 +33,10 @@ npm run audit:security
 
 Dependency-update automation is fail-closed for first-party packages: Dependabot
 may update external npm and GitHub Actions dependencies, but it must ignore the
-internal `@franken/*` workspace scope and exclude it from broad npm update
-groups. Run `npm run check:dependabot-supply-chain` after editing
-`.github/dependabot.yml` to verify that registry-driven update PRs cannot
-confuse internal workspace packages with public packages.
+internal `@franken/*` workspace scope for all update types and exclude it from
+every npm update group. Run `npm run check:dependabot-supply-chain` after
+editing `.github/dependabot.yml` to verify that registry-driven update PRs
+cannot confuse internal workspace packages with public packages.
 
 ## 2. Configure environment
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",
     "check:package-manager": "node scripts/check-package-manager.mjs",
+    "check:dependabot-supply-chain": "node scripts/check-dependabot-supply-chain.mjs",
     "create:project": "bash scripts/create-project.sh",
     "deps:outdated:major": "node scripts/check-major-outdated.mjs",
     "lint": "node scripts/check-workspace-lint-coverage.mjs && turbo run lint",

--- a/scripts/check-dependabot-supply-chain.mjs
+++ b/scripts/check-dependabot-supply-chain.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Dependabot supply-chain guard.
+ *
+ * Dependabot should never be allowed to "update" first-party @franken/*
+ * workspace packages from the public npm registry. Those versions are controlled
+ * by the release workflow, not by registry freshness checks. Broad npm groups
+ * must also explicitly exclude the internal scope so a risky catch-all update
+ * cannot hide namespace-confusion changes beside unrelated third-party bumps.
+ *
+ * Run: node scripts/check-dependabot-supply-chain.mjs [--config .github/dependabot.yml]
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const INTERNAL_SCOPE_PATTERN = '@franken/*';
+
+function usage() {
+  console.error('Usage: node scripts/check-dependabot-supply-chain.mjs [--config .github/dependabot.yml]');
+}
+
+function parseArgs(argv) {
+  const args = { config: resolve(repoRoot, '.github/dependabot.yml') };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--config' && argv[i + 1]) {
+      args.config = resolve(process.cwd(), argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    usage();
+    process.exit(2);
+  }
+  return args;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function hasPattern(patterns, expected) {
+  return asArray(patterns).some((pattern) => pattern === expected);
+}
+
+function unquote(value) {
+  return value.trim().replace(/^['"]|['"]$/g, '');
+}
+
+function parseDependabotConfig(raw) {
+  const updates = [];
+  let update = null;
+  let groupName = null;
+  let ignoreRule = null;
+  let mode = null;
+
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+#.*$/, '');
+    if (!line.trim()) continue;
+
+    const updateMatch = line.match(/^\s{2}-\s+package-ecosystem:\s+(.+)$/);
+    if (updateMatch) {
+      update = { 'package-ecosystem': unquote(updateMatch[1]), groups: {}, ignore: [] };
+      updates.push(update);
+      groupName = null;
+      ignoreRule = null;
+      mode = null;
+      continue;
+    }
+    if (!update) continue;
+
+    const directoryMatch = line.match(/^\s{4}directory:\s+(.+)$/);
+    if (directoryMatch) {
+      update.directory = unquote(directoryMatch[1]);
+      continue;
+    }
+
+    if (/^\s{4}groups:\s*$/.test(line)) {
+      mode = 'groups';
+      groupName = null;
+      continue;
+    }
+    if (/^\s{4}ignore:\s*$/.test(line)) {
+      mode = 'ignore';
+      groupName = null;
+      continue;
+    }
+
+    const groupMatch = line.match(/^ {6}([^\s][^:]*):\s*$/);
+    if (groupMatch && mode === 'groups') {
+      groupName = unquote(groupMatch[1]);
+      update.groups[groupName] = update.groups[groupName] ?? {};
+      continue;
+    }
+    if (line.match(/^\s{8}patterns:\s*$/) && mode === 'groups' && groupName) {
+      mode = 'group-patterns';
+      update.groups[groupName].patterns = update.groups[groupName].patterns ?? [];
+      continue;
+    }
+    if (line.match(/^\s{8}exclude-patterns:\s*$/) && groupName) {
+      mode = 'group-exclude-patterns';
+      update.groups[groupName]['exclude-patterns'] = update.groups[groupName]['exclude-patterns'] ?? [];
+      continue;
+    }
+
+    const ignoreMatch = line.match(/^\s{6}-\s+dependency-name:\s+(.+)$/);
+    if (ignoreMatch && (mode === 'ignore' || mode === 'ignore-update-types')) {
+      ignoreRule = { 'dependency-name': unquote(ignoreMatch[1]), 'update-types': [] };
+      update.ignore.push(ignoreRule);
+      mode = 'ignore';
+      continue;
+    }
+    if (line.match(/^\s{8}update-types:\s*$/) && ignoreRule) {
+      mode = 'ignore-update-types';
+      continue;
+    }
+
+    const listMatch = line.match(/^\s+-\s+(.+)$/);
+    if (!listMatch) continue;
+    const value = unquote(listMatch[1]);
+    if (mode === 'group-patterns' && groupName) {
+      update.groups[groupName].patterns.push(value);
+    } else if (mode === 'group-exclude-patterns' && groupName) {
+      update.groups[groupName]['exclude-patterns'].push(value);
+    } else if (mode === 'ignore-update-types' && ignoreRule) {
+      ignoreRule['update-types'].push(value);
+    }
+  }
+
+  return { updates };
+}
+
+function loadDependabotConfig(configPath) {
+  if (!existsSync(configPath)) {
+    throw new Error(`Dependabot config not found: ${configPath}`);
+  }
+  return parseDependabotConfig(readFileSync(configPath, 'utf8'));
+}
+
+export function validateDependabotSupplyChainConfig(config) {
+  const failures = [];
+  const updates = asArray(config.updates);
+  const npmUpdates = updates.filter((entry) => entry && typeof entry === 'object' && entry['package-ecosystem'] === 'npm');
+
+  if (npmUpdates.length === 0) {
+    failures.push('Dependabot must include at least one npm update entry so workspace dependency policy is explicit.');
+    return failures;
+  }
+
+  for (const update of npmUpdates) {
+    const directory = typeof update.directory === 'string' ? update.directory : '<missing directory>';
+    const ignoreRules = asArray(update.ignore);
+    const ignoresInternalScope = ignoreRules.some((rule) => {
+      if (!rule || typeof rule !== 'object') return false;
+      return rule['dependency-name'] === INTERNAL_SCOPE_PATTERN && hasPattern(rule['update-types'], 'version-update:semver-major') && hasPattern(rule['update-types'], 'version-update:semver-minor') && hasPattern(rule['update-types'], 'version-update:semver-patch');
+    });
+
+    if (!ignoresInternalScope) {
+      failures.push(
+        `npm Dependabot entry ${directory} must ignore ${INTERNAL_SCOPE_PATTERN} for major/minor/patch updates; internal workspace releases are not registry-driven.`,
+      );
+    }
+
+    for (const [name, group] of Object.entries(update.groups ?? {})) {
+      if (!group || typeof group !== 'object') continue;
+      if (!hasPattern(group.patterns, '*')) continue;
+      if (!hasPattern(group['exclude-patterns'], INTERNAL_SCOPE_PATTERN)) {
+        failures.push(
+          `npm Dependabot group ${name} in ${directory} uses catch-all pattern "*" without exclude-patterns: ["${INTERNAL_SCOPE_PATTERN}"].`,
+        );
+      }
+    }
+  }
+
+  return failures;
+}
+
+export function checkDependabotSupplyChainConfig(configPath) {
+  const config = loadDependabotConfig(configPath);
+  return validateDependabotSupplyChainConfig(config);
+}
+
+const invokedAsMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsMain) {
+  const { config } = parseArgs(process.argv.slice(2));
+  let failures;
+  try {
+    failures = checkDependabotSupplyChainConfig(config);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  if (failures.length > 0) {
+    console.error('Dependabot supply-chain guard failed:');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('Dependabot supply-chain guard OK — internal @franken/* updates are excluded from registry-driven dependency PRs.');
+}

--- a/scripts/check-dependabot-supply-chain.mjs
+++ b/scripts/check-dependabot-supply-chain.mjs
@@ -4,8 +4,8 @@
  *
  * Dependabot should never be allowed to "update" first-party @franken/*
  * workspace packages from the public npm registry. Those versions are controlled
- * by the release workflow, not by registry freshness checks. Broad npm groups
- * must also explicitly exclude the internal scope so a risky catch-all update
+ * by the release workflow, not by registry freshness checks. Every npm group
+ * must also explicitly exclude the internal scope so risky grouped updates
  * cannot hide namespace-confusion changes beside unrelated third-party bumps.
  *
  * Run: node scripts/check-dependabot-supply-chain.mjs [--config .github/dependabot.yml]
@@ -13,12 +13,15 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import * as yaml from 'js-yaml';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const INTERNAL_SCOPE_PATTERN = '@franken/*';
 
 function usage() {
-  console.error('Usage: node scripts/check-dependabot-supply-chain.mjs [--config .github/dependabot.yml]');
+  console.error(
+    'Usage: node scripts/check-dependabot-supply-chain.mjs [--config .github/dependabot.yml]',
+  );
 }
 
 function parseArgs(argv) {
@@ -44,130 +47,53 @@ function hasPattern(patterns, expected) {
   return asArray(patterns).some((pattern) => pattern === expected);
 }
 
-function unquote(value) {
-  return value.trim().replace(/^['"]|['"]$/g, '');
-}
-
-function parseDependabotConfig(raw) {
-  const updates = [];
-  let update = null;
-  let groupName = null;
-  let ignoreRule = null;
-  let mode = null;
-
-  for (const rawLine of raw.split(/\r?\n/)) {
-    const line = rawLine.replace(/\s+#.*$/, '');
-    if (!line.trim()) continue;
-
-    const updateMatch = line.match(/^\s{2}-\s+package-ecosystem:\s+(.+)$/);
-    if (updateMatch) {
-      update = { 'package-ecosystem': unquote(updateMatch[1]), groups: {}, ignore: [] };
-      updates.push(update);
-      groupName = null;
-      ignoreRule = null;
-      mode = null;
-      continue;
-    }
-    if (!update) continue;
-
-    const directoryMatch = line.match(/^\s{4}directory:\s+(.+)$/);
-    if (directoryMatch) {
-      update.directory = unquote(directoryMatch[1]);
-      continue;
-    }
-
-    if (/^\s{4}groups:\s*$/.test(line)) {
-      mode = 'groups';
-      groupName = null;
-      continue;
-    }
-    if (/^\s{4}ignore:\s*$/.test(line)) {
-      mode = 'ignore';
-      groupName = null;
-      continue;
-    }
-
-    const groupMatch = line.match(/^ {6}([^\s][^:]*):\s*$/);
-    if (groupMatch && mode === 'groups') {
-      groupName = unquote(groupMatch[1]);
-      update.groups[groupName] = update.groups[groupName] ?? {};
-      continue;
-    }
-    if (line.match(/^\s{8}patterns:\s*$/) && mode === 'groups' && groupName) {
-      mode = 'group-patterns';
-      update.groups[groupName].patterns = update.groups[groupName].patterns ?? [];
-      continue;
-    }
-    if (line.match(/^\s{8}exclude-patterns:\s*$/) && groupName) {
-      mode = 'group-exclude-patterns';
-      update.groups[groupName]['exclude-patterns'] = update.groups[groupName]['exclude-patterns'] ?? [];
-      continue;
-    }
-
-    const ignoreMatch = line.match(/^\s{6}-\s+dependency-name:\s+(.+)$/);
-    if (ignoreMatch && (mode === 'ignore' || mode === 'ignore-update-types')) {
-      ignoreRule = { 'dependency-name': unquote(ignoreMatch[1]), 'update-types': [] };
-      update.ignore.push(ignoreRule);
-      mode = 'ignore';
-      continue;
-    }
-    if (line.match(/^\s{8}update-types:\s*$/) && ignoreRule) {
-      mode = 'ignore-update-types';
-      continue;
-    }
-
-    const listMatch = line.match(/^\s+-\s+(.+)$/);
-    if (!listMatch) continue;
-    const value = unquote(listMatch[1]);
-    if (mode === 'group-patterns' && groupName) {
-      update.groups[groupName].patterns.push(value);
-    } else if (mode === 'group-exclude-patterns' && groupName) {
-      update.groups[groupName]['exclude-patterns'].push(value);
-    } else if (mode === 'ignore-update-types' && ignoreRule) {
-      ignoreRule['update-types'].push(value);
-    }
-  }
-
-  return { updates };
-}
-
 function loadDependabotConfig(configPath) {
   if (!existsSync(configPath)) {
     throw new Error(`Dependabot config not found: ${configPath}`);
   }
-  return parseDependabotConfig(readFileSync(configPath, 'utf8'));
+  const parsed = yaml.load(readFileSync(configPath, 'utf8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Dependabot config must be a YAML object.');
+  }
+  return parsed;
 }
 
 export function validateDependabotSupplyChainConfig(config) {
   const failures = [];
   const updates = asArray(config.updates);
-  const npmUpdates = updates.filter((entry) => entry && typeof entry === 'object' && entry['package-ecosystem'] === 'npm');
+  const npmUpdates = updates.filter(
+    (entry) =>
+      entry && typeof entry === 'object' && entry['package-ecosystem'] === 'npm',
+  );
 
   if (npmUpdates.length === 0) {
-    failures.push('Dependabot must include at least one npm update entry so workspace dependency policy is explicit.');
+    failures.push(
+      'Dependabot must include at least one npm update entry so workspace dependency policy is explicit.',
+    );
     return failures;
   }
 
   for (const update of npmUpdates) {
-    const directory = typeof update.directory === 'string' ? update.directory : '<missing directory>';
+    const directory =
+      typeof update.directory === 'string' ? update.directory : '<missing directory>';
     const ignoreRules = asArray(update.ignore);
     const ignoresInternalScope = ignoreRules.some((rule) => {
       if (!rule || typeof rule !== 'object') return false;
-      return rule['dependency-name'] === INTERNAL_SCOPE_PATTERN && hasPattern(rule['update-types'], 'version-update:semver-major') && hasPattern(rule['update-types'], 'version-update:semver-minor') && hasPattern(rule['update-types'], 'version-update:semver-patch');
+      const updateTypes = asArray(rule['update-types']);
+      return rule['dependency-name'] === INTERNAL_SCOPE_PATTERN && updateTypes.length === 0;
     });
 
     if (!ignoresInternalScope) {
       failures.push(
-        `npm Dependabot entry ${directory} must ignore ${INTERNAL_SCOPE_PATTERN} for major/minor/patch updates; internal workspace releases are not registry-driven.`,
+        `npm Dependabot entry ${directory} must ignore ${INTERNAL_SCOPE_PATTERN} without update-types filters; internal workspace releases are not registry-driven, including security advisories.`,
       );
     }
 
     for (const [name, group] of Object.entries(update.groups ?? {})) {
       if (!group || typeof group !== 'object') continue;
-      if (!hasPattern(group.patterns, '*')) continue;
       if (!hasPattern(group['exclude-patterns'], INTERNAL_SCOPE_PATTERN)) {
         failures.push(
-          `npm Dependabot group ${name} in ${directory} uses catch-all pattern "*" without exclude-patterns: ["${INTERNAL_SCOPE_PATTERN}"].`,
+          `npm Dependabot group ${name} in ${directory} must include exclude-patterns: ["${INTERNAL_SCOPE_PATTERN}"] before it can group dependency updates.`,
         );
       }
     }
@@ -181,7 +107,8 @@ export function checkDependabotSupplyChainConfig(configPath) {
   return validateDependabotSupplyChainConfig(config);
 }
 
-const invokedAsMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedAsMain =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (invokedAsMain) {
   const { config } = parseArgs(process.argv.slice(2));
   let failures;
@@ -200,5 +127,7 @@ if (invokedAsMain) {
     process.exit(1);
   }
 
-  console.log('Dependabot supply-chain guard OK — internal @franken/* updates are excluded from registry-driven dependency PRs.');
+  console.log(
+    'Dependabot supply-chain guard OK — internal @franken/* updates are excluded from registry-driven dependency PRs.',
+  );
 }

--- a/scripts/check-dependabot-supply-chain.mjs
+++ b/scripts/check-dependabot-supply-chain.mjs
@@ -76,11 +76,19 @@ export function validateDependabotSupplyChainConfig(config) {
   for (const update of npmUpdates) {
     const directory =
       typeof update.directory === 'string' ? update.directory : '<missing directory>';
+    if (Object.prototype.hasOwnProperty.call(update, 'target-branch')) {
+      failures.push(
+        `npm Dependabot entry ${directory} must not set target-branch; security updates are evaluated on the default branch and need this internal-scope policy there.`,
+      );
+    }
+
     const ignoreRules = asArray(update.ignore);
     const ignoresInternalScope = ignoreRules.some((rule) => {
       if (!rule || typeof rule !== 'object') return false;
-      const updateTypes = asArray(rule['update-types']);
-      return rule['dependency-name'] === INTERNAL_SCOPE_PATTERN && updateTypes.length === 0;
+      return (
+        rule['dependency-name'] === INTERNAL_SCOPE_PATTERN &&
+        Object.keys(rule).every((key) => key === 'dependency-name')
+      );
     });
 
     if (!ignoresInternalScope) {

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -5,7 +5,8 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
-const SCRIPT = resolve(ROOT, 'scripts/check-major-outdated.mjs');
+const OUTDATED_SCRIPT = resolve(ROOT, 'scripts/check-major-outdated.mjs');
+const DEPENDABOT_SUPPLY_CHAIN_SCRIPT = resolve(ROOT, 'scripts/check-dependabot-supply-chain.mjs');
 
 function writeJson(value: unknown, filename = 'outdated.json') {
   const dir = mkdtempSync(join(tmpdir(), 'franken-outdated-'));
@@ -14,8 +15,22 @@ function writeJson(value: unknown, filename = 'outdated.json') {
   return file;
 }
 
+function writeText(content: string, filename: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'franken-dependabot-'));
+  const file = join(dir, filename);
+  writeFileSync(file, content, 'utf8');
+  return file;
+}
+
 function runOutdatedGuard(report: unknown, baseline: unknown = []) {
-  return spawnSync(process.execPath, [SCRIPT, '--input', writeJson(report), '--baseline', writeJson(baseline, 'baseline.json')], {
+  return spawnSync(process.execPath, [OUTDATED_SCRIPT, '--input', writeJson(report), '--baseline', writeJson(baseline, 'baseline.json')], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+function runDependabotSupplyChainGuard(config: string) {
+  return spawnSync(process.execPath, [DEPENDABOT_SUPPLY_CHAIN_SCRIPT, '--config', writeText(config, 'dependabot.yml')], {
     cwd: ROOT,
     encoding: 'utf8',
   });
@@ -134,7 +149,49 @@ describe('dependency CI guards for issue #1414', () => {
     expect(result.stdout).toContain('no unapproved direct dependencies are behind the latest major release');
   });
 
-  it('wires dependency audit, major outdated check, and SBOM artifact generation into CI', () => {
+  it('fails dependabot configs that allow registry-driven internal workspace updates', () => {
+    const result = runDependabotSupplyChainGuard(`
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    groups:
+      all-npm:
+        patterns:
+          - "*"
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('@franken/*');
+    expect(result.stderr).toContain('exclude-patterns');
+    expect(result.stderr).toContain('must ignore');
+  });
+
+  it('accepts dependabot configs that exclude internal packages from broad npm updates', () => {
+    const result = runDependabotSupplyChainGuard(`
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    groups:
+      external-npm:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@franken/*"
+    ignore:
+      - dependency-name: "@franken/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Dependabot supply-chain guard OK');
+  });
+
+  it('wires dependency audit, major outdated check, dependabot guard, and SBOM artifact generation into CI', () => {
     const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
       scripts?: Record<string, string>;
     };
@@ -142,8 +199,10 @@ describe('dependency CI guards for issue #1414', () => {
 
     expect(packageJson.scripts?.['audit:dependencies']).toBe('node scripts/check-package-manager.mjs && npm audit');
     expect(packageJson.scripts?.['deps:outdated:major']).toBe('node scripts/check-major-outdated.mjs');
+    expect(packageJson.scripts?.['check:dependabot-supply-chain']).toBe('node scripts/check-dependabot-supply-chain.mjs');
     expect(workflow).toContain('npm run audit:dependencies');
     expect(workflow).toContain('npm run deps:outdated:major');
+    expect(workflow).toContain('npm run check:dependabot-supply-chain');
     expect(workflow).toContain('npm sbom --sbom-format cyclonedx');
     expect(workflow).toContain('actions/upload-artifact@v4');
     expect(workflow).toContain('dependency-sbom-cyclonedx');

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -167,7 +167,7 @@ updates:
     expect(result.stderr).toContain('must ignore');
   });
 
-  it('fails internal-scope ignores that only cover version-update PRs', () => {
+  it('fails internal-scope ignores that only cover filtered update PRs', () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -187,6 +187,43 @@ updates:
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('without update-types filters');
+
+    const versionFiltered = runDependabotSupplyChainGuard(`
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    groups:
+      external-npm:
+        patterns: ["*"]
+        exclude-patterns: ["@franken/*"]
+    ignore:
+      - dependency-name: "@franken/*"
+        versions: ["<1.0.0"]
+`);
+
+    expect(versionFiltered.status).toBe(1);
+    expect(versionFiltered.stderr).toContain('without update-types filters');
+  });
+
+  it('fails npm entries that target release branches instead of default-branch security coverage', () => {
+    const result = runDependabotSupplyChainGuard(`
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: release/0.45
+    groups:
+      external-npm:
+        patterns: ["*"]
+        exclude-patterns: ["@franken/*"]
+    ignore:
+      - dependency-name: "@franken/*"
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('target-branch');
+    expect(result.stderr).toContain('default branch');
   });
 
   it('fails every npm group that lacks an internal-scope exclusion', () => {

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -167,7 +167,7 @@ updates:
     expect(result.stderr).toContain('must ignore');
   });
 
-  it('accepts dependabot configs that exclude internal packages from broad npm updates', () => {
+  it('fails internal-scope ignores that only cover version-update PRs', () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -175,16 +175,56 @@ updates:
     directory: /
     groups:
       external-npm:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "@franken/*"
+        patterns: ["*"]
+        exclude-patterns: ["@franken/*"]
     ignore:
       - dependency-name: "@franken/*"
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('without update-types filters');
+  });
+
+  it('fails every npm group that lacks an internal-scope exclusion', () => {
+    const result = runDependabotSupplyChainGuard(`
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    groups:
+      safe-inline:
+        patterns: ["*"]
+        exclude-patterns: ["@franken/*"]
+      unsafe-production:
+        dependency-type: production
+    ignore:
+      - dependency-name: "@franken/*"
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('unsafe-production');
+    expect(result.stderr).toContain('exclude-patterns');
+  });
+
+  it('accepts dependabot configs that exclude internal packages from all npm updates', () => {
+    const result = runDependabotSupplyChainGuard(`
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    groups:
+      external-npm:
+        patterns: ["*"]
+        exclude-patterns: ["@franken/*"]
+      production-only:
+        dependency-type: production
+        exclude-patterns: ["@franken/*"]
+    ignore:
+      - dependency-name: "@franken/*"
 `);
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- Add a fail-closed Dependabot supply-chain guard that requires npm update entries to ignore `@franken/*` for major/minor/patch registry updates.
- Exclude `@franken/*` from the broad npm Dependabot group so internal workspace package versions remain release-workflow controlled.
- Wire the guard into CI and document the operator workflow in security/quickstart docs.

## Verification
- `node scripts/check-dependabot-supply-chain.mjs`
- `npm run test:root -- tests/unit/dependency-ci-guards.test.ts`
- `npm run check:dependabot-supply-chain`
- `node scripts/check-workspace-deps.mjs`
- `npm run lint:security`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run audit:security`

Closes #1803
