### PR TITLE
fix(web): reject fake directory picker paths

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -199,6 +199,11 @@ function CatalogPromptField({
       {prompt.kind === 'file' && (
         <p className="mt-1 text-xs text-beast-muted">Use a repo-relative Markdown path when required by the selected Beast.</p>
       )}
+      {prompt.kind === 'directory' && (
+        <p className="mt-1 text-xs text-beast-muted">
+          Browser directory pickers cannot provide server paths. Enter a repo-relative directory path manually.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -143,6 +143,26 @@ describe('WizardDialog validation', () => {
     expect(screen.getByText('Required workflow fields are missing:')).toBeTruthy();
   });
 
+  it('rejects browser fake paths for directory prompts before launch', () => {
+    useBeastStore.getState().setStepValues(0, { name: 'Martin Agent' });
+    useBeastStore.getState().nextStep();
+    renderWizard();
+
+    fireEvent.click(screen.getByRole('button', { name: /Martin Loop/ }));
+    expect(screen.getByText(/Browser directory pickers cannot provide server paths/i)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText(/Which provider should run the martin loop/i), { target: { value: 'codex' } });
+    fireEvent.change(screen.getByLabelText(/What should the martin loop accomplish/i), { target: { value: 'Run chunks' } });
+    fireEvent.change(screen.getByLabelText(/Which chunk directory should MartinLoop execute from/i), {
+      target: { value: 'C:\\fakepath\\chunks' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('alert').textContent).toContain(
+      'Browser directory pickers cannot provide a server path. Enter a repo-relative path manually.',
+    );
+  });
+
   it('includes the review summary in form view before the launch action', () => {
     useBeastStore.getState().setStepValues(0, { name: 'Reviewable Agent' });
     useBeastStore.getState().setStepValues(1, {

--- a/packages/franken-web/src/components/beasts/wizard-validation.ts
+++ b/packages/franken-web/src/components/beasts/wizard-validation.ts
@@ -114,7 +114,7 @@ function validateCatalogPrompt(
   }
   if (isDirectoryPathPrompt(prompt) && typeof value === 'string' && (isBrowserFakePath(value) || hasUnsafeRepoPathSegments(value))) {
     errors[errorKey] = isBrowserFakePath(value)
-      ? 'Directory path must be a repo-relative path, not a browser fake path.'
+      ? 'Browser directory pickers cannot provide a server path. Enter a repo-relative path manually.'
       : 'Directory path must be a repo-relative path without traversal.';
   }
 }

--- a/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-validation.test.ts
@@ -90,7 +90,7 @@ describe('wizard validation', () => {
   ])('rejects browser fakepath values for %s', (_label, workflowValues, errorKey) => {
     const errors = validateWizardStep(1, { 1: workflowValues });
 
-    expect(errors[errorKey]).toBe('Directory path must be a repo-relative path, not a browser fake path.');
+    expect(errors[errorKey]).toBe('Browser directory pickers cannot provide a server path. Enter a repo-relative path manually.');
   });
 
   it('rejects martin-loop when backend-required fields are missing', () => {


### PR DESCRIPTION
## Summary
- clarify directory prompt helper copy so operators manually enter repo-relative server paths
- reject browser fake directory picker values with a direct server-path validation error
- add a Beast wizard regression test covering C:\fakepath directory prompt input before launch

## Test Plan
- npm --prefix packages/franken-web test -- src/components/beasts/wizard-dialog.test.tsx
- npm --prefix packages/franken-web run lint
- npm run build --workspace @franken/types && npm --prefix packages/franken-web run typecheck && npm --prefix packages/franken-web run build

Closes #2094