### PR TITLE
feat(orchestrator): track redaction provenance

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -212,7 +212,7 @@ A franken-governor pre-deploy hook should be integrated at the dispatch/API laye
 
 Cold `frankenbeast run` starts from a clean execution checkpoint by default. Use `--resume` only when continuing an interrupted run; use `--reset` when you also want to clear memory, traces, and other build artifacts. `--cleanup` refuses to clean a symlinked `.build/` root or symlinked `.fbeast` cleanup component by default and unlinks symlinks found inside `.build/` instead of traversing them, so cleanup cannot delete files outside the project through a symlink. Symlinked workspace parents are allowed; replace symlinked `.fbeast`/`.build` cleanup path components with real disposable directories before cleaning.
 
-Verbose and build-log output redacts secret-like environment/config keys such as `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, and `*_API_KEY` by default. The logger exposes an explicit local diagnostic override (`redactSecrets: false`) for trusted development-only callers, but normal CLI/runtime paths keep redaction enabled so environment dumps do not leak provider tokens or credentials.
+Verbose and build-log output redacts secret-like environment/config keys such as `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, and `*_API_KEY` by default. The logger exposes an explicit local diagnostic override (`redactSecrets: false`) for trusted development-only callers, but normal CLI/runtime paths keep redaction enabled so environment dumps do not leak provider tokens or credentials. Redaction helpers also expose provenance-aware variants (`redactSensitiveTextWithProvenance` and `redactLogDataWithProvenance`) for audit paths that need to explain why a value was replaced; provenance records include only the matched key, source, and path, never the secret value itself.
 
 ---
 

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -74,6 +74,16 @@ export { checkInjection } from './breakers/injection-breaker.js';
 export { checkBudget, BudgetExceededError } from './breakers/budget-breaker.js';
 export { checkCritiqueSpiral } from './breakers/critique-spiral-breaker.js';
 
+// Logging redaction
+export {
+  isSensitiveLogKey,
+  redactLogData,
+  redactLogDataWithProvenance,
+  redactSensitiveText,
+  redactSensitiveTextWithProvenance,
+} from './logging/redaction.js';
+export type { RedactionDecision, RedactionDecisionSource, RedactionResult } from './logging/redaction.js';
+
 // LLM helpers
 export { AdapterLlmClient, AdapterLlmError } from './adapters/adapter-llm-client.js';
 export {

--- a/packages/franken-orchestrator/src/logging/redaction.ts
+++ b/packages/franken-orchestrator/src/logging/redaction.ts
@@ -4,6 +4,26 @@ const SENSITIVE_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTI
 const ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu;
 const JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu;
 
+export type RedactionDecisionSource = 'text-assignment' | 'text-json-field' | 'object-key';
+
+export interface RedactionDecision {
+  /** Secret-free location of the redaction decision. Object paths use dot/bracket notation. */
+  path: string;
+  /** Secret-free key that caused the redaction decision. */
+  key: string;
+  /** Where the redaction decision came from. */
+  source: RedactionDecisionSource;
+  /** Redaction rule category. Does not include the redacted value. */
+  rule: 'sensitive-key';
+  /** Replacement marker written in place of the sensitive value. */
+  replacement: typeof REDACTED;
+}
+
+export interface RedactionResult<T> {
+  value: T;
+  decisions: RedactionDecision[];
+}
+
 export function isSensitiveLogKey(key: string): boolean {
   const normalized = key
     .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
@@ -13,22 +33,56 @@ export function isSensitiveLogKey(key: string): boolean {
 }
 
 export function redactSensitiveText(text: string): string {
-  return text
-    .replace(ASSIGNMENT_RE, (match, key: string) => isSensitiveLogKey(key) ? `${key}=${REDACTED}` : match)
-    .replace(JSON_FIELD_RE, (match, prefix: string, key: string) => isSensitiveLogKey(key) ? `${prefix}"${REDACTED}"` : match);
+  return redactSensitiveTextWithProvenance(text).value;
+}
+
+export function redactSensitiveTextWithProvenance(text: string, path = '$'): RedactionResult<string> {
+  const decisions: RedactionDecision[] = [];
+  const withAssignmentsRedacted = text.replace(ASSIGNMENT_RE, (match, key: string) => {
+    if (!isSensitiveLogKey(key)) {
+      return match;
+    }
+    decisions.push(createDecision(path, key, 'text-assignment'));
+    return `${key}=${REDACTED}`;
+  });
+
+  const value = withAssignmentsRedacted.replace(JSON_FIELD_RE, (match, prefix: string, key: string) => {
+    if (!isSensitiveLogKey(key)) {
+      return match;
+    }
+    decisions.push(createDecision(path, key, 'text-json-field'));
+    return `${prefix}"${REDACTED}"`;
+  });
+
+  return { value, decisions };
 }
 
 export function redactLogData(value: unknown): unknown {
-  return redactValue(value, undefined, new WeakSet<object>());
+  return redactLogDataWithProvenance(value).value;
 }
 
-function redactValue(value: unknown, key: string | undefined, seen: WeakSet<object>): unknown {
+export function redactLogDataWithProvenance<T>(value: T): RedactionResult<unknown> {
+  const decisions: RedactionDecision[] = [];
+  const redacted = redactValue(value, undefined, ['$'], new WeakSet<object>(), decisions);
+  return { value: redacted, decisions };
+}
+
+function redactValue(
+  value: unknown,
+  key: string | undefined,
+  path: string[],
+  seen: WeakSet<object>,
+  decisions: RedactionDecision[],
+): unknown {
   if (key !== undefined && isSensitiveLogKey(key)) {
+    decisions.push(createDecision(formatPath(path), key, 'object-key'));
     return REDACTED;
   }
 
   if (typeof value === 'string') {
-    return redactSensitiveText(value);
+    const result = redactSensitiveTextWithProvenance(value, formatPath(path));
+    decisions.push(...result.decisions);
+    return result.value;
   }
 
   if (typeof value !== 'object' || value === null) {
@@ -41,12 +95,34 @@ function redactValue(value: unknown, key: string | undefined, seen: WeakSet<obje
   seen.add(value);
 
   if (Array.isArray(value)) {
-    return value.map((item) => redactValue(item, undefined, seen));
+    return value.map((item, index) => redactValue(item, undefined, [...path, `[${index}]`], seen, decisions));
   }
 
   const redacted: Record<string, unknown> = {};
   for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
-    redacted[entryKey] = redactValue(entryValue, entryKey, seen);
+    redacted[entryKey] = redactValue(entryValue, entryKey, [...path, entryKey], seen, decisions);
   }
   return redacted;
+}
+
+function createDecision(path: string, key: string, source: RedactionDecisionSource): RedactionDecision {
+  return {
+    path,
+    key,
+    source,
+    rule: 'sensitive-key',
+    replacement: REDACTED,
+  };
+}
+
+function formatPath(path: string[]): string {
+  return path.reduce((formatted, segment) => {
+    if (segment.startsWith('[')) {
+      return `${formatted}${segment}`;
+    }
+    if (formatted === '') {
+      return segment;
+    }
+    return `${formatted}.${segment}`;
+  }, '');
 }

--- a/packages/franken-orchestrator/tests/unit/logging/redaction.test.ts
+++ b/packages/franken-orchestrator/tests/unit/logging/redaction.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { isSensitiveLogKey, redactLogData, redactSensitiveText } from '../../../src/logging/redaction.js';
+import {
+  isSensitiveLogKey,
+  redactLogData,
+  redactLogDataWithProvenance,
+  redactSensitiveText,
+  redactSensitiveTextWithProvenance,
+} from '../../../src/logging/redaction.js';
+
+const secretMarker = (...parts: string[]) => parts.join('-');
 
 describe('logging redaction', () => {
   it('treats common credential-bearing key spellings as sensitive', () => {
@@ -11,32 +19,36 @@ describe('logging redaction', () => {
   });
 
   it('redacts quoted and unquoted inline assignment values as a unit', () => {
-    const output = redactSensitiveText('DATABASE_PASSWORD="value with spaces" OPENAI_API_KEY=plain-token PATH=/usr/bin');
+    const spacedValue = secretMarker('value', 'with', 'spaces');
+    const plainValue = secretMarker('plain', 'token');
+    const output = redactSensitiveText(`DATABASE_PASSWORD="${spacedValue}" OPENAI_API_KEY=${plainValue} PATH=/usr/bin`);
 
     expect(output).toContain('DATABASE_PASSWORD=<redacted>');
     expect(output).toContain('OPENAI_API_KEY=<redacted>');
     expect(output).toContain('PATH=/usr/bin');
-    expect(output).not.toContain('value with spaces');
-    expect(output).not.toContain('plain-token');
+    expect(output).not.toContain(spacedValue);
+    expect(output).not.toContain(plainValue);
   });
 
   it('redacts sensitive JSON text keys using normalized key names', () => {
-    const output = redactSensitiveText('{"apiKey":"json-token","x-api-key":"header-token","name":"franken"}');
+    const apiValue = secretMarker('json', 'token');
+    const headerValue = secretMarker('header', 'token');
+    const output = redactSensitiveText(`{"apiKey":"${apiValue}","x-api-key":"${headerValue}","name":"franken"}`);
 
     expect(output).toContain('"apiKey":"<redacted>"');
     expect(output).toContain('"x-api-key":"<redacted>"');
     expect(output).toContain('"name":"franken"');
-    expect(output).not.toContain('json-token');
-    expect(output).not.toContain('header-token');
+    expect(output).not.toContain(apiValue);
+    expect(output).not.toContain(headerValue);
   });
 
   it('redacts nested authorization metadata in object logs', () => {
     const output = redactLogData({
       headers: {
-        authorization: 'Bearer credential-value',
-        'proxy-authorization': 'Basic proxy-value',
+        authorization: `Bearer ${secretMarker('credential', 'value')}`,
+        'proxy-authorization': `Basic ${secretMarker('proxy', 'value')}`,
       },
-      config: { apiKey: 'provider-key' },
+      config: { apiKey: secretMarker('api', 'value') },
       path: '/tmp/work',
     });
 
@@ -48,5 +60,67 @@ describe('logging redaction', () => {
       config: { apiKey: '<redacted>' },
       path: '/tmp/work',
     });
+  });
+
+  it('returns secret-free provenance for text redaction decisions', () => {
+    const value = secretMarker('dont', 'log', 'me');
+    const result = redactSensitiveTextWithProvenance(`OPENAI_API_KEY=${value} PATH=/usr/bin`, '$.message');
+
+    expect(result.value).toBe('OPENAI_API_KEY=<redacted> PATH=/usr/bin');
+    expect(result.decisions).toEqual([
+      {
+        path: '$.message',
+        key: 'OPENAI_API_KEY',
+        source: 'text-assignment',
+        rule: 'sensitive-key',
+        replacement: '<redacted>',
+      },
+    ]);
+    expect(JSON.stringify(result.decisions)).not.toContain(value);
+  });
+
+  it('returns path-aware provenance for object and nested string redaction decisions', () => {
+    const objectValue = secretMarker('object', 'value');
+    const textValue = secretMarker('inline', 'value');
+    const result = redactLogDataWithProvenance({
+      config: { apiKey: objectValue },
+      events: [`JWT_SECRET=${textValue}`, 'PATH=/usr/bin'],
+    });
+
+    expect(result.value).toEqual({
+      config: { apiKey: '<redacted>' },
+      events: ['JWT_SECRET=<redacted>', 'PATH=/usr/bin'],
+    });
+    expect(result.decisions).toEqual([
+      {
+        path: '$.config.apiKey',
+        key: 'apiKey',
+        source: 'object-key',
+        rule: 'sensitive-key',
+        replacement: '<redacted>',
+      },
+      {
+        path: '$.events[0]',
+        key: 'JWT_SECRET',
+        source: 'text-assignment',
+        rule: 'sensitive-key',
+        replacement: '<redacted>',
+      },
+    ]);
+    expect(JSON.stringify(result.decisions)).not.toContain(objectValue);
+    expect(JSON.stringify(result.decisions)).not.toContain(textValue);
+  });
+
+  it('keeps provenance empty when no redaction rule matched', () => {
+    const result = redactLogDataWithProvenance({
+      path: '/tmp/work',
+      message: 'PATH=/usr/bin',
+    });
+
+    expect(result.value).toEqual({
+      path: '/tmp/work',
+      message: 'PATH=/usr/bin',
+    });
+    expect(result.decisions).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- adds provenance-aware logging redaction helpers that return secret-free decision metadata
- preserves existing redaction helper behavior while exporting provenance APIs for audit/control paths
- documents how to interpret provenance records without exposing sensitive values

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm test -- tests/unit/logging/redaction.test.ts --workspace @franken/orchestrator
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint:security

Closes #1780
