### PR TITLE
fix(orchestrator): isolate chat continuation by session

### DIFF
--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -14,6 +14,7 @@ type UnifiedRequest = {
   }>;
   max_tokens?: number;
   session_id?: string;
+  sessionContinue?: boolean;
 };
 
 type UnifiedResponse = {
@@ -59,7 +60,7 @@ export class AdapterLlmClient implements ILlmClient {
     this.defaultModel = defaultModel;
   }
 
-  async complete(prompt: string): Promise<string> {
+  async complete(prompt: string, options?: { sessionContinue?: boolean; sessionId?: string }): Promise<string> {
     const requestId = `llm-${deterministicNow()}-${seededRandom.random().toString(16).slice(2)}`;
     const model = this.defaultModel;
     
@@ -68,6 +69,8 @@ export class AdapterLlmClient implements ILlmClient {
       provider: 'adapter',
       model,
       messages: [{ role: 'user', content: prompt }],
+      ...(options?.sessionId ? { session_id: options.sessionId } : {}),
+      ...(options?.sessionContinue !== undefined ? { sessionContinue: options.sessionContinue } : {}),
     };
 
     let span: any;

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -24,6 +24,7 @@ type CliTransformed = {
   model: string | undefined;
   chatMode: boolean;
   sessionContinue: boolean;
+  sessionId?: string | undefined;
   cacheSession?: CliCacheSessionHint | undefined;
   requestId?: string | undefined;
 };
@@ -96,6 +97,7 @@ export class CliLlmAdapter implements IAdapter {
   private readonly registry: ProviderRegistry;
   private readonly responseProviders = new Map<string, string>();
   private readonly responseSessions = new Map<string, { provider: string; model?: string | undefined; sessionKey: string }>();
+  private readonly chatNativeSessions = new Map<string, string>();
   private chatCallCount = 0;
 
   constructor(
@@ -131,6 +133,7 @@ export class CliLlmAdapter implements IAdapter {
       messages: Array<{ role: string; content: string }>;
       cacheSession?: CliCacheSessionHint;
       sessionContinue?: boolean;
+      session_id?: string;
     };
     const userMessages = req.messages.filter((m) => m.role === 'user');
     const last = userMessages[userMessages.length - 1];
@@ -145,6 +148,7 @@ export class CliLlmAdapter implements IAdapter {
       model: this.opts.model,
       chatMode: this.opts.chatMode,
       sessionContinue,
+      ...(req.session_id ? { sessionId: req.session_id } : {}),
       ...(req.id ? { requestId: req.id } : {}),
     };
     if (cacheSession) {
@@ -154,7 +158,7 @@ export class CliLlmAdapter implements IAdapter {
   }
 
   async execute(providerRequest: unknown): Promise<string> {
-    const { prompt, maxTurns, model, chatMode, sessionContinue, requestId, cacheSession } = providerRequest as CliTransformed;
+    const { prompt, maxTurns, model, chatMode, sessionContinue, sessionId, requestId, cacheSession } = providerRequest as CliTransformed;
     if (chatMode) this.chatCallCount++;
     const providers = normalizeProviderChain(this.provider.name, this.opts.providers);
     const exhaustedProviders = new Map<string, CommandFailure>();
@@ -186,6 +190,7 @@ export class CliLlmAdapter implements IAdapter {
             model: activeModel,
             chatMode,
             sessionContinue,
+            ...(sessionId ? { sessionId: this.resolveProviderSessionId(activeProvider, sessionId, sessionContinue) } : {}),
             extraArgs: this.resolveExtraArgs(activeProvider),
           }),
           env: provider.filterEnv(this.captureEnv()),
@@ -239,7 +244,13 @@ export class CliLlmAdapter implements IAdapter {
       }
 
       if (result.exitCode === 0) {
-        if (requestId) {
+      if (chatMode && sessionId) {
+        const nativeSessionId = this.extractNativeSessionId(result.stdout);
+        if (nativeSessionId) {
+          this.chatNativeSessions.set(this.chatSessionMapKey(activeProvider, sessionId), nativeSessionId);
+        }
+      }
+      if (requestId) {
           const replayRunId = this.resolveReplayRunId(requestId);
           const normalizedOutput = provider.normalizeOutput(result.stdout);
           this.opts.replayRecorder?.({
@@ -328,6 +339,38 @@ export class CliLlmAdapter implements IAdapter {
     }
     this.responseSessions.delete(requestId);
     return session;
+  }
+
+  private resolveProviderSessionId(provider: string, appSessionId: string, sessionContinue: boolean): string | undefined {
+    if (!sessionContinue) {
+      return appSessionId;
+    }
+    return this.resolveNativeChatSessionId(provider, appSessionId);
+  }
+
+  private resolveNativeChatSessionId(provider: string, appSessionId: string): string | undefined {
+    return this.chatNativeSessions.get(this.chatSessionMapKey(provider, appSessionId));
+  }
+
+  private chatSessionMapKey(provider: string, appSessionId: string): string {
+    return `${provider}:${appSessionId}`;
+  }
+
+  private extractNativeSessionId(stdout: string): string | undefined {
+    for (const line of stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const event = JSON.parse(trimmed) as { session_id?: unknown; sessionId?: unknown };
+        const sessionId = event.session_id ?? event.sessionId;
+        if (typeof sessionId === 'string' && sessionId.length > 0) {
+          return sessionId;
+        }
+      } catch {
+        // Non-JSON provider output is normal for non-streaming CLIs.
+      }
+    }
+    return undefined;
   }
 
   private resolveProvider(name: string): ICliProvider {

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -130,13 +130,14 @@ export class CliLlmAdapter implements IAdapter {
       id?: string;
       messages: Array<{ role: string; content: string }>;
       cacheSession?: CliCacheSessionHint;
+      sessionContinue?: boolean;
     };
     const userMessages = req.messages.filter((m) => m.role === 'user');
     const last = userMessages[userMessages.length - 1];
     const cacheSession = req.cacheSession;
     const cacheCapabilities = resolveProviderCacheCapabilities(this.provider);
     const sessionContinue = this.opts.chatMode
-      ? this.chatCallCount > 0
+      ? req.sessionContinue ?? this.chatCallCount > 0
       : Boolean(cacheSession?.key && cacheCapabilities.nativeWorkSessions);
     const transformed: CliTransformed = {
       prompt: last?.content ?? '',

--- a/packages/franken-orchestrator/src/chat/conversation-engine.ts
+++ b/packages/franken-orchestrator/src/chat/conversation-engine.ts
@@ -100,7 +100,7 @@ export class ConversationEngine {
         // sessions that this engine has actually primed with a prior LLM reply so
         // a shared HTTP runtime cannot leak continuation state across independent
         // or resumed chat sessions.
-        const sessionId = options.sessionId;
+        const sessionId = this.sessionContinuation ? options.sessionId : undefined;
         const shouldContinue = this.sessionContinuation
           && (sessionId ? this.primedSessions.has(sessionId) : history.length > 0);
         const prompt = shouldContinue

--- a/packages/franken-orchestrator/src/chat/conversation-engine.ts
+++ b/packages/franken-orchestrator/src/chat/conversation-engine.ts
@@ -25,16 +25,25 @@ export interface ConversationEngineOptions {
   sessionContinuation?: boolean;
 }
 
+interface ConversationEngineTurnOptions {
+  sessionId?: string;
+}
+
+type ContinuationAwareLlmClient = ILlmClient & {
+  complete(prompt: string, options?: { sessionContinue?: boolean; sessionId?: string }): Promise<string>;
+};
+
 export class ConversationEngine {
-  private readonly llm: ILlmClient;
+  private readonly llm: ContinuationAwareLlmClient;
   private readonly router: IntentRouter;
   private readonly policy: EscalationPolicy;
   private readonly promptBuilder: PromptBuilder;
   private readonly budgetPerSession: number | undefined;
   private readonly sessionContinuation: boolean;
+  private readonly primedSessions = new Set<string>();
 
   constructor({ llm, projectName, maxTranscriptLength, budgetPerSession, sessionContinuation }: ConversationEngineOptions) {
-    this.llm = llm;
+    this.llm = llm as ContinuationAwareLlmClient;
     this.router = new IntentRouter();
     this.policy = new EscalationPolicy();
     this.promptBuilder = new PromptBuilder({
@@ -48,6 +57,7 @@ export class ConversationEngine {
   async processTurn(
     input: string,
     history: TranscriptMessage[],
+    options: ConversationEngineTurnOptions = {},
   ): Promise<TurnResult> {
     // Budget check: reject if cumulative cost exceeds session budget
     if (this.budgetPerSession !== undefined) {
@@ -84,15 +94,25 @@ export class ConversationEngine {
 
     if (outcome.kind === 'reply') {
       try {
-        // First turn for each transcript: full prompt with system context + history.
+        // First reply turn for each live session: full prompt with system context + history.
         // Subsequent turns with session continuation: raw input only
         // (CLI session already has context from --continue). Scope the decision to
-        // the passed transcript so a shared HTTP runtime cannot leak continuation
-        // state across independent chat sessions.
-        const prompt = (this.sessionContinuation && history.length > 0)
+        // sessions that this engine has actually primed with a prior LLM reply so
+        // a shared HTTP runtime cannot leak continuation state across independent
+        // or resumed chat sessions.
+        const sessionId = options.sessionId;
+        const shouldContinue = this.sessionContinuation
+          && (sessionId ? this.primedSessions.has(sessionId) : history.length > 0);
+        const prompt = shouldContinue
           ? input
           : this.promptBuilder.build([...history, userMessage]);
-        const response = await this.llm.complete(prompt);
+        const response = await this.llm.complete(prompt, {
+          sessionContinue: shouldContinue,
+          ...(sessionId ? { sessionId } : {}),
+        });
+        if (sessionId) {
+          this.primedSessions.add(sessionId);
+        }
         const replyOutcome: ReplyOutcome = {
           kind: 'reply',
           content: response,

--- a/packages/franken-orchestrator/src/chat/conversation-engine.ts
+++ b/packages/franken-orchestrator/src/chat/conversation-engine.ts
@@ -32,7 +32,6 @@ export class ConversationEngine {
   private readonly promptBuilder: PromptBuilder;
   private readonly budgetPerSession: number | undefined;
   private readonly sessionContinuation: boolean;
-  private turnCount = 0;
 
   constructor({ llm, projectName, maxTranscriptLength, budgetPerSession, sessionContinuation }: ConversationEngineOptions) {
     this.llm = llm;
@@ -85,13 +84,14 @@ export class ConversationEngine {
 
     if (outcome.kind === 'reply') {
       try {
-        // First turn: full prompt with system context + history.
+        // First turn for each transcript: full prompt with system context + history.
         // Subsequent turns with session continuation: raw input only
-        // (CLI session already has context from --continue).
-        const prompt = (this.sessionContinuation && this.turnCount > 0)
+        // (CLI session already has context from --continue). Scope the decision to
+        // the passed transcript so a shared HTTP runtime cannot leak continuation
+        // state across independent chat sessions.
+        const prompt = (this.sessionContinuation && history.length > 0)
           ? input
           : this.promptBuilder.build([...history, userMessage]);
-        this.turnCount++;
         const response = await this.llm.complete(prompt);
         const replyOutcome: ReplyOutcome = {
           kind: 'reply',

--- a/packages/franken-orchestrator/src/chat/runtime.ts
+++ b/packages/franken-orchestrator/src/chat/runtime.ts
@@ -274,7 +274,7 @@ export class ChatRuntime {
       }
     }
 
-    const result = await this.engine.processTurn(input, state.transcript);
+    const result = await this.engine.processTurn(input, state.transcript, { sessionId: state.sessionId });
     const transcript = [...state.transcript, ...result.newMessages];
 
     switch (result.outcome.kind) {

--- a/packages/franken-orchestrator/src/skills/providers/claude-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/claude-provider.ts
@@ -28,8 +28,12 @@ export class ClaudeProvider implements ICliProvider {
     ];
 
     if (opts.sessionContinue) {
-      args.push('--continue');
-    } else {
+      if (opts.sessionId) {
+        args.push('--resume', opts.sessionId);
+      } else {
+        args.push('--continue');
+      }
+    } else if (!opts.chatMode || !opts.sessionId) {
       args.push('--no-session-persistence');
     }
 

--- a/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
@@ -24,6 +24,8 @@ export interface ProviderOpts {
   readonly chatMode?: boolean | undefined;
   /** When true, ask the provider to resume its native CLI session if supported. */
   readonly sessionContinue?: boolean | undefined;
+  /** Provider-native session id to resume, when known. */
+  readonly sessionId?: string | undefined;
 }
 
 export interface ProviderCacheCapabilities {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -489,6 +489,49 @@ describe('Chat HTTP Routes', () => {
     expect(llmComplete).toHaveBeenNthCalledWith(2, 'second');
   });
 
+  it('builds a full first-turn prompt for each HTTP chat session when continuation is enabled', async () => {
+    app = createChatApp({
+      sessionStoreDir: TMP,
+      llm: { complete: llmComplete },
+      projectName: 'test-project',
+      sessionContinuation: true,
+    });
+
+    const firstCreate = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const secondCreate = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: first } = await firstCreate.json();
+    const { data: second } = await secondCreate.json();
+
+    await app.request(`/v1/chat/sessions/${first.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'hello from first session' }),
+    });
+    await app.request(`/v1/chat/sessions/${second.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'hello from second session' }),
+    });
+
+    expect(llmComplete).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('You are Frankenbeast for project test-project.'),
+    );
+    expect(llmComplete).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('user: hello from second session'),
+    );
+    expect(llmComplete).not.toHaveBeenNthCalledWith(2, 'hello from second session');
+  });
+
   it('rate limits repeated message submissions before invoking the runtime', async () => {
     app = createChatApp({
       sessionStoreDir: TMP,

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -486,7 +486,10 @@ describe('Chat HTTP Routes', () => {
       body: JSON.stringify({ content: 'second' }),
     });
 
-    expect(llmComplete).toHaveBeenNthCalledWith(2, 'second');
+    expect(llmComplete).toHaveBeenNthCalledWith(2, 'second', expect.objectContaining({
+      sessionContinue: true,
+      sessionId: created.id,
+    }));
   });
 
   it('builds a full first-turn prompt for each HTTP chat session when continuation is enabled', async () => {
@@ -524,10 +527,18 @@ describe('Chat HTTP Routes', () => {
     expect(llmComplete).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('You are Frankenbeast for project test-project.'),
+      expect.objectContaining({
+        sessionContinue: false,
+        sessionId: second.id,
+      }),
     );
     expect(llmComplete).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('user: hello from second session'),
+      expect.objectContaining({
+        sessionContinue: false,
+        sessionId: second.id,
+      }),
     );
     expect(llmComplete).not.toHaveBeenNthCalledWith(2, 'hello from second session');
   });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -190,6 +190,30 @@ describe('CliLlmAdapter', () => {
         requestId: 'req-2',
       });
     });
+    it('honors explicit chat continuation overrides in chat mode', async () => {
+      const { spawnFn } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+      const adapter = new CliLlmAdapter(claudeProvider, { ...baseOpts, chatMode: true }, spawnFn);
+
+      const first = adapter.transformRequest({
+        id: 'req-chat-1',
+        provider: 'adapter',
+        model: 'adapter',
+        messages: [{ role: 'user', content: 'first session full prompt' }],
+        sessionContinue: false,
+      });
+      expect(first.sessionContinue).toBe(false);
+
+      await adapter.execute({ ...first, prompt: 'first session full prompt' });
+
+      const second = adapter.transformRequest({
+        id: 'req-chat-2',
+        provider: 'adapter',
+        model: 'adapter',
+        messages: [{ role: 'user', content: 'second session full prompt' }],
+        sessionContinue: false,
+      });
+      expect(second.sessionContinue).toBe(false);
+    });
   });
 
   describe('execute', () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -319,6 +319,68 @@ describe('CliLlmAdapter', () => {
         expect(calls[0]!.options.stdio).toEqual(['pipe', 'pipe', 'pipe']);
       });
 
+      it('persists and resumes the native Claude session for matching chat session ids', async () => {
+        const firstStdout = '{"type":"result","session_id":"native-a","result":"first"}\n';
+        const { spawnFn, calls } = createMockSpawn({ stdout: firstStdout, exitCode: 0 });
+        const adapter = new CliLlmAdapter(claudeProvider, { ...baseOpts, chatMode: true }, spawnFn);
+
+        await adapter.execute({
+          prompt: 'full prompt',
+          maxTurns: 1,
+          chatMode: true,
+          sessionContinue: false,
+          sessionId: 'app-a',
+        });
+        expect(calls[0]!.args).not.toContain('--no-session-persistence');
+        expect(calls[0]!.args).not.toContain('--continue');
+
+        await adapter.execute({
+          prompt: 'raw followup',
+          maxTurns: 1,
+          chatMode: true,
+          sessionContinue: true,
+          sessionId: 'app-a',
+        });
+        expect(calls[1]!.args).toContain('--resume');
+        expect(calls[1]!.args[calls[1]!.args.indexOf('--resume') + 1]).toBe('native-a');
+        expect(calls[1]!.args).not.toContain('--continue');
+      });
+
+      it('resumes the matching native Claude session after another chat session speaks', async () => {
+        const { spawnFn, calls } = createQueuedSpawn([
+          { stdout: '{"type":"result","session_id":"native-a","result":"first"}\n', exitCode: 0 },
+          { stdout: '{"type":"result","session_id":"native-b","result":"second"}\n', exitCode: 0 },
+          { stdout: '{"type":"result","session_id":"native-a","result":"third"}\n', exitCode: 0 },
+        ]);
+        const adapter = new CliLlmAdapter(claudeProvider, { ...baseOpts, chatMode: true }, spawnFn);
+
+        await adapter.execute({
+          prompt: 'session a prompt',
+          maxTurns: 1,
+          chatMode: true,
+          sessionContinue: false,
+          sessionId: 'app-a',
+        });
+        await adapter.execute({
+          prompt: 'session b prompt',
+          maxTurns: 1,
+          chatMode: true,
+          sessionContinue: false,
+          sessionId: 'app-b',
+        });
+        await adapter.execute({
+          prompt: 'session a raw followup',
+          maxTurns: 1,
+          chatMode: true,
+          sessionContinue: true,
+          sessionId: 'app-a',
+        });
+
+        expect(calls[2]!.args).toContain('--resume');
+        expect(calls[2]!.args[calls[2]!.args.indexOf('--resume') + 1]).toBe('native-a');
+        expect(calls[2]!.args).not.toContain('native-b');
+      });
+
       it('filters CLAUDE* env vars via provider.filterEnv()', async () => {
         const originalEnv = process.env;
         process.env = {

--- a/packages/franken-orchestrator/tests/unit/chat/conversation-engine.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/conversation-engine.test.ts
@@ -33,8 +33,14 @@ describe('ConversationEngine', () => {
 
     await engine.processTurn('who are you?', []);
 
-    expect(llm.complete).toHaveBeenCalledWith(expect.stringContaining('You are Frankenbeast'));
-    expect(llm.complete).toHaveBeenCalledWith(expect.stringContaining('Do not describe yourself as Claude, Codex, or any underlying model or provider'));
+    expect(llm.complete).toHaveBeenCalledWith(
+      expect.stringContaining('You are Frankenbeast'),
+      expect.objectContaining({ sessionContinue: false }),
+    );
+    expect(llm.complete).toHaveBeenCalledWith(
+      expect.stringContaining('Do not describe yourself as Claude, Codex, or any underlying model or provider'),
+      expect.objectContaining({ sessionContinue: false }),
+    );
   });
 
   it('does NOT call the LLM for execute outcomes', async () => {

--- a/packages/franken-orchestrator/tests/unit/chat/conversation-engine.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/conversation-engine.test.ts
@@ -43,6 +43,18 @@ describe('ConversationEngine', () => {
     );
   });
 
+  it('does not pass chat session ids to the provider when continuation is disabled', async () => {
+    const llm = mockLlm('response');
+    const engine = new ConversationEngine({ llm, projectName: 'test', sessionContinuation: false });
+
+    await engine.processTurn('hello', [], { sessionId: 'session-1' });
+
+    expect(llm.complete).toHaveBeenCalledWith(
+      expect.stringContaining('You are Frankenbeast'),
+      { sessionContinue: false },
+    );
+  });
+
   it('does NOT call the LLM for execute outcomes', async () => {
     const llm = mockLlm();
     const engine = new ConversationEngine({ llm, projectName: 'test' });

--- a/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/runtime-parity.test.ts
@@ -26,7 +26,10 @@ describe('chat runtime parity', () => {
       transcript: first.transcript,
     });
 
-    expect(llm.complete).toHaveBeenNthCalledWith(2, 'second');
+    expect(llm.complete).toHaveBeenNthCalledWith(2, 'second', expect.objectContaining({
+      sessionContinue: true,
+      sessionId: 'session-1',
+    }));
     expect(second.displayMessages[0]?.kind).toBe('reply');
   });
 

--- a/packages/franken-orchestrator/tests/unit/cli/chat-repl.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-repl.test.ts
@@ -51,7 +51,7 @@ describe('ChatRepl', () => {
     });
     await repl.start();
 
-    expect(mockProcessTurn).toHaveBeenCalledWith('hello', expect.any(Array));
+    expect(mockProcessTurn).toHaveBeenCalledWith('hello', expect.any(Array), { sessionId: 'test' });
     expect(outputs.some(o => o.includes('Hello!'))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- removes shared ConversationEngine turnCount state from continuation decisions
- scopes continuation skipping to sessions with existing transcript history
- adds HTTP regression coverage so each new session gets a full first-turn prompt

## Test Plan
- TMPDIR=$PWD/.tmp VITEST_CACHE_DIR=$PWD/.cache/vitest npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-routes.test.ts -t "builds a full first-turn prompt" (fails before fix)
- TMPDIR=$PWD/.tmp VITEST_CACHE_DIR=$PWD/.cache/vitest npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-routes.test.ts -t "session continuation|full first-turn prompt"
- TMPDIR=$PWD/.tmp VITEST_CACHE_DIR=$PWD/.cache/vitest npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-routes.test.ts
- TMPDIR=$PWD/.tmp VITEST_CACHE_DIR=$PWD/.cache/vitest npm --prefix packages/franken-orchestrator test -- tests/unit/chat/runtime-parity.test.ts
- npm --prefix packages/franken-orchestrator run lint
- npm run build
- npm --prefix packages/franken-orchestrator run typecheck
- TMPDIR=$PWD/.tmp VITEST_CACHE_DIR=$PWD/.cache/vitest npm --prefix packages/franken-orchestrator test -- tests/integration/chat/chat-routes.test.ts tests/unit/chat/runtime-parity.test.ts

Closes #1951