### PR TITLE
fix(orchestrator): reject invalid triage issue numbers

### DIFF
--- a/packages/franken-orchestrator/src/issues/issue-triage.ts
+++ b/packages/franken-orchestrator/src/issues/issue-triage.ts
@@ -91,11 +91,18 @@ Return ONLY the JSON array, no other text.`;
   private toTriageResults(parsed: unknown[]): TriageResult[] {
     const results = parsed.map((entry): TriageResult => {
       const obj = entry as Record<string, unknown>;
+      const issueNumber = obj['issueNumber'];
+      if (typeof issueNumber !== 'number') {
+        throw new Error(`Invalid triage issueNumber: ${JSON.stringify(issueNumber)}`);
+      }
+      if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+        throw new Error(`Invalid triage issueNumber: ${JSON.stringify(issueNumber)}`);
+      }
       const complexity = typeof obj['complexity'] === 'string' && VALID_COMPLEXITIES.has(obj['complexity'])
         ? (obj['complexity'] as IssueComplexity)
         : 'one-shot';
       return {
-        issueNumber: typeof obj['issueNumber'] === 'number' ? obj['issueNumber'] : 0,
+        issueNumber,
         complexity,
         rationale: typeof obj['rationale'] === 'string' ? obj['rationale'] : 'No rationale provided',
         estimatedScope: typeof obj['estimatedScope'] === 'string' ? obj['estimatedScope'] : 'Unknown scope',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-triage.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-triage.test.ts
@@ -170,6 +170,30 @@ describe('IssueTriage', () => {
       expect(results[0]!.complexity).toBe('one-shot');
     });
 
+    it('rejects triage entries with missing issueNumber instead of defaulting to 0', async () => {
+      const completeFn = vi.fn<CompleteFn>(async () =>
+        JSON.stringify([
+          { complexity: 'one-shot', rationale: 'Missing number', estimatedScope: '1 file' },
+        ]),
+      );
+      const triage = new IssueTriage(completeFn);
+
+      await expect(triage.triage([makeIssue({ number: 1 })])).rejects.toThrow('Invalid triage issueNumber');
+      expect(completeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects triage entries with non-integer issueNumber values', async () => {
+      const completeFn = vi.fn<CompleteFn>(async () =>
+        JSON.stringify([
+          { issueNumber: '1', complexity: 'one-shot', rationale: 'Wrong type', estimatedScope: '1 file' },
+        ]),
+      );
+      const triage = new IssueTriage(completeFn);
+
+      await expect(triage.triage([makeIssue({ number: 1 })])).rejects.toThrow('Invalid triage issueNumber');
+      expect(completeFn).toHaveBeenCalledTimes(2);
+    });
+
     it('retries once on malformed JSON then succeeds', async () => {
       let callCount = 0;
       const completeFn = vi.fn<CompleteFn>(async () => {


### PR DESCRIPTION
## Summary
- Reject triage entries whose issueNumber is missing, non-numeric, non-integer, or non-positive instead of defaulting them to 0.
- Add unit coverage for malformed triage issueNumber values so malformed LLM output surfaces as a parse/triage failure.

Fixes #2018

## Test plan
- `npm exec --yes --package=vitest@4.1.9 --package=typescript@5.9.3 -- vitest run tests/unit/issues/issue-triage.test.ts --config /tmp/frankenbeast-vitest-empty.config.mjs`
- `npm exec --yes --package=typescript@5.9.3 -- tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict src/issues/issue-triage.ts`

Note: the normal workspace test command was attempted first but this isolated worktree has no node_modules, so `vitest.config.ts` could not resolve `vitest/config`; the targeted verification above used temporary npm exec packages plus an empty Vitest config.