### PR TITLE
fix(orchestrator): clear approval metadata in response

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -310,6 +310,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
           id: session.id,
           approved,
           state: session.state,
+          pendingApproval: session.pendingApproval,
           ...(result?.outcome ? { outcome: result.outcome } : {}),
           ...(result?.tier ? { tier: result.tier } : {}),
           ...(result ? { displayMessages: result.displayMessages, events: result.events } : {}),

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -252,7 +252,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
 
     return withChatMutationAdmission(c, session.id, async () => {
       if (!session.pendingApproval && session.state !== 'pending_approval') {
-        return c.json({ data: { id: session.id, approved, state: session.state } });
+        return c.json({ data: { id: session.id, approved, state: session.state, pendingApproval: null } });
       }
 
       let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -46,8 +46,8 @@ describe('chat approval route persistence', () => {
     });
 
     expect(response.status).toBe(200);
-    const body = await response.json() as { data: { approved: boolean; state: string } };
-    expect(body.data).toMatchObject({ approved: true, state: 'approved' });
+    const body = await response.json() as { data: { approved: boolean; state: string; pendingApproval?: unknown } };
+    expect(body.data).toMatchObject({ approved: true, state: 'approved', pendingApproval: null });
     const stored = sessionStore.get(session.id);
     expect(stored?.state).toBe('approved');
     expect(stored?.pendingApproval).toBeNull();
@@ -69,8 +69,8 @@ describe('chat approval route persistence', () => {
     });
 
     expect(response.status).toBe(200);
-    const body = await response.json() as { data: { approved: boolean; state: string } };
-    expect(body.data).toMatchObject({ approved: false, state: 'rejected' });
+    const body = await response.json() as { data: { approved: boolean; state: string; pendingApproval?: unknown } };
+    expect(body.data).toMatchObject({ approved: false, state: 'rejected', pendingApproval: null });
     const stored = sessionStore.get(session.id);
     expect(stored?.state).toBe('rejected');
     expect(stored?.pendingApproval).toBeNull();

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -30,6 +30,25 @@ describe('chat approval route persistence', () => {
     rmSync(sessionStoreDir, { recursive: true, force: true });
   });
 
+  it('reports no pending approval for no-op HTTP approval responses', async () => {
+    const app = createChatApp({
+      sessionStore,
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'chat-approval-route-test',
+    });
+    const session = sessionStore.create('project-1');
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { approved: boolean; state: string; pendingApproval?: unknown } };
+    expect(body.data).toMatchObject({ approved: true, state: session.state, pendingApproval: null });
+  });
+
   it('clears pending approval metadata when a session is approved over HTTP', async () => {
     const app = createChatApp({
       sessionStore,

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -96,6 +96,7 @@ export const ApproveResultSchema = z.object({
   id: z.string(),
   approved: z.boolean(),
   state: z.string(),
+  pendingApproval: PendingApprovalSchema.nullable(),
   outcome: TurnOutcomeSchema.optional(),
   tier: z.string().optional(),
   displayMessages: z.array(z.unknown()).optional(),


### PR DESCRIPTION
## Summary
- include the cleared pendingApproval value in REST approval responses
- update the shared API contract for approval results
- assert approve/reject responses report pendingApproval: null after resolution

## Test Plan
- TMPDIR=/home/pfkagent/tmp npm test -- --run tests/unit/http/chat-routes-approval.test.ts --workspace @franken/orchestrator
- TMPDIR=/home/pfkagent/tmp npm run typecheck --workspace @franken/types
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/types
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/observer
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/brain
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/critique
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/governor
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/planner
- TMPDIR=/home/pfkagent/tmp npm run typecheck --workspace @franken/orchestrator
- TMPDIR=/home/pfkagent/tmp npm run lint --workspace @franken/orchestrator
- TMPDIR=/home/pfkagent/tmp npm run build --workspace @franken/orchestrator

Closes #1945