### PR TITLE
feat(learning): add per-agent improvement scorecards

### DIFF
--- a/packages/franken-critique/README.md
+++ b/packages/franken-critique/README.md
@@ -137,6 +137,12 @@ Callers that need a different window can construct `new LessonRecorder(memory, {
 
 Each mined pattern includes a stable `key`, evaluator name, normalized finding, threshold, occurrence count, ordered distinct task ids, first/last seen timestamps, and operator guidance. Repeated observations from the same task do not increment the pattern, and warning-only findings are ignored so the signal stays focused on true blockers. The default threshold is 3 distinct tasks; tests or replay callers can pass `blockerPatternThreshold` and a shared `blockerPatternStore` in `LessonRecorderOptions` when multiple recorder instances should mine against the same in-process history.
 
+## Per-agent improvement scorecards
+
+Callers that know the worker/agent identity can construct `new LessonRecorder(memory, { agentId })` to attach an `agentImprovementScorecard` to each recorded critique lesson. The recorder trims and validates the id up front; blank ids throw so PM summaries do not group lessons under an ambiguous agent.
+
+Each scorecard is structured for worker retrospectives and PM/liveness handoffs, with schema version, `agentId`, task/evaluator ids, generated timestamp, initial/final score, score delta, failing/resolved iterations, critical/warning/info finding counts, and LLM-friendly improvement signals. Use it to compare an agent's recovered critique loops over time without parsing free-form lesson prose.
+
 ## Package scripts
 
 Run these from the package directory with `npm run <script>`, or from the repository root with `npm run <script> --workspace @franken/critique`.

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -33,6 +33,7 @@ export type {
   LessonCooldownMetadata,
   LessonCooldownSuppression,
   CrossTaskBlockerPattern,
+  AgentImprovementScorecard,
   LessonRecordingResult,
   ReviewerFeedbackLessonEntry,
   ReviewerFeedbackLessonCapture,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -7,6 +7,7 @@ import type {
   PostPrLessonExtractionTemplate,
   LessonRollbackWorkflow,
   CrossTaskBlockerPattern,
+  AgentImprovementScorecard,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
@@ -33,6 +34,8 @@ const DEFAULT_BLOCKER_PATTERN_THRESHOLD = 3;
 const MIN_BLOCKER_PATTERN_THRESHOLD = 2;
 const BLOCKER_PATTERN_GUIDANCE =
   'Equivalent blocker findings have recurred across distinct tasks; PM/liveness handoffs should treat this as a cross-task pattern and route a durable mitigation instead of rediscovering it per task.';
+const AGENT_IMPROVEMENT_SCORECARD_GUIDANCE =
+  'Use this per-agent scorecard in worker retrospectives and PM handoff summaries to compare improvement over time without parsing free-form lesson prose.';
 
 export interface BlockerPatternObservation {
   readonly taskId: TaskId;
@@ -65,6 +68,8 @@ export interface LessonRecorderOptions {
   readonly blockerPatternThreshold?: number;
   /** Shared blocker-pattern state for mining recurrent blockers across recorder instances. */
   readonly blockerPatternStore?: Map<string, BlockerPatternState>;
+  /** Optional per-agent identifier used to attach deterministic improvement scorecards to learned lessons. */
+  readonly agentId?: string;
 }
 
 const LESSON_EXPERIMENT_SANDBOX_REASON =
@@ -138,6 +143,7 @@ export class LessonRecorder {
   private readonly blockerPatternThreshold: number;
   private readonly blockerPatterns: Map<string, BlockerPatternState>;
   private readonly pendingBlockerAdmissions: Map<string, Promise<void>>;
+  private readonly agentId?: string;
   private readonly pendingBlockerObservations = new WeakMap<
     CritiqueLesson,
     PendingBlockerPatternObservation[]
@@ -172,6 +178,15 @@ export class LessonRecorder {
     this.pendingBlockerAdmissions = getPendingBlockerAdmissions(
       this.blockerPatterns,
     );
+    if (options.agentId !== undefined) {
+      const agentId = options.agentId.trim();
+      if (!agentId) {
+        throw new RangeError(
+          'LessonRecorder agentId must be a non-empty string when provided.',
+        );
+      }
+      this.agentId = agentId;
+    }
     const now = options.now ?? ((): Date => new Date());
     this.now = (): string => normalizeTimestamp(now());
     this.cooldowns = options.cooldownStore ?? new Map<string, number>();
@@ -371,6 +386,19 @@ export class LessonRecorder {
           ),
           postPrLessonExtractionTemplate:
             createPostPrLessonExtractionTemplate(),
+          ...(this.agentId
+            ? {
+                agentImprovementScorecard: createAgentImprovementScorecard(
+                  this.agentId,
+                  taskId,
+                  evalResult.evaluatorName,
+                  failingIteration,
+                  allIterations,
+                  critiqueFindings,
+                  recordedAt,
+                ),
+              }
+            : {}),
           cooldown: {
             key: cooldownKey,
             windowMs: this.cooldownMs,
@@ -651,6 +679,14 @@ export class LessonRecorder {
     return {
       ...lesson,
       timestamp: recordedAt,
+      ...(lesson.agentImprovementScorecard
+        ? {
+            agentImprovementScorecard: {
+              ...lesson.agentImprovementScorecard,
+              generatedAt: recordedAt,
+            },
+          }
+        : {}),
       cooldown: {
         ...lesson.cooldown,
         recordedAt,
@@ -741,6 +777,100 @@ function createBlockerPatternKey(
 
 function normalizeBlockerFinding(message: string): string {
   return message.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function createAgentImprovementScorecard(
+  agentId: string,
+  taskId: TaskId,
+  evaluatorName: string,
+  failingIteration: CritiqueIteration,
+  allIterations: readonly CritiqueIteration[],
+  currentFindings: readonly {
+    readonly message: string;
+    readonly severity: string;
+  }[],
+  generatedAt: string,
+): AgentImprovementScorecard {
+  const evaluatorFailures = allIterations.filter((iteration) =>
+    iteration.result.results.some(
+      (result) =>
+        result.evaluatorName === evaluatorName && result.verdict === 'fail',
+    ),
+  );
+  const failingIterations = evaluatorFailures.map((iteration) => iteration.index);
+  const allFindings = evaluatorFailures.flatMap((iteration) =>
+    iteration.result.results
+      .filter(
+        (result) =>
+          result.evaluatorName === evaluatorName && result.verdict === 'fail',
+      )
+      .flatMap((result) =>
+        result.findings.filter(
+          (finding) => finding.location !== EVALUATOR_EXCEPTION_LOCATION,
+        ),
+      ),
+  );
+  const findings = allFindings.length > 0 ? allFindings : currentFindings;
+  const initialScore =
+    failingIteration.result.results.find(
+      (result) => result.evaluatorName === evaluatorName,
+    )?.score ?? failingIteration.result.overallScore;
+  const passingIteration = allIterations.find(
+    (iteration) =>
+      iteration.result.verdict === 'pass' || iteration.result.verdict === 'warn',
+  );
+  const finalScore = passingIteration?.result.overallScore ?? initialScore;
+  const findingCounts = countScorecardFindings(findings);
+  const scoreDelta = roundScore(finalScore - initialScore);
+  const improvementSignals = [
+    `Recovered from ${failingIterations.length} failing critique ${
+      failingIterations.length === 1 ? 'iteration' : 'iterations'
+    } before ${passingIteration?.result.verdict ?? 'recovery'}.`,
+    `Improved ${evaluatorName} score by ${scoreDelta}.`,
+    ...(findingCounts.critical > 0
+      ? [
+          `Resolved ${findingCounts.critical} critical blocker ${
+            findingCounts.critical === 1 ? 'finding' : 'findings'
+          }.`,
+        ]
+      : []),
+  ];
+
+  return {
+    schemaVersion: 'agent-improvement-scorecard-v1',
+    agentId,
+    taskId,
+    evaluatorName,
+    generatedAt,
+    initialScore: roundScore(initialScore),
+    finalScore: roundScore(finalScore),
+    scoreDelta,
+    failingIterations,
+    resolvedIteration: passingIteration?.index ?? failingIteration.index,
+    findingCounts,
+    improvementSignals,
+    guidance: AGENT_IMPROVEMENT_SCORECARD_GUIDANCE,
+  };
+}
+
+function countScorecardFindings(
+  findings: readonly { readonly severity: string }[],
+): AgentImprovementScorecard['findingCounts'] {
+  const counts = { critical: 0, warning: 0, info: 0, total: findings.length };
+  for (const finding of findings) {
+    if (finding.severity === 'critical') {
+      counts.critical += 1;
+    } else if (finding.severity === 'warning') {
+      counts.warning += 1;
+    } else {
+      counts.info += 1;
+    }
+  }
+  return counts;
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 1000) / 1000;
 }
 
 function createPostPrLessonExtractionTemplate(): PostPrLessonExtractionTemplate {

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -794,7 +794,11 @@ function createAgentImprovementScorecard(
   const evaluatorFailures = allIterations.filter((iteration) =>
     iteration.result.results.some(
       (result) =>
-        result.evaluatorName === evaluatorName && result.verdict === 'fail',
+        result.evaluatorName === evaluatorName &&
+        result.verdict === 'fail' &&
+        result.findings.some(
+          (finding) => finding.location !== EVALUATOR_EXCEPTION_LOCATION,
+        ),
     ),
   );
   const failingIterations = evaluatorFailures.map((iteration) => iteration.index);

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -812,14 +812,23 @@ function createAgentImprovementScorecard(
   );
   const findings = allFindings.length > 0 ? allFindings : currentFindings;
   const initialScore =
+    evaluatorFailures[0]?.result.results.find(
+      (result) => result.evaluatorName === evaluatorName,
+    )?.score ??
     failingIteration.result.results.find(
       (result) => result.evaluatorName === evaluatorName,
-    )?.score ?? failingIteration.result.overallScore;
+    )?.score ??
+    failingIteration.result.overallScore;
   const passingIteration = allIterations.find(
     (iteration) =>
       iteration.result.verdict === 'pass' || iteration.result.verdict === 'warn',
   );
-  const finalScore = passingIteration?.result.overallScore ?? initialScore;
+  const finalScore =
+    passingIteration?.result.results.find(
+      (result) => result.evaluatorName === evaluatorName,
+    )?.score ??
+    passingIteration?.result.overallScore ??
+    initialScore;
   const findingCounts = countScorecardFindings(findings);
   const scoreDelta = roundScore(finalScore - initialScore);
   const improvementSignals = [

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -197,6 +197,39 @@ export interface CrossTaskBlockerPattern {
   readonly guidance: string;
 }
 
+/** Deterministic per-agent learning summary for worker retrospectives and PM handoffs. */
+export interface AgentImprovementScorecard {
+  /** Stable schema identifier for PM/liveness tooling. */
+  readonly schemaVersion: 'agent-improvement-scorecard-v1';
+  /** Agent or worker identifier supplied by the recorder caller. */
+  readonly agentId: string;
+  readonly taskId: TaskId;
+  readonly evaluatorName: string;
+  /** Timestamp when the scorecard was generated. */
+  readonly generatedAt: string;
+  /** First failing score for this evaluator in the recovered critique loop. */
+  readonly initialScore: number;
+  /** Final recovered overall score from the pass/warn iteration. */
+  readonly finalScore: number;
+  /** Rounded difference between finalScore and initialScore. */
+  readonly scoreDelta: number;
+  /** Failing iteration indexes for this evaluator that contributed feedback. */
+  readonly failingIterations: readonly number[];
+  /** Iteration that recovered to pass/warn. */
+  readonly resolvedIteration: number;
+  /** Finding counts across the agent's failing iterations for this evaluator. */
+  readonly findingCounts: {
+    readonly critical: number;
+    readonly warning: number;
+    readonly info: number;
+    readonly total: number;
+  };
+  /** LLM-friendly bullets that can be copied into retrospectives without parsing prose. */
+  readonly improvementSignals: readonly string[];
+  /** Operator-facing guidance for interpreting the scorecard. */
+  readonly guidance: string;
+}
+
 /** Summary returned by LessonRecorder.record for PM/liveness consumers. */
 export interface LessonRecordingResult {
   readonly recorded: number;
@@ -226,6 +259,8 @@ export interface CritiqueLesson {
   readonly cooldown?: LessonCooldownMetadata;
   /** Cross-task blocker patterns associated with this lesson, if any crossed the threshold. */
   readonly blockerPatterns?: readonly CrossTaskBlockerPattern[];
+  /** Optional per-agent learning scorecard for worker retrospectives and PM handoffs. */
+  readonly agentImprovementScorecard?: AgentImprovementScorecard;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -38,6 +38,13 @@ function createIteration(
     ],
     shortCircuited: false,
   };
+  return createIterationFromResult(index, result);
+}
+
+function createIterationFromResult(
+  index: number,
+  result: CritiqueResult,
+): CritiqueIteration {
   return {
     index,
     input: { content: `iteration ${index}`, metadata: {} },
@@ -267,6 +274,87 @@ describe('LessonRecorder', () => {
       ],
       guidance:
         'Use this per-agent scorecard in worker retrospectives and PM handoff summaries to compare improvement over time without parsing free-form lesson prose.',
+    });
+  });
+
+  it('uses the first failed evaluator score and recovered evaluator score in per-agent scorecards', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, { agentId: 'worker-alpha' });
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIterationFromResult(0, {
+          verdict: 'fail',
+          overallScore: 0.2,
+          shortCircuited: false,
+          results: [
+            {
+              evaluatorName: 'quality-gate',
+              verdict: 'fail',
+              score: 0.1,
+              findings: [{ message: 'missing verifier', severity: 'warning' }],
+            },
+            {
+              evaluatorName: 'style-gate',
+              verdict: 'pass',
+              score: 0.9,
+              findings: [],
+            },
+          ],
+        }),
+        createIterationFromResult(1, {
+          verdict: 'fail',
+          overallScore: 0.4,
+          shortCircuited: false,
+          results: [
+            {
+              evaluatorName: 'quality-gate',
+              verdict: 'fail',
+              score: 0.5,
+              findings: [{ message: 'partial verifier', severity: 'warning' }],
+            },
+          ],
+        }),
+        createIterationFromResult(2, {
+          verdict: 'pass',
+          overallScore: 0.6,
+          shortCircuited: false,
+          results: [
+            {
+              evaluatorName: 'quality-gate',
+              verdict: 'pass',
+              score: 0.95,
+              findings: [],
+            },
+            {
+              evaluatorName: 'style-gate',
+              verdict: 'warn',
+              score: 0.25,
+              findings: [{ message: 'style nit', severity: 'warning' }],
+            },
+          ],
+        }),
+      ],
+    };
+
+    await recorder.record(result, 'scorecard-task');
+
+    const firstLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(firstLesson.agentImprovementScorecard).toMatchObject({
+      evaluatorName: 'quality-gate',
+      initialScore: 0.1,
+      finalScore: 0.95,
+      scoreDelta: 0.85,
+      failingIterations: [0, 1],
+      resolvedIteration: 2,
+      findingCounts: {
+        critical: 0,
+        warning: 2,
+        info: 0,
+        total: 2,
+      },
     });
   });
 

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -207,6 +207,75 @@ describe('LessonRecorder', () => {
     });
   });
 
+  it('attaches a deterministic per-agent improvement scorecard to recorded lessons when an agent id is configured', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      agentId: 'worker-alpha',
+      now: (): string => '2026-07-12T00:00:00.000Z',
+    });
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'quality-gate', [
+          {
+            message: 'PR handoff omitted verification evidence',
+            severity: 'warning',
+            suggestion: 'Add the targeted test command and result.',
+          },
+          {
+            message: 'Reviewer blocker was left unresolved',
+            severity: 'critical',
+            suggestion: 'Resolve the review thread before merge.',
+          },
+        ]),
+        createIteration(1, 'fail', 'quality-gate', [
+          {
+            message: 'Verification evidence is present but incomplete',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(2, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'scorecard-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(lesson.agentImprovementScorecard).toEqual({
+      schemaVersion: 'agent-improvement-scorecard-v1',
+      agentId: 'worker-alpha',
+      taskId: 'scorecard-task',
+      evaluatorName: 'quality-gate',
+      generatedAt: '2026-07-12T00:00:00.000Z',
+      initialScore: 0.3,
+      finalScore: 1,
+      scoreDelta: 0.7,
+      failingIterations: [0, 1],
+      resolvedIteration: 2,
+      findingCounts: {
+        critical: 1,
+        warning: 2,
+        info: 0,
+        total: 3,
+      },
+      improvementSignals: [
+        'Recovered from 2 failing critique iterations before pass.',
+        'Improved quality-gate score by 0.7.',
+        'Resolved 1 critical blocker finding.',
+      ],
+      guidance:
+        'Use this per-agent scorecard in worker retrospectives and PM handoff summaries to compare improvement over time without parsing free-form lesson prose.',
+    });
+  });
+
+  it('rejects blank per-agent scorecard ids so PM summaries do not group lessons under an ambiguous agent', () => {
+    expect(
+      () => new LessonRecorder(createMockMemoryPort(), { agentId: '  ' }),
+    ).toThrow('LessonRecorder agentId must be a non-empty string when provided.');
+  });
+
   it('attaches an LLM-friendly post-PR lesson extraction template to recorded lessons', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -358,6 +358,80 @@ describe('LessonRecorder', () => {
     });
   });
 
+  it('excludes evaluator infrastructure exceptions from per-agent scorecards', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, { agentId: 'worker-alpha' });
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIterationFromResult(0, {
+          verdict: 'fail',
+          overallScore: 0.05,
+          shortCircuited: false,
+          results: [
+            {
+              evaluatorName: 'quality-gate',
+              verdict: 'fail',
+              score: 0.05,
+              findings: [
+                {
+                  message: 'evaluator crashed',
+                  severity: 'critical',
+                  location: EVALUATOR_EXCEPTION_LOCATION,
+                },
+              ],
+            },
+          ],
+        }),
+        createIterationFromResult(1, {
+          verdict: 'fail',
+          overallScore: 0.4,
+          shortCircuited: false,
+          results: [
+            {
+              evaluatorName: 'quality-gate',
+              verdict: 'fail',
+              score: 0.4,
+              findings: [{ message: 'missing verifier', severity: 'warning' }],
+            },
+          ],
+        }),
+        createIterationFromResult(2, {
+          verdict: 'pass',
+          overallScore: 1,
+          shortCircuited: false,
+          results: [
+            {
+              evaluatorName: 'quality-gate',
+              verdict: 'pass',
+              score: 1,
+              findings: [],
+            },
+          ],
+        }),
+      ],
+    };
+
+    await recorder.record(result, 'scorecard-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(port.recordLesson).toHaveBeenCalledTimes(1);
+    expect(lesson.agentImprovementScorecard).toMatchObject({
+      initialScore: 0.4,
+      finalScore: 1,
+      scoreDelta: 0.6,
+      failingIterations: [1],
+      findingCounts: {
+        critical: 0,
+        warning: 1,
+        info: 0,
+        total: 1,
+      },
+    });
+  });
+
   it('rejects blank per-agent scorecard ids so PM summaries do not group lessons under an ambiguous agent', () => {
     expect(
       () => new LessonRecorder(createMockMemoryPort(), { agentId: '  ' }),

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -5,6 +5,7 @@ import type {
   CritiquePipelineResult,
   CritiqueResult as DeprecatedCritiqueResult,
   LessonRollbackWorkflow,
+  AgentImprovementScorecard,
   SessionId,
 } from '@franken/critique';
 
@@ -65,5 +66,30 @@ describe('public critique type contracts', () => {
     };
 
     expect(workflow.workflowId).toBe('lesson-rollback-v1');
+  });
+
+  it('exports per-agent improvement scorecards from the public barrel', () => {
+    const scorecard: AgentImprovementScorecard = {
+      schemaVersion: 'agent-improvement-scorecard-v1',
+      agentId: 'worker-alpha',
+      taskId: 'task-1',
+      evaluatorName: 'quality-gate',
+      generatedAt: '2026-07-12T00:00:00.000Z',
+      initialScore: 0.2,
+      finalScore: 1,
+      scoreDelta: 0.8,
+      failingIterations: [0],
+      resolvedIteration: 1,
+      findingCounts: {
+        critical: 1,
+        warning: 0,
+        info: 0,
+        total: 1,
+      },
+      improvementSignals: ['Recovered from 1 failing critique iteration before pass.'],
+      guidance: 'copy into PM handoff',
+    };
+
+    expect(scorecard.schemaVersion).toBe('agent-improvement-scorecard-v1');
   });
 });


### PR DESCRIPTION
## Summary
- Adds an optional `agentId` LessonRecorder option that attaches deterministic `agentImprovementScorecard` metadata to recorded critique lessons.
- Exports the scorecard contract for PM/liveness consumers and documents how callers should use it in retrospectives and handoffs.
- Covers scorecard generation and blank-agent-id validation with targeted tests.

## Test Plan
- npm run test --workspace @franken/critique
- npm run typecheck --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/critique

Closes #1858