### PR TITLE
fix(web): fall back when websocket send throws

### DIFF
--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -903,7 +903,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
     setStatus('sending');
 
-    if (!optimisticAdd) {
+    const sendViaHttpFallback = async (): Promise<void> => {
       let fallbackRefreshError: Error | null = null;
       try {
         const result = await clientRef.current.sendMessage(sessionId, content);
@@ -973,7 +973,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           ? error
           : new Error('The fallback chat request failed before the turn could start.');
         setMessages((current) => [
-          ...current.filter((message) => !isFailedUserDraftForContent(message, content)),
+          ...current.filter((message) => message.id !== clientMessageId && !isFailedUserDraftForContent(message, content)),
           { ...optimisticMessage, receipt: 'failed', error: sendError.message, canRetry: true },
         ]);
         addErrorBanner(makeBanner(
@@ -990,28 +990,43 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       if (fallbackRefreshError) {
         throw fallbackRefreshError;
       }
+    };
+
+    if (!optimisticAdd) {
+      await sendViaHttpFallback();
       return;
     }
 
     const liveSocket = socket as WebSocket;
-    await new Promise<void>((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        failPendingSend(clientMessageId, new Error('Server did not acknowledge the message. Your draft was kept.'));
-      }, SOCKET_SEND_ACK_TIMEOUT_MS);
-      pendingSendsRef.current.set(clientMessageId, { timeoutId, resolve, reject });
-      try {
-        liveSocket.send(JSON.stringify({
-          type: 'message.send',
-          clientMessageId,
-          content,
-        }));
-      } catch (error) {
-        failPendingSend(
-          clientMessageId,
-          error instanceof Error ? error : new Error('Message failed to send. Your draft was kept.'),
-        );
+    let immediateSendError: Error | null = null;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          failPendingSend(clientMessageId, new Error('Server did not acknowledge the message. Your draft was kept.'));
+        }, SOCKET_SEND_ACK_TIMEOUT_MS);
+        pendingSendsRef.current.set(clientMessageId, { timeoutId, resolve, reject });
+        try {
+          liveSocket.send(JSON.stringify({
+            type: 'message.send',
+            clientMessageId,
+            content,
+          }));
+        } catch (error) {
+          immediateSendError = error instanceof Error
+            ? error
+            : new Error('Message failed to send. Your draft was kept.');
+          clearTimeout(timeoutId);
+          pendingSendsRef.current.delete(clientMessageId);
+          reject(immediateSendError);
+        }
+      });
+    } catch (error) {
+      if (error === immediateSendError) {
+        await sendViaHttpFallback();
+        return;
       }
-    });
+      throw error;
+    }
   }
 
   async function retryMessage(messageId: string): Promise<void> {

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -564,6 +564,34 @@ describe('useChatSession', () => {
     expect(result.current.status).toBe('idle');
   });
 
+  it('falls back to HTTP when an open websocket throws during send', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+    });
+    socket.send = vi.fn(() => {
+      throw new Error('socket closed during send');
+    });
+
+    await act(async () => {
+      await result.current.send('fallback after websocket race');
+    });
+
+    expect(mockSendMessage).toHaveBeenCalledWith('chat-1', 'fallback after websocket race');
+    expect(result.current.status).toBe('idle');
+    expect(result.current.messages).not.toContainEqual(expect.objectContaining({
+      content: 'fallback after websocket race',
+      receipt: 'failed',
+    }));
+    expect(result.current.errorBanners).toHaveLength(0);
+  });
+
   it('removes stale failed drafts when retrying the same prompt', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 


### PR DESCRIPTION
## Summary
- Reuses the HTTP fallback path when an open websocket throws synchronously during chat send.
- Removes the optimistic websocket draft before recording fallback failure/refresh results so the UI does not get stuck in sending state.
- Adds a regression test for a send/disconnect race.

## Test Plan
- npm test -- tests/hooks/use-chat-session.test.ts -t 'falls back to HTTP when an open websocket throws during send'
- npm test -- tests/hooks/use-chat-session.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web
- npm run lint --workspace @franken/web (passes with existing warnings)

Closes #2146