### PR TITLE
fix(observer): validate webhook retry bounds

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -370,6 +370,39 @@ describe('WebhookNotifier', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
+    it('rejects invalid retry delay bounds during retry configuration validation', () => {
+      const invalidOptions = [
+        { retry: { maxRetries: 1, baseDelayMs: -1 } },
+        { retry: { maxRetries: 1, baseDelayMs: Number.NaN } },
+        { retry: { maxRetries: 1, baseDelayMs: Number.POSITIVE_INFINITY } },
+        { retry: { maxRetries: 1, maxDelayMs: -1 } },
+        { retry: { maxRetries: 1, maxDelayMs: Number.NaN } },
+        { retry: { maxRetries: 1, maxDelayMs: Number.POSITIVE_INFINITY } },
+      ]
+
+      for (const options of invalidOptions) {
+        expect(() => createNotifier(options)).toThrow(/retry\.(baseDelayMs|maxDelayMs) must be a finite non-negative number/)
+      }
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('passes only finite non-negative bounded delays to sleepFn', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
+      const sleepFn = vi.fn().mockResolvedValue(undefined)
+      const notifier = createNotifier({
+        retry: { maxRetries: 3, baseDelayMs: 100, maxDelayMs: 150, jitter: true },
+        sleep: sleepFn,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow()
+
+      for (const [delay] of sleepFn.mock.calls) {
+        expect(Number.isFinite(delay)).toBe(true)
+        expect(delay).toBeGreaterThanOrEqual(0)
+        expect(delay).toBeLessThanOrEqual(150)
+      }
+    })
+
     it('adds jitter (delay is not exactly baseDelayMs * 2^i)', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
       const sleepFn = vi.fn().mockResolvedValue(undefined)

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -81,6 +81,13 @@ function validateNonNegativeInteger(value: number, fieldName: string): number {
   return value
 }
 
+function validateFiniteNonNegativeNumber(value: number, fieldName: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${fieldName} must be a finite non-negative number`)
+  }
+  return value
+}
+
 function parseUrlOrigin(value: string, fieldName: string): string {
   try {
     return new URL(value).origin
@@ -123,8 +130,8 @@ export class WebhookNotifier {
     this.retry = options.retry
       ? {
           maxRetries: validateNonNegativeInteger(options.retry.maxRetries, 'retry.maxRetries'),
-          baseDelayMs: options.retry.baseDelayMs ?? 200,
-          maxDelayMs: options.retry.maxDelayMs ?? 30_000,
+          baseDelayMs: validateFiniteNonNegativeNumber(options.retry.baseDelayMs ?? 200, 'retry.baseDelayMs'),
+          maxDelayMs: validateFiniteNonNegativeNumber(options.retry.maxDelayMs ?? 30_000, 'retry.maxDelayMs'),
           jitter: options.retry.jitter ?? true,
         }
       : null


### PR DESCRIPTION
## Summary
- validate WebhookNotifier retry delay bounds during construction
- add regression coverage for invalid baseDelayMs/maxDelayMs and bounded finite sleep delays

Closes #2156

## Test plan
- `npm run test --workspace @franken/observer -- WebhookNotifier.test.ts`
- `git diff --check`