### PR TITLE
docs(governor): refresh ramp-up wiring status

### DIFF
--- a/packages/franken-governor/docs/RAMP_UP.md
+++ b/packages/franken-governor/docs/RAMP_UP.md
@@ -19,7 +19,7 @@
 ## Current Orchestrator Wiring
 - `packages/franken-orchestrator/src/cli/dep-factory.ts` imports `@franken/governor` lazily when `modules.governor` is enabled.
 - TTY CLI runs use `CliChannel` through `ApprovalGateway` and `GovernorPortAdapter`.
-- Non-TTY CLI runs use the orchestrator adapter's configured default decision path instead of prompting on stdin.
+- Non-TTY CLI runs reject approvals by default through `GovernorPortAdapter` without prompting on stdin, and only auto-approve when `FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1` is set.
 - Missing enabled governor packages fail closed by default. Unsafe all-approve fallback requires the explicit `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opt-out documented in the root ramp-up guide.
 
 ## Narrow Integration Notes

--- a/tests/docs-issue-2099.test.ts
+++ b/tests/docs-issue-2099.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readText = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+describe('issue #2099 governor ramp-up wiring status docs', () => {
+  it('documents current governor wiring instead of stale ghost/stub-only status', () => {
+    const rampUp = readText('packages/franken-governor/docs/RAMP_UP.md');
+
+    expect(rampUp).toContain('**Status**: **Integrated safety module**');
+    expect(rampUp).toContain('loads `@franken/governor` when the governor module is enabled');
+    expect(rampUp).toContain('falls back to the local passthrough governor only when the module is explicitly disabled');
+    expect(rampUp).toContain('`GovernorPortAdapter`');
+    expect(rampUp).toContain('`CliChannel`');
+    expect(rampUp).toContain('Non-TTY CLI runs reject approvals by default');
+    expect(rampUp).toContain('`FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=1`');
+    expect(rampUp).toContain('`FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1`');
+
+    expect(rampUp).not.toMatch(/\bGHOST\b/u);
+    expect(rampUp).not.toContain('currently **unwired**');
+    expect(rampUp).not.toContain('auto-approves all tasks and budget increases because it uses a no-op governor stub');
+  });
+});


### PR DESCRIPTION
## Summary
- Clarify non-TTY franken-governor ramp-up wiring now rejects by default through GovernorPortAdapter unless the explicit noninteractive approval env var is set
- Add issue #2099 docs regression coverage to prevent stale GHOST/unwired/stub-only claims from returning

## Test Plan
- npm run test:root -- tests/docs-issue-2099.test.ts tests/docs-issue-949.test.ts
- npm run typecheck -- --filter=@franken/governor --filter=@franken/orchestrator

Closes #2099