### PR TITLE
fix(live-bench): bound long model path segments

### DIFF
--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { join, parse, relative, resolve, sep } from 'node:path';
 import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
@@ -162,12 +163,18 @@ function isLeapYear(year: number): boolean {
   return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
 }
 
+const MAX_MODEL_PATH_SEGMENT_BYTES = 255;
+
 function modelPathSegment(model: string): string {
   const codeUnits = Buffer.alloc(model.length * 2);
   for (let index = 0; index < model.length; index += 1) {
     codeUnits.writeUInt16BE(model.charCodeAt(index), index * 2);
   }
-  return `model-${codeUnits.toString('hex')}`;
+  const encoded = `model-${codeUnits.toString('hex')}`;
+  if (Buffer.byteLength(encoded) <= MAX_MODEL_PATH_SEGMENT_BYTES) {
+    return encoded;
+  }
+  return `model-sha256-${createHash('sha256').update(codeUnits).digest('hex')}`;
 }
 
 function assertSafePathSegment(value: string, label: string): void {

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../src/types.js';
 import { FixtureStore } from '../src/workspace/fixture-store.js';
@@ -162,6 +162,30 @@ describe('workspace provisioning', () => {
     expect(uppercaseBase64Lookalike.runDir).not.toBe(lowercaseBase64Lookalike.runDir);
     expect(uppercaseBase64Lookalike.runDir.toLowerCase()).not.toBe(lowercaseBase64Lookalike.runDir.toLowerCase());
     expect(readFileSync(join(uppercaseBase64Lookalike.evidenceDir, 'sentinel.txt'), 'utf8')).toBe('keep uppercase lookalike\n');
+  });
+
+  it('bounds long model path segments while preserving distinct model directories and metadata', () => {
+    const fixturesRoot = tempRoot('live-bench-fixtures-');
+    const runsRoot = tempRoot('live-bench-runs-');
+    createFixture(fixturesRoot);
+
+    const provisioner = new WorkspaceProvisioner({
+      fixtures: new FixtureStore(fixturesRoot),
+      runsRoot,
+    });
+
+    const longModel = 'a'.repeat(126);
+    const otherLongModel = `${'a'.repeat(125)}b`;
+    const provisioned = provisioner.provision({ ...row, runId: 'run-long-model', model: longModel }, task);
+    const otherProvisioned = provisioner.provision({ ...row, runId: 'run-long-model', model: otherLongModel }, task);
+
+    const modelSegment = basename(provisioned.runDir);
+    expect(Buffer.byteLength(modelSegment)).toBeLessThanOrEqual(255);
+    expect(modelSegment).toMatch(/^model-sha256-[a-f0-9]{64}$/);
+    expect(otherProvisioned.runDir).not.toBe(provisioned.runDir);
+    expect(existsSync(provisioned.workspaceDir)).toBe(true);
+    const environment = JSON.parse(readFileSync(provisioned.environmentPath, 'utf8')) as Record<string, unknown>;
+    expect(environment.model).toBe(longModel);
   });
 
   it('rejects non-canonical and timezone-less run timestamps', () => {


### PR DESCRIPTION
## Summary
- bound long live-bench model path segments with a sha256 digest once the encoded component would exceed filesystem NAME_MAX
- preserve existing full UTF-16 hex segments for short model ids
- add regression coverage for long model ids, distinct directories, successful provisioning, and environment metadata preservation

Closes #2165

## Test plan
- `npm run build --workspace @franken/types`
- `npm run test --workspace @franken/live-bench -- --run tests/workspace-provisioner.test.ts`
- `npm run typecheck --workspace @franken/live-bench`

Note: this isolated worktree initially had no node_modules, so targeted package dependencies were installed with `npm install --ignore-scripts --no-audit --no-fund --package-lock=false --workspace @franken/live-bench` after `npm ci --ignore-scripts` failed because the existing lockfile is out of sync.