### PR TITLE
test(orchestrator): make Beast SSE stream tests event-driven

### DIFF
--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -61,6 +61,7 @@ async function readSseEventsUntil(
     onConnected?: () => void;
     timeoutMs?: number;
     continueAfterMatchMs?: number;
+    allowTimeout?: boolean;
   } = {},
 ): Promise<ParsedSseEvent[]> {
   const controller = new AbortController();
@@ -99,10 +100,12 @@ async function readSseEventsUntil(
       text += decoder.decode(value, { stream: true });
       const events = parseSseEvents(text);
       if (until(events)) {
-        if (!observedExpectedEvents && options.continueAfterMatchMs !== undefined) {
-          observedExpectedEvents = true;
-          settleSignal = AbortSignal.timeout(options.continueAfterMatchMs);
-          settleSignal.addEventListener('abort', abortAfterSettling, { once: true });
+        if (options.continueAfterMatchMs !== undefined) {
+          if (!observedExpectedEvents) {
+            observedExpectedEvents = true;
+            settleSignal = AbortSignal.timeout(options.continueAfterMatchMs);
+            settleSignal.addEventListener('abort', abortAfterSettling, { once: true });
+          }
           continue;
         }
         observedExpectedEvents = true;
@@ -121,10 +124,10 @@ async function readSseEventsUntil(
   }
 
   const finalEvents = parseSseEvents(text);
-  if (timedOut) {
+  if (timedOut && !options.allowTimeout) {
     throw new Error(`Timed out waiting for expected SSE events. Received: ${text}`);
   }
-  if (!until(finalEvents)) {
+  if (!timedOut && !until(finalEvents)) {
     throw new Error(`SSE stream ended before expected events were observed. Received: ${text}`);
   }
 
@@ -328,12 +331,17 @@ describe('Beast SSE routes', () => {
     expect(events.find((e) => e.id === '2')).toBeDefined();
   });
 
-  it.each<Array<[string, { headers?: HeadersInit; query?: string }]>>([
+  const malformedReconnectCursorCases: Array<[
+    string,
+    { headers?: HeadersInit; query?: string },
+  ]> = [
     ['partial numeric Last-Event-ID header', { headers: { 'Last-Event-ID': '10abc' } }],
     ['non-numeric lastEventId query', { query: 'lastEventId=abc' }],
     ['negative lastEventId query', { query: 'lastEventId=-1' }],
     ['unsafe integer Last-Event-ID header', { headers: { 'Last-Event-ID': '9007199254740992' } }],
-  ])('rejects malformed reconnect cursor: %s', async (_label, options) => {
+  ];
+
+  it.each(malformedReconnectCursorCases)('rejects malformed reconnect cursor: %s', async (_label, options) => {
     const getSnapshot = vi.fn(() => ({ agents: [{ id: 'a1', status: 'idle' }] }));
     const ctx = createSseApp({ getSnapshot });
     ticketStore = ctx.ticketStore;
@@ -371,21 +379,19 @@ describe('Beast SSE routes', () => {
     expect(await res.json()).toMatchObject({ error: { code: 'INVALID_LAST_EVENT_ID' } });
   });
 
-  it('does not send snapshot on reconnect with Last-Event-ID', async () => {
+  it('does not send snapshot on reconnect with Last-Event-ID when no events are missed', async () => {
     const ctx = createSseApp({
       getSnapshot: () => ({ agents: [] }),
     });
     ticketStore = ctx.ticketStore;
-
-    ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
 
     const ticket = await issueTicket(ctx.app);
 
     const events = await readSseEventsUntil(
       ctx.app,
       'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
-      (candidateEvents) => candidateEvents.some((e) => e.id === '1'),
-      { headers: { 'Last-Event-ID': '0' }, continueAfterMatchMs: 25 },
+      () => false,
+      { headers: { 'Last-Event-ID': '0' }, timeoutMs: 50, allowTimeout: true },
     );
     expect(events.find((e) => e.event === 'snapshot')).toBeUndefined();
   });
@@ -401,6 +407,7 @@ describe('Beast SSE routes', () => {
       'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
       (candidateEvents) => candidateEvents.filter((e) => e.event === 'run.log').length === 5,
       {
+        continueAfterMatchMs: 25,
         onConnected: () => {
           for (let i = 0; i < 5; i++) {
             ctx.bus.publish({ type: 'run.log', data: { line: `line-${i}` } });

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -56,16 +56,23 @@ async function readSseEventsUntil(
   app: Hono,
   url: string,
   until: (events: ParsedSseEvent[]) => boolean,
-  options: { headers?: HeadersInit; onConnected?: () => void; timeoutMs?: number } = {},
+  options: {
+    headers?: HeadersInit;
+    onConnected?: () => void;
+    timeoutMs?: number;
+    continueAfterMatchMs?: number;
+  } = {},
 ): Promise<ParsedSseEvent[]> {
   const controller = new AbortController();
   const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? 1_000);
   let timedOut = false;
   let observedExpectedEvents = false;
+  let settleSignal: AbortSignal | undefined;
   const abortOnTimeout = () => {
     timedOut = true;
     controller.abort(timeoutSignal.reason);
   };
+  const abortAfterSettling = () => controller.abort(settleSignal?.reason);
 
   timeoutSignal.addEventListener('abort', abortOnTimeout, { once: true });
 
@@ -92,6 +99,12 @@ async function readSseEventsUntil(
       text += decoder.decode(value, { stream: true });
       const events = parseSseEvents(text);
       if (until(events)) {
+        if (!observedExpectedEvents && options.continueAfterMatchMs !== undefined) {
+          observedExpectedEvents = true;
+          settleSignal = AbortSignal.timeout(options.continueAfterMatchMs);
+          settleSignal.addEventListener('abort', abortAfterSettling, { once: true });
+          continue;
+        }
         observedExpectedEvents = true;
         controller.abort();
         return events;
@@ -103,6 +116,7 @@ async function readSseEventsUntil(
     }
   } finally {
     timeoutSignal.removeEventListener('abort', abortOnTimeout);
+    settleSignal?.removeEventListener('abort', abortAfterSettling);
     reader.releaseLock();
   }
 
@@ -284,7 +298,7 @@ describe('Beast SSE routes', () => {
         candidateEvents.some((e) => e.id === '2')
         && candidateEvents.some((e) => e.id === '3')
       ),
-      { headers: { 'Last-Event-ID': '1' } },
+      { headers: { 'Last-Event-ID': '1' }, continueAfterMatchMs: 25 },
     );
 
     // Should NOT contain event id=1 (already seen)
@@ -307,13 +321,14 @@ describe('Beast SSE routes', () => {
       ctx.app,
       `http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`,
       (candidateEvents) => candidateEvents.some((e) => e.id === '2'),
+      { continueAfterMatchMs: 25 },
     );
 
     expect(events.find((e) => e.id === '1')).toBeUndefined();
     expect(events.find((e) => e.id === '2')).toBeDefined();
   });
 
-  it.each([
+  it.each<Array<[string, { headers?: HeadersInit; query?: string }]>>([
     ['partial numeric Last-Event-ID header', { headers: { 'Last-Event-ID': '10abc' } }],
     ['non-numeric lastEventId query', { query: 'lastEventId=abc' }],
     ['negative lastEventId query', { query: 'lastEventId=-1' }],
@@ -370,7 +385,7 @@ describe('Beast SSE routes', () => {
       ctx.app,
       'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
       (candidateEvents) => candidateEvents.some((e) => e.id === '1'),
-      { headers: { 'Last-Event-ID': '0' } },
+      { headers: { 'Last-Event-ID': '0' }, continueAfterMatchMs: 25 },
     );
     expect(events.find((e) => e.event === 'snapshot')).toBeUndefined();
   });

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -36,11 +36,13 @@ async function issueTicket(app: Hono): Promise<string> {
  * Parse raw SSE text into structured events.
  * Each SSE event block is separated by a blank line.
  */
-function parseSseEvents(text: string): Array<{ id?: string; event?: string; data?: string }> {
+type ParsedSseEvent = { id?: string; event?: string; data?: string };
+
+function parseSseEvents(text: string): ParsedSseEvent[] {
   const blocks = text.split('\n\n').filter((b) => b.trim().length > 0);
   return blocks.map((block) => {
     const lines = block.split('\n');
-    const event: { id?: string; event?: string; data?: string } = {};
+    const event: ParsedSseEvent = {};
     for (const line of lines) {
       if (line.startsWith('id:')) event.id = line.slice(3).trim();
       else if (line.startsWith('event:')) event.event = line.slice(6).trim();
@@ -48,6 +50,67 @@ function parseSseEvents(text: string): Array<{ id?: string; event?: string; data
     }
     return event;
   });
+}
+
+async function readSseEventsUntil(
+  app: Hono,
+  url: string,
+  until: (events: ParsedSseEvent[]) => boolean,
+  options: { headers?: HeadersInit; onConnected?: () => void; timeoutMs?: number } = {},
+): Promise<ParsedSseEvent[]> {
+  const controller = new AbortController();
+  const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? 1_000);
+  let timedOut = false;
+  let observedExpectedEvents = false;
+  const abortOnTimeout = () => {
+    timedOut = true;
+    controller.abort(timeoutSignal.reason);
+  };
+
+  timeoutSignal.addEventListener('abort', abortOnTimeout, { once: true });
+
+  const req = new Request(url, {
+    signal: controller.signal,
+    headers: options.headers,
+  });
+  const res = await app.request(req);
+  if (!res.body) {
+    timeoutSignal.removeEventListener('abort', abortOnTimeout);
+    throw new Error('Expected SSE response body to be readable');
+  }
+
+  options.onConnected?.();
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      const events = parseSseEvents(text);
+      if (until(events)) {
+        observedExpectedEvents = true;
+        controller.abort();
+        return events;
+      }
+    }
+  } catch (error) {
+    if (!observedExpectedEvents && !timedOut) {
+      throw error;
+    }
+  } finally {
+    timeoutSignal.removeEventListener('abort', abortOnTimeout);
+    reader.releaseLock();
+  }
+
+  if (timedOut) {
+    throw new Error(`Timed out waiting for expected SSE events. Received: ${text}`);
+  }
+
+  return parseSseEvents(text);
 }
 
 describe('Beast SSE routes', () => {
@@ -152,23 +215,20 @@ describe('Beast SSE routes', () => {
 
     const ticket = await issueTicket(ctx.app);
 
-    // Schedule events to publish after the stream connects
-    setTimeout(() => {
-      ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
-      ctx.bus.publish({ type: 'run.status', data: { runId: 'r1', status: 'active' } });
-    }, 30);
-
-    // Abort after events have been delivered
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 150);
-
-    const req = new Request('http://localhost/v1/beasts/events/stream?ticket=' + ticket, {
-      signal: controller.signal,
-    });
-    const res = await ctx.app.request(req);
-    const text = await res.text();
-
-    const events = parseSseEvents(text);
+    const events = await readSseEventsUntil(
+      ctx.app,
+      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      (candidateEvents) => (
+        candidateEvents.some((e) => e.event === 'agent.status')
+        && candidateEvents.some((e) => e.event === 'run.status')
+      ),
+      {
+        onConnected: () => {
+          ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
+          ctx.bus.publish({ type: 'run.status', data: { runId: 'r1', status: 'active' } });
+        },
+      },
+    );
     const agentEvent = events.find((e) => e.event === 'agent.status');
     const runEvent = events.find((e) => e.event === 'run.status');
 
@@ -189,16 +249,11 @@ describe('Beast SSE routes', () => {
 
     const ticket = await issueTicket(ctx.app);
 
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 100);
-
-    const req = new Request('http://localhost/v1/beasts/events/stream?ticket=' + ticket, {
-      signal: controller.signal,
-    });
-    const res = await ctx.app.request(req);
-    const text = await res.text();
-
-    const events = parseSseEvents(text);
+    const events = await readSseEventsUntil(
+      ctx.app,
+      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      (candidateEvents) => candidateEvents.some((e) => e.event === 'snapshot'),
+    );
     const snapshot = events.find((e) => e.event === 'snapshot');
 
     expect(snapshot).toBeDefined();
@@ -217,18 +272,16 @@ describe('Beast SSE routes', () => {
 
     const ticket = await issueTicket(ctx.app);
 
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 100);
-
     // Reconnect with Last-Event-ID=1 — should replay events 2 and 3
-    const req = new Request('http://localhost/v1/beasts/events/stream?ticket=' + ticket, {
-      signal: controller.signal,
-      headers: { 'Last-Event-ID': '1' },
-    });
-    const res = await ctx.app.request(req);
-    const text = await res.text();
-
-    const events = parseSseEvents(text);
+    const events = await readSseEventsUntil(
+      ctx.app,
+      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      (candidateEvents) => (
+        candidateEvents.some((e) => e.id === '2')
+        && candidateEvents.some((e) => e.id === '3')
+      ),
+      { headers: { 'Last-Event-ID': '1' } },
+    );
 
     // Should NOT contain event id=1 (already seen)
     expect(events.find((e) => e.id === '1')).toBeUndefined();
@@ -245,15 +298,12 @@ describe('Beast SSE routes', () => {
     ctx.bus.publish({ type: 'run.status', data: { runId: 'r1', status: 'active' } });
 
     const ticket = await issueTicket(ctx.app);
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 100);
 
-    const req = new Request(`http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`, {
-      signal: controller.signal,
-    });
-    const res = await ctx.app.request(req);
-    const text = await res.text();
-    const events = parseSseEvents(text);
+    const events = await readSseEventsUntil(
+      ctx.app,
+      `http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`,
+      (candidateEvents) => candidateEvents.some((e) => e.id === '2'),
+    );
 
     expect(events.find((e) => e.id === '1')).toBeUndefined();
     expect(events.find((e) => e.id === '2')).toBeDefined();
@@ -308,19 +358,16 @@ describe('Beast SSE routes', () => {
     });
     ticketStore = ctx.ticketStore;
 
+    ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
+
     const ticket = await issueTicket(ctx.app);
 
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 100);
-
-    const req = new Request('http://localhost/v1/beasts/events/stream?ticket=' + ticket, {
-      signal: controller.signal,
-      headers: { 'Last-Event-ID': '0' },
-    });
-    const res = await ctx.app.request(req);
-    const text = await res.text();
-
-    const events = parseSseEvents(text);
+    const events = await readSseEventsUntil(
+      ctx.app,
+      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      (candidateEvents) => candidateEvents.some((e) => e.id === '1'),
+      { headers: { 'Last-Event-ID': '0' } },
+    );
     expect(events.find((e) => e.event === 'snapshot')).toBeUndefined();
   });
 
@@ -330,22 +377,18 @@ describe('Beast SSE routes', () => {
 
     const ticket = await issueTicket(ctx.app);
 
-    setTimeout(() => {
-      for (let i = 0; i < 5; i++) {
-        ctx.bus.publish({ type: 'run.log', data: { line: `line-${i}` } });
-      }
-    }, 30);
-
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 150);
-
-    const req = new Request('http://localhost/v1/beasts/events/stream?ticket=' + ticket, {
-      signal: controller.signal,
-    });
-    const res = await ctx.app.request(req);
-    const text = await res.text();
-
-    const events = parseSseEvents(text).filter((e) => e.id && e.event === 'run.log');
+    const events = (await readSseEventsUntil(
+      ctx.app,
+      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      (candidateEvents) => candidateEvents.filter((e) => e.event === 'run.log').length === 5,
+      {
+        onConnected: () => {
+          for (let i = 0; i < 5; i++) {
+            ctx.bus.publish({ type: 'run.log', data: { line: `line-${i}` } });
+          }
+        },
+      },
+    )).filter((e) => e.id && e.event === 'run.log');
     expect(events.length).toBe(5);
 
     const ids = events.map((e) => parseInt(e.id!, 10));

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -106,11 +106,15 @@ async function readSseEventsUntil(
     reader.releaseLock();
   }
 
+  const finalEvents = parseSseEvents(text);
   if (timedOut) {
     throw new Error(`Timed out waiting for expected SSE events. Received: ${text}`);
   }
+  if (!until(finalEvents)) {
+    throw new Error(`SSE stream ended before expected events were observed. Received: ${text}`);
+  }
 
-  return parseSseEvents(text);
+  return finalEvents;
 }
 
 describe('Beast SSE routes', () => {


### PR DESCRIPTION
## Summary
- replace wall-clock sleeps in Beast SSE integration tests with a helper that reads stream chunks until expected events are observed
- publish live-stream events only after the SSE request is connected
- keep a bounded timeout as a failure guard for broken streams

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/integration/beasts/sse-stream.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #2153