### PR TITLE
test(root): harden npm ls dependency verification

### DIFF
--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -11,6 +11,53 @@ const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 const ALL_PACKAGES = getWorkspacePackageDirNames();
 
+type NpmLsResult = {
+  status: number | null;
+  stdout: string | Buffer;
+  stderr?: string | Buffer;
+  error?: Error;
+};
+
+type NpmLsPackage = {
+  dependencies?: Record<string, NpmLsPackage>;
+  invalid?: boolean;
+  missing?: boolean;
+  problems?: string[];
+};
+
+const toOutput = (value: string | Buffer | undefined) =>
+  typeof value === "string" ? value : (value?.toString("utf8") ?? "");
+
+const hasResolvedDependency = (
+  dependencyTree: NpmLsPackage,
+  packageName: string,
+): boolean => {
+  const directDependency = dependencyTree.dependencies?.[packageName];
+  if (
+    directDependency &&
+    !directDependency.missing &&
+    !directDependency.invalid
+  ) {
+    return true;
+  }
+
+  return Object.values(dependencyTree.dependencies ?? {}).some((dependency) =>
+    hasResolvedDependency(dependency, packageName),
+  );
+};
+
+const assertFrankenTypesResolved = (result: NpmLsResult) => {
+  expect(result.error).toBeUndefined();
+  expect(result.status).toBe(0);
+
+  const stdout = toOutput(result.stdout);
+  expect(stdout.trim()).not.toBe("");
+
+  const parsed = JSON.parse(stdout) as NpmLsPackage;
+  expect(parsed.problems ?? []).toHaveLength(0);
+  expect(hasResolvedDependency(parsed, "@franken/types")).toBe(true);
+};
+
 describe("Chunk 10: full verification pass", () => {
   describe("verification command portability", () => {
     it("does not rely on shell pipeline parsing in the default suite", () => {
@@ -33,17 +80,60 @@ describe("Chunk 10: full verification pass", () => {
   });
 
   describe("workspace resolution", () => {
+    it("accepts npm warnings when structured output proves @franken/types resolved", () => {
+      expect(() =>
+        assertFrankenTypesResolved({
+          status: 0,
+          stdout: JSON.stringify({
+            dependencies: {
+              "@franken/types": {
+                version: "0.9.0",
+              },
+            },
+          }),
+          stderr: ["npm", "WARN", "config optional workspace warning"].join(
+            " ",
+          ),
+        }),
+      ).not.toThrow();
+    });
+
+    it("fails when structured output does not contain @franken/types", () => {
+      expect(() =>
+        assertFrankenTypesResolved({
+          status: 0,
+          stdout: JSON.stringify({
+            dependencies: {},
+          }),
+          stderr: "",
+        }),
+      ).toThrow();
+    });
+
+    it("fails when structured output reports dependency problems", () => {
+      expect(() =>
+        assertFrankenTypesResolved({
+          status: 0,
+          stdout: JSON.stringify({
+            problems: ["missing: @franken/types@file:packages/franken-types"],
+            dependencies: {
+              "@franken/types": {
+                missing: true,
+              },
+            },
+          }),
+          stderr: "",
+        }),
+      ).toThrow();
+    });
+
     it("npm ls @franken/types resolves without errors", () => {
-      const result = spawnSync(npmCommand, ["ls", "@franken/types"], {
+      const result = spawnSync(npmCommand, ["ls", "--json", "@franken/types"], {
         cwd: ROOT,
         encoding: "utf8",
       });
-      const output = `${result.stdout}\n${result.stderr}`;
 
-      expect(result.status).toBe(0);
-      expect(output).not.toContain("ERR!");
-      expect(output).not.toContain("WARN");
-      expect(output).toContain("@franken/types");
+      assertFrankenTypesResolved(result);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace the root verify-everything `npm ls @franken/types` check with `npm ls --json @franken/types` and structured dependency-tree assertions.
- Add regression coverage that allows harmless npm warning text when structured output proves `@franken/types` resolved.
- Add negative coverage for missing/problematic structured dependency output.

## Test Plan
- `npm run test:root -- tests/verify-everything.test.ts`
- `npm run test:root`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx prettier --check tests/verify-everything.test.ts`

Closes #1903
