### PR TITLE
fix(observer): enforce webhook target allowlist

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -678,7 +678,7 @@ detector.on('loop-detected', result => {
 
 `send()` throws on non-2xx responses and network errors. For fire-and-forget use inside event handlers, handle rejections with `.catch()` or `void`.
 
-Webhook targets are deny-by-default: configure `allowedTargetOrigins` with the trusted webhook origins that may receive HITL payloads. The configured `url` must resolve to one of those origins before any network request is attempted. Legacy deployments can set `allowUnlistedTarget: true` as an explicit unsafe opt-out while they migrate to an allowlist.
+Webhook targets are deny-by-default: configure `allowedTargetOrigins` with the trusted webhook origins that may receive HITL payloads. The configured `url` must resolve to one of those origins before any network request is attempted, and redirects are not followed automatically so an allowlisted endpoint cannot forward the POST body to an unlisted origin. Legacy deployments can set `allowUnlistedTarget: true` as an explicit unsafe opt-out while they migrate to an allowlist.
 
 ---
 

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -655,6 +655,8 @@ import { WebhookNotifier, CircuitBreaker, LoopDetector } from '@franken/observer
 
 const notifier = new WebhookNotifier({
   url: process.env.SLACK_WEBHOOK_URL!,
+  // Required allowlist: the configured target URL must resolve to one of these origins.
+  allowedTargetOrigins: ['https://hooks.slack.com'],
   // Optional extra headers (auth, custom content-type, etc.)
   headers: { 'X-Source': 'frankenbeast' },
 })
@@ -675,6 +677,8 @@ detector.on('loop-detected', result => {
 ```
 
 `send()` throws on non-2xx responses and network errors. For fire-and-forget use inside event handlers, handle rejections with `.catch()` or `void`.
+
+Webhook targets are deny-by-default: configure `allowedTargetOrigins` with the trusted webhook origins that may receive HITL payloads. The configured `url` must resolve to one of those origins before any network request is attempted. Legacy deployments can set `allowUnlistedTarget: true` as an explicit unsafe opt-out while they migrate to an allowlist.
 
 ---
 

--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.ts
@@ -5,7 +5,7 @@ import { fetchWithRetry, type HttpRetryOptions } from '../../export/httpRetry.js
 
 export type FetchFn = (
   url: string,
-  init?: { method?: string; headers?: Record<string, string>; body?: string },
+  init?: { method?: string; headers?: Record<string, string>; body?: string; redirect?: 'error' | 'follow' | 'manual' },
 ) => Promise<{ ok: boolean; status: number; statusText?: string }>
 
 export interface LangfuseAdapterOptions {

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -8,6 +8,16 @@ describe('WebhookNotifier', () => {
   let mockFetch: ReturnType<typeof vi.fn>
 
   const drainAsync = () => Promise.resolve()
+  const webhookUrl = 'https://hooks.example.com/signal'
+  const allowedTargetOrigins = ['https://hooks.example.com']
+
+  const createNotifier = (options: Partial<ConstructorParameters<typeof WebhookNotifier>[0]> = {}) =>
+    new WebhookNotifier({
+      url: webhookUrl,
+      allowedTargetOrigins,
+      fetch: mockFetch,
+      ...options,
+    })
 
   beforeEach(() => {
     mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' })
@@ -15,28 +25,28 @@ describe('WebhookNotifier', () => {
 
   describe('send()', () => {
     it('POSTs to the configured URL', async () => {
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await notifier.send({ type: 'test' })
       const [url] = mockFetch.mock.calls[0]
       expect(url).toBe('https://hooks.example.com/signal')
     })
 
     it('uses HTTP POST method', async () => {
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await notifier.send({ type: 'test' })
       const [, init] = mockFetch.mock.calls[0]
       expect(init.method).toBe('POST')
     })
 
     it('sends Content-Type: application/json', async () => {
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await notifier.send({ type: 'test' })
       const [, init] = mockFetch.mock.calls[0]
       expect(init.headers['Content-Type']).toBe('application/json')
     })
 
     it('serialises the payload as a JSON body', async () => {
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await notifier.send({ type: 'circuit-breaker', spendUsd: 1.5, limitUsd: 1.0 })
       const [, init] = mockFetch.mock.calls[0]
       const body = JSON.parse(init.body as string)
@@ -44,7 +54,7 @@ describe('WebhookNotifier', () => {
     })
 
     it('merges custom headers with Content-Type', async () => {
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         headers: { 'X-Api-Key': 'test-api-key', Authorization: 'Bearer test-token' },
         fetch: mockFetch,
@@ -57,7 +67,7 @@ describe('WebhookNotifier', () => {
     })
 
     it('custom headers can override Content-Type', async () => {
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         headers: { 'Content-Type': 'application/vnd.custom+json' },
         fetch: mockFetch,
@@ -69,27 +79,58 @@ describe('WebhookNotifier', () => {
 
     it('throws if the HTTP response is not ok', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' })
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow('500')
     })
 
     it('error message includes the status text', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden' })
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow('Forbidden')
     })
 
     it('rethrows if fetch itself rejects (network error)', async () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow('ECONNREFUSED')
     })
 
     it('accepts any JSON-serialisable payload', async () => {
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await notifier.send(['a', 'b', 'c'])
       const [, init] = mockFetch.mock.calls[0]
       expect(JSON.parse(init.body as string)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('requires an explicit target allowlist by default', () => {
+      expect(() => new WebhookNotifier({ url: webhookUrl, fetch: mockFetch })).toThrow(
+        'Webhook target allowlist is required',
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('denies webhook targets outside the configured allowlist before sending', async () => {
+      const notifier = new WebhookNotifier({
+        url: 'https://evil.example.net/signal',
+        allowedTargetOrigins,
+        fetch: mockFetch,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook target origin https://evil.example.net is not allowed',
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('allows explicit unsafe opt-out for legacy deployments', async () => {
+      const notifier = new WebhookNotifier({
+        url: 'https://legacy.example.net/signal',
+        allowUnlistedTarget: true,
+        fetch: mockFetch,
+      })
+
+      await notifier.send({ type: 'test' })
+      expect(mockFetch).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -103,7 +144,7 @@ describe('WebhookNotifier', () => {
         return { ok: true, status: 200, statusText: 'OK' }
       })
 
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       const breaker = new CircuitBreaker({ limitUsd: 1.0 })
 
       breaker.on('limit-reached', result => {
@@ -122,7 +163,7 @@ describe('WebhookNotifier', () => {
     })
 
     it('does not fire when spend is below the limit', async () => {
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       const breaker = new CircuitBreaker({ limitUsd: 5.0 })
       breaker.on('limit-reached', result => {
         void notifier.send({ type: 'circuit-breaker', ...result })
@@ -135,7 +176,7 @@ describe('WebhookNotifier', () => {
 
   describe('retry with exponential backoff', () => {
     it('succeeds without retrying when first attempt is ok', async () => {
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 2 },
@@ -150,7 +191,7 @@ describe('WebhookNotifier', () => {
         .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
         .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 3 },
@@ -163,7 +204,7 @@ describe('WebhookNotifier', () => {
 
     it('throws after exhausting all retries', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 2 },
@@ -176,7 +217,7 @@ describe('WebhookNotifier', () => {
     it('doubles the delay on each retry (exponential backoff)', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 3, baseDelayMs: 100, jitter: false },
@@ -192,7 +233,7 @@ describe('WebhookNotifier', () => {
     it('caps delay at maxDelayMs', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 4, baseDelayMs: 100, maxDelayMs: 250, jitter: false },
@@ -210,7 +251,7 @@ describe('WebhookNotifier', () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
       const randomSpy = vi.spyOn(seededRandom, 'random').mockReturnValue(0.99)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 1, baseDelayMs: 200, maxDelayMs: 200, jitter: true },
@@ -229,7 +270,7 @@ describe('WebhookNotifier', () => {
     it('does not retry non-transient 4xx responses', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 3 },
@@ -247,7 +288,7 @@ describe('WebhookNotifier', () => {
         .mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests' })
         .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 2, jitter: false },
@@ -264,7 +305,7 @@ describe('WebhookNotifier', () => {
       mockFetch
         .mockRejectedValueOnce(new Error('ECONNREFUSED'))
         .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 2 },
@@ -276,7 +317,7 @@ describe('WebhookNotifier', () => {
 
     it('throws the last network error after exhausting retries', async () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 1 },
@@ -287,7 +328,7 @@ describe('WebhookNotifier', () => {
 
     it('is backwards-compatible: no retry option means single attempt', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' })
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow('500')
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
@@ -295,9 +336,7 @@ describe('WebhookNotifier', () => {
     it('rejects negative maxRetries during retry configuration validation', () => {
       expect(
         () =>
-          new WebhookNotifier({
-            url: 'https://hooks.example.com/signal',
-            fetch: mockFetch,
+          createNotifier({
             retry: { maxRetries: -2 },
           }),
       ).toThrow('retry.maxRetries must be a non-negative integer')
@@ -307,9 +346,7 @@ describe('WebhookNotifier', () => {
     it('rejects non-finite maxRetries during retry configuration validation', () => {
       expect(
         () =>
-          new WebhookNotifier({
-            url: 'https://hooks.example.com/signal',
-            fetch: mockFetch,
+          createNotifier({
             retry: { maxRetries: Number.NaN },
           }),
       ).toThrow('retry.maxRetries must be a non-negative integer')
@@ -319,9 +356,7 @@ describe('WebhookNotifier', () => {
     it('rejects fractional maxRetries during retry configuration validation', () => {
       expect(
         () =>
-          new WebhookNotifier({
-            url: 'https://hooks.example.com/signal',
-            fetch: mockFetch,
+          createNotifier({
             retry: { maxRetries: 1.5 },
           }),
       ).toThrow('retry.maxRetries must be a non-negative integer')
@@ -331,7 +366,7 @@ describe('WebhookNotifier', () => {
     it('adds jitter (delay is not exactly baseDelayMs * 2^i)', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)
-      const notifier = new WebhookNotifier({
+      const notifier = createNotifier({
         url: 'https://hooks.example.com/signal',
         fetch: mockFetch,
         retry: { maxRetries: 2, baseDelayMs: 100, jitter: true },
@@ -356,7 +391,7 @@ describe('WebhookNotifier', () => {
         return { ok: true, status: 200, statusText: 'OK' }
       })
 
-      const notifier = new WebhookNotifier({ url: 'https://hooks.example.com/signal', fetch: mockFetch })
+      const notifier = createNotifier()
       const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 2 })
 
       detector.on('loop-detected', result => {

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -38,6 +38,13 @@ describe('WebhookNotifier', () => {
       expect(init.method).toBe('POST')
     })
 
+    it('does not follow redirects automatically', async () => {
+      const notifier = createNotifier()
+      await notifier.send({ type: 'test' })
+      const [, init] = mockFetch.mock.calls[0]
+      expect(init.redirect).toBe('manual')
+    })
+
     it('sends Content-Type: application/json', async () => {
       const notifier = createNotifier()
       await notifier.send({ type: 'test' })

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -19,6 +19,17 @@ export interface WebhookNotifierOptions {
   /** URL to POST the JSON payload to. */
   url: string
   /**
+   * Explicit allowlist of webhook target origins. Defaults to deny-by-default:
+   * callers must either include the configured URL's origin here or set
+   * `allowUnlistedTarget: true` for a deliberate legacy/unsafe opt-out.
+   */
+  allowedTargetOrigins?: readonly string[]
+  /**
+   * Explicit unsafe opt-out for legacy deployments that cannot provide an
+   * allowlist yet. Prefer `allowedTargetOrigins` for normal operation.
+   */
+  allowUnlistedTarget?: boolean
+  /**
    * Additional HTTP headers merged on every request.
    * Content-Type is set to application/json by default and can be
    * overridden here.
@@ -54,6 +65,7 @@ export interface WebhookNotifierOptions {
  * ```ts
  * const notifier = new WebhookNotifier({
  *   url: 'https://hooks.example.com/signal',
+ *   allowedTargetOrigins: ['https://hooks.example.com'],
  *   retry: { maxRetries: 3, baseDelayMs: 200, maxDelayMs: 5000 },
  * })
  * ```
@@ -69,8 +81,27 @@ function validateNonNegativeInteger(value: number, fieldName: string): number {
   return value
 }
 
+function parseUrlOrigin(value: string, fieldName: string): string {
+  try {
+    return new URL(value).origin
+  } catch {
+    throw new TypeError(`${fieldName} must be an absolute URL`)
+  }
+}
+
+function normalizeAllowedTargetOrigins(origins: readonly string[] | undefined): ReadonlySet<string> | null {
+  if (!origins || origins.length === 0) {
+    return null
+  }
+
+  return new Set(origins.map(origin => parseUrlOrigin(origin, 'allowedTargetOrigins entry')))
+}
+
 export class WebhookNotifier {
   private readonly url: string
+  private readonly targetOrigin: string
+  private readonly allowedTargetOrigins: ReadonlySet<string> | null
+  private readonly allowUnlistedTarget: boolean
   private readonly extraHeaders: Record<string, string>
   private readonly fetchFn: FetchFn
   private readonly retry: Required<WebhookRetryOptions> | null
@@ -78,6 +109,14 @@ export class WebhookNotifier {
 
   constructor(options: WebhookNotifierOptions) {
     this.url = options.url
+    this.targetOrigin = parseUrlOrigin(options.url, 'url')
+    this.allowedTargetOrigins = normalizeAllowedTargetOrigins(options.allowedTargetOrigins)
+    this.allowUnlistedTarget = options.allowUnlistedTarget ?? false
+    if (!this.allowUnlistedTarget && this.allowedTargetOrigins === null) {
+      throw new Error(
+        'Webhook target allowlist is required; set allowedTargetOrigins or explicitly opt out with allowUnlistedTarget: true',
+      )
+    }
     this.extraHeaders = options.headers ?? {}
     this.fetchFn = options.fetch ?? (globalThis.fetch as unknown as FetchFn)
     this.sleepFn = options.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)))
@@ -92,6 +131,8 @@ export class WebhookNotifier {
   }
 
   async send(payload: unknown): Promise<void> {
+    this.assertTargetAllowed()
+
     const maxAttempts = this.retry ? 1 + this.retry.maxRetries : 1
     let lastError: unknown
 
@@ -133,5 +174,14 @@ export class WebhookNotifier {
     }
 
     throw lastError
+  }
+
+  private assertTargetAllowed(): void {
+    if (this.allowUnlistedTarget) {
+      return
+    }
+    if (!this.allowedTargetOrigins?.has(this.targetOrigin)) {
+      throw new Error(`Webhook target origin ${this.targetOrigin} is not allowed`)
+    }
   }
 }

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -150,6 +150,7 @@ export class WebhookNotifier {
       try {
         response = await this.fetchFn(this.url, {
           method: 'POST',
+          redirect: 'manual',
           headers: {
             'Content-Type': 'application/json',
             ...this.extraHeaders,


### PR DESCRIPTION
## Summary
- Adds deny-by-default webhook target allowlist enforcement to WebhookNotifier.
- Adds explicit allowUnlistedTarget opt-out for legacy deployments.
- Documents allowedTargetOrigins operator guidance.

## Verification
- npm ci
- npm run build --workspace @franken/types
- npm test -- --run src/notify/WebhookNotifier.test.ts (from packages/franken-observer)
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer (passes with pre-existing warnings)

Closes #1781