### PR TITLE
fix(security): deny cross-profile state access by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,8 @@ Execution controls such as `--budget`, `--provider`, `--providers`, and `--no-pr
 
 Numeric env values are parsed as numbers and then validated with the same schema as JSON config files. Unset numeric variables leave the lower-priority source in effect. Boolean env overrides apply whenever the variable is present; set the value to `true` to enable the field, and any other present value disables it.
 
+If `stateDir` is set to a path inside a sibling Hermes profile such as `.hermes/profiles/<profile>/...`, Frankenbeast fails closed by default when `<profile>` does not match the active `HERMES_PROFILE` (or `default` when unset). Set `allowCrossProfileStateAccess: true` in an operator-owned config file only for deliberate migrations/imports that must read or write another profile's state.
+
 ### Operator environment variables
 
 Set `FRANKENBEAST_PLAIN_BANNER=1` to force the CLI startup banner to use the plain ASCII fallback instead of the image-rendered graphic banner. This is useful for CI logs, terminals with limited image rendering support, and log processors that should receive a text-only banner layout. The fallback banner may still include ANSI color codes; leave the variable unset, or set it to any value other than `1`, to keep the normal graphic banner path.

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Execution controls such as `--budget`, `--provider`, `--providers`, and `--no-pr
 
 Numeric env values are parsed as numbers and then validated with the same schema as JSON config files. Unset numeric variables leave the lower-priority source in effect. Boolean env overrides apply whenever the variable is present; set the value to `true` to enable the field, and any other present value disables it.
 
-If `stateDir` is set to a path inside a sibling Hermes profile such as `.hermes/profiles/<profile>/...`, Frankenbeast fails closed by default when `<profile>` does not match the active `HERMES_PROFILE` (or `default` when unset). Set `allowCrossProfileStateAccess: true` in an operator-owned config file only for deliberate migrations/imports that must read or write another profile's state.
+If `stateDir` is set to a path inside a sibling Hermes profile such as `.hermes/profiles/<profile>/...`, Frankenbeast fails closed by default when `<profile>` does not match the active `HERMES_PROFILE` (or `default` when unset). Set `allowCrossProfileStateAccess: true` in an operator-owned config file outside the checked-out repository only for deliberate migrations/imports that must read or write another profile's state; repository-local `.fbeast/config.json` cannot self-approve this opt-in.
 
 ### Operator environment variables
 

--- a/frankenbeast.config.example.json
+++ b/frankenbeast.config.example.json
@@ -4,5 +4,6 @@
   "maxDurationMs": 300000,
   "enableHeartbeat": false,
   "enableTracing": false,
-  "minCritiqueScore": 0.7
+  "minCritiqueScore": 0.7,
+  "allowCrossProfileStateAccess": false
 }

--- a/frankenbeast.example.json
+++ b/frankenbeast.example.json
@@ -5,6 +5,7 @@
   "enableHeartbeat": false,
   "enableTracing": false,
   "minCritiqueScore": 0.7,
+  "allowCrossProfileStateAccess": false,
 
   "providers": {
     "default": "claude",

--- a/packages/franken-orchestrator/src/beast-loop.ts
+++ b/packages/franken-orchestrator/src/beast-loop.ts
@@ -1,7 +1,7 @@
 import type { BeastLoopDeps } from './deps.js';
 import type { BeastInput, BeastResult } from './types.js';
 import type { OrchestratorConfig } from './config/orchestrator-config.js';
-import { defaultConfig } from './config/orchestrator-config.js';
+import { defaultConfig, validateCrossProfileStateDir } from './config/orchestrator-config.js';
 import { createContext } from './context/context-factory.js';
 import { runIngestion, InjectionDetectedError } from './phases/ingestion.js';
 import { runHydration } from './phases/hydration.js';
@@ -33,6 +33,10 @@ export class BeastLoop {
   constructor(deps: BeastLoopDeps, config?: Partial<OrchestratorConfig>) {
     this.deps = deps;
     this.config = { ...defaultConfig(), ...config };
+    const stateDirIssue = validateCrossProfileStateDir(this.config);
+    if (stateDirIssue) {
+      throw new Error(stateDirIssue);
+    }
   }
 
   async run(input: BeastInput): Promise<BeastResult> {

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -148,6 +148,8 @@ function stripRepositoryLocalCommandTrust(fileConfig: Partial<OrchestratorConfig
   const sanitized = JSON.parse(JSON.stringify(fileConfig)) as Partial<OrchestratorConfig>;
   const root = sanitized as Record<string, unknown>;
 
+  delete root['allowCrossProfileStateAccess'];
+
   const providers = root['providers'];
   if (isRecord(providers) && isRecord(providers['overrides'])) {
     for (const override of Object.values(providers['overrides'])) {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -44,7 +44,7 @@ import { NetworkLogStore } from '../network/network-logs.js';
 import { NetworkSupervisor } from '../network/network-supervisor.js';
 import { renderNetworkHelp } from '../network/network-help.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
-import { defaultConfig, parseOrchestratorConfig } from '../config/orchestrator-config.js';
+import { defaultConfig, parseOrchestratorConfig, validateCrossProfileStateDir } from '../config/orchestrator-config.js';
 import { resolveManagedChatAttachment, runManagedChatRepl } from '../network/chat-attach.js';
 import {
   healthcheckNetworkService,
@@ -152,6 +152,23 @@ export function shouldShowMissingRunPlanGuidance(
     && !args.planDir
     && !args.planName
     && planNeedsGuidance;
+}
+
+export function validateStateDirBeforeScaffold(
+  config: OrchestratorConfig,
+  paths: Pick<ReturnType<typeof getProjectPaths>, 'stateDir'>,
+): void {
+  const configuredStateDir = config.stateDir;
+  const stateDir = configuredStateDir ?? paths.stateDir;
+  const issue = validateCrossProfileStateDir({
+    stateDir,
+    allowCrossProfileStateAccess: configuredStateDir
+      ? config.allowCrossProfileStateAccess
+      : false,
+  });
+  if (issue) {
+    throw new Error(issue);
+  }
 }
 
 export interface ResumeTarget {
@@ -985,6 +1002,7 @@ export async function main(): Promise<void> {
     return;
   }
 
+  validateStateDirBeforeScaffold(config, paths);
   scaffoldFrankenbeast(paths);
 
   if (args.subcommand === 'beasts-daemon') {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -159,7 +159,7 @@ export function validateStateDirBeforeScaffold(
   paths: Pick<ReturnType<typeof getProjectPaths>, 'stateDir'>,
 ): void {
   const configuredStateDir = config.stateDir;
-  const stateDir = configuredStateDir ?? paths.stateDir;
+  const stateDir = resolveScaffoldStateDir(config, paths);
   const issue = validateCrossProfileStateDir({
     stateDir,
     allowCrossProfileStateAccess: configuredStateDir
@@ -169,6 +169,13 @@ export function validateStateDirBeforeScaffold(
   if (issue) {
     throw new Error(issue);
   }
+}
+
+export function resolveScaffoldStateDir(
+  config: OrchestratorConfig,
+  paths: Pick<ReturnType<typeof getProjectPaths>, 'stateDir'>,
+): string {
+  return config.stateDir ?? paths.stateDir;
 }
 
 export interface ResumeTarget {
@@ -1002,8 +1009,9 @@ export async function main(): Promise<void> {
     return;
   }
 
-  validateStateDirBeforeScaffold(config, paths);
-  scaffoldFrankenbeast(paths);
+  const scaffoldPaths = { ...paths, stateDir: resolveScaffoldStateDir(config, paths) };
+  validateStateDirBeforeScaffold(config, scaffoldPaths);
+  scaffoldFrankenbeast(scaffoldPaths);
 
   if (args.subcommand === 'beasts-daemon') {
     await runBeastDaemonCommand(args, config, root, paths);

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -493,10 +493,14 @@ export class Session {
     if (this.config.maxTotalTokens !== undefined) {
       loopConfig.maxTotalTokens = this.config.maxTotalTokens;
     }
-    if (this.config.orchestratorConfig?.allowCrossProfileStateAccess !== undefined) {
+    const configuredStateDir = this.config.orchestratorConfig?.stateDir;
+    if (
+      configuredStateDir !== undefined &&
+      this.config.orchestratorConfig?.allowCrossProfileStateAccess !== undefined
+    ) {
       loopConfig.allowCrossProfileStateAccess = this.config.orchestratorConfig.allowCrossProfileStateAccess;
     }
-    loopConfig.stateDir = this.config.orchestratorConfig?.stateDir ?? paths.stateDir;
+    loopConfig.stateDir = configuredStateDir ?? paths.stateDir;
 
     try {
       const promptConfig = loadPromptConfigFromEnv();

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -493,6 +493,9 @@ export class Session {
     if (this.config.maxTotalTokens !== undefined) {
       loopConfig.maxTotalTokens = this.config.maxTotalTokens;
     }
+    if (this.config.orchestratorConfig?.allowCrossProfileStateAccess !== undefined) {
+      loopConfig.allowCrossProfileStateAccess = this.config.orchestratorConfig.allowCrossProfileStateAccess;
+    }
     loopConfig.stateDir = this.config.orchestratorConfig?.stateDir ?? paths.stateDir;
 
     try {

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs';
-import { resolve, sep } from 'node:path';
+import { basename, dirname, join, resolve, sep } from 'node:path';
 import { z } from 'zod';
 import { NetworkConfigFieldsSchema, validateNetworkConfig } from '../network/network-config.js';
 import { validateProviderCommandOverride } from './provider-command-override-policy.js';
@@ -102,7 +102,27 @@ function resolvedPathCandidates(path: string): string[] {
     const real = realpathSync(lexical);
     return real === lexical ? [lexical] : [real, lexical];
   } catch {
-    return [lexical];
+    const ancestorResolved = resolveExistingAncestor(lexical);
+    return ancestorResolved && ancestorResolved !== lexical ? [ancestorResolved, lexical] : [lexical];
+  }
+}
+
+function resolveExistingAncestor(lexical: string): string | undefined {
+  const missingParts: string[] = [];
+  let current = lexical;
+
+  while (true) {
+    try {
+      const resolved = realpathSync(current);
+      return missingParts.length > 0 ? join(resolved, ...missingParts.reverse()) : resolved;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) {
+        return undefined;
+      }
+      missingParts.push(basename(current));
+      current = parent;
+    }
   }
 }
 

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -1,3 +1,4 @@
+import { resolve, sep } from 'node:path';
 import { z } from 'zod';
 import { NetworkConfigFieldsSchema, validateNetworkConfig } from '../network/network-config.js';
 import { validateProviderCommandOverride } from './provider-command-override-policy.js';
@@ -94,6 +95,21 @@ export const ProvidersConfigSchema = createProvidersConfigSchema();
 const MIN_TOTAL_TOKEN_BUDGET = 10_000;
 const MIN_DURATION_MS_PER_CRITIQUE_ITERATION = 10_000;
 
+function hermesProfileFromPath(path: string): string | undefined {
+  const parts = resolve(path).split(sep);
+  for (let index = 0; index < parts.length - 2; index += 1) {
+    if (parts[index] === '.hermes' && parts[index + 1] === 'profiles') {
+      return parts[index + 2];
+    }
+  }
+  return undefined;
+}
+
+function activeHermesProfile(): string {
+  const profile = process.env.HERMES_PROFILE?.trim();
+  return profile && profile.length > 0 ? profile : 'default';
+}
+
 const BaseOrchestratorConfigSchema = z.object({
   /** Maximum plan-critique iterations before escalation. */
   maxCritiqueIterations: z.number().int().min(1).max(10).default(3),
@@ -140,6 +156,9 @@ const BaseOrchestratorConfigSchema = z.object({
   /** Directory for durable Beast phase state snapshots. */
   stateDir: z.string().optional(),
 
+  /** Whether stateDir may deliberately point at another Hermes profile. Defaults denied. */
+  allowCrossProfileStateAccess: z.boolean().default(false),
+
   /** Consolidation: typed provider list for ProviderRegistry. */
   consolidatedProviders: z.array(ProviderConfigSchema).optional(),
 });
@@ -151,6 +170,22 @@ function createOrchestratorConfigSchema(options: OrchestratorConfigParseOptions 
     NetworkConfigFieldsSchema.shape,
   ).superRefine((config, ctx) => {
     validateNetworkConfig(config, ctx);
+
+    const targetProfile = config.stateDir ? hermesProfileFromPath(config.stateDir) : undefined;
+    const currentProfile = activeHermesProfile();
+    if (
+      targetProfile !== undefined &&
+      targetProfile !== currentProfile &&
+      !config.allowCrossProfileStateAccess
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['stateDir'],
+        message:
+          `stateDir points at Hermes profile '${targetProfile}' while the active profile is '${currentProfile}'. ` +
+          'Cross-profile state access is denied by default; set allowCrossProfileStateAccess: true only for deliberate migrations or imports.',
+      });
+    }
 
     config.consolidatedProviders?.forEach((provider, index) => {
       if (!provider.type.endsWith('-cli') || !provider.cliPath) return;

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import { z } from 'zod';
 import { NetworkConfigFieldsSchema, validateNetworkConfig } from '../network/network-config.js';
@@ -95,8 +96,18 @@ export const ProvidersConfigSchema = createProvidersConfigSchema();
 const MIN_TOTAL_TOKEN_BUDGET = 10_000;
 const MIN_DURATION_MS_PER_CRITIQUE_ITERATION = 10_000;
 
-function hermesProfileFromPath(path: string): string | undefined {
-  const parts = resolve(path).split(sep);
+function resolvedPathCandidates(path: string): string[] {
+  const lexical = resolve(path);
+  try {
+    const real = realpathSync(lexical);
+    return real === lexical ? [lexical] : [real, lexical];
+  } catch {
+    return [lexical];
+  }
+}
+
+function hermesProfileFromResolvedPath(path: string): string | undefined {
+  const parts = path.split(sep);
   for (let index = 0; index < parts.length - 2; index += 1) {
     if (parts[index] === '.hermes' && parts[index + 1] === 'profiles') {
       return parts[index + 2];
@@ -105,9 +116,36 @@ function hermesProfileFromPath(path: string): string | undefined {
   return undefined;
 }
 
+function hermesProfileFromPath(path: string): string | undefined {
+  for (const candidate of resolvedPathCandidates(path)) {
+    const profile = hermesProfileFromResolvedPath(candidate);
+    if (profile !== undefined) {
+      return profile;
+    }
+  }
+  return undefined;
+}
+
 function activeHermesProfile(): string {
   const profile = process.env.HERMES_PROFILE?.trim();
   return profile && profile.length > 0 ? profile : 'default';
+}
+
+export function validateCrossProfileStateDir(config: {
+  readonly stateDir?: string | undefined;
+  readonly allowCrossProfileStateAccess?: boolean | undefined;
+}): string | undefined {
+  const targetProfile = config.stateDir ? hermesProfileFromPath(config.stateDir) : undefined;
+  const currentProfile = activeHermesProfile();
+  if (
+    targetProfile !== undefined &&
+    targetProfile !== currentProfile &&
+    !config.allowCrossProfileStateAccess
+  ) {
+    return `stateDir points at Hermes profile '${targetProfile}' while the active profile is '${currentProfile}'. ` +
+      'Cross-profile state access is denied by default; set allowCrossProfileStateAccess: true only for deliberate migrations or imports.';
+  }
+  return undefined;
 }
 
 const BaseOrchestratorConfigSchema = z.object({
@@ -171,19 +209,12 @@ function createOrchestratorConfigSchema(options: OrchestratorConfigParseOptions 
   ).superRefine((config, ctx) => {
     validateNetworkConfig(config, ctx);
 
-    const targetProfile = config.stateDir ? hermesProfileFromPath(config.stateDir) : undefined;
-    const currentProfile = activeHermesProfile();
-    if (
-      targetProfile !== undefined &&
-      targetProfile !== currentProfile &&
-      !config.allowCrossProfileStateAccess
-    ) {
+    const stateDirIssue = validateCrossProfileStateDir(config);
+    if (stateDirIssue) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['stateDir'],
-        message:
-          `stateDir points at Hermes profile '${targetProfile}' while the active profile is '${currentProfile}'. ` +
-          'Cross-profile state access is denied by default; set allowCrossProfileStateAccess: true only for deliberate migrations or imports.',
+        message: stateDirIssue,
       });
     }
 

--- a/packages/franken-orchestrator/test/cli/config-loading.test.ts
+++ b/packages/franken-orchestrator/test/cli/config-loading.test.ts
@@ -151,6 +151,19 @@ describe('Config file loading', () => {
     )).rejects.toThrow(/repo-configured command override/);
   });
 
+  it('ignores repository-local cross-profile state access opt-ins', async () => {
+    const defaultConfigPath = join(tmpDir, '.fbeast', 'config.json');
+    mkdirSync(join(tmpDir, '.fbeast'), { recursive: true });
+    writeFileSync(defaultConfigPath, JSON.stringify({
+      allowCrossProfileStateAccess: true,
+      maxDurationMs: 60000,
+    }));
+
+    const config = await loadConfig(baseArgs({ config: defaultConfigPath }), defaultConfigPath);
+
+    expect(config.allowCrossProfileStateAccess).toBe(false);
+  });
+
   it('treats symlink aliases to repository config as repo-local for provider command trust', async () => {
     const defaultConfigPath = join(tmpDir, '.fbeast', 'config.json');
     const aliasedConfigPath = join(tmpDir, '.fbeast', 'trusted.json');
@@ -197,6 +210,19 @@ describe('Config file loading', () => {
     );
 
     expect(config.providers.overrides['claude']?.command).toBe('/tmp/operator-controlled/claude-wrapper');
+  });
+
+  it('allows explicit operator-owned configs outside the repository to opt into cross-profile state access', async () => {
+    const defaultConfigPath = join(tmpDir, 'repo', '.fbeast', 'config.json');
+    const configPath = join(tmpDir, 'operator-config.json');
+    writeFileSync(configPath, JSON.stringify({
+      allowCrossProfileStateAccess: true,
+      maxDurationMs: 60000,
+    }));
+
+    const config = await loadConfig(baseArgs({ config: configPath }), defaultConfigPath);
+
+    expect(config.allowCrossProfileStateAccess).toBe(true);
   });
 
   it('does not derive a repository boundary from non-standard default config paths', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -246,7 +246,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, buildDashboardProviderSnapshot, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, validateStateDirBeforeScaffold, runNetworkCommand } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, buildDashboardProviderSnapshot, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, validateStateDirBeforeScaffold, resolveScaffoldStateDir, runNetworkCommand } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths, readActivePlanName, writeActivePlanName } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -856,6 +856,16 @@ describe('validateStateDirBeforeScaffold', () => {
       stateDir,
       allowCrossProfileStateAccess: true,
     }, { stateDir: join(tmpdir(), 'unused-default-state') })).not.toThrow();
+  });
+
+  it('scaffolds the configured stateDir instead of the repo default when present', () => {
+    const defaultStateDir = symlinkedCrossProfileState();
+    const configuredStateDir = join(tmpdir(), 'operator-state-dir');
+
+    expect(resolveScaffoldStateDir({
+      ...defaultConfig(),
+      stateDir: configuredStateDir,
+    }, { stateDir: defaultStateDir })).toBe(configuredStateDir);
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -246,10 +246,11 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, buildDashboardProviderSnapshot, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, runNetworkCommand } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, buildDashboardProviderSnapshot, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, validateStateDirBeforeScaffold, runNetworkCommand } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths, readActivePlanName, writeActivePlanName } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
+import { defaultConfig } from '../../../src/config/orchestrator-config.js';
 import { createInterface } from 'node:readline';
 
 // ── Tests ──
@@ -807,6 +808,54 @@ describe('runDirectCli', () => {
     expect(exit).toHaveBeenCalledWith(1);
     expect(errorSpy).toHaveBeenCalledWith('Fatal:', 'boom');
     errorSpy.mockRestore();
+  });
+});
+
+describe('validateStateDirBeforeScaffold', () => {
+  const priorProfile = process.env.HERMES_PROFILE;
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    if (priorProfile === undefined) {
+      delete process.env.HERMES_PROFILE;
+    } else {
+      process.env.HERMES_PROFILE = priorProfile;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function symlinkedCrossProfileState(): string {
+    const root = join(tmpdir(), `franken-pre-scaffold-state-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    tempDirs.push(root);
+    const target = join(root, '.hermes', 'profiles', 'prod');
+    const link = join(root, 'repo', '.fbeast', 'state-link');
+    mkdirSync(target, { recursive: true });
+    mkdirSync(join(root, 'repo', '.fbeast'), { recursive: true });
+    symlinkSync(target, link, 'dir');
+    return join(link, 'state');
+  }
+
+  it('does not let an opt-in without configured stateDir approve the repo default stateDir', () => {
+    process.env.HERMES_PROFILE = 'default';
+    const stateDir = symlinkedCrossProfileState();
+
+    expect(() => validateStateDirBeforeScaffold({
+      ...defaultConfig(),
+      allowCrossProfileStateAccess: true,
+    }, { stateDir })).toThrow("Hermes profile 'prod'");
+  });
+
+  it('allows an operator opt-in only for the stateDir supplied by the same config', () => {
+    process.env.HERMES_PROFILE = 'default';
+    const stateDir = symlinkedCrossProfileState();
+
+    expect(() => validateStateDirBeforeScaffold({
+      ...defaultConfig(),
+      stateDir,
+      allowCrossProfileStateAccess: true,
+    }, { stateDir: join(tmpdir(), 'unused-default-state') })).not.toThrow();
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -75,6 +75,28 @@ describe('OrchestratorConfig', () => {
         expect(result.error.issues[0]?.message).toContain("Hermes profile 'prod'");
       }
     });
+
+    it('rejects stateDir children under symlinked ancestors that resolve into another profile', () => {
+      process.env.HERMES_PROFILE = 'default';
+      const root = join(
+        tmpdir(),
+        `franken-state-symlink-child-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      tmpDirs.push(root);
+      const target = join(root, '.hermes', 'profiles', 'prod');
+      const link = join(root, 'repo', '.fbeast', 'state-link');
+      mkdirSync(target, { recursive: true });
+      mkdirSync(join(root, 'repo', '.fbeast'), { recursive: true });
+      symlinkSync(target, link, 'dir');
+
+      const result = OrchestratorConfigSchema.safeParse({ stateDir: join(link, 'state') });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path).toEqual(['stateDir']);
+        expect(result.error.issues[0]?.message).toContain("Hermes profile 'prod'");
+      }
+    });
   });
 
   describe('validation', () => {

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
 import { OrchestratorConfigSchema, defaultConfig } from '../../../src/config/orchestrator-config.js';
 
 describe('OrchestratorConfig', () => {
@@ -11,6 +12,43 @@ describe('OrchestratorConfig', () => {
       expect(config.enableHeartbeat).toBe(false);
       expect(config.enableTracing).toBe(false);
       expect(config.minCritiqueScore).toBe(0.7);
+      expect(config.allowCrossProfileStateAccess).toBe(false);
+    });
+  });
+
+  describe('cross-profile state access', () => {
+    const priorProfile = process.env.HERMES_PROFILE;
+
+    afterEach(() => {
+      if (priorProfile === undefined) {
+        delete process.env.HERMES_PROFILE;
+      } else {
+        process.env.HERMES_PROFILE = priorProfile;
+      }
+    });
+
+    it('rejects stateDir values that target another Hermes profile by default', () => {
+      process.env.HERMES_PROFILE = 'default';
+      const result = OrchestratorConfigSchema.safeParse({
+        stateDir: join('/srv/hermes', '.hermes', 'profiles', 'prod', 'state'),
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path).toEqual(['stateDir']);
+        expect(result.error.issues[0]?.message).toContain('Cross-profile state access is denied by default');
+      }
+    });
+
+    it('allows explicit cross-profile state access only when the operator opts in', () => {
+      process.env.HERMES_PROFILE = 'default';
+      const result = OrchestratorConfigSchema.parse({
+        stateDir: join('/srv/hermes', '.hermes', 'profiles', 'prod', 'state'),
+        allowCrossProfileStateAccess: true,
+      });
+
+      expect(result.stateDir).toContain(join('.hermes', 'profiles', 'prod', 'state'));
+      expect(result.allowCrossProfileStateAccess).toBe(true);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, afterEach } from 'vitest';
 import { OrchestratorConfigSchema, defaultConfig } from '../../../src/config/orchestrator-config.js';
@@ -18,12 +20,16 @@ describe('OrchestratorConfig', () => {
 
   describe('cross-profile state access', () => {
     const priorProfile = process.env.HERMES_PROFILE;
+    const tmpDirs: string[] = [];
 
     afterEach(() => {
       if (priorProfile === undefined) {
         delete process.env.HERMES_PROFILE;
       } else {
         process.env.HERMES_PROFILE = priorProfile;
+      }
+      for (const dir of tmpDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
       }
     });
 
@@ -49,6 +55,25 @@ describe('OrchestratorConfig', () => {
 
       expect(result.stateDir).toContain(join('.hermes', 'profiles', 'prod', 'state'));
       expect(result.allowCrossProfileStateAccess).toBe(true);
+    });
+
+    it('rejects symlinked stateDir values that resolve into another Hermes profile', () => {
+      process.env.HERMES_PROFILE = 'default';
+      const root = join(tmpdir(), `franken-state-symlink-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      tmpDirs.push(root);
+      const target = join(root, '.hermes', 'profiles', 'prod', 'state');
+      const link = join(root, 'repo', '.fbeast', 'state');
+      mkdirSync(target, { recursive: true });
+      mkdirSync(join(root, 'repo', '.fbeast'), { recursive: true });
+      symlinkSync(target, link, 'dir');
+
+      const result = OrchestratorConfigSchema.safeParse({ stateDir: link });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path).toEqual(['stateDir']);
+        expect(result.error.issues[0]?.message).toContain("Hermes profile 'prod'");
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- fail closed when orchestrator stateDir points at a sibling Hermes profile unless explicitly allowed
- add config default/docs/examples for allowCrossProfileStateAccess
- add regression coverage for denied and explicitly allowed cross-profile state paths

## Test Plan
- npm test --workspace @franken/orchestrator -- --run tests/unit/config/orchestrator-config.test.ts
- npm test --workspace @franken/orchestrator
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #1784