### PR TITLE
fix(governor): sweep expired session tokens

### DIFF
--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -61,7 +61,11 @@ export { GovernorAuditRecorder } from './audit/index.js';
 export { formatApprovalResponseSignaturePayload, SignatureVerifier } from './security/index.js';
 export type { ApprovalResponseSignaturePayloadFields } from './security/index.js';
 export { createSessionToken, SessionTokenStore } from './security/index.js';
-export type { CreateSessionTokenParams, SessionTokenStoreOptions } from './security/index.js';
+export type {
+  CreateSessionTokenParams,
+  SessionTokenStoreOptions,
+  SweepExpiredSessionTokenOptions,
+} from './security/index.js';
 
 export { CliChannel } from './channels/index.js';
 export type { ReadlineAdapter, CliChannelDeps } from './channels/index.js';

--- a/packages/franken-governor/src/security/index.ts
+++ b/packages/franken-governor/src/security/index.ts
@@ -6,4 +6,4 @@ export type { ApprovalResponseSignaturePayloadFields } from './signature-verifie
 export { createSessionToken } from './session-token.js';
 export type { CreateSessionTokenParams } from './session-token.js';
 export { SessionTokenStore } from './session-token-store.js';
-export type { SessionTokenStoreOptions } from './session-token-store.js';
+export type { SessionTokenStoreOptions, SweepExpiredSessionTokenOptions } from './session-token-store.js';

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -24,6 +24,14 @@ export interface SessionTokenStoreOptions {
   readonly persistenceFile?: string;
 }
 
+export interface SweepExpiredSessionTokenOptions {
+  /**
+   * Milliseconds since the Unix epoch. Exposed so tests and callers that already
+   * have a clock reading can sweep deterministically without relying on globals.
+   */
+  readonly nowMs?: number;
+}
+
 interface SerializedSessionToken {
   readonly tokenId: string;
   readonly approvalId: string;
@@ -43,33 +51,39 @@ export class SessionTokenStore {
   }
 
   store(token: SessionToken): void {
+    const nowMs = wallClockNow();
     if (!this.persistenceFile) {
-      this.pruneExpiredTokens();
+      this.pruneExpiredTokens(nowMs);
       this.tokens.set(token.tokenId, token);
       return;
     }
 
     this.withFileLock(() => {
       this.loadPersistedTokens();
-      this.pruneExpiredTokens();
+      this.pruneExpiredTokens(nowMs);
       this.tokens.set(token.tokenId, token);
       this.persist();
     });
   }
 
-  cleanupExpired(): number {
+  sweepExpired(options: SweepExpiredSessionTokenOptions = {}): number {
+    const nowMs = options.nowMs ?? wallClockNow();
     if (!this.persistenceFile) {
-      return this.pruneExpiredTokens();
+      return this.pruneExpiredTokens(nowMs);
     }
 
     return this.withFileLock(() => {
       const expiredPersisted = this.loadPersistedTokens();
-      const pruned = this.pruneExpiredTokens();
+      const pruned = this.pruneExpiredTokens(nowMs);
       if (expiredPersisted + pruned > 0) {
         this.persist();
       }
       return expiredPersisted + pruned;
     });
+  }
+
+  cleanupExpired(): number {
+    return this.sweepExpired();
   }
 
   get(tokenId: string): SessionToken | undefined {
@@ -104,10 +118,10 @@ export class SessionTokenStore {
     return scope === undefined || token.scope === scope;
   }
 
-  private pruneExpiredTokens(): number {
+  private pruneExpiredTokens(nowMs: number = wallClockNow()): number {
     let pruned = 0;
     for (const [tokenId, token] of this.tokens) {
-      if (this.isExpired(token)) {
+      if (this.isExpired(token, nowMs)) {
         this.tokens.delete(tokenId);
         pruned += 1;
       }
@@ -265,8 +279,8 @@ export class SessionTokenStore {
     renameSync(tmpPath, this.persistenceFile);
   }
 
-  private isExpired(token: SessionToken): boolean {
+  private isExpired(token: SessionToken, nowMs: number = wallClockNow()): boolean {
     const expiresAtMs = token.expiresAt.getTime();
-    return !Number.isFinite(expiresAtMs) || wallClockNow() >= expiresAtMs;
+    return !Number.isFinite(expiresAtMs) || nowMs >= expiresAtMs;
   }
 }

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -48,7 +48,23 @@ describe('SessionTokenStore', () => {
     expect(store.get(token.tokenId)).toBeUndefined();
   });
 
-  it('cleanupExpired() prunes expired in-memory tokens that were never queried', () => {
+  it('sweepExpired() prunes multiple expired in-memory tokens without querying their ids', () => {
+    const store = new SessionTokenStore();
+    const expiredA = makeToken(1000);
+    const expiredB = makeToken(1500);
+    const fresh = makeToken(10_000);
+
+    store.store(expiredA);
+    store.store(expiredB);
+    store.store(fresh);
+
+    expect(store.sweepExpired({ nowMs: expiredB.expiresAt.getTime() + 1 })).toBe(2);
+    expect(store.get(expiredA.tokenId)).toBeUndefined();
+    expect(store.get(expiredB.tokenId)).toBeUndefined();
+    expect(store.get(fresh.tokenId)).toEqual(fresh);
+  });
+
+  it('cleanupExpired() remains available as a compatibility alias', () => {
     const store = new SessionTokenStore();
     const expired = makeToken(1000);
     const fresh = makeToken(10_000);
@@ -202,7 +218,7 @@ describe('SessionTokenStore', () => {
     }
   });
 
-  it('cleanupExpired() rewrites persisted stores with unqueried expired tokens', () => {
+  it('sweepExpired() rewrites persisted stores with unqueried expired tokens', () => {
     const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
     const persistenceFile = join(dir, 'tokens.json');
     try {
@@ -212,12 +228,10 @@ describe('SessionTokenStore', () => {
       store.store(expired);
       store.store(fresh);
 
-      vi.advanceTimersByTime(2000);
-
       const beforeCleanup = JSON.parse(readFileSync(persistenceFile, 'utf8'));
       expect(beforeCleanup).toHaveLength(2);
 
-      expect(store.cleanupExpired()).toBe(1);
+      expect(store.sweepExpired({ nowMs: expired.expiresAt.getTime() + 1 })).toBe(1);
 
       const persisted = JSON.parse(readFileSync(persistenceFile, 'utf8'));
       expect(persisted).toHaveLength(1);


### PR DESCRIPTION
## Summary
- Add public `SessionTokenStore.sweepExpired({ nowMs })` for explicit cleanup of abandoned expired tokens.
- Keep `cleanupExpired()` as a compatibility alias.
- Export the sweep options type and cover in-memory plus persisted sweep behavior.

Closes #1966

## Test plan
- `npm exec --workspace @franken/governor -- vitest run tests/unit/security/session-token-store.test.ts`
- `npm run typecheck --workspace @franken/governor`