### PR TITLE
test(orchestrator): cover Windows keychain target escaping

### DIFF
--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
@@ -167,6 +167,21 @@ describe('OsKeychainStore', () => {
         "$cred = Get-StoredCredential -Target 'frankenbeast/team''s/token'; if ($cred) { $cred.GetNetworkCredential().Password }",
       );
     });
+
+    it('keeps shell metacharacters inside the quoted PowerShell credential target', async () => {
+      mock.responses.set('Get-StoredCredential', { stdout: 'resolved-value\r\n', stderr: '', exitCode: 0 });
+
+      await store.resolve("prod'; Start-Process calc; 'token");
+
+      const resolveCall = mock.calls.find(c => c.command === 'powershell');
+      expect(resolveCall).toBeDefined();
+      expect(resolveCall!.args[0]).toBe('-NoProfile');
+      expect(resolveCall!.args[1]).toBe('-Command');
+      expect(resolveCall!.args[2]).toBe(
+        "$cred = Get-StoredCredential -Target 'frankenbeast/prod''; Start-Process calc; ''token'; if ($cred) { $cred.GetNetworkCredential().Password }",
+      );
+      expect(resolveCall!.args[2]).not.toContain("frankenbeast/prod'; Start-Process calc; 'token");
+    });
   });
 
   describe('unsupported platform', () => {


### PR DESCRIPTION
## Summary
- Adds a regression test for Windows OS keychain credential targets containing PowerShell metacharacters.
- Verifies apostrophes are doubled so injected command text stays inside the quoted `Get-StoredCredential -Target` literal.

## Test Plan
- `npm --workspace @franken/orchestrator test -- tests/unit/network/secret-backends/os-keychain-store.test.ts`
- `npm run build`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run lint` (passes with existing warnings)

Closes #1984
