### PR TITLE
test(mcp-suite): keep test files in lint coverage

### DIFF
--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint src/",
+    "lint": "eslint src/ \"src/**/*.test.ts\" \"src/**/*.integration.test.ts\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --reporter=verbose",
     "test:integration": "vitest run --reporter=verbose src/**/*.integration.test.ts",

--- a/scripts/check-workspace-lint-coverage.mjs
+++ b/scripts/check-workspace-lint-coverage.mjs
@@ -47,6 +47,7 @@ const lintPathConfig = (lintScript) => {
   const invocations = [];
   let currentDir = '';
   let currentInvocation = null;
+  let skippingOrFallback = false;
   let skipNext = false;
   let optionAwaitingValue = null;
   let awaitingCdTarget = false;
@@ -85,6 +86,11 @@ const lintPathConfig = (lintScript) => {
 
     if (shellCommandSeparators.has(token)) {
       finishInvocation();
+      skippingOrFallback = token === '||';
+      continue;
+    }
+
+    if (skippingOrFallback) {
       continue;
     }
 
@@ -99,6 +105,7 @@ const lintPathConfig = (lintScript) => {
           cwd: currentDir,
           targets: [],
           ignorePatterns: [],
+          ignoreDisabled: false,
           passOnNoPatterns: false,
         };
       }
@@ -118,6 +125,11 @@ const lintPathConfig = (lintScript) => {
 
       if (optionName === '--pass-on-no-patterns') {
         currentInvocation.passOnNoPatterns = true;
+        continue;
+      }
+
+      if (optionName === '--no-ignore') {
+        currentInvocation.ignoreDisabled = true;
         continue;
       }
 
@@ -147,6 +159,15 @@ const globToRegExp = (glob) => {
           .split(',')
           .map((part) => part.replace(/[|\\{}()[\]^$+?.]/gu, '\\$&'));
         source += `(?:${alternatives.join('|')})`;
+        index = closeIndex;
+        continue;
+      }
+    }
+
+    if (char === '[') {
+      const closeIndex = glob.indexOf(']', index + 1);
+      if (closeIndex !== -1) {
+        source += glob.slice(index, closeIndex + 1);
         index = closeIndex;
         continue;
       }
@@ -206,8 +227,8 @@ const lintTargetCoversTestFile = (target, testFile) => {
 };
 
 const lintScriptCoversTestFile = (lintScript, testFile) => {
-  return lintPathConfig(lintScript).some(({ targets, ignorePatterns }) => {
-    if (ignorePatterns.some((pattern) => pathMatchesGlob(pattern, testFile) || lintTargetCoversTestFile(pattern, testFile))) {
+  return lintPathConfig(lintScript).some(({ targets, ignorePatterns, ignoreDisabled }) => {
+    if (!ignoreDisabled && ignorePatterns.some((pattern) => pathMatchesGlob(pattern, testFile) || lintTargetCoversTestFile(pattern, testFile))) {
       return false;
     }
 

--- a/scripts/check-workspace-lint-coverage.mjs
+++ b/scripts/check-workspace-lint-coverage.mjs
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
@@ -27,58 +27,135 @@ const normalizePathToken = (token) => token
   .replace(/^\.\//u, '')
   .replace(/:\d+(?::\d+)?$/u, '');
 
-const lintPathTargets = (lintScript) => {
+const shellCommandSeparators = new Set(['&&', '||', ';']);
+
+const joinRelativePath = (baseDir, target) => {
+  const normalizedTarget = normalizePathToken(target);
+  if (baseDir === '' && normalizedTarget === '.') return '.';
+  if (normalizedTarget === '') return baseDir;
+  if (normalizedTarget.startsWith('/')) return normalizedTarget.slice(1);
+  return posix.normalize(posix.join(baseDir, normalizedTarget)).replace(/^\.\/?/u, '');
+};
+
+const lintPathConfig = (lintScript) => {
   const tokens = lintScript.match(/(?:[^\s'"]+|"[^"]*"|'[^']*')+/gu) ?? [];
   const targets = [];
+  const ignorePatterns = [];
+  let currentDir = '';
   let seenEslint = false;
   let skipNext = false;
+  let optionAwaitingValue = null;
+  let awaitingCdTarget = false;
 
   for (const rawToken of tokens) {
     const token = normalizePathToken(rawToken);
+
+    if (awaitingCdTarget) {
+      currentDir = joinRelativePath(currentDir, token);
+      awaitingCdTarget = false;
+      continue;
+    }
+
+    if (optionAwaitingValue !== null) {
+      if (optionAwaitingValue === '--ignore-pattern') {
+        ignorePatterns.push(joinRelativePath(currentDir, token));
+      }
+
+      optionAwaitingValue = null;
+      continue;
+    }
 
     if (skipNext) {
       skipNext = false;
       continue;
     }
 
-    if (token === '&&' || token === '||' || token === ';') {
+    if (shellCommandSeparators.has(token)) {
       seenEslint = false;
       continue;
     }
 
     if (!seenEslint) {
+      if (token === 'cd') {
+        awaitingCdTarget = true;
+        continue;
+      }
+
       seenEslint = token === 'eslint' || token.endsWith('/eslint');
       continue;
     }
 
     if (token.startsWith('-')) {
       const optionName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+      if (optionName === '--ignore-pattern') {
+        if (token.includes('=')) {
+          ignorePatterns.push(joinRelativePath(currentDir, token.slice(token.indexOf('=') + 1)));
+        } else {
+          optionAwaitingValue = optionName;
+        }
+        continue;
+      }
+
       skipNext = lintOptionNamesWithValues.has(optionName) && !token.includes('=');
       continue;
     }
 
-    targets.push(token);
+    targets.push(joinRelativePath(currentDir, token));
   }
 
-  return targets;
+  return { targets, ignorePatterns };
 };
 
-const pathPrefixBeforeGlob = (target) => {
-  const globIndex = target.search(/[?*[{]/u);
-  if (globIndex === -1) return target;
+const globToRegExp = (glob) => {
+  let source = '^';
+  for (let index = 0; index < glob.length; index += 1) {
+    const char = glob[index];
+    const next = glob[index + 1];
 
-  const prefix = target.slice(0, globIndex);
-  const lastSlash = prefix.lastIndexOf('/');
-  return lastSlash === -1 ? '' : prefix.slice(0, lastSlash + 1);
+    if (char === '*' && next === '*') {
+      const afterGlobstar = glob[index + 2];
+      if (afterGlobstar === '/') {
+        source += '(?:.*/)?';
+        index += 2;
+      } else {
+        source += '.*';
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '*') {
+      source += '[^/]*';
+      continue;
+    }
+
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+
+    source += char.replace(/[|\\{}()[\]^$+?.]/gu, '\\$&');
+  }
+
+  source += '$';
+  return new RegExp(source, 'u');
+};
+
+const pathMatchesGlob = (pattern, testFile) => {
+  if (!/[?*[{]/u.test(pattern)) return false;
+  return globToRegExp(pattern).test(testFile);
 };
 
 const lintTargetCoversTestFile = (target, testFile) => {
   const normalizedTarget = normalizePathToken(target);
   if (normalizedTarget === '.' || normalizedTarget === '') return normalizedTarget === '.';
 
-  const prefix = pathPrefixBeforeGlob(normalizedTarget);
-  if (prefix !== normalizedTarget) {
-    return prefix === '' || testFile.startsWith(prefix);
+  if (pathMatchesGlob(normalizedTarget, testFile)) {
+    return true;
+  }
+
+  if (/[?*[{]/u.test(normalizedTarget)) {
+    return false;
   }
 
   if (normalizedTarget.endsWith('/')) {
@@ -88,9 +165,14 @@ const lintTargetCoversTestFile = (target, testFile) => {
   return testFile === normalizedTarget || testFile.startsWith(`${normalizedTarget}/`);
 };
 
-const lintScriptCoversTestFile = (lintScript, testFile) => (
-  lintPathTargets(lintScript).some((target) => lintTargetCoversTestFile(target, testFile))
-);
+const lintScriptCoversTestFile = (lintScript, testFile) => {
+  const { targets, ignorePatterns } = lintPathConfig(lintScript);
+  if (ignorePatterns.some((pattern) => pathMatchesGlob(pattern, testFile) || lintTargetCoversTestFile(pattern, testFile))) {
+    return false;
+  }
+
+  return targets.some((target) => lintTargetCoversTestFile(target, testFile));
+};
 
 const collectTestFiles = (dir, relativeDir = '') => {
   if (!existsSync(dir)) return [];

--- a/scripts/check-workspace-lint-coverage.mjs
+++ b/scripts/check-workspace-lint-coverage.mjs
@@ -6,6 +6,7 @@ const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
 const testFilePattern = /(?:^|\/).+\.(?:integration\.)?test\.[cm]?[jt]sx?$/u;
 const ignoredTestSearchDirs = new Set(['dist', 'node_modules', 'coverage', '.turbo']);
 const lintOptionNamesWithValues = new Set([
+  '--cache-location',
   '--config',
   '-c',
   '--ext',
@@ -13,11 +14,15 @@ const lintOptionNamesWithValues = new Set([
   '-f',
   '--global',
   '--ignore-pattern',
+  '--max-warnings',
+  '--output-file',
+  '-o',
   '--parser',
   '--parser-options',
   '--plugin',
   '--resolve-plugins-relative-to',
   '--rule',
+  '--stdin-filename',
 ]);
 
 const normalizePathToken = (token) => token
@@ -39,13 +44,21 @@ const joinRelativePath = (baseDir, target) => {
 
 const lintPathConfig = (lintScript) => {
   const tokens = lintScript.match(/(?:[^\s'"]+|"[^"]*"|'[^']*')+/gu) ?? [];
-  const targets = [];
-  const ignorePatterns = [];
+  const invocations = [];
   let currentDir = '';
-  let seenEslint = false;
+  let currentInvocation = null;
   let skipNext = false;
   let optionAwaitingValue = null;
   let awaitingCdTarget = false;
+
+  const finishInvocation = () => {
+    if (currentInvocation === null) return;
+    if (currentInvocation.targets.length === 0 && !currentInvocation.passOnNoPatterns) {
+      currentInvocation.targets.push(joinRelativePath(currentInvocation.cwd, '.'));
+    }
+    invocations.push(currentInvocation);
+    currentInvocation = null;
+  };
 
   for (const rawToken of tokens) {
     const token = normalizePathToken(rawToken);
@@ -58,7 +71,7 @@ const lintPathConfig = (lintScript) => {
 
     if (optionAwaitingValue !== null) {
       if (optionAwaitingValue === '--ignore-pattern') {
-        ignorePatterns.push(joinRelativePath(currentDir, token));
+        currentInvocation?.ignorePatterns.push(joinRelativePath(currentDir, token));
       }
 
       optionAwaitingValue = null;
@@ -71,17 +84,24 @@ const lintPathConfig = (lintScript) => {
     }
 
     if (shellCommandSeparators.has(token)) {
-      seenEslint = false;
+      finishInvocation();
       continue;
     }
 
-    if (!seenEslint) {
+    if (currentInvocation === null) {
       if (token === 'cd') {
         awaitingCdTarget = true;
         continue;
       }
 
-      seenEslint = token === 'eslint' || token.endsWith('/eslint');
+      if (token === 'eslint' || token.endsWith('/eslint')) {
+        currentInvocation = {
+          cwd: currentDir,
+          targets: [],
+          ignorePatterns: [],
+          passOnNoPatterns: false,
+        };
+      }
       continue;
     }
 
@@ -89,10 +109,15 @@ const lintPathConfig = (lintScript) => {
       const optionName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
       if (optionName === '--ignore-pattern') {
         if (token.includes('=')) {
-          ignorePatterns.push(joinRelativePath(currentDir, token.slice(token.indexOf('=') + 1)));
+          currentInvocation.ignorePatterns.push(joinRelativePath(currentDir, token.slice(token.indexOf('=') + 1)));
         } else {
           optionAwaitingValue = optionName;
         }
+        continue;
+      }
+
+      if (optionName === '--pass-on-no-patterns') {
+        currentInvocation.passOnNoPatterns = true;
         continue;
       }
 
@@ -100,10 +125,12 @@ const lintPathConfig = (lintScript) => {
       continue;
     }
 
-    targets.push(joinRelativePath(currentDir, token));
+    currentInvocation.targets.push(joinRelativePath(currentDir, token));
   }
 
-  return { targets, ignorePatterns };
+  finishInvocation();
+
+  return invocations;
 };
 
 const globToRegExp = (glob) => {
@@ -111,6 +138,19 @@ const globToRegExp = (glob) => {
   for (let index = 0; index < glob.length; index += 1) {
     const char = glob[index];
     const next = glob[index + 1];
+
+    if (char === '{') {
+      const closeIndex = glob.indexOf('}', index + 1);
+      if (closeIndex !== -1) {
+        const alternatives = glob
+          .slice(index + 1, closeIndex)
+          .split(',')
+          .map((part) => part.replace(/[|\\{}()[\]^$+?.]/gu, '\\$&'));
+        source += `(?:${alternatives.join('|')})`;
+        index = closeIndex;
+        continue;
+      }
+    }
 
     if (char === '*' && next === '*') {
       const afterGlobstar = glob[index + 2];
@@ -166,12 +206,13 @@ const lintTargetCoversTestFile = (target, testFile) => {
 };
 
 const lintScriptCoversTestFile = (lintScript, testFile) => {
-  const { targets, ignorePatterns } = lintPathConfig(lintScript);
-  if (ignorePatterns.some((pattern) => pathMatchesGlob(pattern, testFile) || lintTargetCoversTestFile(pattern, testFile))) {
-    return false;
-  }
+  return lintPathConfig(lintScript).some(({ targets, ignorePatterns }) => {
+    if (ignorePatterns.some((pattern) => pathMatchesGlob(pattern, testFile) || lintTargetCoversTestFile(pattern, testFile))) {
+      return false;
+    }
 
-  return targets.some((target) => lintTargetCoversTestFile(target, testFile));
+    return targets.some((target) => lintTargetCoversTestFile(target, testFile));
+  });
 };
 
 const collectTestFiles = (dir, relativeDir = '') => {

--- a/scripts/check-workspace-lint-coverage.mjs
+++ b/scripts/check-workspace-lint-coverage.mjs
@@ -1,47 +1,178 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const root = fileURLToPath(new URL('..', import.meta.url));
-const packagesDir = join(root, 'packages');
-const docsPath = join(root, 'docs', 'lint-coverage.md');
-const docs = existsSync(docsPath) ? readFileSync(docsPath, 'utf8') : '';
-const failures = [];
+const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
+const testFilePattern = /(?:^|\/).+\.(?:integration\.)?test\.[cm]?[jt]sx?$/u;
+const ignoredTestSearchDirs = new Set(['dist', 'node_modules', 'coverage', '.turbo']);
+const lintOptionNamesWithValues = new Set([
+  '--config',
+  '-c',
+  '--ext',
+  '--format',
+  '-f',
+  '--global',
+  '--ignore-pattern',
+  '--parser',
+  '--parser-options',
+  '--plugin',
+  '--resolve-plugins-relative-to',
+  '--rule',
+]);
 
-for (const entry of readdirSync(packagesDir, { withFileTypes: true }).filter((dirent) => dirent.isDirectory())) {
-  const manifestPath = join(packagesDir, entry.name, 'package.json');
-  if (!existsSync(manifestPath)) continue;
+const normalizePathToken = (token) => token
+  .trim()
+  .replace(/^['"]|['"]$/gu, '')
+  .replace(/\\/gu, '/')
+  .replace(/^\.\//u, '')
+  .replace(/:\d+(?::\d+)?$/u, '');
 
-  const packagePath = `packages/${entry.name}`;
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  const lintScript = manifest.scripts?.lint;
-  const configExists = ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs']
-    .some((configName) => existsSync(join(packagesDir, entry.name, configName)));
-  const documented = docs.includes(`| \`${manifest.name}\` | \`${packagePath}\` |`);
+const lintPathTargets = (lintScript) => {
+  const tokens = lintScript.match(/(?:[^\s'"]+|"[^"]*"|'[^']*')+/gu) ?? [];
+  const targets = [];
+  let seenEslint = false;
+  let skipNext = false;
 
-  if (typeof lintScript !== 'string' || lintScript.trim().length === 0) {
-    failures.push(`${packagePath} (${manifest.name}) is missing scripts.lint`);
+  for (const rawToken of tokens) {
+    const token = normalizePathToken(rawToken);
+
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+
+    if (token === '&&' || token === '||' || token === ';') {
+      seenEslint = false;
+      continue;
+    }
+
+    if (!seenEslint) {
+      seenEslint = token === 'eslint' || token.endsWith('/eslint');
+      continue;
+    }
+
+    if (token.startsWith('-')) {
+      const optionName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+      skipNext = lintOptionNamesWithValues.has(optionName) && !token.includes('=');
+      continue;
+    }
+
+    targets.push(token);
   }
 
-  if (!configExists) {
-    failures.push(`${packagePath} (${manifest.name}) is missing an ESLint config`);
+  return targets;
+};
+
+const pathPrefixBeforeGlob = (target) => {
+  const globIndex = target.search(/[?*[{]/u);
+  if (globIndex === -1) return target;
+
+  const prefix = target.slice(0, globIndex);
+  const lastSlash = prefix.lastIndexOf('/');
+  return lastSlash === -1 ? '' : prefix.slice(0, lastSlash + 1);
+};
+
+const lintTargetCoversTestFile = (target, testFile) => {
+  const normalizedTarget = normalizePathToken(target);
+  if (normalizedTarget === '.' || normalizedTarget === '') return normalizedTarget === '.';
+
+  const prefix = pathPrefixBeforeGlob(normalizedTarget);
+  if (prefix !== normalizedTarget) {
+    return prefix === '' || testFile.startsWith(prefix);
   }
 
-  if (!documented) {
-    failures.push(`${packagePath} (${manifest.name}) is missing from docs/lint-coverage.md`);
+  if (normalizedTarget.endsWith('/')) {
+    return testFile.startsWith(normalizedTarget);
   }
+
+  return testFile === normalizedTarget || testFile.startsWith(`${normalizedTarget}/`);
+};
+
+const lintScriptCoversTestFile = (lintScript, testFile) => (
+  lintPathTargets(lintScript).some((target) => lintTargetCoversTestFile(target, testFile))
+);
+
+const collectTestFiles = (dir, relativeDir = '') => {
+  if (!existsSync(dir)) return [];
+
+  const testFiles = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (ignoredTestSearchDirs.has(entry.name)) continue;
+      testFiles.push(...collectTestFiles(join(dir, entry.name), relativeDir === '' ? entry.name : `${relativeDir}/${entry.name}`));
+      continue;
+    }
+
+    const relativePath = relativeDir === '' ? entry.name : `${relativeDir}/${entry.name}`;
+    if (entry.isFile() && testFilePattern.test(relativePath)) {
+      testFiles.push(relativePath);
+    }
+  }
+
+  return testFiles;
+};
+
+export const collectWorkspaceLintCoverageFailures = (root = defaultRoot) => {
+  const packagesDir = join(root, 'packages');
+  const docsPath = join(root, 'docs', 'lint-coverage.md');
+  const docs = existsSync(docsPath) ? readFileSync(docsPath, 'utf8') : '';
+  const failures = [];
+
+  if (!existsSync(packagesDir) || !statSync(packagesDir).isDirectory()) {
+    failures.push('packages/ directory is missing');
+    return failures;
+  }
+
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true }).filter((dirent) => dirent.isDirectory())) {
+    const packageDir = join(packagesDir, entry.name);
+    const manifestPath = join(packageDir, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+
+    const packagePath = `packages/${entry.name}`;
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const lintScript = manifest.scripts?.lint;
+    const configExists = ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs']
+      .some((configName) => existsSync(join(packageDir, configName)));
+    const documented = docs.includes(`| \`${manifest.name}\` | \`${packagePath}\` |`);
+
+    if (typeof lintScript !== 'string' || lintScript.trim().length === 0) {
+      failures.push(`${packagePath} (${manifest.name}) is missing scripts.lint`);
+    }
+
+    if (!configExists) {
+      failures.push(`${packagePath} (${manifest.name}) is missing an ESLint config`);
+    }
+
+    if (!documented) {
+      failures.push(`${packagePath} (${manifest.name}) is missing from docs/lint-coverage.md`);
+    }
+
+    if (typeof lintScript === 'string' && lintScript.trim().length > 0) {
+      for (const testFile of collectTestFiles(packageDir)) {
+        if (!lintScriptCoversTestFile(lintScript, testFile)) {
+          failures.push(`${packagePath} (${manifest.name}) lint script does not cover test file ${testFile}`);
+        }
+      }
+    }
+  }
+
+  if (!docs.includes('npm run lint')) {
+    failures.push('docs/lint-coverage.md must document the root npm run lint gate');
+  }
+
+  return failures;
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const failures = collectWorkspaceLintCoverageFailures(process.argv[2] ?? defaultRoot);
+
+  if (failures.length > 0) {
+    console.error('Workspace lint coverage is incomplete:');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('Workspace lint coverage is explicit for every package.');
 }
-
-if (!docs.includes('npm run lint')) {
-  failures.push('docs/lint-coverage.md must document the root npm run lint gate');
-}
-
-if (failures.length > 0) {
-  console.error('Workspace lint coverage is incomplete:');
-  for (const failure of failures) {
-    console.error(`- ${failure}`);
-  }
-  process.exit(1);
-}
-
-console.log('Workspace lint coverage is explicit for every package.');

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -541,6 +541,121 @@ describe("Turborepo configuration", () => {
       );
     });
 
+    it("does not count lint targets that only run as OR fallbacks", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "src"), {
+        recursive: true,
+      });
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"));
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint src/ || eslint tests/" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/example.test.ts",
+      );
+    });
+
+    it("matches character-class globs in lint targets", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "src"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint 'src/**/*.[jt]s'" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "src", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "Workspace lint coverage is explicit for every package.",
+      );
+    });
+
+    it("honors no-ignore when ignore patterns are present", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint tests/ --ignore-pattern 'tests/**' --no-ignore" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "Workspace lint coverage is explicit for every package.",
+      );
+    });
+
     it("CI runs the root typecheck Turbo task explicitly", () => {
       const ciWorkflow = readFileSync(
         join(ROOT, ".github/workflows/ci.yml"),

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -235,6 +235,121 @@ describe("Turborepo configuration", () => {
       );
     });
 
+    it("requires lint globs to match nested test files", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests", "unit"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint tests/*.test.ts" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "unit", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/unit/example.test.ts",
+      );
+    });
+
+    it("does not count ESLint targets that are excluded by ignore patterns", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint tests/ --ignore-pattern 'tests/**'" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/example.test.ts",
+      );
+    });
+
+    it("resolves lint targets from the script cwd after cd commands", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "src"), {
+        recursive: true,
+      });
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"));
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "cd src && eslint ." },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/example.test.ts",
+      );
+    });
+
     it("CI runs the root typecheck Turbo task explicitly", () => {
       const ciWorkflow = readFileSync(
         join(ROOT, ".github/workflows/ci.yml"),

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync, existsSync, readdirSync } from "node:fs";
+import {
+  readFileSync,
+  existsSync,
+  readdirSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ROOT, readJson, getWorkspacePackages } from "./helpers/workspaces.js";
 
@@ -185,6 +194,45 @@ describe("Turborepo configuration", () => {
         "utf8",
       );
       expect(ciWorkflow).toContain("run: npm run lint");
+    });
+
+    it("lint coverage check fails when package tests are outside the lint targets", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "src"), {
+        recursive: true,
+      });
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"));
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint src/" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/example.test.ts",
+      );
     });
 
     it("CI runs the root typecheck Turbo task explicitly", () => {

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -350,6 +350,197 @@ describe("Turborepo configuration", () => {
       );
     });
 
+    it("treats bare eslint as package-wide lint coverage", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "Workspace lint coverage is explicit for every package.",
+      );
+    });
+
+    it("rejects pass-on-no-patterns when bare eslint has no lint target", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint --pass-on-no-patterns" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/example.test.ts",
+      );
+    });
+
+    it("matches brace globs in lint targets", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "src"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint 'src/**/*.{ts,tsx}'" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "src", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "Workspace lint coverage is explicit for every package.",
+      );
+    });
+
+    it("scopes ignore patterns to the ESLint invocation that declared them", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint src/ --ignore-pattern 'tests/**' && eslint tests/" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "Workspace lint coverage is explicit for every package.",
+      );
+    });
+
+    it("skips value-taking ESLint option arguments before collecting lint targets", () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "franken-lint-coverage-"));
+      mkdirSync(join(fixtureRoot, "docs"));
+      mkdirSync(join(fixtureRoot, "packages", "example", "src"), {
+        recursive: true,
+      });
+      mkdirSync(join(fixtureRoot, "packages", "example", "tests"));
+      writeFileSync(
+        join(fixtureRoot, "docs", "lint-coverage.md"),
+        "The root gate is `npm run lint`.\n\n| Workspace | Path | Lint posture |\n| --- | --- | --- |\n| `@franken/example` | `packages/example` | fixture |\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "package.json"),
+        JSON.stringify({
+          name: "@franken/example",
+          scripts: { lint: "eslint src/ --cache-location tests/" },
+        }),
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "eslint.config.js"),
+        "export default [];\n",
+      );
+      writeFileSync(
+        join(fixtureRoot, "packages", "example", "tests", "example.test.ts"),
+        "export {};\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "scripts", "check-workspace-lint-coverage.mjs"), fixtureRoot],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/example (@franken/example) lint script does not cover test file tests/example.test.ts",
+      );
+    });
+
     it("CI runs the root typecheck Turbo task explicitly", () => {
       const ciWorkflow = readFileSync(
         join(ROOT, ".github/workflows/ci.yml"),


### PR DESCRIPTION
## Summary
- make @franken/mcp-suite lint script explicitly include colocated test and integration test files
- extend the workspace lint coverage guard to detect existing test files that are outside package lint targets
- add a regression fixture proving the guard fails when tests live outside linted paths

Closes #2032

## Test plan
- node scripts/check-workspace-lint-coverage.mjs
- npx vitest run tests/turborepo.test.ts
- npm run lint --workspace @franken/mcp-suite
- git diff --check