### PR TITLE
test(observer): cover missing audit hash content

### DIFF
--- a/packages/franken-observer/src/audit-event.test.ts
+++ b/packages/franken-observer/src/audit-event.test.ts
@@ -328,6 +328,25 @@ describe('AuditTrail', () => {
     });
   });
 
+  it('verify() reports every missing hashed content entry', () => {
+    const trail = new AuditTrail();
+    const event = createAuditEvent('test', {}, {
+      phase: 'p',
+      provider: 'pr',
+      input: 'hello',
+      output: 'result',
+    });
+    trail.append(event);
+
+    expect(trail.verify(new Map())).toEqual({
+      valid: false,
+      mismatches: [
+        `${event.eventId}: input content missing`,
+        `${event.eventId}: output content missing`,
+      ],
+    });
+  });
+
   it('verify() checks empty string content against hash', () => {
     const trail = new AuditTrail();
     const event = createAuditEvent('test', {}, { phase: 'p', provider: 'pr', input: '' });


### PR DESCRIPTION
## Summary
- Adds regression coverage that `AuditTrail.verify()` reports both missing input and output content when hashes are present.
- Confirms the existing missing-content verification path cannot silently pass when all hashed content is absent.

## Test Plan
- `npm run build --workspace @franken/types`
- `npm run test --workspace @franken/observer -- audit-event.test.ts`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (passes with existing warnings in unrelated observer files)
- `git diff --check`

Closes #2048
