### PR TITLE
fix(orchestrator): accept common interview approvals

### DIFF
--- a/packages/franken-orchestrator/src/planning/interview-loop.ts
+++ b/packages/franken-orchestrator/src/planning/interview-loop.ts
@@ -134,6 +134,6 @@ export class InterviewLoop implements GraphBuilder {
 
   private isApproved(response: string): boolean {
     const normalized = response.trim().toLowerCase();
-    return normalized === 'yes' || normalized === 'y';
+    return ['yes', 'y', 'yeah', 'yea', 'true', '1'].includes(normalized);
   }
 }

--- a/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
@@ -315,7 +315,19 @@ describe('InterviewLoop', () => {
       expect(graphBuilder.build).toHaveBeenCalledOnce();
     });
 
-    it('treats anything other than yes/y as rejection', async () => {
+    it.each(['yeah', 'yea', 'true', '1'])('treats "%s" as approval', async (approval) => {
+      const llm = mockLlm(questionsResponse, designDocResponse);
+      const io = mockIO('JWT', 'Yes', 'PostgreSQL', approval);
+      const graphBuilder = mockGraphBuilder();
+      const loop = new InterviewLoop(llm, io, graphBuilder);
+
+      const graph = await loop.build(intent);
+
+      expect(graph).toBeDefined();
+      expect(graphBuilder.build).toHaveBeenCalledOnce();
+    });
+
+    it('treats negative responses as rejection', async () => {
       const llm = mockLlm(questionsResponse, designDocResponse, revisedDesignDocResponse);
       const io = mockIO('JWT', 'Yes', 'PostgreSQL', 'nah', 'fix it', 'yes');
       const graphBuilder = mockGraphBuilder();


### PR DESCRIPTION
## Summary
- Expand interview approval recognition to accept common affirmative inputs (`yeah`, `yea`, `true`, `1`) in addition to `yes`/`y`.
- Add focused InterviewLoop unit coverage for the new approval variants while keeping negative responses on the revision path.

Fixes #1900

## Test plan
- `npm test --workspace @franken/orchestrator -- tests/unit/interview-loop.test.ts`

## Notes
- fbeast MCP tools were not available in this worker tool schema, so I followed AGENTS.md using normal terminal/file/git/gh verification.