### PR TITLE
fix(governor): validate timeout and token TTL config

### DIFF
--- a/packages/franken-governor/src/core/config.ts
+++ b/packages/franken-governor/src/core/config.ts
@@ -8,6 +8,8 @@ export interface GovernorConfig {
 
 export type GovernorConfigOverrides = Partial<GovernorConfig>;
 
+export const MAX_TIMEOUT_MS = 2_147_483_647;
+
 export function defaultConfig(): GovernorConfig {
   return {
     timeoutMs: 300_000,
@@ -23,8 +25,15 @@ function assertPositiveFiniteNumber(value: number, fieldName: string): void {
   }
 }
 
+function assertWithinTimerLimit(value: number, fieldName: string): void {
+  if (value > MAX_TIMEOUT_MS) {
+    throw new RangeError(`${fieldName} must be less than or equal to ${MAX_TIMEOUT_MS}`);
+  }
+}
+
 export function validateGovernorConfig(config: GovernorConfig): GovernorConfig {
   assertPositiveFiniteNumber(config.timeoutMs, 'timeoutMs');
+  assertWithinTimerLimit(config.timeoutMs, 'timeoutMs');
   assertPositiveFiniteNumber(config.sessionTokenTtlMs, 'sessionTokenTtlMs');
   return config;
 }

--- a/packages/franken-governor/src/core/config.ts
+++ b/packages/franken-governor/src/core/config.ts
@@ -6,6 +6,8 @@ export interface GovernorConfig {
   readonly signingSecret?: string;
 }
 
+export type GovernorConfigOverrides = Partial<GovernorConfig>;
+
 export function defaultConfig(): GovernorConfig {
   return {
     timeoutMs: 300_000,
@@ -13,4 +15,23 @@ export function defaultConfig(): GovernorConfig {
     operatorName: 'operator',
     sessionTokenTtlMs: 3_600_000,
   };
+}
+
+function assertPositiveFiniteNumber(value: number, fieldName: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${fieldName} must be a positive finite number`);
+  }
+}
+
+export function validateGovernorConfig(config: GovernorConfig): GovernorConfig {
+  assertPositiveFiniteNumber(config.timeoutMs, 'timeoutMs');
+  assertPositiveFiniteNumber(config.sessionTokenTtlMs, 'sessionTokenTtlMs');
+  return config;
+}
+
+export function normalizeGovernorConfig(overrides: GovernorConfigOverrides = {}): GovernorConfig {
+  return validateGovernorConfig({
+    ...defaultConfig(),
+    ...overrides,
+  });
 }

--- a/packages/franken-governor/src/gateway/approval-gateway.ts
+++ b/packages/franken-governor/src/gateway/approval-gateway.ts
@@ -1,5 +1,5 @@
 import type { ApprovalRequest, ApprovalResponse, ApprovalOutcome } from '../core/types.js';
-import type { GovernorConfig } from '../core/config.js';
+import { validateGovernorConfig, type GovernorConfig } from '../core/config.js';
 import type { ApprovalChannel } from './approval-channel.js';
 import {
   formatApprovalResponseSignaturePayload,
@@ -45,6 +45,12 @@ export class ApprovalGateway {
   private readonly sessionTokenStore: SessionTokenStore | undefined;
 
   constructor(deps: ApprovalGatewayDeps) {
+    try {
+      validateGovernorConfig(deps.config);
+    } catch (error) {
+      throw new ApprovalConfigurationError((error as Error).message);
+    }
+
     try {
       assertValidSessionTokenTtl(deps.config.sessionTokenTtlMs);
     } catch (error) {

--- a/packages/franken-governor/src/gateway/governor-factory.ts
+++ b/packages/franken-governor/src/gateway/governor-factory.ts
@@ -7,13 +7,14 @@ import { GovernorAuditRecorder } from '../audit/audit-recorder.js';
 import { CliChannel, type ReadlineAdapter } from '../channels/cli-channel.js';
 import type { GovernorMemoryPort } from '../audit/governor-memory-port.js';
 import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
-import { defaultConfig, type GovernorConfig } from '../core/config.js';
+import { normalizeGovernorConfig, type GovernorConfig } from '../core/config.js';
 import type { SessionTokenStore } from '../security/session-token-store.js';
 import type { SignatureVerifier } from '../security/signature-verifier.js';
 import {
   createEvaluatorsFromApprovalPolicyManifest,
   type ApprovalPolicyManifest,
 } from '../security/approval-policy-manifest.js';
+import { ApprovalConfigurationError } from '../errors/index.js';
 
 export interface CreateGovernorOptions {
   readonly readline: ReadlineAdapter;
@@ -39,10 +40,12 @@ export interface CreateGovernorOptions {
 }
 
 export function createGovernor(options: CreateGovernorOptions): GovernorCritiqueAdapter {
-  const config: GovernorConfig = {
-    ...defaultConfig(),
-    ...options.config,
-  };
+  let config: GovernorConfig;
+  try {
+    config = normalizeGovernorConfig(options.config);
+  } catch (error) {
+    throw new ApprovalConfigurationError((error as Error).message);
+  }
 
   const channel = new CliChannel({
     readline: options.readline,

--- a/packages/franken-governor/tests/unit/core/config.test.ts
+++ b/packages/franken-governor/tests/unit/core/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { defaultConfig, normalizeGovernorConfig, validateGovernorConfig } from '../../../src/core/config.js';
+import {
+  MAX_TIMEOUT_MS,
+  defaultConfig,
+  normalizeGovernorConfig,
+  validateGovernorConfig,
+} from '../../../src/core/config.js';
 import type { GovernorConfig } from '../../../src/core/config.js';
 
 describe('GovernorConfig', () => {
@@ -47,6 +52,16 @@ describe('GovernorConfig', () => {
     expect(() => normalizeGovernorConfig({ timeoutMs })).toThrow(
       'timeoutMs must be a positive finite number',
     );
+  });
+
+  it('rejects timeoutMs overrides above the Node timer limit', () => {
+    expect(() => normalizeGovernorConfig({ timeoutMs: MAX_TIMEOUT_MS + 1 })).toThrow(
+      `timeoutMs must be less than or equal to ${MAX_TIMEOUT_MS}`,
+    );
+  });
+
+  it('accepts timeoutMs overrides at the Node timer limit', () => {
+    expect(normalizeGovernorConfig({ timeoutMs: MAX_TIMEOUT_MS }).timeoutMs).toBe(MAX_TIMEOUT_MS);
   });
 
   it.each([

--- a/packages/franken-governor/tests/unit/core/config.test.ts
+++ b/packages/franken-governor/tests/unit/core/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { defaultConfig } from '../../../src/core/config.js';
+import { defaultConfig, normalizeGovernorConfig, validateGovernorConfig } from '../../../src/core/config.js';
 import type { GovernorConfig } from '../../../src/core/config.js';
 
 describe('GovernorConfig', () => {
@@ -21,5 +21,48 @@ describe('GovernorConfig', () => {
   it('defaultConfig has sessionTokenTtlMs > 0', () => {
     const config = defaultConfig();
     expect(config.sessionTokenTtlMs).toBeGreaterThan(0);
+  });
+
+  it('normalizes valid overrides over defaults', () => {
+    const config = normalizeGovernorConfig({
+      timeoutMs: 12_345,
+      sessionTokenTtlMs: 67_890,
+      operatorName: 'alice',
+    });
+
+    expect(config).toMatchObject({
+      timeoutMs: 12_345,
+      sessionTokenTtlMs: 67_890,
+      operatorName: 'alice',
+      requireSignedApprovals: false,
+    });
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('rejects invalid %s timeoutMs overrides', (_name: string, timeoutMs: number) => {
+    expect(() => normalizeGovernorConfig({ timeoutMs })).toThrow(
+      'timeoutMs must be a positive finite number',
+    );
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('rejects invalid %s sessionTokenTtlMs overrides', (_name: string, sessionTokenTtlMs: number) => {
+    expect(() => normalizeGovernorConfig({ sessionTokenTtlMs })).toThrow(
+      'sessionTokenTtlMs must be a positive finite number',
+    );
+  });
+
+  it('validates direct GovernorConfig values', () => {
+    const config: GovernorConfig = { ...defaultConfig(), timeoutMs: 1, sessionTokenTtlMs: 1 };
+
+    expect(validateGovernorConfig(config)).toBe(config);
   });
 });

--- a/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/approval-gateway-security.test.ts
@@ -260,12 +260,30 @@ describe('ApprovalGateway — security integration', () => {
   });
 
   it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('rejects invalid %s timeoutMs config before contacting the channel', (_name: string, timeoutMs: number) => {
+    const channel = makeFakeChannel();
+    const auditRecorder = makeFakeAuditRecorder();
+
+    expect(() => new ApprovalGateway({
+      channel,
+      auditRecorder,
+      config: { ...defaultConfig(), timeoutMs },
+    })).toThrow(ApprovalConfigurationError);
+    expect(channel.requestApproval).not.toHaveBeenCalled();
+    expect(auditRecorder.record).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ['NaN', Number.NaN],
     ['Infinity', Number.POSITIVE_INFINITY],
     ['zero', 0],
     ['negative', -1],
     ['overflow', Number.MAX_SAFE_INTEGER],
-  ])('rejects invalid %s sessionTokenTtlMs config before contacting the channel', (_name, sessionTokenTtlMs) => {
+  ])('rejects invalid %s sessionTokenTtlMs config before contacting the channel', (_name: string, sessionTokenTtlMs: number) => {
     const channel = makeFakeChannel();
     const auditRecorder = makeFakeAuditRecorder();
 

--- a/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
@@ -7,6 +7,7 @@ import {
   type ApprovalPolicyManifest,
 } from '../../../src/security/approval-policy-manifest.js';
 import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
+import { ApprovalConfigurationError } from '../../../src/errors/index.js';
 import type { ReadlineAdapter } from '../../../src/channels/cli-channel.js';
 import type { EpisodicTraceRecord, GovernorMemoryPort } from '../../../src/audit/governor-memory-port.js';
 import type { RationaleBlock } from '@franken/types';
@@ -194,5 +195,16 @@ describe('createGovernor', () => {
       approvalPolicyManifest: unsignedManifest,
       allowUnsignedPolicyManifest: true,
     })).not.toThrow();
+  });
+
+  it.each([
+    ['timeoutMs', { timeoutMs: 0 }],
+    ['sessionTokenTtlMs', { sessionTokenTtlMs: Number.POSITIVE_INFINITY }],
+  ])('rejects invalid %s overrides before wiring the gateway', (_name: string, config) => {
+    expect(() => createGovernor({
+      readline: makeReadline(['a']),
+      memoryPort: makeMemoryPort(),
+      config,
+    })).toThrow(ApprovalConfigurationError);
   });
 });


### PR DESCRIPTION
## Summary
- add governor config normalization/validation for finite positive `timeoutMs` and `sessionTokenTtlMs` overrides
- apply validation in `createGovernor()` and direct `ApprovalGateway` construction paths
- add regressions for zero, negative, NaN, and Infinity timeout/TTL overrides

Closes #1967

## Test plan
- `npm test --workspace @franken/governor -- --run tests/unit/core/config.test.ts tests/unit/gateway/approval-gateway-security.test.ts tests/unit/gateway/governor-factory.test.ts`
- `npm run build --workspace @franken/types && npm run typecheck --workspace @franken/governor`