### PR TITLE
docs(dx): document Franken env overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,21 @@ CHROMA_URL=http://localhost:8000
 
 # ── Orchestrator runtime config ──
 # These map to OrchestratorConfig env overrides in packages/franken-orchestrator/src/cli/config-loader.ts.
+# Precedence for `frankenbeast run`: CLI flags > FRANKEN_* env vars > config file > built-in defaults.
+# Matrix:
+#   FRANKEN_MAX_TOTAL_TOKENS          -> maxTotalTokens          integer tokens; default 100000; must be >= 10000
+#   FRANKEN_MAX_DURATION_MS           -> maxDurationMs           integer ms; default 300000; must be >= 1000 and >= maxCritiqueIterations * 10000
+#   FRANKEN_MAX_CRITIQUE_ITERATIONS   -> maxCritiqueIterations   integer critique passes; default 3; valid range 1..10
+#   FRANKEN_ENABLE_HEARTBEAT          -> enableHeartbeat         boolean string; only "true" enables it; default false
+#   FRANKEN_ENABLE_TRACING            -> enableTracing           boolean string; only "true" enables it; default false; --verbose also enables tracing
+#   FRANKEN_ENABLE_REFLECTION         -> enableReflection        boolean string; only "true" enables it; default false
+#   FRANKEN_MIN_CRITIQUE_SCORE        -> minCritiqueScore        numeric score; default 0.7; must be >= 0 and < 1
 FRANKEN_MAX_TOTAL_TOKENS=100000
 FRANKEN_MAX_DURATION_MS=300000
 FRANKEN_MAX_CRITIQUE_ITERATIONS=3
 FRANKEN_ENABLE_HEARTBEAT=false
 FRANKEN_ENABLE_TRACING=false
-FRANKEN_ENABLE_REFLECTION=true
+FRANKEN_ENABLE_REFLECTION=false
 FRANKEN_MIN_CRITIQUE_SCORE=0.7
 
 # ── Local encrypted secret store / headless runs ──

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -56,6 +56,29 @@ describe('local setup scripts', () => {
     expect(read('scripts/verify-setup.ts')).toContain("check('Node.js >=22.13.0 <23 || >=24.0.0 <26'");
   });
 
+  it('keeps root env example aligned with orchestrator runtime config overrides', () => {
+    const envExample = read('.env.example');
+    const readme = read('README.md');
+
+    expect(envExample).toContain('CLI flags > FRANKEN_* env vars > config file > built-in defaults');
+    expect(envExample).toContain('FRANKEN_ENABLE_REFLECTION         -> enableReflection');
+    expect(envExample).toContain('boolean string; only "true" enables it; default false');
+    expect(envExample).toMatch(/^FRANKEN_ENABLE_REFLECTION=false$/m);
+
+    for (const frankenOverride of [
+      'FRANKEN_MAX_TOTAL_TOKENS',
+      'FRANKEN_MAX_DURATION_MS',
+      'FRANKEN_MAX_CRITIQUE_ITERATIONS',
+      'FRANKEN_ENABLE_HEARTBEAT',
+      'FRANKEN_ENABLE_TRACING',
+      'FRANKEN_ENABLE_REFLECTION',
+      'FRANKEN_MIN_CRITIQUE_SCORE',
+    ]) {
+      expect(envExample).toContain(frankenOverride);
+      expect(readme).toContain(frankenOverride);
+    }
+  });
+
   it('verify-setup checks the live Chroma v2 heartbeat and no removed firewall service', () => {
     const source = read('scripts/verify-setup.ts');
 


### PR DESCRIPTION
## Summary
- add a user-facing FRANKEN_* runtime config matrix to the root .env.example
- align FRANKEN_ENABLE_REFLECTION with the documented false default
- add a root docs regression that checks .env.example and README cover the same runtime override surface

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run bootstrap:dry-run
- npm run typecheck
- npm run lint
- npm run build

Closes #2137