### PR TITLE
fix(orchestrator): align Gemini API key availability

### DIFF
--- a/packages/franken-orchestrator/src/providers/gemini-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-api-adapter.ts
@@ -19,6 +19,20 @@ export interface GeminiApiOptions {
   maxTokens?: number;
 }
 
+function normalizeApiKey(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveGeminiApiKey(options: GeminiApiOptions): string {
+  return (
+    normalizeApiKey(options.apiKey) ??
+    normalizeApiKey(process.env['GOOGLE_API_KEY']) ??
+    normalizeApiKey(process.env['GEMINI_API_KEY']) ??
+    ''
+  );
+}
+
 export class GeminiApiAdapter implements ILlmProvider {
   readonly name = 'gemini-api';
   readonly type: ProviderType = 'gemini-api';
@@ -33,22 +47,15 @@ export class GeminiApiAdapter implements ILlmProvider {
   };
 
   private client: GoogleGenAI;
+  private readonly apiKey: string;
 
   constructor(private options: GeminiApiOptions = {}) {
-    const apiKey =
-      options.apiKey ??
-      process.env['GOOGLE_API_KEY'] ??
-      process.env['GEMINI_API_KEY'] ??
-      '';
-    this.client = new GoogleGenAI({ apiKey });
+    this.apiKey = resolveGeminiApiKey(options);
+    this.client = new GoogleGenAI({ apiKey: this.apiKey });
   }
 
   async isAvailable(): Promise<boolean> {
-    return !!(
-      this.options.apiKey ||
-      process.env['GOOGLE_API_KEY'] ||
-      process.env['GEMINI_API_KEY']
-    );
+    return this.apiKey.length > 0;
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-api-adapter.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import type { BrainSnapshot, LlmMessage, LlmStreamEvent, ToolDefinition } from '@franken/types';
+
+const googleGenAIConstructorOptions = vi.hoisted(() => ({
+  values: [] as Array<{ apiKey?: string }>,
+}));
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: vi.fn(function (this: object, options: { apiKey?: string }) {
+    googleGenAIConstructorOptions.values.push(options);
+    return { models: { generateContentStream: vi.fn() } };
+  }),
+}));
+
 import { GeminiApiAdapter } from '../../../src/providers/gemini-api-adapter.js';
 
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
@@ -9,6 +21,10 @@ async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<L
 }
 
 describe('GeminiApiAdapter', () => {
+  beforeEach(() => {
+    googleGenAIConstructorOptions.values = [];
+  });
+
   describe('properties', () => {
     it('has correct name and type', () => {
       const adapter = new GeminiApiAdapter({ apiKey: 'test-key' });
@@ -43,6 +59,57 @@ describe('GeminiApiAdapter', () => {
       const adapter = new GeminiApiAdapter();
       expect(await adapter.isAvailable()).toBe(true);
       delete process.env['GEMINI_API_KEY'];
+    });
+
+    it('falls back to GOOGLE_API_KEY for blank option keys consistently', async () => {
+      const origG = process.env['GOOGLE_API_KEY'];
+      const origGm = process.env['GEMINI_API_KEY'];
+      process.env['GOOGLE_API_KEY'] = 'gk-env';
+      delete process.env['GEMINI_API_KEY'];
+      try {
+        const adapter = new GeminiApiAdapter({ apiKey: '' });
+        expect(await adapter.isAvailable()).toBe(true);
+        expect(googleGenAIConstructorOptions.values.at(-1)).toEqual({ apiKey: 'gk-env' });
+      } finally {
+        if (origG === undefined) delete process.env['GOOGLE_API_KEY'];
+        else process.env['GOOGLE_API_KEY'] = origG;
+        if (origGm === undefined) delete process.env['GEMINI_API_KEY'];
+        else process.env['GEMINI_API_KEY'] = origGm;
+      }
+    });
+
+    it('falls back to GEMINI_API_KEY for whitespace-only option keys consistently', async () => {
+      const origG = process.env['GOOGLE_API_KEY'];
+      const origGm = process.env['GEMINI_API_KEY'];
+      delete process.env['GOOGLE_API_KEY'];
+      process.env['GEMINI_API_KEY'] = 'gm-env';
+      try {
+        const adapter = new GeminiApiAdapter({ apiKey: '  \t\n  ' });
+        expect(await adapter.isAvailable()).toBe(true);
+        expect(googleGenAIConstructorOptions.values.at(-1)).toEqual({ apiKey: 'gm-env' });
+      } finally {
+        if (origG === undefined) delete process.env['GOOGLE_API_KEY'];
+        else process.env['GOOGLE_API_KEY'] = origG;
+        if (origGm === undefined) delete process.env['GEMINI_API_KEY'];
+        else process.env['GEMINI_API_KEY'] = origGm;
+      }
+    });
+
+    it('returns false for whitespace-only keys when no env fallback is set', async () => {
+      const origG = process.env['GOOGLE_API_KEY'];
+      const origGm = process.env['GEMINI_API_KEY'];
+      delete process.env['GOOGLE_API_KEY'];
+      delete process.env['GEMINI_API_KEY'];
+      try {
+        const adapter = new GeminiApiAdapter({ apiKey: '   ' });
+        expect(await adapter.isAvailable()).toBe(false);
+        expect(googleGenAIConstructorOptions.values.at(-1)).toEqual({ apiKey: '' });
+      } finally {
+        if (origG === undefined) delete process.env['GOOGLE_API_KEY'];
+        else process.env['GOOGLE_API_KEY'] = origG;
+        if (origGm === undefined) delete process.env['GEMINI_API_KEY'];
+        else process.env['GEMINI_API_KEY'] = origGm;
+      }
     });
 
     it('returns false when no API key', async () => {


### PR DESCRIPTION
## Summary
- Centralizes Gemini API key resolution so construction and availability use the same normalized key.
- Treats blank/whitespace option keys as absent, allowing GOOGLE_API_KEY/GEMINI_API_KEY fallback consistently.
- Adds regression coverage for blank and whitespace option-key cases.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/providers/gemini-api-adapter.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/observer && npm run build --workspace @franken/brain && npm run build --workspace @franken/planner && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #2057
