### PR TITLE
fix(governor): reject duplicate approval waiters

### DIFF
--- a/packages/franken-governor/src/gateway/approval-waiter-registry.ts
+++ b/packages/franken-governor/src/gateway/approval-waiter-registry.ts
@@ -3,6 +3,7 @@ import type { ApprovalResponse } from '../core/types.js';
 interface PendingApproval {
   readonly taskId: string;
   readonly summary: string;
+  readonly hasRealWaiter: boolean;
   resolve: (response: ApprovalResponse) => void;
 }
 
@@ -51,6 +52,7 @@ export class ApprovalWaiterRegistry {
     this.pending.set(requestId, {
       taskId,
       summary,
+      hasRealWaiter: existing?.hasRealWaiter ?? false,
       resolve: existing?.resolve ?? (() => {}),
     });
   }
@@ -60,8 +62,13 @@ export class ApprovalWaiterRegistry {
    * `resolve(requestId, response)` is called for this `requestId`.
    */
   waitFor(requestId: string, taskId: string, summary: string): Promise<ApprovalResponse> {
+    const existing = this.pending.get(requestId);
+    if (existing?.hasRealWaiter) {
+      return Promise.reject(new Error(`Approval waiter already registered for requestId ${requestId}`));
+    }
+
     return new Promise<ApprovalResponse>((resolvePromise) => {
-      this.pending.set(requestId, { taskId, summary, resolve: resolvePromise });
+      this.pending.set(requestId, { taskId, summary, hasRealWaiter: true, resolve: resolvePromise });
     });
   }
 

--- a/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
+++ b/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
@@ -126,6 +126,54 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
     await expect(outcomePromise).resolves.toMatchObject({ decision: 'APPROVE' });
   });
 
+  it('rejects duplicate real waiters without orphaning the original requestId waiter', async () => {
+    const registry = new ApprovalWaiterRegistry();
+
+    const firstWaiter = registry.waitFor('req-duplicate-1', 'task-1', 'First approval');
+
+    await expect(
+      registry.waitFor('req-duplicate-1', 'task-2', 'Duplicate approval'),
+    ).rejects.toThrow('Approval waiter already registered for requestId req-duplicate-1');
+
+    expect(registry.size).toBe(1);
+
+    const response = {
+      requestId: 'req-duplicate-1',
+      decision: 'APPROVE' as const,
+      respondedBy: 'operator',
+      respondedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+
+    expect(registry.resolve('req-duplicate-1', response)).toBe(true);
+    await expect(firstWaiter).resolves.toBe(response);
+    expect(registry.size).toBe(0);
+  });
+
+  it('allows a real waiter to replace a placeholder and preserves it across later placeholder refreshes', async () => {
+    const registry = new ApprovalWaiterRegistry();
+
+    registry.register('req-placeholder-1', 'task-placeholder', 'Placeholder approval');
+    const waiter = registry.waitFor('req-placeholder-1', 'task-real', 'Real approval');
+
+    registry.register('req-placeholder-1', 'task-refreshed', 'Refreshed approval');
+
+    expect(registry.get('req-placeholder-1')).toEqual({
+      taskId: 'task-refreshed',
+      summary: 'Refreshed approval',
+    });
+
+    const response = {
+      requestId: 'req-placeholder-1',
+      decision: 'REGEN' as const,
+      feedback: 'Add tests',
+      respondedBy: 'operator',
+      respondedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+
+    expect(registry.resolve('req-placeholder-1', response)).toBe(true);
+    await expect(waiter).resolves.toBe(response);
+  });
+
   /**
    * Regression coverage for a Codex review follow-up on PR #452:
    * `ApprovalGateway`'s own timeout fired without telling the channel, so


### PR DESCRIPTION
## Summary
- track whether an approval registry entry has a real waiter versus a placeholder
- reject duplicate real waiters for the same requestId instead of overwriting the original resolver
- cover duplicate waiter rejection and placeholder refresh preservation with regression tests

## Test Plan
- npm test --workspace @franken/governor -- tests/unit/server/http-approval-waiters.test.ts
- npm run lint --workspace @franken/governor
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/governor && npm run build --workspace @franken/governor

Closes #1956