### PR TITLE
fix(orchestrator): require review for new runtime tools

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -128,6 +128,8 @@ fbeast mcp init --hooks
 
 The `fbeast` CLI in this repo exposes MCP operations (`init`, `uninstall`, `beast`) under the `mcp` subcommand; any other command is forwarded to `frankenbeast`. MCP data is stored in `.fbeast/beast.db`.
 
+Runtime skill tools are gated conservatively. Installed `tools.json` entries default to `requiresHitl: true` unless the manifest explicitly marks a reviewed safe tool with `requiresHitl: false`, and MCP skills without a `tools.json` manifest expose their server alias as human-approval-required because the concrete runtime tools are unknown. Review new tool manifests before opting any tool out of HITL.
+
 ## Project structure
 
 ```text

--- a/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/skill-manager-adapter.ts
@@ -28,14 +28,14 @@ export class SkillManagerAdapter implements ISkillsModule {
       const descriptors: SkillDescriptor[] = [];
 
       if (isServerAliasExecutable(name, tools)) {
-        descriptors.push(createDescriptor(name, name, undefined, aliasToolFor(name, tools)?.requiresHitl ?? false));
+        descriptors.push(createDescriptor(name, name, undefined, aliasToolFor(name, tools)?.requiresHitl ?? true));
       }
 
       for (const tool of tools) {
         if (tool.name !== name) {
-          descriptors.push(createDescriptor(tool.name, tool.name, name, tool.requiresHitl ?? false));
+          descriptors.push(createDescriptor(tool.name, tool.name, name, tool.requiresHitl ?? true));
         }
-        descriptors.push(createDescriptor(namespacedToolId(name, tool.name), tool.name, name, tool.requiresHitl ?? false));
+        descriptors.push(createDescriptor(namespacedToolId(name, tool.name), tool.name, name, tool.requiresHitl ?? true));
       }
 
       return descriptors;

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -117,6 +117,11 @@ export class SkillManager {
       join(skillDir, 'mcp.json'),
       JSON.stringify(mcpConfig, null, 2),
     );
+
+    const toolsPath = join(skillDir, 'tools.json');
+    if (existsSync(toolsPath)) {
+      rmSync(toolsPath);
+    }
   }
 
   enable(name: string): void {

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -81,6 +81,11 @@ export class SkillManager {
         [catalogEntry.name]: catalogEntry.installConfig,
       },
     });
+    const tools = catalogEntry.toolDefinitions?.length
+      ? requireSecurityReviewByDefault(
+        SkillToolManifestSchema.parse(catalogEntry.toolDefinitions),
+      )
+      : undefined;
     const skillDir = join(this.skillsDir, catalogEntry.name);
     mkdirSync(skillDir, { recursive: true });
 
@@ -89,10 +94,7 @@ export class SkillManager {
       JSON.stringify(mcpConfig, null, 2),
     );
 
-    if (catalogEntry.toolDefinitions?.length) {
-      const tools = requireSecurityReviewByDefault(
-        SkillToolManifestSchema.parse(catalogEntry.toolDefinitions),
-      );
+    if (tools) {
       writeFileSync(
         join(skillDir, 'tools.json'),
         JSON.stringify(tools, null, 2),

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -23,6 +23,15 @@ import { ProviderSkillTranslator } from './provider-skill-translator.js';
 
 const SAFE_NAME = /^[a-zA-Z0-9_-]+$/;
 
+function requireSecurityReviewByDefault(
+  tools: ToolDefinition[],
+): ToolDefinition[] {
+  return tools.map((tool) => ({
+    ...tool,
+    requiresHitl: tool.requiresHitl ?? true,
+  }));
+}
+
 export class SkillManager {
   private readonly enabledSkills: Set<string>;
 
@@ -81,9 +90,12 @@ export class SkillManager {
     );
 
     if (catalogEntry.toolDefinitions?.length) {
+      const tools = requireSecurityReviewByDefault(
+        SkillToolManifestSchema.parse(catalogEntry.toolDefinitions),
+      );
       writeFileSync(
         join(skillDir, 'tools.json'),
-        JSON.stringify(catalogEntry.toolDefinitions, null, 2),
+        JSON.stringify(tools, null, 2),
       );
     }
   }
@@ -154,7 +166,7 @@ export class SkillManager {
     const toolsPath = join(this.skillsDir, name, 'tools.json');
     if (!existsSync(toolsPath)) return [];
     const raw = JSON.parse(readFileSync(toolsPath, 'utf-8'));
-    return SkillToolManifestSchema.parse(raw);
+    return requireSecurityReviewByDefault(SkillToolManifestSchema.parse(raw));
   }
 
   writeContext(name: string, content: string): void {

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -94,11 +94,14 @@ export class SkillManager {
       JSON.stringify(mcpConfig, null, 2),
     );
 
+    const toolsPath = join(skillDir, 'tools.json');
     if (tools) {
       writeFileSync(
-        join(skillDir, 'tools.json'),
+        toolsPath,
         JSON.stringify(tools, null, 2),
       );
+    } else if (existsSync(toolsPath)) {
+      rmSync(toolsPath);
     }
   }
 

--- a/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/mcp-execution-adapters.test.ts
@@ -48,7 +48,7 @@ describe('MCP execution adapters', () => {
     writeFileSync(join(skillsDir, 'github', 'mcp.json'), JSON.stringify({ mcpServers: { github: { command: 'github' } } }));
     writeFileSync(join(skillsDir, 'github', 'tools.json'), JSON.stringify([
       { name: 'create_issue', description: 'Create issue', inputSchema: {}, requiresHitl: true },
-      { name: 'list_repos', description: 'List repos', inputSchema: {} },
+      { name: 'list_repos', description: 'List repos', inputSchema: {}, requiresHitl: false },
     ]));
     const manager = new SkillManager(skillsDir, new Set(['github']));
     const adapter = new SkillManagerAdapter(manager);
@@ -83,7 +83,9 @@ describe('MCP execution adapters', () => {
     const adapter = new SkillManagerAdapter(manager);
 
     expect(adapter.hasSkill('dynamic')).toBe(true);
-    expect(adapter.getAvailableSkills().map(skill => skill.id)).toEqual(['dynamic']);
+    expect(adapter.getAvailableSkills()).toEqual([
+      expect.objectContaining({ id: 'dynamic', requiresHitl: true, executionType: 'mcp' }),
+    ]);
   });
 
   it('McpSdkAdapter fails closed when no live MCP transport is configured', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -136,6 +136,33 @@ describe('SkillManager', () => {
       expect(existsSync(join(skillsDir, 'github', 'mcp.json'))).toBe(false);
       expect(manager.exists('github')).toBe(false);
     });
+
+    it('removes stale tool manifests when reinstalling without tool definitions', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx', args: ['old-server'] },
+        authFields: [],
+        toolDefinitions: [
+          { name: 'list_repos', description: 'List', inputSchema: {}, requiresHitl: false },
+        ],
+      });
+      expect(manager.readTools('github')).toEqual([
+        expect.objectContaining({ name: 'list_repos', requiresHitl: false }),
+      ]);
+
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx', args: ['new-server'] },
+        authFields: [],
+      });
+
+      expect(existsSync(join(skillsDir, 'github', 'tools.json'))).toBe(false);
+      expect(manager.readTools('github')).toEqual([]);
+    });
   });
 
   describe('installCustom()', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -120,6 +120,22 @@ describe('SkillManager', () => {
         requiresHitl: true,
       });
     });
+
+    it('rejects invalid catalog tool definitions before writing mcp.json', async () => {
+      await expect(manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+        toolDefinitions: [
+          { name: 'create_issue', inputSchema: {} } as never,
+        ],
+      })).rejects.toThrow();
+
+      expect(existsSync(join(skillsDir, 'github', 'mcp.json'))).toBe(false);
+      expect(manager.exists('github')).toBe(false);
+    });
   });
 
   describe('installCustom()', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -115,7 +115,10 @@ describe('SkillManager', () => {
       expect(existsSync(join(skillsDir, 'github', 'tools.json'))).toBe(true);
       const tools = JSON.parse(readFileSync(join(skillsDir, 'github', 'tools.json'), 'utf-8'));
       expect(tools).toHaveLength(1);
-      expect(tools[0].name).toBe('create_issue');
+      expect(tools[0]).toMatchObject({
+        name: 'create_issue',
+        requiresHitl: true,
+      });
     });
   });
 
@@ -262,7 +265,27 @@ describe('SkillManager', () => {
       });
       const tools = manager.readTools('github');
       expect(tools).toHaveLength(1);
-      expect(tools[0]!.name).toBe('create_issue');
+      expect(tools[0]).toMatchObject({
+        name: 'create_issue',
+        requiresHitl: true,
+      });
+    });
+
+    it('preserves explicit safe-tool security review opt-outs', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+        toolDefinitions: [
+          { name: 'list_repos', description: 'List', inputSchema: {}, requiresHitl: false },
+        ],
+      });
+      const tools = manager.readTools('github');
+      expect(tools).toEqual([
+        expect.objectContaining({ name: 'list_repos', requiresHitl: false }),
+      ]);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -182,6 +182,24 @@ describe('SkillManager', () => {
       expect(existsSync(join(skillsDir, 'broken-custom', 'mcp.json'))).toBe(false);
       expect(manager.listInstalled()).toEqual([]);
     });
+
+    it('removes stale tool manifests when replacing a skill with a custom install', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx', args: ['old-server'] },
+        authFields: [],
+        toolDefinitions: [
+          { name: 'list_repos', description: 'List', inputSchema: {}, requiresHitl: false },
+        ],
+      });
+
+      await manager.installCustom('github', { command: 'node', args: ['server.js'] });
+
+      expect(existsSync(join(skillsDir, 'github', 'tools.json'))).toBe(false);
+      expect(manager.readTools('github')).toEqual([]);
+    });
   });
 
   describe('enable()/disable()', () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,10 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-12 — Runtime tool manifest security defaults
+- Default new/runtime skill tools to `requiresHitl: true` after schema validation, and preserve explicit `requiresHitl: false` only for reviewed safe tools.
+- Validate catalog `toolDefinitions` before creating/writing skill install files; otherwise a failed install can leave a partial MCP skill on disk and accidentally expose unknown runtime tools.
+- Regression tests should cover omitted HITL defaulting, explicit safe-tool opt-outs, manifest readback, no-tools MCP alias behavior, and invalid tool manifests leaving no partial install.
+
 ## 2026-07-11 — Approval replay command extraction guardrails
 - Approval replay commands are model-derived state, not fresh operator input. Keep the replay helper narrow: accept only trimmed single-line printable non-slash command descriptions, fail closed on multiline/control-command payloads, preserve the pending approval, and make operators reject/re-submit an explicit `/run` for overrides.
 - Regression coverage should include the low-level replay helper and the HTTP approval route so unsafe payloads do not reach the runtime/LLM and error responses do not echo injected command text.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -3,7 +3,7 @@
 ## 2026-07-12 — Runtime tool manifest security defaults
 - Default new/runtime skill tools to `requiresHitl: true` after schema validation, and preserve explicit `requiresHitl: false` only for reviewed safe tools.
 - Validate catalog `toolDefinitions` before creating/writing skill install files; otherwise a failed install can leave a partial MCP skill on disk and accidentally expose unknown runtime tools.
-- Regression tests should cover omitted HITL defaulting, explicit safe-tool opt-outs, manifest readback, no-tools MCP alias behavior, and invalid tool manifests leaving no partial install.
+- Regression tests should cover omitted HITL defaulting, explicit safe-tool opt-outs, manifest readback, stale-manifest removal on reinstall, no-tools MCP alias behavior, and invalid tool manifests leaving no partial install.
 
 ## 2026-07-11 — Approval replay command extraction guardrails
 - Approval replay commands are model-derived state, not fresh operator input. Keep the replay helper narrow: accept only trimmed single-line printable non-slash command descriptions, fail closed on multiline/control-command payloads, preserve the pending approval, and make operators reject/re-submit an explicit `/run` for overrides.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -3,7 +3,7 @@
 ## 2026-07-12 — Runtime tool manifest security defaults
 - Default new/runtime skill tools to `requiresHitl: true` after schema validation, and preserve explicit `requiresHitl: false` only for reviewed safe tools.
 - Validate catalog `toolDefinitions` before creating/writing skill install files; otherwise a failed install can leave a partial MCP skill on disk and accidentally expose unknown runtime tools.
-- Regression tests should cover omitted HITL defaulting, explicit safe-tool opt-outs, manifest readback, stale-manifest removal on reinstall, no-tools MCP alias behavior, and invalid tool manifests leaving no partial install.
+- Regression tests should cover omitted HITL defaulting, explicit safe-tool opt-outs, manifest readback, stale-manifest removal on catalog reinstall and custom install replacement, no-tools MCP alias behavior, and invalid tool manifests leaving no partial install.
 
 ## 2026-07-11 — Approval replay command extraction guardrails
 - Approval replay commands are model-derived state, not fresh operator input. Keep the replay helper narrow: accept only trimmed single-line printable non-slash command descriptions, fail closed on multiline/control-command payloads, preserve the pending approval, and make operators reject/re-submit an explicit `/run` for overrides.


### PR DESCRIPTION
## Summary
- Default installed runtime tool manifests to require HITL security review unless explicitly reviewed safe with `requiresHitl: false`
- Treat MCP skills without `tools.json` as approval-required because their concrete runtime tools are unknown
- Document the runtime skill-tool review semantics in the quickstart

## Test Plan
- `npm --workspace @franken/orchestrator test -- tests/unit/skills/skill-manager.test.ts tests/unit/adapters/mcp-execution-adapters.test.ts tests/unit/skills/provider-skill-translator.test.ts`
- `npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run build`
- `npm --workspace @franken/orchestrator run lint` (passes with pre-existing warnings)

Closes #1787