### PR TITLE
fix(orchestrator): cap context snapshot imports

### DIFF
--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -68,6 +68,10 @@ npm run test:coverage --workspace=@franken/orchestrator
 
 Integration and E2E scripts enable broader runtime paths with `INTEGRATION=true` or `E2E=true`; use them when the needed local services, credentials, and fixtures are available.
 
+## Security limits
+
+Context snapshot imports are size-limited before JSON parsing to reduce resource-exhaustion risk from untrusted or corrupted resume/import files. `loadContext(filePath)` defaults to a 1 MiB cap, opens snapshots in nonblocking mode, rejects non-regular paths from the opened file descriptor, and enforces the same byte cap while reading so oversized content is rejected even if the file changes after metadata inspection. Trusted tooling that intentionally owns a larger snapshot must opt in per import with `loadContext(filePath, { maxBytes })`; invalid overrides such as `0`, negative, non-finite, or unsafe integer values fail closed.
+
 ## Package areas
 
 | Area | Paths | Responsibility |

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -153,8 +153,11 @@ export {
   deserializeContext,
   saveContext,
   loadContext,
+  ContextSnapshotSizeError,
+  ContextSnapshotFileTypeError,
+  DEFAULT_CONTEXT_SNAPSHOT_MAX_BYTES,
 } from './resilience/context-serializer.js';
-export type { ContextSnapshot } from './resilience/context-serializer.js';
+export type { ContextSnapshot, LoadContextOptions } from './resilience/context-serializer.js';
 export { GracefulShutdown } from './resilience/graceful-shutdown.js';
 export type { ShutdownHandler } from './resilience/graceful-shutdown.js';
 export { checkModuleHealth, allHealthy } from './resilience/module-initializer.js';

--- a/packages/franken-orchestrator/src/resilience/context-serializer.ts
+++ b/packages/franken-orchestrator/src/resilience/context-serializer.ts
@@ -1,4 +1,5 @@
-import { writeFile, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { writeFile, open } from 'node:fs/promises';
 import { BeastContext, type AuditEntry } from '../context/franken-context.js';
 import type { BeastPhase } from '../types.js';
 import type { PlanGraph } from '../deps.js';
@@ -33,6 +34,36 @@ export interface SerializedError {
   readonly name: string;
   readonly message: string;
   readonly stack?: string | undefined;
+}
+
+export const DEFAULT_CONTEXT_SNAPSHOT_MAX_BYTES = 1024 * 1024;
+
+export interface LoadContextOptions {
+  /**
+   * Maximum import size for a serialized context snapshot. The default fails
+   * closed at 1 MiB to avoid resource exhaustion from untrusted or corrupted
+   * resume/import files; callers that intentionally own larger snapshots must
+   * opt in explicitly for that import.
+   */
+  readonly maxBytes?: number | undefined;
+}
+
+export class ContextSnapshotSizeError extends Error {
+  constructor(
+    public readonly filePath: string,
+    public readonly actualBytes: number,
+    public readonly maxBytes: number,
+  ) {
+    super(`Context snapshot import is ${actualBytes} bytes, exceeding the configured ${maxBytes} byte limit`);
+    this.name = 'ContextSnapshotSizeError';
+  }
+}
+
+export class ContextSnapshotFileTypeError extends Error {
+  constructor(public readonly filePath: string) {
+    super('Context snapshot import path must be a regular file');
+    this.name = 'ContextSnapshotFileTypeError';
+  }
 }
 
 /** Serialize a BeastContext to a JSON snapshot. */
@@ -96,9 +127,52 @@ export async function saveContext(ctx: BeastContext, filePath: string): Promise<
   await writeFile(filePath, JSON.stringify(snapshot, null, 2), 'utf-8');
 }
 
-/** Load context snapshot from a file. */
-export async function loadContext(filePath: string): Promise<BeastContext> {
-  const raw = await readFile(filePath, 'utf-8');
+function normalizeMaxBytes(maxBytes: number | undefined): number {
+  const resolved = maxBytes ?? DEFAULT_CONTEXT_SNAPSHOT_MAX_BYTES;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError('Context snapshot import maxBytes must be a positive safe integer');
+  }
+  return resolved;
+}
+
+/** Load context snapshot from a size-limited JSON file. */
+export async function loadContext(filePath: string, options: LoadContextOptions = {}): Promise<BeastContext> {
+  const maxBytes = normalizeMaxBytes(options.maxBytes);
+  const raw = await readRegularFileWithinLimit(filePath, maxBytes);
   const snapshot: ContextSnapshot = JSON.parse(raw);
   return deserializeContext(snapshot);
+}
+
+async function readRegularFileWithinLimit(filePath: string, maxBytes: number): Promise<string> {
+  const handle = await open(filePath, constants.O_RDONLY | constants.O_NONBLOCK);
+  try {
+    const stats = await handle.stat();
+    if (!stats.isFile()) {
+      throw new ContextSnapshotFileTypeError(filePath);
+    }
+    if (stats.size > maxBytes) {
+      throw new ContextSnapshotSizeError(filePath, stats.size, maxBytes);
+    }
+
+    const chunks: Buffer[] = [];
+    const buffer = Buffer.alloc(Math.min(64 * 1024, maxBytes + 1));
+    let totalBytes = 0;
+
+    while (totalBytes <= maxBytes) {
+      const bytesToRead = Math.min(buffer.length, maxBytes + 1 - totalBytes);
+      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, null);
+      if (bytesRead === 0) {
+        return Buffer.concat(chunks, totalBytes).toString('utf-8');
+      }
+      totalBytes += bytesRead;
+      if (totalBytes > maxBytes) {
+        throw new ContextSnapshotSizeError(filePath, totalBytes, maxBytes);
+      }
+      chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+    }
+
+    throw new ContextSnapshotSizeError(filePath, totalBytes, maxBytes);
+  } finally {
+    await handle.close();
+  }
 }

--- a/packages/franken-orchestrator/tests/unit/resilience/context-serializer.test.ts
+++ b/packages/franken-orchestrator/tests/unit/resilience/context-serializer.test.ts
@@ -1,24 +1,36 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { unlink } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { promisify } from 'node:util';
 import { BeastContext } from '../../../src/context/franken-context.js';
 import {
   serializeContext,
   deserializeContext,
   saveContext,
   loadContext,
+  ContextSnapshotSizeError,
+  ContextSnapshotFileTypeError,
 } from '../../../src/resilience/context-serializer.js';
 
+const execFileAsync = promisify(execFile);
+
 describe('ContextSerializer', () => {
-  const tmpFiles: string[] = [];
+  const tmpDirs: string[] = [];
+  const fifoIt = process.platform === 'win32' ? it.skip : it;
 
   afterEach(async () => {
-    for (const f of tmpFiles) {
-      try { await unlink(f); } catch { /* ignore */ }
+    for (const dir of tmpDirs) {
+      await rm(dir, { recursive: true, force: true });
     }
-    tmpFiles.length = 0;
+    tmpDirs.length = 0;
   });
+
+  async function tempFile(name: string): Promise<string> {
+    const dir = await mkdtemp(join(process.cwd(), '.tmp-context-serializer-'));
+    tmpDirs.push(dir);
+    return join(dir, name);
+  }
 
   function makeContext(): BeastContext {
     const ctx = new BeastContext('proj-1', 'sess-1', 'Build a feature');
@@ -75,8 +87,7 @@ describe('ContextSerializer', () => {
 
   it('saves context to file and loads it back', async () => {
     const ctx = makeContext();
-    const filePath = join(tmpdir(), `beast-ctx-test-${Date.now()}.json`);
-    tmpFiles.push(filePath);
+    const filePath = await tempFile('beast-ctx-test.json');
 
     await saveContext(ctx, filePath);
     const restored = await loadContext(filePath);
@@ -85,6 +96,59 @@ describe('ContextSerializer', () => {
     expect(restored.sessionId).toBe(ctx.sessionId);
     expect(restored.phase).toBe(ctx.phase);
     expect(restored.plan?.tasks).toEqual(ctx.plan?.tasks);
+  });
+
+  it('rejects oversized context snapshot imports before parsing the body', async () => {
+    const ctx = makeContext();
+    const filePath = await tempFile('beast-ctx-oversized.json');
+
+    await saveContext(ctx, filePath);
+
+    await expect(loadContext(filePath, { maxBytes: 64 })).rejects.toBeInstanceOf(ContextSnapshotSizeError);
+    await expect(loadContext(filePath, { maxBytes: 64 })).rejects.toMatchObject({
+      name: 'ContextSnapshotSizeError',
+      maxBytes: 64,
+    });
+  });
+
+  it('rejects non-regular context snapshot import paths before reading', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.tmp-context-serializer-non-file-'));
+    tmpDirs.push(dir);
+
+    await expect(loadContext(dir)).rejects.toBeInstanceOf(ContextSnapshotFileTypeError);
+    await expect(loadContext(dir)).rejects.toMatchObject({
+      name: 'ContextSnapshotFileTypeError',
+      filePath: dir,
+    });
+  });
+
+  fifoIt('rejects FIFO context snapshot import paths without waiting for a writer', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.tmp-context-serializer-fifo-'));
+    tmpDirs.push(dir);
+    const fifoPath = join(dir, 'snapshot.fifo');
+    await execFileAsync('mkfifo', [fifoPath]);
+
+    await expect(loadContext(fifoPath)).rejects.toBeInstanceOf(ContextSnapshotFileTypeError);
+  });
+
+  it('allows explicit per-import size overrides for trusted large snapshots', async () => {
+    const ctx = makeContext();
+    const filePath = await tempFile('beast-ctx-large-allowed.json');
+
+    await saveContext(ctx, filePath);
+    await expect(loadContext(filePath, { maxBytes: 4096 })).resolves.toMatchObject({
+      projectId: ctx.projectId,
+      sessionId: ctx.sessionId,
+    });
+  });
+
+  it('fails closed for invalid context snapshot maxBytes overrides', async () => {
+    const filePath = await tempFile('beast-ctx-invalid-limit.json');
+
+    await saveContext(makeContext(), filePath);
+
+    await expect(loadContext(filePath, { maxBytes: 0 })).rejects.toThrow(RangeError);
+    await expect(loadContext(filePath, { maxBytes: Number.POSITIVE_INFINITY })).rejects.toThrow(RangeError);
   });
 
   it('round-trips recovery/error-handling fields', () => {


### PR DESCRIPTION
## Summary
- add a default 1 MiB pre-parse cap for context snapshot imports
- expose `ContextSnapshotSizeError`, `DEFAULT_CONTEXT_SNAPSHOT_MAX_BYTES`, and `LoadContextOptions` for explicit trusted overrides
- document the fail-closed snapshot import behavior

## Verification
- `TMPDIR=$PWD/.tmp npm test --workspace=@franken/orchestrator -- tests/unit/resilience/context-serializer.test.ts`
- `npm test --workspace=@franken/orchestrator -- --no-cache --pool=threads --maxWorkers=1 --no-file-parallelism tests/unit/resilience/context-serializer.test.ts`
- `npm run typecheck --workspace=@franken/orchestrator`
- `npm run build --workspace=@franken/orchestrator`

Closes #1798