### PR TITLE
test(orchestrator): stabilize http abort disconnect test

### DIFF
--- a/packages/franken-orchestrator/tests/unit/http/http-server-utils.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/http-server-utils.test.ts
@@ -32,18 +32,24 @@ describe('http-server-utils', () => {
       throw new Error('server did not bind to a TCP address');
     }
 
-    const request = await import('node:http').then(({ get }) => get(`http://127.0.0.1:${address.port}/stream`));
-    request.on('error', () => {
-      // Expected after destroying the client side of the long-lived request.
-    });
-    await handlerReady;
-    request.destroy();
+    try {
+      const request = await import('node:http').then(({ get }) => get(`http://127.0.0.1:${address.port}/stream`));
+      request.on('error', () => {
+        // Expected after destroying the client side of the long-lived request.
+      });
 
-    await expect(Promise.race([
-      aborted.then(() => 'aborted'),
-      new Promise((resolve) => setTimeout(() => resolve('timeout'), 5_000)),
-    ])).resolves.toBe('aborted');
-    server.closeAllConnections();
-    await closeHttpServer(server);
+      // Wait until the Hono handler has attached the abort listener before destroying
+      // the request. This avoids relying on wall-clock disconnect timing in slow CI.
+      await handlerReady;
+      request.destroy();
+
+      await expect(Promise.race([
+        aborted.then(() => 'aborted'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 5_000)),
+      ])).resolves.toBe('aborted');
+    } finally {
+      server.closeAllConnections();
+      await closeHttpServer(server);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- keep the http-server-utils abort-disconnect test cleanup in a finally block
- document the handler-ready synchronization so the test remains independent of wall-clock disconnect timing

## Test plan
- npm run test --workspace @franken/orchestrator -- tests/unit/http/http-server-utils.test.ts
- npm run build
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1932