### PR TITLE
feat(orchestrator): add scoped credential inventory

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -28,6 +28,7 @@ export type NetworkAction =
   | 'restart'
   | 'logs'
   | 'config'
+  | 'credentials'
   | 'help'
   | undefined;
 
@@ -102,7 +103,7 @@ export interface CliArgs {
 }
 
 const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'skill', 'security']);
-const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'help']);
+const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
@@ -219,6 +220,7 @@ Network Commands:
   network restart <service|all>       Restart one managed service or all
   network logs <service|all>          Show service logs
   network config [--set a.b.c=value]  Inspect or update operator config
+  network credentials                 Print scoped credential refs inventory (never secret values)
   network help                        Show network command help
 
 Beast Commands:

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -967,6 +967,12 @@ export async function main(): Promise<void> {
   const runPlanDir = planDirOverride ?? paths.plansDir;
   const runPlanNeedsGuidance = defaultRunPlanNeedsGuidance(runPlanDir);
 
+  if (suppressBanner) {
+    scaffoldFrankenbeast(paths);
+    await runNetworkCommand(args, config, root, paths);
+    return;
+  }
+
   const logger = new BeastLogger({ verbose: args.verbose });
   if (args.config) {
     logger.info(`Loaded config from ${args.config}`, 'config');

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -43,6 +43,7 @@ import { NetworkStateStore } from '../network/network-state-store.js';
 import { NetworkLogStore } from '../network/network-logs.js';
 import { NetworkSupervisor } from '../network/network-supervisor.js';
 import { renderNetworkHelp } from '../network/network-help.js';
+import { buildCredentialInventoryReport } from '../network/credential-inventory.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
 import { defaultConfig, parseOrchestratorConfig } from '../config/orchestrator-config.js';
 import { resolveManagedChatAttachment, runManagedChatRepl } from '../network/chat-attach.js';
@@ -1491,6 +1492,11 @@ export async function runNetworkCommand(
       dashboard: config.dashboard,
       comms: config.comms,
     }, null, 2));
+    return;
+  }
+
+  if (action === 'credentials') {
+    deps.print(JSON.stringify(buildCredentialInventoryReport(config), null, 2));
     return;
   }
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -922,7 +922,8 @@ export async function main(): Promise<void> {
   }
 
   const root = resolveProjectRoot(args.baseDir);
-  if (process.env.FRANKENBEAST_NETWORK_MANAGED !== '1') {
+  const suppressBanner = args.subcommand === 'network' && args.networkAction === 'credentials';
+  if (!suppressBanner && process.env.FRANKENBEAST_NETWORK_MANAGED !== '1') {
     printLine(await renderBanner(root));
   }
 

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -968,7 +968,6 @@ export async function main(): Promise<void> {
   const runPlanNeedsGuidance = defaultRunPlanNeedsGuidance(runPlanDir);
 
   if (suppressBanner) {
-    scaffoldFrankenbeast(paths);
     await runNetworkCommand(args, config, root, paths);
     return;
   }

--- a/packages/franken-orchestrator/src/network/credential-inventory.ts
+++ b/packages/franken-orchestrator/src/network/credential-inventory.ts
@@ -1,6 +1,6 @@
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 
-export type CredentialInventoryStatus = 'configured' | 'missing' | 'inactive-configured' | 'inactive-missing' | 'optional-configured' | 'optional-missing';
+export type CredentialInventoryStatus = 'configured' | 'missing' | 'inactive-configured' | 'inactive-missing' | 'optional-configured' | 'optional-missing' | 'invalid-whitespace';
 
 export interface CredentialInventoryEntry {
   readonly scope: string;
@@ -17,18 +17,20 @@ export interface CredentialInventoryReport {
 }
 
 function credentialStatus(ref: string | undefined, active: boolean, required = true): CredentialInventoryStatus {
-  const present = Boolean(ref?.trim());
+  const trimmed = ref?.trim();
+  const present = Boolean(trimmed);
+  if (present && ref !== trimmed) return 'invalid-whitespace';
   if (!required) return present ? 'optional-configured' : 'optional-missing';
   if (active) return present ? 'configured' : 'missing';
   return present ? 'inactive-configured' : 'inactive-missing';
 }
 
 function entry(scope: string, configPath: string, ref: string | undefined, active: boolean, required = true): CredentialInventoryEntry {
-  const normalizedRef = ref?.trim();
+  const trimmed = ref?.trim();
   return {
     scope,
     configPath,
-    ref: normalizedRef ? normalizedRef : null,
+    ref: trimmed ? (ref ?? null) : null,
     status: credentialStatus(ref, active, required),
   };
 }
@@ -55,6 +57,6 @@ export function buildCredentialInventoryReport(config: OrchestratorConfig): Cred
       entry('comms.whatsapp.app', 'comms.whatsapp.appSecretRef', config.comms.whatsapp.appSecretRef, config.comms.whatsapp.enabled),
       entry('comms.whatsapp.verify', 'comms.whatsapp.verifyTokenRef', config.comms.whatsapp.verifyTokenRef, config.comms.whatsapp.enabled),
     ],
-    guidance: 'Inventory reports secret-store reference names only; resolve values through the configured secure backend and never paste credential values into logs, issues, PRs, prompts, or telemetry. Treat missing required entries as setup gaps before exposing services; optional-missing entries are informational.',
+    guidance: 'Inventory reports secret-store reference names only; resolve values through the configured secure backend and never paste credential values into logs, issues, PRs, prompts, or telemetry. Treat missing required entries and invalid-whitespace entries as setup gaps before exposing services; optional-missing entries are informational.',
   };
 }

--- a/packages/franken-orchestrator/src/network/credential-inventory.ts
+++ b/packages/franken-orchestrator/src/network/credential-inventory.ts
@@ -35,25 +35,41 @@ function entry(scope: string, configPath: string, ref: string | undefined, activ
   };
 }
 
-export function buildCredentialInventoryReport(config: OrchestratorConfig): CredentialInventoryReport {
-  const commsActive = config.comms.enabled
-    || config.comms.slack.enabled
+function anyCommsChannelActive(config: OrchestratorConfig): boolean {
+  return config.comms.slack.enabled
     || config.comms.discord.enabled
     || config.comms.telegram.enabled
     || config.comms.whatsapp.enabled;
+}
+
+function commsActive(config: OrchestratorConfig): boolean {
+  return config.comms.enabled || anyCommsChannelActive(config);
+}
+
+function operatorCredentialActive(config: OrchestratorConfig): boolean {
+  return config.beastsDaemon.enabled
+    || config.chat.enabled
+    || config.dashboard.enabled
+    || commsActive(config);
+}
+
+export function buildCredentialInventoryReport(config: OrchestratorConfig): CredentialInventoryReport {
+  const isCommsActive = commsActive(config);
 
   return {
     mode: config.network.mode,
     secureBackend: config.network.secureBackend,
     credentials: [
-      entry('network.operator', 'network.operatorTokenRef', config.network.operatorTokenRef, true),
-      entry('comms.orchestrator', 'comms.orchestratorTokenRef', config.comms.orchestratorTokenRef, commsActive, false),
+      entry('network.operator', 'network.operatorTokenRef', config.network.operatorTokenRef, operatorCredentialActive(config)),
+      entry('comms.orchestrator', 'comms.orchestratorTokenRef', config.comms.orchestratorTokenRef, isCommsActive, false),
       entry('comms.slack.bot', 'comms.slack.botTokenRef', config.comms.slack.botTokenRef, config.comms.slack.enabled),
       entry('comms.slack.signing', 'comms.slack.signingSecretRef', config.comms.slack.signingSecretRef, config.comms.slack.enabled),
       entry('comms.discord', 'comms.discord.botTokenRef', config.comms.discord.botTokenRef, config.comms.discord.enabled),
+      entry('comms.discord.public', 'comms.discord.publicKeyRef', config.comms.discord.publicKeyRef, config.comms.discord.enabled),
       entry('comms.telegram', 'comms.telegram.botTokenRef', config.comms.telegram.botTokenRef, config.comms.telegram.enabled),
       entry('comms.telegram.webhook', 'comms.telegram.webhookSecretTokenRef', config.comms.telegram.webhookSecretTokenRef, config.comms.telegram.enabled),
       entry('comms.whatsapp.access', 'comms.whatsapp.accessTokenRef', config.comms.whatsapp.accessTokenRef, config.comms.whatsapp.enabled),
+      entry('comms.whatsapp.phone-number', 'comms.whatsapp.phoneNumberIdRef', config.comms.whatsapp.phoneNumberIdRef, config.comms.whatsapp.enabled),
       entry('comms.whatsapp.app', 'comms.whatsapp.appSecretRef', config.comms.whatsapp.appSecretRef, config.comms.whatsapp.enabled),
       entry('comms.whatsapp.verify', 'comms.whatsapp.verifyTokenRef', config.comms.whatsapp.verifyTokenRef, config.comms.whatsapp.enabled),
     ],

--- a/packages/franken-orchestrator/src/network/credential-inventory.ts
+++ b/packages/franken-orchestrator/src/network/credential-inventory.ts
@@ -17,16 +17,18 @@ export interface CredentialInventoryReport {
 }
 
 function credentialStatus(ref: string | undefined, active: boolean, required = true): CredentialInventoryStatus {
-  if (!required) return ref ? 'optional-configured' : 'optional-missing';
-  if (active) return ref ? 'configured' : 'missing';
-  return ref ? 'inactive-configured' : 'inactive-missing';
+  const present = Boolean(ref?.trim());
+  if (!required) return present ? 'optional-configured' : 'optional-missing';
+  if (active) return present ? 'configured' : 'missing';
+  return present ? 'inactive-configured' : 'inactive-missing';
 }
 
 function entry(scope: string, configPath: string, ref: string | undefined, active: boolean, required = true): CredentialInventoryEntry {
+  const normalizedRef = ref?.trim();
   return {
     scope,
     configPath,
-    ref: ref ?? null,
+    ref: normalizedRef ? normalizedRef : null,
     status: credentialStatus(ref, active, required),
   };
 }

--- a/packages/franken-orchestrator/src/network/credential-inventory.ts
+++ b/packages/franken-orchestrator/src/network/credential-inventory.ts
@@ -1,0 +1,59 @@
+import type { OrchestratorConfig } from '../config/orchestrator-config.js';
+
+export type CredentialInventoryStatus = 'configured' | 'missing' | 'inactive-configured' | 'inactive-missing';
+
+export interface CredentialInventoryEntry {
+  readonly scope: string;
+  readonly configPath: string;
+  readonly ref: string | null;
+  readonly status: CredentialInventoryStatus;
+}
+
+export interface CredentialInventoryReport {
+  readonly mode: OrchestratorConfig['network']['mode'];
+  readonly secureBackend: OrchestratorConfig['network']['secureBackend'];
+  readonly credentials: CredentialInventoryEntry[];
+  readonly guidance: string;
+}
+
+function credentialStatus(ref: string | undefined, active: boolean): CredentialInventoryStatus {
+  if (active) return ref ? 'configured' : 'missing';
+  return ref ? 'inactive-configured' : 'inactive-missing';
+}
+
+function entry(scope: string, configPath: string, ref: string | undefined, active: boolean): CredentialInventoryEntry {
+  return {
+    scope,
+    configPath,
+    ref: ref ?? null,
+    status: credentialStatus(ref, active),
+  };
+}
+
+export function buildCredentialInventoryReport(config: OrchestratorConfig): CredentialInventoryReport {
+  const commsActive = config.comms.enabled
+    || config.comms.slack.enabled
+    || config.comms.discord.enabled
+    || config.comms.telegram.enabled
+    || config.comms.whatsapp.enabled;
+
+  return {
+    mode: config.network.mode,
+    secureBackend: config.network.secureBackend,
+    credentials: [
+      entry('network.operator', 'network.operatorTokenRef', config.network.operatorTokenRef, true),
+      entry('comms.orchestrator', 'comms.orchestratorTokenRef', config.comms.orchestratorTokenRef, commsActive),
+      entry('comms.slack.bot', 'comms.slack.botTokenRef', config.comms.slack.botTokenRef, config.comms.slack.enabled),
+      entry('comms.slack.signing', 'comms.slack.signingSecretRef', config.comms.slack.signingSecretRef, config.comms.slack.enabled),
+      entry('comms.discord', 'comms.discord.botTokenRef', config.comms.discord.botTokenRef, config.comms.discord.enabled),
+      entry('comms.discord.public-key', 'comms.discord.publicKeyRef', config.comms.discord.publicKeyRef, config.comms.discord.enabled),
+      entry('comms.telegram', 'comms.telegram.botTokenRef', config.comms.telegram.botTokenRef, config.comms.telegram.enabled),
+      entry('comms.telegram.webhook', 'comms.telegram.webhookSecretTokenRef', config.comms.telegram.webhookSecretTokenRef, config.comms.telegram.enabled),
+      entry('comms.whatsapp.access', 'comms.whatsapp.accessTokenRef', config.comms.whatsapp.accessTokenRef, config.comms.whatsapp.enabled),
+      entry('comms.whatsapp.phone-number', 'comms.whatsapp.phoneNumberIdRef', config.comms.whatsapp.phoneNumberIdRef, config.comms.whatsapp.enabled),
+      entry('comms.whatsapp.app', 'comms.whatsapp.appSecretRef', config.comms.whatsapp.appSecretRef, config.comms.whatsapp.enabled),
+      entry('comms.whatsapp.verify', 'comms.whatsapp.verifyTokenRef', config.comms.whatsapp.verifyTokenRef, config.comms.whatsapp.enabled),
+    ],
+    guidance: 'Inventory reports secret-store reference names only; resolve values through the configured secure backend and never paste credential values into logs, issues, PRs, prompts, or telemetry.',
+  };
+}

--- a/packages/franken-orchestrator/src/network/credential-inventory.ts
+++ b/packages/franken-orchestrator/src/network/credential-inventory.ts
@@ -1,6 +1,6 @@
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 
-export type CredentialInventoryStatus = 'configured' | 'missing' | 'inactive-configured' | 'inactive-missing';
+export type CredentialInventoryStatus = 'configured' | 'missing' | 'inactive-configured' | 'inactive-missing' | 'optional-configured' | 'optional-missing';
 
 export interface CredentialInventoryEntry {
   readonly scope: string;
@@ -16,17 +16,18 @@ export interface CredentialInventoryReport {
   readonly guidance: string;
 }
 
-function credentialStatus(ref: string | undefined, active: boolean): CredentialInventoryStatus {
+function credentialStatus(ref: string | undefined, active: boolean, required = true): CredentialInventoryStatus {
+  if (!required) return ref ? 'optional-configured' : 'optional-missing';
   if (active) return ref ? 'configured' : 'missing';
   return ref ? 'inactive-configured' : 'inactive-missing';
 }
 
-function entry(scope: string, configPath: string, ref: string | undefined, active: boolean): CredentialInventoryEntry {
+function entry(scope: string, configPath: string, ref: string | undefined, active: boolean, required = true): CredentialInventoryEntry {
   return {
     scope,
     configPath,
     ref: ref ?? null,
-    status: credentialStatus(ref, active),
+    status: credentialStatus(ref, active, required),
   };
 }
 
@@ -42,18 +43,16 @@ export function buildCredentialInventoryReport(config: OrchestratorConfig): Cred
     secureBackend: config.network.secureBackend,
     credentials: [
       entry('network.operator', 'network.operatorTokenRef', config.network.operatorTokenRef, true),
-      entry('comms.orchestrator', 'comms.orchestratorTokenRef', config.comms.orchestratorTokenRef, commsActive),
+      entry('comms.orchestrator', 'comms.orchestratorTokenRef', config.comms.orchestratorTokenRef, commsActive, false),
       entry('comms.slack.bot', 'comms.slack.botTokenRef', config.comms.slack.botTokenRef, config.comms.slack.enabled),
       entry('comms.slack.signing', 'comms.slack.signingSecretRef', config.comms.slack.signingSecretRef, config.comms.slack.enabled),
       entry('comms.discord', 'comms.discord.botTokenRef', config.comms.discord.botTokenRef, config.comms.discord.enabled),
-      entry('comms.discord.public-key', 'comms.discord.publicKeyRef', config.comms.discord.publicKeyRef, config.comms.discord.enabled),
       entry('comms.telegram', 'comms.telegram.botTokenRef', config.comms.telegram.botTokenRef, config.comms.telegram.enabled),
       entry('comms.telegram.webhook', 'comms.telegram.webhookSecretTokenRef', config.comms.telegram.webhookSecretTokenRef, config.comms.telegram.enabled),
       entry('comms.whatsapp.access', 'comms.whatsapp.accessTokenRef', config.comms.whatsapp.accessTokenRef, config.comms.whatsapp.enabled),
-      entry('comms.whatsapp.phone-number', 'comms.whatsapp.phoneNumberIdRef', config.comms.whatsapp.phoneNumberIdRef, config.comms.whatsapp.enabled),
       entry('comms.whatsapp.app', 'comms.whatsapp.appSecretRef', config.comms.whatsapp.appSecretRef, config.comms.whatsapp.enabled),
       entry('comms.whatsapp.verify', 'comms.whatsapp.verifyTokenRef', config.comms.whatsapp.verifyTokenRef, config.comms.whatsapp.enabled),
     ],
-    guidance: 'Inventory reports secret-store reference names only; resolve values through the configured secure backend and never paste credential values into logs, issues, PRs, prompts, or telemetry.',
+    guidance: 'Inventory reports secret-store reference names only; resolve values through the configured secure backend and never paste credential values into logs, issues, PRs, prompts, or telemetry. Treat missing required entries as setup gaps before exposing services; optional-missing entries are informational.',
   };
 }

--- a/packages/franken-orchestrator/src/network/network-help.ts
+++ b/packages/franken-orchestrator/src/network/network-help.ts
@@ -12,6 +12,7 @@ SYNOPSIS
   frankenbeast network restart <service|all>
   frankenbeast network logs <service|all>
   frankenbeast network config [--set path=value]
+  frankenbeast network credentials
   frankenbeast network help
 
 DESCRIPTION
@@ -33,6 +34,12 @@ SECURITY MODES
   insecure  Local-development convenience mode with redaction and no plaintext
             persistence in config, state, or logs controlled by Frankenbeast.
 
+CREDENTIAL INVENTORY
+  frankenbeast network credentials prints structured JSON for every scoped
+  credential reference used by the managed network. The report includes only
+  config reference names and status values; it never resolves or prints secret
+  values. Treat missing entries as explicit setup gaps before exposing services.
+
 EXAMPLES
   frankenbeast network up
   frankenbeast network up -d
@@ -41,5 +48,6 @@ EXAMPLES
   frankenbeast network stop all
   frankenbeast network logs dashboard-web
   frankenbeast network config --set chat.model=claude-sonnet-4-6
+  frankenbeast network credentials
 `.trim();
 }

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -228,6 +228,12 @@ describe('parseArgs', () => {
     expect(args.networkAction).toBe('config');
   });
 
+  it('parses network credentials inventory', () => {
+    const args = parseArgs(['network', 'credentials']);
+    expect(args.subcommand).toBe('network');
+    expect(args.networkAction).toBe('credentials');
+  });
+
   it('parses network config --set', () => {
     const args = parseArgs(['network', 'config', '--set', 'chat.model=claude-sonnet-4-6']);
     expect(args.subcommand).toBe('network');

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -394,6 +394,12 @@ describe('runNetworkCommand', () => {
       status: 'configured',
     });
     expect(report.credentials).toContainEqual({
+      scope: 'comms.orchestrator',
+      configPath: 'comms.orchestratorTokenRef',
+      ref: 'prod/orchestrator-token',
+      status: 'optional-configured',
+    });
+    expect(report.credentials).toContainEqual({
       scope: 'comms.discord',
       configPath: 'comms.discord.botTokenRef',
       ref: 'prod/discord-bot-token',
@@ -405,6 +411,12 @@ describe('runNetworkCommand', () => {
       ref: 'prod/telegram-bot-token',
       status: 'inactive-configured',
     });
+    expect(report.credentials).not.toContainEqual(expect.objectContaining({
+      configPath: 'comms.discord.publicKeyRef',
+    }));
+    expect(report.credentials).not.toContainEqual(expect.objectContaining({
+      configPath: 'comms.whatsapp.phoneNumberIdRef',
+    }));
     expect(JSON.stringify(report)).not.toContain('super-secret-value');
     expect(JSON.stringify(report)).not.toContain('Bearer');
   });

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -351,6 +351,8 @@ describe('runNetworkCommand', () => {
     config.network.operatorTokenRef = 'prod/operator-token';
     config.comms.enabled = true;
     config.comms.orchestratorTokenRef = 'prod/orchestrator-token';
+    config.comms.slack.enabled = true;
+    config.comms.slack.botTokenRef = '   ';
     config.comms.discord.enabled = true;
     config.comms.discord.botTokenRef = 'prod/discord-bot-token';
     config.comms.telegram.enabled = false;
@@ -398,6 +400,12 @@ describe('runNetworkCommand', () => {
       configPath: 'comms.orchestratorTokenRef',
       ref: 'prod/orchestrator-token',
       status: 'optional-configured',
+    });
+    expect(report.credentials).toContainEqual({
+      scope: 'comms.slack.bot',
+      configPath: 'comms.slack.botTokenRef',
+      ref: null,
+      status: 'missing',
     });
     expect(report.credentials).toContainEqual({
       scope: 'comms.discord',

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -355,8 +355,14 @@ describe('runNetworkCommand', () => {
     config.comms.slack.botTokenRef = '   ';
     config.comms.discord.enabled = true;
     config.comms.discord.botTokenRef = 'prod/discord-bot-token';
+    config.comms.discord.publicKeyRef = undefined;
     config.comms.telegram.enabled = false;
     config.comms.telegram.botTokenRef = 'prod/telegram-bot-token';
+    config.comms.whatsapp.enabled = true;
+    config.comms.whatsapp.accessTokenRef = 'prod/whatsapp-access-token';
+    config.comms.whatsapp.phoneNumberIdRef = undefined;
+    config.comms.whatsapp.appSecretRef = 'prod/whatsapp-app-secret';
+    config.comms.whatsapp.verifyTokenRef = 'prod/whatsapp-verify-token';
     const print = vi.fn();
 
     await runNetworkCommand(
@@ -419,14 +425,54 @@ describe('runNetworkCommand', () => {
       ref: 'prod/telegram-bot-token',
       status: 'inactive-configured',
     });
-    expect(report.credentials).not.toContainEqual(expect.objectContaining({
+    expect(report.credentials).toContainEqual({
+      scope: 'comms.discord.public',
       configPath: 'comms.discord.publicKeyRef',
-    }));
-    expect(report.credentials).not.toContainEqual(expect.objectContaining({
+      ref: null,
+      status: 'missing',
+    });
+    expect(report.credentials).toContainEqual({
+      scope: 'comms.whatsapp.phone-number',
       configPath: 'comms.whatsapp.phoneNumberIdRef',
-    }));
+      ref: null,
+      status: 'missing',
+    });
     expect(JSON.stringify(report)).not.toContain('super-secret-value');
     expect(JSON.stringify(report)).not.toContain('Bearer');
+  });
+
+  it('marks the operator token inactive when no managed service is selected', async () => {
+    const config = defaultConfig();
+    config.beastsDaemon.enabled = false;
+    config.chat.enabled = false;
+    config.dashboard.enabled = false;
+    config.comms.enabled = false;
+
+    const print = vi.fn();
+    await runNetworkCommand(
+      makeArgs({ networkAction: 'credentials' }),
+      config,
+      '/repo/frankenbeast',
+      makePaths(),
+      {
+        resolveServices: vi.fn(() => []),
+        createSupervisor: vi.fn(),
+        print,
+        printError: vi.fn(),
+        renderHelp: () => 'network help',
+        waitForShutdown: vi.fn(async () => undefined),
+      },
+    );
+
+    const report = JSON.parse(print.mock.calls.at(-1)?.[0] as string) as {
+      credentials: Array<{ scope: string; configPath: string; ref: string | null; status: string }>;
+    };
+    expect(report.credentials).toContainEqual({
+      scope: 'network.operator',
+      configPath: 'network.operatorTokenRef',
+      ref: null,
+      status: 'inactive-missing',
+    });
   });
 
   it('start stop and restart target one service or all', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -346,6 +346,69 @@ describe('runNetworkCommand', () => {
     expect(print).toHaveBeenCalledWith(expect.stringContaining('chat-server: running'));
   });
 
+  it('prints a scoped credential inventory without secret values', async () => {
+    const config = defaultConfig();
+    config.network.operatorTokenRef = 'prod/operator-token';
+    config.comms.enabled = true;
+    config.comms.orchestratorTokenRef = 'prod/orchestrator-token';
+    config.comms.discord.enabled = true;
+    config.comms.discord.botTokenRef = 'prod/discord-bot-token';
+    config.comms.telegram.enabled = false;
+    config.comms.telegram.botTokenRef = 'prod/telegram-bot-token';
+    const print = vi.fn();
+
+    await runNetworkCommand(
+      makeArgs({ networkAction: 'credentials' }),
+      config,
+      '/repo/frankenbeast',
+      makePaths(),
+      {
+        resolveServices: vi.fn(() => []),
+        createSupervisor: vi.fn(() => ({
+          up: vi.fn(),
+          stopAll: vi.fn(),
+          down: vi.fn(),
+          status: vi.fn(),
+          stop: vi.fn(),
+          logs: vi.fn(),
+        })),
+        print,
+        printError: vi.fn(),
+        renderHelp: () => 'network help',
+        waitForShutdown: vi.fn(async () => undefined),
+      },
+    );
+
+    const report = JSON.parse(print.mock.calls.at(-1)?.[0] as string) as {
+      mode: string;
+      secureBackend: string;
+      credentials: Array<{ scope: string; configPath: string; ref: string | null; status: string }>;
+    };
+
+    expect(report.mode).toBe('secure');
+    expect(report.secureBackend).toBe('local-encrypted');
+    expect(report.credentials).toContainEqual({
+      scope: 'network.operator',
+      configPath: 'network.operatorTokenRef',
+      ref: 'prod/operator-token',
+      status: 'configured',
+    });
+    expect(report.credentials).toContainEqual({
+      scope: 'comms.discord',
+      configPath: 'comms.discord.botTokenRef',
+      ref: 'prod/discord-bot-token',
+      status: 'configured',
+    });
+    expect(report.credentials).toContainEqual({
+      scope: 'comms.telegram',
+      configPath: 'comms.telegram.botTokenRef',
+      ref: 'prod/telegram-bot-token',
+      status: 'inactive-configured',
+    });
+    expect(JSON.stringify(report)).not.toContain('super-secret-value');
+    expect(JSON.stringify(report)).not.toContain('Bearer');
+  });
+
   it('start stop and restart target one service or all', async () => {
     const services = [makeService('chat-server'), makeService('dashboard-web')];
     const up = vi.fn(async () => ({

--- a/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/network-run.test.ts
@@ -348,7 +348,7 @@ describe('runNetworkCommand', () => {
 
   it('prints a scoped credential inventory without secret values', async () => {
     const config = defaultConfig();
-    config.network.operatorTokenRef = 'prod/operator-token';
+    config.network.operatorTokenRef = ' prod/operator-token ';
     config.comms.enabled = true;
     config.comms.orchestratorTokenRef = 'prod/orchestrator-token';
     config.comms.slack.enabled = true;
@@ -392,8 +392,8 @@ describe('runNetworkCommand', () => {
     expect(report.credentials).toContainEqual({
       scope: 'network.operator',
       configPath: 'network.operatorTokenRef',
-      ref: 'prod/operator-token',
-      status: 'configured',
+      ref: ' prod/operator-token ',
+      status: 'invalid-whitespace',
     });
     expect(report.credentials).toContainEqual({
       scope: 'comms.orchestrator',

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -906,6 +906,24 @@ describe('main() execution', () => {
     expect(mockSessionStart).toHaveBeenCalled();
   });
 
+  it('prints network credentials as parseable JSON without a banner', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    mockParseArgs.mockReturnValue({
+      ...(mockParseArgs() as Record<string, unknown>),
+      subcommand: 'network',
+      networkAction: 'credentials',
+    } as ReturnType<typeof mockParseArgs>);
+
+    await main();
+
+    const stdout = info.mock.calls.map((call) => String(call[0]));
+    expect(stdout).not.toContain('[BANNER]');
+    expect(JSON.parse(stdout.at(-1) ?? '{}')).toMatchObject({
+      mode: 'secure',
+      credentials: expect.any(Array),
+    });
+  });
+
   it('does not hide non-file init config loading errors behind init fallback defaults', async () => {
     const tempDir = join(tmpdir(), `franken-run-init-${Date.now()}-${Math.random()}`);
     tempDirs.push(tempDir);

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -918,6 +918,7 @@ describe('main() execution', () => {
 
     const stdout = info.mock.calls.map((call) => String(call[0]));
     expect(stdout).not.toContain('[BANNER]');
+    expect(scaffoldFrankenbeast).not.toHaveBeenCalled();
     expect(JSON.parse(stdout.at(-1) ?? '{}')).toMatchObject({
       mode: 'secure',
       credentials: expect.any(Array),


### PR DESCRIPTION
## Summary
- adds  as a structured scoped credential-reference inventory
- reports configured/missing/inactive credential refs without resolving or printing secret values
- documents the command in network help and CLI usage

## Verification
- 
> @franken/orchestrator@0.42.3 test
> vitest run tests/unit/cli/args.test.ts tests/unit/cli/network-run.test.ts


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.9 [39m[90m/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator[39m

 [32m✓[39m tests/unit/cli/args.test.ts [2m([22m[2m102 tests[22m[2m)[22m[32m 47[2mms[22m[39m
 [32m✓[39m tests/unit/cli/network-run.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 116[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m116 passed[39m[22m[90m (116)[39m
[2m   Start at [22m 20:40:24
[2m   Duration [22m 2.43s[2m (transform 1.78s, setup 109ms, import 2.29s, tests 163ms, environment 0ms)[22m
- 
> @franken/orchestrator@0.42.3 lint
> eslint src/ tests/ test/


/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
  35:20   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  35:50   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  36:17   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  37:26   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  37:114  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  38:10   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  76:15   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/adapters/middleware-firewall-adapter.ts
  4:3  warning  'FirewallViolation' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
  42:3  warning  Unused eslint-disable directive (no problems were reported from 'no-control-regex')

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/cli/run.ts
   8:17  warning  'open' is defined but never used   @typescript-eslint/no-unused-vars
  11:24  warning  'spawn' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/cli/session.ts
  140:25  warning  'baseBranch' is assigned a value but never used  @typescript-eslint/no-unused-vars
  140:37  warning  'noPr' is assigned a value but never used        @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/deps.ts
  248:6  warning  '_TypesAndInterfacesTest' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/http/routes/network-routes.ts
  3:17  warning  'open' is defined but never used   @typescript-eslint/no-unused-vars
  5:10  warning  'spawn' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/issues/issue-runner.ts
  245:5  warning  'cumulativeTokens' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
  246:5  warning  'budgetTokens' is defined but never used. Allowed unused args must match /^_/u      @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/planning/chunk-file-graph-builder.ts
   79:5  warning  Unused eslint-disable directive (no problems were reported from 'no-control-regex')
  105:7  warning  Unused eslint-disable directive (no problems were reported from 'no-control-regex')

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/src/providers/openai-api-adapter.ts
  5:3  warning  'LlmMessage' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/test/adapters/cli-observer-bridge.test.ts
  11:9  warning  'defaultConfig' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/test/cli/config-loading.test.ts
    1:55  warning  'vi' is defined but never used                         @typescript-eslint/no-unused-vars
  254:13  warning  'Session' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/test/cli/trace-viewer.test.ts
  30:58  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  33:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/e2e/budget-exceeded.test.ts
  12:19  warning  'ports' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/e2e/cli-skill-execution.test.ts
  152:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  227:12  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/e2e/happy-path.test.ts
  12:19  warning  'ports' is assigned a value but never used  @typescript-eslint/no-unused-vars
  57:19  warning  'ports' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/e2e/hitl-pause.test.ts
  18:13  warning  'loop' is assigned a value but never used    @typescript-eslint/no-unused-vars
  29:15  warning  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
  33:33  warning  'ports2' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/e2e/self-correction.test.ts
  4:15  warning  'PlanGraph' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
  9:10  warning  'SkillManagerAdapter' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/integration/e2e-consolidated-deps.test.ts
  8:10  warning  'AuditTrail' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/integration/providers/provider-switch-audit.test.ts
    6:3   warning  'BrainSnapshot' is defined but never used  @typescript-eslint/no-unused-vars
   90:22  warning  '_' is assigned a value but never used     @typescript-eslint/no-unused-vars
  108:22  warning  '_' is assigned a value but never used     @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
  125:9   warning  'aiderProvider' is assigned a value but never used  @typescript-eslint/no-unused-vars
  229:14  warning  Unexpected any. Specify a different type            @typescript-eslint/no-explicit-any
  250:14  warning  Unexpected any. Specify a different type            @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
   9:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  27:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  27:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  53:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  53:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  90:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  90:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/adapters/provider-registry-adapter.test.ts
   30:55  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   47:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   48:71  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   51:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   53:65  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   61:55  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  106:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  109:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/beasts/definitions/resolve-cli-entrypoint.test.ts
  2:10  warning  'resolve' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/beasts/execution/error-reporting.test.ts
  170:13  warning  'supervisor' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
  114:31  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  118:31  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  124:31  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/chunk-file-graph-builder.test.ts
  2:46  warning  'mkdirSync' is defined but never used  @typescript-eslint/no-unused-vars
  6:15  warning  'PlanGraph' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/chunk-file-writer.test.ts
  2:43  warning  'writeFileSync' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
   50:80   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   70:69   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  152:106  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/chat-repl.test.ts
   47:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   48:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   61:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   62:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   76:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   77:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   95:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   96:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  112:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  113:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  136:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  137:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  158:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  159:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  180:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  181:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  210:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  211:33  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  226:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  227:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  252:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  253:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  268:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  269:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  295:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  296:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  317:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  318:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  335:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  336:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
  303:73  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  318:12  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  330:79  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  340:12  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  352:12  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  368:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
  55:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/resolve-operator-token.test.ts
  6:15  warning  'OrchestratorConfig' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/run.test.ts
    17:3   warning  'mockAdapterComplete' is assigned a value but never used  @typescript-eslint/no-unused-vars
   399:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
   404:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
   419:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
   419:45  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
   435:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
   439:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
  1339:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
  1581:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
  1590:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
  1641:61  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
  1681:10  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
  2480:30  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
   6:15  warning  'ProjectPaths' is defined but never used                  @typescript-eslint/no-unused-vars
  11:5   warning  'adapterCtorArg' is assigned a value but never used       @typescript-eslint/no-unused-vars
  12:5   warning  'progressCtorInner' is assigned a value but never used    @typescript-eslint/no-unused-vars
  13:5   warning  'progressCtorOptions' is assigned a value but never used  @typescript-eslint/no-unused-vars
  14:5   warning  'progressInstance' is assigned a value but never used     @typescript-eslint/no-unused-vars
  85:5   warning  Unexpected aliasing of 'this' to local variable           @typescript-eslint/no-this-alias

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/comms/chat-runtime-comms-adapter.test.ts
   52:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   52:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  139:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  139:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/comms/comms-run-config.test.ts
  6:8  warning  'CommsRunConfig' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/context/franken-context.test.ts
  1:36  warning  'beforeEach' is defined but never used  @typescript-eslint/no-unused-vars
  1:48  warning  'afterEach' is defined but never used   @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
  315:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  333:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  350:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  514:63  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  514:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  529:63  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  529:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  544:63  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  544:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  559:63  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  559:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  580:63  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  580:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
   93:33  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  209:30  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  219:28  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  239:30  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  276:32  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  299:30  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
  1:36  warning  'beforeEach' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/interview-loop.test.ts
  5:38  warning  'PlanTask' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/issues/issue-graph-builder.test.ts
  4:15  warning  'PlanGraph' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
   45:10  warning  'BeastLoop' is defined but never used                @typescript-eslint/no-unused-vars
  154:21  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  162:10  warning  'makeIssueRuntimeSupport' is defined but never used  @typescript-eslint/no-unused-vars
  345:13  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
  381:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  397:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  467:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  499:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  539:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/logging/beast-logger.test.ts
  2:57  warning  'statSync' is defined but never used  @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
  190:87  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/network/secret-resolver.test.ts
  54:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/network/secret-store.test.ts
  35:49  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
    1:32  warning  'vi' is defined but never used             @typescript-eslint/no-unused-vars
    5:16  warning  'collectEvents' is defined but never used  @typescript-eslint/no-unused-vars
  109:12  warning  Unexpected any. Specify a different type   @typescript-eslint/no-explicit-any
  122:12  warning  Unexpected any. Specify a different type   @typescript-eslint/no-explicit-any
  129:12  warning  Unexpected any. Specify a different type   @typescript-eslint/no-explicit-any
  135:12  warning  Unexpected any. Specify a different type   @typescript-eslint/no-explicit-any
  141:12  warning  Unexpected any. Specify a different type   @typescript-eslint/no-explicit-any
  157:12  warning  Unexpected any. Specify a different type   @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
  158:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/providers/gemini-api-adapter.test.ts
  166:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  186:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  200:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  201:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  206:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/providers/openai-api-adapter.test.ts
  130:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  154:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/providers/token-aggregator.test.ts
    4:3   warning  'LlmRequest' is defined but never used     @typescript-eslint/no-unused-vars
    7:3   warning  'BrainSnapshot' is defined but never used  @typescript-eslint/no-unused-vars
  219:22  warning  '_' is assigned a value but never used     @typescript-eslint/no-unused-vars

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/skills/provider-skill-translator.test.ts
   2:15   warning  'McpConfig' is defined but never used     @typescript-eslint/no-unused-vars
  21:75   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  21:95   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  21:119  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  21:145  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/pfkagent/dev/resolve-wt/issue-1783/packages/franken-orchestrator/tests/unit/skills/providers/cli-provider.test.ts
  85:17  warning  'SECRET' is assigned a value but never used  @typescript-eslint/no-unused-vars

✖ 193 problems (0 errors, 193 warnings)
  0 errors and 3 warnings potentially fixable with the `--fix` option.
- 
> frankenbeast@0.46.0 lint:security
> node scripts/check-plain-http.mjs && node scripts/check-hardcoded-secrets.mjs && node scripts/audit-todo-markers.mjs

No non-loopback plain HTTP URLs found in production JavaScript/TypeScript sources.
No hard-coded example secret values found in environment examples or production sources.
No tracked code-comment markers found in production JavaScript/TypeScript sources.
- 
> frankenbeast@0.46.0 typecheck
> turbo run typecheck


   • Packages in scope: @franken/brain, @franken/critique, @franken/governor, @franken/live-bench, @franken/mcp-suite, @franken/observer, @franken/orchestrator, @franken/planner, @franken/types, @franken/web
   • Running typecheck in 10 packages
   • Remote caching disabled, using shared worktree cache

@franken/types:typecheck: cache hit, replaying logs 7a03b876a202214d
@franken/types:typecheck: 
@franken/types:typecheck: > @franken/types@0.9.0 typecheck
@franken/types:typecheck: > tsc --noEmit
@franken/types:typecheck: 
@franken/types:build: cache hit, replaying logs dcfd9c24246e0456
@franken/types:build: 
@franken/types:build: > @franken/types@0.9.0 build
@franken/types:build: > tsc
@franken/types:build: 
@franken/governor:typecheck: cache hit, replaying logs 024de987ac45d52d
@franken/governor:typecheck: 
@franken/governor:typecheck: > @franken/governor@0.5.14 typecheck
@franken/governor:typecheck: > tsc --noEmit
@franken/governor:typecheck: 
@franken/brain:typecheck: cache hit, replaying logs 7b14b7b05007aa18
@franken/brain:typecheck: 
@franken/brain:typecheck: > @franken/brain@0.7.5 typecheck
@franken/brain:typecheck: > tsc --noEmit
@franken/brain:typecheck: 
@franken/planner:typecheck: cache hit, replaying logs f31764985a0e3952
@franken/planner:typecheck: 
@franken/planner:typecheck: > @franken/planner@0.4.14 typecheck
@franken/planner:typecheck: > tsc --noEmit
@franken/planner:typecheck: 
@franken/critique:build: cache hit, replaying logs 9e1d9d5ce753d43e
@franken/critique:build: 
@franken/critique:build: > @franken/critique@0.7.0 build
@franken/critique:build: > tsc
@franken/critique:build: 
@franken/observer:build: cache hit, replaying logs 5b9ab5fa808e3837
@franken/observer:build: 
@franken/observer:build: > @franken/observer@0.7.16 build
@franken/observer:build: > tsc
@franken/observer:build: 
@franken/brain:build: cache hit, replaying logs 6bef121ed77d6c9b
@franken/brain:build: 
@franken/brain:build: > @franken/brain@0.7.5 build
@franken/brain:build: > tsc
@franken/brain:build: 
@franken/planner:build: cache hit, replaying logs 553d84e4d3eb26d2
@franken/planner:build: 
@franken/planner:build: > @franken/planner@0.4.14 build
@franken/planner:build: > tsc
@franken/planner:build: 
@franken/critique:typecheck: cache hit, replaying logs 4b7bb9df7082f959
@franken/critique:typecheck: 
@franken/critique:typecheck: > @franken/critique@0.7.0 typecheck
@franken/critique:typecheck: > tsc --noEmit
@franken/critique:typecheck: 
@franken/governor:build: cache hit, replaying logs ffc983f490de642e
@franken/governor:build: 
@franken/governor:build: > @franken/governor@0.5.14 build
@franken/governor:build: > tsc
@franken/governor:build: 
@franken/web:typecheck: cache hit, replaying logs 9eae8c0c41be438d
@franken/web:typecheck: 
@franken/web:typecheck: > @franken/web@0.2.6 typecheck
@franken/web:typecheck: > tsc --noEmit
@franken/web:typecheck: 
@franken/observer:typecheck: cache hit, replaying logs e0e8f50ca82a40e8
@franken/observer:typecheck: 
@franken/observer:typecheck: > @franken/observer@0.7.16 typecheck
@franken/observer:typecheck: > tsc --noEmit
@franken/observer:typecheck: 
@franken/orchestrator:typecheck: cache hit, replaying logs 6a54627e8785d490
@franken/orchestrator:typecheck: 
@franken/orchestrator:typecheck: > @franken/orchestrator@0.42.3 typecheck
@franken/orchestrator:typecheck: > tsc --noEmit
@franken/orchestrator:typecheck: 
@franken/live-bench:typecheck: cache hit, replaying logs e09d59158497f8f4
@franken/live-bench:typecheck: 
@franken/live-bench:typecheck: > @franken/live-bench@0.2.7 typecheck
@franken/live-bench:typecheck: > tsc --noEmit
@franken/live-bench:typecheck: 
@franken/orchestrator:build: cache hit, replaying logs da6f528803308ce5
@franken/orchestrator:build: 
@franken/orchestrator:build: > @franken/orchestrator@0.42.3 build
@franken/orchestrator:build: > tsc
@franken/orchestrator:build: 
@franken/mcp-suite:typecheck: cache hit, replaying logs 8cd74b557b845181
@franken/mcp-suite:typecheck: 
@franken/mcp-suite:typecheck: > @franken/mcp-suite@0.2.7 typecheck
@franken/mcp-suite:typecheck: > tsc --noEmit
@franken/mcp-suite:typecheck: 

 Tasks:    17 successful, 17 total
Cached:    17 cached, 17 total
  Time:    214ms >>> FULL TURBO
- 
> frankenbeast@0.46.0 build
> turbo run build


   • Packages in scope: @franken/brain, @franken/critique, @franken/governor, @franken/live-bench, @franken/mcp-suite, @franken/observer, @franken/orchestrator, @franken/planner, @franken/types, @franken/web
   • Running build in 10 packages
   • Remote caching disabled, using shared worktree cache

@franken/types:build: cache hit, replaying logs dcfd9c24246e0456
@franken/types:build: 
@franken/types:build: > @franken/types@0.9.0 build
@franken/types:build: > tsc
@franken/types:build: 
@franken/web:build: cache hit, replaying logs 792a7100d669a38e
@franken/web:build: 
@franken/web:build: > @franken/web@0.2.6 build
@franken/web:build: > tsc && vite build
@franken/web:build: 
@franken/web:build: vite v8.1.3 building client environment for production...
@franken/web:build: [2K@franken/web:build: transforming...✓ 176 modules transformed.
@franken/web:build: rendering chunks...
@franken/web:build: computing gzip size...
@franken/web:build: dist/index.html                                             0.40 kB │ gzip:   0.27 kB
@franken/web:build: dist/assets/frankenbeast-github-logo-478x72-BXm0GkrF.png  583.11 kB
@franken/web:build: dist/assets/index-C4acY8PJ.css                             56.53 kB │ gzip:  11.29 kB
@franken/web:build: dist/assets/index-yzqO8cLO.js                             489.39 kB │ gzip: 140.51 kB
@franken/web:build: 
@franken/web:build: ✓ built in 558ms
@franken/brain:build: cache hit, replaying logs 6bef121ed77d6c9b
@franken/brain:build: 
@franken/brain:build: > @franken/brain@0.7.5 build
@franken/brain:build: > tsc
@franken/brain:build: 
@franken/critique:build: cache hit, replaying logs 9e1d9d5ce753d43e
@franken/critique:build: 
@franken/critique:build: > @franken/critique@0.7.0 build
@franken/critique:build: > tsc
@franken/critique:build: 
@franken/planner:build: cache hit, replaying logs 553d84e4d3eb26d2
@franken/planner:build: 
@franken/planner:build: > @franken/planner@0.4.14 build
@franken/planner:build: > tsc
@franken/planner:build: 
@franken/governor:build: cache hit, replaying logs ffc983f490de642e
@franken/governor:build: 
@franken/governor:build: > @franken/governor@0.5.14 build
@franken/governor:build: > tsc
@franken/governor:build: 
@franken/observer:build: cache hit, replaying logs 5b9ab5fa808e3837
@franken/observer:build: 
@franken/observer:build: > @franken/observer@0.7.16 build
@franken/observer:build: > tsc
@franken/observer:build: 
@franken/live-bench:build: cache hit, replaying logs f61bcff6c90a14be
@franken/live-bench:build: 
@franken/live-bench:build: > @franken/live-bench@0.2.7 build
@franken/live-bench:build: > tsc && node -e "require('node:fs').chmodSync('dist/cli/main.js', 0o755)"
@franken/live-bench:build: 
@franken/orchestrator:build: cache hit, replaying logs da6f528803308ce5
@franken/orchestrator:build: 
@franken/orchestrator:build: > @franken/orchestrator@0.42.3 build
@franken/orchestrator:build: > tsc
@franken/orchestrator:build: 
@franken/mcp-suite:build: cache hit, replaying logs 149bc9c22714915e
@franken/mcp-suite:build: 
@franken/mcp-suite:build: > @franken/mcp-suite@0.2.7 build
@franken/mcp-suite:build: > tsc
@franken/mcp-suite:build: 

 Tasks:    10 successful, 10 total
Cached:    10 cached, 10 total
  Time:    76ms >>> FULL TURBO

Closes #1783