### PR TITLE
fix(cli): support normalized workspace root entries

### DIFF
--- a/packages/franken-orchestrator/src/cli/project-root.ts
+++ b/packages/franken-orchestrator/src/cli/project-root.ts
@@ -52,7 +52,7 @@ function findWorkspaceRoot(start: string): string | undefined {
           : packageJson.workspaces?.packages;
         const rel = relative(current, start);
         const isInsidePackagesDir = rel === 'packages' || rel.startsWith(`packages/`);
-        if (workspaces?.includes('packages/*') && (start === current || isInsidePackagesDir)) {
+        if (workspaces?.some(isPackagesWorkspaceEntry) && (start === current || isInsidePackagesDir)) {
           return current;
         }
       } catch {
@@ -66,6 +66,11 @@ function findWorkspaceRoot(start: string): string | undefined {
     }
     current = parent;
   }
+}
+
+function isPackagesWorkspaceEntry(entry: string): boolean {
+  const normalized = entry.replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  return normalized === 'packages/*';
 }
 
 /**

--- a/packages/franken-orchestrator/tests/unit/cli/project-root.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/project-root.test.ts
@@ -40,6 +40,18 @@ describe('project-root', () => {
 
       expect(resolveProjectRoot(packageDir)).toBe(repoRoot);
     });
+
+    it('normalizes workspace entries when walking up from a workspace package directory', () => {
+      const repoRoot = resolve(testDir, 'repo');
+      const packageDir = resolve(repoRoot, 'packages/franken-orchestrator');
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        resolve(repoRoot, 'package.json'),
+        JSON.stringify({ private: true, workspaces: ['./packages/*'] }),
+      );
+
+      expect(resolveProjectRoot(packageDir)).toBe(repoRoot);
+    });
   });
 
   describe('getProjectPaths', () => {


### PR DESCRIPTION
Closes #1953

## Summary
- Normalize workspace entries before detecting the repo root from package cwd
- Add regression coverage for `./packages/*` workspace entries

## Test plan
- `npm run test --workspace @franken/orchestrator -- --run tests/unit/cli/project-root.test.ts`

Notes: fbeast MCP tools were not available in this worker, so I used normal terminal/file/git/gh verification.