### PR TITLE
feat(learning): add PM handoff quality rubric

### DIFF
--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -72,6 +72,21 @@ Integration and E2E scripts enable broader runtime paths with `INTEGRATION=true`
 
 Context snapshot imports are size-limited before JSON parsing to reduce resource-exhaustion risk from untrusted or corrupted resume/import files. `loadContext(filePath)` defaults to a 1 MiB cap, opens snapshots in nonblocking mode, rejects non-regular paths from the opened file descriptor, and enforces the same byte cap while reading so oversized content is rejected even if the file changes after metadata inspection. Trusted tooling that intentionally owns a larger snapshot must opt in per import with `loadContext(filePath, { maxBytes })`; invalid overrides such as `0`, negative, non-finite, or unsafe integer values fail closed.
 
+## PM handoff quality rubric
+
+Provider handoffs include a deterministic PM handoff quality rubric generated from the current brain snapshot. The rubric gives receiving PMs and liveness tooling a structured signal for whether a handoff is ready to promote, retire, or hand to a fresh worker.
+
+The rubric checks six criteria:
+
+- Scope and objective: issue/task, business goal, and out-of-scope boundaries.
+- Current state and decisions: completed work, current phase, and key decisions.
+- Verification evidence: test, lint, build, fixture, or deterministic verifier commands and outcomes.
+- Blockers and next action: blockers, owner, and explicit next step.
+- Artifacts and links: branch, PR, worktree, diff, docs, URLs, or telemetry records.
+- Learning and reuse: reusable lessons, retrospectives, Codex/CI feedback, and promotion/retirement rationale.
+
+Each criterion reports `pass` only when matching evidence is present in working memory, recent events, or checkpoint context; sparse handoffs report `needs-attention` with guidance instead of inventing missing evidence.
+
 ## Package areas
 
 | Area | Paths | Responsibility |

--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -85,7 +85,7 @@ The rubric checks six criteria:
 - Artifacts and links: branch, PR, worktree, diff, docs, URLs, or telemetry records.
 - Learning and reuse: reusable lessons, retrospectives, Codex/CI feedback, and promotion/retirement rationale.
 
-Each criterion reports `pass` only when matching evidence is present in working memory, recent events, or checkpoint context; sparse handoffs report `needs-attention` with guidance instead of inventing missing evidence.
+Each criterion reports `pass` only when matching evidence is present in working memory, recent events, or checkpoint context; sparse handoffs report `needs-attention` with guidance instead of inventing missing evidence. Structured tooling can import `assessPmHandoffQuality` from `@franken/orchestrator` when it needs the rubric score without parsing handoff prose.
 
 ## Package areas
 

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -76,6 +76,17 @@ export { checkCritiqueSpiral } from './breakers/critique-spiral-breaker.js';
 
 // LLM helpers
 export { AdapterLlmClient, AdapterLlmError } from './adapters/adapter-llm-client.js';
+export {
+  PM_HANDOFF_QUALITY_RUBRIC,
+  assessPmHandoffQuality,
+  formatHandoff,
+} from './providers/format-handoff.js';
+export type {
+  PmHandoffQualityAssessment,
+  PmHandoffRubricCriterion,
+  PmHandoffRubricResult,
+  PmHandoffRubricStatus,
+} from './providers/format-handoff.js';
 export { LlmSkillHandler } from './skills/llm-skill-handler.js';
 export { LlmPlanner } from './skills/llm-planner.js';
 

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -2,6 +2,7 @@ import type { BrainSnapshot, EpisodicEvent } from '@franken/types';
 
 /** Rough char-to-token ratio (1 token ≈ 4 chars) */
 const CHARS_PER_TOKEN = 4;
+const MAX_RUBRIC_EVIDENCE_CHARS = 240;
 
 export type PmHandoffRubricStatus = 'pass' | 'needs-attention';
 
@@ -26,6 +27,11 @@ export interface PmHandoffQualityAssessment {
   readonly total: number;
   readonly results: readonly PmHandoffRubricResult[];
   readonly operatorGuidance: string;
+}
+
+interface HandoffEvidenceEntry {
+  readonly searchable: string;
+  readonly display: string;
 }
 
 export const PM_HANDOFF_QUALITY_RUBRIC: readonly PmHandoffRubricCriterion[] = [
@@ -130,7 +136,10 @@ export function assessPmHandoffQuality(
   const evidenceCorpus = buildHandoffEvidenceCorpus(snapshot);
   const results = PM_HANDOFF_QUALITY_RUBRIC.map((criterion) => {
     const evidence = evidenceCorpus
-      .filter((entry) => criterion.evidencePatterns.some((pattern) => pattern.test(entry)))
+      .filter((entry) =>
+        criterion.evidencePatterns.some((pattern) => pattern.test(entry.searchable)),
+      )
+      .map((entry) => entry.display)
       .slice(0, 3);
     return {
       id: criterion.id,
@@ -203,32 +212,63 @@ function formatPmHandoffQualityRubric(
   ].join('\n');
 }
 
-function buildHandoffEvidenceCorpus(snapshot: BrainSnapshot): string[] {
+function buildHandoffEvidenceCorpus(
+  snapshot: BrainSnapshot,
+): HandoffEvidenceEntry[] {
   const entries = [
-    ...Object.entries(snapshot.working).map(
-      ([key, value]) => `working.${key}: ${summarizeUnknown(value)}`,
-    ),
+    ...Object.entries(snapshot.working)
+      .map(([key, value]) => formatWorkingEvidence(key, value))
+      .filter((entry): entry is HandoffEvidenceEntry => entry !== null),
     ...snapshot.episodic.map(formatEpisodicEvidence),
   ];
 
   if (snapshot.checkpoint) {
-    entries.push(
-      `checkpoint: phase=${snapshot.checkpoint.phase} step=${snapshot.checkpoint.step} context=${summarizeUnknown(snapshot.checkpoint.context)}`,
+    const searchable = normalizeEvidence(
+      [
+        snapshot.checkpoint.phase,
+        String(snapshot.checkpoint.step),
+        summarizeUnknown(snapshot.checkpoint.context),
+      ].join(' '),
     );
+    if (searchable.length > 0) {
+      entries.push({
+        searchable,
+        display: `checkpoint: phase=${snapshot.checkpoint.phase} step=${snapshot.checkpoint.step} context=${truncateEvidence(searchable)}`,
+      });
+    }
   }
 
-  return entries
-    .map((entry) => entry.replace(/\s+/g, ' ').trim())
-    .filter((entry) => entry.length > 0);
+  return entries;
 }
 
-function formatEpisodicEvidence(event: EpisodicEvent): string {
+function formatWorkingEvidence(
+  key: string,
+  value: unknown,
+): HandoffEvidenceEntry | null {
+  const searchable = normalizeEvidence(summarizeUnknown(value));
+  if (searchable.length === 0) {
+    return null;
+  }
+  return {
+    searchable,
+    display: `working.${key}: ${truncateEvidence(searchable)}`,
+  };
+}
+
+function formatEpisodicEvidence(event: EpisodicEvent): HandoffEvidenceEntry {
   const details = event.details ? ` details=${summarizeUnknown(event.details)}` : '';
   const step = event.step ? ` step=${event.step}` : '';
-  return `event.${event.type}:${step} ${event.summary}${details}`;
+  const searchable = normalizeEvidence(`${step} ${event.summary}${details}`);
+  return {
+    searchable,
+    display: `event.${event.type}:${step} ${truncateEvidence(searchable)}`,
+  };
 }
 
 function summarizeUnknown(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
   if (typeof value === 'string') {
     return value;
   }
@@ -237,4 +277,16 @@ function summarizeUnknown(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function normalizeEvidence(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncateEvidence(value: string): string {
+  const normalized = normalizeEvidence(value);
+  if (normalized.length <= MAX_RUBRIC_EVIDENCE_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_RUBRIC_EVIDENCE_CHARS - 1)}…`;
 }

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -2,7 +2,7 @@ import type { BrainSnapshot, EpisodicEvent } from '@franken/types';
 
 /** Rough char-to-token ratio (1 token ≈ 4 chars) */
 const CHARS_PER_TOKEN = 4;
-const MAX_RUBRIC_EVIDENCE_CHARS = 240;
+const MAX_RUBRIC_EVIDENCE_CHARS = 120;
 
 export type PmHandoffRubricStatus = 'pass' | 'needs-attention';
 
@@ -57,13 +57,17 @@ export const PM_HANDOFF_QUALITY_RUBRIC: readonly PmHandoffRubricCriterion[] = [
     id: 'verification',
     label: 'Verification evidence',
     guidance: 'Include deterministic test, lint, build, or verifier commands and their outcome before promotion or retirement.',
-    evidencePatterns: [/\b(test|lint|typecheck|build|verified|verification|pass(?:ed)?|fail(?:ed)?|fixture)\b/i],
+    evidencePatterns: [/\b(test|lint|typecheck|build|verified|verification|pass(?:ed)?|fail(?:ed)?|fixture|npm|pnpm|yarn|vitest|tsc|eslint|pytest)\b/i],
+    requiredEvidencePatterns: [
+      /\b(test|lint|typecheck|build|verified|verification|fixture|npm|pnpm|yarn|vitest|tsc|eslint|pytest)\b/i,
+      /\b(pass(?:ed)?|fail(?:ed)?|exit|0 errors|green|succeed(?:ed)?)\b/i,
+    ],
   },
   {
     id: 'blockers',
     label: 'Blockers and next action',
     guidance: 'Make blockers, owner, and next action explicit instead of leaving the receiving PM to infer what to do.',
-    evidencePatterns: [/\b(blocker|blocked|risk|next action|next step|owner|assignee|needs review|follow[- ]?up)\b/i],
+    evidencePatterns: [/\b(blocker|blockers|blocked|risk|next action|next step|next steps|owner|assignee|needs review|follow[- ]?up)\b/i],
   },
   {
     id: 'artifacts',
@@ -146,7 +150,7 @@ export function assessPmHandoffQuality(
         criterion.evidencePatterns.some((pattern) => pattern.test(entry.searchable)),
       )
       .map((entry) => entry.display)
-      .slice(0, 3);
+      .slice(0, 1);
     return {
       id: criterion.id,
       label: criterion.label,

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -11,6 +11,7 @@ export interface PmHandoffRubricCriterion {
   readonly label: string;
   readonly guidance: string;
   readonly evidencePatterns: readonly RegExp[];
+  readonly requiredEvidencePatterns?: readonly RegExp[];
 }
 
 export interface PmHandoffRubricResult {
@@ -39,7 +40,12 @@ export const PM_HANDOFF_QUALITY_RUBRIC: readonly PmHandoffRubricCriterion[] = [
     id: 'scope',
     label: 'Scope and objective',
     guidance: 'Name the issue/task, business goal, and out-of-scope boundaries so the next PM does not re-discover intent.',
-    evidencePatterns: [/\b(issue|task|goal|objective|scope|out[- ]of[- ]scope)\b/i],
+    evidencePatterns: [/\b(issue|task|goal|objective|scope|out[- ]of[- ]scope|boundary|boundaries)\b/i],
+    requiredEvidencePatterns: [
+      /\b(issue|task|scope)\b/i,
+      /\b(goal|objective)\b/i,
+      /\b(out[- ]of[- ]scope|boundary|boundaries)\b/i,
+    ],
   },
   {
     id: 'state',
@@ -144,7 +150,7 @@ export function assessPmHandoffQuality(
     return {
       id: criterion.id,
       label: criterion.label,
-      status: evidence.length > 0 ? 'pass' : 'needs-attention',
+      status: criterionPasses(criterion, evidenceCorpus) ? 'pass' : 'needs-attention',
       evidence,
       guidance: criterion.guidance,
     } satisfies PmHandoffRubricResult;
@@ -163,6 +169,20 @@ export function assessPmHandoffQuality(
         ? 'PM handoff includes evidence for every rubric criterion.'
         : 'PM handoff is missing one or more rubric criteria; add the missing evidence before promotion or retirement.',
   };
+}
+
+function criterionPasses(
+  criterion: PmHandoffRubricCriterion,
+  evidenceCorpus: readonly HandoffEvidenceEntry[],
+): boolean {
+  if (criterion.requiredEvidencePatterns) {
+    return criterion.requiredEvidencePatterns.every((pattern) =>
+      evidenceCorpus.some((entry) => pattern.test(entry.searchable)),
+    );
+  }
+  return evidenceCorpus.some((entry) =>
+    criterion.evidencePatterns.some((pattern) => pattern.test(entry.searchable)),
+  );
 }
 
 /**
@@ -203,12 +223,12 @@ function formatPmHandoffQualityRubric(
   assessment: PmHandoffQualityAssessment,
 ): string {
   return [
-    `PM handoff quality rubric: ${assessment.passed}/${assessment.total} (${assessment.score})`,
+    `PM rubric: ${assessment.passed}/${assessment.total} (${assessment.score})`,
     ...assessment.results.map((result) => {
-      const evidence = result.evidence.length > 0 ? result.evidence.join('; ') : result.guidance;
-      return `  - ${result.label}: ${result.status} — ${evidence}`;
+      const evidence = result.evidence.length > 0 ? result.evidence.join('; ') : 'missing evidence';
+      return `  - ${result.id}: ${result.status} — ${evidence}`;
     }),
-    `PM guidance: ${assessment.operatorGuidance}`,
+    `PM guidance: ${assessment.passed === assessment.total ? 'complete' : 'add missing evidence before promotion/retirement'}`,
   ].join('\n');
 }
 
@@ -294,6 +314,9 @@ function pruneEmptyEvidence(value: unknown): unknown {
   if (typeof value === 'string') {
     const normalized = normalizeEvidence(value);
     return normalized.length === 0 ? undefined : normalized;
+  }
+  if (typeof value === 'boolean') {
+    return value ? value : undefined;
   }
   if (Array.isArray(value)) {
     const items = value

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -3,6 +3,70 @@ import type { BrainSnapshot, EpisodicEvent } from '@franken/types';
 /** Rough char-to-token ratio (1 token ≈ 4 chars) */
 const CHARS_PER_TOKEN = 4;
 
+export type PmHandoffRubricStatus = 'pass' | 'needs-attention';
+
+export interface PmHandoffRubricCriterion {
+  readonly id: string;
+  readonly label: string;
+  readonly guidance: string;
+  readonly evidencePatterns: readonly RegExp[];
+}
+
+export interface PmHandoffRubricResult {
+  readonly id: string;
+  readonly label: string;
+  readonly status: PmHandoffRubricStatus;
+  readonly evidence: readonly string[];
+  readonly guidance: string;
+}
+
+export interface PmHandoffQualityAssessment {
+  readonly score: number;
+  readonly passed: number;
+  readonly total: number;
+  readonly results: readonly PmHandoffRubricResult[];
+  readonly operatorGuidance: string;
+}
+
+export const PM_HANDOFF_QUALITY_RUBRIC: readonly PmHandoffRubricCriterion[] = [
+  {
+    id: 'scope',
+    label: 'Scope and objective',
+    guidance: 'Name the issue/task, business goal, and out-of-scope boundaries so the next PM does not re-discover intent.',
+    evidencePatterns: [/\b(issue|task|goal|objective|scope|out[- ]of[- ]scope)\b/i],
+  },
+  {
+    id: 'state',
+    label: 'Current state and decisions',
+    guidance: 'Preserve completed work, current phase, and key decisions with enough context for a fresh worker to resume safely.',
+    evidencePatterns: [/\b(decision|phase|status|completed|remaining|checkpoint|current state)\b/i],
+  },
+  {
+    id: 'verification',
+    label: 'Verification evidence',
+    guidance: 'Include deterministic test, lint, build, or verifier commands and their outcome before promotion or retirement.',
+    evidencePatterns: [/\b(test|lint|typecheck|build|verified|verification|pass(?:ed)?|fail(?:ed)?|fixture)\b/i],
+  },
+  {
+    id: 'blockers',
+    label: 'Blockers and next action',
+    guidance: 'Make blockers, owner, and next action explicit instead of leaving the receiving PM to infer what to do.',
+    evidencePatterns: [/\b(blocker|blocked|risk|next action|next step|owner|assignee|needs review|follow[- ]?up)\b/i],
+  },
+  {
+    id: 'artifacts',
+    label: 'Artifacts and links',
+    guidance: 'Point to concrete artifacts such as branch, PR, worktree, diff, docs, or telemetry records that the next PM can inspect.',
+    evidencePatterns: [/\b(branch|pr|pull request|worktree|diff|artifact|doc|url|https?:\/\/|telemetry)\b/i],
+  },
+  {
+    id: 'learning',
+    label: 'Learning and reuse',
+    guidance: 'Capture reusable lessons, retrospective notes, Codex/CI feedback, or promotion/retirement rationale without one-off noise.',
+    evidencePatterns: [/\b(lesson|learning|retrospective|retro|rubric|codex|ci feedback|reuse|promot(?:e|ion)|retir(?:e|ement))\b/i],
+  },
+];
+
 /**
  * Truncate a BrainSnapshot to fit within a token budget.
  * Removes episodic events (oldest first) and working memory entries
@@ -56,6 +120,43 @@ function estimateChars(snapshot: BrainSnapshot): number {
 }
 
 /**
+ * Evaluate the snapshot with a deterministic PM handoff quality rubric.
+ * The result is intentionally evidence-based and LLM-readable so PM/liveness
+ * tooling can flag missing handoff sections without inventing context.
+ */
+export function assessPmHandoffQuality(
+  snapshot: BrainSnapshot,
+): PmHandoffQualityAssessment {
+  const evidenceCorpus = buildHandoffEvidenceCorpus(snapshot);
+  const results = PM_HANDOFF_QUALITY_RUBRIC.map((criterion) => {
+    const evidence = evidenceCorpus
+      .filter((entry) => criterion.evidencePatterns.some((pattern) => pattern.test(entry)))
+      .slice(0, 3);
+    return {
+      id: criterion.id,
+      label: criterion.label,
+      status: evidence.length > 0 ? 'pass' : 'needs-attention',
+      evidence,
+      guidance: criterion.guidance,
+    } satisfies PmHandoffRubricResult;
+  });
+  const passed = results.filter((result) => result.status === 'pass').length;
+  const total = results.length;
+  const score = total === 0 ? 0 : Number((passed / total).toFixed(2));
+
+  return {
+    score,
+    passed,
+    total,
+    results,
+    operatorGuidance:
+      passed === total
+        ? 'PM handoff includes evidence for every rubric criterion.'
+        : 'PM handoff is missing one or more rubric criteria; add the missing evidence before promotion or retirement.',
+  };
+}
+
+/**
  * Format a BrainSnapshot as human-readable text for provider handoff.
  * Shared across all adapters — each injects this via their own mechanism
  * (CLI flag, system prompt, GEMINI.md, etc.).
@@ -74,6 +175,8 @@ export function formatHandoff(snapshot: BrainSnapshot): string {
     ...snapshot.episodic.slice(-10).map(
       (e) => `  [${e.type}] ${e.summary}`,
     ),
+    '',
+    formatPmHandoffQualityRubric(assessPmHandoffQuality(snapshot)),
   ];
 
   if (snapshot.checkpoint) {
@@ -85,4 +188,53 @@ export function formatHandoff(snapshot: BrainSnapshot): string {
 
   lines.push('--- END HANDOFF ---');
   return lines.join('\n');
+}
+
+function formatPmHandoffQualityRubric(
+  assessment: PmHandoffQualityAssessment,
+): string {
+  return [
+    `PM handoff quality rubric: ${assessment.passed}/${assessment.total} (${assessment.score})`,
+    ...assessment.results.map((result) => {
+      const evidence = result.evidence.length > 0 ? result.evidence.join('; ') : result.guidance;
+      return `  - ${result.label}: ${result.status} — ${evidence}`;
+    }),
+    `PM guidance: ${assessment.operatorGuidance}`,
+  ].join('\n');
+}
+
+function buildHandoffEvidenceCorpus(snapshot: BrainSnapshot): string[] {
+  const entries = [
+    ...Object.entries(snapshot.working).map(
+      ([key, value]) => `working.${key}: ${summarizeUnknown(value)}`,
+    ),
+    ...snapshot.episodic.map(formatEpisodicEvidence),
+  ];
+
+  if (snapshot.checkpoint) {
+    entries.push(
+      `checkpoint: phase=${snapshot.checkpoint.phase} step=${snapshot.checkpoint.step} context=${summarizeUnknown(snapshot.checkpoint.context)}`,
+    );
+  }
+
+  return entries
+    .map((entry) => entry.replace(/\s+/g, ' ').trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function formatEpisodicEvidence(event: EpisodicEvent): string {
+  const details = event.details ? ` details=${summarizeUnknown(event.details)}` : '';
+  const step = event.step ? ` step=${event.step}` : '';
+  return `event.${event.type}:${step} ${event.summary}${details}`;
+}
+
+function summarizeUnknown(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -225,7 +225,10 @@ function buildHandoffEvidenceCorpus(
   if (snapshot.checkpoint) {
     const searchable = normalizeEvidence(
       [
+        'checkpoint',
+        'phase',
         snapshot.checkpoint.phase,
+        'step',
         String(snapshot.checkpoint.step),
         summarizeUnknown(snapshot.checkpoint.context),
       ].join(' '),

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -245,20 +245,21 @@ function formatWorkingEvidence(
   key: string,
   value: unknown,
 ): HandoffEvidenceEntry | null {
-  const searchable = normalizeEvidence(summarizeUnknown(value));
-  if (searchable.length === 0) {
+  const valueEvidence = normalizeEvidence(summarizeUnknown(value));
+  if (valueEvidence.length === 0) {
     return null;
   }
+  const searchable = normalizeEvidence(`${splitEvidenceKey(key)} ${valueEvidence}`);
   return {
     searchable,
-    display: `working.${key}: ${truncateEvidence(searchable)}`,
+    display: `working.${key}: ${truncateEvidence(valueEvidence)}`,
   };
 }
 
 function formatEpisodicEvidence(event: EpisodicEvent): HandoffEvidenceEntry {
   const details = event.details ? ` details=${summarizeUnknown(event.details)}` : '';
   const step = event.step ? ` step=${event.step}` : '';
-  const searchable = normalizeEvidence(`${step} ${event.summary}${details}`);
+  const searchable = normalizeEvidence(`${event.type} ${step} ${event.summary}${details}`);
   return {
     searchable,
     display: `event.${event.type}:${step} ${truncateEvidence(searchable)}`,
@@ -272,11 +273,44 @@ function summarizeUnknown(value: unknown): string {
   if (typeof value === 'string') {
     return value;
   }
+  const pruned = pruneEmptyEvidence(value);
+  if (pruned === undefined) {
+    return '';
+  }
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(pruned);
   } catch {
     return String(value);
   }
+}
+
+function pruneEmptyEvidence(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const normalized = normalizeEvidence(value);
+    return normalized.length === 0 ? undefined : normalized;
+  }
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => pruneEmptyEvidence(item))
+      .filter((item) => item !== undefined);
+    return items.length === 0 ? undefined : items;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([key, entryValue]) => [key, pruneEmptyEvidence(entryValue)] as const)
+      .filter(([, entryValue]) => entryValue !== undefined);
+    return entries.length === 0 ? undefined : Object.fromEntries(entries);
+  }
+  return value;
+}
+
+function splitEvidenceKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ');
 }
 
 function normalizeEvidence(value: string): string {

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -104,7 +104,7 @@ describe('assessPmHandoffQuality', () => {
         working: {
           goal: 'Resolve issue #1862 without broadening scope; out-of-scope: unrelated learning changes',
           status: 'implementation completed with decisions recorded',
-          verificationCommand: 'npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts',
+          verificationCommand: 'npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts passed',
           blocker: 'needs review before merge',
           pr: 'https://github.com/djm204/frankenbeast/pull/9999',
           retrospective: 'lesson captured for PM handoffs',
@@ -194,6 +194,40 @@ describe('assessPmHandoffQuality', () => {
     const state = assessment.results.find((result) => result.id === 'state');
     expect(state?.status).toBe('pass');
     expect(state?.evidence.join(' ')).toContain('checkpoint: phase=execution');
+  });
+
+  it('accepts plural blocker and next-step headings', () => {
+    const assessment = assessPmHandoffQuality(
+      makeSnapshot({
+        working: {
+          blockers: 'none',
+          nextSteps: 'run tests',
+        },
+        episodic: [],
+      }),
+    );
+
+    expect(assessment.results.find((result) => result.id === 'blockers')?.status).toBe('pass');
+  });
+
+  it('requires command and outcome signals for verification evidence', () => {
+    const missingOutcome = assessPmHandoffQuality(
+      makeSnapshot({
+        working: { task: 'build login page' },
+        episodic: [],
+      }),
+    );
+    expect(missingOutcome.results.find((result) => result.id === 'verification')?.status).toBe(
+      'needs-attention',
+    );
+
+    const verified = assessPmHandoffQuality(
+      makeSnapshot({
+        working: { verification: 'npm test passed' },
+        episodic: [],
+      }),
+    );
+    expect(verified.results.find((result) => result.id === 'verification')?.status).toBe('pass');
   });
 
   it('bounds large checkpoint context evidence in the formatted rubric', () => {

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -146,8 +146,23 @@ describe('assessPmHandoffQuality', () => {
           blocker: null,
           pr: undefined,
           issue: '   ',
+          handoff: { verification: '', blocker: null, nested: { pr: ' ' } },
         },
-        episodic: [],
+        episodic: [
+          {
+            type: 'observation',
+            summary: 'Agent said hello',
+            details: { blocker: null, verification: '' },
+            createdAt: '2026-03-22T00:00:00.000Z',
+          },
+        ],
+        checkpoint: {
+          runId: 'run-1',
+          phase: '2',
+          step: 0,
+          context: { pr: '', verification: null },
+          timestamp: '2026-03-22T00:00:00.000Z',
+        },
       }),
     );
 

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { BrainSnapshot } from '@franken/types';
-import { formatHandoff, truncateSnapshot } from '../../../src/providers/format-handoff.js';
+import {
+  assessPmHandoffQuality,
+  formatHandoff,
+  truncateSnapshot,
+} from '../../../src/providers/format-handoff.js';
 
 function makeSnapshot(overrides: Partial<BrainSnapshot> = {}): BrainSnapshot {
   return {
@@ -71,6 +75,68 @@ describe('formatHandoff', () => {
     expect(text).toMatch(/^--- BRAIN STATE HANDOFF ---/);
     expect(text).toMatch(/--- END HANDOFF ---$/);
   });
+
+  it('includes the PM handoff quality rubric with operator guidance', () => {
+    const text = formatHandoff(
+      makeSnapshot({
+        working: {
+          issue: '#1862 add PM handoff quality rubric',
+          status: 'completed docs and implementation',
+          verification: 'npm test -- --run tests/unit/providers/format-handoff.test.ts passed',
+          blocker: 'needs review before merge PR',
+          artifact: 'branch resolve/issue-1862-feat-learning-add-pm-handoff-quality-rubric',
+          lesson: 'Future workers can use this rubric before promotion',
+        },
+      }),
+    );
+
+    expect(text).toContain('PM handoff quality rubric: 6/6 (1)');
+    expect(text).toContain('Scope and objective: pass');
+    expect(text).toContain('Verification evidence: pass');
+    expect(text).toContain('PM handoff includes evidence for every rubric criterion.');
+  });
+});
+
+describe('assessPmHandoffQuality', () => {
+  it('scores a complete PM handoff with deterministic evidence for every criterion', () => {
+    const assessment = assessPmHandoffQuality(
+      makeSnapshot({
+        working: {
+          goal: 'Resolve issue #1862 without broadening scope',
+          status: 'implementation completed with decisions recorded',
+          verificationCommand: 'npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts',
+          blocker: 'needs review before merge',
+          pr: 'https://github.com/djm204/frankenbeast/pull/9999',
+          retrospective: 'lesson captured for PM handoffs',
+        },
+      }),
+    );
+
+    expect(assessment.score).toBe(1);
+    expect(assessment.passed).toBe(6);
+    expect(assessment.results.every((result) => result.status === 'pass')).toBe(true);
+  });
+
+  it('flags sparse handoffs instead of inventing missing evidence', () => {
+    const assessment = assessPmHandoffQuality(
+      makeSnapshot({
+        working: {},
+        episodic: [
+          {
+            type: 'observation',
+            summary: 'Agent said hello',
+            createdAt: '2026-03-22T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    expect(assessment.score).toBe(0);
+    expect(assessment.results.map((result) => result.status)).toEqual(
+      Array.from({ length: 6 }, () => 'needs-attention'),
+    );
+    expect(assessment.operatorGuidance).toContain('missing one or more rubric criteria');
+  });
 });
 
 describe('truncateSnapshot', () => {
@@ -106,7 +172,7 @@ describe('truncateSnapshot', () => {
         medium: 'y'.repeat(500),
       },
     });
-    const truncated = truncateSnapshot(snapshot, 300);
+    const truncated = truncateSnapshot(snapshot, 500);
     const workingKeys = Object.keys(truncated.working as Record<string, unknown>);
 
     // Largest value should be removed first

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -166,8 +166,33 @@ describe('assessPmHandoffQuality', () => {
       }),
     );
 
-    expect(assessment.score).toBe(0);
-    expect(assessment.results.every((result) => result.evidence.length === 0)).toBe(true);
+    expect(assessment.score).toBe(0.17);
+    expect(assessment.results.find((result) => result.id === 'state')?.status).toBe('pass');
+    expect(
+      assessment.results
+        .filter((result) => result.id !== 'state')
+        .every((result) => result.evidence.length === 0),
+    ).toBe(true);
+  });
+
+  it('counts checkpoint labels as current-state evidence', () => {
+    const assessment = assessPmHandoffQuality(
+      makeSnapshot({
+        working: {},
+        episodic: [],
+        checkpoint: {
+          runId: 'run-1',
+          phase: 'execution',
+          step: 4,
+          context: {},
+          timestamp: '2026-03-22T00:00:00.000Z',
+        },
+      }),
+    );
+
+    const state = assessment.results.find((result) => result.id === 'state');
+    expect(state?.status).toBe('pass');
+    expect(state?.evidence.join(' ')).toContain('checkpoint: phase=execution');
   });
 
   it('bounds large checkpoint context evidence in the formatted rubric', () => {

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -137,6 +137,46 @@ describe('assessPmHandoffQuality', () => {
     );
     expect(assessment.operatorGuidance).toContain('missing one or more rubric criteria');
   });
+
+  it('ignores empty placeholder fields when scoring evidence', () => {
+    const assessment = assessPmHandoffQuality(
+      makeSnapshot({
+        working: {
+          verification: '',
+          blocker: null,
+          pr: undefined,
+          issue: '   ',
+        },
+        episodic: [],
+      }),
+    );
+
+    expect(assessment.score).toBe(0);
+    expect(assessment.results.every((result) => result.evidence.length === 0)).toBe(true);
+  });
+
+  it('bounds large checkpoint context evidence in the formatted rubric', () => {
+    const text = formatHandoff(
+      makeSnapshot({
+        working: {},
+        episodic: [],
+        checkpoint: {
+          runId: 'run-1',
+          phase: 'decision',
+          step: 2,
+          context: { huge: 'verified '.repeat(200) },
+          timestamp: '2026-03-22T00:00:00.000Z',
+        },
+      }),
+    );
+
+    const checkpointEvidence = text
+      .split('\n')
+      .find((line) => line.includes('checkpoint: phase=decision'));
+    expect(checkpointEvidence).toBeTruthy();
+    expect(checkpointEvidence!.length).toBeLessThan(360);
+    expect(checkpointEvidence).toContain('…');
+  });
 });
 
 describe('truncateSnapshot', () => {

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -80,7 +80,7 @@ describe('formatHandoff', () => {
     const text = formatHandoff(
       makeSnapshot({
         working: {
-          issue: '#1862 add PM handoff quality rubric',
+          issue: '#1862 add PM handoff quality rubric with goal to improve PM handoffs; out-of-scope: unrelated learning changes',
           status: 'completed docs and implementation',
           verification: 'npm test -- --run tests/unit/providers/format-handoff.test.ts passed',
           blocker: 'needs review before merge PR',
@@ -90,10 +90,10 @@ describe('formatHandoff', () => {
       }),
     );
 
-    expect(text).toContain('PM handoff quality rubric: 6/6 (1)');
-    expect(text).toContain('Scope and objective: pass');
-    expect(text).toContain('Verification evidence: pass');
-    expect(text).toContain('PM handoff includes evidence for every rubric criterion.');
+    expect(text).toContain('PM rubric: 6/6 (1)');
+    expect(text).toContain('scope: pass');
+    expect(text).toContain('verification: pass');
+    expect(text).toContain('PM guidance: complete');
   });
 });
 
@@ -102,7 +102,7 @@ describe('assessPmHandoffQuality', () => {
     const assessment = assessPmHandoffQuality(
       makeSnapshot({
         working: {
-          goal: 'Resolve issue #1862 without broadening scope',
+          goal: 'Resolve issue #1862 without broadening scope; out-of-scope: unrelated learning changes',
           status: 'implementation completed with decisions recorded',
           verificationCommand: 'npm test --workspace @franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts',
           blocker: 'needs review before merge',
@@ -147,6 +147,7 @@ describe('assessPmHandoffQuality', () => {
           pr: undefined,
           issue: '   ',
           handoff: { verification: '', blocker: null, nested: { pr: ' ' } },
+          absentSignals: { verification: false, blocker: false, pr: false },
         },
         episodic: [
           {
@@ -293,6 +294,23 @@ describe('truncateSnapshot', () => {
     truncateSnapshot(snapshot, 500);
 
     expect(snapshot.episodic).toHaveLength(50);
+  });
+
+  it('keeps formatted output within a tight 300-token budget after trimming', () => {
+    const snapshot = makeSnapshot({
+      episodic: Array.from({ length: 50 }, (_, i) => ({
+        type: 'observation' as const,
+        summary: `Step ${i}: ${'x'.repeat(200)}`,
+        createdAt: '2026-03-22T00:00:00.000Z',
+      })),
+      working: {
+        task: 'fix auth',
+        huge: 'x'.repeat(5000),
+      },
+    });
+    const text = formatHandoff(truncateSnapshot(snapshot, 300));
+
+    expect(text.length).toBeLessThanOrEqual(300 * 4);
   });
 
   it('produces valid output that formatHandoff can render', () => {


### PR DESCRIPTION
## Summary
- Add a deterministic PM handoff quality rubric to provider handoff formatting.
- Expose structured assessment output for PM/liveness tooling with explicit missing-evidence guidance.
- Document rubric criteria for operators and future workers.

## Verification
- npm ci
- npm run build --workspace=@franken/types
- npm run build --workspace=@franken/observer
- npm run build --workspace=@franken/brain
- npm run build --workspace=@franken/critique
- npm run build --workspace=@franken/governor
- npm run build --workspace=@franken/planner
- TMPDIR="/home/pfkagent/dev/resolve-wt/issue-1862/.tmp/franken-orchestrator" npm test --workspace=@franken/orchestrator -- --run tests/unit/providers/format-handoff.test.ts --reporter=dot
- npm run typecheck --workspace=@franken/orchestrator
- npm run lint --workspace=@franken/orchestrator
- npm run build --workspace=@franken/orchestrator

Closes #1862