### PR TITLE
docs: correct secret backend defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,10 +634,10 @@ Frankenbeast stores secrets outside the config file. The config references secre
 
 | Backend | Key | Best for |
 |---------|-----|----------|
-| OS keychain (Keychain/GNOME/DPAPI) | `os-keychain` | Explicit opt-in for local dev that should use native credential storage |
+| Local encrypted file | `local-encrypted` | Default backend; zero-install local dev, CI/CD, offline, or minimal environments |
+| OS keychain (Keychain/GNOME/DPAPI) | `os-keychain` | Explicit opt-in for single-machine local dev when you want OS-managed storage and no passphrase prompt |
 | 1Password | `1password` | Teams using 1Password vaults |
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
-| Local encrypted file | `local-encrypted` | Default backend; CI/CD, offline, or minimal environments |
 
 Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config.json`, then set `network.secureBackend` there. If you omit `network.secureBackend`, the config schema and init flow use `local-encrypted`; `os-keychain` is never selected automatically. `frankenbeast init` reads and updates `.fbeast/config.json`.
 
@@ -653,7 +653,7 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 ```json
 { "network": { "secureBackend": "os-keychain" } }
 ```
-Set this in `.fbeast/config.json` before running `frankenbeast init` when you want local secrets in the native macOS Keychain, GNOME Secret Service, or Windows Credential Manager instead of the default encrypted file. The token is generated and stored in the OS keychain automatically (no passphrase prompt).
+Set this in `.fbeast/config.json` before running `frankenbeast init` when you want local secrets in the native macOS Keychain, GNOME Secret Service, or Windows Credential Manager instead of the default encrypted file. The token is generated and stored in the OS keychain automatically (no passphrase prompt). Use `os-keychain` only when you explicitly select it; it is convenient for single-machine local development, but it is not the default backend.
 
 **1Password / Bitwarden:**
 ```json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -997,10 +997,10 @@ Frankenbeast stores secrets outside the config file. Config references secrets b
 
 | Backend | `secureBackend` value | Best for |
 |---------|----------------------|----------|
-| OS keychain (Keychain / GNOME / DPAPI) | `os-keychain` | Explicit opt-in for local development that should use native credential storage |
+| Local encrypted file | `local-encrypted` | Default backend; zero-install local development, CI/CD, and offline environments |
+| OS keychain (Keychain / GNOME / DPAPI) | `os-keychain` | Explicit opt-in for single-machine local development that should use native credential storage |
 | 1Password | `1password` | Teams using 1Password vaults |
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
-| Local encrypted file | `local-encrypted` | Default backend; CI/CD and offline environments |
 
 When `network.secureBackend` is unset, the `NetworkOperatorConfigSchema` field default applies `local-encrypted`; the OS keychain backend is available only when selected explicitly.
 
@@ -1024,6 +1024,7 @@ flowchart LR
 - `ISecretStore` — four-method interface: `get(key)`, `set(key, value)`, `delete(key)`, `has(key)`
 - `SecretResolver` — reads `*Ref` fields from `OrchestratorConfig`, resolves each key, returns a typed `ResolvedSecrets` record
 - `frankenbeast init` — interactive wizard: generates operator token, writes to backend
+- `network.secureBackend` — defaults to `local-encrypted` when omitted; select `os-keychain` explicitly for OS-managed single-machine local development without passphrase prompts
 - `FRANKENBEAST_PASSPHRASE` — env var for headless `local-encrypted` decryption (CI/CD)
 - Legacy backend keys (`macos-keychain`, `windows-credential-manager`, `linux-secret-service`) are remapped to `os-keychain` at parse time
 


### PR DESCRIPTION
## Summary
- Update Secret Management docs to identify `local-encrypted` as the default backend
- Clarify that `os-keychain` is explicitly selected for OS-managed single-machine local development
- Align the architecture backend table with README guidance

Closes #1939

## Test plan
- `git diff --check`
- Targeted docs search for stale `os-keychain` default/local-dev wording