### PR TITLE
fix(orchestrator): require beasts action for mode flag

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -524,9 +524,12 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     throw new TypeError('--mode is only supported for beasts commands');
   }
 
+  if (beastExecutionMode !== undefined && beastAction === undefined) {
+    throw new TypeError('--mode requires a beasts action: create, spawn, status, or logs');
+  }
+
   if (
     beastExecutionMode !== undefined
-    && beastAction !== undefined
     && beastAction !== 'create'
     && beastAction !== 'spawn'
     && beastAction !== 'status'

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -138,6 +138,7 @@ describe('parseArgs', () => {
   it('rejects invalid beasts execution modes', () => {
     expect(() => parseArgs(['beasts', 'spawn', 'martin-loop', '--mode', 'vm'])).toThrow('Invalid beast execution mode');
     expect(() => parseArgs(['run', '--mode', 'container'])).toThrow('--mode is only supported for beasts commands');
+    expect(() => parseArgs(['beasts', '--mode', 'process'])).toThrow('--mode requires a beasts action: create, spawn, status, or logs');
     expect(() => parseArgs(['beasts', 'kill', 'run-1', '--mode', 'container'])).toThrow('--mode is only supported for beasts create, spawn, status, and logs');
   });
 


### PR DESCRIPTION
Fixes #1982

## Summary
- reject `frankenbeast beasts --mode ...` during argument parsing when no beasts action is provided
- keep existing validation for supported mode actions
- add regression coverage for the missing-action case

## Test plan
- `npm exec --yes --package=tsx -- tsx -e "import { parseArgs } from './packages/franken-orchestrator/src/cli/args.ts'; import assert from 'node:assert/strict'; assert.throws(() => parseArgs(['beasts','--mode','process']), /--mode requires a beasts action: create, spawn, status, or logs/); assert.equal(parseArgs(['beasts','spawn','martin-loop','--mode','process']).beastExecutionMode, 'process'); console.log('targeted parseArgs checks passed');"`
- Attempted `npm exec --yes --package=vitest -- vitest run packages/franken-orchestrator/tests/unit/cli/args.test.ts`; blocked because this isolated worktree has no local dependencies and the repo Vitest config imports `vitest/config` from local `node_modules`.
