### PR TITLE
fix(critique): evict expired rate-limit buckets

### DIFF
--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -16,9 +16,25 @@ export interface CritiqueAppOptions {
   pipeline?: CritiquePipeline;
 }
 
+export interface RateLimitBucket {
+  count: number;
+  resetAt: number;
+}
+
+export function evictExpiredRateLimitBuckets(
+  requestCounts: Map<string, RateLimitBucket>,
+  now: number,
+): void {
+  for (const [ip, bucket] of requestCounts) {
+    if (bucket.resetAt <= now) {
+      requestCounts.delete(ip);
+    }
+  }
+}
+
 export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
   const app = new Hono();
-  const requestCounts = new Map<string, { count: number; resetAt: number }>();
+  const requestCounts = new Map<string, RateLimitBucket>();
 
   // Bearer auth middleware
   const bearerToken = options.bearerToken;
@@ -26,18 +42,24 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
     app.use('/v1/*', async (c, next) => {
       const auth = c.req.header('Authorization');
       if (!timingSafeBearerTokenMatches(auth, bearerToken)) {
-        return c.json({ error: { message: 'Unauthorized', type: 'auth_error' } }, 401);
+        return c.json(
+          { error: { message: 'Unauthorized', type: 'auth_error' } },
+          401,
+        );
       }
       return next();
     });
   }
 
-  // Rate limiting middleware
+  // Rate limiting middleware. Each rate-limited request performs a lightweight
+  // sweep so buckets whose windows expired are not retained indefinitely when
+  // their original clients never return.
   if (options.rateLimitPerMinute) {
     const limit = options.rateLimitPerMinute;
     app.use('/v1/*', async (c, next) => {
       const ip = c.req.header('x-forwarded-for') ?? 'unknown';
       const now = wallClockNow();
+      evictExpiredRateLimitBuckets(requestCounts, now);
       const entry = requestCounts.get(ip);
 
       if (entry && entry.resetAt > now) {
@@ -79,7 +101,12 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
 
     if (!options.pipeline) {
       return c.json(
-        { error: { message: 'No critique pipeline configured', type: 'config_error' } },
+        {
+          error: {
+            message: 'No critique pipeline configured',
+            type: 'config_error',
+          },
+        },
         503,
       );
     }
@@ -92,8 +119,8 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
     return c.json({
       verdict: result.verdict,
       score: result.overallScore,
-      findings: result.results.flatMap(r =>
-        r.findings.map(f => ({
+      findings: result.results.flatMap((r) =>
+        r.findings.map((f) => ({
           evaluator: r.evaluatorName,
           severity: f.severity,
           message: f.message,
@@ -101,7 +128,7 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
           suggestion: f.suggestion,
         })),
       ),
-      evaluatorsRun: result.results.map(r => r.evaluatorName),
+      evaluatorsRun: result.results.map((r) => r.evaluatorName),
       shortCircuited: result.shortCircuited,
     });
   });

--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -16,6 +16,10 @@ export interface CritiqueAppOptions {
   pipeline?: CritiquePipeline;
 }
 
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_CLEANUP_INTERVAL_MS = RATE_LIMIT_WINDOW_MS;
+const RATE_LIMIT_MAX_BUCKETS = 10_000;
+
 export interface RateLimitBucket {
   count: number;
   resetAt: number;
@@ -32,9 +36,28 @@ export function evictExpiredRateLimitBuckets(
   }
 }
 
+export function evictOldestRateLimitBucket(
+  requestCounts: Map<string, RateLimitBucket>,
+): void {
+  let oldestIp: string | undefined;
+  let oldestResetAt = Infinity;
+
+  for (const [ip, bucket] of requestCounts) {
+    if (bucket.resetAt < oldestResetAt) {
+      oldestIp = ip;
+      oldestResetAt = bucket.resetAt;
+    }
+  }
+
+  if (oldestIp !== undefined) {
+    requestCounts.delete(oldestIp);
+  }
+}
+
 export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
   const app = new Hono();
   const requestCounts = new Map<string, RateLimitBucket>();
+  let nextRateLimitCleanupAt = 0;
 
   // Bearer auth middleware
   const bearerToken = options.bearerToken;
@@ -51,15 +74,18 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
     });
   }
 
-  // Rate limiting middleware. Each rate-limited request performs a lightweight
-  // sweep so buckets whose windows expired are not retained indefinitely when
-  // their original clients never return.
+  // Rate limiting middleware. Expired buckets are swept at a fixed cadence and
+  // the active bucket map has a hard cap so high-cardinality forwarded-address
+  // traffic cannot force an O(bucket count) scan on every request.
   if (options.rateLimitPerMinute) {
     const limit = options.rateLimitPerMinute;
     app.use('/v1/*', async (c, next) => {
       const ip = c.req.header('x-forwarded-for') ?? 'unknown';
       const now = wallClockNow();
-      evictExpiredRateLimitBuckets(requestCounts, now);
+      if (now >= nextRateLimitCleanupAt) {
+        evictExpiredRateLimitBuckets(requestCounts, now);
+        nextRateLimitCleanupAt = now + RATE_LIMIT_CLEANUP_INTERVAL_MS;
+      }
       const entry = requestCounts.get(ip);
 
       if (entry && entry.resetAt > now) {
@@ -71,7 +97,13 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
         }
         entry.count++;
       } else {
-        requestCounts.set(ip, { count: 1, resetAt: now + 60_000 });
+        requestCounts.set(ip, {
+          count: 1,
+          resetAt: now + RATE_LIMIT_WINDOW_MS,
+        });
+        if (requestCounts.size > RATE_LIMIT_MAX_BUCKETS) {
+          evictOldestRateLimitBucket(requestCounts);
+        }
       }
 
       return next();

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createCritiqueApp,
   evictExpiredRateLimitBuckets,
+  evictOldestRateLimitBucket,
 } from '../../../src/server/app.js';
 import { timingSafeBearerTokenMatches } from '../../../src/server/token-auth.js';
 import { CritiquePipeline } from '../../../src/pipeline/critique-pipeline.js';
@@ -167,6 +168,18 @@ describe('Critique Hono Server', () => {
       evictExpiredRateLimitBuckets(requestCounts, 3_000);
 
       expect([...requestCounts.keys()]).toEqual(['active']);
+    });
+
+    it('evicts the oldest rate-limit bucket when the active bucket cap is exceeded', () => {
+      const requestCounts = new Map([
+        ['oldest', { count: 1, resetAt: 1_000 }],
+        ['newest', { count: 1, resetAt: 3_000 }],
+        ['middle', { count: 1, resetAt: 2_000 }],
+      ]);
+
+      evictOldestRateLimitBucket(requestCounts);
+
+      expect([...requestCounts.keys()]).toEqual(['newest', 'middle']);
     });
 
     it('returns 429 after exceeding limit', async () => {

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { createCritiqueApp } from '../../../src/server/app.js';
+import {
+  createCritiqueApp,
+  evictExpiredRateLimitBuckets,
+} from '../../../src/server/app.js';
 import { timingSafeBearerTokenMatches } from '../../../src/server/token-auth.js';
 import { CritiquePipeline } from '../../../src/pipeline/critique-pipeline.js';
-import type { Evaluator, EvaluationInput, EvaluationResult } from '../../../src/types/evaluation.js';
+import type {
+  Evaluator,
+  EvaluationInput,
+  EvaluationResult,
+} from '../../../src/types/evaluation.js';
 
 /** Minimal evaluator that always passes. */
 function makePassEvaluator(name = 'test-eval'): Evaluator {
@@ -103,13 +110,25 @@ describe('Critique Hono Server', () => {
 
   describe('auth', () => {
     it('compares bearer tokens through a timing-safe helper', () => {
-      expect(timingSafeBearerTokenMatches('Bearer secret-token', 'secret-token')).toBe(true);
-      expect(timingSafeBearerTokenMatches('Bearer secret-token', 'secret-token-extra')).toBe(false);
-      expect(timingSafeBearerTokenMatches('Basic secret-token', 'secret-token')).toBe(false);
+      expect(
+        timingSafeBearerTokenMatches('Bearer secret-token', 'secret-token'),
+      ).toBe(true);
+      expect(
+        timingSafeBearerTokenMatches(
+          'Bearer secret-token',
+          'secret-token-extra',
+        ),
+      ).toBe(false);
+      expect(
+        timingSafeBearerTokenMatches('Basic secret-token', 'secret-token'),
+      ).toBe(false);
     });
 
     it('returns 401 without bearer token', async () => {
-      const app = createCritiqueApp({ bearerToken: 'secret-token', pipeline: makePipeline() });
+      const app = createCritiqueApp({
+        bearerToken: 'secret-token',
+        pipeline: makePipeline(),
+      });
       const res = await app.request('/v1/review', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -120,7 +139,10 @@ describe('Critique Hono Server', () => {
     });
 
     it('returns 200 with valid bearer token', async () => {
-      const app = createCritiqueApp({ bearerToken: 'secret-token', pipeline: makePipeline() });
+      const app = createCritiqueApp({
+        bearerToken: 'secret-token',
+        pipeline: makePipeline(),
+      });
       const res = await app.request('/v1/review', {
         method: 'POST',
         headers: {
@@ -135,8 +157,23 @@ describe('Critique Hono Server', () => {
   });
 
   describe('rate limiting', () => {
+    it('evicts expired inactive rate-limit buckets during cleanup', () => {
+      const requestCounts = new Map([
+        ['stale-a', { count: 1, resetAt: 1_000 }],
+        ['active', { count: 1, resetAt: 5_000 }],
+        ['stale-b', { count: 1, resetAt: 2_000 }],
+      ]);
+
+      evictExpiredRateLimitBuckets(requestCounts, 3_000);
+
+      expect([...requestCounts.keys()]).toEqual(['active']);
+    });
+
     it('returns 429 after exceeding limit', async () => {
-      const app = createCritiqueApp({ rateLimitPerMinute: 2, pipeline: makePipeline() });
+      const app = createCritiqueApp({
+        rateLimitPerMinute: 2,
+        pipeline: makePipeline(),
+      });
 
       // First two requests should succeed
       for (let i = 0; i < 2; i++) {


### PR DESCRIPTION
## Summary
- Add explicit rate-limit bucket cleanup for expired critique server clients
- Sweep expired entries during rate-limited request handling so inactive clients do not remain retained indefinitely
- Cover cleanup behavior alongside the existing 429 threshold test

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1922/.tmp npm run test --workspace @franken/critique -- tests/unit/server/app.test.ts --pool=vmThreads --reporter=verbose
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1922/.tmp npm run test --workspace @franken/critique -- --pool=vmThreads
- npm run typecheck --workspace @franken/critique
- npm run build --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npx prettier --check packages/franken-critique/src/server/app.ts packages/franken-critique/tests/unit/server/app.test.ts

Closes #1922