### PR TITLE
fix(orchestrator): treat empty issue filters as no-op

### DIFF
--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -187,6 +187,11 @@ export class Session {
       const issues = await fetcher.fetch(fetchOptions);
       logger.info(`Found ${issues.length} issue(s)`, 'issues');
 
+      if (issues.length === 0) {
+        logger.info('No issues matched the provided filters; exiting without triage or execution.', 'issues');
+        return;
+      }
+
       // Triage
       logger.info('Triaging issues...', 'issues');
       const triageResults = await triage.triage(issues);

--- a/packages/franken-orchestrator/src/issues/issue-fetcher.ts
+++ b/packages/franken-orchestrator/src/issues/issue-fetcher.ts
@@ -51,10 +51,6 @@ export class IssueFetcher implements IIssueFetcher {
     const stdout = await this.run('gh', args);
     const raw: RawGithubIssue[] = JSON.parse(stdout) as RawGithubIssue[];
 
-    if (raw.length === 0) {
-      throw new Error('No issues found matching the provided filters');
-    }
-
     return raw.map((issue) => ({
       number: issue.number,
       title: issue.title,

--- a/packages/franken-orchestrator/tests/unit/cli/session-issues.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-issues.test.ts
@@ -335,6 +335,24 @@ describe('Session.runIssues()', () => {
     expect(mockFinalize).toHaveBeenCalledTimes(1);
   });
 
+  it('treats empty issue filters as a no-op before triage or review', async () => {
+    const { Session } = await import('../../../src/cli/session.js');
+    mockFetcher.fetch.mockResolvedValueOnce([]);
+    const config = makeConfig();
+    const session = new Session(config);
+
+    await expect(session.runIssues()).resolves.toBeUndefined();
+
+    expect(mockTriageInstance.triage).not.toHaveBeenCalled();
+    expect(mockReviewInstance.review).not.toHaveBeenCalled();
+    expect(mockRunnerInstance.run).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'No issues matched the provided filters; exiting without triage or execution.',
+      'issues',
+    );
+    expect(mockFinalize).toHaveBeenCalledTimes(1);
+  });
+
   it('finalizes issue-mode dependencies when execution throws', async () => {
     const { Session } = await import('../../../src/cli/session.js');
     mockRunnerInstance.run.mockRejectedValueOnce(new Error('runner failed'));

--- a/packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { IssueFetcher } from '../../../src/issues/issue-fetcher.js';
-import type { GithubIssue, IIssueFetcher, IssueFetchOptions } from '../../../src/issues/types.js';
+import type { GithubIssue, IIssueFetcher } from '../../../src/issues/types.js';
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
 type ExecFn = (file: string, args: string[], callback: ExecCallback) => void;
@@ -52,8 +52,7 @@ describe('IssueFetcher', () => {
       const execFn = vi.fn(makeExecFn('[]'));
       const fetcher = new IssueFetcher(execFn);
 
-      // Will throw because 0 results, but we can check the command built
-      await expect(fetcher.fetch({})).rejects.toThrow();
+      await expect(fetcher.fetch({})).resolves.toEqual([]);
 
       expect(execFn).toHaveBeenCalledOnce();
       const [file, args] = execFn.mock.calls[0]!;
@@ -178,11 +177,11 @@ describe('IssueFetcher', () => {
       expect(issues[1]!.labels).toEqual(['enhancement']);
     });
 
-    it('throws descriptive error when fetch returns 0 results', async () => {
+    it('returns an empty issue list when filters match no issues', async () => {
       const execFn = makeExecFn('[]');
       const fetcher = new IssueFetcher(execFn);
 
-      await expect(fetcher.fetch({})).rejects.toThrow(/no issues found/i);
+      await expect(fetcher.fetch({})).resolves.toEqual([]);
     });
 
     it('throws descriptive error when gh command fails', async () => {


### PR DESCRIPTION
## Summary
- return an empty issue list when gh filters match no issues instead of throwing
- short-circuit issue-mode empty results before triage, review, or execution
- update IssueFetcher and Session.runIssues regression tests for empty-filter no-op behavior

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/issues/issue-fetcher.test.ts tests/unit/cli/session-issues.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)
- npm run test --workspace @franken/orchestrator (one unrelated timeout in tests/unit/vitest-env.test.ts during full run; targeted rerun passed)
- npm run test --workspace @franken/orchestrator -- tests/unit/vitest-env.test.ts

Closes #2020