### PR TITLE
docs(cli): clarify Gemini API prerequisites

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -12,7 +12,7 @@ The beast harness is split across two CLIs. This guide covers both.
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26`
-- For API-backed `frankenbeast` provider registry runs, an API key for at least one supported provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`
+- For API-backed `frankenbeast` provider registry runs, an API key for at least one supported provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or either `GOOGLE_API_KEY` / `GEMINI_API_KEY` for `gemini-api`
 - For `fbeast mcp beast` preset activation, one of the supported Beast provider paths: `anthropic-api` with `ANTHROPIC_API_KEY`, or an installed/logged-in `claude` / `codex` CLI for `claude-cli` / `codex-cli`
 
 ```bash

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -419,15 +419,36 @@ describe('local setup scripts', () => {
   it('keeps the CLI Beast guide aligned with supported Beast activation providers', () => {
     const runCliBeastGuide = read('docs/guides/run-cli-beast.md');
     const beastModeSource = read('packages/franken-mcp-suite/src/cli/beast-mode.ts');
+    const providerConfigSource = read('packages/franken-orchestrator/src/providers/provider-config.ts');
 
     expect(runCliBeastGuide).toContain('`OLLAMA_BASE_URL` is a legacy/forward-looking endpoint variable');
     expect(runCliBeastGuide).toContain('Setting `OLLAMA_BASE_URL` alone will not enable an Ollama-backed run in this build');
     expect(runCliBeastGuide).toContain('http://localhost:11434');
     expect(runCliBeastGuide).toContain('intentionally leaves `OLLAMA_BASE_URL` out');
     expect(runCliBeastGuide).toContain('current provider schema');
+    expect(runCliBeastGuide).toContain('GOOGLE_API_KEY` / `GEMINI_API_KEY` for `gemini-api`');
+    expect(runCliBeastGuide).toContain('anthropic-api');
+    expect(runCliBeastGuide).toContain('openai-api');
+    expect(runCliBeastGuide).toContain('gemini-api');
     expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=anthropic-api');
     expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=codex-cli');
     expect(runCliBeastGuide).toContain('fbeast mcp beast --provider=claude-cli');
+
+    const providerTypesMatch = providerConfigSource.match(/PROVIDER_TYPES = \[([\s\S]*?)\] as const/);
+    expect(providerTypesMatch).not.toBeNull();
+    const providerTypes = providerTypesMatch?.[1] ?? '';
+    for (const providerType of [
+      'claude-cli',
+      'codex-cli',
+      'gemini-cli',
+      'anthropic-api',
+      'openai-api',
+      'gemini-api',
+    ]) {
+      expect(providerTypes).toContain(providerType);
+      expect(runCliBeastGuide).toContain(providerType);
+    }
+    expect(providerTypes).not.toMatch(/ollama/i);
 
     const providersMatch = beastModeSource.match(/SUPPORTED_BEAST_PROVIDERS = new Set\(\[([^\]]+)\]\)/);
     expect(providersMatch).not.toBeNull();


### PR DESCRIPTION
## Summary
- clarify `run-cli-beast` Gemini API prerequisites by naming `gemini-api`
- strengthen local setup docs tests so the guide stays aligned with provider config and excludes Ollama from current provider types

## Test Plan
- npm ci
- `TMPDIR=$PWD/.tmp VITEST_MAX_THREADS=1 npm run test:root -- --run tests/local-setup-scripts.test.ts -t 'keeps the CLI Beast guide aligned|documents current local env vars'`
- `git diff --check`
- `npm run typecheck -- --filter=@franken/types`
- `npx tsc --noEmit -p tsconfig.test.json` (fails on pre-existing unrelated observer/web/test typing errors)

Closes #1986
