### PR TITLE
docs(dx): align README quickstart with bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,13 +370,15 @@ For CLI entrypoints such as `frankenbeast chat-server`, `frankenbeast network`, 
 
 ## Quick Start
 
+For a fresh checkout, follow the same supported first-run path as [ONBOARDING.md](ONBOARDING.md) and [docs/guides/quickstart.md](docs/guides/quickstart.md): use bootstrap so Node.js, npm/Corepack, `.env` defaults, dependency installation, and optional Docker-service checks stay in sync.
+
 ```bash
 # Clone the repository
 git clone <repo-url> frankenbeast
 cd frankenbeast
 
-# Install all dependencies
-npm install
+# Run the canonical local setup path without optional Docker services
+npm run bootstrap -- --no-docker
 
 # Optional: scaffold a standalone quick-start example into ../my-frankenbeast-app
 npm run create:project -- quick-start ../my-frankenbeast-app
@@ -390,6 +392,8 @@ npm test
 # Run root-level Vitest tests only
 npm run test:root
 ```
+
+For CI-style validation without mutating files or installing dependencies, run `./scripts/bootstrap.sh --dry-run`. If you intentionally need a manual dependency install instead of bootstrap, run it from the repository root with the Corepack-activated npm version from `packageManager`, copy or merge `.env.example` into `.env`, and note that you are skipping bootstrap's environment validation and optional Docker-service prompts.
 
 The root Vitest suite also checks local Markdown links in README/docs/package READMEs. Local link targets are treated as untrusted input: keep them simple repository-relative paths and do not add shell metacharacters such as backticks, `$`, `;`, `&`, `|`, `<`, or `>`. External `http(s)` links and same-page anchors are ignored by that local filesystem check.
 

--- a/tests/docs-issue-2069.test.ts
+++ b/tests/docs-issue-2069.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+const bootstrapCommand = 'npm run bootstrap -- --no-docker';
+
+describe('issue #2069 README bootstrap onboarding alignment', () => {
+  it('keeps the README Quick Start aligned with the canonical bootstrap first-run path', () => {
+    const readme = readDoc('README.md');
+    const quickStart = readme.slice(
+      readme.indexOf('## Quick Start'),
+      readme.indexOf('## Run the Dashboard with MCP Mode'),
+    );
+
+    expect(quickStart).toContain(bootstrapCommand);
+    expect(quickStart).toContain('ONBOARDING.md');
+    expect(quickStart).toContain('docs/guides/quickstart.md');
+    expect(quickStart).toContain('skipping bootstrap');
+    expect(quickStart).not.toContain('# Install all dependencies\nnpm install');
+  });
+
+  it('keeps all first-run docs on the same default install command', () => {
+    expect(readDoc('README.md')).toContain(bootstrapCommand);
+    expect(readDoc('ONBOARDING.md')).toContain(bootstrapCommand);
+    expect(readDoc('docs/guides/quickstart.md')).toContain(bootstrapCommand);
+  });
+});


### PR DESCRIPTION
## Summary
- update the later README Quick Start to use `npm run bootstrap -- --no-docker` as the default fresh-checkout setup path
- document dry-run and manual-install caveats so raw installs are clearly advanced alternatives
- add a regression test that keeps README, ONBOARDING, and docs/guides/quickstart.md aligned on the bootstrap command

## Test Plan
- `npm run test:root -- tests/docs-issue-2069.test.ts tests/docs-issue-1094.test.ts`
- `./scripts/bootstrap.sh --dry-run`
- `git diff --check`
- `npm run test:root`
- `npm run typecheck`

Closes #2069