### PR TITLE
fix(web): surface Beast API structured error messages

### DIFF
--- a/packages/franken-web/src/lib/beast-api.test.ts
+++ b/packages/franken-web/src/lib/beast-api.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BeastApiClient, BeastApiError } from './beast-api';
+
+const BASE_URL = 'http://localhost:3737';
+
+describe('BeastApiClient', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('surfaces structured backend error messages and codes for create-agent failures', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'Definition id is required.',
+        details: { field: 'definitionId' },
+      },
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const client = new BeastApiClient(BASE_URL);
+
+    await expect(client.createAgent({
+      definitionId: '',
+      initAction: { kind: 'design-interview', command: 'start', config: {} },
+      initConfig: {},
+    })).rejects.toMatchObject({
+      name: 'BeastApiError',
+      message: 'Definition id is required. (HTTP 400, VALIDATION_FAILED)',
+      status: 400,
+      code: 'VALIDATION_FAILED',
+      details: { field: 'definitionId' },
+    } satisfies Partial<BeastApiError>);
+  });
+
+  it('surfaces text backend error bodies instead of only HTTP status', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('Container runtime guard rejected launch', {
+      status: 409,
+      headers: { 'Content-Type': 'text/plain' },
+    }));
+
+    const client = new BeastApiClient(BASE_URL);
+
+    await expect(client.startAgent('agent-1')).rejects.toThrow('Container runtime guard rejected launch (HTTP 409)');
+  });
+
+  it('falls back to HTTP status when a failed response has no body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+
+    const client = new BeastApiClient(BASE_URL);
+
+    await expect(client.listAgents()).rejects.toThrow('HTTP 500');
+  });
+});

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -1,7 +1,6 @@
 import { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 import type {
   ApiDataEnvelope,
-  ApiErrorEnvelope,
   BeastCatalogEntry,
   BeastContainerRuntimeStatus,
   BeastInterviewPrompt,
@@ -375,22 +374,47 @@ export class BeastApiClient {
 
   private async toError(response: Response): Promise<BeastApiError> {
     const fallbackMessage = `HTTP ${response.status}`;
+    let responseText = '';
     try {
-      const body = await response.json() as ApiErrorEnvelope;
-      const serverMessage = body.error?.message;
+      responseText = (await response.text()).trim();
+    } catch {
+      return new BeastApiError(fallbackMessage, response.status);
+    }
+
+    if (!responseText) {
+      return new BeastApiError(fallbackMessage, response.status);
+    }
+
+    try {
+      const body = JSON.parse(responseText) as Record<string, unknown>;
+      const nestedError = typeof body.error === 'object' && body.error !== null
+        ? body.error as { code?: unknown; message?: unknown; details?: unknown }
+        : undefined;
+      const serverMessage = typeof nestedError?.message === 'string'
+        ? nestedError.message
+        : typeof body.message === 'string'
+          ? body.message
+          : typeof body.error === 'string'
+            ? body.error
+            : undefined;
       if (serverMessage) {
-        const code = body.error.code;
+        const code = typeof nestedError?.code === 'string'
+          ? nestedError.code
+          : typeof body.code === 'string'
+            ? body.code
+            : undefined;
         const codeSuffix = code ? `, ${code}` : '';
         return new BeastApiError(
           `${serverMessage} (HTTP ${response.status}${codeSuffix})`,
           response.status,
           code,
-          body.error.details,
+          nestedError?.details,
         );
       }
     } catch {
-      // Fall through with HTTP status message for empty, malformed, or non-JSON bodies.
+      return new BeastApiError(`${responseText} (HTTP ${response.status})`, response.status);
     }
+
     return new BeastApiError(fallbackMessage, response.status);
   }
 }


### PR DESCRIPTION
## Summary
- Parse Beast API error response bodies as text before throwing so structured JSON and plain text backend details are preserved.
- Include backend error codes/status metadata in BeastApiError messages and fields.
- Add focused BeastApiClient coverage for create-agent structured errors, text errors, and empty-body fallback.

Closes #2114

## Test plan
- npm run test --workspace @franken/web -- src/lib/beast-api.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/web
- git diff --check