### PR TITLE
fix(observer): validate attribution token counts

### DIFF
--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -41,6 +41,29 @@ describe('CostCalculator', () => {
       expect(cost).toBe(0)
     })
 
+    it.each([
+      ['negative prompt tokens', { promptTokens: -1, completionTokens: 0 }],
+      ['negative completion tokens', { promptTokens: 0, completionTokens: -1 }],
+      ['fractional prompt tokens', { promptTokens: 1.5, completionTokens: 0 }],
+      ['fractional completion tokens', { promptTokens: 0, completionTokens: 1.5 }],
+      ['NaN prompt tokens', { promptTokens: Number.NaN, completionTokens: 0 }],
+      ['NaN completion tokens', { promptTokens: 0, completionTokens: Number.NaN }],
+      ['infinite prompt tokens', { promptTokens: Number.POSITIVE_INFINITY, completionTokens: 0 }],
+      ['infinite completion tokens', { promptTokens: 0, completionTokens: Number.POSITIVE_INFINITY }],
+      ['unsafe prompt tokens', { promptTokens: Number.MAX_SAFE_INTEGER + 1, completionTokens: 0 }],
+      ['unsafe completion tokens', { promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER + 1 }],
+    ])('rejects %s before cost calculation', (_name, tokens) => {
+      const calc = new CostCalculator(DEFAULT_PRICING)
+
+      expect(() =>
+        calc.calculate({
+          model: 'gpt-4o',
+          promptTokens: tokens.promptTokens,
+          completionTokens: tokens.completionTokens,
+        }),
+      ).toThrow(RangeError)
+    })
+
     it('emits a warning when encountering an unknown model', () => {
       const warnings: string[] = []
       const warnCalc = new CostCalculator(DEFAULT_PRICING, {

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -18,7 +18,18 @@ export class CostCalculator {
       ((model) => console.warn(`[CostCalculator] Unknown model "${model}" — cost will be 0. Add it to the pricing table.`))
   }
 
+  private static assertValidTokenCount(value: number, label: string): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(
+        `CostCalculator: ${label} must be a non-negative safe integer, received ${value}`,
+      )
+    }
+  }
+
   calculate(entry: TokenRecord): number {
+    CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
+    CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
+
     const model = this.pricing[entry.model]
     if (model === undefined) {
       if (!this.warnedModels.has(entry.model)) {

--- a/packages/franken-observer/src/cost/ModelAttribution.test.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.test.ts
@@ -27,6 +27,10 @@ describe('ModelAttribution', () => {
       ['negative completion tokens', { promptTokens: 0, completionTokens: -1 }],
       ['fractional prompt tokens', { promptTokens: 1.5, completionTokens: 0 }],
       ['fractional completion tokens', { promptTokens: 0, completionTokens: 1.5 }],
+      ['NaN prompt tokens', { promptTokens: Number.NaN, completionTokens: 0 }],
+      ['NaN completion tokens', { promptTokens: 0, completionTokens: Number.NaN }],
+      ['infinite prompt tokens', { promptTokens: Number.POSITIVE_INFINITY, completionTokens: 0 }],
+      ['infinite completion tokens', { promptTokens: 0, completionTokens: Number.POSITIVE_INFINITY }],
       ['unsafe prompt tokens', { promptTokens: Number.MAX_SAFE_INTEGER + 1, completionTokens: 0 }],
       ['unsafe completion tokens', { promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER + 1 }],
     ])('rejects %s before mutating state', (_name, tokens) => {
@@ -58,6 +62,23 @@ describe('ModelAttribution', () => {
 
       expect(() =>
         attr.record({ model: 'gpt-4o', promptTokens: 1, completionTokens: 0, success: false }),
+      ).toThrow(RangeError)
+
+      expect(attr.report()).toEqual(before)
+    })
+
+    it('rejects aggregate totals that would overflow across models before mutating state', () => {
+      const attr = new ModelAttribution(DEFAULT_PRICING)
+      attr.record({
+        model: 'gpt-4o',
+        promptTokens: Number.MAX_SAFE_INTEGER,
+        completionTokens: 0,
+        success: true,
+      })
+      const before = attr.report()
+
+      expect(() =>
+        attr.record({ model: 'claude-opus-4-6', promptTokens: 1, completionTokens: 0, success: true }),
       ).toThrow(RangeError)
 
       expect(attr.report()).toEqual(before)

--- a/packages/franken-observer/src/cost/ModelAttribution.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.ts
@@ -27,6 +27,8 @@ interface ModelState {
 export class ModelAttribution {
   private readonly calc: CostCalculator
   private readonly state = new Map<string, ModelState>()
+  private totalPromptTokens = 0
+  private totalCompletionTokens = 0
 
   constructor(pricing: PricingTable) {
     this.calc = new CostCalculator(pricing)
@@ -66,12 +68,18 @@ export class ModelAttribution {
     const completionTokens = ModelAttribution.safeAdd(existing.completionTokens, entry.completionTokens)
     ModelAttribution.safeAdd(promptTokens, completionTokens)
 
+    const totalPromptTokens = ModelAttribution.safeAdd(this.totalPromptTokens, entry.promptTokens)
+    const totalCompletionTokens = ModelAttribution.safeAdd(this.totalCompletionTokens, entry.completionTokens)
+    ModelAttribution.safeAdd(totalPromptTokens, totalCompletionTokens)
+
     this.state.set(entry.model, {
       totalCalls: existing.totalCalls + 1,
       successfulCalls: existing.successfulCalls + (entry.success ? 1 : 0),
       promptTokens,
       completionTokens,
     })
+    this.totalPromptTokens = totalPromptTokens
+    this.totalCompletionTokens = totalCompletionTokens
   }
 
   report(): AttributionRow[] {


### PR DESCRIPTION
## Summary
- validate raw token counts in CostCalculator before pricing math
- track ModelAttribution aggregate token totals and reject cross-model overflow before mutating state
- add regression coverage for NaN, Infinity, unsafe, fractional, negative, and overflow token counts

Fixes #1957

## Test plan
- `npm exec --yes --package=vitest@4.1.9 -- vitest run packages/franken-observer/src/cost/ModelAttribution.test.ts packages/franken-observer/src/cost/CostCalculator.test.ts --config /tmp/frankenbeast-vitest.config.mjs`
- `git diff --check`

## Notes
- `npm run test --workspace @franken/observer -- src/cost/ModelAttribution.test.ts src/cost/CostCalculator.test.ts` was blocked before installing dependencies because this worktree has no node_modules and the package vitest config imports vitest/config.
- `npm ci --ignore-scripts` was attempted as targeted dependency setup but the existing lockfile is out of sync with package.json esbuild optional packages, so no dependency tree was installed.