### PR TITLE
fix(orchestrator): normalize workspace root patterns

### DIFF
--- a/packages/franken-orchestrator/src/cli/project-root.ts
+++ b/packages/franken-orchestrator/src/cli/project-root.ts
@@ -37,6 +37,14 @@ export function resolveProjectRoot(baseDir: string): string {
   return findWorkspaceRoot(start) ?? start;
 }
 
+function normalizeWorkspacePattern(workspace: string): string {
+  return workspace.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function hasPackagesWorkspace(workspaces: string[] | undefined): boolean {
+  return workspaces?.some((workspace) => normalizeWorkspacePattern(workspace) === 'packages/*') ?? false;
+}
+
 function findWorkspaceRoot(start: string): string | undefined {
   let current = start;
 
@@ -52,7 +60,7 @@ function findWorkspaceRoot(start: string): string | undefined {
           : packageJson.workspaces?.packages;
         const rel = relative(current, start);
         const isInsidePackagesDir = rel === 'packages' || rel.startsWith(`packages/`);
-        if (workspaces?.includes('packages/*') && (start === current || isInsidePackagesDir)) {
+        if (hasPackagesWorkspace(workspaces) && (start === current || isInsidePackagesDir)) {
           return current;
         }
       } catch {

--- a/packages/franken-orchestrator/tests/unit/cli/project-root.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/project-root.test.ts
@@ -40,6 +40,30 @@ describe('project-root', () => {
 
       expect(resolveProjectRoot(packageDir)).toBe(repoRoot);
     });
+
+    it('normalizes dot-prefixed packages workspace entries before resolving the repo root', () => {
+      const repoRoot = resolve(testDir, 'repo-dot-workspace');
+      const packageDir = resolve(repoRoot, 'packages/franken-orchestrator');
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        resolve(repoRoot, 'package.json'),
+        JSON.stringify({ private: true, workspaces: ['./packages/*'] }),
+      );
+
+      expect(resolveProjectRoot(packageDir)).toBe(repoRoot);
+    });
+
+    it('normalizes dot-prefixed packages entries in object workspaces before resolving the repo root', () => {
+      const repoRoot = resolve(testDir, 'repo-object-workspace');
+      const packageDir = resolve(repoRoot, 'packages/franken-orchestrator');
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        resolve(repoRoot, 'package.json'),
+        JSON.stringify({ private: true, workspaces: { packages: ['./packages/*'] } }),
+      );
+
+      expect(resolveProjectRoot(packageDir)).toBe(repoRoot);
+    });
   });
 
   describe('getProjectPaths', () => {


### PR DESCRIPTION
## Summary
- Normalize workspace patterns before checking for package workspace roots
- Support dot-prefixed entries such as `./packages/*` in array and object workspace configs
- Add targeted project-root regression coverage

## Test Plan
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run test --workspace @franken/orchestrator -- tests/unit/cli/project-root.test.ts`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/types`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/planner`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/brain`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/observer`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/critique`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/governor`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run typecheck --workspace @franken/orchestrator`
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)
- `TMPDIR="/home/pfkagent/.hermes/kanban/workspaces/t_6efc2048/frankenbeast/.tmp" npm run build --workspace @franken/orchestrator`

Closes #1953