### PR TITLE
fix(orchestrator): redact secret-like logger metadata

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -212,6 +212,8 @@ A franken-governor pre-deploy hook should be integrated at the dispatch/API laye
 
 Cold `frankenbeast run` starts from a clean execution checkpoint by default. Use `--resume` only when continuing an interrupted run; use `--reset` when you also want to clear memory, traces, and other build artifacts.
 
+Verbose and build-log output redacts secret-like environment/config keys such as `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, and `*_API_KEY` by default. The logger exposes an explicit local diagnostic override (`redactSecrets: false`) for trusted development-only callers, but normal CLI/runtime paths keep redaction enabled so environment dumps do not leak provider tokens or credentials.
+
 ---
 
 ## 7. Chat REPL and server

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -62,6 +62,7 @@ import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } f
 import { loadRunConfigFromEnv, type RunConfig } from './run-config-loader.js';
 import { resolveProviderCatalogEntry, resolveProviderType } from '../providers/provider-config.js';
 import type { ProviderRegistry as LlmProviderRegistry } from '../providers/provider-registry.js';
+import { redactLogData } from '../logging/redaction.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -908,7 +909,7 @@ export async function main(): Promise<void> {
   }
 
   if (args.verbose) {
-    printLine('Config:', JSON.stringify(config, null, 2));
+    printLine('Config:', JSON.stringify(redactLogData(config), null, 2));
   }
 
   if (resumeTarget) {

--- a/packages/franken-orchestrator/src/logger.ts
+++ b/packages/franken-orchestrator/src/logger.ts
@@ -1,5 +1,6 @@
 import type { ILogger } from './deps.js';
 import { wallClockNow } from '@franken/types';
+import { redactLogData, redactSensitiveText } from './logging/redaction.js';
 
 
 function printLine(...args: unknown[]): void {
@@ -7,7 +8,7 @@ function printLine(...args: unknown[]): void {
 }
 function formatLine(prefix: string, msg: string): string {
   const timestamp = new Date(wallClockNow()).toISOString();
-  return `${timestamp} ${prefix} ${msg}`;
+  return `${timestamp} ${prefix} ${redactSensitiveText(msg)}`;
 }
 
 function formatDebug(prefix: string, msg: string, data?: unknown): string {
@@ -15,7 +16,7 @@ function formatDebug(prefix: string, msg: string, data?: unknown): string {
   if (data === undefined) {
     return base;
   }
-  return `${base} ${JSON.stringify(data)}`;
+  return `${base} ${JSON.stringify(redactLogData(data))}`;
 }
 
 export class ConsoleLogger implements ILogger {

--- a/packages/franken-orchestrator/src/logging/beast-logger.ts
+++ b/packages/franken-orchestrator/src/logging/beast-logger.ts
@@ -11,6 +11,7 @@ import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, tr
 import { resolve } from 'node:path';
 import type { ILogger } from '../deps.js';
 import { isCommandFailure } from '../errors/command-failure.js';
+import { redactLogData, redactSensitiveText } from './redaction.js';
 
 
 function printLine(...args: unknown[]): void {
@@ -232,6 +233,11 @@ function highlightServices(msg: string): string {
 export interface BeastLoggerOptions {
   readonly verbose: boolean;
   readonly captureForFile?: boolean;
+  /**
+   * Redact secret-looking environment/config keys from terminal and file logs.
+   * Defaults to true; set false only for an explicit local diagnostic override.
+   */
+  readonly redactSecrets?: boolean | undefined;
   /** When set, log entries are appended to this file immediately (crash-safe). */
   readonly logFile?: string | undefined;
   /** Maximum active log file size before rotating to .1, .2, etc. Defaults to 10 MiB. */
@@ -243,6 +249,7 @@ export interface BeastLoggerOptions {
 export class BeastLogger implements ILogger {
   private readonly verbose: boolean;
   private readonly captureForFile: boolean;
+  private readonly redactSecrets: boolean;
   private readonly logFile: string | undefined;
   private readonly maxLogFileBytes: number;
   private readonly maxRotatedLogFiles: number;
@@ -253,6 +260,7 @@ export class BeastLogger implements ILogger {
   constructor(options: BeastLoggerOptions) {
     this.verbose = options.verbose;
     this.captureForFile = options.captureForFile ?? false;
+    this.redactSecrets = options.redactSecrets ?? true;
     this.logFile = options.logFile;
     this.maxLogFileBytes = options.maxLogFileBytes ?? DEFAULT_MAX_LOG_FILE_BYTES;
     this.maxRotatedLogFiles = options.maxRotatedLogFiles ?? DEFAULT_ROTATED_LOG_FILES;
@@ -262,7 +270,8 @@ export class BeastLogger implements ILogger {
     const { data, source: src } = resolveArgs(dataOrSource, source);
     const ts = this.timestamp();
     const badge = src ? formatBadge(src) : '';
-    const display = data !== undefined ? `${msg}  ${formatCompact(data)}` : msg;
+    const safeMsg = this.redactMessage(msg);
+    const display = data !== undefined ? `${safeMsg}  ${formatCompact(data, this.redactSecrets)}` : safeMsg;
     printLine(`${ts} ${A.cyan}${A.bold} INFO${A.reset} ${badge}${display}`);
     this.capture('INFO', this.withBadgeAndData(msg, data, src));
   }
@@ -284,7 +293,8 @@ export class BeastLogger implements ILogger {
     const { data, source: src } = resolveArgs(dataOrSource, source);
     const ts = this.timestamp();
     const badge = src ? formatBadge(src) : '';
-    const display = data !== undefined ? `${msg}  ${formatCompact(data)}` : msg;
+    const safeMsg = this.redactMessage(msg);
+    const display = data !== undefined ? `${safeMsg}  ${formatCompact(data, this.redactSecrets)}` : safeMsg;
     printLine(`${ts} ${A.yellow}${A.bold} WARN${A.reset} ${badge}${A.yellow}${display}${A.reset}`);
     this.capture('WARN', this.withBadgeAndData(msg, data, src));
   }
@@ -399,17 +409,23 @@ export class BeastLogger implements ILogger {
   }
 
   private withData(msg: string, data: unknown): string {
-    if (data === undefined) return msg;
+    const safeMsg = this.redactMessage(msg);
+    if (data === undefined) return safeMsg;
     if (isCommandFailure(data)) {
-      return `${msg} | ${data.summary}`;
+      return `${safeMsg} | ${this.redactMessage(data.summary)}`;
     }
-    return `${msg} | ${safeStringify(data)}`;
+    return `${safeMsg} | ${safeStringify(data, this.redactSecrets)}`;
   }
 
   private withBadgeAndData(msg: string, data: unknown, source: string | undefined): string {
     const badge = source ? `[${source}] ` : '';
-    const body = data !== undefined ? `${msg} | ${safePrettyStringify(data)}` : msg;
+    const safeMsg = this.redactMessage(msg);
+    const body = data !== undefined ? `${safeMsg} | ${safePrettyStringify(data, this.redactSecrets)}` : safeMsg;
     return `${badge}${body}`;
+  }
+
+  private redactMessage(msg: string): string {
+    return this.redactSecrets ? redactSensitiveText(msg) : msg;
   }
 }
 
@@ -442,19 +458,21 @@ function centerAnsi(text: string, width: number): string {
   return `${' '.repeat(leftPad)}${text}`;
 }
 
-function safeStringify(value: unknown): string {
+function safeStringify(value: unknown, redactSecrets = true): string {
   try {
-    return JSON.stringify(value, (_key, v) => typeof v === 'bigint' ? v.toString() : v);
+    const safeValue = redactSecrets ? redactLogData(value) : value;
+    return JSON.stringify(safeValue, (_key, v) => typeof v === 'bigint' ? v.toString() : v);
   } catch {
-    return String(value);
+    return redactSecrets ? redactSensitiveText(String(value)) : String(value);
   }
 }
 
 /** Pretty-print for build.log — truncates long string values to keep logs readable. */
-function safePrettyStringify(value: unknown): string {
+function safePrettyStringify(value: unknown, redactSecrets = true): string {
   const MAX_STRING_LEN = 200;
   try {
-    const pretty = JSON.stringify(value, (_key, v) => {
+    const safeValue = redactSecrets ? redactLogData(value) : value;
+    const pretty = JSON.stringify(safeValue, (_key, v) => {
       if (typeof v === 'bigint') return v.toString();
       if (typeof v === 'string' && v.length > MAX_STRING_LEN) {
         return v.slice(0, MAX_STRING_LEN) + `... (${v.length} chars)`;
@@ -463,15 +481,16 @@ function safePrettyStringify(value: unknown): string {
     }, 2);
     return pretty;
   } catch {
-    return String(value);
+    return redactSecrets ? redactSensitiveText(String(value)) : String(value);
   }
 }
 
-function formatCompact(data: unknown): string {
-  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-    return safeStringify(data);
+function formatCompact(data: unknown, redactSecrets = true): string {
+  const safeData = redactSecrets ? redactLogData(data) : data;
+  if (typeof safeData !== 'object' || safeData === null || Array.isArray(safeData)) {
+    return safeStringify(safeData, redactSecrets);
   }
-  const entries = Object.entries(data as Record<string, unknown>);
+  const entries = Object.entries(safeData as Record<string, unknown>);
   if (entries.length === 0) return '';
-  return entries.map(([k, v]) => `${k}=${typeof v === 'string' ? v : safeStringify(v)}`).join(' ');
+  return entries.map(([k, v]) => `${k}=${typeof v === 'string' ? v : safeStringify(v, redactSecrets)}`).join(' ');
 }

--- a/packages/franken-orchestrator/src/logging/redaction.ts
+++ b/packages/franken-orchestrator/src/logging/redaction.ts
@@ -1,0 +1,52 @@
+const REDACTED = '<redacted>';
+
+const SENSITIVE_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu;
+const ENV_ASSIGNMENT_RE = /\b([A-Z][A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|API_KEY|PRIVATE_KEY|ACCESS_KEY|CLAUDE_SESSION)[A-Z0-9_]*)\s*=\s*([^\s,;]+)/giu;
+const JSON_FIELD_RE = /("[^"]*(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|API_KEY|PRIVATE_KEY|ACCESS_KEY|CLAUDE_SESSION)[^"]*"\s*:\s*")([^"\\]*(?:\\.[^"\\]*)*)"/giu;
+
+export function isSensitiveLogKey(key: string): boolean {
+  const normalized = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .toUpperCase();
+  return SENSITIVE_KEY_RE.test(normalized);
+}
+
+export function redactSensitiveText(text: string): string {
+  return text
+    .replace(ENV_ASSIGNMENT_RE, (_match, key: string) => `${key}=${REDACTED}`)
+    .replace(JSON_FIELD_RE, (_match, key: string) => `${key}${REDACTED}"`);
+}
+
+export function redactLogData(value: unknown): unknown {
+  return redactValue(value, undefined, new WeakSet<object>());
+}
+
+function redactValue(value: unknown, key: string | undefined, seen: WeakSet<object>): unknown {
+  if (key !== undefined && isSensitiveLogKey(key)) {
+    return REDACTED;
+  }
+
+  if (typeof value === 'string') {
+    return redactSensitiveText(value);
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, undefined, seen));
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+    redacted[entryKey] = redactValue(entryValue, entryKey, seen);
+  }
+  return redacted;
+}

--- a/packages/franken-orchestrator/src/logging/redaction.ts
+++ b/packages/franken-orchestrator/src/logging/redaction.ts
@@ -1,8 +1,8 @@
 const REDACTED = '<redacted>';
 
-const SENSITIVE_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu;
-const ENV_ASSIGNMENT_RE = /\b([A-Z][A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|API_KEY|PRIVATE_KEY|ACCESS_KEY|CLAUDE_SESSION)[A-Z0-9_]*)\s*=\s*([^\s,;]+)/giu;
-const JSON_FIELD_RE = /("[^"]*(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|API_KEY|PRIVATE_KEY|ACCESS_KEY|CLAUDE_SESSION)[^"]*"\s*:\s*")([^"\\]*(?:\\.[^"\\]*)*)"/giu;
+const SENSITIVE_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|PROXY[_-]?AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu;
+const ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu;
+const JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu;
 
 export function isSensitiveLogKey(key: string): boolean {
   const normalized = key
@@ -14,8 +14,8 @@ export function isSensitiveLogKey(key: string): boolean {
 
 export function redactSensitiveText(text: string): string {
   return text
-    .replace(ENV_ASSIGNMENT_RE, (_match, key: string) => `${key}=${REDACTED}`)
-    .replace(JSON_FIELD_RE, (_match, key: string) => `${key}${REDACTED}"`);
+    .replace(ASSIGNMENT_RE, (match, key: string) => isSensitiveLogKey(key) ? `${key}=${REDACTED}` : match)
+    .replace(JSON_FIELD_RE, (match, prefix: string, key: string) => isSensitiveLogKey(key) ? `${prefix}"${REDACTED}"` : match);
 }
 
 export function redactLogData(value: unknown): unknown {

--- a/packages/franken-orchestrator/tests/unit/logger.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logger.test.ts
@@ -41,6 +41,25 @@ describe('ConsoleLogger', () => {
     );
   });
 
+  it('redacts secret-like environment data in verbose debug logs', () => {
+    const logSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleLogger({ verbose: true });
+
+    logger.debug('env dump OPENAI_API_KEY=sk-test-secret', {
+      PATH: '/usr/bin',
+      OPENAI_API_KEY: 'sk-test-secret',
+      nested: { GITHUB_TOKEN: 'gho_test_secret' },
+    });
+
+    const output = logSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain('OPENAI_API_KEY=<redacted>');
+    expect(output).toContain('"OPENAI_API_KEY":"<redacted>"');
+    expect(output).toContain('"GITHUB_TOKEN":"<redacted>"');
+    expect(output).toContain('"PATH":"/usr/bin"');
+    expect(output).not.toContain('sk-test-secret');
+    expect(output).not.toContain('gho_test_secret');
+  });
+
   it('logs warn through the shared output path without calling console.warn', () => {
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
@@ -311,6 +311,43 @@ describe('BeastLogger', () => {
       expect(entries[0]).toContain('"error": "boom"');
     });
 
+    it('redacts secret-like environment keys from terminal and captured file logs by default', () => {
+      const logger = new BeastLogger({ verbose: true, captureForFile: true });
+
+      logger.info('Environment snapshot GITHUB_TOKEN=gho_test_secret', {
+        PATH: '/usr/bin',
+        OPENAI_API_KEY: 'sk-test-secret',
+        nested: { DATABASE_PASSWORD: 'database-secret' },
+      });
+
+      const terminal = stripAnsi(consoleLogSpy.mock.calls[0]![0] as string);
+      const entries = logger.getLogEntries();
+
+      expect(terminal).toContain('GITHUB_TOKEN=<redacted>');
+      expect(terminal).toContain('OPENAI_API_KEY=<redacted>');
+      expect(terminal).toContain('PATH=/usr/bin');
+      expect(entries[0]).toContain('"OPENAI_API_KEY": "<redacted>"');
+      expect(entries[0]).toContain('"DATABASE_PASSWORD": "<redacted>"');
+      expect(entries[0]).not.toContain('gho_test_secret');
+      expect(entries[0]).not.toContain('sk-test-secret');
+      expect(entries[0]).not.toContain('database-secret');
+    });
+
+    it('allows an explicit unsafe local override for secret redaction', () => {
+      const logger = new BeastLogger({ verbose: true, captureForFile: true, redactSecrets: false });
+
+      logger.warn('Environment snapshot GITHUB_TOKEN=gho_test_secret', {
+        OPENAI_API_KEY: 'sk-test-secret',
+      });
+
+      const terminal = stripAnsi(consoleLogSpy.mock.calls[0]![0] as string);
+      const entries = logger.getLogEntries();
+
+      expect(terminal).toContain('GITHUB_TOKEN=gho_test_secret');
+      expect(terminal).toContain('OPENAI_API_KEY=sk-test-secret');
+      expect(entries[0]).toContain('"OPENAI_API_KEY": "sk-test-secret"');
+    });
+
     it('renders command failures concisely on the terminal but captures full fields in file logs', () => {
       const failure: CommandFailure = {
         kind: 'command_failed',

--- a/packages/franken-orchestrator/tests/unit/logging/redaction.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logging/redaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { isSensitiveLogKey, redactLogData, redactSensitiveText } from '../../../src/logging/redaction.js';
+
+describe('logging redaction', () => {
+  it('treats common credential-bearing key spellings as sensitive', () => {
+    expect(isSensitiveLogKey('authorization')).toBe(true);
+    expect(isSensitiveLogKey('proxy-authorization')).toBe(true);
+    expect(isSensitiveLogKey('apiKey')).toBe(true);
+    expect(isSensitiveLogKey('x-api-key')).toBe(true);
+    expect(isSensitiveLogKey('normalPath')).toBe(false);
+  });
+
+  it('redacts quoted and unquoted inline assignment values as a unit', () => {
+    const output = redactSensitiveText('DATABASE_PASSWORD="value with spaces" OPENAI_API_KEY=plain-token PATH=/usr/bin');
+
+    expect(output).toContain('DATABASE_PASSWORD=<redacted>');
+    expect(output).toContain('OPENAI_API_KEY=<redacted>');
+    expect(output).toContain('PATH=/usr/bin');
+    expect(output).not.toContain('value with spaces');
+    expect(output).not.toContain('plain-token');
+  });
+
+  it('redacts sensitive JSON text keys using normalized key names', () => {
+    const output = redactSensitiveText('{"apiKey":"json-token","x-api-key":"header-token","name":"franken"}');
+
+    expect(output).toContain('"apiKey":"<redacted>"');
+    expect(output).toContain('"x-api-key":"<redacted>"');
+    expect(output).toContain('"name":"franken"');
+    expect(output).not.toContain('json-token');
+    expect(output).not.toContain('header-token');
+  });
+
+  it('redacts nested authorization metadata in object logs', () => {
+    const output = redactLogData({
+      headers: {
+        authorization: 'Bearer credential-value',
+        'proxy-authorization': 'Basic proxy-value',
+      },
+      config: { apiKey: 'provider-key' },
+      path: '/tmp/work',
+    });
+
+    expect(output).toEqual({
+      headers: {
+        authorization: '<redacted>',
+        'proxy-authorization': '<redacted>',
+      },
+      config: { apiKey: '<redacted>' },
+      path: '/tmp/work',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add default-on logger redaction for secret-like environment/config keys in compact, JSON, and captured build-log metadata
- redact inline env-assignment strings in log messages while preserving non-sensitive context
- route verbose CLI config dumps through the same redactor and document the default behavior plus explicit unsafe local diagnostic override

## Verification
- npm run test --workspace @franken/orchestrator -- tests/unit/logger.test.ts tests/unit/logging/beast-logger.test.ts tests/unit/logging/redaction.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/observer && npm run build --workspace @franken/brain && npm run build --workspace @franken/planner && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run lint:security

Closes #1801
