### PR TITLE
fix(mcp-suite): harden generated hook shell assignments

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook-scripts.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-scripts.ts
@@ -10,6 +10,10 @@ function shellSingleQuote(value: string): string {
   return `'${value.split(`'`).join(`'\\''`)}'`;
 }
 
+// Generated hook scripts are executed by POSIX shells. Values written into
+// shell assignments must use single-quote escaping; JSON double-quoted strings
+// still allow command substitution and variable expansion in shell contexts.
+
 export interface HookScriptPaths {
   preTool: string;
   postTool: string;
@@ -73,7 +77,7 @@ if [[ "$DB_PATH" != /* ]]; then
     SEARCH_DIR="$PARENT_DIR"
   done
 fi
-NODE_BIN=${JSON.stringify(process.execPath)}
+NODE_BIN=${shellSingleQuote(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
@@ -140,7 +144,7 @@ if [[ "$DB_PATH" != /* ]]; then
     SEARCH_DIR="$PARENT_DIR"
   done
 fi
-NODE_BIN=${JSON.stringify(process.execPath)}
+NODE_BIN=${shellSingleQuote(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
@@ -199,7 +203,7 @@ if [[ "$DB_PATH" != /* ]]; then
     SEARCH_DIR="$PARENT_DIR"
   done
 fi
-NODE_BIN=${JSON.stringify(process.execPath)}
+NODE_BIN=${shellSingleQuote(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
@@ -265,7 +269,7 @@ if [[ "$DB_PATH" != /* ]]; then
     SEARCH_DIR="$PARENT_DIR"
   done
 fi
-NODE_BIN=${JSON.stringify(process.execPath)}
+NODE_BIN=${shellSingleQuote(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0
@@ -324,7 +328,7 @@ if [[ "$DB_PATH" != /* ]]; then
     SEARCH_DIR="$PARENT_DIR"
   done
 fi
-NODE_BIN=${JSON.stringify(process.execPath)}
+NODE_BIN=${shellSingleQuote(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT=$(cat)
@@ -391,7 +395,7 @@ if [[ "$DB_PATH" != /* ]]; then
     SEARCH_DIR="$PARENT_DIR"
   done
 fi
-NODE_BIN=${JSON.stringify(process.execPath)}
+NODE_BIN=${shellSingleQuote(process.execPath)}
 HOOK_TIMEOUT_SECONDS="\${FBEAST_HOOK_TIMEOUT_SECONDS:-2}"
 
 INPUT_FILE=$(mktemp -t fbeast-hook-input.XXXXXX) || exit 0

--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -675,4 +675,33 @@ describe('fbeast init', () => {
     expect(hooks.hooks.PostToolUse[0].hooks[0].command).toBe(shellQuote(postScript));
     expect(readFileSync(preScript, 'utf-8')).toContain('fbeast-hook pre-tool');
   });
+
+  it('single-quotes shell assignment values in generated helper scripts', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const claudeDir = join(root, '.claude');
+    const geminiDir = join(root, '.gemini');
+    const mockSpawn = () => ({ status: 0 });
+
+    runInit({ root, claudeDir, hooks: true, client: 'claude' });
+    runInit({ root, claudeDir: geminiDir, hooks: true, client: 'gemini' });
+    runInit({ root, claudeDir: join(root, '.codex'), hooks: true, client: 'codex', spawn: mockSpawn });
+
+    const scripts = [
+      join(root, '.fbeast', 'hooks', 'fbeast-claude-pre-tool.sh'),
+      join(root, '.fbeast', 'hooks', 'fbeast-claude-post-tool.sh'),
+      join(root, '.fbeast', 'hooks', 'gemini-before-tool.sh'),
+      join(root, '.fbeast', 'hooks', 'gemini-after-tool.sh'),
+      join(root, '.codex', 'hooks', 'fbeast-codex-pre-tool.sh'),
+      join(root, '.codex', 'hooks', 'fbeast-codex-post-tool.sh'),
+    ];
+
+    for (const script of scripts) {
+      const content = readFileSync(script, 'utf-8');
+      expect(content).toContain(`NODE_BIN=${shellQuote(process.execPath)}`);
+      expect(content).not.toContain(`NODE_BIN=${JSON.stringify(process.execPath)}`);
+      expect(content).not.toMatch(/^DB_PATH="/m);
+      expect(content).not.toMatch(/^NODE_BIN="/m);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- hardens generated Claude/Gemini/Codex hook helper scripts by single-quoting shell assignment values instead of JSON double-quoting them
- adds regression coverage that verifies generated helper scripts do not emit double-quoted `NODE_BIN`/`DB_PATH` shell assignments

## Test Plan
- [x] `npm test -- --run src/cli/init.test.ts` (from `packages/franken-mcp-suite`)
- [x] `npm run lint` (from `packages/franken-mcp-suite`)
- [x] `npx turbo run build --filter=@franken/mcp-suite`
- [x] `npx turbo run typecheck --filter=@franken/mcp-suite`
- [x] `npm run lint:security`
- [x] `npm run check:package-manager`

Closes #1795
