### PR TITLE
test(orchestrator): lint singular test fixtures

### DIFF
--- a/packages/franken-orchestrator/package.json
+++ b/packages/franken-orchestrator/package.json
@@ -29,7 +29,7 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "INTEGRATION=true vitest run",
     "test:e2e": "E2E=true vitest run",
-    "lint": "eslint src/ tests/",
+    "lint": "eslint src/ tests/ test/",
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [

--- a/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
+++ b/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
@@ -137,4 +137,15 @@ describe('Vitest environment flags', () => {
       expect(config).toContain(`'${e2eRoot}/**/*.test.ts'`);
     }
   });
+
+  it('lints every package test tree that Vitest can execute', () => {
+    const packageRoot = resolve(import.meta.dirname, '../..');
+    const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    const lintScript = packageJson.scripts?.['lint'] ?? '';
+
+    expect(lintScript).toContain('tests/');
+    expect(lintScript).toContain('test/');
+  });
 });


### PR DESCRIPTION
## Summary
- Include the singular `test/` fixture tree in `@franken/orchestrator` lint coverage.
- Add a regression guard that keeps orchestrator lint coverage aligned with Vitest's executable test trees.

## Test Plan
- `TMPDIR=$PWD/.tmp/vitest npm run test --workspace=@franken/orchestrator -- --run tests/unit/vitest-env.test.ts`
- `npm run lint --workspace=@franken/orchestrator`
- `npm run lint`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace=@franken/orchestrator`
- `npm run build --workspace=@franken/orchestrator`

Closes #1977