### PR TITLE
fix(orchestrator): validate chat session ids

### DIFF
--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -4,6 +4,18 @@ import { join, resolve, sep } from 'node:path';
 import { ChatSessionSchema, type ChatSession } from './types.js';
 import { isoNow, now as deterministicNow } from '@franken/types';
 
+const MAX_CHAT_SESSION_ID_LENGTH = 128;
+
+export function isValidChatSessionId(id: string): boolean {
+  return id.length > 0
+    && id.length <= MAX_CHAT_SESSION_ID_LENGTH
+    && id !== '.'
+    && id !== '..'
+    && !id.includes('/')
+    && !id.includes('\\')
+    && !id.includes('\0');
+}
+
 export interface CorruptChatSessionFile {
   id: string;
   projectId?: string;
@@ -106,8 +118,13 @@ export class FileSessionStore implements ISessionStore {
   }
 
   delete(id: string): void {
+    const path = this.safeFilePath(id);
+    if (path === undefined) {
+      return;
+    }
+
     try {
-      unlinkSync(this.filePath(id));
+      unlinkSync(path);
     } catch {
       // swallow ENOENT
     }
@@ -118,6 +135,11 @@ export class FileSessionStore implements ISessionStore {
   }
 
   private safeFilePath(id: string): string | undefined {
+    if (!isValidChatSessionId(id)) {
+      console.warn(`[chat-session-store] ignoring invalid chat session id ${JSON.stringify(id)}`);
+      return undefined;
+    }
+
     const resolvedStoreDir = resolve(this.storeDir);
     const resolvedPath = resolve(this.storeDir, `${id}.json`);
     if (resolvedPath === resolvedStoreDir || !resolvedPath.startsWith(`${resolvedStoreDir}${sep}`)) {

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { approvalRuntimeInput, UnsafeApprovalCommandError } from '../../chat/approval-input.js';
-import type { CorruptChatSessionFile, ISessionStore } from '../../chat/session-store.js';
+import { isValidChatSessionId, type CorruptChatSessionFile, type ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
 import { ChatRuntime, pendingApprovalRuntimeState } from '../../chat/runtime.js';
 import type { TurnRunner } from '../../chat/turn-runner.js';
@@ -46,11 +46,19 @@ export interface ChatRoutesDeps {
 }
 
 function getSessionOrThrow(store: ISessionStore, id: string) {
+  validateChatSessionId(id);
   const session = store.get(id);
   if (!session) {
     throw new HttpError(404, 'NOT_FOUND', `Session '${id}' not found`);
   }
   return session;
+}
+
+function validateChatSessionId(id: string): string {
+  if (!isValidChatSessionId(id)) {
+    throw new HttpError(400, 'INVALID_SESSION_ID', 'Invalid chat session id');
+  }
+  return id;
 }
 
 function sessionResponse(
@@ -149,7 +157,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
 
   // Get session
   app.get('/v1/chat/sessions/:id', (c) => {
-    const id = c.req.param('id');
+    const id = validateChatSessionId(c.req.param('id'));
     const session = getSessionOrThrow(sessionStore, id);
     return c.json({
       data: sessionResponse(session),
@@ -157,7 +165,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
   });
 
   app.post('/v1/chat/sessions/:id/socket-ticket', (c) => {
-    const id = c.req.param('id');
+    const id = validateChatSessionId(c.req.param('id'));
     getSessionOrThrow(sessionStore, id);
     return c.json({
       data: { ticket: issueSocketTicket(id) },
@@ -166,7 +174,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
 
   // Submit message
   app.post('/v1/chat/sessions/:id/messages', async (c) => {
-    const id = c.req.param('id');
+    const id = validateChatSessionId(c.req.param('id'));
     const body = await parseJsonBody(c);
     const { content, executionMode } = validateBody(SubmitMessageBody, body);
     const session = getSessionOrThrow(sessionStore, id);
@@ -224,7 +232,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
   // callers mint a short-lived, one-shot ticket with normal fetch credentials,
   // then place only that ticket in the stream URL.
   app.post('/v1/chat/sessions/:id/stream/ticket', (c) => {
-    const id = c.req.param('id');
+    const id = validateChatSessionId(c.req.param('id'));
     getSessionOrThrow(sessionStore, id);
     if (!operatorToken) {
       return c.json({ ticket: null });
@@ -245,7 +253,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
 
   // Approve action
   app.post('/v1/chat/sessions/:id/approve', async (c) => {
-    const id = c.req.param('id');
+    const id = validateChatSessionId(c.req.param('id'));
     const body = await parseJsonBody(c);
     const { approved } = validateBody(ApproveBody, body);
     const session = getSessionOrThrow(sessionStore, id);

--- a/packages/franken-orchestrator/src/http/sse.ts
+++ b/packages/franken-orchestrator/src/http/sse.ts
@@ -1,7 +1,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import { streamSSE } from 'hono/streaming';
 import type { Context } from 'hono';
-import type { ISessionStore } from '../chat/session-store.js';
+import { isValidChatSessionId, type ISessionStore } from '../chat/session-store.js';
 import type { TurnRunner, TurnEvent } from '../chat/turn-runner.js';
 import type { SseConnectionTicketStore } from '../beasts/events/sse-connection-ticket.js';
 import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthAllowed } from './operator-auth.js';
@@ -21,6 +21,13 @@ export function createSseHandler(deps: SseHandlerDeps) {
     if (!id) {
       return c.json(
         { error: { code: 'BAD_REQUEST', message: 'Missing session id' } },
+        400,
+      );
+    }
+
+    if (!isValidChatSessionId(id)) {
+      return c.json(
+        { error: { code: 'INVALID_SESSION_ID', message: 'Invalid chat session id' } },
         400,
       );
     }

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -187,6 +187,7 @@ describe('FileSessionStore', () => {
     writeFileSync(outsidePath, JSON.stringify({ ok: true }), 'utf-8');
 
     expect(nestedStore.get('../config')).toBeUndefined();
+    nestedStore.delete('../config');
 
     expect(existsSync(outsidePath)).toBe(true);
     expect(nestedStore.listCorruptions()).toEqual([]);

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-session-id-validation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-session-id-validation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createChatApp } from '../../../src/http/chat-app.js';
+import type { ISessionStore } from '../../../src/chat/session-store.js';
+import type { ChatSession } from '../../../src/chat/types.js';
+
+function mockSessionStore(): ISessionStore {
+  return {
+    create: vi.fn(),
+    get: vi.fn(),
+    save: vi.fn(),
+    list: vi.fn(() => []),
+    listSessions: vi.fn(() => []),
+    listCorruptions: vi.fn(() => []),
+    delete: vi.fn(),
+  };
+}
+
+function createApp(sessionStore: ISessionStore) {
+  return createChatApp({
+    sessionStore,
+    llm: { complete: vi.fn().mockResolvedValue('hello') },
+    projectName: 'session-id-validation-test',
+  });
+}
+
+const INVALID_SESSION_ID_CASES: Array<[path: string, method: string, body: Record<string, unknown> | undefined]> = [
+  ['/v1/chat/sessions/..%2Fconfig', 'GET', undefined],
+  ['/v1/chat/sessions/..%2Fconfig/socket-ticket', 'POST', undefined],
+  ['/v1/chat/sessions/..%2Fconfig/messages', 'POST', { content: 'hello' }],
+  ['/v1/chat/sessions/..%2Fconfig/stream/ticket', 'POST', undefined],
+  ['/v1/chat/sessions/..%2Fconfig/approve', 'POST', { approved: true }],
+  ['/v1/chat/sessions/..%2Fconfig/stream', 'GET', undefined],
+];
+
+describe('chat route session id validation', () => {
+  it.each(INVALID_SESSION_ID_CASES)('rejects invalid id before session-store access for %s', async (path: string, method: string, body: Record<string, unknown> | undefined) => {
+    const sessionStore = mockSessionStore();
+    const app = createApp(sessionStore);
+
+    const response = await app.request(path, {
+      method,
+      ...(body === undefined
+        ? {}
+        : {
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'INVALID_SESSION_ID' },
+    });
+    expect(sessionStore.get).not.toHaveBeenCalled();
+  });
+
+  it('continues to load valid chat session ids', async () => {
+    const session: ChatSession = {
+      id: 'chat-1234-abcd',
+      projectId: 'project-1',
+      transcript: [],
+      state: 'active',
+      tokenTotals: { cheap: 0, premiumReasoning: 0, premiumExecution: 0 },
+      costUsd: 0,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:01.000Z',
+    };
+    const sessionStore = mockSessionStore();
+    vi.mocked(sessionStore.get).mockReturnValue(session);
+    const app = createApp(sessionStore);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: { id: session.id } });
+    expect(sessionStore.get).toHaveBeenCalledWith(session.id);
+  });
+});


### PR DESCRIPTION
## Summary
- reject unsafe chat session route ids before any session-store filesystem lookup
- share session-id validation with FileSessionStore and harden delete paths
- add route and session-store regression coverage for encoded traversal ids

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/chat/session-store.test.ts tests/unit/http/chat-routes-session-id-validation.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator (one process-supervisor timing assertion failed in full suite; targeted rerun of tests/unit/beasts/execution/process-supervisor.test.ts passed)
- npm run test --workspace @franken/orchestrator -- tests/unit/beasts/execution/process-supervisor.test.ts

Closes #2143