### PR TITLE
fix(security): harden token comparisons

### DIFF
--- a/docs/guides/security-token-comparison.md
+++ b/docs/guides/security-token-comparison.md
@@ -1,0 +1,8 @@
+# Token comparison hardening
+
+Use the repo's constant-time token helpers whenever comparing operator, webhook verification, bearer, or other shared-secret tokens supplied by an HTTP client.
+
+- `@franken/orchestrator` exposes `constantTimeTokenEqual()` from `src/http/security/constant-time.ts` for control-plane and webhook token checks.
+- `@franken/critique` routes bearer Authorization checks through `timingSafeBearerTokenMatches()` in `src/server/token-auth.ts`.
+- Do not compare client-supplied secret tokens with `===`, `!==`, prefix checks, or early-return length checks. The helpers hash both sides to fixed-length digests and use `timingSafeEqual`, then require the original lengths to match before accepting.
+- Missing, malformed, partial, or wrong-scheme tokens must fail closed with the existing 401/403 responses; never log token values when reporting authentication failures.

--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import type { CritiquePipeline } from '../pipeline/critique-pipeline.js';
 import { wallClockNow } from '@franken/types';
+import { timingSafeBearerTokenMatches } from './token-auth.js';
 
 const ReviewRequestSchema = z.object({
   code: z.string(),
@@ -20,10 +21,11 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
   const requestCounts = new Map<string, { count: number; resetAt: number }>();
 
   // Bearer auth middleware
-  if (options.bearerToken) {
+  const bearerToken = options.bearerToken;
+  if (bearerToken) {
     app.use('/v1/*', async (c, next) => {
       const auth = c.req.header('Authorization');
-      if (!auth || auth !== `Bearer ${options.bearerToken}`) {
+      if (!timingSafeBearerTokenMatches(auth, bearerToken)) {
         return c.json({ error: { message: 'Unauthorized', type: 'auth_error' } }, 401);
       }
       return next();

--- a/packages/franken-critique/src/server/token-auth.ts
+++ b/packages/franken-critique/src/server/token-auth.ts
@@ -1,0 +1,18 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+function tokenDigest(token: string): Buffer {
+  return createHash('sha256').update(token, 'utf8').digest();
+}
+
+function constantTimeTokenEqual(providedToken: string, expectedToken: string): boolean {
+  const providedDigest = tokenDigest(providedToken);
+  const expectedDigest = tokenDigest(expectedToken);
+  const digestsMatch = timingSafeEqual(providedDigest, expectedDigest);
+  return digestsMatch && providedToken.length === expectedToken.length;
+}
+
+/** Compare an Authorization header to the configured bearer token without a raw string equality check. */
+export function timingSafeBearerTokenMatches(authHeader: string | undefined, bearerToken: string): boolean {
+  if (!authHeader) return false;
+  return constantTimeTokenEqual(authHeader, `Bearer ${bearerToken}`);
+}

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createCritiqueApp } from '../../../src/server/app.js';
+import { timingSafeBearerTokenMatches } from '../../../src/server/token-auth.js';
 import { CritiquePipeline } from '../../../src/pipeline/critique-pipeline.js';
 import type { Evaluator, EvaluationInput, EvaluationResult } from '../../../src/types/evaluation.js';
 
@@ -101,6 +102,12 @@ describe('Critique Hono Server', () => {
   });
 
   describe('auth', () => {
+    it('compares bearer tokens through a timing-safe helper', () => {
+      expect(timingSafeBearerTokenMatches('Bearer secret-token', 'secret-token')).toBe(true);
+      expect(timingSafeBearerTokenMatches('Bearer secret-token', 'secret-token-extra')).toBe(false);
+      expect(timingSafeBearerTokenMatches('Basic secret-token', 'secret-token')).toBe(false);
+    });
+
     it('returns 401 without bearer token', async () => {
       const app = createCritiqueApp({ bearerToken: 'secret-token', pipeline: makePipeline() });
       const res = await app.request('/v1/review', {

--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -1,4 +1,5 @@
-import { randomUUID, timingSafeEqual } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
+import { constantTimeTokenEqual } from '../../http/security/constant-time.js';
 interface TicketEntry {
   token: string;
   scope?: string | undefined;
@@ -104,13 +105,7 @@ export class SseConnectionTicketStore {
       return 'invalid';
     }
 
-    const bufA = Buffer.from(entry.token);
-    const bufB = Buffer.from(operatorToken);
-    if (bufA.length !== bufB.length) {
-      return 'invalid';
-    }
-
-    if (!timingSafeEqual(bufA, bufB)) {
+    if (!constantTimeTokenEqual(operatorToken, entry.token)) {
       return 'invalid';
     }
 

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-router.ts
@@ -3,6 +3,7 @@ import { whatsappSignatureMiddleware } from '../../security/whatsapp-signature.j
 import { WhatsAppWebhookSchema } from './whatsapp-schemas.js';
 import type { ChatGateway } from '../../gateway/chat-gateway.js';
 import type { SessionMapper } from '../../core/session-mapper.js';
+import { constantTimeTokenEqual } from '../../../http/security/constant-time.js';
 
 export interface WhatsAppRouterOptions {
   gateway: ChatGateway;
@@ -22,7 +23,7 @@ export function whatsappRouter(options: WhatsAppRouterOptions) {
     const token = c.req.query('hub.verify_token');
     const challenge = c.req.query('hub.challenge');
 
-    if (mode === 'subscribe' && token === verifyToken) {
+    if (mode === 'subscribe' && token && constantTimeTokenEqual(token, verifyToken)) {
       return c.text(challenge || '');
     }
     return c.json({ error: 'Forbidden' }, 403);

--- a/packages/franken-orchestrator/src/http/security/constant-time.ts
+++ b/packages/franken-orchestrator/src/http/security/constant-time.ts
@@ -1,0 +1,19 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+function tokenDigest(token: string): Buffer {
+  return createHash('sha256').update(token, 'utf8').digest();
+}
+
+/**
+ * Compare untrusted token strings without short-circuiting on length or prefix.
+ *
+ * The raw token lengths still determine whether the match is accepted, but the
+ * equality check always compares fixed-length SHA-256 digests with
+ * timingSafeEqual so mismatches do not leak how much of the token matched.
+ */
+export function constantTimeTokenEqual(providedToken: string, expectedToken: string): boolean {
+  const providedDigest = tokenDigest(providedToken);
+  const expectedDigest = tokenDigest(expectedToken);
+  const digestsMatch = timingSafeEqual(providedDigest, expectedDigest);
+  return digestsMatch && providedToken.length === expectedToken.length;
+}

--- a/packages/franken-orchestrator/src/http/security/transport-security.ts
+++ b/packages/franken-orchestrator/src/http/security/transport-security.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import { wallClockNow } from '@franken/types';
+import { constantTimeTokenEqual } from './constant-time.js';
 export interface IssueSignedTokenOptions {
   expiresInMs?: number;
   secret: string;
@@ -38,12 +39,6 @@ function isCanonicalBase64Url(input: string): boolean {
 
 function signatureFor(payload: string, secret: string): Buffer {
   return createHmac('sha256', secret).update(payload).digest();
-}
-
-function timingSafeStringMatch(left: string, right: string): boolean {
-  const leftBuffer = Buffer.from(left);
-  const rightBuffer = Buffer.from(right);
-  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
 }
 
 export class TransportSecurityService {
@@ -95,7 +90,7 @@ export class TransportSecurityService {
     if (!providedToken) {
       return false;
     }
-    return timingSafeStringMatch(providedToken, expectedToken);
+    return constantTimeTokenEqual(providedToken, expectedToken);
   }
 
   verifySocketRequest(options: VerifySocketRequestOptions) {

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-router.test.ts
@@ -39,6 +39,14 @@ describe('whatsappRouter', () => {
     expect(await res.text()).toBe('123');
   });
 
+  it('rejects verification challenges with malformed or partial tokens', async () => {
+    const tooShort = await app.request('/webhook?hub.mode=subscribe&hub.verify_token=TEST_WHATSAPP&hub.challenge=123');
+    expect(tooShort.status).toBe(403);
+
+    const wrongScheme = await app.request(`/webhook?hub.mode=unsubscribe&hub.verify_token=${encodeURIComponent(verifyToken)}&hub.challenge=123`);
+    expect(wrongScheme.status).toBe(403);
+  });
+
   it('routes incoming text message to gateway', async () => {
     const body = JSON.stringify({
       object: 'whatsapp_business_account',

--- a/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { constantTimeTokenEqual } from '../../../src/http/security/constant-time.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 
 describe('TransportSecurityService', () => {
+  it('uses a digest-backed constant-time token comparator for unequal length tokens', () => {
+    expect(constantTimeTokenEqual('operator-token-123', 'operator-token-123')).toBe(true);
+    expect(constantTimeTokenEqual('operator-token-123', 'operator-token-12')).toBe(false);
+    expect(constantTimeTokenEqual('operator-token-123', '')).toBe(false);
+  });
+
   it('allows signed websocket requests without an Origin header', () => {
     const security = new TransportSecurityService();
     const secret = security.createSecret();


### PR DESCRIPTION
## Summary
- add fixed-digest constant-time token comparison for orchestrator control-plane tokens
- route SSE ticket, operator token, and WhatsApp verify-token checks through timing-safe helpers
- harden critique bearer auth comparison and document token-comparison guidance

## Test Plan
- npm --workspace @franken/orchestrator test -- --run tests/unit/http/transport-security.test.ts tests/unit/beasts/events/sse-connection-ticket.test.ts tests/unit/comms/whatsapp-router.test.ts
- npm --workspace @franken/critique test -- --run tests/unit/server/app.test.ts
- npm --workspace @franken/orchestrator run lint -- src/http/security/constant-time.ts src/http/security/transport-security.ts src/beasts/events/sse-connection-ticket.ts src/comms/channels/whatsapp/whatsapp-router.ts tests/unit/http/transport-security.test.ts tests/unit/beasts/events/sse-connection-ticket.test.ts tests/unit/comms/whatsapp-router.test.ts (0 errors; pre-existing warnings elsewhere)
- npm --workspace @franken/critique run lint -- src/server/app.ts src/server/token-auth.ts tests/unit/server/app.test.ts
- git diff --check

## Notes
- Package typecheck currently reports pre-existing workspace export/dependency diagnostics such as @franken/types missing wallClockNow; changed files only surface those existing imports, not new token-comparison diagnostics.

Closes #1797