### PR TITLE
test(ci): clean publish smoke temp dirs

### DIFF
--- a/scripts/publish-smoke.mjs
+++ b/scripts/publish-smoke.mjs
@@ -24,7 +24,7 @@
  * Run: node scripts/publish-smoke.mjs
  */
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync, existsSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -49,6 +49,11 @@ export function runWithTempCleanup(getDirs, action) {
   } finally {
     cleanupTempDirs(getDirs());
   }
+}
+
+export function isDirectRun(metaUrl, argvPath = process.argv[1], realpath = realpathSync) {
+  if (!argvPath) return false;
+  return fileURLToPath(metaUrl) === realpath(argvPath);
 }
 
 // Packages we install + run. web is a browser SPA (no runtime bin) so it is
@@ -169,6 +174,6 @@ export function main() {
   log('all publish smoke checks passed ✓');
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+if (isDirectRun(import.meta.url)) {
   main();
 }

--- a/tests/unit/publish-smoke-cleanup.test.ts
+++ b/tests/unit/publish-smoke-cleanup.test.ts
@@ -1,11 +1,27 @@
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { runWithTempCleanup } from '../../scripts/publish-smoke.mjs';
+import { isDirectRun, runWithTempCleanup } from '../../scripts/publish-smoke.mjs';
 
 describe('publish smoke temp cleanup', () => {
+  it('recognizes symlinked script invocations as direct runs', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'fbeast-entrypoint-test-'));
+    const realScript = join(tempDir, 'publish-smoke.mjs');
+    const symlinkedScript = join(tempDir, 'publish-smoke-link.mjs');
+    writeFileSync(realScript, 'fixture');
+    symlinkSync(realScript, symlinkedScript);
+
+    try {
+      expect(isDirectRun(pathToFileURL(realScript).href, symlinkedScript)).toBe(true);
+      expect(isDirectRun(pathToFileURL(realScript).href, '')).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('removes created pack and install directories when a mid-script failure throws', () => {
     const stage = mkdtempSync(join(tmpdir(), 'fbeast-pack-'));
     const proj = mkdtempSync(join(tmpdir(), 'fbeast-install-'));


### PR DESCRIPTION
## Summary
- wraps publish-smoke package/install temp directory lifecycle in a finally-backed cleanup helper
- exports small cleanup helpers for focused regression coverage
- adds root Vitest coverage for thrown mid-run cleanup and best-effort removal continuation

## Test Plan
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1994/.tmp npm run test:root -- tests/unit/publish-smoke-cleanup.test.ts
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1994/.tmp npm run lint
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1994/.tmp npm run typecheck
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1994/.tmp npm run build
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1994/.tmp npm run test:root
- TMPDIR=/home/pfkagent/dev/resolve-wt/issue-1994/.tmp node scripts/publish-smoke.mjs

Closes #1994