### PR TITLE
docs(readme): reference ADR directory instead of count

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,7 +926,7 @@ frankenbeast/
 │   ├── RAMP_UP.md               # Concise agent onboarding doc
 │   ├── CONTRACT_MATRIX.md       # Port interface compatibility matrix
 │   ├── beast-loop-explained.md  # Iteration mechanics deep dive
-│   ├── adr/                     # Architecture Decision Records
+│   ├── adr/                     # Architecture Decision Records (see docs/adr/*.md)
 │   ├── guides/                  # Quickstart, run/deploy, provider, agent, verification, and issue-workflow guides
 │   └── plans/                   # Design docs and implementation plans
 ├── tests/                       # Root-level integration tests


### PR DESCRIPTION
## Summary
- Updates the README project structure ADR entry to point at `docs/adr/*.md` instead of relying on a hard-coded count.
- Avoids future drift as ADR files are added or renamed.

## Test Plan
- `node - <<'NODE' ... NODE` (verified README ADR entry and counted 44 ADR markdown files)
- `npm run check:package-manager`

Closes #1907
