### PR TITLE
fix(orchestrator): reject stale approval chat input

### DIFF
--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -118,7 +118,9 @@ export class ChatRuntime {
     const trimmed = input.trim();
     const command = trimmed.startsWith('/') ? trimmed.split(/\s+/)[0]?.toLowerCase() : undefined;
 
-    if (state.pendingApproval && !state.approvalResolved && command !== '/approve' && command !== '/reject') {
+    const isApprovedReplay = state.approvalResolved === true && command === '/run';
+
+    if (state.pendingApproval && command !== '/approve' && command !== '/reject' && !isApprovedReplay) {
       if (trimmed.toLowerCase().startsWith('action rejected by user:')) {
         return this.result({ ...state, pendingApproval: false }, [
           { kind: 'approval', content: 'Rejected.' },

--- a/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
@@ -128,6 +128,32 @@ describe('chat runtime parity', () => {
     expect(engine.processTurn).not.toHaveBeenCalled();
   });
 
+  it('blocks stale normal chat turns even when a caller marks approval resolved', async () => {
+    const engine = { processTurn: vi.fn() };
+    const runner = new TurnRunner({ execute: vi.fn() });
+    const runtime = new ChatRuntime({
+      engine: engine as unknown as ConversationEngine,
+      turnRunner: runner,
+    });
+
+    const result = await runtime.run('please continue anyway', {
+      sessionId: 'session-1',
+      pendingApproval: true,
+      approvalResolved: true,
+      pendingApprovalDescription: 'deploy staging',
+      pendingApprovalContext: { tool: 'execution', command: 'deploy staging', sessionId: 'session-1' },
+      projectId: 'test-project',
+      transcript: [],
+    });
+
+    expect(result.state).toBe('pending_approval');
+    expect(result.pendingApproval).toBe(true);
+    expect(result.pendingApprovalDescription).toBe('deploy staging');
+    expect(result.pendingApprovalContext).toEqual(expect.objectContaining({ command: 'deploy staging' }));
+    expect(result.displayMessages[0]?.content).toContain('Approval is pending');
+    expect(engine.processTurn).not.toHaveBeenCalled();
+  });
+
   it('blocks mutating slash commands while approval is pending', async () => {
     const runtime = createChatRuntime({
       chatLlm: { complete: vi.fn().mockResolvedValue('chat ignored') },
@@ -149,6 +175,35 @@ describe('chat runtime parity', () => {
     expect(result.pendingApprovalDescription).toBe('deploy staging');
     expect(result.pendingApprovalContext).toEqual(expect.objectContaining({ command: 'deploy staging' }));
     expect(result.displayMessages[0]?.content).toContain('Approval is pending');
+  });
+
+  it('allows approved /run replay to resolve pending approval', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      status: 'success',
+      summary: 'deployed',
+      filesChanged: [],
+      testsRun: 0,
+      errors: [],
+    });
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+
+    const result = await runtime.run('/run deploy staging', {
+      sessionId: 'session-1',
+      pendingApproval: true,
+      approvalResolved: true,
+      pendingApprovalDescription: 'deploy staging',
+      pendingApprovalContext: { tool: 'execution', command: 'deploy staging', sessionId: 'session-1' },
+      projectId: 'test-project',
+      transcript: [],
+    });
+
+    expect(result.state).toBe('active');
+    expect(result.pendingApproval).toBe(false);
+    expect(result.displayMessages[0]).toMatchObject({ kind: 'execution', content: expect.stringContaining('deployed') });
+    expect(execute).toHaveBeenCalledWith({ userInput: 'deploy staging' });
   });
 
   it('maps /reject to a rejected approval state', async () => {


### PR DESCRIPTION
## Summary
- Narrows the pending-approval runtime bypass so only approved `/run` replay can proceed while `pendingApproval` is set.
- Keeps stale normal chat input rejected even when a caller accidentally carries `approvalResolved: true`.
- Adds regression coverage for stale normal input and the approved replay path.

## Test Plan
- [x] `TMPDIR=$PWD/.tmp-vitest npm run test --workspace @franken/orchestrator -- tests/unit/chat/runtime-parity.test.ts tests/unit/http/chat-routes-approval.test.ts --maxWorkers=1 --no-file-parallelism`
- [x] `npm run build --workspace @franken/types && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run typecheck --workspace @franken/orchestrator`
- [x] `npm run build --workspace @franken/orchestrator`
- [x] `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)

Closes #1947
