### PR TITLE
fix(orchestrator): parse unnumbered interview questions

### DIFF
--- a/packages/franken-orchestrator/src/planning/interview-loop.ts
+++ b/packages/franken-orchestrator/src/planning/interview-loop.ts
@@ -79,14 +79,38 @@ export class InterviewLoop implements GraphBuilder {
     const questions: string[] = [];
 
     for (const line of lines) {
-      // Match numbered questions like "1. What...?" or "1) What...?"
-      const match = line.match(/^\d+[.)]\s*(.+)/);
-      if (match) {
-        questions.push(match[1]!);
+      const question = this.parseQuestionLine(line);
+      if (question) {
+        questions.push(question);
       }
     }
 
     return questions.slice(0, MAX_QUESTIONS);
+  }
+
+  private parseQuestionLine(line: string): string | null {
+    const patterns = [
+      /^\d+[.)]\s*(.+)/,
+      /^[-*•]\s+(.+)/,
+      /^(?:q(?:uestion)?|clarifying\s+question)\s*\d*\s*[:.)-]\s*(.+)/i,
+    ];
+
+    for (const pattern of patterns) {
+      const match = line.match(pattern);
+      const question = this.stripQuestionPrefix(match?.[1]?.trim());
+      if (question) {
+        return question;
+      }
+    }
+
+    return line.includes('?') ? this.stripQuestionPrefix(line) : null;
+  }
+
+  private stripQuestionPrefix(value: string | undefined): string | null {
+    const question = value
+      ?.replace(/^(?:q(?:uestion)?|clarifying\s+question)\s*\d*\s*[:.)-]\s*/i, '')
+      .trim();
+    return question || null;
   }
 
   private async generateDesignDoc(

--- a/packages/franken-orchestrator/src/planning/interview-loop.ts
+++ b/packages/franken-orchestrator/src/planning/interview-loop.ts
@@ -89,18 +89,22 @@ export class InterviewLoop implements GraphBuilder {
   }
 
   private parseQuestionLine(line: string): string | null {
-    const patterns = [
-      /^\d+[.)]\s*(.+)/,
-      /^[-*•]\s+(.+)/,
-      /^(?:q(?:uestion)?|clarifying\s+question)\s*\d*\s*[:.)-]\s*(.+)/i,
-    ];
+    const numbered = line.match(/^\d+[.)]\s*(.+)/);
+    if (numbered) {
+      return this.stripQuestionPrefix(numbered[1]);
+    }
 
-    for (const pattern of patterns) {
-      const match = line.match(pattern);
-      const question = this.stripQuestionPrefix(match?.[1]?.trim());
-      if (question) {
-        return question;
-      }
+    const bullet = line.match(/^[-*•]\s+(.+)/);
+    if (bullet) {
+      const question = this.stripQuestionPrefix(bullet[1]);
+      return question?.includes('?') ? question : null;
+    }
+
+    const prefixed = line.match(
+      /^(?:q(?:uestion)?|clarifying\s+question)\s*\d*\s*[:.)-]\s*(.+)/i,
+    );
+    if (prefixed) {
+      return this.stripQuestionPrefix(prefixed[1]);
     }
 
     return line.includes('?') ? this.stripQuestionPrefix(line) : null;

--- a/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
@@ -133,6 +133,33 @@ describe('InterviewLoop', () => {
       expect(io.ask).toHaveBeenCalledTimes(6);
     });
 
+    it('parses common unnumbered clarifying question formats', async () => {
+      const bulletQuestions = `- What authentication method do you prefer?
+* Q2: Should we support OAuth?
+Question: What database will be used?
+Clarifying question: Should sessions expire automatically?`;
+      const llm = mockLlm(bulletQuestions, designDocResponse);
+      const io = mockIO('JWT', 'Yes', 'PostgreSQL', 'Yes', 'yes');
+      const graphBuilder = mockGraphBuilder();
+      const loop = new InterviewLoop(llm, io, graphBuilder);
+
+      await loop.build(intent);
+
+      expect(io.ask).toHaveBeenCalledTimes(5);
+      expect((io.ask as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+        'What authentication method do you prefer?',
+      );
+      expect((io.ask as ReturnType<typeof vi.fn>).mock.calls[1][0]).toBe(
+        'Should we support OAuth?',
+      );
+      expect((io.ask as ReturnType<typeof vi.fn>).mock.calls[2][0]).toBe(
+        'What database will be used?',
+      );
+      expect((io.ask as ReturnType<typeof vi.fn>).mock.calls[3][0]).toBe(
+        'Should sessions expire automatically?',
+      );
+    });
+
     it('handles LLM returning no questions gracefully', async () => {
       const noQuestions = 'No clarifying questions needed.';
       const llm = mockLlm(noQuestions, designDocResponse);

--- a/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
@@ -160,6 +160,25 @@ Clarifying question: Should sessions expire automatically?`;
       );
     });
 
+    it('does not treat bullet answer options as clarifying questions', async () => {
+      const mixedQuestions = `1. Which authentication method?
+- JWT
+- OAuth
+2. Which database?`;
+      const llm = mockLlm(mixedQuestions, designDocResponse);
+      const io = mockIO('JWT', 'PostgreSQL', 'yes');
+      const graphBuilder = mockGraphBuilder();
+      const loop = new InterviewLoop(llm, io, graphBuilder);
+
+      await loop.build(intent);
+
+      expect(io.ask).toHaveBeenCalledTimes(3);
+      expect((io.ask as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+        'Which authentication method?',
+      );
+      expect((io.ask as ReturnType<typeof vi.fn>).mock.calls[1][0]).toBe('Which database?');
+    });
+
     it('handles LLM returning no questions gracefully', async () => {
       const noQuestions = 'No clarifying questions needed.';
       const llm = mockLlm(noQuestions, designDocResponse);


### PR DESCRIPTION
## Summary
- Parse common bullet and question-prefixed interview clarifying questions in addition to numbered lists.
- Strip prompt prefixes like Q2:/Question:/Clarifying question: before asking the user.
- Add regression coverage for unnumbered clarifying question formats.

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/interview-loop.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1899