### PR TITLE
fix(web): reconnect Beast SSE after malformed payloads

### DIFF
--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -180,6 +180,12 @@ export class BeastApiClient {
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let lastEventId: string | undefined;
     let failedEventId: string | undefined;
+    class MalformedSsePayloadError extends Error {
+      constructor(readonly originalError: unknown) {
+        super(toError(originalError).message);
+        this.name = 'MalformedSsePayloadError';
+      }
+    }
     const parse = <T>(event: MessageEvent): T => JSON.parse(event.data) as T;
     const parseWithEventId = <T extends object>(event: MessageEvent): T & { eventId?: string } => {
       const parsed = parse<T>(event);
@@ -209,7 +215,7 @@ export class BeastApiClient {
         payload = parsePayload(event);
       } catch (error) {
         rememberFailedEventId(event);
-        throw error;
+        throw new MalformedSsePayloadError(error);
       }
       rememberProcessedEventId(event);
       handler(payload);
@@ -226,6 +232,20 @@ export class BeastApiClient {
         });
       }, 1_000);
     };
+    const reconnectAfterMalformedPayload = (source: EventSource): void => {
+      if (closed || eventSource !== source) return;
+      eventSource = undefined;
+      source.close();
+      scheduleReconnect();
+    };
+    const reportEventError = (error: unknown, source: EventSource): void => {
+      if (error instanceof MalformedSsePayloadError) {
+        handlers.error?.(toError(error.originalError));
+        reconnectAfterMalformedPayload(source);
+        return;
+      }
+      handlers.error?.(toError(error));
+    };
 
     const connect = async () => {
       const body = await this.requestRaw<{ ticket: string }>('/v1/beasts/events/ticket', { method: 'POST' });
@@ -239,49 +259,55 @@ export class BeastApiClient {
       eventSource = nextSource;
 
       nextSource.addEventListener('snapshot', (event) => {
+        if (eventSource !== nextSource) return;
         try {
           handleEvent(event as MessageEvent, parse<BeastSseSnapshot>, handlers.snapshot);
         } catch (error) {
-          handlers.error?.(toError(error));
+          reportEventError(error, nextSource);
         }
       });
       nextSource.addEventListener('agent.status', (event) => {
+        if (eventSource !== nextSource) return;
         try {
           handleEvent(event as MessageEvent, parse<BeastSseAgentStatusEvent>, handlers.agentStatus);
         } catch (error) {
-          handlers.error?.(toError(error));
+          reportEventError(error, nextSource);
         }
       });
       nextSource.addEventListener('agent.event', (event) => {
+        if (eventSource !== nextSource) return;
         try {
           handleEvent(event as MessageEvent, parse<BeastSseAgentEvent>, handlers.agentEvent);
         } catch (error) {
-          handlers.error?.(toError(error));
+          reportEventError(error, nextSource);
         }
       });
       nextSource.addEventListener('run.status', (event) => {
+        if (eventSource !== nextSource) return;
         try {
           handleEvent(event as MessageEvent, parse<BeastSseRunStatusEvent>, handlers.runStatus);
         } catch (error) {
-          handlers.error?.(toError(error));
+          reportEventError(error, nextSource);
         }
       });
       nextSource.addEventListener('run.log', (event) => {
+        if (eventSource !== nextSource) return;
         try {
           handleEvent(event as MessageEvent, parseWithEventId<BeastSseRunLogEvent>, handlers.runLog);
         } catch (error) {
-          handlers.error?.(toError(error));
+          reportEventError(error, nextSource);
         }
       });
       nextSource.addEventListener('run.event', (event) => {
+        if (eventSource !== nextSource) return;
         try {
           handleEvent(event as MessageEvent, parse<BeastSseRunEvent>, handlers.runEvent);
         } catch (error) {
-          handlers.error?.(toError(error));
+          reportEventError(error, nextSource);
         }
       });
       nextSource.addEventListener('error', () => {
-        if (closed) return;
+        if (closed || eventSource !== nextSource) return;
         nextSource.close();
         handlers.error?.(new Error('Beast event stream disconnected; reconnecting'));
         scheduleReconnect();

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -529,6 +529,71 @@ describe('BeastApiClient', () => {
     }
   });
 
+  it('reconnects after malformed handled SSE payloads without accepting later stale-source events', async () => {
+    vi.useFakeTimers();
+    const closeFirst = vi.fn();
+    const closeSecond = vi.fn();
+    const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string; lastEventId?: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string; lastEventId?: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: listeners.length === 1 ? closeFirst : closeSecond,
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const onRunStatus = vi.fn();
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ runStatus: onRunStatus, runLog: vi.fn(), error: onError });
+
+      listeners[0]?.['run.status']?.({
+        data: JSON.stringify({ runId: 'run-1', status: 'running' }),
+        lastEventId: '42',
+      });
+      listeners[0]?.['run.log']?.({
+        data: '{malformed-json',
+        lastEventId: '43',
+      });
+      listeners[0]?.['run.status']?.({
+        data: JSON.stringify({ runId: 'run-1', status: 'completed' }),
+        lastEventId: '44',
+      });
+
+      expect(closeFirst).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(expect.any(SyntaxError));
+      expect(onRunStatus).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(MockEventSource).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=42',
+      );
+
+      unsubscribe();
+      expect(closeSecond).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
   it('acknowledges unhandled SSE events without parsing their payloads', async () => {
     vi.useFakeTimers();
     const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];


### PR DESCRIPTION
## Summary
- close and reconnect the Beast SSE stream when a handled event payload fails to parse
- keep the reconnect cursor at the last successfully parsed event id and ignore stale events from the closed source
- add a regression covering malformed run.log payloads followed by later source events and reconnect URL cursor behavior

## Test Plan
- npm test --workspace @franken/web -- --run tests/lib/beast-api.test.ts -t 'reconnects after malformed handled SSE payloads'
- npm test --workspace @franken/web -- --run tests/lib/beast-api.test.ts
- npm test --workspace @franken/web
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/web

Closes #2082