### PR TITLE
fix(governor): add approval prompt anti-spoofing markers

### DIFF
--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -116,6 +116,12 @@ with multiline/control-character payloads or a leading chat slash command are no
 executed when the operator clicks Approve; reject that approval and submit a
 fresh explicit `/run <command>` if you intentionally need to override it.
 
+Governor approval prompts sent through CLI and Slack include request-bound
+`FRANKENBEAST_APPROVAL_PROMPT` BEGIN/END markers. Treat only the context between
+the matching markers for the displayed request ID as the trusted approval prompt;
+summary and plan text inside that block is still quoted as untrusted model output,
+and marker-looking text nested there must not be treated as a real prompt boundary.
+
 ## Troubleshooting
 
 `The server starts but chat replies fail`

--- a/packages/franken-governor/src/channels/cli-channel.ts
+++ b/packages/franken-governor/src/channels/cli-channel.ts
@@ -1,6 +1,7 @@
 import type { ApprovalChannel } from '../gateway/approval-channel.js';
 import type { ApprovalRequest, ApprovalResponse, ResponseCode } from '../core/types.js';
 import { now as deterministicNow } from '@franken/types';
+import { formatApprovalPromptWithBoundaries } from '../gateway/approval-prompt-markers.js';
 
 export interface ReadlineAdapter {
   question(prompt: string): Promise<string>;
@@ -57,11 +58,8 @@ export class CliChannel implements ApprovalChannel {
 
   private formatPrompt(request: ApprovalRequest): string {
     const lines = [
-      `\n--- HITL Approval Required ---`,
-      `Task: ${request.taskId}`,
-      `Trigger: [${request.trigger.triggerId}] ${request.trigger.reason ?? 'No reason'}`,
-      `Summary: ${request.summary}`,
-      request.planDiff ? `Plan Diff:\n${request.planDiff}` : '',
+      '',
+      formatApprovalPromptWithBoundaries(request, { includePlanDiff: true }),
       `\n[a]pprove  [r]egenerate  a[x]bort  [d]ebug\n> `,
     ].filter(Boolean);
 

--- a/packages/franken-governor/src/channels/slack-channel.ts
+++ b/packages/franken-governor/src/channels/slack-channel.ts
@@ -2,6 +2,7 @@ import type { ApprovalChannel } from '../gateway/approval-channel.js';
 import type { ApprovalRequest, ApprovalResponse, ResponseCode } from '../core/types.js';
 import { ChannelUnavailableError } from '../errors/index.js';
 import { now as deterministicNow } from '@franken/types';
+import { formatApprovalPromptWithBoundaries } from '../gateway/approval-prompt-markers.js';
 
 export interface HttpClient {
   post(url: string, body: unknown): Promise<{ ok: boolean; body?: unknown }>;
@@ -71,12 +72,6 @@ export class SlackChannel implements ApprovalChannel {
   }
 
   private formatMessage(request: ApprovalRequest): string {
-    return [
-      `*HITL Approval Required*`,
-      `*Task:* ${request.taskId}`,
-      `*Trigger:* [${request.trigger.triggerId}] ${request.trigger.reason ?? 'No reason'}`,
-      `*Summary:* ${request.summary}`,
-      `*Request ID:* ${request.requestId}`,
-    ].join('\n');
+    return formatApprovalPromptWithBoundaries(request, { untrustedPrefix: '> ' });
   }
 }

--- a/packages/franken-governor/src/channels/slack-channel.ts
+++ b/packages/franken-governor/src/channels/slack-channel.ts
@@ -74,7 +74,7 @@ export class SlackChannel implements ApprovalChannel {
         {
           type: 'section',
           text: {
-            type: 'mrkdwn',
+            type: 'plain_text',
             text: blockText,
           },
         },

--- a/packages/franken-governor/src/channels/slack-channel.ts
+++ b/packages/franken-governor/src/channels/slack-channel.ts
@@ -2,7 +2,10 @@ import type { ApprovalChannel } from '../gateway/approval-channel.js';
 import type { ApprovalRequest, ApprovalResponse, ResponseCode } from '../core/types.js';
 import { ChannelUnavailableError } from '../errors/index.js';
 import { now as deterministicNow } from '@franken/types';
-import { formatApprovalPromptWithBoundaries } from '../gateway/approval-prompt-markers.js';
+import {
+  approvalPromptBoundary,
+  formatApprovalPromptWithBoundaries,
+} from '../gateway/approval-prompt-markers.js';
 
 export interface HttpClient {
   post(url: string, body: unknown): Promise<{ ok: boolean; body?: unknown }>;
@@ -20,6 +23,18 @@ export interface SlackChannelDeps {
   readonly webhookUrl: string;
   readonly httpClient: HttpClient;
   readonly callbackServer: SlackCallbackServer;
+}
+
+const SLACK_SECTION_TEXT_LIMIT = 3000;
+
+function truncateForSlackSection(text: string, requestId: string): string {
+  if (text.length <= SLACK_SECTION_TEXT_LIMIT) {
+    return text;
+  }
+
+  const endBoundary = approvalPromptBoundary(requestId, 'END');
+  const suffix = `\n> … untrusted approval details truncated to fit Slack section limits; use CLI or logs for the full payload.\n${endBoundary}`;
+  return `${text.slice(0, SLACK_SECTION_TEXT_LIMIT - suffix.length).trimEnd()}${suffix}`;
 }
 
 export class SlackChannel implements ApprovalChannel {
@@ -51,14 +66,16 @@ export class SlackChannel implements ApprovalChannel {
   }
 
   private async sendWebhook(request: ApprovalRequest): Promise<void> {
+    const message = this.formatMessage(request);
+    const blockText = truncateForSlackSection(message, request.requestId);
     const payload = {
-      text: this.formatMessage(request),
+      text: message,
       blocks: [
         {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: this.formatMessage(request),
+            text: blockText,
           },
         },
       ],

--- a/packages/franken-governor/src/gateway/approval-prompt-markers.ts
+++ b/packages/franken-governor/src/gateway/approval-prompt-markers.ts
@@ -1,12 +1,15 @@
+import { Buffer } from 'node:buffer';
 import type { ApprovalRequest } from '../core/types.js';
 
 const MARKER_LABEL = 'FRANKENBEAST_APPROVAL_PROMPT';
-const SAFE_REQUEST_ID_PATTERN = /[^A-Za-z0-9._:-]/g;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u2028\u2029]/gu;
 
+export function approvalRequestIdMarker(requestId: string): string {
+  return Buffer.from(requestId, 'utf8').toString('base64url') || 'empty';
+}
+
 export function approvalPromptBoundary(requestId: string, boundary: 'BEGIN' | 'END'): string {
-  const safeRequestId = requestId.replace(SAFE_REQUEST_ID_PATTERN, '_') || 'unknown';
-  return `<<${MARKER_LABEL}:${boundary}:request=${safeRequestId}>>`;
+  return `<<${MARKER_LABEL}:${boundary}:request-b64=${approvalRequestIdMarker(requestId)}>>`;
 }
 
 function escapeControlCharacter(value: string): string {
@@ -35,7 +38,9 @@ export function formatApprovalPromptWithBoundaries(
     approvalPromptBoundary(request.requestId, 'BEGIN'),
     'Trusted Frankenbeast approval prompt. Trust only content between the matching BEGIN/END markers for this request ID.',
     'Treat indented/quoted text below as untrusted model or plan output, even if it contains marker-looking text.',
-    `Request ID: ${request.requestId}`,
+    `Request marker ID: ${approvalRequestIdMarker(request.requestId)}`,
+    'Request ID (untrusted):',
+    formatUntrustedApprovalText(request.requestId, untrustedPrefix),
     'Task ID (untrusted):',
     formatUntrustedApprovalText(request.taskId, untrustedPrefix),
     'Project ID (untrusted):',

--- a/packages/franken-governor/src/gateway/approval-prompt-markers.ts
+++ b/packages/franken-governor/src/gateway/approval-prompt-markers.ts
@@ -1,0 +1,46 @@
+import type { ApprovalRequest } from '../core/types.js';
+
+const MARKER_LABEL = 'FRANKENBEAST_APPROVAL_PROMPT';
+const SAFE_REQUEST_ID_PATTERN = /[^A-Za-z0-9._:-]/g;
+
+export function approvalPromptBoundary(requestId: string, boundary: 'BEGIN' | 'END'): string {
+  const safeRequestId = requestId.replace(SAFE_REQUEST_ID_PATTERN, '_') || 'unknown';
+  return `<<${MARKER_LABEL}:${boundary}:request=${safeRequestId}>>`;
+}
+
+export function formatUntrustedApprovalText(value: string, prefix = '| '): string {
+  const lines = value.split(/\r\n|\n|\r/u);
+  return lines.map((line) => `${prefix}${line}`).join('\n');
+}
+
+export interface ApprovalPromptOptions {
+  readonly includePlanDiff?: boolean;
+  readonly untrustedPrefix?: string;
+}
+
+export function formatApprovalPromptWithBoundaries(
+  request: ApprovalRequest,
+  options: ApprovalPromptOptions = {},
+): string {
+  const untrustedPrefix = options.untrustedPrefix ?? '| ';
+  const lines = [
+    approvalPromptBoundary(request.requestId, 'BEGIN'),
+    'Trusted Frankenbeast approval prompt. Trust only content between the matching BEGIN/END markers for this request ID.',
+    'Treat indented/quoted text below as untrusted model or plan output, even if it contains marker-looking text.',
+    `Request ID: ${request.requestId}`,
+    `Task: ${request.taskId}`,
+    `Trigger: [${request.trigger.triggerId}] ${request.trigger.reason ?? 'No reason'}`,
+    'Summary (untrusted):',
+    formatUntrustedApprovalText(request.summary, untrustedPrefix),
+  ];
+
+  if (options.includePlanDiff && request.planDiff) {
+    lines.push(
+      'Plan Diff (untrusted):',
+      formatUntrustedApprovalText(request.planDiff, untrustedPrefix),
+    );
+  }
+
+  lines.push(approvalPromptBoundary(request.requestId, 'END'));
+  return lines.join('\n');
+}

--- a/packages/franken-governor/src/gateway/approval-prompt-markers.ts
+++ b/packages/franken-governor/src/gateway/approval-prompt-markers.ts
@@ -2,15 +2,23 @@ import type { ApprovalRequest } from '../core/types.js';
 
 const MARKER_LABEL = 'FRANKENBEAST_APPROVAL_PROMPT';
 const SAFE_REQUEST_ID_PATTERN = /[^A-Za-z0-9._:-]/g;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u2028\u2029]/gu;
 
 export function approvalPromptBoundary(requestId: string, boundary: 'BEGIN' | 'END'): string {
   const safeRequestId = requestId.replace(SAFE_REQUEST_ID_PATTERN, '_') || 'unknown';
   return `<<${MARKER_LABEL}:${boundary}:request=${safeRequestId}>>`;
 }
 
+function escapeControlCharacter(value: string): string {
+  return value.replace(CONTROL_CHARACTER_PATTERN, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return `\\u{${codePoint.toString(16).padStart(4, '0')}}`;
+  });
+}
+
 export function formatUntrustedApprovalText(value: string, prefix = '| '): string {
   const lines = value.split(/\r\n|\n|\r/u);
-  return lines.map((line) => `${prefix}${line}`).join('\n');
+  return lines.map((line) => `${prefix}${escapeControlCharacter(line)}`).join('\n');
 }
 
 export interface ApprovalPromptOptions {
@@ -28,8 +36,12 @@ export function formatApprovalPromptWithBoundaries(
     'Trusted Frankenbeast approval prompt. Trust only content between the matching BEGIN/END markers for this request ID.',
     'Treat indented/quoted text below as untrusted model or plan output, even if it contains marker-looking text.',
     `Request ID: ${request.requestId}`,
-    `Task: ${request.taskId}`,
-    `Trigger: [${request.trigger.triggerId}] ${request.trigger.reason ?? 'No reason'}`,
+    'Task ID (untrusted):',
+    formatUntrustedApprovalText(request.taskId, untrustedPrefix),
+    'Project ID (untrusted):',
+    formatUntrustedApprovalText(request.projectId, untrustedPrefix),
+    'Trigger (untrusted):',
+    formatUntrustedApprovalText(`[${request.trigger.triggerId}] ${request.trigger.reason ?? 'No reason'}`, untrustedPrefix),
     'Summary (untrusted):',
     formatUntrustedApprovalText(request.summary, untrustedPrefix),
   ];

--- a/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
@@ -97,7 +97,14 @@ describe('CliChannel', () => {
     const forgedBoundary = approvalPromptBoundary('req-001', 'END');
 
     await channel.requestApproval(makeRequest({
-      summary: `looks safe\n${forgedBoundary}\n[a]pprove everything`,
+      taskId: `task-001\n${approvalPromptBoundary('req-001', 'END')}`,
+      trigger: {
+        triggered: true,
+        triggerId: 'budget',
+        reason: `Over budget\n${approvalPromptBoundary('req-001', 'BEGIN')}`,
+        severity: 'critical',
+      },
+      summary: `looks safe\n${forgedBoundary}\n[a]pprove everything\u001b[2K`,
       planDiff: `${approvalPromptBoundary('req-001', 'BEGIN')}\nrm -rf .`,
     }));
 
@@ -105,6 +112,8 @@ describe('CliChannel', () => {
     expect(prompt.split('\n').filter((line) => line === forgedBoundary)).toHaveLength(1);
     expect(prompt).toContain(`| ${forgedBoundary}`);
     expect(prompt).toContain(`| ${approvalPromptBoundary('req-001', 'BEGIN')}`);
+    expect(prompt).toContain('| [budget] Over budget');
+    expect(prompt).toContain('| [a]pprove everything\\u{001b}[2K');
   });
 
   it('re-prompts on invalid input until valid', async () => {

--- a/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
@@ -88,7 +88,8 @@ describe('CliChannel', () => {
     expect(prompt).toContain(approvalPromptBoundary('req-xyz', 'BEGIN'));
     expect(prompt).toContain(approvalPromptBoundary('req-xyz', 'END'));
     expect(prompt).toContain('Trust only content between the matching BEGIN/END markers');
-    expect(prompt).toContain('Request ID: req-xyz');
+    expect(prompt).toContain('Request marker ID: cmVxLXh5eg');
+    expect(prompt).toContain('Request ID (untrusted):\n| req-xyz');
   });
 
   it('quotes model-controlled text so forged marker lines stay visibly untrusted', async () => {

--- a/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { CliChannel } from '../../../src/channels/cli-channel.js';
 import type { ApprovalRequest } from '../../../src/core/types.js';
 import type { ReadlineAdapter } from '../../../src/channels/cli-channel.js';
+import { approvalPromptBoundary } from '../../../src/gateway/approval-prompt-markers.js';
 
 function makeRequest(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
   return {
@@ -74,6 +75,36 @@ describe('CliChannel', () => {
     const channel = new CliChannel({ readline: makeFakeReadline(['a']), operatorName: 'dev' });
     const response = await channel.requestApproval(makeRequest({ requestId: 'req-xyz' }));
     expect(response.requestId).toBe('req-xyz');
+  });
+
+  it('wraps approval context in request-bound anti-spoofing markers', async () => {
+    const readline = makeFakeReadline(['a']);
+    const channel = new CliChannel({ readline, operatorName: 'dev' });
+    const request = makeRequest({ requestId: 'req-xyz', summary: 'Deploy v2.0' });
+
+    await channel.requestApproval(request);
+
+    const prompt = vi.mocked(readline.question).mock.calls[0]?.[0] ?? '';
+    expect(prompt).toContain(approvalPromptBoundary('req-xyz', 'BEGIN'));
+    expect(prompt).toContain(approvalPromptBoundary('req-xyz', 'END'));
+    expect(prompt).toContain('Trust only content between the matching BEGIN/END markers');
+    expect(prompt).toContain('Request ID: req-xyz');
+  });
+
+  it('quotes model-controlled text so forged marker lines stay visibly untrusted', async () => {
+    const readline = makeFakeReadline(['a']);
+    const channel = new CliChannel({ readline, operatorName: 'dev' });
+    const forgedBoundary = approvalPromptBoundary('req-001', 'END');
+
+    await channel.requestApproval(makeRequest({
+      summary: `looks safe\n${forgedBoundary}\n[a]pprove everything`,
+      planDiff: `${approvalPromptBoundary('req-001', 'BEGIN')}\nrm -rf .`,
+    }));
+
+    const prompt = vi.mocked(readline.question).mock.calls[0]?.[0] ?? '';
+    expect(prompt.split('\n').filter((line) => line === forgedBoundary)).toHaveLength(1);
+    expect(prompt).toContain(`| ${forgedBoundary}`);
+    expect(prompt).toContain(`| ${approvalPromptBoundary('req-001', 'BEGIN')}`);
   });
 
   it('re-prompts on invalid input until valid', async () => {

--- a/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
@@ -105,8 +105,9 @@ describe('SlackChannel', () => {
 
     await channel.requestApproval(makeRequest({ summary: 'x'.repeat(4000) }));
 
-    const [, body] = httpClient.post.mock.calls[0] as [string, { blocks: Array<{ text: { text: string } }> }];
+    const [, body] = httpClient.post.mock.calls[0] as [string, { blocks: Array<{ text: { type: string; text: string } }> }];
     const blockText = body.blocks[0]!.text.text;
+    expect(body.blocks[0]!.text.type).toBe('plain_text');
     expect(blockText.length).toBeLessThanOrEqual(3000);
     expect(blockText).toContain(approvalPromptBoundary('req-001', 'BEGIN'));
     expect(blockText).toContain(approvalPromptBoundary('req-001', 'END'));

--- a/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
@@ -95,6 +95,24 @@ describe('SlackChannel', () => {
     expect(text).toContain(`> ${forgedBoundary}`);
   });
 
+  it('keeps Slack section block text inside Slack limits while preserving prompt markers', async () => {
+    const httpClient = makeFakeHttpClient();
+    const channel = new SlackChannel({
+      webhookUrl: 'https://hooks.slack.com/test',
+      httpClient,
+      callbackServer: makeFakeCallbackServer(),
+    });
+
+    await channel.requestApproval(makeRequest({ summary: 'x'.repeat(4000) }));
+
+    const [, body] = httpClient.post.mock.calls[0] as [string, { blocks: Array<{ text: { text: string } }> }];
+    const blockText = body.blocks[0]!.text.text;
+    expect(blockText.length).toBeLessThanOrEqual(3000);
+    expect(blockText).toContain(approvalPromptBoundary('req-001', 'BEGIN'));
+    expect(blockText).toContain(approvalPromptBoundary('req-001', 'END'));
+    expect(blockText).toContain('truncated to fit Slack section limits');
+  });
+
   it('throws ChannelUnavailableError with the original network error as cause when webhook POST fails', async () => {
     const networkError = new Error('Network error');
     const httpClient: HttpClient = {

--- a/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/slack-channel.test.ts
@@ -3,6 +3,7 @@ import { SlackChannel } from '../../../src/channels/slack-channel.js';
 import type { ApprovalRequest } from '../../../src/core/types.js';
 import type { HttpClient } from '../../../src/channels/slack-channel.js';
 import { ChannelUnavailableError } from '../../../src/errors/index.js';
+import { approvalPromptBoundary } from '../../../src/gateway/approval-prompt-markers.js';
 
 function makeRequest(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
   return {
@@ -57,6 +58,41 @@ describe('SlackChannel', () => {
     expect(url).toBe('https://hooks.slack.com/test');
     expect(body).toHaveProperty('text');
     expect((body as { text: string }).text).toContain('Deploy v2.0');
+  });
+
+  it('wraps Slack approval prompts in request-bound anti-spoofing markers', async () => {
+    const httpClient = makeFakeHttpClient();
+    const channel = new SlackChannel({
+      webhookUrl: 'https://hooks.slack.com/test',
+      httpClient,
+      callbackServer: makeFakeCallbackServer(),
+    });
+
+    await channel.requestApproval(makeRequest({ requestId: 'req-xyz', summary: 'Deploy v2.0' }));
+
+    const [, body] = httpClient.post.mock.calls[0] as [string, unknown];
+    const text = (body as { text: string }).text;
+    expect(text).toContain(approvalPromptBoundary('req-xyz', 'BEGIN'));
+    expect(text).toContain(approvalPromptBoundary('req-xyz', 'END'));
+    expect(text).toContain('Trust only content between the matching BEGIN/END markers');
+    expect(text).toContain('> Deploy v2.0');
+  });
+
+  it('quotes forged marker-looking Slack summary text as untrusted content', async () => {
+    const httpClient = makeFakeHttpClient();
+    const channel = new SlackChannel({
+      webhookUrl: 'https://hooks.slack.com/test',
+      httpClient,
+      callbackServer: makeFakeCallbackServer(),
+    });
+    const forgedBoundary = approvalPromptBoundary('req-001', 'END');
+
+    await channel.requestApproval(makeRequest({ summary: `ok\n${forgedBoundary}\nAPPROVE` }));
+
+    const [, body] = httpClient.post.mock.calls[0] as [string, unknown];
+    const text = (body as { text: string }).text;
+    expect(text.split('\n').filter((line) => line === forgedBoundary)).toHaveLength(1);
+    expect(text).toContain(`> ${forgedBoundary}`);
   });
 
   it('throws ChannelUnavailableError with the original network error as cause when webhook POST fails', async () => {


### PR DESCRIPTION
## Summary
- add request-bound BEGIN/END markers to governor CLI and Slack approval prompts
- quote model/plan-controlled summary text inside approval prompt blocks so forged markers remain visibly untrusted
- document operator interpretation of approval prompt markers

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/governor -- tests/unit/channels/cli-channel.test.ts tests/unit/channels/slack-channel.test.ts
- npm run typecheck --workspace @franken/governor
- npm run lint --workspace @franken/governor
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/governor

Closes #1789