### PR TITLE
test(ci): document root tests in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run workspace lint gate
         run: npm run lint
 
-      - name: Run CI test suite
+      - name: Run root and package CI test suite
         run: npm run test:ci
 
       - name: Phantom dependency check (every runtime import is declared)

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -150,13 +150,17 @@ on:
       const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
         scripts?: Record<string, string>;
       };
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+      const buildTestLint = expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint');
+      const ciTestStep = expectSteps(buildTestLint).find((step) => step.name === 'Run root and package CI test suite');
+      const testCiScript = packageJson.scripts?.['test:ci'] ?? '';
 
-      expect(content).toMatch(/name:\s*Run CI test suite/);
-      expect(packageJson.scripts?.['test:ci']).toContain('npm run ci:test:root');
+      expect(ciTestStep, 'CI should have an explicit root-and-package test step').toBeTruthy();
+      expect(ciTestStep?.run).toBe('npm run test:ci');
+      expect(packageJson.scripts?.['ci:test:root']).toBe('node scripts/retry-ci-command.mjs -- npm run test:root');
+      expect(testCiScript).toContain('npm run ci:test:root');
+      expect(testCiScript.indexOf('npm run ci:test:root')).toBeLessThan(testCiScript.indexOf('npm run ci:test:packages'));
       expect(content).not.toMatch(/npm run test:root --/);
-      expect(packageJson.scripts?.['test:ci']?.indexOf('npm run ci:test:root')).toBeLessThan(
-        packageJson.scripts?.['test:ci']?.indexOf('npm run ci:test:packages') ?? -1,
-      );
     });
 
     it('runs a bootstrap dry-run after deterministic install and fails the workflow on prerequisite errors', () => {
@@ -200,10 +204,10 @@ on:
       expect(content).not.toContain('run: npx turbo run test');
     });
 
-    it('documents the package build, typecheck, workspace lint, and shared CI test targets in step names', () => {
+    it('documents the package build, typecheck, workspace lint, and shared root/package CI test targets in step names', () => {
       expect(content).toMatch(/name:\s*Run package build and typecheck/);
       expect(content).toMatch(/name:\s*Run workspace lint gate/);
-      expect(content).toMatch(/name:\s*Run CI test suite/);
+      expect(content).toMatch(/name:\s*Run root and package CI test suite/);
     });
 
     it('keeps workflow linting in a dedicated workflow so broken ci.yml syntax can be reported', () => {


### PR DESCRIPTION
## Summary
- Rename the CI test step to make root-plus-package coverage explicit.
- Strengthen the CI workflow regression test so the workflow step must run npm run test:ci and test:ci must run ci:test:root before package tests.

## Test Plan
- npm run test:root -- tests/unit/ci-workflow.test.ts tests/unit/todo-markers.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #1944