### PR TITLE
docs(adr): refresh local-encrypted passphrase guidance

### DIFF
--- a/docs/adr/019-secret-backend-comparison.md
+++ b/docs/adr/019-secret-backend-comparison.md
@@ -46,10 +46,10 @@ Support 4 backends and publish the following recommendation ranking:
 
 #### Local Encrypted (`local-encrypted`)
 
-- Stores encrypted blob at `.frankenbeast/secrets.enc`
+- Stores encrypted blob at `.fbeast/secrets.enc` with key-derivation metadata at `.fbeast/secrets.meta.json`
 - AES-256-GCM encryption with PBKDF2 key derivation from a user-supplied passphrase
 - The `.enc` file is safe to commit to a private repo (encrypted), but the passphrase must be stored separately
-- In CI, supply the passphrase via an environment variable (`FRANKENBEAST_STORE_PASSPHRASE`) which is itself stored in the CI system's secret store
+- In CI/headless runtime flows, mount or persist `.fbeast/config.json`, `.fbeast/secrets.enc`, and `.fbeast/secrets.meta.json` (or the whole `.fbeast` secret-store state), then supply the passphrase via `FRANKENBEAST_PASSPHRASE`, which is itself stored in the CI system's secret store
 - Passphrase loss = permanent secret loss (no key escrow)
 - **Default fallback when no other backend is configured**
 
@@ -62,11 +62,15 @@ Support 4 backends and publish the following recommendation ranking:
 
 ### Backend Selection in Config
 
-```yaml
-# .frankenbeast/config.yaml
-network:
-  secureBackend: "1password"   # or: os-keychain | local-encrypted | bitwarden
+```json
+{
+  "network": {
+    "secureBackend": "1password"
+  }
+}
 ```
+
+The config file lives at `.fbeast/config.json`; valid backend values are `1password`, `os-keychain`, `local-encrypted`, and `bitwarden`.
 
 If `secureBackend` is omitted, the system defaults to `local-encrypted`.
 

--- a/tests/docs-issue-2084.test.ts
+++ b/tests/docs-issue-2084.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), "utf8");
+
+describe("issue #2084 ADR-019 local-encrypted operator guidance", () => {
+  it("uses the current local-encrypted storage paths and passphrase env var", () => {
+    const adr = readDoc("docs/adr/019-secret-backend-comparison.md");
+
+    expect(adr).toContain(".fbeast/secrets.enc");
+    expect(adr).toContain(".fbeast/secrets.meta.json");
+    expect(adr).toContain("FRANKENBEAST_PASSPHRASE");
+    expect(adr).not.toContain(".frankenbeast/secrets.enc");
+    expect(adr).not.toContain("FRANKENBEAST_STORE_PASSPHRASE");
+  });
+});


### PR DESCRIPTION
## Summary
- Update ADR-019 local-encrypted storage guidance to use `.fbeast/secrets.enc` plus `.fbeast/secrets.meta.json`
- Replace stale `FRANKENBEAST_STORE_PASSPHRASE` guidance with `FRANKENBEAST_PASSPHRASE`
- Add a root docs regression test for the ADR guidance

## Test Plan
- npm run test:root -- tests/docs-issue-2084.test.ts
- npm run test:root -- tests/docs-issue-1094.test.ts
- npm run test:root
- git diff --check

Closes #2084