### PR TITLE
fix(orchestrator): cover 1Password keys with symbols

### DIFF
--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -131,6 +131,57 @@ describe('OnePasswordStore', () => {
       });
     });
 
+    it('resolves keys with spaces and URL-reserved symbols through the raw stored title', async () => {
+      const key = 'providers.openai/workspace token?region=us east&scope=chat';
+      const title = 'frankenbeast/providers.openai/workspace token?region=us east&scope=chat';
+      mock.responses.set('--format=json', {
+        stdout: JSON.stringify({ id: 'reserved-symbol-item-id' }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('read', {
+        stdout: RESOLVED_SLACK_BOT_TOKEN,
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
+
+      await store.store(key, TEST_SLACK_BOT_TOKEN);
+      const value = await store.resolve(key);
+
+      expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: ['item', 'get', title, '--vault=frankenbeast'],
+      });
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: [
+          'item',
+          'create',
+          '--category=Login',
+          `--title=${title}`,
+          '--vault=frankenbeast',
+          `password=${TEST_SLACK_BOT_TOKEN}`,
+        ],
+      });
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: [
+          'item',
+          'get',
+          title,
+          '--vault=frankenbeast',
+          '--format=json',
+        ],
+      });
+      expect(mock.calls).toContainEqual({
+        command: 'op',
+        args: ['read', 'op://frankenbeast/reserved-symbol-item-id/password'],
+      });
+    });
+
     it('returns undefined when secret not found', async () => {
       mock.responses.set('--format=json', { stdout: '', stderr: 'not found', exitCode: 1 });
       const value = await store.resolve('nonexistent');


### PR DESCRIPTION
## Summary
- Adds explicit regression coverage for 1Password secret keys containing spaces and URL-reserved symbols.
- Verifies store and resolve use the same raw 1Password item title, then read by item id instead of an encoded key path.

## Test Plan
- `CI=1 TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1950/.tmp npm --prefix packages/franken-orchestrator test -- --run tests/unit/network/secret-backends/one-password-store.test.ts --pool=forks --no-file-parallelism --reporter=verbose`
- `npm run build`
- `npm --prefix packages/franken-orchestrator run typecheck`
- `npm --prefix packages/franken-orchestrator run build`
- `npm --prefix packages/franken-orchestrator run lint` (passes with existing warnings)

Closes #1950