### PR TITLE
fix(mcp-suite): validate brain memory query limits

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -100,6 +100,20 @@ describe('createBrainAdapter', () => {
     expect(episodicResult.some((row) => row.type === 'episodic')).toBe(true);
   });
 
+  it('rejects unsafe query limits before reading memory', async () => {
+    const brain = createBrainAdapter('/tmp/beast.db');
+    const mockBrain = brainInstances[0];
+
+    for (const invalidLimit of [NaN, Infinity, 0, -1, 1.5, 1001, Number.MAX_SAFE_INTEGER + 1]) {
+      await expect(
+        brain.query({ query: 'task', limit: invalidLimit as number }),
+      ).rejects.toThrow('limit must be a positive integer between 1 and 1000');
+    }
+
+    expect(mockBrain.episodic.recall).not.toHaveBeenCalled();
+    expect(mockBrain.working.snapshot).not.toHaveBeenCalled();
+  });
+
   it('rejects unsupported memory type', async () => {
     const brain = createBrainAdapter('/tmp/beast.db');
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -33,8 +33,18 @@ export interface BrainAdapter {
 }
 
 const SUPPORTED_MEMORY_TYPES = ['working', 'episodic'] as const;
+const DEFAULT_QUERY_LIMIT = 20;
+const MAX_QUERY_LIMIT = 1000;
 
 type SupportedMemoryType = (typeof SUPPORTED_MEMORY_TYPES)[number];
+
+function resolveQueryLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_QUERY_LIMIT;
+  if (!Number.isFinite(limit) || !Number.isSafeInteger(limit) || limit < 1 || limit > MAX_QUERY_LIMIT) {
+    throw new Error(`limit must be a positive integer between 1 and ${MAX_QUERY_LIMIT}`);
+  }
+  return limit;
+}
 
 export function createBrainAdapter(dbPath: string): BrainAdapter {
   const brain = new SqliteBrain(dbPath);
@@ -74,11 +84,12 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
   return {
     async query(input) {
       const memoryType = resolveMemoryType(input.type);
+      const limit = resolveQueryLimit(input.limit);
       const results: BrainMemoryEntry[] = [];
 
       // Search episodic memory
       if (!memoryType || memoryType === 'episodic') {
-        const events = brain.episodic.recall(input.query, input.limit ?? 20);
+        const events = brain.episodic.recall(input.query, limit);
         for (const event of events) {
           results.push({
             key: String(event.id ?? event.summary),
@@ -101,7 +112,7 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
         }
       }
 
-      return results.slice(0, input.limit ?? 20);
+      return results.slice(0, limit);
     },
 
     async store(input) {


### PR DESCRIPTION
## Summary
- validates direct brain-adapter memory query limits before recall/slicing
- rejects non-finite, fractional, out-of-range, and unsafe integer limits with a clear error
- adds adapter-level regression coverage so invalid limits do not touch memory backends

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/adapters/brain-adapter.test.ts src/servers/memory.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/orchestrator
- npm --prefix packages/franken-mcp-suite run typecheck
- npm --prefix packages/franken-mcp-suite run build
- npm --prefix packages/franken-mcp-suite run lint (passes with pre-existing warnings)
- git diff --check

Closes #2016
