### PR TITLE
fix(orchestrator): support managed chat rejection

### DIFF
--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -266,10 +266,24 @@ async function awaitRemoteReply(socket: WebSocket, verbose: boolean): Promise<vo
   });
 }
 
+function sendManagedChatInput(socket: WebSocket, input: string): void {
+  if (input === '/approve' || input === '/reject') {
+    socket.send(JSON.stringify({ type: 'approval.respond', approved: input === '/approve' }));
+    return;
+  }
+
+  socket.send(JSON.stringify({
+    type: 'message.send',
+    clientMessageId: deterministicUuid('packages/franken-orchestrator/src/network/chat-attach.ts'),
+    content: input,
+  }));
+}
+
 export const __chatAttachTestHooks = {
   awaitRemoteReply,
   createRemoteSession,
   parseManagedChatMessage,
+  sendManagedChatInput,
 };
 
 export async function runManagedChatRepl(options: {
@@ -293,17 +307,7 @@ export async function runManagedChatRepl(options: {
         break;
       }
 
-      if (input === '/approve') {
-        session.socket.send(JSON.stringify({ type: 'approval.respond', approved: true }));
-        await awaitRemoteReply(session.socket, verbose);
-        continue;
-      }
-
-      session.socket.send(JSON.stringify({
-        type: 'message.send',
-        clientMessageId: deterministicUuid('packages/franken-orchestrator/src/network/chat-attach.ts'),
-        content: input,
-      }));
+      sendManagedChatInput(session.socket, input);
       await awaitRemoteReply(session.socket, verbose);
     }
   } finally {

--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -194,6 +194,35 @@ describe('resolveManagedChatAttachment', () => {
     expect(source).not.toContain(directConsoleCall);
   });
 
+  it('sends approval and rejection responses for managed chat slash commands', () => {
+    const send = vi.fn();
+    const socket = { send } as unknown as WebSocket;
+
+    __chatAttachTestHooks.sendManagedChatInput(socket, '/approve');
+    __chatAttachTestHooks.sendManagedChatInput(socket, '/reject');
+
+    expect(send).toHaveBeenNthCalledWith(1, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }));
+    expect(send).toHaveBeenNthCalledWith(2, JSON.stringify({
+      type: 'approval.respond',
+      approved: false,
+    }));
+  });
+
+  it('sends non-command input as a managed chat message', () => {
+    const send = vi.fn();
+    const socket = { send } as unknown as WebSocket;
+
+    __chatAttachTestHooks.sendManagedChatInput(socket, 'hello beast');
+
+    expect(JSON.parse(send.mock.calls[0]?.[0] as string)).toMatchObject({
+      type: 'message.send',
+      content: 'hello beast',
+    });
+  });
+
   it('rejects malformed websocket frames while waiting for session readiness', async () => {
     stubRemoteSessionFetch();
     stubManagedChatWebSocket();


### PR DESCRIPTION
## Summary
- Add /reject handling to managed chat attachment, sending approval.respond with approved: false.
- Share the managed chat input sender across /approve, /reject, and normal messages.
- Add regression coverage for approval, rejection, and normal message sends.

Closes #1935

## Test plan
- npm run test --workspace @franken/orchestrator -- tests/unit/cli/chat-attach.test.ts
- git diff --check

## Notes
- fbeast MCP tools were not available in this environment, so I used normal git/GitHub/terminal verification.