### PR TITLE
fix(types): harden JSON pointer handling

### DIFF
--- a/packages/franken-types/README.md
+++ b/packages/franken-types/README.md
@@ -33,8 +33,15 @@ Subpath exports are available for focused imports:
 
 ```ts
 import { resolveContainedPath } from '@franken/types/path-containment';
+import { parseJsonPointer, setJsonPointerValue } from '@franken/types/json-pointer';
 import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 ```
+
+## Safe JSON Pointer handling
+
+Use `parseJsonPointer`, `getJsonPointerValue`, `setJsonPointerValue`, or `assertSafeJsonPointer` before accepting JSON Pointer input from API, control-plane, approval, token, or state-mutation paths. The helpers default to deny-by-default behavior for prototype-pollution segments (`__proto__`, `constructor`, and `prototype`), validate RFC 6901 escaping, cap segment counts/lengths, and write missing branches as own data properties instead of following inherited properties.
+
+Only pass `{ allowUnsafePrototypeSegments: true }` for trusted migration or compatibility code that must treat those names as data keys. Keep the default for untrusted operator, dashboard, LLM, or network input.
 
 ## Export groups
 
@@ -45,6 +52,7 @@ import { createSeededRandom, deterministicUuid } from '@franken/types/utils';
 | Core context | `src/context.ts`, `src/orchestration.ts`, `src/token.ts` | Shared `FrankenContext`, task outcomes, phases, and token-spend contracts. |
 | Provider contracts | `src/provider.ts`, `src/llm.ts` | LLM provider interfaces, stream events, tool schemas, MCP server config, and critique finding shapes. |
 | Skills and comms | `src/skill.ts`, `src/comms.ts` | Skill metadata schemas and communication payload contracts. |
+| JSON Pointer hardening | `src/json-pointer.ts` | RFC 6901 parsing plus deny-by-default prototype-pollution guards for state/config patching. |
 | Deterministic helpers | `src/deterministic.ts`, `src/utils/` | Seeded random, deterministic UUIDs, and clock helpers used by tests and reproducible runs. |
 | API DTOs | `src/api-contracts.ts` | Shared web/API contract data transfer objects. |
 
@@ -67,6 +75,7 @@ The package test script writes temporary files under `../../.tmp/franken-types` 
 | --- | --- |
 | `src/index.ts` | Main package export barrel. |
 | `src/path-containment.ts` | Root containment helpers exported as a subpath. |
+| `src/json-pointer.ts` | Safe JSON Pointer helpers exported from the main entrypoint and `@franken/types/json-pointer`. |
 | `src/utils/` | Utility subpath exports. |
 | `docs/RAMP_UP.md` | Deeper architecture and contributor ramp-up notes. |
 | `CHANGELOG.md` | Package release history. |

--- a/packages/franken-types/package.json
+++ b/packages/franken-types/package.json
@@ -13,6 +13,10 @@
       "import": "./dist/path-containment.js",
       "types": "./dist/path-containment.d.ts"
     },
+    "./json-pointer": {
+      "import": "./dist/json-pointer.js",
+      "types": "./dist/json-pointer.d.ts"
+    },
     "./utils": {
       "import": "./dist/utils/index.js",
       "types": "./dist/utils/index.d.ts"

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -107,6 +107,9 @@ export {
 // Web/API contract DTOs
 export * from './api-contracts.js';
 
+// Safe JSON Pointer helpers
+export * from './json-pointer.js';
+
 // Deterministic utilities
 export * from './utils/index.js';
 

--- a/packages/franken-types/src/json-pointer.ts
+++ b/packages/franken-types/src/json-pointer.ts
@@ -55,7 +55,6 @@ export function parseJsonPointer(pointer: string, options: JsonPointerOptions = 
   const segments = rawSegments.map((segment) => decodeJsonPointerSegment(segment));
   for (const segment of segments) {
     assertSafeJsonPointerSegment(segment, options);
-    parseArrayIndex(segment, options);
   }
   return Object.freeze(segments);
 }
@@ -99,6 +98,7 @@ export function setJsonPointerValue<T extends JsonContainer>(
   }
 
   let current: JsonContainer = target;
+  assertWritableJsonContainer(current);
   for (let index = 0; index < segments.length - 1; index += 1) {
     const segment = segments[index];
     const nextSegment = segments[index + 1];
@@ -107,6 +107,7 @@ export function setJsonPointerValue<T extends JsonContainer>(
       if (!isJsonContainer(existing)) {
         throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not resolve to an object or array.`);
       }
+      assertWritableJsonContainer(existing);
       current = existing;
       continue;
     }
@@ -163,6 +164,12 @@ function isJsonContainer(value: unknown): value is JsonContainer {
   return isObjectLike(value) && (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
 }
 
+function assertWritableJsonContainer(value: JsonContainer): void {
+  if (value === Object.prototype || value === Array.prototype) {
+    throw new UnsafeJsonPointerError('Refusing to mutate a built-in prototype object through a JSON Pointer.');
+  }
+}
+
 function parseArrayIndex(segment: string, options: JsonPointerOptions): number | undefined {
   if (!/^(0|[1-9]\d*)$/u.test(segment)) {
     return undefined;
@@ -196,7 +203,12 @@ function writeOwnContainerValue(container: JsonContainer, segment: string, value
     if (index === undefined) {
       throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' is not a valid array index.`);
     }
-    container[index] = value;
+    Object.defineProperty(container, index, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value,
+    });
     return;
   }
 

--- a/packages/franken-types/src/json-pointer.ts
+++ b/packages/franken-types/src/json-pointer.ts
@@ -39,7 +39,7 @@ export function parseJsonPointer(pointer: string, options: JsonPointerOptions = 
     throw new UnsafeJsonPointerError('JSON Pointer must be empty or start with `/`.');
   }
 
-  const maxSegments = options.maxSegments ?? DEFAULT_MAX_SEGMENTS;
+  const maxSegments = getOwnNumberOption(options, 'maxSegments', DEFAULT_MAX_SEGMENTS);
   if (!Number.isSafeInteger(maxSegments) || maxSegments < 0) {
     throw new UnsafeJsonPointerError('JSON Pointer maxSegments must be a non-negative safe integer.');
   }
@@ -97,6 +97,8 @@ export function setJsonPointerValue<T extends JsonContainer>(
     throw new UnsafeJsonPointerError('Refusing to replace the JSON Pointer root object in-place.');
   }
 
+  validateSetJsonPointerTraversal(target, segments, options);
+
   let current: JsonContainer = target;
   assertWritableJsonContainer(current);
   for (let index = 0; index < segments.length - 1; index += 1) {
@@ -112,7 +114,7 @@ export function setJsonPointerValue<T extends JsonContainer>(
       continue;
     }
 
-    if (options.createMissing === false) {
+    if (getOwnBooleanOption(options, 'createMissing') === false) {
       throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not exist.`);
     }
 
@@ -144,20 +146,63 @@ function decodeJsonPointerSegment(segment: string): string {
 }
 
 function assertSafeJsonPointerSegment(segment: string, options: JsonPointerOptions): void {
-  const maxSegmentLength = options.maxSegmentLength ?? DEFAULT_MAX_SEGMENT_LENGTH;
+  const maxSegmentLength = getOwnNumberOption(options, 'maxSegmentLength', DEFAULT_MAX_SEGMENT_LENGTH);
   if (!Number.isSafeInteger(maxSegmentLength) || maxSegmentLength < 0) {
     throw new UnsafeJsonPointerError('JSON Pointer maxSegmentLength must be a non-negative safe integer.');
   }
   if (segment.length > maxSegmentLength) {
     throw new UnsafeJsonPointerError(`JSON Pointer segment exceeds ${maxSegmentLength} characters.`);
   }
-  if (!options.allowUnsafePrototypeSegments && UNSAFE_JSON_POINTER_SEGMENTS.has(segment)) {
+  if (getOwnBooleanOption(options, 'allowUnsafePrototypeSegments') !== true && UNSAFE_JSON_POINTER_SEGMENTS.has(segment)) {
     throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' is blocked because it can mutate object prototypes.`);
   }
 }
 
 function isObjectLike(value: unknown): value is object {
   return typeof value === 'object' && value !== null;
+}
+
+function validateSetJsonPointerTraversal(target: JsonContainer, segments: readonly string[], options: SetJsonPointerOptions): void {
+  let current: JsonContainer = target;
+  assertWritableJsonContainer(current);
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index];
+    const nextSegment = segments[index + 1];
+    if (hasOwnContainerValue(current, segment, options)) {
+      const existing = readOwnContainerValue(current, segment, options);
+      if (!isJsonContainer(existing)) {
+        throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not resolve to an object or array.`);
+      }
+      assertWritableJsonContainer(existing);
+      current = existing;
+      continue;
+    }
+
+    if (getOwnBooleanOption(options, 'createMissing') === false) {
+      throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not exist.`);
+    }
+    current = shouldCreateArrayForSegment(nextSegment, options) ? [] : Object.create(null) as Record<string, unknown>;
+  }
+
+  if (Array.isArray(current)) {
+    parseArrayIndex(segments.at(-1) as string, options);
+  }
+}
+
+function getOwnNumberOption<K extends 'maxSegments' | 'maxSegmentLength' | 'maxArrayIndex'>(
+  options: JsonPointerOptions,
+  key: K,
+  defaultValue: number,
+): number {
+  return Object.prototype.hasOwnProperty.call(options, key) ? options[key] as number : defaultValue;
+}
+
+function getOwnBooleanOption(
+  options: JsonPointerOptions | SetJsonPointerOptions,
+  key: 'allowUnsafePrototypeSegments' | 'createMissing',
+): boolean | undefined {
+  const optionRecord = options as Record<string, boolean | undefined>;
+  return Object.prototype.hasOwnProperty.call(optionRecord, key) ? optionRecord[key] : undefined;
 }
 
 function isJsonContainer(value: unknown): value is JsonContainer {
@@ -184,7 +229,7 @@ function parseArrayIndex(segment: string, options: JsonPointerOptions): number |
   if (!/^(0|[1-9]\d*)$/u.test(segment)) {
     return undefined;
   }
-  const maxArrayIndex = options.maxArrayIndex ?? DEFAULT_MAX_ARRAY_INDEX;
+  const maxArrayIndex = getOwnNumberOption(options, 'maxArrayIndex', DEFAULT_MAX_ARRAY_INDEX);
   if (!Number.isSafeInteger(maxArrayIndex) || maxArrayIndex < 0) {
     throw new UnsafeJsonPointerError('JSON Pointer maxArrayIndex must be a non-negative safe integer.');
   }

--- a/packages/franken-types/src/json-pointer.ts
+++ b/packages/franken-types/src/json-pointer.ts
@@ -1,6 +1,7 @@
 const UNSAFE_JSON_POINTER_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
 const DEFAULT_MAX_SEGMENTS = 128;
 const DEFAULT_MAX_SEGMENT_LENGTH = 512;
+const DEFAULT_MAX_ARRAY_INDEX = 10_000;
 
 type JsonContainer = Record<string, unknown> | unknown[];
 
@@ -20,6 +21,7 @@ export interface JsonPointerOptions {
   readonly allowUnsafePrototypeSegments?: boolean;
   readonly maxSegments?: number;
   readonly maxSegmentLength?: number;
+  readonly maxArrayIndex?: number;
 }
 
 export interface SetJsonPointerOptions extends JsonPointerOptions {
@@ -37,11 +39,15 @@ export function parseJsonPointer(pointer: string, options: JsonPointerOptions = 
     throw new UnsafeJsonPointerError('JSON Pointer must be empty or start with `/`.');
   }
 
-  const rawSegments = pointer.slice(1).split('/');
   const maxSegments = options.maxSegments ?? DEFAULT_MAX_SEGMENTS;
   if (!Number.isSafeInteger(maxSegments) || maxSegments < 0) {
     throw new UnsafeJsonPointerError('JSON Pointer maxSegments must be a non-negative safe integer.');
   }
+  if (countJsonPointerSegments(pointer, maxSegments) > maxSegments) {
+    throw new UnsafeJsonPointerError(`JSON Pointer contains too many path segments; limit is ${maxSegments}.`);
+  }
+
+  const rawSegments = pointer.slice(1).split('/');
   if (rawSegments.length > maxSegments) {
     throw new UnsafeJsonPointerError(`JSON Pointer contains too many path segments; limit is ${maxSegments}.`);
   }
@@ -49,6 +55,7 @@ export function parseJsonPointer(pointer: string, options: JsonPointerOptions = 
   const segments = rawSegments.map((segment) => decodeJsonPointerSegment(segment));
   for (const segment of segments) {
     assertSafeJsonPointerSegment(segment, options);
+    parseArrayIndex(segment, options);
   }
   return Object.freeze(segments);
 }
@@ -65,8 +72,8 @@ export function getJsonPointerValue(target: unknown, pointer: string, options: J
       return undefined;
     }
     if (Array.isArray(current)) {
-      const index = parseArrayIndex(segment);
-      if (index === undefined || index >= current.length) {
+      const index = parseArrayIndex(segment, options);
+      if (index === undefined || index >= current.length || !Object.prototype.hasOwnProperty.call(current, index)) {
         return undefined;
       }
       current = current[index];
@@ -95,7 +102,7 @@ export function setJsonPointerValue<T extends JsonContainer>(
   for (let index = 0; index < segments.length - 1; index += 1) {
     const segment = segments[index];
     const nextSegment = segments[index + 1];
-    const existing = readOwnContainerValue(current, segment);
+    const existing = readOwnContainerValue(current, segment, options);
     if (existing !== undefined) {
       if (!isJsonContainer(existing)) {
         throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not resolve to an object or array.`);
@@ -108,13 +115,23 @@ export function setJsonPointerValue<T extends JsonContainer>(
       throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not exist.`);
     }
 
-    const nextContainer = shouldCreateArrayForSegment(nextSegment) ? [] : Object.create(null) as Record<string, unknown>;
-    writeOwnContainerValue(current, segment, nextContainer);
+    const nextContainer = shouldCreateArrayForSegment(nextSegment, options) ? [] : Object.create(null) as Record<string, unknown>;
+    writeOwnContainerValue(current, segment, nextContainer, options);
     current = nextContainer;
   }
 
-  writeOwnContainerValue(current, segments.at(-1) as string, value);
+  writeOwnContainerValue(current, segments.at(-1) as string, value, options);
   return target;
+}
+
+function countJsonPointerSegments(pointer: string, maxSegments: number): number {
+  let segments = 0;
+  for (const char of pointer) {
+    if (char !== '/') continue;
+    segments += 1;
+    if (segments > maxSegments) return segments;
+  }
+  return segments;
 }
 
 function decodeJsonPointerSegment(segment: string): string {
@@ -146,29 +163,36 @@ function isJsonContainer(value: unknown): value is JsonContainer {
   return isObjectLike(value) && (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
 }
 
-function parseArrayIndex(segment: string): number | undefined {
+function parseArrayIndex(segment: string, options: JsonPointerOptions): number | undefined {
   if (!/^(0|[1-9]\d*)$/u.test(segment)) {
     return undefined;
   }
+  const maxArrayIndex = options.maxArrayIndex ?? DEFAULT_MAX_ARRAY_INDEX;
+  if (!Number.isSafeInteger(maxArrayIndex) || maxArrayIndex < 0) {
+    throw new UnsafeJsonPointerError('JSON Pointer maxArrayIndex must be a non-negative safe integer.');
+  }
   const index = Number(segment);
-  return Number.isSafeInteger(index) ? index : undefined;
+  if (!Number.isSafeInteger(index) || index > maxArrayIndex) {
+    throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' exceeds the maximum allowed array index of ${maxArrayIndex}.`);
+  }
+  return index;
 }
 
-function shouldCreateArrayForSegment(segment: string): boolean {
-  return parseArrayIndex(segment) !== undefined;
+function shouldCreateArrayForSegment(segment: string, options: JsonPointerOptions): boolean {
+  return parseArrayIndex(segment, options) !== undefined;
 }
 
-function readOwnContainerValue(container: JsonContainer, segment: string): unknown {
+function readOwnContainerValue(container: JsonContainer, segment: string, options: JsonPointerOptions): unknown {
   if (Array.isArray(container)) {
-    const index = parseArrayIndex(segment);
-    return index === undefined ? undefined : container[index];
+    const index = parseArrayIndex(segment, options);
+    return index === undefined || !Object.prototype.hasOwnProperty.call(container, index) ? undefined : container[index];
   }
   return Object.prototype.hasOwnProperty.call(container, segment) ? container[segment] : undefined;
 }
 
-function writeOwnContainerValue(container: JsonContainer, segment: string, value: unknown): void {
+function writeOwnContainerValue(container: JsonContainer, segment: string, value: unknown, options: JsonPointerOptions): void {
   if (Array.isArray(container)) {
-    const index = parseArrayIndex(segment);
+    const index = parseArrayIndex(segment, options);
     if (index === undefined) {
       throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' is not a valid array index.`);
     }

--- a/packages/franken-types/src/json-pointer.ts
+++ b/packages/franken-types/src/json-pointer.ts
@@ -102,8 +102,8 @@ export function setJsonPointerValue<T extends JsonContainer>(
   for (let index = 0; index < segments.length - 1; index += 1) {
     const segment = segments[index];
     const nextSegment = segments[index + 1];
-    const existing = readOwnContainerValue(current, segment, options);
-    if (existing !== undefined) {
+    if (hasOwnContainerValue(current, segment, options)) {
+      const existing = readOwnContainerValue(current, segment, options);
       if (!isJsonContainer(existing)) {
         throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not resolve to an object or array.`);
       }
@@ -165,9 +165,19 @@ function isJsonContainer(value: unknown): value is JsonContainer {
 }
 
 function assertWritableJsonContainer(value: JsonContainer): void {
-  if (value === Object.prototype || value === Array.prototype) {
-    throw new UnsafeJsonPointerError('Refusing to mutate a built-in prototype object through a JSON Pointer.');
+  if (isPrototypeObject(value)) {
+    throw new UnsafeJsonPointerError('Refusing to mutate a prototype object through a JSON Pointer.');
   }
+}
+
+function isPrototypeObject(value: JsonContainer): boolean {
+  if (value === Array.prototype) {
+    return true;
+  }
+  const constructorValue = Object.prototype.hasOwnProperty.call(value, 'constructor')
+    ? (value as Record<string, unknown>).constructor
+    : undefined;
+  return typeof constructorValue === 'function' && constructorValue.prototype === value;
 }
 
 function parseArrayIndex(segment: string, options: JsonPointerOptions): number | undefined {
@@ -195,6 +205,14 @@ function readOwnContainerValue(container: JsonContainer, segment: string, option
     return index === undefined || !Object.prototype.hasOwnProperty.call(container, index) ? undefined : container[index];
   }
   return Object.prototype.hasOwnProperty.call(container, segment) ? container[segment] : undefined;
+}
+
+function hasOwnContainerValue(container: JsonContainer, segment: string, options: JsonPointerOptions): boolean {
+  if (Array.isArray(container)) {
+    const index = parseArrayIndex(segment, options);
+    return index !== undefined && Object.prototype.hasOwnProperty.call(container, index);
+  }
+  return Object.prototype.hasOwnProperty.call(container, segment);
 }
 
 function writeOwnContainerValue(container: JsonContainer, segment: string, value: unknown, options: JsonPointerOptions): void {

--- a/packages/franken-types/src/json-pointer.ts
+++ b/packages/franken-types/src/json-pointer.ts
@@ -1,0 +1,185 @@
+const UNSAFE_JSON_POINTER_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+const DEFAULT_MAX_SEGMENTS = 128;
+const DEFAULT_MAX_SEGMENT_LENGTH = 512;
+
+type JsonContainer = Record<string, unknown> | unknown[];
+
+export class UnsafeJsonPointerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsafeJsonPointerError';
+  }
+}
+
+export interface JsonPointerOptions {
+  /**
+   * Allows prototype-related path segments as ordinary data keys. Keep false
+   * for untrusted input; enabling this is an explicit operator/developer
+   * override for trusted migration or compatibility paths.
+   */
+  readonly allowUnsafePrototypeSegments?: boolean;
+  readonly maxSegments?: number;
+  readonly maxSegmentLength?: number;
+}
+
+export interface SetJsonPointerOptions extends JsonPointerOptions {
+  /**
+   * Create missing intermediate objects/arrays while writing. Defaults to true.
+   */
+  readonly createMissing?: boolean;
+}
+
+export function parseJsonPointer(pointer: string, options: JsonPointerOptions = {}): readonly string[] {
+  if (pointer === '') {
+    return [];
+  }
+  if (!pointer.startsWith('/')) {
+    throw new UnsafeJsonPointerError('JSON Pointer must be empty or start with `/`.');
+  }
+
+  const rawSegments = pointer.slice(1).split('/');
+  const maxSegments = options.maxSegments ?? DEFAULT_MAX_SEGMENTS;
+  if (!Number.isSafeInteger(maxSegments) || maxSegments < 0) {
+    throw new UnsafeJsonPointerError('JSON Pointer maxSegments must be a non-negative safe integer.');
+  }
+  if (rawSegments.length > maxSegments) {
+    throw new UnsafeJsonPointerError(`JSON Pointer contains too many path segments; limit is ${maxSegments}.`);
+  }
+
+  const segments = rawSegments.map((segment) => decodeJsonPointerSegment(segment));
+  for (const segment of segments) {
+    assertSafeJsonPointerSegment(segment, options);
+  }
+  return Object.freeze(segments);
+}
+
+export function assertSafeJsonPointer(pointer: string, options: JsonPointerOptions = {}): void {
+  parseJsonPointer(pointer, options);
+}
+
+export function getJsonPointerValue(target: unknown, pointer: string, options: JsonPointerOptions = {}): unknown {
+  const segments = parseJsonPointer(pointer, options);
+  let current = target;
+  for (const segment of segments) {
+    if (!isObjectLike(current)) {
+      return undefined;
+    }
+    if (Array.isArray(current)) {
+      const index = parseArrayIndex(segment);
+      if (index === undefined || index >= current.length) {
+        return undefined;
+      }
+      current = current[index];
+      continue;
+    }
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export function setJsonPointerValue<T extends JsonContainer>(
+  target: T,
+  pointer: string,
+  value: unknown,
+  options: SetJsonPointerOptions = {},
+): T {
+  const segments = parseJsonPointer(pointer, options);
+  if (segments.length === 0) {
+    throw new UnsafeJsonPointerError('Refusing to replace the JSON Pointer root object in-place.');
+  }
+
+  let current: JsonContainer = target;
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index];
+    const nextSegment = segments[index + 1];
+    const existing = readOwnContainerValue(current, segment);
+    if (existing !== undefined) {
+      if (!isJsonContainer(existing)) {
+        throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not resolve to an object or array.`);
+      }
+      current = existing;
+      continue;
+    }
+
+    if (options.createMissing === false) {
+      throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' does not exist.`);
+    }
+
+    const nextContainer = shouldCreateArrayForSegment(nextSegment) ? [] : Object.create(null) as Record<string, unknown>;
+    writeOwnContainerValue(current, segment, nextContainer);
+    current = nextContainer;
+  }
+
+  writeOwnContainerValue(current, segments.at(-1) as string, value);
+  return target;
+}
+
+function decodeJsonPointerSegment(segment: string): string {
+  const invalidEscape = /~(?![01])/u;
+  if (invalidEscape.test(segment)) {
+    throw new UnsafeJsonPointerError('JSON Pointer contains an invalid escape sequence. Use `~0` for `~` and `~1` for `/`.');
+  }
+  return segment.replaceAll('~1', '/').replaceAll('~0', '~');
+}
+
+function assertSafeJsonPointerSegment(segment: string, options: JsonPointerOptions): void {
+  const maxSegmentLength = options.maxSegmentLength ?? DEFAULT_MAX_SEGMENT_LENGTH;
+  if (!Number.isSafeInteger(maxSegmentLength) || maxSegmentLength < 0) {
+    throw new UnsafeJsonPointerError('JSON Pointer maxSegmentLength must be a non-negative safe integer.');
+  }
+  if (segment.length > maxSegmentLength) {
+    throw new UnsafeJsonPointerError(`JSON Pointer segment exceeds ${maxSegmentLength} characters.`);
+  }
+  if (!options.allowUnsafePrototypeSegments && UNSAFE_JSON_POINTER_SEGMENTS.has(segment)) {
+    throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' is blocked because it can mutate object prototypes.`);
+  }
+}
+
+function isObjectLike(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+function isJsonContainer(value: unknown): value is JsonContainer {
+  return isObjectLike(value) && (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+}
+
+function parseArrayIndex(segment: string): number | undefined {
+  if (!/^(0|[1-9]\d*)$/u.test(segment)) {
+    return undefined;
+  }
+  const index = Number(segment);
+  return Number.isSafeInteger(index) ? index : undefined;
+}
+
+function shouldCreateArrayForSegment(segment: string): boolean {
+  return parseArrayIndex(segment) !== undefined;
+}
+
+function readOwnContainerValue(container: JsonContainer, segment: string): unknown {
+  if (Array.isArray(container)) {
+    const index = parseArrayIndex(segment);
+    return index === undefined ? undefined : container[index];
+  }
+  return Object.prototype.hasOwnProperty.call(container, segment) ? container[segment] : undefined;
+}
+
+function writeOwnContainerValue(container: JsonContainer, segment: string, value: unknown): void {
+  if (Array.isArray(container)) {
+    const index = parseArrayIndex(segment);
+    if (index === undefined) {
+      throw new UnsafeJsonPointerError(`JSON Pointer segment '${segment}' is not a valid array index.`);
+    }
+    container[index] = value;
+    return;
+  }
+
+  Object.defineProperty(container, segment, {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value,
+  });
+}

--- a/packages/franken-types/tests/json-pointer.test.ts
+++ b/packages/franken-types/tests/json-pointer.test.ts
@@ -72,6 +72,42 @@ describe('safe JSON Pointer helpers', () => {
     expect(target).toEqual({});
   });
 
+  it('allows large numeric object keys when they are not array indexes', () => {
+    const target = { agentsById: { '4294967294': { name: 'agent' } } };
+
+    expect(getJsonPointerValue(target, '/agentsById/4294967294/name')).toBe('agent');
+    setJsonPointerValue(target, '/agentsById/4294967294/enabled', true);
+
+    expect(target.agentsById['4294967294']).toEqual({ name: 'agent', enabled: true });
+  });
+
+  it('rejects writes that target built-in prototype objects', () => {
+    expect(() => setJsonPointerValue(Object.prototype as Record<string, unknown>, '/polluted', true)).toThrow(/prototype object/i);
+    expect(() => setJsonPointerValue({ branch: Object.prototype }, '/branch/polluted', true)).toThrow(/prototype object/i);
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+
+  it('defines array entries as own properties instead of invoking inherited setters', () => {
+    const target = new Array(1) as unknown[];
+    let setterCalled = false;
+    Object.defineProperty(Array.prototype, '0', {
+      configurable: true,
+      set() {
+        setterCalled = true;
+      },
+    });
+
+    try {
+      setJsonPointerValue(target, '/0', 'safe');
+
+      expect(setterCalled).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(target, 0)).toBe(true);
+      expect(target[0]).toBe('safe');
+    } finally {
+      delete (Array.prototype as unknown as Record<string, unknown>)['0'];
+    }
+  });
+
   it('checks segment count before materializing oversized pointer arrays', () => {
     const oversized = `/${'x/'.repeat(129)}`;
 

--- a/packages/franken-types/tests/json-pointer.test.ts
+++ b/packages/franken-types/tests/json-pointer.test.ts
@@ -84,7 +84,17 @@ describe('safe JSON Pointer helpers', () => {
   it('rejects writes that target built-in prototype objects', () => {
     expect(() => setJsonPointerValue(Object.prototype as Record<string, unknown>, '/polluted', true)).toThrow(/prototype object/i);
     expect(() => setJsonPointerValue({ branch: Object.prototype }, '/branch/polluted', true)).toThrow(/prototype object/i);
+    expect(() => setJsonPointerValue({ dateProto: Date.prototype as Record<string, unknown> }, '/dateProto/polluted', true)).toThrow(/prototype object/i);
     expect(Object.prototype).not.toHaveProperty('polluted');
+    expect(Date.prototype).not.toHaveProperty('polluted');
+  });
+
+  it('preserves own undefined intermediates instead of replacing them', () => {
+    const target: Record<string, unknown> = { limits: undefined };
+
+    expect(() => setJsonPointerValue(target, '/limits/max', 10)).toThrow(/does not resolve to an object or array/i);
+    expect(Object.prototype.hasOwnProperty.call(target, 'limits')).toBe(true);
+    expect(target.limits).toBeUndefined();
   });
 
   it('defines array entries as own properties instead of invoking inherited setters', () => {

--- a/packages/franken-types/tests/json-pointer.test.ts
+++ b/packages/franken-types/tests/json-pointer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertSafeJsonPointer,
+  getJsonPointerValue,
+  parseJsonPointer,
+  setJsonPointerValue,
+  UnsafeJsonPointerError,
+} from '../src/json-pointer.js';
+
+describe('safe JSON Pointer helpers', () => {
+  it('parses and resolves RFC 6901 escaped path segments', () => {
+    const document = {
+      agents: [
+        {
+          config: {
+            'a/b': { '~enabled': true },
+          },
+        },
+      ],
+    };
+
+    expect(parseJsonPointer('/agents/0/config/a~1b/~0enabled')).toEqual(['agents', '0', 'config', 'a/b', '~enabled']);
+    expect(getJsonPointerValue(document, '/agents/0/config/a~1b/~0enabled')).toBe(true);
+  });
+
+  it('rejects prototype-polluting segments by default', () => {
+    const pollutedBefore = ({} as Record<string, unknown>).polluted;
+    const target: Record<string, unknown> = {};
+
+    for (const pointer of ['/__proto__/polluted', '/constructor/prototype/polluted', '/safe/prototype/polluted']) {
+      expect(() => setJsonPointerValue(target, pointer, true)).toThrow(UnsafeJsonPointerError);
+    }
+
+    expect(({} as Record<string, unknown>).polluted).toBe(pollutedBefore);
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+
+  it('writes missing branches as own data properties without inherited traversal', () => {
+    const target: Record<string, unknown> = {};
+
+    setJsonPointerValue(target, '/agents/0/moduleConfig/firewall', false);
+
+    expect(target).toEqual({ agents: [{ moduleConfig: { firewall: false } }] });
+    expect(getJsonPointerValue(target, '/agents/0/moduleConfig/firewall')).toBe(false);
+  });
+
+  it('requires an explicit override for unsafe compatibility keys and still avoids prototype mutation', () => {
+    const target: Record<string, unknown> = {};
+
+    setJsonPointerValue(target, '/__proto__/polluted', 'data-only', { allowUnsafePrototypeSegments: true });
+
+    expect(Object.prototype).not.toHaveProperty('polluted');
+    expect(Object.prototype.hasOwnProperty.call(target, '__proto__')).toBe(true);
+    expect(getJsonPointerValue(target, '/__proto__/polluted', { allowUnsafePrototypeSegments: true })).toBe('data-only');
+    expect(() => assertSafeJsonPointer('/__proto__/polluted')).toThrow(/blocked/i);
+  });
+
+  it('fails closed on invalid pointer syntax and unsafe oversized paths', () => {
+    expect(() => parseJsonPointer('agents/0')).toThrow(/start with/i);
+    expect(() => parseJsonPointer('/agents/~2bad')).toThrow(/invalid escape/i);
+    expect(() => parseJsonPointer('/a/b', { maxSegments: 1 })).toThrow(/too many/i);
+    expect(() => parseJsonPointer('/long', { maxSegmentLength: 2 })).toThrow(/exceeds/i);
+  });
+});

--- a/packages/franken-types/tests/json-pointer.test.ts
+++ b/packages/franken-types/tests/json-pointer.test.ts
@@ -72,6 +72,13 @@ describe('safe JSON Pointer helpers', () => {
     expect(target).toEqual({});
   });
 
+  it('validates nested array indexes before mutating missing branches', () => {
+    const target: Record<string, unknown> = {};
+
+    expect(() => setJsonPointerValue(target, '/agents/0/4294967294/name', 'agent')).toThrow(/maximum allowed array index/i);
+    expect(target).toEqual({});
+  });
+
   it('allows large numeric object keys when they are not array indexes', () => {
     const target = { agentsById: { '4294967294': { name: 'agent' } } };
 
@@ -84,7 +91,7 @@ describe('safe JSON Pointer helpers', () => {
   it('rejects writes that target built-in prototype objects', () => {
     expect(() => setJsonPointerValue(Object.prototype as Record<string, unknown>, '/polluted', true)).toThrow(/prototype object/i);
     expect(() => setJsonPointerValue({ branch: Object.prototype }, '/branch/polluted', true)).toThrow(/prototype object/i);
-    expect(() => setJsonPointerValue({ dateProto: Date.prototype as Record<string, unknown> }, '/dateProto/polluted', true)).toThrow(/prototype object/i);
+    expect(() => setJsonPointerValue({ dateProto: Date.prototype as unknown as Record<string, unknown> }, '/dateProto/polluted', true)).toThrow(/prototype object/i);
     expect(Object.prototype).not.toHaveProperty('polluted');
     expect(Date.prototype).not.toHaveProperty('polluted');
   });
@@ -133,6 +140,25 @@ describe('safe JSON Pointer helpers', () => {
     expect(Object.prototype.hasOwnProperty.call(target, '__proto__')).toBe(true);
     expect(getJsonPointerValue(target, '/__proto__/polluted', { allowUnsafePrototypeSegments: true })).toBe('data-only');
     expect(() => assertSafeJsonPointer('/__proto__/polluted')).toThrow(/blocked/i);
+  });
+
+  it('ignores inherited option overrides for security defaults', () => {
+    Object.defineProperty(Object.prototype, 'allowUnsafePrototypeSegments', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(Object.prototype, 'maxArrayIndex', {
+      configurable: true,
+      value: Number.MAX_SAFE_INTEGER,
+    });
+
+    try {
+      expect(() => assertSafeJsonPointer('/__proto__/polluted')).toThrow(/blocked/i);
+      expect(() => setJsonPointerValue({}, '/agents/4294967294/name', 'agent')).toThrow(/maximum allowed array index/i);
+    } finally {
+      delete (Object.prototype as unknown as Record<string, unknown>).allowUnsafePrototypeSegments;
+      delete (Object.prototype as unknown as Record<string, unknown>).maxArrayIndex;
+    }
   });
 
   it('fails closed on invalid pointer syntax and unsafe oversized paths', () => {

--- a/packages/franken-types/tests/json-pointer.test.ts
+++ b/packages/franken-types/tests/json-pointer.test.ts
@@ -44,6 +44,40 @@ describe('safe JSON Pointer helpers', () => {
     expect(getJsonPointerValue(target, '/agents/0/moduleConfig/firewall')).toBe(false);
   });
 
+  it('does not traverse inherited array indexes when writing nested paths', () => {
+    const inherited = { polluted: false };
+    Object.defineProperty(Array.prototype, '0', {
+      configurable: true,
+      writable: true,
+      value: inherited,
+    });
+
+    try {
+      const target = new Array(1) as unknown[];
+
+      setJsonPointerValue(target, '/0/enabled', true);
+
+      expect(inherited).toEqual({ polluted: false });
+      expect(Object.prototype.hasOwnProperty.call(target, 0)).toBe(true);
+      expect(target[0]).toEqual({ enabled: true });
+    } finally {
+      delete (Array.prototype as unknown as Record<string, unknown>)['0'];
+    }
+  });
+
+  it('bounds array indexes before creating sparse arrays', () => {
+    const target: Record<string, unknown> = {};
+
+    expect(() => setJsonPointerValue(target, '/agents/4294967294/name', 'agent')).toThrow(/maximum allowed array index/i);
+    expect(target).toEqual({});
+  });
+
+  it('checks segment count before materializing oversized pointer arrays', () => {
+    const oversized = `/${'x/'.repeat(129)}`;
+
+    expect(() => parseJsonPointer(oversized)).toThrow(/too many path segments/i);
+  });
+
   it('requires an explicit override for unsafe compatibility keys and still avoids prototype mutation', () => {
     const target: Record<string, unknown> = {};
 

--- a/scripts/vitest-source-aliases.ts
+++ b/scripts/vitest-source-aliases.ts
@@ -9,6 +9,7 @@ const FRANKEN_SOURCE_ENTRYPOINTS = {
   '@franken/critique': 'packages/franken-critique/src/index.ts',
   '@franken/governor': 'packages/franken-governor/src/index.ts',
   '@franken/types/path-containment': 'packages/franken-types/src/path-containment.ts',
+  '@franken/types/json-pointer': 'packages/franken-types/src/json-pointer.ts',
   '@franken/types/utils': 'packages/franken-types/src/utils/index.ts',
   '@franken/types': 'packages/franken-types/src/index.ts',
   '@franken/orchestrator': 'packages/franken-orchestrator/src/index.ts',

--- a/tasks/issue-1794-json-pointer-progress.md
+++ b/tasks/issue-1794-json-pointer-progress.md
@@ -1,0 +1,9 @@
+# Issue 1794 JSON Pointer Hardening Progress
+
+- [x] Read task, issue, shared lessons, and repo guidance.
+- [x] Create isolated issue branch/worktree.
+- [x] Add deny-by-default JSON Pointer helpers that reject prototype-pollution segments.
+- [x] Add focused tests for allowed parsing/writes, denied unsafe segments, and explicit override behavior.
+- [x] Update package docs for operator/developer guidance.
+- [x] Run targeted package tests/typecheck/build/lint and broader relevant checks.
+- [ ] Commit, push, open PR, run GitHub Codex review gate, merge if clean.

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -33,6 +33,8 @@ const EXPECTED_ALIASES: Record<string, string> = {
   "@franken/governor": "./packages/franken-governor/src/index.ts",
   "@franken/types/path-containment":
     "./packages/franken-types/src/path-containment.ts",
+  "@franken/types/json-pointer":
+    "./packages/franken-types/src/json-pointer.ts",
   "@franken/types/utils": "./packages/franken-types/src/utils/index.ts",
   "@franken/types": "./packages/franken-types/src/index.ts",
   "@franken/orchestrator": "./packages/franken-orchestrator/src/index.ts",

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -13,6 +13,7 @@ const EXPECTED_ALIASES = {
   '@franken/critique': resolve(ROOT, 'packages/franken-critique/src/index.ts'),
   '@franken/governor': resolve(ROOT, 'packages/franken-governor/src/index.ts'),
   '@franken/types/path-containment': resolve(ROOT, 'packages/franken-types/src/path-containment.ts'),
+  '@franken/types/json-pointer': resolve(ROOT, 'packages/franken-types/src/json-pointer.ts'),
   '@franken/types/utils': resolve(ROOT, 'packages/franken-types/src/utils/index.ts'),
   '@franken/types': resolve(ROOT, 'packages/franken-types/src/index.ts'),
   '@franken/orchestrator': resolve(ROOT, 'packages/franken-orchestrator/src/index.ts'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,9 @@
       "@franken/types/path-containment": [
         "./packages/franken-types/src/path-containment.ts"
       ],
+      "@franken/types/json-pointer": [
+        "./packages/franken-types/src/json-pointer.ts"
+      ],
       "@franken/types/utils": [
         "./packages/franken-types/src/utils/index.ts"
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
       '@franken/observer': resolve(__dirname, 'packages/franken-observer/src/index.ts'),
       '@franken/critique': resolve(__dirname, 'packages/franken-critique/src/index.ts'),
       '@franken/governor': resolve(__dirname, 'packages/franken-governor/src/index.ts'),
+      '@franken/types/json-pointer': resolve(__dirname, 'packages/franken-types/src/json-pointer.ts'),
       '@franken/types/utils': resolve(__dirname, 'packages/franken-types/src/utils/index.ts'),
       '@franken/types': resolve(__dirname, 'packages/franken-types/src/index.ts'),
       '@franken/orchestrator': resolve(__dirname, 'packages/franken-orchestrator/src/index.ts'),


### PR DESCRIPTION
## Summary
- Adds safe RFC 6901 JSON Pointer helpers to @franken/types with deny-by-default prototype-pollution segment checks.
- Exports a focused @franken/types/json-pointer subpath and documents default/override semantics.
- Covers allowed pointer parsing/writes, denied prototype-pollution paths, explicit trusted override behavior, and invalid pointer limits.

## Verification
- npm test --workspace=@franken/types -- json-pointer.test.ts
- npm run typecheck --workspace=@franken/types
- npm run build --workspace=@franken/types
- npm run lint --workspace=@franken/types
- npm test --workspace=@franken/types
- git diff --check

Closes #1794