### PR TITLE
fix(orchestrator): harden analytics filter inputs

### DIFF
--- a/docs/superpowers/specs/2026-04-26-observer-analytics-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-26-observer-analytics-dashboard-design.md
@@ -180,10 +180,14 @@ Returns global or filtered summary metrics:
 
 Query params:
 
-- `sessionId` optional
+- `sessionId` optional; printable text only, max 256 characters
 - `timeWindow` optional
-- `toolQuery` optional
+- `toolQuery` optional; printable text only, max 128 characters
 - `outcome` optional
+
+Text filters are validated before analytics reads run. Operators should expect malformed,
+oversized, or control-character-bearing filter values to fail closed with
+`invalid_filter_text` rather than being interpreted as SQLite syntax.
 
 ### `GET /api/analytics/events`
 

--- a/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
+++ b/packages/franken-orchestrator/src/analytics/sqlite-analytics-service.ts
@@ -317,8 +317,15 @@ function hasColumn(db: Database.Database, table: string, column: string): boolea
   if (!hasTable(db, table)) {
     return false;
   }
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  const rows = db.prepare(`PRAGMA table_info(${quoteSqlIdentifier(table)})`).all() as Array<{ name: string }>;
   return rows.some((row) => row.name === column);
+}
+
+function quoteSqlIdentifier(identifier: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    throw new Error(`Unsafe SQLite identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
 }
 
 function auditRowToEvent(row: AuditRow): AnalyticsEvent {

--- a/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/analytics-routes.ts
@@ -17,32 +17,49 @@ const OUTCOMES = new Set<AnalyticsOutcome>([
 const TIME_WINDOWS = ['24h', '7d', '30d', 'all'] as const;
 const TIME_WINDOW_SET = new Set<string>(TIME_WINDOWS);
 
-type FilterValidationError = 'invalid_time_window' | 'invalid_outcome';
-type FiltersResult = { ok: true; filters: AnalyticsFilters } | { ok: false; reason: FilterValidationError };
+type TextFilterParameter = 'sessionId' | 'toolQuery';
+type NonTextFilterValidationError = 'invalid_time_window' | 'invalid_outcome';
+type FiltersResult =
+  | { ok: true; filters: AnalyticsFilters }
+  | { ok: false; reason: NonTextFilterValidationError }
+  | { ok: false; reason: 'invalid_filter_text'; parameter: TextFilterParameter };
 type PageRequestResult =
   | { ok: true; request: AnalyticsPageRequest }
-  | { ok: false; reason: FilterValidationError }
+  | { ok: false; reason: NonTextFilterValidationError }
+  | { ok: false; reason: 'invalid_filter_text'; parameter: TextFilterParameter }
   | { ok: false; reason: 'invalid_pagination'; parameter: 'page' | 'pageSize' };
+
+const TEXT_FILTER_LIMITS: Record<TextFilterParameter, number> = {
+  sessionId: 256,
+  toolQuery: 128,
+};
 
 export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
   const app = new Hono();
 
   app.get('/summary', async (c) => {
     const result = readFilters(c.req.query());
-    if (!result.ok) return invalidFilter(c, result.reason);
+    if (!result.ok) {
+      return result.reason === 'invalid_filter_text' ? invalidTextFilter(c, result.parameter) : invalidFilter(c, result.reason);
+    }
     return c.json(await deps.analytics.getSummary(result.filters));
   });
 
   app.get('/sessions', async (c) => {
     const result = readFilters(c.req.query());
-    if (!result.ok) return invalidFilter(c, result.reason);
+    if (!result.ok) {
+      return result.reason === 'invalid_filter_text' ? invalidTextFilter(c, result.parameter) : invalidFilter(c, result.reason);
+    }
     return c.json({ sessions: await deps.analytics.listSessions(result.filters) });
   });
 
   app.get('/events', async (c) => {
     const result = readPageRequest(c.req.query());
     if (!result.ok) {
-      return result.reason === 'invalid_pagination' ? invalidPagination(c, result.parameter) : invalidFilter(c, result.reason);
+      if (result.reason === 'invalid_pagination') {
+        return invalidPagination(c, result.parameter);
+      }
+      return result.reason === 'invalid_filter_text' ? invalidTextFilter(c, result.parameter) : invalidFilter(c, result.reason);
     }
     return c.json(await deps.analytics.listEvents(result.request));
   });
@@ -61,7 +78,9 @@ export function createAnalyticsRoutes(deps: AnalyticsRouteDeps): Hono {
 function readPageRequest(query: Record<string, string>): PageRequestResult {
   const filters = readFilters(query);
   if (!filters.ok) {
-    return { ok: false, reason: filters.reason };
+    return filters.reason === 'invalid_filter_text'
+      ? { ok: false, reason: filters.reason, parameter: filters.parameter }
+      : { ok: false, reason: filters.reason };
   }
   const page = readPositiveInteger(query['page']);
   if (!page.ok) {
@@ -91,18 +110,44 @@ function readFilters(query: Record<string, string>): FiltersResult {
   if (outcome && !OUTCOMES.has(outcome as AnalyticsOutcome)) {
     return { ok: false, reason: 'invalid_outcome' };
   }
+  const sessionId = query['sessionId'];
+  const toolQuery = query['toolQuery'];
+  const sessionIdValidation = validateTextFilter('sessionId', sessionId);
+  if (!sessionIdValidation.ok) {
+    return sessionIdValidation;
+  }
+  const toolQueryValidation = validateTextFilter('toolQuery', toolQuery);
+  if (!toolQueryValidation.ok) {
+    return toolQueryValidation;
+  }
   return {
     ok: true,
     filters: {
-      ...(query['sessionId'] ? { sessionId: query['sessionId'] } : {}),
-      ...(query['toolQuery'] ? { toolQuery: query['toolQuery'] } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(toolQuery ? { toolQuery } : {}),
       ...(outcome ? { outcome: outcome as AnalyticsOutcome } : {}),
       ...(timeWindow ? { timeWindow } : {}),
     },
   };
 }
 
-function invalidFilter(c: Context, reason: FilterValidationError) {
+type TextFilterValidationResult = { ok: true } | { ok: false; reason: 'invalid_filter_text'; parameter: TextFilterParameter };
+
+function validateTextFilter(parameter: TextFilterParameter, value: string | undefined): TextFilterValidationResult {
+  if (value === undefined || value === '') {
+    return { ok: true };
+  }
+  if (value.length > TEXT_FILTER_LIMITS[parameter] || !isPrintableFilterText(value)) {
+    return { ok: false, reason: 'invalid_filter_text', parameter };
+  }
+  return { ok: true };
+}
+
+function isPrintableFilterText(value: string): boolean {
+  return /^[\u0020-\u007e]+$/.test(value);
+}
+
+function invalidFilter(c: Context, reason: NonTextFilterValidationError) {
   return reason === 'invalid_outcome' ? invalidOutcome(c) : invalidTimeWindow(c);
 }
 
@@ -122,6 +167,17 @@ function invalidOutcome(c: Context) {
       message: 'Unsupported Analytics outcome filter',
       code: 'invalid_outcome',
       allowedValues: [...OUTCOMES],
+    },
+  }, 400);
+}
+
+function invalidTextFilter(c: Context, parameter: TextFilterParameter) {
+  return c.json({
+    error: {
+      message: 'Unsafe Analytics filter value',
+      code: 'invalid_filter_text',
+      parameter,
+      expected: 'printable text within dashboard filter length limits',
     },
   }, 400);
 }

--- a/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/analytics-routes.test.ts
@@ -125,6 +125,29 @@ describe('analytics routes', () => {
   });
 
   it.each([
+    ['/summary?sessionId=session-a%00OR%201%3D1', 'sessionId', 'getSummary'],
+    [`/sessions?sessionId=${'a'.repeat(257)}`, 'sessionId', 'listSessions'],
+    ['/events?toolQuery=exec%0AUNION%20SELECT%20secret', 'toolQuery', 'listEvents'],
+    [`/events?toolQuery=${'x'.repeat(129)}`, 'toolQuery', 'listEvents'],
+  ] as const)('rejects unsafe analytics filter text for %s before reading analytics data', async (path, parameter, serviceMethod) => {
+    const service = mockAnalyticsService();
+    const app = createAnalyticsRoutes({ analytics: service });
+
+    const res = await app.request(path);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: {
+        message: 'Unsafe Analytics filter value',
+        code: 'invalid_filter_text',
+        parameter,
+        expected: 'printable text within dashboard filter length limits',
+      },
+    });
+    expect(service[serviceMethod]).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ['/summary?outcome=faild', 'getSummary'],
     ['/sessions?outcome=blocked', 'listSessions'],
     ['/events?outcome=unknown', 'listEvents'],


### PR DESCRIPTION
## Summary
- Reject unsafe Analytics dashboard text filters before any analytics reads run
- Quote SQLite identifiers used by analytics schema introspection
- Document fail-closed filter bounds for operators

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/http/analytics-routes.test.ts tests/unit/analytics/analytics-service.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings outside touched files)

Closes #1799