### PR TITLE
fix: specify radix for parseInt examples

### DIFF
--- a/docs/plans/consolidation/phase8-integration/03_dashboard-simple-advanced.md
+++ b/docs/plans/consolidation/phase8-integration/03_dashboard-simple-advanced.md
@@ -1099,7 +1099,7 @@ export function SecurityPanel({ mode }: { mode: 'simple' | 'advanced' }) {
                 value={security.maxTokenBudget ?? ''}
                 placeholder="Unlimited"
                 onChange={(e) => updateSecurity({
-                  maxTokenBudget: e.target.value ? parseInt(e.target.value) : undefined,
+                  maxTokenBudget: e.target.value ? parseInt(e.target.value, 10) : undefined,
                 })}
               />
             </label>

--- a/docs/plans/consolidation/phase8-integration/04_cli-commands.md
+++ b/docs/plans/consolidation/phase8-integration/04_cli-commands.md
@@ -227,7 +227,7 @@ export function registerDashboardCommand(program: Command): void {
     .option('--no-open', 'Don\'t open browser')
     .action(async (opts) => {
       const { startDashboard } = await import('@franken/web');
-      const url = await startDashboard({ port: parseInt(opts.port) });
+      const url = await startDashboard({ port: parseInt(opts.port, 10) });
       process.stdout.write(`Dashboard running at ${url}`);
       if (opts.open !== false) {
         const open = await import('open');


### PR DESCRIPTION
Closes #2121

## Summary
- add explicit base-10 radix arguments to parseInt examples in the phase 8 integration docs
- verified tracked JS/TS/Markdown parseInt and Number.parseInt calls include explicit radix arguments

## Test plan
- python3 targeted parseInt radix scan over tracked JS/TS/Markdown files
- git diff --check