### PR TITLE
feat(learning): add lesson rollback workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,17 @@ Raw user input is scrubbed for PII and scanned for injection attacks by the fire
 
 The Planner generates a Task DAG. The Critique module audits it with 8 evaluators (deterministic evaluators run first, then heuristic). If critique fails, the orchestrator forces a re-plan (max 3 iterations). After 3 failures, it escalates to a human via MOD-07.
 
+#### Lesson rollback workflow
+
+Critique lessons recorded after a recovered failure include a `rollbackWorkflow` object for PM/liveness consumers. Use it when a lesson is later found to be incorrect, stale, over-broad, or harmful:
+
+1. Quarantine the target lesson so it stops being promoted into new worker handoffs.
+2. Attach the rollback reason, evidence URLs, and verifier command to the lesson audit trail.
+3. Either record a replacement lesson with fresh traceability evidence or retire the original lesson with no replacement.
+4. Run the verifier command and include the result in the PM handoff before removing the rollback block.
+
+Rollback requests must provide a stable lesson id, a concrete rollback reason, evidence such as a review comment/regression/operator report, and a verification command. If any of that evidence is missing, PM tooling should keep the lesson blocked instead of silently retiring or replacing it.
+
 ### Phase 3: Validated Execution
 
 **Modules:** MOD-02 (Skills) + MOD-07 (Governor)

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -29,6 +29,7 @@ export type {
   EpisodicTrace,
   LessonTestTraceabilityEntry,
   LessonExperimentSandbox,
+  LessonRollbackWorkflow,
   LessonCooldownMetadata,
   LessonCooldownSuppression,
   CrossTaskBlockerPattern,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -5,6 +5,7 @@ import type {
   LessonRecordingResult,
   ReviewerFeedbackLessonCapture,
   PostPrLessonExtractionTemplate,
+  LessonRollbackWorkflow,
   CrossTaskBlockerPattern,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
@@ -68,6 +69,34 @@ export interface LessonRecorderOptions {
 
 const LESSON_EXPERIMENT_SANDBOX_REASON =
   'New critique lessons are experimental until their traceability map and regression evidence are independently verified.';
+
+const LESSON_ROLLBACK_INSUFFICIENT_EVIDENCE_GUIDANCE =
+  'Do not roll back a lesson unless the rollback request names the lesson, explains the bad/stale guidance, links review or regression evidence, and includes a verification command for the replacement or retirement decision.';
+
+const LESSON_ROLLBACK_WORKFLOW: LessonRollbackWorkflow = {
+  workflowId: 'lesson-rollback-v1',
+  eligibleStates: ['experimental', 'promoted'],
+  steps: [
+    'Quarantine the target lesson so PM/liveness tooling stops promoting it into new handoffs.',
+    'Attach the rollback reason, evidence URLs, and verifier command to the lesson audit trail.',
+    'Either record a replacement lesson with fresh traceability evidence or mark the original lesson retired with no replacement.',
+    'Run the verifier command and include the result in the PM handoff before removing the rollback block.',
+  ],
+  requiredEvidence: [
+    'Stable lesson identifier or traceability entry',
+    'Reason the lesson is incorrect, stale, over-broad, or harmful',
+    'Review comment, failed regression, operator report, or incident link proving rollback is warranted',
+    'Verification command for the replacement lesson or retired state',
+  ],
+  requestSchema: {
+    lessonId: 'string',
+    rollbackReason: 'string',
+    evidenceUrls: 'string[]',
+    replacementLesson: 'string-or-null',
+    verificationCommand: 'string',
+  },
+  insufficientEvidenceGuidance: LESSON_ROLLBACK_INSUFFICIENT_EVIDENCE_GUIDANCE,
+};
 
 const MISSING_REVIEWER_SUGGESTION_GUIDANCE =
   'Reviewer feedback did not include suggestions for every finding; PM handoffs should preserve the original message and ask a reviewer to attach remediation guidance before promotion.';
@@ -185,7 +214,8 @@ export class LessonRecorder {
   ): Promise<void> {
     await this.withBlockerPatternAdmissionLock(extractedLesson, async () => {
       let lesson = this.withCurrentBlockerPatterns(extractedLesson);
-      const cooldownKey = this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
+      const cooldownKey =
+        this.cooldownMs > 0 ? lesson.cooldown?.key : undefined;
       let admissionSettled: ((admitted: boolean) => void) | undefined;
       let admissionPromise: Promise<boolean> | undefined;
       if (cooldownKey) {
@@ -321,6 +351,7 @@ export class LessonRecorder {
             ],
             verificationCommand: LESSON_TRACEABILITY_VERIFICATION_COMMAND,
           },
+          rollbackWorkflow: createLessonRollbackWorkflow(),
           testTraceability: [
             {
               lessonId,
@@ -718,6 +749,16 @@ function createPostPrLessonExtractionTemplate(): PostPrLessonExtractionTemplate 
     instructions: [...POST_PR_LESSON_EXTRACTION_TEMPLATE.instructions],
     requiredEvidence: [...POST_PR_LESSON_EXTRACTION_TEMPLATE.requiredEvidence],
     outputSchema: { ...POST_PR_LESSON_EXTRACTION_TEMPLATE.outputSchema },
+  };
+}
+
+function createLessonRollbackWorkflow(): LessonRollbackWorkflow {
+  return {
+    ...LESSON_ROLLBACK_WORKFLOW,
+    eligibleStates: [...LESSON_ROLLBACK_WORKFLOW.eligibleStates],
+    steps: [...LESSON_ROLLBACK_WORKFLOW.steps],
+    requiredEvidence: [...LESSON_ROLLBACK_WORKFLOW.requiredEvidence],
+    requestSchema: { ...LESSON_ROLLBACK_WORKFLOW.requestSchema },
   };
 }
 

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -69,6 +69,28 @@ export interface LessonExperimentSandbox {
   readonly verificationCommand: string;
 }
 
+/** Structured workflow that tells PM/liveness tooling how to roll back a bad lesson safely. */
+export interface LessonRollbackWorkflow {
+  /** Stable workflow identifier for downstream PM/liveness tooling. */
+  readonly workflowId: 'lesson-rollback-v1';
+  /** Lesson states where rollback is valid. */
+  readonly eligibleStates: readonly ('experimental' | 'promoted')[];
+  /** Deterministic rollback actions in execution order. */
+  readonly steps: readonly string[];
+  /** Evidence required before a rollback can retire or quarantine a lesson. */
+  readonly requiredEvidence: readonly string[];
+  /** JSON object shape expected when an LLM or operator requests rollback. */
+  readonly requestSchema: {
+    readonly lessonId: 'string';
+    readonly rollbackReason: 'string';
+    readonly evidenceUrls: 'string[]';
+    readonly replacementLesson: 'string-or-null';
+    readonly verificationCommand: 'string';
+  };
+  /** Explicit failure guidance when the rollback request lacks enough evidence. */
+  readonly insufficientEvidenceGuidance: string;
+}
+
 /** A normalized reviewer finding captured alongside a learned critique lesson. */
 export interface ReviewerFeedbackLessonEntry {
   /** Iteration where the reviewer feedback was emitted. */
@@ -194,6 +216,8 @@ export interface CritiqueLesson {
   readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
   /** Present for new lessons that must remain quarantined until independently verified. */
   readonly experimentSandbox?: LessonExperimentSandbox;
+  /** LLM-friendly workflow for rolling back an incorrect, stale, or harmful learned lesson. */
+  readonly rollbackWorkflow?: LessonRollbackWorkflow;
   /** Structured reviewer feedback that produced the lesson and should be reusable in PM handoffs. */
   readonly reviewerFeedback?: ReviewerFeedbackLessonCapture;
   /** Structured template for extracting reusable lessons from post-PR review/merge evidence. */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -318,6 +318,78 @@ describe('LessonRecorder', () => {
     });
   });
 
+  it('attaches a deterministic lesson rollback workflow to recorded lessons', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message: 'lesson overgeneralized a one-off reviewer preference',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'rollback-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(lesson.rollbackWorkflow).toEqual({
+      workflowId: 'lesson-rollback-v1',
+      eligibleStates: ['experimental', 'promoted'],
+      steps: [
+        'Quarantine the target lesson so PM/liveness tooling stops promoting it into new handoffs.',
+        'Attach the rollback reason, evidence URLs, and verifier command to the lesson audit trail.',
+        'Either record a replacement lesson with fresh traceability evidence or mark the original lesson retired with no replacement.',
+        'Run the verifier command and include the result in the PM handoff before removing the rollback block.',
+      ],
+      requiredEvidence: [
+        'Stable lesson identifier or traceability entry',
+        'Reason the lesson is incorrect, stale, over-broad, or harmful',
+        'Review comment, failed regression, operator report, or incident link proving rollback is warranted',
+        'Verification command for the replacement lesson or retired state',
+      ],
+      requestSchema: {
+        lessonId: 'string',
+        rollbackReason: 'string',
+        evidenceUrls: 'string[]',
+        replacementLesson: 'string-or-null',
+        verificationCommand: 'string',
+      },
+      insufficientEvidenceGuidance:
+        'Do not roll back a lesson unless the rollback request names the lesson, explains the bad/stale guidance, links review or regression evidence, and includes a verification command for the replacement or retirement decision.',
+    });
+  });
+
+  it('does not attach rollback workflow guidance when no actionable lesson is recorded', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message:
+              'rollback guidance should not attach to evaluator exceptions',
+            severity: 'critical',
+            location: EVALUATOR_EXCEPTION_LOCATION,
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'rollback-exception-task');
+
+    expect(port.recordLesson).not.toHaveBeenCalled();
+  });
+
   it('attaches learning cooldown metadata to recorded lessons for PM/liveness tooling', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port, {
@@ -1044,8 +1116,7 @@ describe('LessonRecorder', () => {
       iterations: [
         createIteration(0, 'fail', 'codex-review', [
           {
-            message:
-              'Shared recorder stores must not miss threshold crossing',
+            message: 'Shared recorder stores must not miss threshold crossing',
             severity: 'critical',
           },
         ]),

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -4,6 +4,7 @@ import type { ProviderCritiqueFinding } from '@franken/types';
 import type {
   CritiquePipelineResult,
   CritiqueResult as DeprecatedCritiqueResult,
+  LessonRollbackWorkflow,
   SessionId,
 } from '@franken/critique';
 
@@ -35,7 +36,9 @@ describe('public critique type contracts', () => {
     };
     const compatibilityAlias: DeprecatedCritiqueResult = pipelineResult;
 
-    expect(compatibilityAlias.results[0]?.findings[0]?.message).toBe(providerFinding.message);
+    expect(compatibilityAlias.results[0]?.findings[0]?.message).toBe(
+      providerFinding.message,
+    );
   });
 
   it('uses the branded @franken/types SessionId contract for critique sessions', () => {
@@ -43,5 +46,24 @@ describe('public critique type contracts', () => {
 
     expectTypeOf(sessionId).toMatchTypeOf<SessionId>();
     expect(sessionId).toBe('critique-session-1');
+  });
+
+  it('exports lesson rollback workflow metadata from the public barrel', () => {
+    const workflow: LessonRollbackWorkflow = {
+      workflowId: 'lesson-rollback-v1',
+      eligibleStates: ['experimental'],
+      steps: ['quarantine lesson'],
+      requiredEvidence: ['regression evidence'],
+      requestSchema: {
+        lessonId: 'string',
+        rollbackReason: 'string',
+        evidenceUrls: 'string[]',
+        replacementLesson: 'string-or-null',
+        verificationCommand: 'string',
+      },
+      insufficientEvidenceGuidance: 'keep rollback blocked',
+    };
+
+    expect(workflow.workflowId).toBe('lesson-rollback-v1');
   });
 });


### PR DESCRIPTION
## Summary
- Add structured `rollbackWorkflow` metadata to recorded critique lessons so PM/liveness tooling has deterministic rollback steps.
- Extend the public critique lesson contract with a rollback request schema and insufficient-evidence guidance.
- Document the operator-facing lesson rollback workflow in the README.

## Verification
- `npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts` (40 tests)
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/critique`
- `npm run lint --workspace @franken/critique`
- `npx prettier --check packages/franken-critique/src/memory/lesson-recorder.ts packages/franken-critique/src/types/contracts.ts packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts`

Closes #1860
