### PR TITLE
feat(governor): add signed approval policy manifests

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -469,6 +469,59 @@ const gateway = new ApprovalGateway({
 
 When `requireSignedApprovals` is `true`, the gateway throws `SignatureVerificationError` if a response has an invalid or missing signature.
 
+### Signed Approval Policy Manifests
+
+Operators can ship approval policy order/config as a signed manifest instead of constructing evaluator arrays inline. Manifest loading fails closed by default: unsigned manifests are rejected unless the caller sets `allowUnsignedPolicyManifest: true`, and signed manifests require a configured `SignatureVerifier`. Secrets are never included in manifest payloads, errors, or audit output.
+
+```typescript
+import {
+  createGovernor,
+  formatApprovalPolicyManifestPayload,
+  SignatureVerifier,
+  type ApprovalPolicyManifest,
+} from '@franken/governor';
+
+const verifier = new SignatureVerifier(process.env.FRANKEN_GOVERNOR_POLICY_SECRET!);
+const unsigned = {
+  schemaVersion: 1,
+  manifestId: 'approval-policy/production',
+  issuedAt: '2026-07-13T00:00:00.000Z',
+  policies: [
+    { triggerId: 'skill' },
+    { triggerId: 'budget' },
+    { triggerId: 'confidence', config: { threshold: 0.8 } },
+    { triggerId: 'ambiguity' },
+  ],
+} satisfies Omit<ApprovalPolicyManifest, 'signature'>;
+
+const signatureMetadata = {
+  algorithm: 'hmac-sha256' as const,
+  keyId: 'ops-2026-07',
+  value: '',
+};
+const manifest: ApprovalPolicyManifest = {
+  ...unsigned,
+  signature: {
+    ...signatureMetadata,
+    value: verifier.sign(formatApprovalPolicyManifestPayload({
+      ...unsigned,
+      signature: signatureMetadata,
+    })),
+  },
+};
+
+const governor = createGovernor({
+  readline: readlineAdapter,
+  memoryPort,
+  approvalPolicyManifest: manifest,
+  policyManifestSignatureVerifier: verifier,
+  skillMetadata,
+  budgetState,
+});
+```
+
+The canonical policy-manifest payload is stable JSON with sorted object keys and the signature `value` removed (signature `algorithm` and `keyId` metadata remain authenticated). Policy array order is preserved because evaluator order can be security-significant. Supported built-in policy IDs are `skill`, `budget`, `confidence`, and `ambiguity`; only `confidence` accepts `config.threshold` (0–1). Use `allowUnsignedPolicyManifest` only for local fixtures or one-off operator overrides, not production.
+
 ### Session Tokens
 
 On APPROVE, the gateway can issue a scoped, time-limited `SessionToken`. A `GovernorCritiqueAdapter` that is wired with the same `SessionTokenStore` accepts `rationale.approvalSessionTokenId` for later risky actions, but only while the token is unexpired and scoped to the selected tool (or task when no tool is selected). Expired, missing, or wrong-scope tokens fail closed to a fresh operator prompt without printing token values:

--- a/packages/franken-governor/docs/adr/ADR-005-signed-approvals-hmac.md
+++ b/packages/franken-governor/docs/adr/ADR-005-signed-approvals-hmac.md
@@ -14,6 +14,8 @@ Use HMAC-SHA256 signatures via Node.js `node:crypto`. The `ApprovalResponse` inc
 
 The signature payload is a deterministic, non-JSON approval-response byte string formatted as `requestId:<url-encoded-id>|decision:<url-encoded-decision>|respondedBy:<url-encoded-responder>|feedback:<feedback-state>`. `feedback:<feedback-state>` is `feedback:u` when feedback is omitted and `feedback:s:<url-encoded-feedback>` when feedback is present. Signing `respondedBy` and `feedback` ensures the recorded responder identity and optional rationale cannot be tampered with after the decision is signed.
 
+Approval policy manifests use the same HMAC primitive but a separate canonical payload: stable JSON with sorted object keys, the signature `value` omitted, signature `algorithm`/`keyId` metadata authenticated, and policy array order preserved. Manifest loading is fail-closed by default: unsigned manifests require an explicit `allowUnsignedPolicyManifest` override, and signed manifests require a configured verifier. Supported built-in policy IDs are `skill`, `budget`, `confidence`, and `ambiguity`; `confidence` may carry a threshold config.
+
 ## Consequences
 
 - **Positive:** Simple, well-understood crypto primitive; no PKI infrastructure needed.

--- a/packages/franken-governor/src/gateway/governor-factory.ts
+++ b/packages/franken-governor/src/gateway/governor-factory.ts
@@ -9,6 +9,11 @@ import type { GovernorMemoryPort } from '../audit/governor-memory-port.js';
 import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
 import { defaultConfig, type GovernorConfig } from '../core/config.js';
 import type { SessionTokenStore } from '../security/session-token-store.js';
+import type { SignatureVerifier } from '../security/signature-verifier.js';
+import {
+  createEvaluatorsFromApprovalPolicyManifest,
+  type ApprovalPolicyManifest,
+} from '../security/approval-policy-manifest.js';
 
 export interface CreateGovernorOptions {
   readonly readline: ReadlineAdapter;
@@ -23,6 +28,14 @@ export interface CreateGovernorOptions {
   readonly budgetState?: BudgetStateSource;
   /** Shared operator-session token store for approval issuance and validation. */
   readonly sessionTokenStore?: SessionTokenStore;
+  /**
+   * Signed approval policy manifest. When present it becomes the evaluator
+   * source after signature verification; unsigned manifests are rejected unless
+   * allowUnsignedPolicyManifest is explicitly true.
+   */
+  readonly approvalPolicyManifest?: ApprovalPolicyManifest;
+  readonly policyManifestSignatureVerifier?: SignatureVerifier;
+  readonly allowUnsignedPolicyManifest?: boolean;
 }
 
 export function createGovernor(options: CreateGovernorOptions): GovernorCritiqueAdapter {
@@ -37,11 +50,18 @@ export function createGovernor(options: CreateGovernorOptions): GovernorCritique
   });
 
   const auditRecorder = new GovernorAuditRecorder(options.memoryPort);
+  const policyManifestOptions = {
+    ...(options.policyManifestSignatureVerifier ? { verifier: options.policyManifestSignatureVerifier } : {}),
+    ...(options.allowUnsignedPolicyManifest !== undefined ? { allowUnsigned: options.allowUnsignedPolicyManifest } : {}),
+  };
+  const evaluators = options.approvalPolicyManifest !== undefined
+    ? createEvaluatorsFromApprovalPolicyManifest(options.approvalPolicyManifest, policyManifestOptions)
+    : (options.evaluators ?? []);
 
   return new GovernorCritiqueAdapter({
     channel,
     auditRecorder,
-    evaluators: options.evaluators ?? [],
+    evaluators,
     projectId: options.projectId ?? 'default',
     config,
     ...(options.skillMetadata ? { skillMetadata: options.skillMetadata } : {}),

--- a/packages/franken-governor/src/index.ts
+++ b/packages/franken-governor/src/index.ts
@@ -58,8 +58,22 @@ export type { GovernorAppOptions } from './server/index.js';
 export type { GovernorMemoryPort, EpisodicTraceRecord } from './audit/index.js';
 export { GovernorAuditRecorder } from './audit/index.js';
 
-export { formatApprovalResponseSignaturePayload, SignatureVerifier } from './security/index.js';
-export type { ApprovalResponseSignaturePayloadFields } from './security/index.js';
+export {
+  createEvaluatorsFromApprovalPolicyManifest,
+  formatApprovalPolicyManifestPayload,
+  formatApprovalResponseSignaturePayload,
+  SignatureVerifier,
+  verifySignedApprovalPolicyManifest,
+} from './security/index.js';
+export type {
+  ApprovalPolicyManifest,
+  ApprovalPolicyManifestPolicy,
+  ApprovalPolicyManifestSignature,
+  ApprovalPolicyManifestTriggerId,
+  ApprovalPolicyManifestVerificationOptions,
+  ApprovalResponseSignaturePayloadFields,
+  VerifiedApprovalPolicyManifest,
+} from './security/index.js';
 export {
   createSessionToken,
   formatApprovalSessionTokenScope,

--- a/packages/franken-governor/src/security/approval-policy-manifest.ts
+++ b/packages/franken-governor/src/security/approval-policy-manifest.ts
@@ -1,0 +1,206 @@
+import { ApprovalConfigurationError, SignatureVerificationError } from '../errors/index.js';
+import { AmbiguityTrigger } from '../triggers/ambiguity-trigger.js';
+import { BudgetTrigger } from '../triggers/budget-trigger.js';
+import { ConfidenceTrigger } from '../triggers/confidence-trigger.js';
+import { SkillTrigger } from '../triggers/skill-trigger.js';
+import type { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
+import type { SignatureVerifier } from './signature-verifier.js';
+
+export type ApprovalPolicyTriggerId = 'skill' | 'budget' | 'confidence' | 'ambiguity';
+export type ApprovalPolicyManifestTriggerId = ApprovalPolicyTriggerId;
+
+export interface ApprovalPolicyManifestSignature {
+  readonly algorithm: 'hmac-sha256';
+  readonly value: string;
+  readonly keyId?: string;
+}
+
+export interface ApprovalPolicyManifestPolicy {
+  readonly triggerId: ApprovalPolicyTriggerId;
+  readonly enabled?: boolean;
+  readonly config?: {
+    readonly threshold?: number;
+  };
+}
+
+export interface ApprovalPolicyManifest {
+  readonly schemaVersion: 1;
+  readonly manifestId: string;
+  readonly issuedAt: string;
+  readonly policies: ReadonlyArray<ApprovalPolicyManifestPolicy>;
+  readonly signature?: ApprovalPolicyManifestSignature;
+}
+
+export interface VerifiedApprovalPolicyManifest {
+  readonly manifestId: string;
+  readonly signed: boolean;
+  readonly signatureKeyId?: string;
+}
+
+export interface ApprovalPolicyManifestVerificationOptions {
+  readonly verifier?: SignatureVerifier;
+  /**
+   * Explicit operator override for development/test fixtures. Production callers
+   * should leave this false so manifest loading fails closed when unsigned.
+   */
+  readonly allowUnsigned?: boolean;
+}
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { readonly [key: string]: JsonValue };
+
+function stableJson(value: JsonValue): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(',')}]`;
+
+  const entries = Object.entries(value)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`).join(',')}}`;
+}
+
+function manifestPayloadShape(manifest: ApprovalPolicyManifest | Omit<ApprovalPolicyManifest, 'signature'>): JsonValue {
+  const signature = 'signature' in manifest ? manifest.signature : undefined;
+  return {
+    schemaVersion: manifest.schemaVersion,
+    manifestId: manifest.manifestId,
+    issuedAt: manifest.issuedAt,
+    policies: manifest.policies.map((policy) => ({
+      triggerId: policy.triggerId,
+      ...(policy.enabled !== undefined ? { enabled: policy.enabled } : {}),
+      ...(policy.config !== undefined ? { config: { ...policy.config } } : {}),
+    })),
+    ...(signature !== undefined
+      ? {
+        signature: {
+          algorithm: signature.algorithm,
+          ...(signature.keyId !== undefined ? { keyId: signature.keyId } : {}),
+        },
+      }
+      : {}),
+  };
+}
+
+/**
+ * Canonical payload signed for approval policy manifests.
+ *
+ * The signature block is intentionally excluded. Policy array order is preserved
+ * because evaluator order can be security-significant; object keys are sorted so
+ * independently generated manifests produce the same HMAC bytes.
+ */
+export function formatApprovalPolicyManifestPayload(
+  manifest: ApprovalPolicyManifest | Omit<ApprovalPolicyManifest, 'signature'>,
+): string {
+  return stableJson(manifestPayloadShape(manifest));
+}
+
+export function verifySignedApprovalPolicyManifest(
+  manifest: ApprovalPolicyManifest,
+  options: ApprovalPolicyManifestVerificationOptions = {},
+): VerifiedApprovalPolicyManifest {
+  assertManifestShape(manifest);
+
+  const signature = manifest.signature;
+  if (signature === undefined) {
+    if (options.allowUnsigned === true) {
+      return { manifestId: manifest.manifestId, signed: false };
+    }
+    throw new ApprovalConfigurationError(
+      `Approval policy manifest ${manifest.manifestId} is unsigned. Refusing to load without allowUnsigned override.`,
+    );
+  }
+
+  if (signature.algorithm !== 'hmac-sha256') {
+    throw new ApprovalConfigurationError(
+      `Unsupported approval policy manifest signature algorithm: ${String(signature.algorithm)}`,
+    );
+  }
+  if (options.verifier === undefined) {
+    throw new ApprovalConfigurationError(
+      `Approval policy manifest ${manifest.manifestId} is signed but no verifier is configured.`,
+    );
+  }
+
+  const payload = formatApprovalPolicyManifestPayload(manifest);
+  if (!options.verifier.verify(payload, signature.value)) {
+    throw new SignatureVerificationError(
+      `Approval policy manifest ${manifest.manifestId} signature verification failed`,
+    );
+  }
+
+  return {
+    manifestId: manifest.manifestId,
+    signed: true,
+    ...(signature.keyId !== undefined ? { signatureKeyId: signature.keyId } : {}),
+  };
+}
+
+export function createEvaluatorsFromApprovalPolicyManifest(
+  manifest: ApprovalPolicyManifest,
+  options: ApprovalPolicyManifestVerificationOptions = {},
+): TriggerEvaluator[] {
+  verifySignedApprovalPolicyManifest(manifest, options);
+  return manifest.policies
+    .filter((policy) => policy.enabled !== false)
+    .map((policy) => createEvaluator(policy));
+}
+
+function createEvaluator(policy: ApprovalPolicyManifestPolicy): TriggerEvaluator {
+  const triggerId = policy.triggerId as string;
+  switch (triggerId) {
+    case 'skill':
+      assertNoUnsupportedConfig(policy);
+      return new SkillTrigger();
+    case 'budget':
+      assertNoUnsupportedConfig(policy);
+      return new BudgetTrigger();
+    case 'ambiguity':
+      assertNoUnsupportedConfig(policy);
+      return new AmbiguityTrigger();
+    case 'confidence': {
+      assertKnownConfigKeys(policy, ['threshold']);
+      const threshold = policy.config?.threshold;
+      if (threshold !== undefined && (!Number.isFinite(threshold) || threshold < 0 || threshold > 1)) {
+        throw new ApprovalConfigurationError(
+          `Approval policy manifest confidence threshold must be a number between 0 and 1.`,
+        );
+      }
+      return new ConfidenceTrigger(threshold);
+    }
+    default:
+      throw new ApprovalConfigurationError(`Unsupported approval policy triggerId: ${triggerId}`);
+  }
+}
+
+function assertKnownConfigKeys(
+  policy: ApprovalPolicyManifestPolicy,
+  allowedKeys: ReadonlyArray<string>,
+): void {
+  for (const key of Object.keys(policy.config ?? {})) {
+    if (!allowedKeys.includes(key)) {
+      throw new ApprovalConfigurationError(`Unsupported ${policy.triggerId} policy config key: ${key}`);
+    }
+  }
+}
+
+function assertNoUnsupportedConfig(policy: ApprovalPolicyManifestPolicy): void {
+  assertKnownConfigKeys(policy, []);
+}
+
+function assertManifestShape(manifest: ApprovalPolicyManifest): void {
+  if (manifest.schemaVersion !== 1) {
+    throw new ApprovalConfigurationError('Approval policy manifest schemaVersion must be 1.');
+  }
+  if (manifest.manifestId.trim() === '') {
+    throw new ApprovalConfigurationError('Approval policy manifest manifestId must be non-empty.');
+  }
+  if (Number.isNaN(Date.parse(manifest.issuedAt))) {
+    throw new ApprovalConfigurationError(
+      `Approval policy manifest ${manifest.manifestId} issuedAt must be an ISO timestamp.`,
+    );
+  }
+  if (manifest.policies.length === 0) {
+    throw new ApprovalConfigurationError(
+      `Approval policy manifest ${manifest.manifestId} must contain at least one policy.`,
+    );
+  }
+}

--- a/packages/franken-governor/src/security/index.ts
+++ b/packages/franken-governor/src/security/index.ts
@@ -9,3 +9,16 @@ export { formatApprovalSessionTokenScope, formatSessionTokenScope } from './sess
 export type { SessionTokenScopeFields } from './session-token-scope.js';
 export { SessionTokenStore } from './session-token-store.js';
 export type { SessionTokenStoreOptions, SweepExpiredSessionTokenOptions } from './session-token-store.js';
+export {
+  createEvaluatorsFromApprovalPolicyManifest,
+  formatApprovalPolicyManifestPayload,
+  verifySignedApprovalPolicyManifest,
+} from './approval-policy-manifest.js';
+export type {
+  ApprovalPolicyManifest,
+  ApprovalPolicyManifestPolicy,
+  ApprovalPolicyManifestSignature,
+  ApprovalPolicyManifestTriggerId,
+  ApprovalPolicyManifestVerificationOptions,
+  VerifiedApprovalPolicyManifest,
+} from './approval-policy-manifest.js';

--- a/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-factory.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { BudgetTrigger } from '../../../src/triggers/budget-trigger.js';
 import { SkillTrigger } from '../../../src/triggers/skill-trigger.js';
 import { createGovernor } from '../../../src/gateway/governor-factory.js';
+import {
+  formatApprovalPolicyManifestPayload,
+  type ApprovalPolicyManifest,
+} from '../../../src/security/approval-policy-manifest.js';
+import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
 import type { ReadlineAdapter } from '../../../src/channels/cli-channel.js';
 import type { EpisodicTraceRecord, GovernorMemoryPort } from '../../../src/audit/governor-memory-port.js';
 import type { RationaleBlock } from '@franken/types';
@@ -35,6 +40,19 @@ function makeMemoryPort(): GovernorMemoryPort & { records: EpisodicTraceRecord[]
 }
 
 describe('createGovernor', () => {
+  const policyVerifier = new SignatureVerifier('policy-factory-secret');
+
+  function signPolicyManifest(manifest: Omit<ApprovalPolicyManifest, 'signature'>): ApprovalPolicyManifest {
+    const signatureMetadata = { algorithm: 'hmac-sha256' as const, value: '' };
+    return {
+      ...manifest,
+      signature: {
+        ...signatureMetadata,
+        value: policyVerifier.sign(formatApprovalPolicyManifestPayload({ ...manifest, signature: signatureMetadata })),
+      },
+    };
+  }
+
   it('wires readline, memory audit recording, config, and project id into a GovernorCritiqueAdapter', async () => {
     const readline = makeReadline(['a']);
     const memoryPort = makeMemoryPort();
@@ -128,5 +146,53 @@ describe('createGovernor', () => {
     expect(result).toEqual({ verdict: 'approved' });
     expect(readline.question).not.toHaveBeenCalled();
     expect(memoryPort.recordDecision).not.toHaveBeenCalled();
+  });
+
+  it('uses signed approval policy manifests as the evaluator source', async () => {
+    const memoryPort = makeMemoryPort();
+    const governor = createGovernor({
+      readline: makeReadline(['a']),
+      memoryPort,
+      approvalPolicyManifest: signPolicyManifest({
+        schemaVersion: 1,
+        manifestId: 'approval-policy/default',
+        issuedAt: '2026-07-13T00:00:00.000Z',
+        policies: [{ triggerId: 'confidence', config: { threshold: 0.9 } }],
+      }),
+      policyManifestSignatureVerifier: policyVerifier,
+    });
+
+    const result = await governor.verifyRationale(makeRationale({ confidenceScore: 0.5 }));
+
+    expect(result).toEqual({ verdict: 'approved' });
+    expect(memoryPort.records[0]).toMatchObject({
+      input: {
+        triggerId: 'confidence',
+        triggerReason: 'Low confidence: score 0.5 below threshold 0.9',
+      },
+    });
+  });
+
+  it('refuses unsigned approval policy manifests unless explicitly overridden', () => {
+    const unsignedManifest: ApprovalPolicyManifest = {
+      schemaVersion: 1,
+      manifestId: 'approval-policy/unsigned',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [{ triggerId: 'budget' }],
+    };
+
+    expect(() => createGovernor({
+      readline: makeReadline(['a']),
+      memoryPort: makeMemoryPort(),
+      approvalPolicyManifest: unsignedManifest,
+      policyManifestSignatureVerifier: policyVerifier,
+    })).toThrow('Approval policy manifest approval-policy/unsigned is unsigned');
+
+    expect(() => createGovernor({
+      readline: makeReadline(['a']),
+      memoryPort: makeMemoryPort(),
+      approvalPolicyManifest: unsignedManifest,
+      allowUnsignedPolicyManifest: true,
+    })).not.toThrow();
   });
 });

--- a/packages/franken-governor/tests/unit/public-api.test.ts
+++ b/packages/franken-governor/tests/unit/public-api.test.ts
@@ -19,4 +19,10 @@ describe('public API exports', () => {
     expect(publicApi.SignatureVerificationError).toBeDefined();
     expect(publicApi.TriggerEvaluationError).toBeDefined();
   });
+
+  it('re-exports signed policy manifest helpers from the package root', () => {
+    expect(publicApi.formatApprovalPolicyManifestPayload).toBeDefined();
+    expect(publicApi.verifySignedApprovalPolicyManifest).toBeDefined();
+    expect(publicApi.createEvaluatorsFromApprovalPolicyManifest).toBeDefined();
+  });
 });

--- a/packages/franken-governor/tests/unit/security/approval-policy-manifest.test.ts
+++ b/packages/franken-governor/tests/unit/security/approval-policy-manifest.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEvaluatorsFromApprovalPolicyManifest,
+  formatApprovalPolicyManifestPayload,
+  verifySignedApprovalPolicyManifest,
+  type ApprovalPolicyManifest,
+} from '../../../src/security/approval-policy-manifest.js';
+import { SignatureVerifier } from '../../../src/security/signature-verifier.js';
+
+describe('signed approval policy manifests', () => {
+  const verifier = new SignatureVerifier('policy-fixture-secret');
+
+  function signManifest(manifest: Omit<ApprovalPolicyManifest, 'signature'>): ApprovalPolicyManifest {
+    const signatureMetadata = { algorithm: 'hmac-sha256' as const, keyId: 'test-key', value: '' };
+    return {
+      ...manifest,
+      signature: {
+        ...signatureMetadata,
+        value: verifier.sign(formatApprovalPolicyManifestPayload({ ...manifest, signature: signatureMetadata })),
+      },
+    };
+  }
+
+  it('formats manifests deterministically without including the signature bytes', () => {
+    const manifest = signManifest({
+      schemaVersion: 1,
+      manifestId: 'approval-policy/default',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [
+        { triggerId: 'skill' },
+        { triggerId: 'confidence', config: { threshold: 0.72 } },
+      ],
+    });
+
+    expect(formatApprovalPolicyManifestPayload(manifest)).toBe(
+      '{"issuedAt":"2026-07-13T00:00:00.000Z","manifestId":"approval-policy/default","policies":[{"triggerId":"skill"},{"config":{"threshold":0.72},"triggerId":"confidence"}],"schemaVersion":1,"signature":{"algorithm":"hmac-sha256","keyId":"test-key"}}',
+    );
+  });
+
+  it('verifies a signed manifest and builds evaluators in manifest order', () => {
+    const manifest = signManifest({
+      schemaVersion: 1,
+      manifestId: 'approval-policy/default',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [
+        { triggerId: 'skill' },
+        { triggerId: 'confidence', config: { threshold: 0.8 } },
+      ],
+    });
+
+    expect(verifySignedApprovalPolicyManifest(manifest, { verifier })).toMatchObject({
+      manifestId: 'approval-policy/default',
+      signed: true,
+      signatureKeyId: 'test-key',
+    });
+
+    const evaluators = createEvaluatorsFromApprovalPolicyManifest(manifest, { verifier });
+    expect(evaluators.map((evaluator) => evaluator.triggerId)).toEqual(['skill', 'confidence']);
+    expect(evaluators[1]!.evaluate({ confidenceScore: 0.7 })).toMatchObject({
+      triggered: true,
+      reason: 'Low confidence: score 0.7 below threshold 0.8',
+    });
+  });
+
+  it('fails closed for unsigned manifests unless an explicit operator override is set', () => {
+    const manifest: ApprovalPolicyManifest = {
+      schemaVersion: 1,
+      manifestId: 'approval-policy/unsigned',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [{ triggerId: 'budget' }],
+    };
+
+    expect(() => verifySignedApprovalPolicyManifest(manifest, { verifier })).toThrow(
+      'Approval policy manifest approval-policy/unsigned is unsigned',
+    );
+    expect(createEvaluatorsFromApprovalPolicyManifest(manifest, { verifier, allowUnsigned: true })[0]!.triggerId)
+      .toBe('budget');
+  });
+
+  it('rejects tampered or unsupported policy manifests without exposing secret material', () => {
+    const manifest = signManifest({
+      schemaVersion: 1,
+      manifestId: 'approval-policy/tamper',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [{ triggerId: 'ambiguity' }],
+    });
+    const tampered: ApprovalPolicyManifest = {
+      ...manifest,
+      policies: [{ triggerId: 'confidence', config: { threshold: 0.2 } }],
+    };
+
+    expect(() => verifySignedApprovalPolicyManifest(tampered, { verifier })).toThrow(
+      'Approval policy manifest approval-policy/tamper signature verification failed',
+    );
+    expect(() => createEvaluatorsFromApprovalPolicyManifest({
+      ...manifest,
+      signature: { algorithm: 'ed25519', value: 'not-supported' },
+    }, { verifier })).toThrow('Unsupported approval policy manifest signature algorithm: ed25519');
+  });
+
+  it('authenticates key ids as signature metadata', () => {
+    const manifest = signManifest({
+      schemaVersion: 1,
+      manifestId: 'approval-policy/keyid',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [{ triggerId: 'budget' }],
+    });
+
+    expect(() => verifySignedApprovalPolicyManifest({
+      ...manifest,
+      signature: { ...manifest.signature!, keyId: 'spoofed-key' },
+    }, { verifier })).toThrow('Approval policy manifest approval-policy/keyid signature verification failed');
+  });
+
+  it('rejects unknown trigger IDs and unknown confidence config keys from JSON manifests', () => {
+    const unknownTrigger = signManifest({
+      schemaVersion: 1,
+      manifestId: 'approval-policy/unknown-trigger',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [{ triggerId: 'confidnce' as 'confidence' }],
+    });
+    expect(() => createEvaluatorsFromApprovalPolicyManifest(unknownTrigger, { verifier })).toThrow(
+      'Unsupported approval policy triggerId: confidnce',
+    );
+
+    const typoConfig = signManifest({
+      schemaVersion: 1,
+      manifestId: 'approval-policy/typo-config',
+      issuedAt: '2026-07-13T00:00:00.000Z',
+      policies: [{ triggerId: 'confidence', config: { threshhold: 0.9 } as { threshold: number } }],
+    });
+    expect(() => createEvaluatorsFromApprovalPolicyManifest(typoConfig, { verifier })).toThrow(
+      'Unsupported confidence policy config key: threshhold',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds signed approval policy manifest helpers for canonical HMAC payload formatting, verification, and evaluator construction.
- Wires signed manifests into `createGovernor` with fail-closed defaults and an explicit unsigned-manifest override for local/operator use.
- Documents manifest signing semantics in the governor README and HMAC ADR.

## Verification
- `npm run test --workspace @franken/governor -- tests/unit/security/approval-policy-manifest.test.ts tests/unit/gateway/governor-factory.test.ts tests/unit/public-api.test.ts`
- `npm run typecheck --workspace @franken/governor`
- `npm run build --workspace @franken/governor`
- `npm run lint --workspace @franken/governor` (passes with 3 pre-existing warnings in unrelated tests)
- `npm run test --workspace @franken/governor` (230 tests pass)

Closes #1778
