### PR TITLE
docs: clarify orchestrator resume checkpoint behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ frankenbeast --design-doc docs/my-feature-design.md
 frankenbeast --plan-dir ./my-chunks/
 ```
 
-Cold `frankenbeast run` clears checkpoint/chunk-session state before execution. Use `frankenbeast run --resume` when a previous run was interrupted and you want to continue from saved checkpoint/chunk-session data. `--resume` requires an existing checkpoint for the selected plan; if that checkpoint is missing, the command fails fast with a missing-checkpoint error instead of silently starting a cold run.
+Cold `frankenbeast run` clears checkpoint/chunk-session state before execution. Use `frankenbeast run --resume` only when a previous run was interrupted and saved checkpoint state exists; the run resumes from that checkpoint/chunk-session data. If the checkpoint is missing, the resume command fails fast with a missing-checkpoint error instead of silently starting a cold run.
 
 ### Subcommands
 


### PR DESCRIPTION
## Summary
- Clarifies that `frankenbeast run --resume` is active and resumes from saved checkpoint/chunk-session state.
- Documents the checkpoint precondition and fail-fast missing-checkpoint behavior.

Closes #1937

## Test plan
- `git diff --check`
- targeted README search for stale resume/unwired wording: no matches

## Notes
- fbeast MCP tools were not available in this worker tool schema, so I used normal terminal/file/git/gh verification per AGENTS.md.