### PR TITLE
test(observer): document webhook async drain

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -7,7 +7,12 @@ import { LoopDetector } from '../incident/LoopDetector.js'
 describe('WebhookNotifier', () => {
   let mockFetch: ReturnType<typeof vi.fn>
 
-  const drainAsync = () => Promise.resolve()
+  const drainAlreadyQueuedMicrotasks = async () => {
+    // CircuitBreaker emits limit events synchronously. The below-limit negative
+    // path should only need to drain promise continuations already queued by
+    // the test harness; do not use a zero-delay macrotask sleep.
+    await Promise.resolve()
+  }
   const webhookUrl = 'https://hooks.example.com/signal'
   const allowedTargetOrigins = ['https://hooks.example.com']
 
@@ -176,7 +181,7 @@ describe('WebhookNotifier', () => {
         void notifier.send({ type: 'circuit-breaker', ...result })
       })
       breaker.check(1.0) // below limit
-      await drainAsync()
+      await drainAlreadyQueuedMicrotasks()
       expect(mockFetch).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Summary
- Renames the WebhookNotifier negative-path async drain helper to describe the deterministic microtask boundary.
- Documents why the below-limit CircuitBreaker assertion must not rely on a zero-delay macrotask sleep.
- Leaves the existing no-delivery assertion intact and confirms no raw zero-delay timer remains in the targeted test.

## Test Plan
- npm run test --workspace @franken/observer -- src/notify/WebhookNotifier.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer (passes with existing warnings outside this file)

References closed #1123 as stale-closeout evidence.
Closes #2155