### PR TITLE
fix(orchestrator): harden browser control cookie mutations

### DIFF
--- a/docs/adr/034-control-plane-operator-auth.md
+++ b/docs/adr/034-control-plane-operator-auth.md
@@ -51,7 +51,13 @@ Consistent with ADR-034, the gate is conditional on an operator token being
 configured; `startChatServer` independently fails closed by refusing to expose
 a server (managed mode or non-loopback host) when no token is set. Requests
 that present no token or an incorrect token are rejected with `401` via
-`TransportSecurityService.verifyOperatorToken` (constant-time comparison).
+`TransportSecurityService.verifyOperatorToken` (constant-time comparison). When
+browser clients authenticate through the HttpOnly operator cookie, unsafe
+methods (`POST`/`PATCH`/`PUT`/`DELETE`) also require a same-origin `Origin`
+header and reject non-`same-origin` Fetch Metadata signals such as
+`Sec-Fetch-Site: cross-site`, `same-site`, or `none`. Bearer-token clients keep
+working for CLI/API automation; the extra browser-cookie check is a CSRF-style
+mutation guard, not a replacement for operator tokens.
 
 ## Consequences
 

--- a/docs/adr/034-control-plane-operator-auth.md
+++ b/docs/adr/034-control-plane-operator-auth.md
@@ -55,7 +55,11 @@ that present no token or an incorrect token are rejected with `401` via
 browser clients authenticate through the HttpOnly operator cookie, unsafe
 methods (`POST`/`PATCH`/`PUT`/`DELETE`) also require a same-origin `Origin`
 header and reject non-`same-origin` Fetch Metadata signals such as
-`Sec-Fetch-Site: cross-site`, `same-site`, or `none`. Bearer-token clients keep
+`Sec-Fetch-Site: cross-site`, `same-site`, or `none`. For TLS-terminated
+reverse proxies, `x-forwarded-proto` and `x-forwarded-host` are honored when
+checking the external same-origin URL so legitimate HTTPS dashboard posts are
+not downgraded to the internal Node `http://` adapter origin. Bearer-token
+clients keep
 working for CLI/API automation; the extra browser-cookie check is a CSRF-style
 mutation guard, not a replacement for operator tokens.
 

--- a/packages/franken-orchestrator/src/http/operator-auth.ts
+++ b/packages/franken-orchestrator/src/http/operator-auth.ts
@@ -45,8 +45,8 @@ export function isCookieOperatorAuthAllowed(options: {
     return true;
   }
 
-  if (options.secFetchSite) {
-    return options.secFetchSite === 'same-origin' || options.secFetchSite === 'none';
+  if (options.secFetchSite && options.secFetchSite !== 'same-origin') {
+    return false;
   }
 
   if (!options.origin) {

--- a/packages/franken-orchestrator/src/http/operator-auth.ts
+++ b/packages/franken-orchestrator/src/http/operator-auth.ts
@@ -35,11 +35,26 @@ function isUnsafeMethod(method: string): boolean {
   return !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(method.toUpperCase());
 }
 
+function originFromRequestUrl(requestUrl: string, forwardedProto?: string | undefined, forwardedHost?: string | undefined): string {
+  const url = new URL(requestUrl);
+  const proto = forwardedProto?.split(',')[0]?.trim().toLowerCase();
+  const host = forwardedHost?.split(',')[0]?.trim();
+  if (proto === 'http' || proto === 'https') {
+    url.protocol = `${proto}:`;
+  }
+  if (host) {
+    url.host = host;
+  }
+  return url.origin;
+}
+
 export function isCookieOperatorAuthAllowed(options: {
   method: string;
   origin?: string | undefined;
   requestUrl: string;
   secFetchSite?: string | undefined;
+  forwardedProto?: string | undefined;
+  forwardedHost?: string | undefined;
 }): boolean {
   if (!isUnsafeMethod(options.method)) {
     return true;
@@ -54,7 +69,11 @@ export function isCookieOperatorAuthAllowed(options: {
   }
 
   try {
-    return new URL(options.origin).origin === new URL(options.requestUrl).origin;
+    return new URL(options.origin).origin === originFromRequestUrl(
+      options.requestUrl,
+      options.forwardedProto,
+      options.forwardedHost,
+    );
   } catch {
     return false;
   }
@@ -73,6 +92,8 @@ export function requireOperatorAuth(options: OperatorAuthOptions) {
       origin: c.req.header('origin'),
       requestUrl: c.req.url,
       secFetchSite: c.req.header('sec-fetch-site'),
+      forwardedProto: c.req.header('x-forwarded-proto'),
+      forwardedHost: c.req.header('x-forwarded-host'),
     })) {
       throw new HttpError(403, 'FORBIDDEN', 'Cookie operator authentication requires a same-origin request');
     }

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -45,6 +45,8 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
       origin: c.req.header('origin'),
       requestUrl: c.req.url,
       secFetchSite: c.req.header('sec-fetch-site'),
+      forwardedProto: c.req.header('x-forwarded-proto'),
+      forwardedHost: c.req.header('x-forwarded-host'),
     })) {
       return c.json({ error: { code: 'FORBIDDEN', message: 'Cookie operator authentication requires a same-origin request' } }, 403);
     }

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -53,6 +53,8 @@ function authenticateTicketRequest(c: Context, operatorToken: string): Response 
     origin: c.req.header('origin'),
     requestUrl: c.req.url,
     secFetchSite: c.req.header('sec-fetch-site'),
+    forwardedProto: c.req.header('x-forwarded-proto'),
+    forwardedHost: c.req.header('x-forwarded-host'),
   })) {
     return c.json({ error: { code: 'FORBIDDEN', message: 'Cookie operator authentication requires a same-origin request' } }, 403);
   }

--- a/packages/franken-orchestrator/src/http/sse.ts
+++ b/packages/franken-orchestrator/src/http/sse.ts
@@ -99,6 +99,8 @@ function hasValidStreamCredential(
     origin: c.req.header('origin'),
     requestUrl: c.req.url,
     secFetchSite: c.req.header('sec-fetch-site'),
+    forwardedProto: c.req.header('x-forwarded-proto'),
+    forwardedHost: c.req.header('x-forwarded-host'),
   })) {
     return false;
   }

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -90,6 +90,26 @@ describe('Beast SSE routes', () => {
     expect(body.ticket).toBeDefined();
   });
 
+  it('POST /v1/beasts/events/ticket accepts proxied HTTPS same-origin operator cookies', async () => {
+    const ctx = createSseApp();
+    ticketStore = ctx.ticketStore;
+
+    const res = await ctx.app.request('http://internal.local/v1/beasts/events/ticket', {
+      method: 'POST',
+      headers: {
+        cookie: `frankenbeast_operator_token=${OPERATOR_TOKEN}`,
+        origin: 'https://dashboard.example.com',
+        'sec-fetch-site': 'same-origin',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'dashboard.example.com',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ticket).toBeDefined();
+  });
+
   it('POST /v1/beasts/events/ticket rejects cross-origin operator cookies', async () => {
     const ctx = createSseApp();
     ticketStore = ctx.ticketStore;

--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -115,6 +115,40 @@ describe('control-plane operator auth', () => {
     }
   });
 
+  describe('rejects browser cookie mutations without same-origin proof', () => {
+    it('denies network mutations when cookie auth lacks an Origin header', async () => {
+      const app = buildApp();
+      const res = await app.request('http://localhost/v1/network/start', {
+        method: 'POST',
+        headers: {
+          cookie: `frankenbeast_operator_token=${encodeURIComponent(OPERATOR_TOKEN)}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ target: 'dashboard-web' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: { code: 'FORBIDDEN' } });
+    });
+
+    it('denies cookie-authenticated mutations with Sec-Fetch-Site: none', async () => {
+      const app = buildApp();
+      const res = await app.request('http://localhost/v1/network/start', {
+        method: 'POST',
+        headers: {
+          cookie: `frankenbeast_operator_token=${encodeURIComponent(OPERATOR_TOKEN)}`,
+          origin: 'http://localhost',
+          'sec-fetch-site': 'none',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ target: 'dashboard-web' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: { code: 'FORBIDDEN' } });
+    });
+  });
+
   describe('authenticated requests pass the auth gate', () => {
     it('network status -> 200 with operator token', async () => {
       const app = buildApp();

--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -147,6 +147,23 @@ describe('control-plane operator auth', () => {
       expect(res.status).toBe(403);
       expect(await res.json()).toMatchObject({ error: { code: 'FORBIDDEN' } });
     });
+    it('accepts proxied HTTPS same-origin cookie mutations with forwarded proto and host', async () => {
+      const app = buildApp();
+      const res = await app.request('http://internal.local/v1/network/start', {
+        method: 'POST',
+        headers: {
+          cookie: `frankenbeast_operator_token=${encodeURIComponent(OPERATOR_TOKEN)}`,
+          origin: 'https://dashboard.example.com',
+          'sec-fetch-site': 'same-origin',
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'dashboard.example.com',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ target: 'dashboard-web' }),
+      });
+
+      expect(res.status).toBe(200);
+    });
   });
 
   describe('authenticated requests pass the auth gate', () => {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -144,6 +144,26 @@ describe('dashboard routes', () => {
       expect(body.ticket).toBeTruthy();
     });
 
+    it('POST /events/ticket accepts proxied HTTPS same-origin operator cookies', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+
+      const res = await app.request('http://internal.local/events/ticket', {
+        method: 'POST',
+        headers: {
+          cookie: `frankenbeast_operator_token=${TEST_DASHBOARD_TOKEN}`,
+          origin: 'https://dashboard.example.com',
+          'sec-fetch-site': 'same-origin',
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'dashboard.example.com',
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { ticket?: string };
+      expect(body.ticket).toBeTruthy();
+    });
+
     it('rejects raw streams without a ticket', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);

--- a/packages/franken-orchestrator/tests/unit/http/operator-auth.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/operator-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { extractOperatorTokenCookie, isCookieOperatorAuthAllowed, requireOperatorAuth } from '../../../src/http/operator-auth.js';
 import { errorHandler } from '../../../src/http/middleware.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
@@ -12,7 +12,7 @@ describe('operator auth', () => {
   it('accepts operator auth from cookies without exposing bearer headers to browser code', async () => {
     const app = new Hono();
     app.use('/v1/chat/*', requireOperatorAuth({ operatorToken: 'op-secret', security: new TransportSecurityService() }));
-    app.post('/v1/chat/sessions', (c) => c.json({ ok: true }));
+    app.post('/v1/chat/sessions', (c: Context) => c.json({ ok: true }));
 
     const res = await app.request('/v1/chat/sessions', {
       method: 'POST',
@@ -29,7 +29,7 @@ describe('operator auth', () => {
     const app = new Hono();
     app.use('/v1/network/*', requireOperatorAuth({ operatorToken: 'op-secret', security: new TransportSecurityService() }));
     app.onError(errorHandler);
-    app.post('/v1/network/up', (c) => c.json({ ok: true }));
+    app.post('/v1/network/up', (c: Context) => c.json({ ok: true }));
 
     const res = await app.request('/v1/network/up', {
       method: 'POST',
@@ -46,7 +46,7 @@ describe('operator auth', () => {
     const app = new Hono();
     app.use('/v1/network/*', requireOperatorAuth({ operatorToken: 'op-secret', security: new TransportSecurityService() }));
     app.onError(errorHandler);
-    app.post('/v1/network/up', (c) => c.json({ ok: true }));
+    app.post('/v1/network/up', (c: Context) => c.json({ ok: true }));
 
     const res = await app.request('http://localhost/v1/network/up', {
       method: 'POST',
@@ -59,16 +59,29 @@ describe('operator auth', () => {
     expect(res.status).toBe(200);
   });
 
-  it('uses Sec-Fetch-Site as the cookie auth origin signal when present', () => {
+  it('requires both a same-origin Origin header and a safe fetch-site signal for cookie mutations', () => {
     expect(isCookieOperatorAuthAllowed({
       method: 'POST',
       requestUrl: 'http://localhost/v1/network/up',
+      origin: 'http://localhost',
       secFetchSite: 'same-origin',
     })).toBe(true);
     expect(isCookieOperatorAuthAllowed({
       method: 'POST',
       requestUrl: 'http://localhost/v1/network/up',
+      origin: 'http://localhost',
       secFetchSite: 'cross-site',
+    })).toBe(false);
+    expect(isCookieOperatorAuthAllowed({
+      method: 'POST',
+      requestUrl: 'http://localhost/v1/network/up',
+      origin: 'http://localhost',
+      secFetchSite: 'none',
+    })).toBe(false);
+    expect(isCookieOperatorAuthAllowed({
+      method: 'POST',
+      requestUrl: 'http://localhost/v1/network/up',
+      secFetchSite: 'same-origin',
     })).toBe(false);
   });
 
@@ -76,7 +89,7 @@ describe('operator auth', () => {
     const app = new Hono();
     app.use('/v1/chat/*', requireOperatorAuth({ operatorToken: 'op-secret', security: new TransportSecurityService() }));
     app.onError(errorHandler);
-    app.post('/v1/chat/sessions', (c) => c.json({ ok: true }));
+    app.post('/v1/chat/sessions', (c: Context) => c.json({ ok: true }));
 
     const res = await app.request('/v1/chat/sessions', { method: 'POST' });
 

--- a/packages/franken-orchestrator/tests/unit/http/operator-auth.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/operator-auth.test.ts
@@ -80,6 +80,14 @@ describe('operator auth', () => {
     })).toBe(false);
     expect(isCookieOperatorAuthAllowed({
       method: 'POST',
+      requestUrl: 'http://internal.local/v1/network/up',
+      origin: 'https://dashboard.example.com',
+      secFetchSite: 'same-origin',
+      forwardedProto: 'https',
+      forwardedHost: 'dashboard.example.com',
+    })).toBe(true);
+    expect(isCookieOperatorAuthAllowed({
+      method: 'POST',
       requestUrl: 'http://localhost/v1/network/up',
       secFetchSite: 'same-origin',
     })).toBe(false);


### PR DESCRIPTION
## Summary
- hardens HttpOnly operator-cookie auth so browser-originated control-plane mutations require a same-origin `Origin` header
- rejects unsafe cookie-authenticated mutations when Fetch Metadata reports a non-same-origin site, including `Sec-Fetch-Site: none`
- documents the browser-cookie CSRF-style mutation guard in ADR-034

## Test Plan
- `npm --workspace @franken/orchestrator test -- --run tests/unit/http/operator-auth.test.ts tests/integration/http/control-plane-auth.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run lint` (passes with pre-existing warnings)
- `npm --workspace @franken/orchestrator run build`

Closes #1796
