### PR TITLE
fix(orchestrator): escape Windows keychain targets

### DIFF
--- a/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
@@ -7,6 +7,10 @@ type StdinRunner = (command: string, args: string[], stdin: string) => Promise<C
 const SERVICE = 'frankenbeast';
 const KEYS_META_KEY = '__frankenbeast_keys__';
 
+function quotePowerShellSingleQuotedString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 export interface OsKeychainStoreOptions {
   runner: CliRunner;
   stdinRunner?: StdinRunner | undefined;
@@ -289,10 +293,11 @@ export class OsKeychainStore implements ISecretStore {
   private async resolveWin32(key: string): Promise<string | undefined> {
     // cmdkey /list does not display passwords; use PowerShell to retrieve
     const target = `${SERVICE}/${key}`;
+    const quotedTarget = quotePowerShellSingleQuotedString(target);
     const result = await this.runner('powershell', [
       '-NoProfile',
       '-Command',
-      `$cred = Get-StoredCredential -Target '${target}'; if ($cred) { $cred.GetNetworkCredential().Password }`,
+      `$cred = Get-StoredCredential -Target ${quotedTarget}; if ($cred) { $cred.GetNetworkCredential().Password }`,
     ]);
     if (result.exitCode !== 0 || !result.stdout.trim()) {
       return undefined;

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
@@ -154,6 +154,19 @@ describe('OsKeychainStore', () => {
       const addCall = mock.calls.find(c => c.args.some(a => a.includes('/generic:')));
       expect(addCall).toBeDefined();
     });
+
+    it('escapes apostrophes in PowerShell credential targets when resolving', async () => {
+      mock.responses.set('Get-StoredCredential', { stdout: 'resolved-value\r\n', stderr: '', exitCode: 0 });
+
+      const value = await store.resolve("team's/token");
+
+      expect(value).toBe('resolved-value');
+      const resolveCall = mock.calls.find(c => c.command === 'powershell');
+      expect(resolveCall).toBeDefined();
+      expect(resolveCall!.args).toContain(
+        "$cred = Get-StoredCredential -Target 'frankenbeast/team''s/token'; if ($cred) { $cred.GetNetworkCredential().Password }",
+      );
+    });
   });
 
   describe('unsupported platform', () => {


### PR DESCRIPTION
## Summary
- Escape apostrophes before interpolating Windows keychain targets into the PowerShell Get-StoredCredential command
- Add a regression test for credential keys containing apostrophes

## Test Plan
- TMPDIR=$PWD/.tmp npm run test --workspace @franken/orchestrator -- tests/unit/network/secret-backends/os-keychain-store.test.ts
- TMPDIR=$PWD/.tmp npm run test --workspace @franken/orchestrator -- tests/unit/network
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator -- tests/unit/network/secret-backends/os-keychain-store.test.ts src/network/secret-backends/os-keychain-store.ts

Closes #1894