### PR TITLE
test(orchestrator): guard e2e zero-test discovery

### DIFF
--- a/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
+++ b/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -8,6 +9,7 @@ type VitestConfig = {
   test?: {
     include?: string[];
     exclude?: string[];
+    passWithNoTests?: boolean;
   };
 };
 
@@ -147,5 +149,35 @@ describe('Vitest environment flags', () => {
 
     expect(lintScript).toContain('tests/');
     expect(lintScript).toContain('test/');
+  });
+
+  it('does not let the package E2E command pass when zero tests are discovered', async () => {
+    const config = await loadPackageVitestConfig({ E2E: 'true' });
+    expect(config.test?.passWithNoTests).not.toBe(true);
+
+    const packageRoot = resolve(import.meta.dirname, '../..');
+    const repoRoot = resolve(packageRoot, '../..');
+    const result = spawnSync(
+      'npm',
+      [
+        'run',
+        'test:e2e',
+        '--workspace=@franken/orchestrator',
+        '--',
+        'test/e2e/__missing-zero-discovery__.test.ts',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          E2E: 'true',
+        },
+      },
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status, output).not.toBe(0);
+    expect(output).toContain('No test files found');
   });
 });


### PR DESCRIPTION
## Summary
- Adds a regression that the orchestrator E2E config does not enable passWithNoTests.
- Exercises the package-level `test:e2e` script against a missing singular `test/e2e` file to prove zero discovery fails instead of passing.
- Existing main already includes both plural `tests/e2e` and singular `test/e2e` globs; this PR locks the zero-test acceptance criterion.

## Test Plan
- `TMPDIR="$PWD/.tmp" XDG_CACHE_HOME="$PWD/.cache" npx turbo run build --filter=@franken/orchestrator...`
- `TMPDIR="$PWD/.tmp" XDG_CACHE_HOME="$PWD/.cache" npm run test --workspace=@franken/orchestrator -- tests/unit/vitest-env.test.ts --pool=forks --maxWorkers=1`
- `TMPDIR="$PWD/.tmp" XDG_CACHE_HOME="$PWD/.cache" npm run test:e2e --workspace=@franken/orchestrator -- test/e2e/e2e-pipeline.test.ts --pool=forks --maxWorkers=1`
- `TMPDIR="$PWD/.tmp" XDG_CACHE_HOME="$PWD/.cache" npm run typecheck --workspace=@franken/orchestrator`
- `TMPDIR="$PWD/.tmp" XDG_CACHE_HOME="$PWD/.cache" npm run lint --workspace=@franken/orchestrator` (passes with pre-existing warnings)

Full package `test:e2e` currently has unrelated existing failures in chunk-pipeline, cli-skill-execution, and hitl-pause; the targeted singular e2e file passes and is discovered.

Closes #1976