### PR TITLE
fix(web): reject path traversal during normalization

### DIFF
--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -92,8 +92,8 @@ Path-style fields entered in the dashboard are normalized client-side before sub
 
 - duplicate separators and `.` segments are collapsed for deterministic display/submission
 - NUL bytes and `..` parent-traversal segments are rejected by default
-- WSL Windows drive paths such as `C:\Users\me\plan.md` are converted to `/mnt/c/Users/me/plan.md`
-- the only traversal override is the explicit `allowParentTraversal` option in `normalizePath`, reserved for already-trusted operator-supplied paths; untrusted UI/API text should keep the default deny-by-default behavior
+- launch submissions use repo-relative paths; absolute paths, drive-letter paths, and UNC paths are rejected at the wizard boundary
+- the only traversal override is the explicit `allowParentTraversal` option in `normalizePath`, reserved for already-trusted operator-supplied paths outside untrusted launch submissions; untrusted UI/API text should keep the default deny-by-default behavior
 
 Execution controls (`start`, `stop`, `restart`, `kill`) still target Beast runs after a tracked agent has dispatched.
 

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -88,6 +88,13 @@ The `Beasts` tab is now tracked-agent based:
 - `martin-loop` uses a directory-style path field
 - agent detail shows init lifecycle status, startup events, linked run id, and linked run logs once dispatch occurs
 
+Path-style fields entered in the dashboard are normalized client-side before submission:
+
+- duplicate separators and `.` segments are collapsed for deterministic display/submission
+- NUL bytes and `..` parent-traversal segments are rejected by default
+- WSL Windows drive paths such as `C:\Users\me\plan.md` are converted to `/mnt/c/Users/me/plan.md`
+- the only traversal override is the explicit `allowParentTraversal` option in `normalizePath`, reserved for already-trusted operator-supplied paths; untrusted UI/API text should keep the default deny-by-default behavior
+
 Execution controls (`start`, `stop`, `restart`, `kill`) still target Beast runs after a tracked agent has dispatched.
 
 ## Environment Variables

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -31,6 +31,24 @@ describe('buildWizardLaunchConfig', () => {
     });
   });
 
+  it('normalizes custom catalog path prompts by prompt kind', () => {
+    const catalog: BeastCatalogEntry[] = [{
+      id: 'custom-path-beast',
+      label: 'Custom Path Beast',
+      description: 'Served by backend catalog',
+      executionModeDefault: 'process',
+      interviewPrompts: [
+        { key: 'artifactFile', prompt: 'Artifact file?', kind: 'file', required: true },
+      ],
+    }];
+
+    expect(buildWizardLaunchConfig({
+      1: { workflowType: 'custom-path-beast', artifactFile: 'docs//./artifact.md' },
+    }, catalog)).toMatchObject({
+      artifactFile: 'docs/artifact.md',
+    });
+  });
+
   it('rejects unsafe path-style fields before launch submission', () => {
     expect(() => buildWizardLaunchConfig({
       1: { workflowType: 'design-interview', goal: 'Draft a billing design', outputPath: '../secret.md' },

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.test.ts
@@ -14,6 +14,33 @@ describe('buildWizardLaunchConfig', () => {
     });
   });
 
+  it('normalizes path-style fields before launch submission', () => {
+    expect(buildWizardLaunchConfig({
+      1: {
+        workflowType: 'chunk-plan',
+        designDocPath: 'docs//./design.md',
+        outputDir: 'tasks/./chunks',
+      },
+    })).toMatchObject({
+      workflow: {
+        designDocPath: 'docs/design.md',
+        outputDir: 'tasks/chunks',
+      },
+      designDocPath: 'docs/design.md',
+      outputDir: 'tasks/chunks',
+    });
+  });
+
+  it('rejects unsafe path-style fields before launch submission', () => {
+    expect(() => buildWizardLaunchConfig({
+      1: { workflowType: 'design-interview', goal: 'Draft a billing design', outputPath: '../secret.md' },
+    })).toThrow(/outputPath: Path traversal is not allowed/i);
+
+    expect(() => buildWizardLaunchConfig({
+      1: { workflowType: 'chunk-plan', designDocPath: '/etc/passwd', outputDir: 'tasks/chunks' },
+    })).toThrow(/designDocPath must be a repo-relative path without traversal/i);
+  });
+
   it('frontloads prompt text and attached files into run config promptConfig', () => {
     const config = buildWizardLaunchConfig({
       1: { workflowType: 'design-interview', goal: 'Draft a billing design', outputPath: 'docs/billing.md' },

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -112,6 +112,18 @@ function normalizeRepoRelativeLaunchPath(fieldName: string, value: string): stri
   return normalized.normalized;
 }
 
+function isCatalogPathPrompt(prompt: { key: string; kind?: string }): boolean {
+  const key = prompt.key.toLowerCase();
+  return (
+    PATH_CONFIG_KEYS.has(prompt.key) ||
+    prompt.kind === 'file' ||
+    prompt.kind === 'directory' ||
+    key.includes('path') ||
+    key.includes('dir') ||
+    key.includes('directory')
+  );
+}
+
 function setNormalizedLaunchPath(
   config: Record<string, unknown>,
   workflow: Record<string, unknown> | undefined,
@@ -162,7 +174,7 @@ export function buildWizardLaunchConfig(
     for (const prompt of selectedWorkflow.interviewPrompts) {
       const value = getPromptValue(workflow, prompt);
       if (!isBlankCatalogValue(value)) {
-        config[prompt.key] = typeof value === 'string' && PATH_CONFIG_KEYS.has(prompt.key)
+        config[prompt.key] = typeof value === 'string' && isCatalogPathPrompt(prompt)
           ? normalizeRepoRelativeLaunchPath(prompt.key, value)
           : value;
       }

--- a/packages/franken-web/src/components/beasts/wizard-launch-config.ts
+++ b/packages/franken-web/src/components/beasts/wizard-launch-config.ts
@@ -1,4 +1,5 @@
 import type { BeastCatalogEntry, BeastContainerRuntimeStatus, BeastExecutionMode } from '../../lib/beast-api';
+import { normalizePath, type ServerEnvironment } from '../../lib/path-utils';
 import { findCatalogEntry, getPromptValue, isBlankCatalogValue } from './wizard-catalog';
 
 export const WIZARD_SECTION_KEYS = ['identity', 'workflow', 'llm', 'modules', 'skills', 'prompts', 'git'] as const;
@@ -17,6 +18,15 @@ const MODULE_NUMBER_BOUNDS = {
     reflectionInterval: { min: 10, max: 600 },
   },
 } as const;
+
+const REPO_RELATIVE_PATH_ENV: ServerEnvironment = {
+  os: 'linux',
+  platform: 'linux',
+  isWsl: false,
+  pathSeparator: '/',
+};
+
+const PATH_CONFIG_KEYS = new Set(['outputPath', 'designDocPath', 'outputDir', 'chunkDirectory']);
 
 interface PromptFile {
   name?: unknown;
@@ -89,6 +99,37 @@ function sanitizeModuleConfig(modules: Record<string, unknown> | undefined): Rec
   return nextModules;
 }
 
+function normalizeRepoRelativeLaunchPath(fieldName: string, value: string): string {
+  if (value.startsWith('/') || value.startsWith('\\') || /^[a-zA-Z]:/.test(value)) {
+    throw new Error(`${fieldName} must be a repo-relative path without traversal.`);
+  }
+
+  const normalized = normalizePath(value, REPO_RELATIVE_PATH_ENV);
+  if (!normalized.valid) {
+    throw new Error(`${fieldName}: ${normalized.error ?? 'Invalid path'}`);
+  }
+
+  return normalized.normalized;
+}
+
+function setNormalizedLaunchPath(
+  config: Record<string, unknown>,
+  workflow: Record<string, unknown> | undefined,
+  configKey: string,
+  workflowKeys: string[],
+  value: string,
+): void {
+  const normalized = normalizeRepoRelativeLaunchPath(configKey, value);
+  config[configKey] = normalized;
+  if (workflow) {
+    for (const workflowKey of workflowKeys) {
+      if (typeof workflow[workflowKey] === 'string') {
+        workflow[workflowKey] = normalized;
+      }
+    }
+  }
+}
+
 export function buildWizardLaunchConfig(
   stepValues: WizardStepValues,
   catalog?: readonly BeastCatalogEntry[],
@@ -102,6 +143,9 @@ export function buildWizardLaunchConfig(
     }
   }
 
+  if (config.workflow && typeof config.workflow === 'object' && !Array.isArray(config.workflow)) {
+    config.workflow = { ...(config.workflow as Record<string, unknown>) };
+  }
   const workflow = config.workflow as Record<string, unknown> | undefined;
   config.modules = sanitizeModuleConfig(config.modules as Record<string, unknown> | undefined);
   const selectedWorkflow = typeof workflow?.workflowType === 'string'
@@ -118,7 +162,9 @@ export function buildWizardLaunchConfig(
     for (const prompt of selectedWorkflow.interviewPrompts) {
       const value = getPromptValue(workflow, prompt);
       if (!isBlankCatalogValue(value)) {
-        config[prompt.key] = value;
+        config[prompt.key] = typeof value === 'string' && PATH_CONFIG_KEYS.has(prompt.key)
+          ? normalizeRepoRelativeLaunchPath(prompt.key, value)
+          : value;
       }
     }
   }
@@ -129,17 +175,17 @@ export function buildWizardLaunchConfig(
       config.goal = goal;
     }
     if (typeof workflow.outputPath === 'string') {
-      config.outputPath = workflow.outputPath;
+      setNormalizedLaunchPath(config, workflow, 'outputPath', ['outputPath'], workflow.outputPath);
     }
   }
 
   if (workflow?.workflowType === 'chunk-plan') {
     const designDocPath = typeof workflow.designDocPath === 'string' ? workflow.designDocPath : workflow.docPath;
     if (typeof designDocPath === 'string') {
-      config.designDocPath = designDocPath;
+      setNormalizedLaunchPath(config, workflow, 'designDocPath', ['designDocPath', 'docPath'], designDocPath);
     }
     if (typeof workflow.outputDir === 'string') {
-      config.outputDir = workflow.outputDir;
+      setNormalizedLaunchPath(config, workflow, 'outputDir', ['outputDir'], workflow.outputDir);
     }
   }
 
@@ -152,7 +198,7 @@ export function buildWizardLaunchConfig(
     }
     const chunkDirectory = typeof workflow.chunkDirectory === 'string' ? workflow.chunkDirectory : workflow.chunkDir;
     if (typeof chunkDirectory === 'string') {
-      config.chunkDirectory = chunkDirectory;
+      setNormalizedLaunchPath(config, workflow, 'chunkDirectory', ['chunkDirectory', 'chunkDir'], chunkDirectory);
     }
   }
 

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -79,6 +79,11 @@ function isDirectoryPathPrompt(prompt: BeastInterviewPrompt): boolean {
   return prompt.kind === 'directory' || key.includes('dir') || key.includes('directory');
 }
 
+function isPathPrompt(prompt: BeastInterviewPrompt): boolean {
+  const key = prompt.key.toLowerCase();
+  return prompt.kind === 'file' || isDirectoryPathPrompt(prompt) || key.includes('path');
+}
+
 function requiredMessage(prompt: BeastInterviewPrompt): string {
   if (prompt.key === 'goal') return 'Design interview goal is required.';
   if (prompt.key === 'outputPath') return 'Design interview output path is required.';
@@ -103,6 +108,9 @@ function validateCatalogPrompt(
   }
   if (prompt.key === 'designDocPath' && typeof value === 'string' && !isRepoRelativeMarkdownDesignDocPath(value)) {
     errors.designDocPath = 'Design doc path must be a repo-relative Markdown file without traversal.';
+  }
+  if (!errors[errorKey] && isPathPrompt(prompt) && typeof value === 'string' && hasUnsafeRepoPathSegments(value)) {
+    errors[errorKey] = 'Path must be a repo-relative path without traversal.';
   }
   if (isDirectoryPathPrompt(prompt) && typeof value === 'string' && (isBrowserFakePath(value) || hasUnsafeRepoPathSegments(value))) {
     errors[errorKey] = isBrowserFakePath(value)

--- a/packages/franken-web/src/lib/path-utils.test.ts
+++ b/packages/franken-web/src/lib/path-utils.test.ts
@@ -3,6 +3,7 @@ import { normalizePath, type ServerEnvironment } from './path-utils';
 
 const linuxEnv: ServerEnvironment = { os: 'linux', platform: 'linux', isWsl: false, pathSeparator: '/' };
 const wslEnv: ServerEnvironment = { os: 'linux', platform: 'linux', isWsl: true, pathSeparator: '/' };
+const windowsEnv: ServerEnvironment = { os: 'win32', platform: 'win32', isWsl: false, pathSeparator: '\\' };
 
 describe('normalizePath', () => {
   it('passes through valid linux paths on linux', () => {
@@ -15,11 +16,19 @@ describe('normalizePath', () => {
     expect(normalizePath('/home//user/./file.txt', linuxEnv)).toEqual({
       normalized: '/home/user/file.txt', valid: true,
     });
+    expect(normalizePath('.', linuxEnv)).toEqual({ normalized: '.', valid: true });
+    expect(normalizePath('./', linuxEnv)).toEqual({ normalized: '.', valid: true });
   });
 
   it('converts Windows paths on WSL', () => {
     expect(normalizePath('C:\\Users\\test\\file.txt', wslEnv)).toEqual({
       normalized: '/mnt/c/Users/test/file.txt', valid: true,
+    });
+  });
+
+  it('preserves UNC roots when normalizing Windows server paths', () => {
+    expect(normalizePath('\\\\server\\share\\chunks', windowsEnv)).toEqual({
+      normalized: '//server/share/chunks', valid: true,
     });
   });
 

--- a/packages/franken-web/src/lib/path-utils.test.ts
+++ b/packages/franken-web/src/lib/path-utils.test.ts
@@ -11,6 +11,12 @@ describe('normalizePath', () => {
     });
   });
 
+  it('normalizes duplicate separators and dot segments without allowing traversal', () => {
+    expect(normalizePath('/home//user/./file.txt', linuxEnv)).toEqual({
+      normalized: '/home/user/file.txt', valid: true,
+    });
+  });
+
   it('converts Windows paths on WSL', () => {
     expect(normalizePath('C:\\Users\\test\\file.txt', wslEnv)).toEqual({
       normalized: '/mnt/c/Users/test/file.txt', valid: true,
@@ -20,5 +26,38 @@ describe('normalizePath', () => {
   it('rejects backslash paths on linux (non-WSL)', () => {
     const result = normalizePath('C:\\Users\\test', linuxEnv);
     expect(result.valid).toBe(false);
+  });
+
+  it('rejects parent traversal segments by default without echoing the unsafe path', () => {
+    const result = normalizePath('/home/user/../secret.txt', linuxEnv);
+
+    expect(result).toEqual({
+      normalized: '',
+      valid: false,
+      error: 'Path traversal is not allowed. Use allowParentTraversal only for trusted operator-supplied paths.',
+    });
+    expect(result.error).not.toContain('secret.txt');
+  });
+
+  it('rejects traversal after WSL path conversion', () => {
+    const result = normalizePath('C:\\Users\\test\\..\\secret.txt', wslEnv);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Path traversal is not allowed/);
+  });
+
+  it('allows explicit trusted operator override for parent traversal segments', () => {
+    expect(normalizePath('../trusted/./file.txt', linuxEnv, { allowParentTraversal: true })).toEqual({
+      normalized: '../trusted/file.txt',
+      valid: true,
+    });
+  });
+
+  it('rejects NUL bytes in paths', () => {
+    expect(normalizePath('/home/user/\0secret.txt', linuxEnv)).toEqual({
+      normalized: '',
+      valid: false,
+      error: 'Path contains a NUL byte',
+    });
   });
 });

--- a/packages/franken-web/src/lib/path-utils.ts
+++ b/packages/franken-web/src/lib/path-utils.ts
@@ -11,21 +11,54 @@ interface PathResult {
   error?: string;
 }
 
-export function normalizePath(path: string, env: ServerEnvironment): PathResult {
+export interface NormalizePathOptions {
+  /**
+   * Explicit override for trusted operator-supplied paths that intentionally
+   * contain `..` segments. Keep the default false for untrusted UI/API text.
+   */
+  allowParentTraversal?: boolean;
+}
+
+const TRAVERSAL_ERROR =
+  'Path traversal is not allowed. Use allowParentTraversal only for trusted operator-supplied paths.';
+
+function normalizeForwardSlashPath(path: string): string {
+  const absolute = path.startsWith('/');
+  const segments = path.split('/').filter(segment => segment.length > 0 && segment !== '.');
+  const normalized = segments.join('/');
+
+  if (absolute) {
+    return `/${normalized}`;
+  }
+
+  return normalized;
+}
+
+function hasParentTraversal(path: string): boolean {
+  return path.split('/').some(segment => segment === '..');
+}
+
+export function normalizePath(path: string, env: ServerEnvironment, options: NormalizePathOptions = {}): PathResult {
   if (!path) return { normalized: '', valid: false, error: 'Path is empty' };
+  if (path.includes('\0')) return { normalized: '', valid: false, error: 'Path contains a NUL byte' };
 
   const hasBackslash = path.includes('\\');
-  const windowsDrivePattern = /^[A-Za-z]:\\/;
+  const windowsDrivePattern = /^[A-Za-z]:[\\/]/;
+
+  let candidatePath = path;
 
   if (env.isWsl && windowsDrivePattern.test(path)) {
     const drive = path[0]!.toLowerCase();
     const rest = path.slice(3).replace(/\\/g, '/');
-    return { normalized: `/mnt/${drive}/${rest}`, valid: true };
-  }
-
-  if (env.os === 'linux' && hasBackslash) {
+    candidatePath = `/mnt/${drive}/${rest}`;
+  } else if (env.os === 'linux' && hasBackslash) {
     return { normalized: path, valid: false, error: 'Windows-style paths are not supported on Linux. Use forward slashes.' };
   }
 
-  return { normalized: path, valid: true };
+  const slashNormalizedPath = candidatePath.replace(/\\/g, '/');
+  if (!options.allowParentTraversal && hasParentTraversal(slashNormalizedPath)) {
+    return { normalized: '', valid: false, error: TRAVERSAL_ERROR };
+  }
+
+  return { normalized: normalizeForwardSlashPath(slashNormalizedPath), valid: true };
 }

--- a/packages/franken-web/src/lib/path-utils.ts
+++ b/packages/franken-web/src/lib/path-utils.ts
@@ -23,15 +23,20 @@ const TRAVERSAL_ERROR =
   'Path traversal is not allowed. Use allowParentTraversal only for trusted operator-supplied paths.';
 
 function normalizeForwardSlashPath(path: string): string {
+  const uncRoot = path.startsWith('//');
   const absolute = path.startsWith('/');
   const segments = path.split('/').filter(segment => segment.length > 0 && segment !== '.');
   const normalized = segments.join('/');
+
+  if (uncRoot) {
+    return `//${normalized}`;
+  }
 
   if (absolute) {
     return `/${normalized}`;
   }
 
-  return normalized;
+  return normalized || '.';
 }
 
 function hasParentTraversal(path: string): boolean {

--- a/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
@@ -37,6 +37,30 @@ describe('wizard validation', () => {
     expect(errors).toEqual({});
   });
 
+  it('rejects unsafe design-interview output paths before launch', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'design-interview', goal: 'Draft billing design', outputPath: '../secret.md' },
+    });
+
+    expect(errors.outputPath).toBe('Path must be a repo-relative path without traversal.');
+  });
+
+  it('rejects unsafe custom catalog file prompts by kind', () => {
+    const errors = validateWizardStep(1, {
+      1: { workflowType: 'custom-beast', artifactFile: '../secret.md' },
+    }, [{
+      id: 'custom-beast',
+      label: 'Custom Beast',
+      description: 'Custom catalog definition',
+      executionModeDefault: 'process',
+      interviewPrompts: [
+        { key: 'artifactFile', prompt: 'Artifact file?', kind: 'file', required: true },
+      ],
+    }]);
+
+    expect(errors.artifactFile).toBe('Path must be a repo-relative path without traversal.');
+  });
+
   it.each([
     '/tmp/design.md',
     'C:\\tmp\\design.md',


### PR DESCRIPTION
## Summary
- Reject NUL bytes and parent-traversal segments in dashboard path normalization by default
- Normalize duplicate separators and dot segments while preserving explicit trusted override semantics
- Document dashboard path-field behavior and override expectations

## Test Plan
- npm --workspace @franken/web test -- src/lib/path-utils.test.ts
- npm --workspace @franken/types run build
- npm --workspace @franken/web run typecheck
- npm --workspace @franken/web run build
- npm --workspace @franken/web run lint (passes with existing warnings)

Closes #1792