### PR TITLE
fix(observer): validate webhook retry counts

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -292,6 +292,42 @@ describe('WebhookNotifier', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
 
+    it('rejects negative maxRetries during retry configuration validation', () => {
+      expect(
+        () =>
+          new WebhookNotifier({
+            url: 'https://hooks.example.com/signal',
+            fetch: mockFetch,
+            retry: { maxRetries: -2 },
+          }),
+      ).toThrow('retry.maxRetries must be a non-negative integer')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('rejects non-finite maxRetries during retry configuration validation', () => {
+      expect(
+        () =>
+          new WebhookNotifier({
+            url: 'https://hooks.example.com/signal',
+            fetch: mockFetch,
+            retry: { maxRetries: Number.NaN },
+          }),
+      ).toThrow('retry.maxRetries must be a non-negative integer')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('rejects fractional maxRetries during retry configuration validation', () => {
+      expect(
+        () =>
+          new WebhookNotifier({
+            url: 'https://hooks.example.com/signal',
+            fetch: mockFetch,
+            retry: { maxRetries: 1.5 },
+          }),
+      ).toThrow('retry.maxRetries must be a non-negative integer')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
     it('adds jitter (delay is not exactly baseDelayMs * 2^i)', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -62,6 +62,13 @@ function isTransientStatus(status: number): boolean {
   return status === 429 || (status >= 500 && status <= 599)
 }
 
+function validateNonNegativeInteger(value: number, fieldName: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${fieldName} must be a non-negative integer`)
+  }
+  return value
+}
+
 export class WebhookNotifier {
   private readonly url: string
   private readonly extraHeaders: Record<string, string>
@@ -76,7 +83,7 @@ export class WebhookNotifier {
     this.sleepFn = options.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)))
     this.retry = options.retry
       ? {
-          maxRetries: options.retry.maxRetries,
+          maxRetries: validateNonNegativeInteger(options.retry.maxRetries, 'retry.maxRetries'),
           baseDelayMs: options.retry.baseDelayMs ?? 200,
           maxDelayMs: options.retry.maxDelayMs ?? 30_000,
           jitter: options.retry.jitter ?? true,


### PR DESCRIPTION
## Summary
- Validate WebhookNotifier retry.maxRetries before sending webhook requests
- Reject negative, non-finite, and fractional retry counts with a clear RangeError
- Add regression coverage so invalid retry counts do not skip fetch and reject with undefined

## Test Plan
- npm run test --workspace @franken/observer -- src/notify/WebhookNotifier.test.ts -t "retry configuration validation"
- npm run build --workspace @franken/types
- npm run test --workspace @franken/observer -- src/notify/WebhookNotifier.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer
- npm run test --workspace @franken/observer

Closes #2015