### PR TITLE
test: harden npm ls dependency check

### DIFF
--- a/tests/verify-everything-meta.test.ts
+++ b/tests/verify-everything-meta.test.ts
@@ -13,4 +13,13 @@ describe('verify-everything test boundaries', () => {
       expect(source).not.toContain(['npx', 'turbo', 'run', pipeline].join(' '));
     }
   });
+
+  it('uses structured npm ls json for dependency resolution checks', () => {
+    const source = readFileSync(VERIFY_EVERYTHING_TEST, 'utf8');
+
+    expect(source).toContain('["ls", "@franken/types", "--json"]');
+    expect(source).toContain('JSON.parse(stdout)');
+    expect(source).not.toContain('not.toContain("ERR!")');
+    expect(source).not.toContain('not.toContain("WARN")');
+  });
 });

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -9,7 +9,47 @@ const exec = (command: string, args: string[]) =>
   execFileSync(command, args, { cwd: ROOT, encoding: "utf8" }).trim();
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
+type NpmLsPackage = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, NpmLsPackage>;
+  problems?: string[];
+  error?: unknown;
+  extraneous?: boolean;
+  invalid?: boolean;
+  missing?: boolean;
+};
+
 const ALL_PACKAGES = getWorkspacePackageDirNames();
+
+const parseNpmLsJson = (stdout: string): NpmLsPackage =>
+  JSON.parse(stdout) as NpmLsPackage;
+
+const findDependency = (
+  tree: NpmLsPackage,
+  packageName: string,
+): NpmLsPackage | undefined => {
+  if (tree.name === packageName) return tree;
+
+  const directDependency = tree.dependencies?.[packageName];
+  if (directDependency) return directDependency;
+
+  for (const dependency of Object.values(tree.dependencies ?? {})) {
+    const match = findDependency(dependency, packageName);
+    if (match) return match;
+  }
+
+  return undefined;
+};
+
+const collectProblems = (tree: NpmLsPackage): string[] => [
+  ...(tree.problems ?? []),
+  ...(tree.error ? [JSON.stringify(tree.error)] : []),
+  ...(tree.extraneous ? [`${tree.name ?? "dependency"} is extraneous`] : []),
+  ...(tree.invalid ? [`${tree.name ?? "dependency"} is invalid`] : []),
+  ...(tree.missing ? [`${tree.name ?? "dependency"} is missing`] : []),
+  ...Object.values(tree.dependencies ?? {}).flatMap(collectProblems),
+];
 
 describe("Chunk 10: full verification pass", () => {
   describe("verification command portability", () => {
@@ -28,16 +68,17 @@ describe("Chunk 10: full verification pass", () => {
 
   describe("workspace resolution", () => {
     it("npm ls @franken/types resolves without errors", () => {
-      const result = spawnSync(npmCommand, ["ls", "@franken/types"], {
+      const result = spawnSync(npmCommand, ["ls", "@franken/types", "--json"], {
         cwd: ROOT,
         encoding: "utf8",
       });
-      const output = `${result.stdout}\n${result.stderr}`;
+      const dependencyTree = parseNpmLsJson(result.stdout);
+      const dependency = findDependency(dependencyTree, "@franken/types");
+      const problems = collectProblems(dependencyTree);
 
-      expect(result.status).toBe(0);
-      expect(output).not.toContain("ERR!");
-      expect(output).not.toContain("WARN");
-      expect(output).toContain("@franken/types");
+      expect(result.status, problems.join("\n")).toBe(0);
+      expect(problems).toEqual([]);
+      expect(dependency?.name).toBe("@franken/types");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes #1903
- Switches the verify-everything npm ls dependency assertion to `--json` output
- Parses the npm dependency tree and checks structured problem fields instead of WARN/ERR substrings
- Adds a meta-test to keep the verify-everything boundary on structured npm ls JSON checks

## Test plan
- `git diff --check`
- `test ! -e node_modules && mkdir node_modules && ln -s /home/pfk/.hermes/hermes-agent/node_modules/vitest node_modules/vitest && /home/pfk/.hermes/hermes-agent/node_modules/.bin/vitest run tests/verify-everything-meta.test.ts --reporter=dot; status=$?; if [ -L node_modules/vitest ]; then unlink node_modules/vitest; fi; rmdir node_modules 2>/dev/null || true; exit $status`
- `node - <<'NODE' ... NODE` to confirm `npm ls @franken/types --json` emits parseable JSON in this dependency-uninstalled worktree (status 1 here because node_modules is absent)

Note: fbeast MCP tools were not available in this worker tool schema, so I used normal terminal/file/git/gh verification per AGENTS.md.