### PR TITLE
test(orchestrator): guard e2e test discovery

### DIFF
--- a/packages/franken-orchestrator/test/e2e/e2e-pipeline.test.ts
+++ b/packages/franken-orchestrator/test/e2e/e2e-pipeline.test.ts
@@ -22,7 +22,7 @@
  *   8. rm -rf /tmp/fb-smoke
  *
  * RUN:
- *   E2E=true npx vitest run test/e2e/e2e-pipeline.test.ts
+ *   npm run test:e2e --workspace @franken/orchestrator -- test/e2e/e2e-pipeline.test.ts
  */
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';

--- a/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
+++ b/packages/franken-orchestrator/tests/unit/vitest-env.test.ts
@@ -8,6 +8,7 @@ type VitestConfig = {
   test?: {
     include?: string[];
     exclude?: string[];
+    passWithNoTests?: boolean;
   };
 };
 
@@ -95,6 +96,13 @@ describe('Vitest environment flags', () => {
     expect(config).toContain("arg.includes('test/e2e/')");
     expect(config).toContain("'tests/e2e/**/*.test.ts'");
     expect(config).toContain("'test/e2e/**/*.test.ts'");
+    expect(config).toContain('passWithNoTests: false');
+  });
+
+  it('fails instead of passing when no E2E tests are discovered', async () => {
+    const config = await loadPackageVitestConfig({ E2E: 'true' });
+
+    expect(config.test?.passWithNoTests).toBe(false);
   });
 
   it('treats false-like suite flags as default unit test selection', async () => {

--- a/packages/franken-orchestrator/vitest.config.ts
+++ b/packages/franken-orchestrator/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
     environment: 'node',
+    passWithNoTests: false,
     include: runMixed
       ? ['tests/**/*.test.ts', 'test/**/*.test.ts']
       : runE2e


### PR DESCRIPTION
## Summary
- keep orchestrator E2E runs fail-closed when no tests are discovered
- add unit coverage for the explicit no-tests guard alongside the singular/plural E2E include check
- update the singular E2E test's run comment to use the package script

Closes #1976

## Test plan
- npm run test --workspace @franken/orchestrator -- tests/unit/vitest-env.test.ts
- npm run test:e2e --workspace @franken/orchestrator -- test/e2e/e2e-pipeline.test.ts
- npm run test:e2e --workspace @franken/orchestrator -- test/e2e/__no_such_file__.test.ts (expected exit 1; verified fail-closed no-test discovery)