### PR TITLE
test: clean dependency guard temp fixtures

### DIFF
--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -1,26 +1,38 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
 const OUTDATED_SCRIPT = resolve(ROOT, 'scripts/check-major-outdated.mjs');
 const DEPENDABOT_SUPPLY_CHAIN_SCRIPT = resolve(ROOT, 'scripts/check-dependabot-supply-chain.mjs');
+const fixtureRoots = new Set<string>();
+
+function cleanupFixtureRoots() {
+  for (const dir of fixtureRoots) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  fixtureRoots.clear();
+}
+
+function writeFixtureFile(prefix: 'franken-outdated-' | 'franken-dependabot-', filename: string, content: string) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  fixtureRoots.add(dir);
+  const file = join(dir, filename);
+  writeFileSync(file, content, 'utf8');
+  return { dir, file };
+}
 
 function writeJson(value: unknown, filename = 'outdated.json') {
-  const dir = mkdtempSync(join(tmpdir(), 'franken-outdated-'));
-  const file = join(dir, filename);
-  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
-  return file;
+  return writeFixtureFile('franken-outdated-', filename, `${JSON.stringify(value, null, 2)}\n`).file;
 }
 
 function writeText(content: string, filename: string) {
-  const dir = mkdtempSync(join(tmpdir(), 'franken-dependabot-'));
-  const file = join(dir, filename);
-  writeFileSync(file, content, 'utf8');
-  return file;
+  return writeFixtureFile('franken-dependabot-', filename, content).file;
 }
+
+afterEach(cleanupFixtureRoots);
 
 function runOutdatedGuard(report: unknown, baseline: unknown = []) {
   return spawnSync(process.execPath, [OUTDATED_SCRIPT, '--input', writeJson(report), '--baseline', writeJson(baseline, 'baseline.json')], {
@@ -37,6 +49,19 @@ function runDependabotSupplyChainGuard(config: string) {
 }
 
 describe('dependency CI guards for issue #1414', () => {
+  it('removes tracked temp fixture roots even when assertions fail before guard execution', () => {
+    const outdatedFixture = writeFixtureFile('franken-outdated-', 'outdated.json', '{}\n');
+    const dependabotFixture = writeFixtureFile('franken-dependabot-', 'dependabot.yml', 'version: 2\n');
+
+    expect(existsSync(outdatedFixture.dir)).toBe(true);
+    expect(existsSync(dependabotFixture.dir)).toBe(true);
+
+    cleanupFixtureRoots();
+
+    expect(existsSync(outdatedFixture.dir)).toBe(false);
+    expect(existsSync(dependabotFixture.dir)).toBe(false);
+  });
+
   it('fails only for dependencies with latest versions on a newer major', () => {
     const result = runOutdatedGuard({
       acorn: {


### PR DESCRIPTION
## Summary
- track dependency guard temp fixture roots created by test helpers
- clean tracked fixture roots after each test with recursive force removal
- add a regression check that both outdated and dependabot fixture roots are cleanup-aware

Fixes #2077

## Test plan
- git diff --check
- npm run test:root -- tests/unit/dependency-ci-guards.test.ts
- verified no new franken-outdated-* or franken-dependabot-* entries remained in tmpdir() after the targeted test run