### PR TITLE
fix(orchestrator): treat empty issue fetch as no-op

### DIFF
--- a/packages/franken-orchestrator/src/issues/issue-fetcher.ts
+++ b/packages/franken-orchestrator/src/issues/issue-fetcher.ts
@@ -51,10 +51,6 @@ export class IssueFetcher implements IIssueFetcher {
     const stdout = await this.run('gh', args);
     const raw: RawGithubIssue[] = JSON.parse(stdout) as RawGithubIssue[];
 
-    if (raw.length === 0) {
-      throw new Error('No issues found matching the provided filters');
-    }
-
     return raw.map((issue) => ({
       number: issue.number,
       title: issue.title,

--- a/packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts
@@ -52,8 +52,7 @@ describe('IssueFetcher', () => {
       const execFn = vi.fn(makeExecFn('[]'));
       const fetcher = new IssueFetcher(execFn);
 
-      // Will throw because 0 results, but we can check the command built
-      await expect(fetcher.fetch({})).rejects.toThrow();
+      await expect(fetcher.fetch({})).resolves.toEqual([]);
 
       expect(execFn).toHaveBeenCalledOnce();
       const [file, args] = execFn.mock.calls[0]!;
@@ -178,11 +177,11 @@ describe('IssueFetcher', () => {
       expect(issues[1]!.labels).toEqual(['enhancement']);
     });
 
-    it('throws descriptive error when fetch returns 0 results', async () => {
+    it('returns an empty array when fetch returns 0 results', async () => {
       const execFn = makeExecFn('[]');
       const fetcher = new IssueFetcher(execFn);
 
-      await expect(fetcher.fetch({})).rejects.toThrow(/no issues found/i);
+      await expect(fetcher.fetch({})).resolves.toEqual([]);
     });
 
     it('throws descriptive error when gh command fails', async () => {


### PR DESCRIPTION
## Summary
- Resolves #2020
- Return an empty issue array when `gh issue list` returns no rows instead of throwing
- Update IssueFetcher unit expectations for empty results

## Test plan
- `npm exec --yes --package=tsx -- tsx -e "..."` (targeted smoke: mocked empty `gh issue list` resolves to `[]` and preserves filters)
- `npm exec --yes --package=vitest -- vitest run packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts` (blocked: ephemeral vitest cannot resolve repo `vitest/config` without local dependencies)

Note: fbeast MCP tools were not available in this worker tool schema, so I used normal terminal/file/git/GitHub verification.