### PR TITLE
fix(lint): require parseInt radix arguments

### DIFF
--- a/eslint.workspace.config.js
+++ b/eslint.workspace.config.js
@@ -9,6 +9,7 @@ export default tseslint.config(
   prettierConfig,
   {
     rules: {
+      'radix': ['error', 'always'],
       'prefer-const': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],

--- a/packages/franken-brain/eslint.config.js
+++ b/packages/franken-brain/eslint.config.js
@@ -9,6 +9,7 @@ export default tseslint.config(
   prettierConfig,
   {
     rules: {
+      'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     },

--- a/packages/franken-critique/eslint.config.js
+++ b/packages/franken-critique/eslint.config.js
@@ -9,6 +9,7 @@ export default tseslint.config(
   prettierConfig,
   {
     rules: {
+      'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',

--- a/packages/franken-orchestrator/eslint.config.js
+++ b/packages/franken-orchestrator/eslint.config.js
@@ -9,6 +9,7 @@ export default tseslint.config(
   prettierConfig,
   {
     rules: {
+      'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-this-alias': 'warn',

--- a/packages/franken-planner/eslint.config.js
+++ b/packages/franken-planner/eslint.config.js
@@ -9,6 +9,7 @@ export default tseslint.config(
   prettierConfig,
   {
     rules: {
+      'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     },

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -523,6 +523,27 @@ describe("npm workspaces configuration", () => {
       }
     });
 
+    it("enforces explicit parseInt radix arguments in ESLint configs", () => {
+      const radixRule = "'radix': ['error', 'always']";
+      const rootConfig = readFileSync(
+        join(ROOT, "eslint.workspace.config.js"),
+        "utf8",
+      );
+
+      expect(rootConfig).toContain(radixRule);
+      for (const path of packageJsonPaths) {
+        const packageDir = path.replace(/\/package\.json$/, "");
+        const configPath = join(ROOT, packageDir, "eslint.config.js");
+        const packageConfig = readFileSync(configPath, "utf8");
+
+        expect(
+          packageConfig.includes("eslint.workspace.config.js") ||
+            packageConfig.includes(radixRule),
+          `${packageDir} must inherit or define the radix rule`,
+        ).toBe(true);
+      }
+    });
+
     it("uses filesystem-safe module URL conversion in the lint coverage audit", () => {
       const auditScript = readFileSync(
         join(ROOT, "scripts/check-workspace-lint-coverage.mjs"),


### PR DESCRIPTION
## Summary
- Enable ESLint radix enforcement across root and standalone workspace configs
- Add a workspace regression test that every package inherits or defines the radix rule

## Test Plan
- npm run test:root -- tests/workspaces.test.ts
- npm run lint
- npm run typecheck
- npm run build

Closes #2121