### PR TITLE
fix(mcp-suite): validate memory query limit safety

### DIFF
--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -91,7 +91,7 @@ describe('Memory Server', () => {
   });
 
   it('rejects invalid query limits before calling the brain adapter', async () => {
-    for (const invalidLimit of ['abc', 'NaN', 'Infinity', '0', '-1']) {
+    for (const invalidLimit of ['abc', 'NaN', 'Infinity', '0', '-1', '1.5', '1001', '9007199254740993']) {
       const brain = {
         query: vi.fn().mockResolvedValue([]),
         store: vi.fn(),

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -51,7 +51,7 @@ function parseMemoryQueryLimit(value: unknown): { ok: true; value: number } | { 
     return { ok: false, message: `limit must be a positive integer between 1 and ${MAX_MEMORY_QUERY_LIMIT}` };
   }
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1 || parsed > MAX_MEMORY_QUERY_LIMIT) {
+  if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_MEMORY_QUERY_LIMIT) {
     return { ok: false, message: `limit must be a positive integer between 1 and ${MAX_MEMORY_QUERY_LIMIT}` };
   }
   return { ok: true, value: parsed };


### PR DESCRIPTION
## Summary
- Require `fbeast_memory_query` limits to be safe integers before calling the brain adapter
- Extend memory server coverage for fractional, out-of-range, and unsafe limit strings

Closes #1975

## Test plan
- `npm run test --workspace @franken/mcp-suite -- src/servers/memory.test.ts`

## Notes
- fbeast MCP tools were not available in this worker schema, so verification used normal terminal/git/gh tooling.