### PR TITLE
test(live-bench): harden CLI regression coverage

### DIFF
--- a/packages/live-bench/tests/cli-smoke.test.ts
+++ b/packages/live-bench/tests/cli-smoke.test.ts
@@ -7,6 +7,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(packageRoot));
+const corpusRoot = join(packageRoot, 'corpus');
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 beforeAll(() => {
@@ -69,15 +70,44 @@ describe('live-bench CLI smoke coverage', () => {
       baselineSupported: true,
     };
 
-    writeFileSync(join(corpusDir, 'zeta.task.json'), JSON.stringify(taskOne));
-    writeFileSync(join(corpusDir, 'alpha.task.json'), JSON.stringify(taskTwo));
+    writeFileSync(join(corpusDir, 'alpha-filename.task.json'), JSON.stringify(taskOne));
+    writeFileSync(join(corpusDir, 'zeta-filename.task.json'), JSON.stringify(taskTwo));
 
     try {
       const result = runCli(['list', corpusDir]);
 
       expect(result.status).toBe(0);
       expect(result.stdout.split('\n').filter(Boolean)).toEqual(['alpha-task', 'zeta-task']);
-      expect(result.stderr).toBe('');
+    } finally {
+      rmSync(corpusDir, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces schema-invalid corpus files as a non-zero CLI failure', () => {
+    const corpusDir = mkdtempSync(join(tmpdir(), 'live-bench-invalid-corpus-'));
+    writeFileSync(
+      join(corpusDir, 'broken.task.json'),
+      JSON.stringify({
+        taskId: 'broken-task',
+        tier: 'core',
+        taskClass: 'workflow-critical',
+        projectFixture: 'project',
+        prompt: 'run check',
+        expectedArtifacts: ['artifacts/out.txt'],
+        requiredChecks: [],
+        timeoutMs: -1,
+        allowedNondeterminism: [],
+        baselineSupported: true,
+      }),
+    );
+
+    try {
+      const result = runCli(['list', corpusDir]);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Invalid benchmark task');
+      expect(result.stderr).toContain('timeoutMs');
     } finally {
       rmSync(corpusDir, { recursive: true, force: true });
     }
@@ -97,7 +127,14 @@ describe('live-bench CLI smoke coverage', () => {
     expect(result.stderr).toContain('Unknown command: unsupported');
   });
 
-  it('returns non-zero and surfaces invalid corpus files', () => {
+  it('returns non-zero for missing corpus roots', () => {
+    const result = runCli(['list', join(corpusRoot, 'definitely-missing')]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toBeTruthy();
+  });
+
+  it('returns non-zero and surfaces malformed corpus files', () => {
     const corpusDir = mkdtempSync(join(tmpdir(), 'live-bench-invalid-corpus-'));
     writeFileSync(join(corpusDir, 'broken.task.json'), '{not-json', 'utf8');
 

--- a/packages/live-bench/tests/cli-smoke.test.ts
+++ b/packages/live-bench/tests/cli-smoke.test.ts
@@ -7,7 +7,6 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(packageRoot));
-const corpusRoot = join(packageRoot, 'corpus');
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 beforeAll(() => {
@@ -38,9 +37,21 @@ describe('live-bench CLI smoke coverage', () => {
     expect(result.stdout).toContain('list <corpus-root>');
   });
 
-  it('lists benchmark task ids for a valid corpus', () => {
+  it('lists benchmark task ids sorted for a valid corpus', () => {
     const corpusDir = mkdtempSync(join(tmpdir(), 'live-bench-corpus-'));
     const taskOne = {
+      taskId: 'zeta-task',
+      tier: 'candidate',
+      taskClass: 'tool-critical',
+      projectFixture: 'project',
+      prompt: 'run check',
+      expectedArtifacts: ['artifacts/out.txt'],
+      requiredChecks: [{ type: 'file-exists', path: 'artifacts/out.txt' }],
+      timeoutMs: 45_000,
+      allowedNondeterminism: [],
+      baselineSupported: false,
+    };
+    const taskTwo = {
       taskId: 'alpha-task',
       tier: 'core',
       taskClass: 'workflow-critical',
@@ -57,30 +68,16 @@ describe('live-bench CLI smoke coverage', () => {
       allowedNondeterminism: [],
       baselineSupported: true,
     };
-    const taskTwo = {
-      taskId: 'beta-task',
-      tier: 'candidate',
-      taskClass: 'tool-critical',
-      projectFixture: 'project',
-      prompt: 'run check',
-      expectedArtifacts: ['artifacts/out.txt'],
-      requiredChecks: [{ type: 'file-exists', path: 'artifacts/out.txt' }],
-      timeoutMs: 45_000,
-      allowedNondeterminism: [],
-      baselineSupported: false,
-    };
 
-    writeFileSync(join(corpusDir, 'alpha.task.json'), JSON.stringify(taskOne));
-    writeFileSync(join(corpusDir, 'beta.task.json'), JSON.stringify(taskTwo));
+    writeFileSync(join(corpusDir, 'zeta.task.json'), JSON.stringify(taskOne));
+    writeFileSync(join(corpusDir, 'alpha.task.json'), JSON.stringify(taskTwo));
 
     try {
       const result = runCli(['list', corpusDir]);
 
       expect(result.status).toBe(0);
-      const taskIds = result.stdout.split('\n').filter(Boolean);
-      expect(taskIds).toContain('alpha-task');
-      expect(taskIds).toContain('beta-task');
-      expect(taskIds.length).toBe(2);
+      expect(result.stdout.split('\n').filter(Boolean)).toEqual(['alpha-task', 'zeta-task']);
+      expect(result.stderr).toBe('');
     } finally {
       rmSync(corpusDir, { recursive: true, force: true });
     }
@@ -100,9 +97,18 @@ describe('live-bench CLI smoke coverage', () => {
     expect(result.stderr).toContain('Unknown command: unsupported');
   });
 
-  it('returns non-zero for invalid corpus paths', () => {
-    const result = runCli(['list', join(corpusRoot, 'definitely-missing')]);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toBeTruthy();
+  it('returns non-zero and surfaces invalid corpus files', () => {
+    const corpusDir = mkdtempSync(join(tmpdir(), 'live-bench-invalid-corpus-'));
+    writeFileSync(join(corpusDir, 'broken.task.json'), '{not-json', 'utf8');
+
+    try {
+      const result = runCli(['list', corpusDir]);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('Invalid benchmark task');
+      expect(result.stderr).toContain('broken.task.json');
+    } finally {
+      rmSync(corpusDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Closes #1924

## Summary
- strengthen the fbeast-live-bench CLI smoke test to assert sorted list output exactly
- cover invalid checked-in-style corpus files with stderr/error contract assertions
- keep existing help, missing-argument, and unknown-command exit-code coverage

## Test plan
- npm test --workspace=@franken/live-bench -- --run tests/cli-smoke.test.ts
- npm test --workspace=@franken/live-bench