### PR TITLE
fix(ci): preserve component latest without root release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,16 +73,20 @@ jobs:
             exit 0
           fi
 
-          # Demote the component release
+          # Promote the most recent root release back to latest. If no root
+          # release exists yet, leave the component latest untouched instead of
+          # demoting it and leaving the repository with no latest release.
+          root_tag=$(gh release list --json tagName --jq '([.[] | select(.tagName | test("^v[0-9]"))][0].tagName // "")' 2>/dev/null || echo '')
+          if [ -z "$root_tag" ]; then
+            echo "No root release found; leaving component latest unchanged: $latest_tag"
+            exit 0
+          fi
+
           echo "Demoting component release: $latest_tag"
           gh release edit "$latest_tag" --latest=false
 
-          # Promote the most recent root release back to latest
-          root_tag=$(gh release list --json tagName --jq '[.[] | select(.tagName | test("^v[0-9]"))][0].tagName' 2>/dev/null || echo '')
-          if [ -n "$root_tag" ]; then
-            echo "Promoting root release: $root_tag"
-            gh release edit "$root_tag" --latest
-          fi
+          echo "Promoting root release: $root_tag"
+          gh release edit "$root_tag" --latest
 
   publish-npm:
     needs: release-please

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -450,6 +450,23 @@ jobs:
     expect(tokenCheckIndex).toBeGreaterThan(privateSkipIndex);
     expect(publishRun).toContain('npm publish "$package_path" --access public --provenance');
   });
+
+  it('does not demote a component latest release unless a root release can be promoted', () => {
+    const latestStep = expectSteps(releasePlease).find((step) => step.name === 'Ensure only root release is marked latest');
+    expect(latestStep).toBeTruthy();
+
+    const latestRun = String(latestStep?.run ?? '');
+    const rootLookupIndex = latestRun.indexOf('root_tag=$(gh release list');
+    const missingRootGuardIndex = latestRun.indexOf('No root release found; leaving component latest unchanged');
+    const demoteIndex = latestRun.indexOf('gh release edit "$latest_tag" --latest=false');
+    const promoteIndex = latestRun.indexOf('gh release edit "$root_tag" --latest');
+
+    expect(rootLookupIndex).toBeGreaterThan(-1);
+    expect(missingRootGuardIndex).toBeGreaterThan(rootLookupIndex);
+    expect(demoteIndex).toBeGreaterThan(missingRootGuardIndex);
+    expect(promoteIndex).toBeGreaterThan(demoteIndex);
+    expect(latestRun).toContain('[0].tagName // ""');
+  });
 });
 
 // release-auto-merge.yml was removed during package consolidation


### PR DESCRIPTION
Fixes #2141.

## Summary
- Look up the most recent root release before demoting a component release marked latest.
- Exit without demoting when no root tag exists so GitHub retains the current latest release.
- Add a release workflow regression assertion for the guard ordering.

## Test plan
- `corepack npm@11.5.1 run test:root -- tests/unit/ci-workflow.test.ts`
- `git diff --check`