### PR TITLE
fix(orchestrator): wrap malformed run config JSON errors

### DIFF
--- a/packages/franken-orchestrator/src/cli/run-config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/run-config-loader.ts
@@ -56,13 +56,32 @@ export const RunConfigSchema = z.object({
 
 export type RunConfig = z.infer<typeof RunConfigSchema>;
 
+export class RunConfigParseError extends Error {
+  public readonly code = 'RUN_CONFIG_PARSE_ERROR';
+
+  constructor(
+    public readonly filePath: string,
+    public readonly reason: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Failed to parse run config JSON at ${filePath}: ${reason}`, options);
+    this.name = 'RunConfigParseError';
+  }
+}
+
 /**
  * Load and validate a RunConfig from a JSON file path.
  * Throws if the file does not exist or the content fails Zod validation.
  */
 export function loadRunConfig(filePath: string): RunConfig {
   const raw = readFileSync(filePath, 'utf-8');
-  const parsed = JSON.parse(raw) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new RunConfigParseError(filePath, reason, error instanceof Error ? { cause: error } : undefined);
+  }
   return RunConfigSchema.parse(parsed);
 }
 

--- a/packages/franken-orchestrator/tests/unit/cli/run-config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run-config-loader.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadRunConfig, loadRunConfigFromEnv, type RunConfig } from '../../../src/cli/run-config-loader.js';
+import {
+  loadRunConfig,
+  loadRunConfigFromEnv,
+  RunConfigParseError,
+  type RunConfig,
+} from '../../../src/cli/run-config-loader.js';
 
 describe('RunConfigLoader', () => {
   let workDir: string | undefined;
@@ -111,6 +116,27 @@ describe('RunConfigLoader', () => {
       await writeFile(filePath, JSON.stringify(config));
 
       expect(() => loadRunConfig(filePath)).toThrow();
+    });
+
+    it('throws a structured parse error with file path and reason for malformed JSON', async () => {
+      workDir = await mkdtemp(join(tmpdir(), 'run-config-'));
+      const filePath = join(workDir, 'malformed.json');
+      await writeFile(filePath, '{"provider": "claude",');
+
+      expect(() => loadRunConfig(filePath)).toThrow(RunConfigParseError);
+
+      try {
+        loadRunConfig(filePath);
+      } catch (error) {
+        expect(error).toBeInstanceOf(RunConfigParseError);
+        expect(error).toMatchObject({
+          code: 'RUN_CONFIG_PARSE_ERROR',
+          filePath,
+          reason: expect.stringContaining('JSON'),
+        });
+        expect((error as Error).message).toContain(filePath);
+        expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+      }
     });
 
     it('throws when file does not exist', () => {


### PR DESCRIPTION
Fixes #1931

## Summary
- add a structured RunConfigParseError for malformed run config JSON
- include the run config file path, parse reason, stable error code, and SyntaxError cause
- cover malformed JSON behavior in the run config loader unit tests

## Test plan
- npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator -- tests/unit/cli/run-config-loader.test.ts