### PR TITLE
fix(web): surface Beast API structured errors

### DIFF
--- a/packages/franken-web/src/lib/beast-api.test.ts
+++ b/packages/franken-web/src/lib/beast-api.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BeastApiClient, BeastApiError } from './beast-api';
+
+const createAgentInput = {
+  definitionId: 'design-interview',
+  initAction: { kind: 'design-interview', command: 'fbeast run agent', config: {} },
+  initConfig: {},
+} as const;
+
+describe('BeastApiClient error handling', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces structured API error messages with status, code, and details', async () => {
+    const details = { field: 'initConfig.provider' };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: {
+        message: 'Provider is required before launching an agent.',
+        code: 'VALIDATION_FAILED',
+        details,
+      },
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })));
+
+    const client = new BeastApiClient('http://beast.test');
+
+    await expect(client.createAgent(createAgentInput)).rejects.toMatchObject({
+      name: 'BeastApiError',
+      message: 'Provider is required before launching an agent. (HTTP 400, VALIDATION_FAILED)',
+      status: 400,
+      code: 'VALIDATION_FAILED',
+      details,
+    } satisfies Partial<BeastApiError>);
+  });
+
+  it('surfaces direct message/error fields and plain text backend errors', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Agent name is already in use.', code: 'DUPLICATE_AGENT' }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response('Container runtime is unavailable.', {
+        status: 503,
+        headers: { 'Content-Type': 'text/plain' },
+      }));
+    vi.stubGlobal('fetch', fetch);
+
+    const client = new BeastApiClient('http://beast.test');
+
+    await expect(client.createAgent(createAgentInput)).rejects.toMatchObject({
+      message: 'Agent name is already in use. (HTTP 409, DUPLICATE_AGENT)',
+      status: 409,
+      code: 'DUPLICATE_AGENT',
+    });
+    await expect(client.createAgent(createAgentInput)).rejects.toMatchObject({
+      message: 'Container runtime is unavailable. (HTTP 503)',
+      status: 503,
+    });
+  });
+
+  it('falls back to status-only errors when the response has no usable body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 500 })));
+
+    const client = new BeastApiClient('http://beast.test');
+
+    await expect(client.createAgent(createAgentInput)).rejects.toMatchObject({
+      message: 'HTTP 500',
+      status: 500,
+    });
+  });
+});

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -1,7 +1,6 @@
 import { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 import type {
   ApiDataEnvelope,
-  ApiErrorEnvelope,
   BeastCatalogEntry,
   BeastContainerRuntimeStatus,
   BeastInterviewPrompt,
@@ -375,24 +374,67 @@ export class BeastApiClient {
 
   private async toError(response: Response): Promise<BeastApiError> {
     const fallbackMessage = `HTTP ${response.status}`;
-    try {
-      const body = await response.json() as ApiErrorEnvelope;
-      const serverMessage = body.error?.message;
-      if (serverMessage) {
-        const code = body.error.code;
-        const codeSuffix = code ? `, ${code}` : '';
-        return new BeastApiError(
-          `${serverMessage} (HTTP ${response.status}${codeSuffix})`,
-          response.status,
-          code,
-          body.error.details,
-        );
-      }
-    } catch {
-      // Fall through with HTTP status message for empty, malformed, or non-JSON bodies.
+    const text = await response.text().catch(() => '');
+    const parsed = parseErrorBody(text);
+    const serverError = extractServerError(parsed, text);
+
+    if (!serverError.message) {
+      return new BeastApiError(fallbackMessage, response.status);
     }
-    return new BeastApiError(fallbackMessage, response.status);
+
+    const codeSuffix = serverError.code ? `, ${serverError.code}` : '';
+    return new BeastApiError(
+      `${serverError.message} (HTTP ${response.status}${codeSuffix})`,
+      response.status,
+      serverError.code,
+      serverError.details,
+    );
   }
+}
+
+function parseErrorBody(text: string): unknown {
+  if (!text.trim()) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractServerError(parsed: unknown, text: string): { message?: string; code?: string; details?: unknown } {
+  if (isRecord(parsed)) {
+    if (isRecord(parsed.error) && typeof parsed.error.message === 'string' && parsed.error.message.trim()) {
+      return {
+        message: parsed.error.message,
+        code: typeof parsed.error.code === 'string' ? parsed.error.code : undefined,
+        details: parsed.error.details,
+      };
+    }
+
+    const directMessage = parsed.message;
+    if (typeof directMessage === 'string' && directMessage.trim()) {
+      return {
+        message: directMessage,
+        code: typeof parsed.code === 'string' ? parsed.code : undefined,
+        details: parsed.details,
+      };
+    }
+
+    if (typeof parsed.error === 'string' && parsed.error.trim()) {
+      return {
+        message: parsed.error,
+        code: typeof parsed.code === 'string' ? parsed.code : undefined,
+        details: parsed.details,
+      };
+    }
+  }
+
+  const trimmedText = text.trim();
+  return trimmedText ? { message: trimmedText } : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -374,7 +374,7 @@ export class BeastApiClient {
 
   private async toError(response: Response): Promise<BeastApiError> {
     const fallbackMessage = `HTTP ${response.status}`;
-    const text = await response.text().catch(() => '');
+    const text = await readResponseText(response);
     const parsed = parseErrorBody(text);
     const serverError = extractServerError(parsed, text);
 
@@ -399,6 +399,23 @@ function parseErrorBody(text: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+async function readResponseText(response: Response): Promise<string> {
+  if (typeof response.text === 'function') {
+    return response.text().catch(() => '');
+  }
+
+  const legacyResponse = response as Response & { json?: () => Promise<unknown> };
+  if (typeof legacyResponse.json === 'function') {
+    try {
+      return JSON.stringify(await legacyResponse.json());
+    } catch {
+      return '';
+    }
+  }
+
+  return '';
 }
 
 function extractServerError(parsed: unknown, text: string): { message?: string; code?: string; details?: unknown } {
@@ -430,7 +447,7 @@ function extractServerError(parsed: unknown, text: string): { message?: string; 
   }
 
   const trimmedText = text.trim();
-  return trimmedText ? { message: trimmedText } : {};
+  return parsed === undefined && trimmedText ? { message: trimmedText } : {};
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/franken-web/src/pages/beasts-page.test.tsx
+++ b/packages/franken-web/src/pages/beasts-page.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BeastsPage } from './beasts-page';
 import { useBeastStore } from '../stores/beast-store';
@@ -26,7 +27,10 @@ const snapshot: DashboardSnapshot = {
   ],
 };
 
-function renderBeastsPage(dashboardClient: DashboardApiClient) {
+function renderBeastsPage(
+  dashboardClient: DashboardApiClient,
+  overrides: Partial<ComponentProps<typeof BeastsPage>> = {},
+) {
   return render(
     <BeastsPage
       agents={[]}
@@ -48,6 +52,7 @@ function renderBeastsPage(dashboardClient: DashboardApiClient) {
       onSelectAgent={() => undefined}
       onStart={() => undefined}
       onStop={() => undefined}
+      {...overrides}
     />,
   );
 }
@@ -73,5 +78,36 @@ describe('BeastsPage', () => {
     expect(await screen.findByText('openai')).toBeTruthy();
     fireEvent.change(screen.getAllByLabelText('Provider')[0]!, { target: { value: 'openai' } });
     expect(screen.getByText('gpt-4.1')).toBeTruthy();
+  });
+
+  it('displays actionable backend launch errors from Beast API failures', async () => {
+    const dashboardClient = {
+      fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    } as unknown as DashboardApiClient;
+    const onLaunch = vi.fn().mockRejectedValue(new Error(
+      'Provider is required before launching an agent. (HTTP 400, VALIDATION_FAILED)',
+    ));
+
+    renderBeastsPage(dashboardClient, { onLaunch });
+    fireEvent.click(screen.getByRole('button', { name: '+ Create Agent' }));
+
+    act(() => {
+      useBeastStore.setState({
+        wizardMode: 'form',
+        wizardStep: 7,
+        highestCompleted: 7,
+        stepValues: {
+          0: { name: 'Validation Agent' },
+          1: { workflowType: 'design-interview', goal: 'Ship a fix', outputPath: 'docs/fix.md' },
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Launch Agent' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Provider is required before launching an agent.');
+    expect(alert.textContent).toContain('HTTP 400, VALIDATION_FAILED');
+    expect(onLaunch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Preserve structured Beast API error bodies when requests fail, including envelope, direct message/error, and plain-text backend messages.
- Keep HTTP status/code/details available on `BeastApiError` so Create Agent/action failures show actionable backend guidance.
- Add targeted Beast API client and Create Agent error-display regression coverage.

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/web -- src/lib/beast-api.test.ts src/pages/beasts-page.test.tsx
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm run lint --workspace @franken/web

Closes #2114