### PR TITLE
fix(orchestrator): reject malformed dashboard static port

### DIFF
--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -520,16 +520,18 @@ export async function resolveDashboardOperatorToken(): Promise<string | undefine
     ?? await readOperatorTokenFromEnvFile(join(process.cwd(), 'packages', 'franken-web', '.env.local'));
 }
 
-async function parseCliArgs(argv: string[]): Promise<DashboardStaticServerOptions> {
+export async function parseCliArgs(argv: string[]): Promise<DashboardStaticServerOptions> {
   const readValue = (flag: string): string | undefined => {
     const index = argv.indexOf(flag);
     return index >= 0 ? argv[index + 1] : undefined;
   };
   const host = readValue('--host') ?? '127.0.0.1';
-  const port = Number.parseInt(readValue('--port') ?? '5173', 10);
+  const portFlagPresent = argv.includes('--port');
+  const rawPort = portFlagPresent ? readValue('--port') : '5173';
   const staticDir = readValue('--static-dir') ?? 'packages/franken-web/dist';
+  const port = rawPort && /^\d+$/.test(rawPort) ? Number(rawPort) : NaN;
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
-    throw new Error(`Invalid --port value: ${readValue('--port') ?? ''}`);
+    throw new Error(`Invalid --port value: ${rawPort ?? ''}`);
   }
   const buildArgStart = argv.indexOf('--build-args');
   return {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { gzipSync } from 'node:zlib';
-import { createDashboardStaticResponse, resolveDashboardOperatorToken, startDashboardStaticServer } from '../../../src/http/dashboard-static-server.js';
+import { createDashboardStaticResponse, parseCliArgs, resolveDashboardOperatorToken, startDashboardStaticServer } from '../../../src/http/dashboard-static-server.js';
 import { createSecretStore } from '../../../src/network/secret-store.js';
 
 import { testCredential } from '../../support/test-credentials.js';
@@ -387,5 +387,23 @@ describe('dashboard static server', () => {
       await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
       await new Promise<void>((resolveClose) => backend.close(() => resolveClose()));
     }
+  });
+
+  it.each([
+    ['5173abc'],
+    ['5173.5'],
+    ['+5173'],
+    ['-1'],
+    [''],
+    ['65536'],
+    [],
+  ])('rejects malformed CLI --port argv %j', async (...values) => {
+    await expect(parseCliArgs(['--port', ...values])).rejects.toThrow(/Invalid --port value/);
+  });
+
+  it('accepts valid integer CLI --port values in range', async () => {
+    await expect(parseCliArgs([])).resolves.toMatchObject({ port: 5173 });
+    await expect(parseCliArgs(['--port', '5173'])).resolves.toMatchObject({ port: 5173 });
+    await expect(parseCliArgs(['--port', '0'])).resolves.toMatchObject({ port: 0 });
   });
 });


### PR DESCRIPTION
## Summary
- export dashboard static CLI arg parsing for focused unit coverage
- validate --port with full-string digit matching before numeric range checks
- cover malformed, missing, and valid dashboard static server port values

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/http/dashboard-static-server.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint
- npm --prefix packages/franken-orchestrator run build

Closes #2085