### PR TITLE
test(ci): run orchestrator e2e smoke in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Run root and package CI test suite
         run: npm run test:ci
 
+      - name: Run orchestrator E2E smoke CI suite
+        run: npm run ci:test:e2e
+
       - name: Phantom dependency check (every runtime import is declared)
         run: node scripts/check-phantom-deps.mjs
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -76,7 +76,7 @@ npm run typecheck
 npm test
 ```
 
-Root scripts currently include `build`, `typecheck`, `test`, `test:ci`, `test:live:bench`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts. Use `test:ci` for the same root-plus-package test target that CI runs locally; it first builds the shared `@franken/types` workspace so fresh checkouts can resolve workspace package exports, and it intentionally excludes Docker smoke, security, dependency, lint, and live/e2e gates that remain separate CI steps. `test:live:bench` is an explicit opt-in for the live benchmark suite and delegates to the gated `@franken/live-bench` `test:live` task, which sets `FBEAST_LIVE_BENCH_E2E=1`.
+Root scripts currently include `build`, `typecheck`, `test`, `test:ci`, `test:e2e`, `test:live:bench`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts. Use `test:ci` for the same root-plus-package test target that CI runs locally; it first builds the shared `@franken/types` workspace so fresh checkouts can resolve workspace package exports, and it intentionally excludes Docker smoke, security, dependency, lint, live benchmark, and the broader orchestrator E2E gate that remains a separate CI step. CI runs a deterministic orchestrator E2E smoke subset through the dedicated `ci:test:e2e` retry-wrapped step so the decision is visible outside the aggregate `test:ci` command. `test:live:bench` is an explicit opt-in for the live benchmark suite and delegates to the gated `@franken/live-bench` `test:live` task, which sets `FBEAST_LIVE_BENCH_E2E=1`.
 
 ## 5. Try the orchestrator CLI
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",
     "ci:test:planner-integration": "node scripts/retry-ci-command.mjs -- npm run test:integration --workspace @franken/planner",
     "ci:test:observer-eval": "node scripts/retry-ci-command.mjs -- npm run test:eval --workspace @franken/observer",
+    "ci:test:e2e": "node scripts/retry-ci-command.mjs -- npm run test:e2e -- tests/e2e/smoke.test.ts tests/e2e/chat/chat-e2e.test.ts",
     "test:root": "vitest run",
     "test:docker:sandbox": "node scripts/run-docker-sandbox-smoke.mjs",
     "test:root:watch": "vitest",

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -163,12 +163,19 @@ describe("Turborepo configuration", () => {
       expect(rootPkg.scripts["ci:test:observer-eval"]).toBe(
         "node scripts/retry-ci-command.mjs -- npm run test:eval --workspace @franken/observer",
       );
+      expect(rootPkg.scripts["ci:test:e2e"]).toBe(
+        "node scripts/retry-ci-command.mjs -- npm run test:e2e -- tests/e2e/smoke.test.ts tests/e2e/chat/chat-e2e.test.ts",
+      );
 
       const ciWorkflow = readFileSync(
         join(ROOT, ".github/workflows/ci.yml"),
         "utf8",
       );
       expect(ciWorkflow).toContain("run: npm run test:ci");
+      expect(ciWorkflow).toContain("run: npm run ci:test:e2e");
+      expect(ciWorkflow.indexOf("run: npm run test:ci")).toBeLessThan(
+        ciWorkflow.indexOf("run: npm run ci:test:e2e"),
+      );
     });
 
     it("typecheck script uses turbo run typecheck", () => {
@@ -214,6 +221,9 @@ describe("Turborepo configuration", () => {
 
       expect(rootPkg.scripts["test:e2e"]).toBe(
         "npm run test:e2e --workspace @franken/orchestrator --",
+      );
+      expect(rootPkg.scripts["ci:test:e2e"]).toBe(
+        "node scripts/retry-ci-command.mjs -- npm run test:e2e -- tests/e2e/smoke.test.ts tests/e2e/chat/chat-e2e.test.ts",
       );
       expect(readme).toContain("npm run test:e2e");
       expect(readme).toContain("E2E=true");

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -157,9 +157,16 @@ on:
 
       expect(ciTestStep, 'CI should have an explicit root-and-package test step').toBeTruthy();
       expect(ciTestStep?.run).toBe('npm run test:ci');
+      const e2eStep = expectSteps(buildTestLint).find((step) => step.name === 'Run orchestrator E2E smoke CI suite');
+      expect(e2eStep, 'CI should make the orchestrator E2E gate explicit').toBeTruthy();
+      expect(e2eStep?.run).toBe('npm run ci:test:e2e');
       expect(packageJson.scripts?.['ci:test:root']).toBe('node scripts/retry-ci-command.mjs -- npm run test:root');
+      expect(packageJson.scripts?.['ci:test:e2e']).toBe(
+        'node scripts/retry-ci-command.mjs -- npm run test:e2e -- tests/e2e/smoke.test.ts tests/e2e/chat/chat-e2e.test.ts',
+      );
       expect(testCiScript).toContain('npm run ci:test:root');
       expect(testCiScript.indexOf('npm run ci:test:root')).toBeLessThan(testCiScript.indexOf('npm run ci:test:packages'));
+      expect(content.indexOf('npm run test:ci')).toBeLessThan(content.indexOf('npm run ci:test:e2e'));
       expect(content).not.toMatch(/npm run test:root --/);
     });
 
@@ -192,10 +199,14 @@ on:
       expect(packageJson.scripts?.['ci:test:observer-eval']).toBe(
         'node scripts/retry-ci-command.mjs -- npm run test:eval --workspace @franken/observer',
       );
+      expect(packageJson.scripts?.['ci:test:e2e']).toBe(
+        'node scripts/retry-ci-command.mjs -- npm run test:e2e -- tests/e2e/smoke.test.ts tests/e2e/chat/chat-e2e.test.ts',
+      );
       expect(packageJson.scripts?.['test:ci']).toBe(
         'npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages && npm run ci:test:planner-integration && npm run ci:test:observer-eval',
       );
       expect(content).toContain('npm run test:ci');
+      expect(content).toContain('run: npm run ci:test:e2e');
       expect(content).not.toContain('run: npm run ci:test:root');
       expect(content).not.toContain('run: npm run ci:test:packages');
       expect(content).not.toContain('run: npm run ci:test:planner-integration');
@@ -208,6 +219,7 @@ on:
       expect(content).toMatch(/name:\s*Run package build and typecheck/);
       expect(content).toMatch(/name:\s*Run workspace lint gate/);
       expect(content).toMatch(/name:\s*Run root and package CI test suite/);
+      expect(content).toMatch(/name:\s*Run orchestrator E2E smoke CI suite/);
     });
 
     it('keeps workflow linting in a dedicated workflow so broken ci.yml syntax can be reported', () => {


### PR DESCRIPTION
## Summary
- add retry-wrapped ci:test:e2e script for a deterministic orchestrator E2E smoke subset
- make the main CI workflow run that E2E smoke gate as a named step after test:ci
- update CI workflow tests and quickstart docs to lock in the visible opt-in

## Test Plan
- npm run test:root -- tests/unit/ci-workflow.test.ts tests/turborepo.test.ts
- npm run build --workspace @franken/types && npm run ci:test:e2e
- npm run typecheck
- npm run lint

Closes #2083