### PR TITLE
fix(web): surface dashboard stream reconnect failures

### DIFF
--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -322,11 +322,14 @@ describe('DashboardApiClient', () => {
 
       try {
         const client = new DashboardApiClient(BASE_URL);
-        const unsub = await client.subscribeToDashboard(vi.fn());
+        const onError = vi.fn();
+        const unsub = await client.subscribeToDashboard(vi.fn(), onError);
 
         listeners[0]!.error!({});
         await vi.advanceTimersByTimeAsync(1_000);
         expect(errorSpy).toHaveBeenCalledWith(expect.any(Error));
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onError.mock.calls[0]![0].message).toBe('Dashboard stream reconnect failed. HTTP 503');
         expect(MockEventSource).toHaveBeenCalledTimes(1);
 
         await vi.advanceTimersByTimeAsync(1_000);

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -22,6 +22,16 @@ function makeMockSnapshot(): DashboardSnapshot {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('DashboardApiClient', () => {
   let originalFetch: typeof globalThis.fetch;
 
@@ -328,8 +338,9 @@ describe('DashboardApiClient', () => {
         listeners[0]!.error!({});
         await vi.advanceTimersByTimeAsync(1_000);
         expect(errorSpy).toHaveBeenCalledWith(expect.any(Error));
-        expect(onError).toHaveBeenCalledWith(expect.any(Error));
-        expect(onError.mock.calls[0]![0].message).toBe('Dashboard stream reconnect failed. HTTP 503');
+        expect(onError).toHaveBeenCalledTimes(2);
+        expect(onError.mock.calls[0]![0].message).toBe('Dashboard stream connection lost. Reconnecting.');
+        expect(onError.mock.calls[1]![0].message).toBe('Dashboard stream reconnect failed. HTTP 503');
         expect(MockEventSource).toHaveBeenCalledTimes(1);
 
         await vi.advanceTimersByTimeAsync(1_000);
@@ -338,6 +349,108 @@ describe('DashboardApiClient', () => {
 
         unsub();
         expect(closeFns[1]).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        errorSpy.mockRestore();
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
+    it('reports EventSource errors after the stream opens and keeps retrying', async () => {
+      vi.useFakeTimers();
+      const closeFns = [vi.fn(), vi.fn()];
+      const listeners: Array<Record<string, (event: { data?: string }) => void>> = [];
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data?: string }) => void) => void;
+        close?: () => void;
+      }) {
+        const index = listeners.length;
+        listeners[index] = {};
+        this.addEventListener = vi.fn((type: string, handler: (event: { data?: string }) => void) => {
+          listeners[index]![type] = handler;
+        });
+        this.close = closeFns[index];
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-1' }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-2' }) });
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const onError = vi.fn();
+        const unsub = await client.subscribeToDashboard(vi.fn(), onError);
+
+        listeners[0]!.error!({});
+
+        expect(closeFns[0]).toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onError.mock.calls[0]![0].message).toBe('Dashboard stream connection lost. Reconnecting.');
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(MockEventSource).toHaveBeenNthCalledWith(2, `${BASE_URL}/api/dashboard/events?ticket=ticket-2`);
+
+        unsub();
+      } finally {
+        vi.useRealTimers();
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
+    it('does not report reconnect ticket failures after unsubscribe', async () => {
+      vi.useFakeTimers();
+      const closeFn = vi.fn();
+      const listeners: Array<Record<string, (event: { data?: string }) => void>> = [];
+      const reconnectTicket = deferred<{ ok: boolean; status: number }>();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data?: string }) => void) => void;
+        close?: () => void;
+      }) {
+        const index = listeners.length;
+        listeners[index] = {};
+        this.addEventListener = vi.fn((type: string, handler: (event: { data?: string }) => void) => {
+          listeners[index]![type] = handler;
+        });
+        this.close = closeFn;
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-1' }) })
+        .mockReturnValueOnce(reconnectTicket.promise);
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const onError = vi.fn();
+        const unsub = await client.subscribeToDashboard(vi.fn(), onError);
+
+        listeners[0]!.error!({});
+        await vi.advanceTimersByTimeAsync(1_000);
+        unsub();
+        reconnectTicket.resolve({ ok: false, status: 503 });
+        await Promise.resolve();
+
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError.mock.calls[0]![0].message).toBe('Dashboard stream connection lost. Reconnecting.');
+        expect(errorSpy).not.toHaveBeenCalledWith(expect.any(Error));
       } finally {
         vi.useRealTimers();
         errorSpy.mockRestore();

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -76,6 +76,7 @@ export class DashboardApiClient {
       reconnectTimer = setTimeout(() => {
         reconnectTimer = undefined;
         void connect().catch((err) => {
+          if (closed) return;
           const error = toError(err);
           console.error(error);
           onError?.(new Error(`Dashboard stream reconnect failed. ${error.message}`));
@@ -113,6 +114,9 @@ export class DashboardApiClient {
         }
       });
       nextEventSource.addEventListener('error', () => {
+        if (!closed) {
+          onError?.(new Error('Dashboard stream connection lost. Reconnecting.'));
+        }
         closeActiveSource();
         scheduleReconnect();
       });

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -76,7 +76,9 @@ export class DashboardApiClient {
       reconnectTimer = setTimeout(() => {
         reconnectTimer = undefined;
         void connect().catch((err) => {
-          console.error(err);
+          const error = toError(err);
+          console.error(error);
+          onError?.(new Error(`Dashboard stream reconnect failed. ${error.message}`));
           scheduleReconnect();
         });
       }, 1_000);

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -817,6 +817,41 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('shows and clears stream reconnect failures reported after subscription setup', async () => {
+    let pushSnapshot!: (nextSnapshot: DashboardSnapshot) => void;
+    let pushError!: (error: Error) => void;
+    const client = mockClient({
+      subscribeToDashboard: vi.fn((
+        onSnapshot: (nextSnapshot: DashboardSnapshot) => void,
+        onError?: (error: Error) => void,
+      ) => {
+        pushSnapshot = onSnapshot;
+        pushError = onError ?? (() => undefined);
+        return Promise.resolve(() => undefined);
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+    await screen.findByRole('switch', { name: 'Enable shell' });
+
+    act(() => {
+      pushError(new Error('Dashboard stream reconnect failed. HTTP 503'));
+    });
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Unable to process dashboard stream update. Dashboard stream reconnect failed. HTTP 503',
+    );
+
+    act(() => {
+      pushSnapshot({ ...snapshot, security: { ...snapshot.security, profile: 'strict' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Unable to process dashboard stream update/)).toBeNull();
+      expect((screen.getByLabelText('Profile:') as HTMLSelectElement).value).toBe('strict');
+    });
+  });
+
   it('keeps mutation failure alerts when retrying the dashboard stream', async () => {
     const client = mockClient({
       subscribeToDashboard: vi.fn()

--- a/tasks/issue-2034-progress.md
+++ b/tasks/issue-2034-progress.md
@@ -1,0 +1,8 @@
+# Issue 2034 Progress
+
+- [x] Inspect GitHub issue #2034 and repository instructions.
+- [x] Inspect relevant dashboard stream client/page/tests.
+- [x] Implement smallest reconnect error surfacing fix.
+- [x] Add/adjust targeted regression tests for post-connect reconnect failures.
+- [x] Run targeted verification.
+- [ ] Commit, push branch, open PR, and request Codex review.


### PR DESCRIPTION
## Summary
- Report dashboard EventSource reconnect ticket failures through the existing stream error callback.
- Surface EventSource error events immediately while keeping the reconnect loop active.
- Suppress late reconnect-ticket failures after unsubscribe so stale consumers are not updated.
- Add regression coverage for post-subscription reconnect failures, UI clearing after a later snapshot, EventSource handoff errors, and post-unsubscribe reconnect races.

Closes #2034

## Test plan
- npm run test --workspace @franken/web -- src/lib/dashboard-api.test.ts src/pages/dashboard-page.test.tsx
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web (passes with existing warnings)
- npm run build --workspace @franken/web

Note: fbeast MCP tools were not available in this worker, so I followed AGENTS.md with normal git/GitHub/terminal verification.