### PR TITLE
fix(types): harden archive entry path resolution

### DIFF
--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -32,9 +32,15 @@ import {
 Subpath exports are available for focused imports:
 
 ```ts
-import { resolveContainedPath } from '@franken/types/path-containment';
+import { resolveArchiveEntryPath, resolveContainedPath } from '@franken/types/path-containment';
 import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 ```
+
+## Path and archive extraction safety
+
+Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes all throw explicit errors before a destination is returned.
+
+Only set `allowUnsafeArchiveEntryPaths: true` for archives from a trusted operator-controlled source that requires legacy non-portable member names. The override still enforces final containment inside the extraction root; extraction code should also refuse archive symlink entries unless the caller has a separate explicit symlink policy.
 
 ## Export groups
 

--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -38,7 +38,7 @@ import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 
 ## Path and archive extraction safety
 
-Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, NUL bytes, Windows alternate data streams, and Windows reserved device names all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor and rejects symlink ancestors or leaves so a lexically safe member cannot write through a symlink outside the extraction root.
+Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, NUL bytes, Windows-trimmed component names, Windows alternate data streams, and Windows reserved device names all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor and rejects symlink ancestors or leaves so a lexically safe member cannot write through a symlink outside the extraction root.
 
 Only set `allowUnsafeArchiveEntryPaths: true` for archives from a trusted operator-controlled source that requires legacy non-portable member names. The override still enforces final containment inside the extraction root; extraction code should also refuse archive symlink entries unless the caller has a separate explicit symlink policy.
 

--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -38,7 +38,7 @@ import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 
 ## Path and archive extraction safety
 
-Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor and rejects symlink ancestors or leaves so a lexically safe member cannot write through a symlink outside the extraction root.
+Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, NUL bytes, Windows alternate data streams, and Windows reserved device names all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor and rejects symlink ancestors or leaves so a lexically safe member cannot write through a symlink outside the extraction root.
 
 Only set `allowUnsafeArchiveEntryPaths: true` for archives from a trusted operator-controlled source that requires legacy non-portable member names. The override still enforces final containment inside the extraction root; extraction code should also refuse archive symlink entries unless the caller has a separate explicit symlink policy.
 

--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -38,7 +38,7 @@ import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 
 ## Path and archive extraction safety
 
-Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes all throw explicit errors before a destination is returned.
+Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor so a lexically safe member cannot write through an existing symlinked directory outside the extraction root.
 
 Only set `allowUnsafeArchiveEntryPaths: true` for archives from a trusted operator-controlled source that requires legacy non-portable member names. The override still enforces final containment inside the extraction root; extraction code should also refuse archive symlink entries unless the caller has a separate explicit symlink policy.
 

--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -38,7 +38,7 @@ import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 
 ## Path and archive extraction safety
 
-Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor so a lexically safe member cannot write through an existing symlinked directory outside the extraction root.
+Use `resolveArchiveEntryPath(extractionRoot, entryName)` before writing files from an untrusted ZIP, tar, or other archive. It denies zip-slip entries by default: parent-directory segments, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes all throw explicit errors before a destination is returned. It also resolves the nearest existing ancestor and rejects symlink ancestors or leaves so a lexically safe member cannot write through a symlink outside the extraction root.
 
 Only set `allowUnsafeArchiveEntryPaths: true` for archives from a trusted operator-controlled source that requires legacy non-portable member names. The override still enforces final containment inside the extraction root; extraction code should also refuse archive symlink entries unless the caller has a separate explicit symlink policy.
 

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -1,8 +1,17 @@
 import { existsSync, realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve, sep, win32 } from 'node:path';
 
 interface ResolveContainedPathOptions {
   relativeTo?: string;
+}
+
+interface ResolveArchiveEntryPathOptions {
+  /**
+   * Explicit operator override for trusted archives with non-portable entry
+   * names. The resolved destination is still constrained to `baseDir`; this
+   * only bypasses the archive-entry lexical denylist.
+   */
+  allowUnsafeArchiveEntryPaths?: boolean;
 }
 
 function isContainedBy(baseRealPath: string, targetRealPath: string): boolean {
@@ -12,6 +21,36 @@ function isContainedBy(baseRealPath: string, targetRealPath: string): boolean {
 
 function containmentError(fieldName: string): Error {
   return new Error(`${fieldName} resolves outside base directory`);
+}
+
+function archiveEntryError(fieldName: string, reason: string): Error {
+  return new Error(`${fieldName} is not a safe archive entry path: ${reason}`);
+}
+
+function isWindowsAbsolutePath(path: string): boolean {
+  return win32.isAbsolute(path) || /^[a-zA-Z]:/.test(path);
+}
+
+function normalizeArchiveEntryPath(entryPath: string, fieldName: string): string {
+  if (entryPath.length === 0) {
+    throw archiveEntryError(fieldName, 'empty path');
+  }
+  if (entryPath.includes('\0')) {
+    throw archiveEntryError(fieldName, 'NUL byte');
+  }
+  if (isAbsolute(entryPath) || isWindowsAbsolutePath(entryPath)) {
+    throw archiveEntryError(fieldName, 'absolute path');
+  }
+
+  const segments = entryPath.split(/[\\/]+/).filter(segment => segment.length > 0 && segment !== '.');
+  if (segments.length === 0) {
+    throw archiveEntryError(fieldName, 'empty path');
+  }
+  if (segments.some(segment => segment === '..')) {
+    throw archiveEntryError(fieldName, 'parent directory segment');
+  }
+
+  return segments.join('/');
 }
 
 function resolveRequestedPath(
@@ -55,6 +94,35 @@ export function resolveContainedPath(
 
   const parentRealPath = realpathSync(dirname(requestedAbsolutePath));
   const targetPath = resolve(parentRealPath, basename(requestedAbsolutePath));
+
+  if (!isContainedBy(baseRealPath, targetPath)) {
+    throw containmentError(fieldName);
+  }
+
+  return targetPath;
+}
+
+/**
+ * Resolve an archive member name under an extraction root without permitting
+ * zip-slip/path-traversal entries. Archive paths are treated as untrusted data:
+ * by default absolute paths, Windows drive/UNC paths, empty names, NUL bytes,
+ * and `..` segments are rejected before the destination is calculated.
+ *
+ * `allowUnsafeArchiveEntryPaths` is an explicit compatibility override for
+ * trusted archives only. Even with the override enabled, the final destination
+ * must still resolve inside `baseDir`.
+ */
+export function resolveArchiveEntryPath(
+  baseDir: string,
+  entryPath: string,
+  fieldName = 'archiveEntryPath',
+  options: ResolveArchiveEntryPathOptions = {},
+): string {
+  const baseRealPath = realpathSync(resolve(baseDir));
+  const safeEntryPath = options.allowUnsafeArchiveEntryPaths
+    ? entryPath
+    : normalizeArchiveEntryPath(entryPath, fieldName);
+  const targetPath = resolve(baseRealPath, safeEntryPath);
 
   if (!isContainedBy(baseRealPath, targetPath)) {
     throw containmentError(fieldName);

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -31,6 +31,11 @@ function isWindowsAbsolutePath(path: string): boolean {
   return win32.isAbsolute(path) || /^[a-zA-Z]:/.test(path);
 }
 
+function isWindowsReservedDeviceSegment(segment: string): boolean {
+  const stem = segment.replace(/[ .]+$/u, '').split('.')[0]?.toUpperCase() ?? '';
+  return /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/u.test(stem);
+}
+
 function normalizeArchiveEntryPath(entryPath: string, fieldName: string): string {
   if (entryPath.length === 0) {
     throw archiveEntryError(fieldName, 'empty path');
@@ -48,6 +53,12 @@ function normalizeArchiveEntryPath(entryPath: string, fieldName: string): string
   }
   if (segments.some(segment => segment === '..')) {
     throw archiveEntryError(fieldName, 'parent directory segment');
+  }
+  if (segments.some(segment => segment.includes(':'))) {
+    throw archiveEntryError(fieldName, 'Windows alternate data stream separator');
+  }
+  if (segments.some(isWindowsReservedDeviceSegment)) {
+    throw archiveEntryError(fieldName, 'Windows reserved device name');
   }
 
   return segments.join('/');
@@ -77,6 +88,24 @@ function lstatIfPresent(path: string): ReturnType<typeof lstatSync> | null {
   }
 }
 
+function rejectSymlinkComponents(baseRealPath: string, targetExistingPath: string, fieldName: string): void {
+  const relativeExistingPath = relative(baseRealPath, targetExistingPath);
+  if (relativeExistingPath === '') {
+    return;
+  }
+  if (relativeExistingPath === '..' || relativeExistingPath.startsWith(`..${sep}`) || isAbsolute(relativeExistingPath)) {
+    throw containmentError(fieldName);
+  }
+
+  let cursor = baseRealPath;
+  for (const segment of relativeExistingPath.split(sep)) {
+    cursor = resolve(cursor, segment);
+    if (lstatSync(cursor).isSymbolicLink()) {
+      throw symbolicLinkError(fieldName);
+    }
+  }
+}
+
 function resolveViaNearestExistingAncestor(baseRealPath: string, requestedAbsolutePath: string, fieldName: string): string {
   const missingSegments: string[] = [];
   let cursor = requestedAbsolutePath;
@@ -95,6 +124,7 @@ function resolveViaNearestExistingAncestor(baseRealPath: string, requestedAbsolu
   if (stats.isSymbolicLink()) {
     throw symbolicLinkError(fieldName);
   }
+  rejectSymlinkComponents(baseRealPath, cursor, fieldName);
 
   const ancestorRealPath = realpathSync(cursor);
   if (!isContainedBy(baseRealPath, ancestorRealPath)) {

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -62,6 +62,32 @@ function resolveRequestedPath(
   return isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(relativeBase, requestedPath);
 }
 
+function resolveViaNearestExistingAncestor(baseRealPath: string, requestedAbsolutePath: string, fieldName: string): string {
+  const missingSegments: string[] = [];
+  let cursor = requestedAbsolutePath;
+
+  while (!existsSync(cursor)) {
+    missingSegments.unshift(basename(cursor));
+    const parent = dirname(cursor);
+    if (parent === cursor) {
+      throw containmentError(fieldName);
+    }
+    cursor = parent;
+  }
+
+  const ancestorRealPath = realpathSync(cursor);
+  if (!isContainedBy(baseRealPath, ancestorRealPath)) {
+    throw containmentError(fieldName);
+  }
+
+  const targetPath = resolve(ancestorRealPath, ...missingSegments);
+  if (!isContainedBy(baseRealPath, targetPath)) {
+    throw containmentError(fieldName);
+  }
+
+  return targetPath;
+}
+
 export function resolveContainedExistingPath(
   baseDir: string,
   requestedPath: string,
@@ -124,9 +150,5 @@ export function resolveArchiveEntryPath(
     : normalizeArchiveEntryPath(entryPath, fieldName);
   const targetPath = resolve(baseRealPath, safeEntryPath);
 
-  if (!isContainedBy(baseRealPath, targetPath)) {
-    throw containmentError(fieldName);
-  }
-
-  return targetPath;
+  return resolveViaNearestExistingAncestor(baseRealPath, targetPath, fieldName);
 }

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -33,7 +33,7 @@ function isWindowsAbsolutePath(path: string): boolean {
 
 function isWindowsReservedDeviceSegment(segment: string): boolean {
   const stem = segment.replace(/[ .]+$/u, '').split('.')[0]?.toUpperCase() ?? '';
-  return /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/u.test(stem);
+  return /^(CON|PRN|AUX|NUL|COM[1-9¹²³]|LPT[1-9¹²³])$/u.test(stem);
 }
 
 function normalizeArchiveEntryPath(entryPath: string, fieldName: string): string {
@@ -53,6 +53,9 @@ function normalizeArchiveEntryPath(entryPath: string, fieldName: string): string
   }
   if (segments.some(segment => segment === '..')) {
     throw archiveEntryError(fieldName, 'parent directory segment');
+  }
+  if (segments.some(segment => /[ .]$/u.test(segment))) {
+    throw archiveEntryError(fieldName, 'Windows-trimmed path segment');
   }
   if (segments.some(segment => segment.includes(':'))) {
     throw archiveEntryError(fieldName, 'Windows alternate data stream separator');

--- a/packages/franken-types/src/path-containment.ts
+++ b/packages/franken-types/src/path-containment.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, lstatSync, realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, relative, resolve, sep, win32 } from 'node:path';
 
 interface ResolveContainedPathOptions {
@@ -62,17 +62,38 @@ function resolveRequestedPath(
   return isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(relativeBase, requestedPath);
 }
 
+function symbolicLinkError(fieldName: string): Error {
+  return new Error(`${fieldName} resolves through a symbolic link`);
+}
+
+function lstatIfPresent(path: string): ReturnType<typeof lstatSync> | null {
+  try {
+    return lstatSync(path);
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+}
+
 function resolveViaNearestExistingAncestor(baseRealPath: string, requestedAbsolutePath: string, fieldName: string): string {
   const missingSegments: string[] = [];
   let cursor = requestedAbsolutePath;
+  let stats = lstatIfPresent(cursor);
 
-  while (!existsSync(cursor)) {
+  while (!stats) {
     missingSegments.unshift(basename(cursor));
     const parent = dirname(cursor);
     if (parent === cursor) {
       throw containmentError(fieldName);
     }
     cursor = parent;
+    stats = lstatIfPresent(cursor);
+  }
+
+  if (stats.isSymbolicLink()) {
+    throw symbolicLinkError(fieldName);
   }
 
   const ancestorRealPath = realpathSync(cursor);

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import {
+  resolveArchiveEntryPath,
   resolveContainedExistingPath,
   resolveContainedPath,
 } from '../src/path-containment.js';
@@ -91,6 +92,45 @@ describe('realpath containment helpers', () => {
       } finally {
         rmSync(outside, { recursive: true, force: true });
       }
+    });
+  });
+
+  it('resolves safe archive entries under the extraction root before nested parents exist', () => {
+    withTempRoot('archive-entry-safe', root => {
+      expect(resolveArchiveEntryPath(root, 'nested/docs/readme.md')).toBe(resolve(root, 'nested/docs/readme.md'));
+      expect(resolveArchiveEntryPath(root, './/nested\\docs/./guide.md')).toBe(resolve(root, 'nested/docs/guide.md'));
+    });
+  });
+
+  it('rejects archive entries that could escape through zip-slip traversal', () => {
+    withTempRoot('archive-entry-zip-slip', root => {
+      expect(() => resolveArchiveEntryPath(root, '../secret.txt')).toThrow(
+        /archiveEntryPath is not a safe archive entry path: parent directory segment/i,
+      );
+      expect(() => resolveArchiveEntryPath(root, 'nested/../../secret.txt')).toThrow(
+        /archiveEntryPath is not a safe archive entry path: parent directory segment/i,
+      );
+    });
+  });
+
+  it('rejects absolute, Windows drive, UNC, empty, and NUL archive entries by default', () => {
+    withTempRoot('archive-entry-denylist', root => {
+      expect(() => resolveArchiveEntryPath(root, '/tmp/evil.txt')).toThrow(/absolute path/i);
+      expect(() => resolveArchiveEntryPath(root, 'C:\\tmp\\evil.txt')).toThrow(/absolute path/i);
+      expect(() => resolveArchiveEntryPath(root, '\\\\server\\share\\evil.txt')).toThrow(/absolute path/i);
+      expect(() => resolveArchiveEntryPath(root, '')).toThrow(/empty path/i);
+      expect(() => resolveArchiveEntryPath(root, '\0evil.txt')).toThrow(/NUL byte/i);
+    });
+  });
+
+  it('keeps explicit unsafe archive-entry overrides contained inside the extraction root', () => {
+    withTempRoot('archive-entry-unsafe-override', root => {
+      expect(resolveArchiveEntryPath(root, 'trusted/../kept.txt', 'archiveEntryPath', {
+        allowUnsafeArchiveEntryPaths: true,
+      })).toBe(resolve(root, 'kept.txt'));
+      expect(() => resolveArchiveEntryPath(root, '../outside.txt', 'archiveEntryPath', {
+        allowUnsafeArchiveEntryPaths: true,
+      })).toThrow(/archiveEntryPath resolves outside base directory/i);
     });
   });
 });

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -122,11 +122,21 @@ describe('realpath containment helpers', () => {
 
       try {
         expect(() => resolveArchiveEntryPath(root, 'linked-outside/pwned.txt')).toThrow(
-          /archiveEntryPath resolves outside base directory/i,
+          /archiveEntryPath resolves through a symbolic link/i,
         );
       } finally {
         rmSync(outside, { recursive: true, force: true });
       }
+    });
+  });
+
+  it('rejects archive entries whose existing leaf is a broken symlink', () => {
+    withTempRoot('archive-entry-broken-symlink', root => {
+      symlinkSync(join(root, '..', `missing-${randomUUID()}`, 'outside.txt'), join(root, 'broken-link'));
+
+      expect(() => resolveArchiveEntryPath(root, 'broken-link')).toThrow(
+        /archiveEntryPath resolves through a symbolic link/i,
+      );
     });
   });
 

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -169,7 +169,15 @@ describe('realpath containment helpers', () => {
       );
       expect(() => resolveArchiveEntryPath(root, 'docs/NUL')).toThrow(/Windows reserved device name/i);
       expect(() => resolveArchiveEntryPath(root, 'docs/con.txt')).toThrow(/Windows reserved device name/i);
-      expect(() => resolveArchiveEntryPath(root, 'docs/LPT1.')).toThrow(/Windows reserved device name/i);
+      expect(() => resolveArchiveEntryPath(root, 'docs/COM¹')).toThrow(/Windows reserved device name/i);
+    });
+  });
+
+  it('rejects Windows-trimmed archive path segments', () => {
+    withTempRoot('archive-entry-windows-trimmed', root => {
+      expect(() => resolveArchiveEntryPath(root, '.. /evil.txt')).toThrow(/Windows-trimmed path segment/i);
+      expect(() => resolveArchiveEntryPath(root, 'docs/name.')).toThrow(/Windows-trimmed path segment/i);
+      expect(() => resolveArchiveEntryPath(root, 'docs/name ')).toThrow(/Windows-trimmed path segment/i);
     });
   });
 

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -140,6 +140,18 @@ describe('realpath containment helpers', () => {
     });
   });
 
+  it('rejects archive entries that pass through any existing symlink component', () => {
+    withTempRoot('archive-entry-contained-symlink', root => {
+      const actual = join(root, 'actual', 'existing');
+      mkdirSync(actual, { recursive: true });
+      symlinkSync(join(root, 'actual'), join(root, 'link'), 'dir');
+
+      expect(() => resolveArchiveEntryPath(root, 'link/existing/file.txt')).toThrow(
+        /archiveEntryPath resolves through a symbolic link/i,
+      );
+    });
+  });
+
   it('rejects absolute, Windows drive, UNC, empty, and NUL archive entries by default', () => {
     withTempRoot('archive-entry-denylist', root => {
       expect(() => resolveArchiveEntryPath(root, '/tmp/evil.txt')).toThrow(/absolute path/i);
@@ -147,6 +159,17 @@ describe('realpath containment helpers', () => {
       expect(() => resolveArchiveEntryPath(root, '\\\\server\\share\\evil.txt')).toThrow(/absolute path/i);
       expect(() => resolveArchiveEntryPath(root, '')).toThrow(/empty path/i);
       expect(() => resolveArchiveEntryPath(root, '\0evil.txt')).toThrow(/NUL byte/i);
+    });
+  });
+
+  it('rejects Windows alternate data streams and reserved device names in archive entries', () => {
+    withTempRoot('archive-entry-windows-names', root => {
+      expect(() => resolveArchiveEntryPath(root, 'docs/victim.txt:payload')).toThrow(
+        /Windows alternate data stream separator/i,
+      );
+      expect(() => resolveArchiveEntryPath(root, 'docs/NUL')).toThrow(/Windows reserved device name/i);
+      expect(() => resolveArchiveEntryPath(root, 'docs/con.txt')).toThrow(/Windows reserved device name/i);
+      expect(() => resolveArchiveEntryPath(root, 'docs/LPT1.')).toThrow(/Windows reserved device name/i);
     });
   });
 

--- a/packages/franken-types/tests/path-containment.test.ts
+++ b/packages/franken-types/tests/path-containment.test.ts
@@ -113,6 +113,23 @@ describe('realpath containment helpers', () => {
     });
   });
 
+  it('rejects lexically safe archive entries whose existing ancestor is a symlink escape', () => {
+    withTempRoot('archive-entry-symlink', root => {
+      const outside = join(root, '..', `outside-${randomUUID()}`);
+      const link = join(root, 'linked-outside');
+      mkdirSync(outside, { recursive: true });
+      symlinkSync(outside, link, 'dir');
+
+      try {
+        expect(() => resolveArchiveEntryPath(root, 'linked-outside/pwned.txt')).toThrow(
+          /archiveEntryPath resolves outside base directory/i,
+        );
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('rejects absolute, Windows drive, UNC, empty, and NUL archive entries by default', () => {
     withTempRoot('archive-entry-denylist', root => {
       expect(() => resolveArchiveEntryPath(root, '/tmp/evil.txt')).toThrow(/absolute path/i);


### PR DESCRIPTION
## Summary
- add `resolveArchiveEntryPath()` to the shared path-containment helpers for archive extraction destinations
- deny zip-slip/path-traversal entry names by default, including `..`, POSIX/Windows absolute paths, drive/UNC paths, empty names, and NUL bytes
- document trusted-archive override semantics and symlink policy guidance

## Verification
- `npm test --workspace=@franken/types -- --run tests/path-containment.test.ts`
- `npm run typecheck --workspace=@franken/types`
- `npm run lint --workspace=@franken/types`
- `npm run build --workspace=@franken/types`
- `TMPDIR="$PWD/.tmp/root-vitest" npm run test:root -- --run tests/tsconfig-paths.test.ts`

Closes #1793