### PR TITLE
test(governor): verify integration test selection

### DIFF
--- a/packages/franken-governor/tests/unit/vitest-selection.test.ts
+++ b/packages/franken-governor/tests/unit/vitest-selection.test.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageJsonPath = fileURLToPath(new URL('../../package.json', import.meta.url));
+const unitConfigPath = fileURLToPath(new URL('../../vitest.config.ts', import.meta.url));
+const integrationConfigPath = fileURLToPath(
+  new URL('../../vitest.integration.config.ts', import.meta.url),
+);
+const integrationTestPath = fileURLToPath(
+  new URL('../integration/full-approval-flow.test.ts', import.meta.url),
+);
+
+describe('governor Vitest suite selection', () => {
+  it('keeps default and coverage runs scoped to unit tests', () => {
+    const unitConfig = readFileSync(unitConfigPath, 'utf8');
+
+    expect(unitConfig).toContain("include: ['tests/unit/**/*.test.ts']");
+    expect(unitConfig).not.toContain('tests/integration');
+  });
+
+  it('exposes a dedicated integration test script, config, and suite', () => {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    const integrationConfig = readFileSync(integrationConfigPath, 'utf8');
+
+    expect(pkg.scripts['test:integration']).toBe(
+      'INTEGRATION=true vitest run --config vitest.integration.config.ts',
+    );
+    expect(integrationConfig).toContain("include: ['tests/integration/**/*.test.ts']");
+    expect(existsSync(integrationTestPath)).toBe(true);
+  });
+});

--- a/packages/franken-governor/vitest.config.ts
+++ b/packages/franken-governor/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    pool: 'threads',
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     include: ['tests/unit/**/*.test.ts'],

--- a/packages/franken-governor/vitest.integration.config.ts
+++ b/packages/franken-governor/vitest.integration.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     alias: createFrankenSourceAliases(import.meta.url),
   },
   test: {
+    pool: 'threads',
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     include: ['tests/integration/**/*.test.ts'],

--- a/tests/vitest-deterministic-mode.test.ts
+++ b/tests/vitest-deterministic-mode.test.ts
@@ -13,6 +13,7 @@ const VITEST_CONFIGS = [
   'packages/franken-critique/vitest.config.ts',
   'packages/franken-critique/vitest.integration.config.ts',
   'packages/franken-governor/vitest.config.ts',
+  'packages/franken-governor/vitest.integration.config.ts',
   'packages/live-bench/vitest.config.ts',
   'packages/franken-mcp-suite/vitest.config.ts',
   'packages/franken-observer/vitest.config.ts',

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -22,6 +22,7 @@ const PACKAGE_CONFIGS = [
   'packages/franken-brain/vitest.config.ts',
   'packages/franken-critique/vitest.config.ts',
   'packages/franken-governor/vitest.config.ts',
+  'packages/franken-governor/vitest.integration.config.ts',
   'packages/franken-mcp-suite/vitest.config.ts',
   'packages/franken-observer/vitest.config.ts',
   'packages/franken-orchestrator/vitest.config.ts',


### PR DESCRIPTION
## Summary
- Add governor Vitest suite-selection regression coverage so the package-level integration lane stays distinct from default unit tests.
- Ensure governor unit and integration Vitest configs use the thread pool in this environment, making `npm run test:integration --workspace=@franken/governor` execute the real integration suite instead of failing before tests load.
- Include governor integration config in shared root config wiring checks.

## Test Plan
- `npm run test:integration --workspace=@franken/governor`
- `npm run test --workspace=@franken/governor -- tests/unit/vitest-selection.test.ts`
- `npm run test:root -- tests/vitest-deterministic-mode.test.ts tests/vitest-package-source-aliases.test.ts --pool=threads`
- `npm run build --workspace=@franken/types`
- `npm run typecheck --workspace=@franken/governor`
- `npm run build --workspace=@franken/governor`
- `npm run lint --workspace=@franken/governor` (passes with existing warnings)
- `TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1963/.tmp npm test --workspace=@franken/governor`

Closes #1963