### PR TITLE
fix(orchestrator): route comms reject actions through slash command

### DIFF
--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -15,6 +15,7 @@ const SLASH_COMMANDS = new Set([
   '/status',
   '/diff',
   '/approve',
+  '/reject',
   '/session',
 ]);
 
@@ -117,7 +118,7 @@ export class ChatRuntime {
     const trimmed = input.trim();
     const command = trimmed.startsWith('/') ? trimmed.split(/\s+/)[0]?.toLowerCase() : undefined;
 
-    if (state.pendingApproval && !state.approvalResolved && command !== '/approve') {
+    if (state.pendingApproval && !state.approvalResolved && command !== '/approve' && command !== '/reject') {
       if (trimmed.toLowerCase().startsWith('action rejected by user:')) {
         return this.result({ ...state, pendingApproval: false }, [
           { kind: 'approval', content: 'Rejected.' },
@@ -222,6 +223,18 @@ export class ChatRuntime {
           },
         ], {
           state: state.pendingApproval ? 'approved' : 'active',
+        });
+      case '/reject':
+        return this.result({
+          ...state,
+          pendingApproval: false,
+        }, [
+          {
+            kind: state.pendingApproval ? 'approval' : 'status',
+            content: state.pendingApproval ? 'Rejected.' : 'Nothing pending.',
+          },
+        ], {
+          state: state.pendingApproval ? 'rejected' : 'active',
         });
       default:
         return this.result(state, []);

--- a/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
+++ b/packages/franken-orchestrator/src/comms/gateway/chat-gateway.ts
@@ -68,12 +68,11 @@ export class ChatGateway extends EventEmitter {
     routeMetadata?: Record<string, unknown>,
   ): Promise<void> {
     // Map action IDs to the appropriate slash command.
-    // /approve approves the pending action; rejection is a plain-text
-    // message that the runtime can interpret as declining.
+    // /approve approves the pending action; /reject denies it.
     const text =
       actionId === 'approve'
         ? '/approve'
-        : `Action rejected by user: ${actionId}`;
+        : '/reject';
 
     const cachedRouteMetadata = routeMetadata ?? this.getRememberedRouteMetadata(sessionId);
 

--- a/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
@@ -151,13 +151,13 @@ describe('chat runtime parity', () => {
     expect(result.displayMessages[0]?.content).toContain('Approval is pending');
   });
 
-  it('maps comms rejection action text to a rejected approval state', async () => {
+  it('maps /reject to a rejected approval state', async () => {
     const runtime = createChatRuntime({
       chatLlm: { complete: vi.fn().mockResolvedValue('chat ignored') },
       projectName: 'test-project',
     });
 
-    const result = await runtime.runtime.run('Action rejected by user: reject', {
+    const result = await runtime.runtime.run('/reject', {
       sessionId: 'session-1',
       pendingApproval: true,
       pendingApprovalDescription: 'deploy staging',

--- a/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/chat-gateway.test.ts
@@ -178,7 +178,7 @@ describe('ChatGateway', () => {
     );
   });
 
-  it('handleAction sends rejection text for reject action', async () => {
+  it('handleAction sends /reject for reject action', async () => {
     const slackAdapter = mockAdapter('slack');
     gateway.registerAdapter(slackAdapter);
 
@@ -187,7 +187,7 @@ describe('ChatGateway', () => {
     expect(runtime.processInbound).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'sess-1',
-        text: 'Action rejected by user: reject',
+        text: '/reject',
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add explicit /reject handling in the shared chat runtime
- route comms reject action callbacks to /reject instead of plain text
- update regression coverage for gateway and runtime reject behavior

## Test Plan
- TMPDIR=$PWD/.tmp npm run test --workspace @franken/orchestrator -- tests/unit/comms/chat-gateway.test.ts tests/unit/chat/runtime-parity.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && TMPDIR=$PWD/.tmp npm run typecheck --workspace @franken/orchestrator && TMPDIR=$PWD/.tmp npm run lint --workspace @franken/orchestrator && TMPDIR=$PWD/.tmp npm run build --workspace @franken/orchestrator
- TMPDIR=$PWD/.tmp npm run test --workspace @franken/orchestrator

Closes #1946