### PR TITLE
docs: correct secret backend defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,12 +633,12 @@ Frankenbeast stores secrets outside the config file. The config references secre
 
 | Backend | Key | Best for |
 |---------|-----|----------|
-| OS keychain (Keychain/GNOME/DPAPI) | `os-keychain` | Local dev on macOS, Linux, Windows |
+| OS keychain (Keychain/GNOME/DPAPI) | `os-keychain` | Explicit opt-in for local dev that should use native credential storage |
 | 1Password | `1password` | Teams using 1Password vaults |
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
-| Local encrypted file | `local-encrypted` | CI/CD or offline environments |
+| Local encrypted file | `local-encrypted` | Default backend; CI/CD, offline, or minimal environments |
 
-Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config.json`, then set `network.secureBackend` there. `frankenbeast init` reads and updates `.fbeast/config.json`.
+Copy the relevant settings from `frankenbeast.example.json` into `.fbeast/config.json`, then set `network.secureBackend` there. If you omit `network.secureBackend`, the config schema and init flow use `local-encrypted`; `os-keychain` is never selected automatically. `frankenbeast init` reads and updates `.fbeast/config.json`.
 
 ### Setup per backend
 
@@ -652,7 +652,7 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 ```json
 { "network": { "secureBackend": "os-keychain" } }
 ```
-Set this in `.fbeast/config.json`, then run `frankenbeast init` — the token is generated and stored in the OS keychain automatically (no passphrase prompt).
+Set this in `.fbeast/config.json` before running `frankenbeast init` when you want local secrets in the native macOS Keychain, GNOME Secret Service, or Windows Credential Manager instead of the default encrypted file. The token is generated and stored in the OS keychain automatically (no passphrase prompt).
 
 **1Password / Bitwarden:**
 ```json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -997,10 +997,12 @@ Frankenbeast stores secrets outside the config file. Config references secrets b
 
 | Backend | `secureBackend` value | Best for |
 |---------|----------------------|----------|
-| OS keychain (Keychain / GNOME / DPAPI) | `os-keychain` | Local development |
+| OS keychain (Keychain / GNOME / DPAPI) | `os-keychain` | Explicit opt-in for local development that should use native credential storage |
 | 1Password | `1password` | Teams using 1Password vaults |
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
-| Local encrypted file | `local-encrypted` | CI/CD and offline environments |
+| Local encrypted file | `local-encrypted` | Default backend; CI/CD and offline environments |
+
+When `network.secureBackend` is unset, `SecureBackendSchema` defaults to `local-encrypted`; the OS keychain backend is available only when selected explicitly.
 
 ### Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1002,7 +1002,7 @@ Frankenbeast stores secrets outside the config file. Config references secrets b
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
 | Local encrypted file | `local-encrypted` | Default backend; CI/CD and offline environments |
 
-When `network.secureBackend` is unset, `SecureBackendSchema` defaults to `local-encrypted`; the OS keychain backend is available only when selected explicitly.
+When `network.secureBackend` is unset, the `NetworkOperatorConfigSchema` field default applies `local-encrypted`; the OS keychain backend is available only when selected explicitly.
 
 ### Architecture
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -313,8 +313,11 @@ describe('local setup scripts', () => {
     expect(readme).toContain('frankenbeast init --verify');
     expect(readme).toContain('review token prompts carefully');
     expect(readme).toContain('frankenbeast init --non-interactive');
+    expect(readme).toContain('If you omit `network.secureBackend`, the config schema and init flow use `local-encrypted`');
+    expect(readme).toContain('`os-keychain` is never selected automatically');
     expect(readme).toContain('Choose the secret backend before the first init run');
     expect(readme).toContain('{ "network": { "secureBackend": "os-keychain" } }');
+    expect(readme).toContain('instead of the default encrypted file');
     expect(readme).toContain('{ "network": { "secureBackend": "1password" } }');
     expect(readme).toContain('{ "network": { "secureBackend": "bitwarden" } }');
     expect(readme).toContain('it applies the same `network.secureBackend` choice');


### PR DESCRIPTION
## Summary
- Clarifies that `local-encrypted` is the default Secret Management backend when `network.secureBackend` is unset.
- Documents `os-keychain` as an explicit opt-in for native local credential storage rather than an automatic local-dev default.
- Adds regression coverage for the README default/backend guidance.

## Test Plan
- `npm exec -- vitest run tests/local-setup-scripts.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build`

Closes #1939
