### PR TITLE
fix(orchestrator): allow global flags before subcommand

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -115,6 +115,43 @@ const BOOLEAN_SHORT_OPTIONS = new Set(['d']);
 const DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const INTEGER_PATTERN = /^[+-]?\d+$/;
 
+function extractSubcommand(argv: string[]): { subcommand: Subcommand; flagArgs: string[] } {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === undefined) break;
+
+    if (arg === '--') {
+      break;
+    }
+
+    if (arg.startsWith('--')) {
+      const optionName = arg.slice(2).split('=', 1)[0] ?? '';
+      if (STRING_OPTIONS.has(optionName) && !arg.includes('=')) {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      const shortName = arg.slice(1, 2);
+      if (BOOLEAN_SHORT_OPTIONS.has(shortName)) {
+        continue;
+      }
+    }
+
+    if (VALID_SUBCOMMANDS.has(arg)) {
+      return {
+        subcommand: arg as Exclude<Subcommand, undefined>,
+        flagArgs: [...argv.slice(0, i), ...argv.slice(i + 1)],
+      };
+    }
+
+    break;
+  }
+
+  return { subcommand: undefined, flagArgs: argv };
+}
+
 const USAGE = `
 Usage: frankenbeast [subcommand] [options]
 
@@ -347,14 +384,8 @@ function parseIntegerOption(name: string, value: string, options: { min?: number
 }
 
 export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
-  // Extract subcommand if first positional arg matches
-  let subcommand: Subcommand;
-  let flagArgs = argv;
-  const first = argv[0];
-  if (first !== undefined && VALID_SUBCOMMANDS.has(first) && !first.startsWith('-')) {
-    subcommand = first as 'init' | 'interview' | 'plan' | 'run' | 'beasts' | 'issues' | 'chat' | 'chat-server' | 'beasts-daemon' | 'network' | 'skill' | 'security';
-    flagArgs = argv.slice(1);
-  }
+  // Extract the first subcommand positional, even when global flags precede it.
+  const { subcommand, flagArgs } = extractSubcommand(argv);
 
   let rawSkillAddCommandArgs: string[] | undefined;
   let parsedFlagArgs = flagArgs;

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -31,6 +31,38 @@ describe('parseArgs', () => {
     expect(args.resume).toBe(true);
   });
 
+  it('parses global flags before the run subcommand', () => {
+    const args = parseArgs(['--provider', 'CLAUDE', 'run', '--resume']);
+    expect(args.subcommand).toBe('run');
+    expect(args.provider).toBe('claude');
+    expect(args.providerSpecified).toBe(true);
+    expect(args.resume).toBe(true);
+  });
+
+  it('parses equals-form global flags before subcommands with positionals', () => {
+    const args = parseArgs(['--base-dir=/tmp/beast', 'network', 'up', '-d']);
+    expect(args.subcommand).toBe('network');
+    expect(args.baseDir).toBe('/tmp/beast');
+    expect(args.networkAction).toBe('up');
+    expect(args.networkDetached).toBe(true);
+  });
+
+  it('does not treat a string option value that matches a subcommand as the subcommand', () => {
+    const args = parseArgs(['--provider', 'run']);
+    expect(args.subcommand).toBeUndefined();
+    expect(args.provider).toBe('run');
+  });
+
+  it('preserves skill add command args when global options precede skill', () => {
+    const args = parseArgs(['--base-dir', '/tmp/beast', 'skill', 'add', 'my-skill', 'npx', '-y', '@acme/mcp-server', '--verbose']);
+    expect(args.subcommand).toBe('skill');
+    expect(args.baseDir).toBe('/tmp/beast');
+    expect(args.skillAction).toBe('add');
+    expect(args.skillCommand).toBe('npx');
+    expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server', '--verbose']);
+    expect(args.verbose).toBe(false);
+  });
+
   it('parses init subcommand', () => {
     const args = parseArgs(['init']);
     expect(args.subcommand).toBe('init');

--- a/tasks/issue-1902-cli-global-flags-progress.md
+++ b/tasks/issue-1902-cli-global-flags-progress.md
@@ -5,9 +5,10 @@
 - [x] Reproduce/cover parser behavior with targeted unit tests.
 - [x] Implement minimal parser fix for global flags before subcommands.
 - [x] Run targeted verification (`npm run test --workspace @franken/orchestrator -- tests/unit/cli/args.test.ts`).
-- [ ] Commit, push branch, open PR, and request Codex review.
-- [ ] Report PR URL, verification, disk, and blockers.
+- [x] Commit, push branch, open PR, and request Codex review.
+- [x] Report PR URL, verification, disk, and blockers.
 
 Notes:
 - fbeast MCP tools were not available in this worker tool schema, so normal file/git/GitHub tooling was used.
 - `npm run typecheck --workspace @franken/orchestrator` was attempted after installing dependencies but failed because local workspace packages such as `@franken/types`/`@franken/observer` have no built type declarations in this worktree.
+- PR: https://github.com/djm204/frankenbeast/pull/1916

--- a/tasks/issue-1902-cli-global-flags-progress.md
+++ b/tasks/issue-1902-cli-global-flags-progress.md
@@ -1,0 +1,13 @@
+# Issue #1902 CLI global flags before subcommand
+
+- [x] Inspect issue #1902 and repo instructions.
+- [x] Confirm worktree, branch, disk headroom, and current status.
+- [x] Reproduce/cover parser behavior with targeted unit tests.
+- [x] Implement minimal parser fix for global flags before subcommands.
+- [x] Run targeted verification (`npm run test --workspace @franken/orchestrator -- tests/unit/cli/args.test.ts`).
+- [ ] Commit, push branch, open PR, and request Codex review.
+- [ ] Report PR URL, verification, disk, and blockers.
+
+Notes:
+- fbeast MCP tools were not available in this worker tool schema, so normal file/git/GitHub tooling was used.
+- `npm run typecheck --workspace @franken/orchestrator` was attempted after installing dependencies but failed because local workspace packages such as `@franken/types`/`@franken/observer` have no built type declarations in this worktree.


### PR DESCRIPTION
## Summary
- allow the CLI parser to extract a recognized subcommand after leading global flags
- keep string option values (for example `--provider run`) from being misclassified as subcommands
- add parser regression coverage for `frankenbeast --provider claude run --resume` and related subcommand/action cases

Closes #1902

## Test plan
- PASS: `npm run test --workspace @franken/orchestrator -- tests/unit/cli/args.test.ts` (99 tests passed)
- PASS: `git diff --check`
- NOTE: `npm run typecheck --workspace @franken/orchestrator` was attempted, but this isolated worktree lacks built local workspace package type declarations such as `@franken/types` and `@franken/observer`, so the command fails before reaching this parser change.

## Notes
- fbeast MCP tools were unavailable in this worker tool schema, so I used normal terminal/file/git/GitHub verification.