### PR TITLE
test(ci): parse release-please workflow yaml

### DIFF
--- a/tests/unit/release-please-config.test.ts
+++ b/tests/unit/release-please-config.test.ts
@@ -1,11 +1,40 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { load } from 'js-yaml';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 
 function readJson(relPath: string): unknown {
   return JSON.parse(readFileSync(resolve(ROOT, relPath), 'utf-8'));
+}
+
+function parseWorkflowYaml(relPath: string): Record<string, unknown> {
+  const source = readFileSync(resolve(ROOT, relPath), 'utf-8');
+  let parsed: unknown;
+  try {
+    parsed = load(source);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${relPath} must be valid YAML: ${message}`);
+  }
+
+  expect(parsed, `${relPath} should parse to an object`).toBeTypeOf('object');
+  expect(parsed, `${relPath} should not parse to null`).not.toBeNull();
+  expect(Array.isArray(parsed), `${relPath} should not parse to an array`).toBe(false);
+  return parsed as Record<string, unknown>;
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  expect(value, `${label} should be an object`).toBeTypeOf('object');
+  expect(value, `${label} should be present`).not.toBeNull();
+  expect(Array.isArray(value), `${label} should not be an array`).toBe(false);
+  return value as Record<string, unknown>;
+}
+
+function expectSteps(job: Record<string, unknown>, label: string): Array<Record<string, unknown>> {
+  expect(Array.isArray(job.steps), `${label}.steps should be an array`).toBe(true);
+  return job.steps as Array<Record<string, unknown>>;
 }
 
 function expandWorkspacePackageDirs(workspaces: string[]): string[] {
@@ -127,5 +156,34 @@ describe('release-please monorepo config', () => {
 
   it('config JSON is valid (has $schema)', () => {
     expect(config).toHaveProperty('$schema');
+  });
+
+  it('release-please workflow YAML is parseable and runs the release policy tests before tagging', () => {
+    const workflow = parseWorkflowYaml('.github/workflows/release-please.yml');
+
+    expect(workflow.name).toBe('Release Please');
+    const triggers = expectRecord(workflow.on, 'release workflow on');
+    const push = expectRecord(triggers.push, 'release workflow on.push');
+    expect(push.branches).toEqual(['main']);
+
+    const jobs = expectRecord(workflow.jobs, 'release workflow jobs');
+    const validateRelease = expectRecord(jobs['validate-release'], 'jobs.validate-release');
+    const releasePlease = expectRecord(jobs['release-please'], 'jobs.release-please');
+
+    expect(releasePlease.needs).toBe('validate-release');
+    const validationStep = expectSteps(validateRelease, 'jobs.validate-release').find(
+      (step) => step.name === 'Validate release before creating tags',
+    );
+    expect(validationStep, 'validate-release should run the release policy test file').toBeTruthy();
+    const validationRun = String(validationStep?.run ?? '');
+    expect(validationRun).toContain('tests/unit/release-please-config.test.ts');
+
+    const releaseStep = expectSteps(releasePlease, 'jobs.release-please').find(
+      (step) => step.uses === 'googleapis/release-please-action@v5',
+    );
+    expect(releaseStep, 'release-please action step should be present').toBeTruthy();
+    const releaseWith = expectRecord(releaseStep?.with, 'release-please action with');
+    expect(releaseWith['config-file']).toBe('release-please-config.json');
+    expect(releaseWith['manifest-file']).toBe('.release-please-manifest.json');
   });
 });


### PR DESCRIPTION
## Summary
- Parse `.github/workflows/release-please.yml` through `js-yaml` in the release policy test suite.
- Assert required release workflow keys: push-to-main trigger, validate-release dependency, release-please action, config file, and manifest file.

## Test Plan
- `npm run test:root -- tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #2136
