### PR TITLE
test(mcp-suite): document tamper-evident audit chaining

### DIFF
--- a/docs/walkthrough-mcp-suite.md
+++ b/docs/walkthrough-mcp-suite.md
@@ -348,3 +348,12 @@ All MCP servers, hooks, and beast runs share `.fbeast/beast.db` (WAL mode,
 | `beast_runs` | `SQLiteBeastRepository` (beast mode) |
 | `beast_run_attempts` | `SQLiteBeastRepository` |
 | `beast_run_events` | `SQLiteBeastRepository` |
+
+The observer's `audit_trail` rows are tamper-evident. Each row stores a full
+SHA-256 hash over the session id, event type, exact stored payload, and previous
+row hash; `parent_hash` therefore forms a per-session chain. SQLite triggers
+reject direct `UPDATE`/`DELETE` attempts by default, and only the observer's
+internal legacy migration path temporarily unlocks rows while `verify` rewrites
+old hash formats. Operators should run `fbeast_observer_verify` before relying
+on a trail; failures identify the first invalid row index without printing the
+row payload.

--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -158,6 +158,21 @@ default central trail from the shared database with:
 fbeast_observer_trail({ sessionId: 'fbeast-central-dispatch' })
 ```
 
+### Tamper-evident audit chain
+
+`fbeast_observer_log` stores each audit row with a SHA-256 hash that binds the
+session id, event type, exact stored payload bytes, and the previous row's hash.
+The `audit_trail` table is append-only by default: direct `UPDATE` and `DELETE`
+statements are rejected by SQLite triggers, and the only code path that unlocks
+mutation is the internal legacy-hash migration used by `fbeast_observer_verify`.
+There is no operator flag to rewrite history; if a row is corrupted, append a
+new explanatory event and keep the broken row for forensics.
+
+Use `fbeast_observer_verify({ sessionId })` before relying on a trail. A clean
+result means every row in that session still matches the hash chain. A failure
+reports the first invalid index so operators can inspect that row without dumping
+sensitive payloads into logs or issue comments.
+
 ## Combined server
 
 `fbeast-mcp` runs all 21 tools in a single MCP server process.

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { createSqliteStore, type SqliteStore } from './sqlite-store.js';
+import { createSqliteStore } from './sqlite-store.js';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -36,16 +36,16 @@ describe('SqliteStore', () => {
 
     const tables = store.db
       .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-      .all()
-      .map((r: any) => r.name);
+      .all() as Array<{ name: string }>;
+    const tableNames = tables.map((row) => row.name);
 
-    expect(tables).toContain('memory');
-    expect(tables).toContain('plans');
-    expect(tables).toContain('audit_trail');
-    expect(tables).toContain('cost_ledger');
-    expect(tables).toContain('governor_log');
-    expect(tables).toContain('firewall_log');
-    expect(tables).not.toContain('skill_state');
+    expect(tableNames).toContain('memory');
+    expect(tableNames).toContain('plans');
+    expect(tableNames).toContain('audit_trail');
+    expect(tableNames).toContain('cost_ledger');
+    expect(tableNames).toContain('governor_log');
+    expect(tableNames).toContain('firewall_log');
+    expect(tableNames).not.toContain('skill_state');
 
     const costColumns = store.db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
     expect(costColumns.map((column) => column.name)).toContain('cost_source');
@@ -128,5 +128,32 @@ describe('SqliteStore', () => {
     });
 
     store.close();
+  });
+
+  it('keeps audit_trail append-only for independent sqlite connections', () => {
+    const dbPath = tracked(tmpDbPath());
+    const store = createSqliteStore(dbPath);
+
+    store.db
+      .prepare('INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash) VALUES (?, ?, ?, ?, ?)')
+      .run('session-external', 'tool_call', 'payload', 'sha256:0', null);
+    store.close();
+
+    const db = new Database(dbPath);
+    try {
+      expect(() => {
+        db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ?').run('tampered', 'session-external');
+      }).toThrowError(/append-only|fbeast_can_mutate_audit_trail/i);
+
+      expect(() => {
+        db.prepare('DELETE FROM audit_trail WHERE session_id = ?').run('session-external');
+      }).toThrowError(/append-only|fbeast_can_mutate_audit_trail/i);
+
+      expect(db.prepare('SELECT payload FROM audit_trail WHERE session_id = ?').get('session-external')).toMatchObject({
+        payload: 'payload',
+      });
+    } finally {
+      db.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- documents the tamper-evident audit log chain for MCP observer operators
- adds coverage that independent SQLite connections cannot update or delete `audit_trail` rows
- clarifies that verification reports the first invalid row without dumping sensitive payloads

## Test Plan
- `npm ci`
- `npm run test --workspace @franken/mcp-suite -- --run src/shared/sqlite-store.test.ts src/adapters/observer-adapter.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run build --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite` (passes with existing warnings outside this change)

Closes #1782
