### PR TITLE
feat(learning): mine cross-task blocker patterns

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -131,6 +131,12 @@ Recorded lessons include a `cooldown` object with the key, window, `recordedAt`,
 
 Callers that need a different window can construct `new LessonRecorder(memory, { cooldownMs })`; pass `cooldownMs: 0` to disable suppression. The recorder uses an advancing wall-clock by default and only uses the injected `now` callback for tests/replay callers that explicitly pass one. Cooldown state is instance-local unless callers pass a reused `cooldownStore` map in `LessonRecorderOptions`, which lets reviewer rebuilds in the same worker suppress duplicate lessons without leaking state into unrelated tests or pipelines. Recorders that reuse the same store also share in-flight admission reservations, so concurrent rebuilds do not double-persist the same equivalent lesson. Invalid negative or non-finite cooldown windows throw a `RangeError` during construction.
 
+## Cross-task blocker pattern mining
+
+`LessonRecorder` also mines repeated blocker patterns while it records critique lessons. Critical findings are normalized by evaluator name and finding text, then counted across distinct task ids. Once the same blocker reaches the configured distinct-task threshold, `record()` surfaces it in `minedBlockerPatterns` and the associated recorded lesson includes `blockerPatterns` for PM/liveness consumers.
+
+Each mined pattern includes a stable `key`, evaluator name, normalized finding, threshold, occurrence count, ordered distinct task ids, first/last seen timestamps, and operator guidance. Repeated observations from the same task do not increment the pattern, and warning-only findings are ignored so the signal stays focused on true blockers. The default threshold is 3 distinct tasks; tests or replay callers can pass `blockerPatternThreshold` and a shared `blockerPatternStore` in `LessonRecorderOptions` when multiple recorder instances should mine against the same in-process history.
+
 ## Package scripts
 
 Run these from the package directory with `npm run <script>`, or from the repository root with `npm run <script> --workspace @franken/critique`.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -31,6 +31,7 @@ export type {
   LessonExperimentSandbox,
   LessonCooldownMetadata,
   LessonCooldownSuppression,
+  CrossTaskBlockerPattern,
   LessonRecordingResult,
   ReviewerFeedbackLessonEntry,
   ReviewerFeedbackLessonCapture,
@@ -75,7 +76,11 @@ export type { CritiqueErrorOptions } from './errors/index.js';
 export { CritiquePipeline } from './pipeline/critique-pipeline.js';
 export { CritiqueLoop } from './loop/critique-loop.js';
 export { LessonRecorder } from './memory/lesson-recorder.js';
-export type { LessonRecorderOptions } from './memory/lesson-recorder.js';
+export type {
+  BlockerPatternObservation,
+  BlockerPatternState,
+  LessonRecorderOptions,
+} from './memory/lesson-recorder.js';
 
 // Evaluators
 export { SafetyEvaluator } from './evaluators/safety.js';

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -5,6 +5,7 @@ import type {
   LessonRecordingResult,
   ReviewerFeedbackLessonCapture,
   PostPrLessonExtractionTemplate,
+  CrossTaskBlockerPattern,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
@@ -23,6 +24,22 @@ const PENDING_ADMISSIONS_BY_COOLDOWN_STORE = new WeakMap<
 
 const LEARNING_COOLDOWN_GUIDANCE =
   'Equivalent critique lessons are suppressed during this cooldown window so PM/liveness tooling does not churn on repeated feedback before promotion or retirement review.';
+const DEFAULT_BLOCKER_PATTERN_THRESHOLD = 3;
+const MIN_BLOCKER_PATTERN_THRESHOLD = 2;
+const BLOCKER_PATTERN_GUIDANCE =
+  'Equivalent blocker findings have recurred across distinct tasks; PM/liveness handoffs should treat this as a cross-task pattern and route a durable mitigation instead of rediscovering it per task.';
+
+export interface BlockerPatternObservation {
+  readonly taskId: TaskId;
+  readonly observedAt: string;
+}
+
+export interface BlockerPatternState {
+  readonly key: string;
+  readonly evaluatorName: string;
+  readonly normalizedFinding: string;
+  readonly observations: BlockerPatternObservation[];
+}
 
 export interface LessonRecorderOptions {
   /** Milliseconds to suppress equivalent lessons after one is admitted. Defaults to 24 hours. */
@@ -31,6 +48,10 @@ export interface LessonRecorderOptions {
   readonly now?: () => Date | string;
   /** Shared cooldown state for reviewer rebuilds that happen in the same process. */
   readonly cooldownStore?: Map<string, number>;
+  /** Distinct task count required before a repeated critical finding is surfaced as a blocker pattern. Defaults to 3. */
+  readonly blockerPatternThreshold?: number;
+  /** Shared blocker-pattern state for mining recurrent blockers across recorder instances. */
+  readonly blockerPatternStore?: Map<string, BlockerPatternState>;
 }
 
 const LESSON_EXPERIMENT_SANDBOX_REASON =
@@ -73,6 +94,8 @@ export class LessonRecorder {
   private readonly now: () => string;
   private readonly cooldowns: Map<string, number>;
   private readonly pendingAdmissions: Map<string, Promise<boolean>>;
+  private readonly blockerPatternThreshold: number;
+  private readonly blockerPatterns: Map<string, BlockerPatternState>;
 
   constructor(memory: MemoryPort, options: LessonRecorderOptions = {}) {
     const cooldownMs = options.cooldownMs ?? DEFAULT_LESSON_COOLDOWN_MS;
@@ -88,6 +111,18 @@ export class LessonRecorder {
 
     this.memory = memory;
     this.cooldownMs = cooldownMs;
+    const blockerPatternThreshold =
+      options.blockerPatternThreshold ?? DEFAULT_BLOCKER_PATTERN_THRESHOLD;
+    if (
+      !Number.isInteger(blockerPatternThreshold) ||
+      blockerPatternThreshold < MIN_BLOCKER_PATTERN_THRESHOLD
+    ) {
+      throw new RangeError(
+        'LessonRecorder blockerPatternThreshold must be an integer greater than or equal to 2.',
+      );
+    }
+    this.blockerPatternThreshold = blockerPatternThreshold;
+    this.blockerPatterns = options.blockerPatternStore ?? new Map();
     const now = options.now ?? ((): Date => new Date());
     this.now = (): string => normalizeTimestamp(now());
     this.cooldowns = options.cooldownStore ?? new Map<string, number>();
@@ -100,10 +135,7 @@ export class LessonRecorder {
     result: CritiqueLoopResult,
     taskId: TaskId,
   ): Promise<LessonRecordingResult> {
-    const recordingResult: MutableLessonRecordingResult = {
-      recorded: 0,
-      suppressedByCooldown: [],
-    };
+    const recordingResult = createMutableLessonRecordingResult();
 
     // Only record lessons from multi-iteration pass/warn successes.
     if (
@@ -120,6 +152,13 @@ export class LessonRecorder {
     for (const iteration of failingIterations) {
       const lessons = this.extractLessons(iteration, result.iterations, taskId);
       for (const lesson of lessons) {
+        addUniqueBlockerPatterns(
+          recordingResult.minedBlockerPatterns,
+          lesson.blockerPatterns,
+        );
+        if (recordingResult.minedBlockerPatterns.length > 0) {
+          exposeMinedBlockerPatterns(recordingResult);
+        }
         const cooldownKey =
           this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
         let admissionSettled: ((admitted: boolean) => void) | undefined;
@@ -220,6 +259,12 @@ export class LessonRecorder {
         const suppressUntil = new Date(
           addCooldownWindowMs(cooldownBaseMs, this.cooldownMs),
         ).toISOString();
+        const blockerPatterns = this.mineBlockerPatterns(
+          taskId,
+          evalResult.evaluatorName,
+          critiqueFindings,
+          recordedAt,
+        );
 
         lessons.push({
           evaluatorName: evalResult.evaluatorName,
@@ -266,11 +311,63 @@ export class LessonRecorder {
             suppressUntil,
             guidance: LEARNING_COOLDOWN_GUIDANCE,
           },
+          ...(blockerPatterns.length > 0 ? { blockerPatterns } : {}),
         });
       }
     }
 
     return lessons;
+  }
+
+  private mineBlockerPatterns(
+    taskId: TaskId,
+    evaluatorName: string,
+    findings: readonly {
+      readonly message: string;
+      readonly severity: string;
+    }[],
+    observedAt: string,
+  ): CrossTaskBlockerPattern[] {
+    const minedPatterns: CrossTaskBlockerPattern[] = [];
+    for (const finding of findings) {
+      if (finding.severity !== 'critical') {
+        continue;
+      }
+
+      const normalizedFinding = normalizeBlockerFinding(finding.message);
+      if (!normalizedFinding) {
+        continue;
+      }
+
+      const key = createBlockerPatternKey(evaluatorName, normalizedFinding);
+      let pattern = this.blockerPatterns.get(key);
+      if (!pattern) {
+        pattern = {
+          key,
+          evaluatorName,
+          normalizedFinding,
+          observations: [],
+        };
+        this.blockerPatterns.set(key, pattern);
+      }
+
+      if (
+        pattern.observations.some(
+          (observation) => observation.taskId === taskId,
+        )
+      ) {
+        continue;
+      }
+
+      pattern.observations.push({ taskId, observedAt });
+      if (pattern.observations.length >= this.blockerPatternThreshold) {
+        minedPatterns.push(
+          createCrossTaskBlockerPattern(pattern, this.blockerPatternThreshold),
+        );
+      }
+    }
+
+    return minedPatterns;
   }
 
   private getCooldownSuppression(
@@ -330,7 +427,6 @@ export class LessonRecorder {
       },
     };
   }
-
 }
 
 function getPendingAdmissions(
@@ -347,6 +443,79 @@ function getPendingAdmissions(
 interface MutableLessonRecordingResult {
   recorded: number;
   suppressedByCooldown: LessonCooldownSuppression[];
+  minedBlockerPatterns: CrossTaskBlockerPattern[];
+}
+
+function createMutableLessonRecordingResult(): MutableLessonRecordingResult {
+  const result = {
+    recorded: 0,
+    suppressedByCooldown: [],
+  } as unknown as MutableLessonRecordingResult;
+  Object.defineProperty(result, 'minedBlockerPatterns', {
+    value: [],
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return result;
+}
+
+function addUniqueBlockerPatterns(
+  target: CrossTaskBlockerPattern[],
+  patterns: readonly CrossTaskBlockerPattern[] | undefined,
+): void {
+  for (const pattern of patterns ?? []) {
+    if (!target.some((existing) => existing.key === pattern.key)) {
+      target.push(pattern);
+    }
+  }
+}
+
+function exposeMinedBlockerPatterns(
+  result: MutableLessonRecordingResult,
+): void {
+  Object.defineProperty(result, 'minedBlockerPatterns', {
+    value: result.minedBlockerPatterns,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function createCrossTaskBlockerPattern(
+  state: BlockerPatternState,
+  threshold: number,
+): CrossTaskBlockerPattern {
+  return {
+    key: state.key,
+    evaluatorName: state.evaluatorName,
+    normalizedFinding: state.normalizedFinding,
+    threshold,
+    occurrences: state.observations.length,
+    taskIds: state.observations.map((observation) => observation.taskId),
+    firstSeenAt: state.observations[0]!.observedAt,
+    lastSeenAt: state.observations[state.observations.length - 1]!.observedAt,
+    guidance: BLOCKER_PATTERN_GUIDANCE,
+  };
+}
+
+function createBlockerPatternKey(
+  evaluatorName: string,
+  normalizedFinding: string,
+): string {
+  const normalizedPattern = JSON.stringify({
+    evaluatorName,
+    normalizedFinding,
+  });
+  return [
+    'blocker-pattern',
+    sanitizeLessonIdPart(evaluatorName),
+    stableHash(normalizedPattern),
+  ].join(':');
+}
+
+function normalizeBlockerFinding(message: string): string {
+  return message.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
 function createPostPrLessonExtractionTemplate(): PostPrLessonExtractionTemplate {

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -104,6 +104,7 @@ export class LessonRecorder {
   private readonly pendingAdmissions: Map<string, Promise<boolean>>;
   private readonly blockerPatternThreshold: number;
   private readonly blockerPatterns: Map<string, BlockerPatternState>;
+  private readonly pendingBlockerAdmissions = new Map<string, Promise<void>>();
   private readonly pendingBlockerObservations = new WeakMap<
     CritiqueLesson,
     PendingBlockerPatternObservation[]
@@ -164,88 +165,93 @@ export class LessonRecorder {
     for (const iteration of failingIterations) {
       const lessons = this.extractLessons(iteration, result.iterations, taskId);
       for (const extractedLesson of lessons) {
-        let lesson = this.withCurrentBlockerPatterns(extractedLesson);
-        const cooldownKey =
-          this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
-        let admissionSettled: ((admitted: boolean) => void) | undefined;
-        let admissionPromise: Promise<boolean> | undefined;
-        if (cooldownKey) {
-          let admittedByAnotherCall = false;
-          while (!admittedByAnotherCall) {
-            const pendingAdmission = this.pendingAdmissions.get(cooldownKey);
-            if (pendingAdmission) {
-              await pendingAdmission;
-              continue;
-            }
-
-            if (this.cooldownMs > 0) {
-              admissionPromise = new Promise<boolean>((resolve) => {
-                admissionSettled = resolve;
-              });
-              this.pendingAdmissions.set(cooldownKey, admissionPromise);
-            }
-
-            lesson = this.withCurrentBlockerPatterns(lesson);
-            const hasMinedBlockerPatterns =
-              (lesson.blockerPatterns?.length ?? 0) > 0;
-            const suppression = this.getCooldownSuppression(
-              lesson,
-              cooldownKey,
-            );
-            if (suppression && !hasMinedBlockerPatterns) {
-              this.commitBlockerPatternObservations(lesson);
-              recordingResult.suppressedByCooldown.push(suppression);
-              admissionSettled?.(false);
-              if (
-                admissionPromise &&
-                this.pendingAdmissions.get(cooldownKey) === admissionPromise
-              ) {
-                this.pendingAdmissions.delete(cooldownKey);
-              }
-              admittedByAnotherCall = true;
-              break;
-            }
-
-            break;
-          }
-
-          if (admittedByAnotherCall) {
-            continue;
-          }
-        }
-
-        try {
-          const admittedLesson = this.withAdmissionTimestamp(lesson);
-          await this.memory.recordLesson(admittedLesson);
-          recordingResult.recorded += 1;
-          this.commitBlockerPatternObservations(lesson);
-          addUniqueBlockerPatterns(
-            recordingResult.minedBlockerPatterns,
-            lesson.blockerPatterns,
-          );
-          if (cooldownKey && this.cooldownMs > 0) {
-            this.cooldowns.set(
-              cooldownKey,
-              Date.parse(admittedLesson.cooldown!.suppressUntil),
-            );
-          }
-          admissionSettled?.(true);
-        } catch {
-          admissionSettled?.(false);
-          // Non-fatal: log failure but don't disrupt the critique flow
-        } finally {
-          if (
-            cooldownKey &&
-            admissionPromise &&
-            this.pendingAdmissions.get(cooldownKey) === admissionPromise
-          ) {
-            this.pendingAdmissions.delete(cooldownKey);
-          }
-        }
+        await this.recordExtractedLesson(extractedLesson, recordingResult);
       }
     }
 
     return recordingResult;
+  }
+
+  private async recordExtractedLesson(
+    extractedLesson: CritiqueLesson,
+    recordingResult: MutableLessonRecordingResult,
+  ): Promise<void> {
+    await this.withBlockerPatternAdmissionLock(extractedLesson, async () => {
+      let lesson = this.withCurrentBlockerPatterns(extractedLesson);
+      const cooldownKey = this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
+      let admissionSettled: ((admitted: boolean) => void) | undefined;
+      let admissionPromise: Promise<boolean> | undefined;
+      if (cooldownKey) {
+        let admittedByAnotherCall = false;
+        while (!admittedByAnotherCall) {
+          const pendingAdmission = this.pendingAdmissions.get(cooldownKey);
+          if (pendingAdmission) {
+            await pendingAdmission;
+            continue;
+          }
+
+          if (this.cooldownMs > 0) {
+            admissionPromise = new Promise<boolean>((resolve) => {
+              admissionSettled = resolve;
+            });
+            this.pendingAdmissions.set(cooldownKey, admissionPromise);
+          }
+
+          lesson = this.withCurrentBlockerPatterns(lesson);
+          const hasMinedBlockerPatterns =
+            (lesson.blockerPatterns?.length ?? 0) > 0;
+          const suppression = this.getCooldownSuppression(lesson, cooldownKey);
+          if (suppression && !hasMinedBlockerPatterns) {
+            this.commitBlockerPatternObservations(lesson);
+            recordingResult.suppressedByCooldown.push(suppression);
+            admissionSettled?.(false);
+            if (
+              admissionPromise &&
+              this.pendingAdmissions.get(cooldownKey) === admissionPromise
+            ) {
+              this.pendingAdmissions.delete(cooldownKey);
+            }
+            admittedByAnotherCall = true;
+            break;
+          }
+
+          break;
+        }
+
+        if (admittedByAnotherCall) {
+          return;
+        }
+      }
+
+      try {
+        const admittedLesson = this.withAdmissionTimestamp(lesson);
+        await this.memory.recordLesson(admittedLesson);
+        recordingResult.recorded += 1;
+        this.commitBlockerPatternObservations(lesson);
+        addUniqueBlockerPatterns(
+          recordingResult.minedBlockerPatterns,
+          lesson.blockerPatterns,
+        );
+        if (cooldownKey && this.cooldownMs > 0) {
+          this.cooldowns.set(
+            cooldownKey,
+            Date.parse(admittedLesson.cooldown!.suppressUntil),
+          );
+        }
+        admissionSettled?.(true);
+      } catch {
+        admissionSettled?.(false);
+        // Non-fatal: log failure but don't disrupt the critique flow
+      } finally {
+        if (
+          cooldownKey &&
+          admissionPromise &&
+          this.pendingAdmissions.get(cooldownKey) === admissionPromise
+        ) {
+          this.pendingAdmissions.delete(cooldownKey);
+        }
+      }
+    });
   }
 
   private extractLessons(
@@ -441,6 +447,55 @@ export class LessonRecorder {
       }
     }
     this.pendingBlockerObservations.delete(lesson);
+  }
+
+  private async withBlockerPatternAdmissionLock<T>(
+    lesson: CritiqueLesson,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const keys = this.getPendingBlockerPatternKeys(lesson);
+    if (keys.length === 0) {
+      return operation();
+    }
+
+    while (true) {
+      const pendingLocks = keys
+        .map((key) => this.pendingBlockerAdmissions.get(key))
+        .filter((lock): lock is Promise<void> => lock !== undefined);
+      if (pendingLocks.length === 0) {
+        break;
+      }
+      await Promise.allSettled(pendingLocks);
+    }
+
+    let releaseLock!: () => void;
+    const lock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    for (const key of keys) {
+      this.pendingBlockerAdmissions.set(key, lock);
+    }
+
+    try {
+      return await operation();
+    } finally {
+      for (const key of keys) {
+        if (this.pendingBlockerAdmissions.get(key) === lock) {
+          this.pendingBlockerAdmissions.delete(key);
+        }
+      }
+      releaseLock();
+    }
+  }
+
+  private getPendingBlockerPatternKeys(lesson: CritiqueLesson): string[] {
+    return Array.from(
+      new Set(
+        (this.pendingBlockerObservations.get(lesson) ?? []).map(
+          (observation) => observation.key,
+        ),
+      ),
+    ).sort();
   }
 
   private withCurrentBlockerPatterns(lesson: CritiqueLesson): CritiqueLesson {

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -47,7 +47,6 @@ interface PendingBlockerPatternObservation {
   readonly evaluatorName: string;
   readonly normalizedFinding: string;
   readonly observedAt: string;
-  readonly shouldBypassCooldown: boolean;
 }
 
 export interface LessonRecorderOptions {
@@ -164,15 +163,8 @@ export class LessonRecorder {
 
     for (const iteration of failingIterations) {
       const lessons = this.extractLessons(iteration, result.iterations, taskId);
-      for (const lesson of lessons) {
-        const hasMinedBlockerPatterns =
-          (lesson.blockerPatterns?.length ?? 0) > 0;
-        const shouldBypassCooldownForBlockerPattern =
-          hasMinedBlockerPatterns ||
-          (this.pendingBlockerObservations
-            .get(lesson)
-            ?.some((observation) => observation.shouldBypassCooldown) ??
-            false);
+      for (const extractedLesson of lessons) {
+        let lesson = this.withCurrentBlockerPatterns(extractedLesson);
         const cooldownKey =
           this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
         let admissionSettled: ((admitted: boolean) => void) | undefined;
@@ -180,11 +172,15 @@ export class LessonRecorder {
         if (cooldownKey) {
           let admittedByAnotherCall = false;
           while (!admittedByAnotherCall) {
+            lesson = this.withCurrentBlockerPatterns(lesson);
+            const hasMinedBlockerPatterns =
+              (lesson.blockerPatterns?.length ?? 0) > 0;
             const suppression = this.getCooldownSuppression(
               lesson,
               cooldownKey,
             );
-            if (suppression && !shouldBypassCooldownForBlockerPattern) {
+            if (suppression && !hasMinedBlockerPatterns) {
+              this.commitBlockerPatternObservations(lesson);
               recordingResult.suppressedByCooldown.push(suppression);
               admittedByAnotherCall = true;
               break;
@@ -377,6 +373,10 @@ export class LessonRecorder {
         continue;
       }
 
+      if (pendingObservations.some((observation) => observation.key === key)) {
+        continue;
+      }
+
       const previousObservationCount = observations.length;
       const previewState: BlockerPatternState = {
         key,
@@ -390,8 +390,6 @@ export class LessonRecorder {
         evaluatorName,
         normalizedFinding,
         observedAt,
-        shouldBypassCooldown:
-          previousObservationCount < this.blockerPatternThreshold,
       });
       if (
         previousObservationCount < this.blockerPatternThreshold &&
@@ -435,6 +433,71 @@ export class LessonRecorder {
       }
     }
     this.pendingBlockerObservations.delete(lesson);
+  }
+
+  private withCurrentBlockerPatterns(lesson: CritiqueLesson): CritiqueLesson {
+    const pendingObservations =
+      this.pendingBlockerObservations.get(lesson) ?? [];
+    const patterns: CrossTaskBlockerPattern[] = [];
+    const seenKeys = new Set<string>();
+    for (const observation of pendingObservations) {
+      if (seenKeys.has(observation.key)) {
+        continue;
+      }
+      seenKeys.add(observation.key);
+      const committedPattern = this.blockerPatterns.get(observation.key);
+      const committedObservations = committedPattern?.observations ?? [];
+      if (
+        committedObservations.some(
+          (entry) => entry.taskId === observation.taskId,
+        )
+      ) {
+        continue;
+      }
+
+      const previewState: BlockerPatternState = {
+        key: observation.key,
+        evaluatorName: observation.evaluatorName,
+        normalizedFinding: observation.normalizedFinding,
+        observations: [
+          ...committedObservations,
+          { taskId: observation.taskId, observedAt: observation.observedAt },
+        ],
+      };
+      if (
+        committedObservations.length < this.blockerPatternThreshold &&
+        previewState.observations.length >= this.blockerPatternThreshold
+      ) {
+        patterns.push(
+          createCrossTaskBlockerPattern(
+            previewState,
+            this.blockerPatternThreshold,
+          ),
+        );
+      }
+    }
+
+    if (patterns.length === 0) {
+      if (!lesson.blockerPatterns) {
+        return lesson;
+      }
+      const { blockerPatterns, ...lessonWithoutPatterns } = lesson;
+      void blockerPatterns;
+      this.pendingBlockerObservations.set(
+        lessonWithoutPatterns,
+        pendingObservations,
+      );
+      this.pendingBlockerObservations.delete(lesson);
+      return lessonWithoutPatterns;
+    }
+
+    const lessonWithPatterns = { ...lesson, blockerPatterns: patterns };
+    this.pendingBlockerObservations.set(
+      lessonWithPatterns,
+      pendingObservations,
+    );
+    this.pendingBlockerObservations.delete(lesson);
+    return lessonWithPatterns;
   }
 
   private getCooldownSuppression(

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -44,6 +44,10 @@ export interface BlockerPatternState {
 interface PendingBlockerPatternObservation {
   readonly key: string;
   readonly taskId: TaskId;
+  readonly evaluatorName: string;
+  readonly normalizedFinding: string;
+  readonly observedAt: string;
+  readonly shouldBypassCooldown: boolean;
 }
 
 export interface LessonRecorderOptions {
@@ -163,6 +167,12 @@ export class LessonRecorder {
       for (const lesson of lessons) {
         const hasMinedBlockerPatterns =
           (lesson.blockerPatterns?.length ?? 0) > 0;
+        const shouldBypassCooldownForBlockerPattern =
+          hasMinedBlockerPatterns ||
+          (this.pendingBlockerObservations
+            .get(lesson)
+            ?.some((observation) => observation.shouldBypassCooldown) ??
+            false);
         const cooldownKey =
           this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
         let admissionSettled: ((admitted: boolean) => void) | undefined;
@@ -174,7 +184,7 @@ export class LessonRecorder {
               lesson,
               cooldownKey,
             );
-            if (suppression && !hasMinedBlockerPatterns) {
+            if (suppression && !shouldBypassCooldownForBlockerPattern) {
               recordingResult.suppressedByCooldown.push(suppression);
               admittedByAnotherCall = true;
               break;
@@ -204,6 +214,7 @@ export class LessonRecorder {
           const admittedLesson = this.withAdmissionTimestamp(lesson);
           await this.memory.recordLesson(admittedLesson);
           recordingResult.recorded += 1;
+          this.commitBlockerPatternObservations(lesson);
           addUniqueBlockerPatterns(
             recordingResult.minedBlockerPatterns,
             lesson.blockerPatterns,
@@ -217,7 +228,6 @@ export class LessonRecorder {
           admissionSettled?.(true);
         } catch {
           admissionSettled?.(false);
-          this.rollbackBlockerPatternObservations(lesson);
           // Non-fatal: log failure but don't disrupt the critique flow
         } finally {
           if (
@@ -268,7 +278,7 @@ export class LessonRecorder {
         const suppressUntil = new Date(
           addCooldownWindowMs(cooldownBaseMs, this.cooldownMs),
         ).toISOString();
-        const blockerPatternUpdate = this.mineBlockerPatterns(
+        const blockerPatternUpdate = this.previewBlockerPatterns(
           taskId,
           evalResult.evaluatorName,
           critiqueFindings,
@@ -335,7 +345,7 @@ export class LessonRecorder {
     return lessons;
   }
 
-  private mineBlockerPatterns(
+  private previewBlockerPatterns(
     taskId: TaskId,
     evaluatorName: string,
     findings: readonly {
@@ -360,34 +370,38 @@ export class LessonRecorder {
       }
 
       const key = createBlockerPatternKey(evaluatorName, normalizedFinding);
-      let pattern = this.blockerPatterns.get(key);
-      if (!pattern) {
-        pattern = {
-          key,
-          evaluatorName,
-          normalizedFinding,
-          observations: [],
-        };
-        this.blockerPatterns.set(key, pattern);
-      }
+      const pattern = this.blockerPatterns.get(key);
+      const observations = pattern?.observations ?? [];
 
-      if (
-        pattern.observations.some(
-          (observation) => observation.taskId === taskId,
-        )
-      ) {
+      if (observations.some((observation) => observation.taskId === taskId)) {
         continue;
       }
 
-      const previousObservationCount = pattern.observations.length;
-      pattern.observations.push({ taskId, observedAt });
-      pendingObservations.push({ key, taskId });
+      const previousObservationCount = observations.length;
+      const previewState: BlockerPatternState = {
+        key,
+        evaluatorName,
+        normalizedFinding,
+        observations: [...observations, { taskId, observedAt }],
+      };
+      pendingObservations.push({
+        key,
+        taskId,
+        evaluatorName,
+        normalizedFinding,
+        observedAt,
+        shouldBypassCooldown:
+          previousObservationCount < this.blockerPatternThreshold,
+      });
       if (
         previousObservationCount < this.blockerPatternThreshold &&
-        pattern.observations.length >= this.blockerPatternThreshold
+        previewState.observations.length >= this.blockerPatternThreshold
       ) {
         minedPatterns.push(
-          createCrossTaskBlockerPattern(pattern, this.blockerPatternThreshold),
+          createCrossTaskBlockerPattern(
+            previewState,
+            this.blockerPatternThreshold,
+          ),
         );
       }
     }
@@ -395,22 +409,29 @@ export class LessonRecorder {
     return { patterns: minedPatterns, observations: pendingObservations };
   }
 
-  private rollbackBlockerPatternObservations(lesson: CritiqueLesson): void {
+  private commitBlockerPatternObservations(lesson: CritiqueLesson): void {
     const pendingObservations =
       this.pendingBlockerObservations.get(lesson) ?? [];
     for (const observation of pendingObservations) {
-      const pattern = this.blockerPatterns.get(observation.key);
+      let pattern = this.blockerPatterns.get(observation.key);
       if (!pattern) {
-        continue;
+        pattern = {
+          key: observation.key,
+          evaluatorName: observation.evaluatorName,
+          normalizedFinding: observation.normalizedFinding,
+          observations: [],
+        };
+        this.blockerPatterns.set(observation.key, pattern);
       }
-      const observationIndex = pattern.observations.findIndex(
-        (entry) => entry.taskId === observation.taskId,
-      );
-      if (observationIndex >= 0) {
-        pattern.observations.splice(observationIndex, 1);
-      }
-      if (pattern.observations.length === 0) {
-        this.blockerPatterns.delete(observation.key);
+      if (
+        !pattern.observations.some(
+          (entry) => entry.taskId === observation.taskId,
+        )
+      ) {
+        pattern.observations.push({
+          taskId: observation.taskId,
+          observedAt: observation.observedAt,
+        });
       }
     }
     this.pendingBlockerObservations.delete(lesson);

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -172,20 +172,6 @@ export class LessonRecorder {
         if (cooldownKey) {
           let admittedByAnotherCall = false;
           while (!admittedByAnotherCall) {
-            lesson = this.withCurrentBlockerPatterns(lesson);
-            const hasMinedBlockerPatterns =
-              (lesson.blockerPatterns?.length ?? 0) > 0;
-            const suppression = this.getCooldownSuppression(
-              lesson,
-              cooldownKey,
-            );
-            if (suppression && !hasMinedBlockerPatterns) {
-              this.commitBlockerPatternObservations(lesson);
-              recordingResult.suppressedByCooldown.push(suppression);
-              admittedByAnotherCall = true;
-              break;
-            }
-
             const pendingAdmission = this.pendingAdmissions.get(cooldownKey);
             if (pendingAdmission) {
               await pendingAdmission;
@@ -198,6 +184,28 @@ export class LessonRecorder {
               });
               this.pendingAdmissions.set(cooldownKey, admissionPromise);
             }
+
+            lesson = this.withCurrentBlockerPatterns(lesson);
+            const hasMinedBlockerPatterns =
+              (lesson.blockerPatterns?.length ?? 0) > 0;
+            const suppression = this.getCooldownSuppression(
+              lesson,
+              cooldownKey,
+            );
+            if (suppression && !hasMinedBlockerPatterns) {
+              this.commitBlockerPatternObservations(lesson);
+              recordingResult.suppressedByCooldown.push(suppression);
+              admissionSettled?.(false);
+              if (
+                admissionPromise &&
+                this.pendingAdmissions.get(cooldownKey) === admissionPromise
+              ) {
+                this.pendingAdmissions.delete(cooldownKey);
+              }
+              admittedByAnotherCall = true;
+              break;
+            }
+
             break;
           }
 

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -161,10 +161,6 @@ export class LessonRecorder {
     for (const iteration of failingIterations) {
       const lessons = this.extractLessons(iteration, result.iterations, taskId);
       for (const lesson of lessons) {
-        addUniqueBlockerPatterns(
-          recordingResult.minedBlockerPatterns,
-          lesson.blockerPatterns,
-        );
         const hasMinedBlockerPatterns =
           (lesson.blockerPatterns?.length ?? 0) > 0;
         const cooldownKey =
@@ -208,6 +204,10 @@ export class LessonRecorder {
           const admittedLesson = this.withAdmissionTimestamp(lesson);
           await this.memory.recordLesson(admittedLesson);
           recordingResult.recorded += 1;
+          addUniqueBlockerPatterns(
+            recordingResult.minedBlockerPatterns,
+            lesson.blockerPatterns,
+          );
           if (cooldownKey && this.cooldownMs > 0) {
             this.cooldowns.set(
               cooldownKey,
@@ -379,9 +379,13 @@ export class LessonRecorder {
         continue;
       }
 
+      const previousObservationCount = pattern.observations.length;
       pattern.observations.push({ taskId, observedAt });
       pendingObservations.push({ key, taskId });
-      if (pattern.observations.length >= this.blockerPatternThreshold) {
+      if (
+        previousObservationCount < this.blockerPatternThreshold &&
+        pattern.observations.length >= this.blockerPatternThreshold
+      ) {
         minedPatterns.push(
           createCrossTaskBlockerPattern(pattern, this.blockerPatternThreshold),
         );

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -41,6 +41,11 @@ export interface BlockerPatternState {
   readonly observations: BlockerPatternObservation[];
 }
 
+interface PendingBlockerPatternObservation {
+  readonly key: string;
+  readonly taskId: TaskId;
+}
+
 export interface LessonRecorderOptions {
   /** Milliseconds to suppress equivalent lessons after one is admitted. Defaults to 24 hours. */
   readonly cooldownMs?: number;
@@ -96,6 +101,10 @@ export class LessonRecorder {
   private readonly pendingAdmissions: Map<string, Promise<boolean>>;
   private readonly blockerPatternThreshold: number;
   private readonly blockerPatterns: Map<string, BlockerPatternState>;
+  private readonly pendingBlockerObservations = new WeakMap<
+    CritiqueLesson,
+    PendingBlockerPatternObservation[]
+  >();
 
   constructor(memory: MemoryPort, options: LessonRecorderOptions = {}) {
     const cooldownMs = options.cooldownMs ?? DEFAULT_LESSON_COOLDOWN_MS;
@@ -156,9 +165,8 @@ export class LessonRecorder {
           recordingResult.minedBlockerPatterns,
           lesson.blockerPatterns,
         );
-        if (recordingResult.minedBlockerPatterns.length > 0) {
-          exposeMinedBlockerPatterns(recordingResult);
-        }
+        const hasMinedBlockerPatterns =
+          (lesson.blockerPatterns?.length ?? 0) > 0;
         const cooldownKey =
           this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
         let admissionSettled: ((admitted: boolean) => void) | undefined;
@@ -170,7 +178,7 @@ export class LessonRecorder {
               lesson,
               cooldownKey,
             );
-            if (suppression) {
+            if (suppression && !hasMinedBlockerPatterns) {
               recordingResult.suppressedByCooldown.push(suppression);
               admittedByAnotherCall = true;
               break;
@@ -209,6 +217,7 @@ export class LessonRecorder {
           admissionSettled?.(true);
         } catch {
           admissionSettled?.(false);
+          this.rollbackBlockerPatternObservations(lesson);
           // Non-fatal: log failure but don't disrupt the critique flow
         } finally {
           if (
@@ -259,14 +268,14 @@ export class LessonRecorder {
         const suppressUntil = new Date(
           addCooldownWindowMs(cooldownBaseMs, this.cooldownMs),
         ).toISOString();
-        const blockerPatterns = this.mineBlockerPatterns(
+        const blockerPatternUpdate = this.mineBlockerPatterns(
           taskId,
           evalResult.evaluatorName,
           critiqueFindings,
           recordedAt,
         );
 
-        lessons.push({
+        const lesson: CritiqueLesson = {
           evaluatorName: evalResult.evaluatorName,
           failureDescription: findingMessages.join('; '),
           correctionApplied: passingIteration
@@ -311,8 +320,15 @@ export class LessonRecorder {
             suppressUntil,
             guidance: LEARNING_COOLDOWN_GUIDANCE,
           },
-          ...(blockerPatterns.length > 0 ? { blockerPatterns } : {}),
-        });
+          ...(blockerPatternUpdate.patterns.length > 0
+            ? { blockerPatterns: blockerPatternUpdate.patterns }
+            : {}),
+        };
+        this.pendingBlockerObservations.set(
+          lesson,
+          blockerPatternUpdate.observations,
+        );
+        lessons.push(lesson);
       }
     }
 
@@ -327,8 +343,12 @@ export class LessonRecorder {
       readonly severity: string;
     }[],
     observedAt: string,
-  ): CrossTaskBlockerPattern[] {
+  ): {
+    patterns: CrossTaskBlockerPattern[];
+    observations: PendingBlockerPatternObservation[];
+  } {
     const minedPatterns: CrossTaskBlockerPattern[] = [];
+    const pendingObservations: PendingBlockerPatternObservation[] = [];
     for (const finding of findings) {
       if (finding.severity !== 'critical') {
         continue;
@@ -360,6 +380,7 @@ export class LessonRecorder {
       }
 
       pattern.observations.push({ taskId, observedAt });
+      pendingObservations.push({ key, taskId });
       if (pattern.observations.length >= this.blockerPatternThreshold) {
         minedPatterns.push(
           createCrossTaskBlockerPattern(pattern, this.blockerPatternThreshold),
@@ -367,7 +388,28 @@ export class LessonRecorder {
       }
     }
 
-    return minedPatterns;
+    return { patterns: minedPatterns, observations: pendingObservations };
+  }
+
+  private rollbackBlockerPatternObservations(lesson: CritiqueLesson): void {
+    const pendingObservations =
+      this.pendingBlockerObservations.get(lesson) ?? [];
+    for (const observation of pendingObservations) {
+      const pattern = this.blockerPatterns.get(observation.key);
+      if (!pattern) {
+        continue;
+      }
+      const observationIndex = pattern.observations.findIndex(
+        (entry) => entry.taskId === observation.taskId,
+      );
+      if (observationIndex >= 0) {
+        pattern.observations.splice(observationIndex, 1);
+      }
+      if (pattern.observations.length === 0) {
+        this.blockerPatterns.delete(observation.key);
+      }
+    }
+    this.pendingBlockerObservations.delete(lesson);
   }
 
   private getCooldownSuppression(
@@ -447,17 +489,11 @@ interface MutableLessonRecordingResult {
 }
 
 function createMutableLessonRecordingResult(): MutableLessonRecordingResult {
-  const result = {
+  return {
     recorded: 0,
     suppressedByCooldown: [],
-  } as unknown as MutableLessonRecordingResult;
-  Object.defineProperty(result, 'minedBlockerPatterns', {
-    value: [],
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  });
-  return result;
+    minedBlockerPatterns: [],
+  };
 }
 
 function addUniqueBlockerPatterns(
@@ -469,17 +505,6 @@ function addUniqueBlockerPatterns(
       target.push(pattern);
     }
   }
-}
-
-function exposeMinedBlockerPatterns(
-  result: MutableLessonRecordingResult,
-): void {
-  Object.defineProperty(result, 'minedBlockerPatterns', {
-    value: result.minedBlockerPatterns,
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  });
 }
 
 function createCrossTaskBlockerPattern(

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -21,6 +21,10 @@ const PENDING_ADMISSIONS_BY_COOLDOWN_STORE = new WeakMap<
   Map<string, number>,
   Map<string, Promise<boolean>>
 >();
+const PENDING_BLOCKER_ADMISSIONS_BY_STORE = new WeakMap<
+  Map<string, BlockerPatternState>,
+  Map<string, Promise<void>>
+>();
 
 const LEARNING_COOLDOWN_GUIDANCE =
   'Equivalent critique lessons are suppressed during this cooldown window so PM/liveness tooling does not churn on repeated feedback before promotion or retirement review.';
@@ -104,7 +108,7 @@ export class LessonRecorder {
   private readonly pendingAdmissions: Map<string, Promise<boolean>>;
   private readonly blockerPatternThreshold: number;
   private readonly blockerPatterns: Map<string, BlockerPatternState>;
-  private readonly pendingBlockerAdmissions = new Map<string, Promise<void>>();
+  private readonly pendingBlockerAdmissions: Map<string, Promise<void>>;
   private readonly pendingBlockerObservations = new WeakMap<
     CritiqueLesson,
     PendingBlockerPatternObservation[]
@@ -136,6 +140,9 @@ export class LessonRecorder {
     }
     this.blockerPatternThreshold = blockerPatternThreshold;
     this.blockerPatterns = options.blockerPatternStore ?? new Map();
+    this.pendingBlockerAdmissions = getPendingBlockerAdmissions(
+      this.blockerPatterns,
+    );
     const now = options.now ?? ((): Date => new Date());
     this.now = (): string => normalizeTimestamp(now());
     this.cooldowns = options.cooldownStore ?? new Map<string, number>();
@@ -629,6 +636,17 @@ function getPendingAdmissions(
   if (!pending) {
     pending = new Map<string, Promise<boolean>>();
     PENDING_ADMISSIONS_BY_COOLDOWN_STORE.set(cooldownStore, pending);
+  }
+  return pending;
+}
+
+function getPendingBlockerAdmissions(
+  blockerPatternStore: Map<string, BlockerPatternState>,
+): Map<string, Promise<void>> {
+  let pending = PENDING_BLOCKER_ADMISSIONS_BY_STORE.get(blockerPatternStore);
+  if (!pending) {
+    pending = new Map<string, Promise<void>>();
+    PENDING_BLOCKER_ADMISSIONS_BY_STORE.set(blockerPatternStore, pending);
   }
   return pending;
 }

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -153,10 +153,34 @@ export interface LessonCooldownSuppression {
   readonly reason: string;
 }
 
+/** A recurring critical finding observed across more than one task. */
+export interface CrossTaskBlockerPattern {
+  /** Stable key that identifies equivalent blocker findings across tasks. */
+  readonly key: string;
+  /** Evaluator that emitted the repeated blocker finding. */
+  readonly evaluatorName: string;
+  /** Normalized blocker finding text used for cross-task equivalence. */
+  readonly normalizedFinding: string;
+  /** Distinct-task threshold required before the pattern is surfaced. */
+  readonly threshold: number;
+  /** Number of distinct tasks observed for this blocker pattern. */
+  readonly occurrences: number;
+  /** Distinct tasks that have observed this blocker, ordered by first observation. */
+  readonly taskIds: readonly TaskId[];
+  /** First time this blocker pattern was observed. */
+  readonly firstSeenAt: string;
+  /** Most recent time this blocker pattern was observed. */
+  readonly lastSeenAt: string;
+  /** Operator-facing guidance for PM/liveness handoffs. */
+  readonly guidance: string;
+}
+
 /** Summary returned by LessonRecorder.record for PM/liveness consumers. */
 export interface LessonRecordingResult {
   readonly recorded: number;
   readonly suppressedByCooldown: readonly LessonCooldownSuppression[];
+  /** Cross-task blocker patterns discovered while recording this critique result. */
+  readonly minedBlockerPatterns: readonly CrossTaskBlockerPattern[];
 }
 
 /** A lesson learned from a successful critique cycle. */
@@ -176,6 +200,8 @@ export interface CritiqueLesson {
   readonly postPrLessonExtractionTemplate?: PostPrLessonExtractionTemplate;
   /** Cooldown guard that prevents equivalent lessons from being re-recorded until suppressUntil. */
   readonly cooldown?: LessonCooldownMetadata;
+  /** Cross-task blocker patterns associated with this lesson, if any crossed the threshold. */
+  readonly blockerPatterns?: readonly CrossTaskBlockerPattern[];
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1016,6 +1016,66 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('serializes blocker mining across recorders that share a blocker store', async () => {
+    const firstPort = createMockMemoryPort();
+    const secondPort = createMockMemoryPort();
+    const sharedBlockerStore = new Map();
+    const releaseFirstRecordLesson: (() => void)[] = [];
+    (firstPort.recordLesson as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirstRecordLesson.push(resolve);
+        }),
+    );
+    const firstRecorder = new LessonRecorder(firstPort, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      blockerPatternStore: sharedBlockerStore,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const secondRecorder = new LessonRecorder(secondPort, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      blockerPatternStore: sharedBlockerStore,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Shared recorder stores must not miss threshold crossing',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const firstRecord = firstRecorder.record(result, 'task-a');
+    await Promise.resolve();
+    expect(firstPort.recordLesson).toHaveBeenCalledTimes(1);
+
+    const secondRecord = secondRecorder.record(result, 'task-b');
+    await Promise.resolve();
+    expect(secondPort.recordLesson).not.toHaveBeenCalled();
+
+    releaseFirstRecordLesson[0]!();
+    await firstRecord;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(secondPort.recordLesson).toHaveBeenCalledTimes(1);
+    const secondSummary = await secondRecord;
+
+    expect(secondSummary.minedBlockerPatterns).toEqual([
+      expect.objectContaining({
+        occurrences: 2,
+        taskIds: ['task-a', 'task-b'],
+      }),
+    ]);
+  });
+
   it('deduplicates repeated critical blocker findings within one lesson', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port, {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -577,7 +577,8 @@ describe('LessonRecorder', () => {
       iterations: [
         createIteration(0, 'fail', 'learning-reviewer', [
           {
-            message: 'Slow memory writes should keep recorded and live cooldowns aligned',
+            message:
+              'Slow memory writes should keep recorded and live cooldowns aligned',
             severity: 'warning',
           },
         ]),
@@ -592,7 +593,9 @@ describe('LessonRecorder', () => {
     await firstRecord;
     const secondSummary = await recorder.record(result, 'second-task');
     const firstLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
-      .calls[0]![0] as { cooldown: { recordedAt: string; suppressUntil: string } };
+      .calls[0]![0] as {
+      cooldown: { recordedAt: string; suppressUntil: string };
+    };
 
     expect(firstLesson.cooldown.recordedAt).toBe('2026-07-12T10:00:00.000Z');
     expect(firstLesson.cooldown.suppressUntil).toBe('2026-07-12T10:00:01.000Z');
@@ -774,6 +777,107 @@ describe('LessonRecorder', () => {
 
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
     expect(secondSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+  });
+
+  it('mines cross-task blocker patterns after equivalent critical findings recur across distinct tasks', async () => {
+    const port = createMockMemoryPort();
+    let now = new Date('2026-07-12T10:00:00.000Z');
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      now: (): Date => now,
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Codex usage-limit blocker stopped the current-head review gate',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const firstSummary = await recorder.record(result, 'task-a');
+    now = new Date('2026-07-12T10:05:00.000Z');
+    const secondSummary = await recorder.record(result, 'task-b');
+    const secondLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[1]![0];
+
+    expect(firstSummary.minedBlockerPatterns).toEqual([]);
+    expect(secondSummary.minedBlockerPatterns).toEqual([
+      {
+        key: expect.stringMatching(/^blocker-pattern:codex-review:/),
+        evaluatorName: 'codex-review',
+        normalizedFinding:
+          'codex usage-limit blocker stopped the current-head review gate',
+        threshold: 2,
+        occurrences: 2,
+        taskIds: ['task-a', 'task-b'],
+        firstSeenAt: '2026-07-12T10:00:00.000Z',
+        lastSeenAt: '2026-07-12T10:05:00.000Z',
+        guidance:
+          'Equivalent blocker findings have recurred across distinct tasks; PM/liveness handoffs should treat this as a cross-task pattern and route a durable mitigation instead of rediscovering it per task.',
+      },
+    ]);
+    expect(secondLesson.blockerPatterns).toEqual(
+      secondSummary.minedBlockerPatterns,
+    );
+  });
+
+  it('does not mine blocker patterns from repeated observations on the same task', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message: 'Approval blocker prevented pushing the prepared fix',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-a');
+    const secondSummary = await recorder.record(result, 'task-a');
+
+    expect(secondSummary.minedBlockerPatterns).toEqual([]);
+  });
+
+  it('does not mine warning-only findings as blocker patterns', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'reviewer', [
+          {
+            message: 'PR handoff omitted one optional verification note',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-a');
+    const secondSummary = await recorder.record(result, 'task-b');
+
+    expect(secondSummary.minedBlockerPatterns).toEqual([]);
   });
 
   it('rejects invalid cooldown windows explicitly', () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -909,6 +909,100 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('counts suppressed repeats and only bypasses cooldown on threshold crossing', async () => {
+    const port = createMockMemoryPort();
+    let now = new Date('2026-07-12T10:00:00.000Z');
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 60_000,
+      blockerPatternThreshold: 3,
+      now: (): Date => now,
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Suppressed repeat should still count toward blocker threshold',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-a');
+    now = new Date('2026-07-12T10:00:10.000Z');
+    const secondSummary = await recorder.record(result, 'task-b');
+    now = new Date('2026-07-12T10:00:20.000Z');
+    const thirdSummary = await recorder.record(result, 'task-c');
+    const thirdLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[1]![0];
+
+    expect(secondSummary).toEqual({
+      recorded: 0,
+      suppressedByCooldown: [expect.objectContaining({ taskId: 'task-b' })],
+      minedBlockerPatterns: [],
+    });
+    expect(thirdSummary.recorded).toBe(1);
+    expect(thirdSummary.suppressedByCooldown).toEqual([]);
+    expect(thirdSummary.minedBlockerPatterns).toEqual([
+      expect.objectContaining({
+        occurrences: 3,
+        taskIds: ['task-a', 'task-b', 'task-c'],
+      }),
+    ]);
+    expect(thirdLesson.blockerPatterns).toEqual(
+      thirdSummary.minedBlockerPatterns,
+    );
+  });
+
+  it('deduplicates repeated critical blocker findings within one lesson', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const firstResult: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message: 'Duplicate critical blocker should be mined once',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+    const duplicateResult: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message: 'Duplicate critical blocker should be mined once',
+            severity: 'critical',
+          },
+          {
+            message: 'Duplicate critical blocker should be mined once',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(firstResult, 'task-a');
+    const secondSummary = await recorder.record(duplicateResult, 'task-b');
+
+    expect(secondSummary.minedBlockerPatterns).toHaveLength(1);
+    expect(secondSummary.minedBlockerPatterns[0]!.taskIds).toEqual([
+      'task-a',
+      'task-b',
+    ]);
+  });
+
   it('keeps already-mined blocker repeats subject to cooldown', async () => {
     const port = createMockMemoryPort();
     let now = new Date('2026-07-12T10:00:00.000Z');

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -909,6 +909,44 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('keeps already-mined blocker repeats subject to cooldown', async () => {
+    const port = createMockMemoryPort();
+    let now = new Date('2026-07-12T10:00:00.000Z');
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 60_000,
+      blockerPatternThreshold: 2,
+      now: (): Date => now,
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Already-routed blocker pattern should not bypass cooldown forever',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-a');
+    now = new Date('2026-07-12T10:00:10.000Z');
+    const secondSummary = await recorder.record(result, 'task-b');
+    now = new Date('2026-07-12T10:00:20.000Z');
+    const thirdSummary = await recorder.record(result, 'task-c');
+
+    expect(secondSummary.recorded).toBe(1);
+    expect(secondSummary.minedBlockerPatterns).toHaveLength(1);
+    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    expect(thirdSummary).toEqual({
+      recorded: 0,
+      suppressedByCooldown: [expect.objectContaining({ taskId: 'task-c' })],
+      minedBlockerPatterns: [],
+    });
+  });
+
   it('rolls back blocker observations when lesson persistence fails', async () => {
     const port = createMockMemoryPort();
     (port.recordLesson as ReturnType<typeof vi.fn>)

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -342,7 +342,11 @@ describe('LessonRecorder', () => {
 
     const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
       .calls[0]![0];
-    expect(summary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(summary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
     expect(lesson.cooldown).toEqual({
       key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
       windowMs: 60_000,
@@ -419,7 +423,11 @@ describe('LessonRecorder', () => {
     const admitted = await recorder.record(result, 'second-task');
 
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(admitted).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(admitted).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
   });
 
   it('honors shared cooldown state across recorder instances', async () => {
@@ -460,6 +468,7 @@ describe('LessonRecorder', () => {
           remainingMs: 30_000,
         }),
       ],
+      minedBlockerPatterns: [],
     });
   });
 
@@ -510,12 +519,17 @@ describe('LessonRecorder', () => {
     ]);
 
     expect(port.recordLesson).toHaveBeenCalledTimes(1);
-    expect(firstSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(firstSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
     expect(secondSummary).toEqual({
       recorded: 0,
       suppressedByCooldown: [
         expect.objectContaining({ taskId: 'second-task' }),
       ],
+      minedBlockerPatterns: [],
     });
   });
 
@@ -552,7 +566,11 @@ describe('LessonRecorder', () => {
     );
 
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(disabledSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(disabledSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
   });
 
   it('aligns local suppression with the recorded cooldown metadata', async () => {
@@ -600,7 +618,11 @@ describe('LessonRecorder', () => {
     expect(firstLesson.cooldown.recordedAt).toBe('2026-07-12T10:00:00.000Z');
     expect(firstLesson.cooldown.suppressUntil).toBe('2026-07-12T10:00:01.000Z');
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(secondSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(secondSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
   });
 
   it('reserves cooldown admission before async persistence completes', async () => {
@@ -642,7 +664,11 @@ describe('LessonRecorder', () => {
     ]);
 
     expect(port.recordLesson).toHaveBeenCalledTimes(1);
-    expect(firstSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(firstSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
     expect(secondSummary).toEqual({
       recorded: 0,
       suppressedByCooldown: [
@@ -652,6 +678,7 @@ describe('LessonRecorder', () => {
           remainingMs: 60_000,
         }),
       ],
+      minedBlockerPatterns: [],
     });
   });
 
@@ -698,8 +725,16 @@ describe('LessonRecorder', () => {
     ]);
 
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(firstSummary).toEqual({ recorded: 0, suppressedByCooldown: [] });
-    expect(secondSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(firstSummary).toEqual({
+      recorded: 0,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
+    expect(secondSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
     expect(thirdSummary).toEqual({
       recorded: 0,
       suppressedByCooldown: [
@@ -708,6 +743,7 @@ describe('LessonRecorder', () => {
           evaluatorName: 'learning-reviewer',
         }),
       ],
+      minedBlockerPatterns: [],
     });
   });
 
@@ -744,7 +780,11 @@ describe('LessonRecorder', () => {
     );
 
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(secondSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(secondSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
   });
 
   it('keeps evaluator names distinct even when their display slugs collide', async () => {
@@ -776,7 +816,11 @@ describe('LessonRecorder', () => {
     const secondSummary = await recorder.record(policyDash, 'second-task');
 
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(secondSummary).toEqual({ recorded: 1, suppressedByCooldown: [] });
+    expect(secondSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
   });
 
   it('mines cross-task blocker patterns after equivalent critical findings recur across distinct tasks', async () => {
@@ -826,6 +870,82 @@ describe('LessonRecorder', () => {
     expect(secondLesson.blockerPatterns).toEqual(
       secondSummary.minedBlockerPatterns,
     );
+  });
+
+  it('persists a mined blocker pattern even when the equivalent lesson is inside cooldown', async () => {
+    const port = createMockMemoryPort();
+    let now = new Date('2026-07-12T10:00:00.000Z');
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 60_000,
+      blockerPatternThreshold: 2,
+      now: (): Date => now,
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Same current-head Codex review blocker should be routed durably',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'task-a');
+    now = new Date('2026-07-12T10:00:30.000Z');
+    const secondSummary = await recorder.record(result, 'task-b');
+    const secondLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[1]![0];
+
+    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    expect(secondSummary.recorded).toBe(1);
+    expect(secondSummary.suppressedByCooldown).toEqual([]);
+    expect(secondSummary.minedBlockerPatterns).toHaveLength(1);
+    expect(secondLesson.blockerPatterns).toEqual(
+      secondSummary.minedBlockerPatterns,
+    );
+  });
+
+  it('rolls back blocker observations when lesson persistence fails', async () => {
+    const port = createMockMemoryPort();
+    (port.recordLesson as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('transient memory failure'))
+      .mockResolvedValue(undefined);
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Memory failure should not leave phantom blocker observations',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const failedSummary = await recorder.record(result, 'task-a');
+    const secondSummary = await recorder.record(result, 'task-b');
+
+    expect(failedSummary).toEqual({
+      recorded: 0,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
+    expect(secondSummary).toEqual({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
   });
 
   it('does not mine blocker patterns from repeated observations on the same task', async () => {
@@ -1067,6 +1187,7 @@ describe('LessonRecorder', () => {
     await expect(recorder.record(result, 'test-task')).resolves.toEqual({
       recorded: 0,
       suppressedByCooldown: [],
+      minedBlockerPatterns: [],
     });
   });
 });

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -957,6 +957,65 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('serializes blocker mining by pattern key before committing observations', async () => {
+    const port = createMockMemoryPort();
+    const releaseRecordLesson: (() => void)[] = [];
+    (port.recordLesson as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRecordLesson.push(resolve);
+        }),
+    );
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 0,
+      blockerPatternThreshold: 2,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'codex-review', [
+          {
+            message:
+              'Concurrent blockers must not cross threshold without reporting',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const firstRecord = recorder.record(result, 'task-a');
+    await Promise.resolve();
+    expect(port.recordLesson).toHaveBeenCalledTimes(1);
+
+    const secondRecord = recorder.record(result, 'task-b');
+    await Promise.resolve();
+    expect(port.recordLesson).toHaveBeenCalledTimes(1);
+
+    releaseRecordLesson[0]!();
+    const firstSummary = await firstRecord;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(firstSummary.minedBlockerPatterns).toEqual([]);
+    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    const secondLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[1]![0];
+
+    releaseRecordLesson[1]!();
+    const secondSummary = await secondRecord;
+
+    expect(secondSummary.minedBlockerPatterns).toEqual([
+      expect.objectContaining({
+        occurrences: 2,
+        taskIds: ['task-a', 'task-b'],
+      }),
+    ]);
+    expect(secondLesson.blockerPatterns).toEqual(
+      secondSummary.minedBlockerPatterns,
+    );
+  });
+
   it('deduplicates repeated critical blocker findings within one lesson', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port, {


### PR DESCRIPTION
## Summary
- add cross-task blocker pattern mining to LessonRecorder for recurring critical findings across distinct tasks
- expose structured minedBlockerPatterns/blockerPatterns metadata for PM/liveness consumers
- document the feature and add success/same-task/warning-only regressions

## Verification
- TMPDIR=$PWD/.tmp/vitest-tmp npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts --pool forks
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/critique
- npx prettier --check packages/franken-critique/src/index.ts packages/franken-critique/src/memory/lesson-recorder.ts packages/franken-critique/src/types/contracts.ts packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts packages/franken-critique/README.md

Closes #1861