### PR TITLE
test(docs): harden markdown link target parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ npm test
 npm run test:root
 ```
 
+The root Vitest suite also checks local Markdown links in README/docs/package READMEs. Local link targets are treated as untrusted input: keep them simple repository-relative paths and do not add shell metacharacters such as backticks, `$`, `;`, `&`, `|`, `<`, or `>`. External `http(s)` links and same-page anchors are ignored by that local filesystem check.
+
 See [ONBOARDING.md](ONBOARDING.md) for the complete first-time setup checklist, including prerequisites, bootstrap, UI startup, troubleshooting, and secret backends. See [docs/guides/quickstart.md](docs/guides/quickstart.md) for the shorter setup guide including Docker services.
 
 ## Run the Dashboard with MCP Mode

--- a/tests/docs-issue-1094.test.ts
+++ b/tests/docs-issue-1094.test.ts
@@ -8,6 +8,21 @@ const readDoc = (path: string) => readFileSync(resolve(ROOT, path), "utf8");
 
 const MARKDOWN_LINK_PATTERN = /!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/gu;
 const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/iu;
+const UNSAFE_LOCAL_MARKDOWN_LINK_PATTERN = /[\u0000-\u001f\u007f`$&;|<>]/u;
+
+const decodeMarkdownLinkTarget = (target: string): string | undefined => {
+  try {
+    return decodeURIComponent(target);
+  } catch {
+    return undefined;
+  }
+};
+
+const isUnsafeLocalMarkdownLinkTarget = (target: string): boolean => {
+  const decoded = decodeMarkdownLinkTarget(target);
+
+  return decoded === undefined || UNSAFE_LOCAL_MARKDOWN_LINK_PATTERN.test(decoded);
+};
 
 const collectMarkdownFiles = (directory: string): string[] =>
   readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -36,12 +51,12 @@ const docsLinkCheckFiles = (): string[] => {
   return [...rootDocs, ...docsTree, ...packageReadmes].sort();
 };
 
-const missingLocalLinks = (): string[] =>
+const markdownLinkIssues = (): string[] =>
   docsLinkCheckFiles().flatMap((filePath) => {
     const markdown = readFileSync(filePath, "utf8");
     const fileDir = dirname(filePath);
     const relativeFile = filePath.slice(ROOT.length + 1);
-    const missing: string[] = [];
+    const issues: string[] = [];
 
     for (const [lineIndex, line] of markdown.split("\n").entries()) {
       for (const match of line.matchAll(MARKDOWN_LINK_PATTERN)) {
@@ -56,20 +71,38 @@ const missingLocalLinks = (): string[] =>
           continue;
         }
 
-        const decodedTarget = decodeURIComponent(pathOnly);
+        if (isUnsafeLocalMarkdownLinkTarget(pathOnly)) {
+          issues.push(`${relativeFile}:${lineIndex + 1} unsafe local Markdown link target`);
+          continue;
+        }
+
+        const decodedTarget = decodeMarkdownLinkTarget(pathOnly);
+        if (decodedTarget === undefined) {
+          issues.push(`${relativeFile}:${lineIndex + 1} malformed local Markdown link target`);
+          continue;
+        }
+
         const targetPath = resolve(fileDir, decodedTarget);
         if (!existsSync(targetPath)) {
-          missing.push(`${relativeFile}:${lineIndex + 1} ${rawTarget}`);
+          issues.push(`${relativeFile}:${lineIndex + 1} missing local Markdown link target`);
         }
       }
     }
 
-    return missing;
+    return issues;
   });
 
-describe("issue #1094 and #1447 local docs links", () => {
-  it("keeps root docs, docs/**, and package READMEs free of broken local Markdown links", () => {
-    expect(missingLocalLinks()).toEqual([]);
+describe("issue #1094, #1447, and #1791 local docs links", () => {
+  it("keeps root docs, docs/**, and package READMEs free of broken or unsafe local Markdown links", () => {
+    expect(markdownLinkIssues()).toEqual([]);
+  });
+
+  it("rejects shell metacharacters and malformed escapes in local Markdown links", () => {
+    expect(isUnsafeLocalMarkdownLinkTarget("docs/guide.md%3Btouch-pwned")).toBe(true);
+    expect(isUnsafeLocalMarkdownLinkTarget("docs/%60whoami%60.md")).toBe(true);
+    expect(isUnsafeLocalMarkdownLinkTarget("docs/%24HOME.md")).toBe(true);
+    expect(isUnsafeLocalMarkdownLinkTarget("docs/bad%ZZ.md")).toBe(true);
+    expect(isUnsafeLocalMarkdownLinkTarget("docs/guides/quickstart.md")).toBe(false);
   });
 
   it("points renamed ADR and design references at existing retained documents", () => {

--- a/tests/docs-issue-1094.test.ts
+++ b/tests/docs-issue-1094.test.ts
@@ -71,7 +71,7 @@ const markdownLinkIssues = (): string[] =>
           continue;
         }
 
-        if (isUnsafeLocalMarkdownLinkTarget(pathOnly)) {
+        if (isUnsafeLocalMarkdownLinkTarget(rawTarget)) {
           issues.push(`${relativeFile}:${lineIndex + 1} unsafe local Markdown link target`);
           continue;
         }
@@ -101,6 +101,7 @@ describe("issue #1094, #1447, and #1791 local docs links", () => {
     expect(isUnsafeLocalMarkdownLinkTarget("docs/guide.md%3Btouch-pwned")).toBe(true);
     expect(isUnsafeLocalMarkdownLinkTarget("docs/%60whoami%60.md")).toBe(true);
     expect(isUnsafeLocalMarkdownLinkTarget("docs/%24HOME.md")).toBe(true);
+    expect(isUnsafeLocalMarkdownLinkTarget("docs/guides/quickstart.md#%60whoami%60")).toBe(true);
     expect(isUnsafeLocalMarkdownLinkTarget("docs/bad%ZZ.md")).toBe(true);
     expect(isUnsafeLocalMarkdownLinkTarget("docs/guides/quickstart.md")).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Harden the local Markdown link checker to fail closed on malformed percent escapes and shell metacharacters in repository-local link targets.
- Keep diagnostic output redacted to file/line plus issue category instead of echoing the untrusted payload.
- Document the local Markdown link safety rule near the root test guidance.

## Verification
- `npm run test:root -- tests/docs-issue-1094.test.ts`
- `npm run test:root`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings in unrelated worktree paths/packages)
- `npm run build`

Closes #1791
