### PR TITLE
fix(orchestrator): reject extra CLI positionals

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -383,6 +383,13 @@ function parseIntegerOption(name: string, value: string, options: { min?: number
   return parsed;
 }
 
+function assertNoExtraPositionals(commandName: string, positionals: string[], maxPositionals: number): void {
+  const unexpected = positionals[maxPositionals];
+  if (unexpected !== undefined) {
+    throw new TypeError(`Unexpected argument '${unexpected}' for ${commandName} command`);
+  }
+}
+
 export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   // Extract the first subcommand positional, even when global flags precede it.
   const { subcommand, flagArgs } = extractSubcommand(argv);
@@ -460,6 +467,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let securityTarget: string | undefined;
 
   if (subcommand === 'network') {
+    assertNoExtraPositionals('network', positionals, 2);
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
       if (!VALID_NETWORK_ACTIONS.has(actionCandidate)) {
@@ -469,6 +477,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     }
     networkTarget = positionals[1];
   } else if (subcommand === 'beasts') {
+    assertNoExtraPositionals('beasts', positionals, 2);
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
       if (!VALID_BEAST_ACTIONS.has(actionCandidate)) {
@@ -485,12 +494,14 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       }
       skillAction = actionCandidate as SkillAction;
     }
+    assertNoExtraPositionals('skill', positionals, skillAction === 'add' ? 3 : 2);
     skillTarget = positionals[1];
     skillCommand = positionals[2];
     skillCommandArgs = rawSkillAddCommandArgs !== undefined
       ? rawSkillAddCommandArgs
       : positionals.length > 3 ? positionals.slice(3) : undefined;
   } else if (subcommand === 'security') {
+    assertNoExtraPositionals('security', positionals, 2);
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
       if (!VALID_SECURITY_ACTIONS.has(actionCandidate)) {

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -390,6 +390,43 @@ function assertNoExtraPositionals(commandName: string, positionals: string[], ma
   }
 }
 
+function maxNetworkPositionals(action: NetworkAction): number {
+  if (action === 'start' || action === 'stop' || action === 'restart' || action === 'logs') return 2;
+  if (action === undefined) return 0;
+  return 1;
+}
+
+function maxBeastPositionals(action: BeastAction): number {
+  if (
+    action === 'create'
+    || action === 'spawn'
+    || action === 'status'
+    || action === 'logs'
+    || action === 'stop'
+    || action === 'kill'
+    || action === 'restart'
+    || action === 'resume'
+    || action === 'delete'
+  ) {
+    return 2;
+  }
+  if (action === undefined) return 0;
+  return 1;
+}
+
+function maxSkillPositionals(action: SkillAction): number {
+  if (action === 'add') return 3;
+  if (action === 'scaffold' || action === 'remove' || action === 'enable' || action === 'disable' || action === 'info') return 2;
+  if (action === undefined) return 0;
+  return 1;
+}
+
+function maxSecurityPositionals(action: SecurityAction): number {
+  if (action === 'set') return 2;
+  if (action === undefined) return 0;
+  return 1;
+}
+
 export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   // Extract the first subcommand positional, even when global flags precede it.
   const { subcommand, flagArgs } = extractSubcommand(argv);
@@ -467,7 +504,6 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let securityTarget: string | undefined;
 
   if (subcommand === 'network') {
-    assertNoExtraPositionals('network', positionals, 2);
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
       if (!VALID_NETWORK_ACTIONS.has(actionCandidate)) {
@@ -475,9 +511,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       }
       networkAction = actionCandidate as NetworkAction;
     }
+    assertNoExtraPositionals('network', positionals, maxNetworkPositionals(networkAction));
     networkTarget = positionals[1];
   } else if (subcommand === 'beasts') {
-    assertNoExtraPositionals('beasts', positionals, 2);
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
       if (!VALID_BEAST_ACTIONS.has(actionCandidate)) {
@@ -485,6 +521,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       }
       beastAction = actionCandidate as BeastAction;
     }
+    assertNoExtraPositionals('beasts', positionals, maxBeastPositionals(beastAction));
     beastTarget = positionals[1];
   } else if (subcommand === 'skill') {
     const actionCandidate = positionals[0];
@@ -494,14 +531,13 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       }
       skillAction = actionCandidate as SkillAction;
     }
-    assertNoExtraPositionals('skill', positionals, skillAction === 'add' ? 3 : 2);
+    assertNoExtraPositionals('skill', positionals, maxSkillPositionals(skillAction));
     skillTarget = positionals[1];
     skillCommand = positionals[2];
     skillCommandArgs = rawSkillAddCommandArgs !== undefined
       ? rawSkillAddCommandArgs
       : positionals.length > 3 ? positionals.slice(3) : undefined;
   } else if (subcommand === 'security') {
-    assertNoExtraPositionals('security', positionals, 2);
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
       if (!VALID_SECURITY_ACTIONS.has(actionCandidate)) {
@@ -509,6 +545,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       }
       securityAction = actionCandidate as SecurityAction;
     }
+    assertNoExtraPositionals('security', positionals, maxSecurityPositionals(securityAction));
     securityTarget = positionals[1];
     if (securityAction === 'set' && securityTarget !== undefined) {
       const validProfiles = new Set(['strict', 'standard', 'permissive']);

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -245,13 +245,25 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['network', 'start', 'chat-server', 'unexpected'])).toThrow(
       "Unexpected argument 'unexpected' for network command",
     );
+    expect(() => parseArgs(['network', 'down', 'staging'])).toThrow(
+      "Unexpected argument 'staging' for network command",
+    );
     expect(() => parseArgs(['beasts', 'logs', 'run-1', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for beasts command",
+    );
+    expect(() => parseArgs(['beasts', 'list', 'unexpected'])).toThrow(
       "Unexpected argument 'unexpected' for beasts command",
     );
     expect(() => parseArgs(['skill', 'enable', 'my-skill', 'unexpected'])).toThrow(
       "Unexpected argument 'unexpected' for skill command",
     );
+    expect(() => parseArgs(['skill', 'list', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for skill command",
+    );
     expect(() => parseArgs(['security', 'set', 'standard', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for security command",
+    );
+    expect(() => parseArgs(['security', 'status', 'unexpected'])).toThrow(
       "Unexpected argument 'unexpected' for security command",
     );
   });

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -241,6 +241,31 @@ describe('parseArgs', () => {
     expect(args.networkAction).toBe('help');
   });
 
+  it('rejects extra positional args for fixed-arity subcommand groups', () => {
+    expect(() => parseArgs(['network', 'start', 'chat-server', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for network command",
+    );
+    expect(() => parseArgs(['beasts', 'logs', 'run-1', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for beasts command",
+    );
+    expect(() => parseArgs(['skill', 'enable', 'my-skill', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for skill command",
+    );
+    expect(() => parseArgs(['security', 'set', 'standard', 'unexpected'])).toThrow(
+      "Unexpected argument 'unexpected' for security command",
+    );
+  });
+
+  it('continues to preserve variadic command args for skill add', () => {
+    const args = parseArgs(['skill', 'add', 'my-skill', 'npx', '-y', '@acme/mcp-server', '--verbose']);
+
+    expect(args.skillAction).toBe('add');
+    expect(args.skillTarget).toBe('my-skill');
+    expect(args.skillCommand).toBe('npx');
+    expect(args.skillCommandArgs).toEqual(['-y', '@acme/mcp-server', '--verbose']);
+    expect(args.verbose).toBe(false);
+  });
+
   it('parses global flags without subcommand', () => {
     const args = parseArgs([
       '--base-dir', '/my/project',


### PR DESCRIPTION
## Summary
- rejects unexpected trailing positional arguments for fixed-arity network, beasts, skill, and security CLI command groups
- preserves variadic command arguments for `skill add <name> <command> [args]`

## Test Plan
- npm test -- --run tests/unit/cli/args.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm run typecheck (packages/franken-orchestrator)
- npm run build (packages/franken-orchestrator)
- npm run lint (packages/franken-orchestrator; existing warnings only)

Closes #1895
