### PR TITLE
fix(mcp-suite): deny unsafe tool argument shapes

### DIFF
--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -154,6 +154,17 @@ fbeast_observer_trail({ sessionId: 'fbeast-central-dispatch' })
 
 `fbeast-mcp` runs all 21 tools in a single MCP server process.
 
+## Tool argument shape hardening
+
+All MCP server and proxy dispatch paths validate tool arguments before governance
+or handlers run. Arguments must be plain JSON objects and may not contain the
+prototype-pollution key denylist (`__proto__`, `prototype`, or `constructor`) at
+any nested level. Accessor properties and non-plain objects are rejected as
+unsafe shapes instead of being inspected, so operator error messages name the
+invalid shape/key without echoing nested payload values. To intentionally pass
+arbitrary content, encode it as a string value accepted by the target tool schema
+rather than adding dynamic object keys.
+
 ## Testing
 
 ```bash

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -367,6 +367,10 @@ describe('proxy server', () => {
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toContain('rejected unsafe argument shape');
         expect(result.content[0].text).toContain('denied property name: __proto__');
+        expect(auditRecord).toHaveBeenCalledTimes(1);
+        const auditedArgs = auditRecord.mock.calls[0]![0].args as { payload: Record<string, unknown> };
+        expect(auditedArgs.payload.ok).toBe(true);
+        expect(auditedArgs.payload['__proto__']).toBe('[denied-property]');
         expect(gateCheck).not.toHaveBeenCalledWith(expect.objectContaining({ tool: 'object_tool' }));
         expect(fakeHandler).not.toHaveBeenCalled();
       } finally {

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -339,6 +339,40 @@ describe('proxy server', () => {
       expect(result.content[0].text).toContain('property key must be string');
       expect(fakeHandler).not.toHaveBeenCalled();
     });
+
+    it('rejects unsafe proxied target argument shapes before governance or handler dispatch', async () => {
+      const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+      const entry = mockRegistry.get('test_tool')!;
+      vi.mocked(entry.makeHandler).mockReturnValue(fakeHandler);
+      mockRegistry.set('object_tool', {
+        name: 'object_tool',
+        server: 'memory',
+        description: 'Object accepting test tool',
+        inputSchema: { type: 'object', properties: { payload: { type: 'object', description: 'Payload' } }, required: ['payload'] },
+        makeHandler: vi.fn().mockReturnValue(fakeHandler),
+      });
+
+      const unsafePayload: Record<string, unknown> = { ok: true };
+      Object.defineProperty(unsafePayload, '__proto__', {
+        enumerable: true,
+        value: { polluted: true },
+      });
+
+      try {
+        const result = await server.callTool('execute_tool', {
+          tool: 'object_tool',
+          args: { payload: unsafePayload },
+        }) as { isError: boolean; content: Array<{ text: string }> };
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('rejected unsafe argument shape');
+        expect(result.content[0].text).toContain('denied property name: __proto__');
+        expect(gateCheck).not.toHaveBeenCalledWith(expect.objectContaining({ tool: 'object_tool' }));
+        expect(fakeHandler).not.toHaveBeenCalled();
+      } finally {
+        mockRegistry.delete('object_tool');
+      }
+    });
   });
 
   describe('deriveProxyRoot', () => {

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createMcpServer, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef, type ToolResult } from '../shared/server-factory.js';
+import { createMcpServer, sanitizeToolArgumentsForAudit, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef, type ToolResult } from '../shared/server-factory.js';
 import { isMain } from '../shared/is-main.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
 import { createGovernanceGate } from '../shared/governance-gate.js';
@@ -80,7 +80,7 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
         // fails the call.
         const recordAudit = async (input: { ok: boolean; decision?: string }): Promise<void> => {
           try {
-            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: toolArgs });
+            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: sanitizeToolArgumentsForAudit(toolArgs) });
           } catch (err) {
             process.stderr.write(`fbeast audit failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`);
           }

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -110,6 +110,52 @@ describe('createMcpServer', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('rejects denied argument-shape keys before invoking handlers', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'cfg',
+      description: 'cfg',
+      inputSchema: { type: 'object', properties: { args: { type: 'object', description: 'a' } }, required: ['args'] },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+
+    const res = await srv.callTool('cfg', { args: { safe: 'ok', constructor: { prototype: { polluted: true } } } });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('rejected unsafe argument shape');
+    expect(res.content[0]!.text).toContain('denied property name: constructor');
+    expect(res.content[0]!.text).not.toContain('polluted');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects accessor and non-plain object argument shapes without reading accessor values', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'cfg',
+      description: 'cfg',
+      inputSchema: { type: 'object', properties: { args: { type: 'object', description: 'a' } }, required: ['args'] },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    const accessorPayload: Record<string, unknown> = {};
+    Object.defineProperty(accessorPayload, 'secret', {
+      enumerable: true,
+      get() {
+        throw new Error('getter should not run');
+      },
+    });
+
+    const accessorRes = await srv.callTool('cfg', { args: accessorPayload });
+    const dateRes = await srv.callTool('cfg', { args: new Date('2026-07-12T00:00:00Z') });
+
+    expect(accessorRes.isError).toBe(true);
+    expect(accessorRes.content[0]!.text).toContain('must be a data property');
+    expect(dateRes.isError).toBe(true);
+    expect(dateRes.content[0]!.text).toContain('must be a plain JSON object');
+    expect(calls).toHaveLength(0);
+  });
+
   it('rejects non-finite number arguments before invoking the handler', async () => {
     const calls: unknown[] = [];
     const tool: ToolDef = {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -156,6 +156,49 @@ describe('createMcpServer', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('depth-limits unsafe shape validation before primitive schema checks can overflow the stack', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'scan',
+      description: 'scan',
+      inputSchema: { type: 'object', properties: { input: { type: 'string', description: 'input' } }, required: ['input'] },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+    let nested: Record<string, unknown> = { leaf: 'x' };
+    for (let i = 0; i < 80; i += 1) nested = { child: nested };
+
+    const res = await srv.callTool('scan', { input: nested });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('exceeds maximum nesting depth');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('sanitizes unsafe rejected payloads before audit sinks serialize them', async () => {
+    const recorded: Array<{ tool: string; ok: boolean; decision?: string; args?: unknown }> = [];
+    const audit: AuditSink = { record: async (e) => { recorded.push(e); JSON.stringify(e.args); } };
+    const tool: ToolDef = {
+      name: 'cfg',
+      description: 'cfg',
+      inputSchema: { type: 'object', properties: { args: { type: 'object', description: 'a' } }, required: ['args'] },
+      handler: async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    };
+    const srv = createMcpServer('t', '1', [tool], { audit });
+    const accessorPayload: Record<string, unknown> = {};
+    Object.defineProperty(accessorPayload, 'secret', {
+      enumerable: true,
+      get() {
+        throw new Error('getter should not run');
+      },
+    });
+
+    const res = await srv.callTool('cfg', { args: accessorPayload });
+
+    expect(res.isError).toBe(true);
+    expect(recorded).toEqual([{ tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { secret: '[accessor]' } } }]);
+  });
+
   it('rejects non-finite number arguments before invoking the handler', async () => {
     const calls: unknown[] = [];
     const tool: ToolDef = {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -129,7 +129,7 @@ describe('createMcpServer', () => {
     expect(calls).toHaveLength(0);
   });
 
-  it('rejects accessor and non-plain object argument shapes without reading accessor values', async () => {
+  it('rejects accessor, array, and non-plain object argument shapes without reading attacker-controlled values', async () => {
     const calls: unknown[] = [];
     const tool: ToolDef = {
       name: 'cfg',
@@ -145,14 +145,34 @@ describe('createMcpServer', () => {
         throw new Error('getter should not run');
       },
     });
+    const accessorArray: unknown[] = [];
+    Object.defineProperty(accessorArray, '0', {
+      enumerable: true,
+      get() {
+        throw new Error('array getter should not run');
+      },
+    });
+    Object.defineProperty(accessorArray, 'constructor', { enumerable: true, value: {} });
+    const taggedObject = Object.create(Date.prototype) as Record<PropertyKey, unknown>;
+    Object.defineProperty(taggedObject, Symbol.toStringTag, {
+      get() {
+        throw new Error('toStringTag should not run');
+      },
+    });
 
     const accessorRes = await srv.callTool('cfg', { args: accessorPayload });
+    const arrayRes = await srv.callTool('cfg', { args: { nested: accessorArray } });
     const dateRes = await srv.callTool('cfg', { args: new Date('2026-07-12T00:00:00Z') });
+    const taggedRes = await srv.callTool('cfg', { args: taggedObject });
 
     expect(accessorRes.isError).toBe(true);
     expect(accessorRes.content[0]!.text).toContain('must be a data property');
+    expect(arrayRes.isError).toBe(true);
+    expect(arrayRes.content[0]!.text).toContain('must be a data property');
     expect(dateRes.isError).toBe(true);
     expect(dateRes.content[0]!.text).toContain('must be a plain JSON object');
+    expect(taggedRes.isError).toBe(true);
+    expect(taggedRes.content[0]!.text).toContain('must be a plain JSON object');
     expect(calls).toHaveLength(0);
   });
 
@@ -192,11 +212,17 @@ describe('createMcpServer', () => {
         throw new Error('getter should not run');
       },
     });
+    const nonJsonPayload = { toJSON: () => { throw new Error('toJSON should not run'); } };
 
-    const res = await srv.callTool('cfg', { args: accessorPayload });
+    const accessorRes = await srv.callTool('cfg', { args: accessorPayload });
+    const nonJsonRes = await srv.callTool('cfg', { args: nonJsonPayload });
 
-    expect(res.isError).toBe(true);
-    expect(recorded).toEqual([{ tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { secret: '[accessor]' } } }]);
+    expect(accessorRes.isError).toBe(true);
+    expect(nonJsonRes.isError).toBe(true);
+    expect(recorded).toEqual([
+      { tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { secret: '[accessor]' } } },
+      { tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { toJSON: '[non-json-value]' } } },
+    ]);
   });
 
   it('rejects non-finite number arguments before invoking the handler', async () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -93,6 +93,7 @@ export interface CreateMcpServerOptions {
 }
 
 const DENIED_ARGUMENT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+const MAX_ARGUMENT_SHAPE_DEPTH = 64;
 
 function isObjectLike(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -106,10 +107,15 @@ function isPlainJsonObject(value: Record<string, unknown>): boolean {
 function validateSafeArgumentShape(
   value: unknown,
   path: string,
+  depth = 0,
+  skipRootChildren: ReadonlySet<string> = new Set(),
 ): { ok: true } | { ok: false; message: string } {
+  if (depth > MAX_ARGUMENT_SHAPE_DEPTH) {
+    return { ok: false, message: `${path} exceeds maximum nesting depth ${MAX_ARGUMENT_SHAPE_DEPTH}` };
+  }
   if (Array.isArray(value)) {
     for (let index = 0; index < value.length; index += 1) {
-      const child = validateSafeArgumentShape(value[index], `${path}[${index}]`);
+      const child = validateSafeArgumentShape(value[index], `${path}[${index}]`, depth + 1, skipRootChildren);
       if (!child.ok) return child;
     }
     return { ok: true };
@@ -134,10 +140,51 @@ function validateSafeArgumentShape(
     if ('get' in descriptor || 'set' in descriptor) {
       return { ok: false, message: `${path}.${key} must be a data property` };
     }
-    const child = validateSafeArgumentShape(descriptor.value, `${path}.${key}`);
+    if (depth === 0 && skipRootChildren.has(key)) {
+      continue;
+    }
+    const child = validateSafeArgumentShape(descriptor.value, `${path}.${key}`, depth + 1, skipRootChildren);
     if (!child.ok) return child;
   }
   return { ok: true };
+}
+
+function sanitizeForAudit(value: unknown, depth = 0): unknown {
+  if (depth > MAX_ARGUMENT_SHAPE_DEPTH) {
+    return '[max-depth]';
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForAudit(item, depth + 1));
+  }
+  if (!isObjectLike(value)) {
+    return value;
+  }
+  if (!isPlainJsonObject(value)) {
+    const tag = Object.prototype.toString.call(value).slice(8, -1) || 'non-plain-object';
+    return `[${tag}]`;
+  }
+  const sanitized: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== 'string') continue;
+    if (DENIED_ARGUMENT_KEYS.has(key)) {
+      sanitized[key] = '[denied-property]';
+      continue;
+    }
+    const descriptor = descriptors[key];
+    if (!descriptor) continue;
+    if ('get' in descriptor || 'set' in descriptor) {
+      sanitized[key] = '[accessor]';
+      continue;
+    }
+    sanitized[key] = sanitizeForAudit(descriptor.value, depth + 1);
+  }
+  return sanitized;
+}
+
+export function sanitizeToolArgumentsForAudit(args: unknown): Record<string, unknown> {
+  const value = sanitizeForAudit(args);
+  return isObjectLike(value) && !Array.isArray(value) ? (value as Record<string, unknown>) : { invalid: value };
 }
 
 export function validateToolArguments(
@@ -148,7 +195,10 @@ export function validateToolArguments(
     return { ok: false, message: `Tool ${tool.name} expects an object argument` };
   }
   const obj = args as Record<string, unknown>;
-  const shape = validateSafeArgumentShape(obj, 'arguments');
+  // The proxy wrapper validates only its envelope here. Its nested `args`
+  // payload is validated after target resolution so governance/audit can record
+  // the real target tool instead of the generic execute_tool wrapper.
+  const shape = validateSafeArgumentShape(obj, 'arguments', 0, tool.name === 'execute_tool' ? new Set(['args']) : new Set());
   if (!shape.ok) {
     return { ok: false, message: `Tool ${tool.name} rejected unsafe argument shape: ${shape.message}` };
   }
@@ -206,10 +256,7 @@ async function dispatchTool(
   };
   // Normalize the raw payload to an object so a malformed (null/array/scalar)
   // probe is still captured in the audit record rather than dropped.
-  const rawArgs: Record<string, unknown> =
-    args !== null && typeof args === 'object' && !Array.isArray(args)
-      ? (args as Record<string, unknown>)
-      : { invalid: args };
+  const rawArgs = sanitizeToolArgumentsForAudit(args);
 
   const tool = toolMap.get(toolName);
   if (!tool) {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -92,6 +92,54 @@ export interface CreateMcpServerOptions {
   audit?: AuditSink;
 }
 
+const DENIED_ARGUMENT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPlainJsonObject(value: Record<string, unknown>): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function validateSafeArgumentShape(
+  value: unknown,
+  path: string,
+): { ok: true } | { ok: false; message: string } {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const child = validateSafeArgumentShape(value[index], `${path}[${index}]`);
+      if (!child.ok) return child;
+    }
+    return { ok: true };
+  }
+  if (!isObjectLike(value)) {
+    return { ok: true };
+  }
+  if (!isPlainJsonObject(value)) {
+    return { ok: false, message: `${path} must be a plain JSON object` };
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== 'string') {
+      return { ok: false, message: `${path} contains non-string property keys` };
+    }
+    if (DENIED_ARGUMENT_KEYS.has(key)) {
+      return { ok: false, message: `${path} contains denied property name: ${key}` };
+    }
+    const descriptor = descriptors[key];
+    if (!descriptor) continue;
+    if ('get' in descriptor || 'set' in descriptor) {
+      return { ok: false, message: `${path}.${key} must be a data property` };
+    }
+    const child = validateSafeArgumentShape(descriptor.value, `${path}.${key}`);
+    if (!child.ok) return child;
+  }
+  return { ok: true };
+}
+
 export function validateToolArguments(
   tool: ToolSchemaDef,
   args: unknown,
@@ -100,17 +148,24 @@ export function validateToolArguments(
     return { ok: false, message: `Tool ${tool.name} expects an object argument` };
   }
   const obj = args as Record<string, unknown>;
+  const shape = validateSafeArgumentShape(obj, 'arguments');
+  if (!shape.ok) {
+    return { ok: false, message: `Tool ${tool.name} rejected unsafe argument shape: ${shape.message}` };
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(obj);
   const schema = tool.inputSchema;
   for (const req of schema.required ?? []) {
-    if (!Object.prototype.hasOwnProperty.call(obj, req) || obj[req] === undefined) {
+    const descriptor = descriptors[req];
+    if (!descriptor || descriptor.value === undefined) {
       return { ok: false, message: `Tool ${tool.name} missing required property: ${req}` };
     }
   }
-  for (const [key, value] of Object.entries(obj)) {
+  for (const [key, descriptor] of Object.entries(descriptors)) {
     const prop = schema.properties[key];
     if (!prop) {
       return { ok: false, message: `Tool ${tool.name} received unknown property: ${key}` };
     }
+    const value = descriptor.value;
     const actual = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
     if (prop.type === 'integer' ? !Number.isInteger(value) : actual !== prop.type) {
       return { ok: false, message: `Tool ${tool.name} property ${key} must be ${prop.type}` };

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -113,9 +113,28 @@ function validateSafeArgumentShape(
   if (depth > MAX_ARGUMENT_SHAPE_DEPTH) {
     return { ok: false, message: `${path} exceeds maximum nesting depth ${MAX_ARGUMENT_SHAPE_DEPTH}` };
   }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { ok: true } : { ok: false, message: `${path} must be a finite number` };
+  }
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
+    return { ok: false, message: `${path} must be a JSON value` };
+  }
   if (Array.isArray(value)) {
-    for (let index = 0; index < value.length; index += 1) {
-      const child = validateSafeArgumentShape(value[index], `${path}[${index}]`, depth + 1, skipRootChildren);
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (key === 'length') continue;
+      if (typeof key !== 'string') {
+        return { ok: false, message: `${path} contains non-string property keys` };
+      }
+      if (DENIED_ARGUMENT_KEYS.has(key)) {
+        return { ok: false, message: `${path} contains denied property name: ${key}` };
+      }
+      const descriptor = descriptors[key];
+      if (!descriptor) continue;
+      if ('get' in descriptor || 'set' in descriptor) {
+        return { ok: false, message: `${path}[${key}] must be a data property` };
+      }
+      const child = validateSafeArgumentShape(descriptor.value, `${path}[${key}]`, depth + 1, skipRootChildren);
       if (!child.ok) return child;
     }
     return { ok: true };
@@ -153,15 +172,36 @@ function sanitizeForAudit(value: unknown, depth = 0): unknown {
   if (depth > MAX_ARGUMENT_SHAPE_DEPTH) {
     return '[max-depth]';
   }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : '[non-finite-number]';
+  }
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
+    return '[non-json-value]';
+  }
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeForAudit(item, depth + 1));
+    const sanitized: unknown[] = [];
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (key === 'length' || typeof key !== 'string') continue;
+      if (DENIED_ARGUMENT_KEYS.has(key)) {
+        Object.defineProperty(sanitized, key, { enumerable: true, value: '[denied-property]' });
+        continue;
+      }
+      const descriptor = descriptors[key];
+      if (!descriptor) continue;
+      if ('get' in descriptor || 'set' in descriptor) {
+        Object.defineProperty(sanitized, key, { enumerable: true, value: '[accessor]' });
+        continue;
+      }
+      Object.defineProperty(sanitized, key, { enumerable: descriptor.enumerable ?? true, value: sanitizeForAudit(descriptor.value, depth + 1) });
+    }
+    return sanitized;
   }
   if (!isObjectLike(value)) {
     return value;
   }
   if (!isPlainJsonObject(value)) {
-    const tag = Object.prototype.toString.call(value).slice(8, -1) || 'non-plain-object';
-    return `[${tag}]`;
+    return '[non-plain-object]';
   }
   const sanitized: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   const descriptors = Object.getOwnPropertyDescriptors(value);


### PR DESCRIPTION
## Summary
- Adds recursive unsafe argument-shape validation to MCP tool dispatch before governance or handlers run.
- Denies prototype-pollution keys (`__proto__`, `prototype`, `constructor`), accessor properties, and non-plain object payloads.
- Covers direct server and proxy dispatch paths with tests and documents the shape hardening behavior.

## Test Plan
- [x] `npm test --workspace @franken/mcp-suite -- --run src/shared/server-factory.test.ts src/servers/proxy.test.ts`
- [x] `npm run lint --workspace @franken/mcp-suite` (passes with existing warnings)
- [x] `npm run typecheck --workspace @franken/mcp-suite` after building workspace dependencies
- [x] `npm run build --workspace @franken/mcp-suite` after building workspace dependencies

Closes #1785
