### PR TITLE
fix: enrich HTTP error context

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -101,6 +101,19 @@ describe('WebhookNotifier', () => {
       await expect(notifier.send({ type: 'test' })).rejects.toThrow('Forbidden')
     })
 
+    it('error message includes webhook endpoint and response body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        text: async () => '{"error":"bad payload"}',
+      })
+      const notifier = createNotifier()
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 422 Unprocessable Entity for https://hooks.example.com/signal: {"error":"bad payload"}',
+      )
+    })
+
     it('rethrows if fetch itself rejects (network error)', async () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
       const notifier = createNotifier()

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -152,15 +152,37 @@ describe('WebhookNotifier', () => {
     })
 
     it('truncates oversized HTTP error bodies', async () => {
+      const text = vi.fn().mockResolvedValue('x'.repeat(3000))
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('x'.repeat(3000)))
+          controller.close()
+        },
+      })
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
         statusText: 'Internal Server Error',
-        text: async () => 'x'.repeat(3000),
+        body: stream,
+        text,
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        `Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/signal: ${'x'.repeat(2048)}…`,
+        `Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/signal: ${'x'.repeat(2048)}`,
+      )
+      expect(text).not.toHaveBeenCalled()
+    })
+
+    it('redacts echoed authentication headers from HTTP error bodies', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () => 'Authorization: Bearer secret-token X-Api-Key=other-secret',
+      })
+      const notifier = createNotifier()
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: Authorization: [REDACTED] X-Api-Key: [REDACTED]',
       )
     })
 

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -212,6 +212,19 @@ describe('WebhookNotifier', () => {
       )
     })
 
+    it('redacts array-valued echoed authentication headers from HTTP error bodies', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        body: responseBody('{"Authorization":["Bearer secret-token"],"x-api-key":["other-secret"]}'),
+      })
+      const notifier = createNotifier()
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/[REDACTED]: {"Authorization":["[REDACTED]"],"x-api-key":["[REDACTED]"]}',
+      )
+    })
+
     it('skips body context instead of buffering non-Web response streams', async () => {
       const text = vi.fn().mockResolvedValue('body from text fallback')
       mockFetch.mockResolvedValue({
@@ -281,6 +294,29 @@ describe('WebhookNotifier', () => {
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
         'Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/[REDACTED]: partial diagnostic',
       )
+    })
+
+    it('stops waiting on slow-drip error-body streams after the overall body deadline', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          await new Promise(resolve => setTimeout(resolve, 25))
+          controller.enqueue(new TextEncoder().encode('x'))
+        },
+        cancel: vi.fn(),
+      })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: stream,
+      })
+      const notifier = createNotifier()
+      const startedAt = Date.now()
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/[REDACTED]:',
+      )
+      expect(Date.now() - startedAt).toBeLessThan(750)
     })
 
     it('rethrows if fetch itself rejects (network error)', async () => {

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -114,6 +114,56 @@ describe('WebhookNotifier', () => {
       )
     })
 
+    it('redacts secret webhook URL components from HTTP error messages', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 410,
+        statusText: 'Gone',
+        text: async () => 'disabled',
+      })
+      const notifier = createNotifier({
+        url: 'https://hooks.example.com/services/XXXXXXXXXXXXXXXXXXXXXXXX?debug=true',
+        allowedTargetOrigins,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 410 Gone for https://hooks.example.com/services/[REDACTED]: disabled',
+      )
+    })
+
+    it('defers reading retryable response bodies until the final attempt', async () => {
+      const text = vi.fn().mockResolvedValue('{"error":"still down"}')
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text,
+      })
+      const notifier = createNotifier({
+        retry: { maxRetries: 1, jitter: false },
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 503 Service Unavailable for https://hooks.example.com/signal: {"error":"still down"}',
+      )
+      expect(text).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('truncates oversized HTTP error bodies', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'x'.repeat(3000),
+      })
+      const notifier = createNotifier()
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        `Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/signal: ${'x'.repeat(2048)}…`,
+      )
+    })
+
     it('rethrows if fetch itself rejects (network error)', async () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
       const notifier = createNotifier()

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -119,15 +119,15 @@ describe('WebhookNotifier', () => {
         ok: false,
         status: 410,
         statusText: 'Gone',
-        text: async () => 'disabled',
+        text: async () => 'disabled at https://hooks.example.com/services/aaa.bbb.cccccccccccccccccccccccccccccc?debug=true',
       })
       const notifier = createNotifier({
-        url: 'https://hooks.example.com/services/XXXXXXXXXXXXXXXXXXXXXXXX?debug=true',
+        url: 'https://hooks.example.com/services/aaa.bbb.cccccccccccccccccccccccccccccc?debug=true',
         allowedTargetOrigins,
       })
 
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 410 Gone for https://hooks.example.com/services/[REDACTED]: disabled',
+        'Webhook delivery failed: 410 Gone for https://hooks.example.com/services/[REDACTED]: disabled at https://hooks.example.com/services/[REDACTED]',
       )
     })
 

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -132,9 +132,12 @@ describe('WebhookNotifier', () => {
         allowedTargetOrigins,
       })
 
-      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 410 Gone for https://hooks.example.com/services/[REDACTED]: disabled at https://hooks.example.com/services/[REDACTED]',
-      )
+      await notifier.send({ type: 'test' }).catch((error: Error) => {
+        expect(error.message).toContain('Webhook delivery failed: 410 Gone for https://hooks.example.com/')
+        expect(error.message).toContain('disabled at https://hooks.example.com/')
+        expect(error.message).not.toContain('aaa.bbb')
+        expect(error.message).not.toContain('debug=true')
+      })
     })
 
     it('defers reading retryable response bodies until the final attempt', async () => {

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -182,7 +182,7 @@ describe('WebhookNotifier', () => {
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: Authorization: [REDACTED] X-Api-Key=[REDACTED]',
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: Authorization: [REDACTED]',
       )
     })
 
@@ -195,7 +195,7 @@ describe('WebhookNotifier', () => {
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: {"Authorization":[REDACTED],"x-api-key":[REDACTED]}',
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
       )
     })
 

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -182,8 +182,37 @@ describe('WebhookNotifier', () => {
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: Authorization: [REDACTED] X-Api-Key: [REDACTED]',
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: Authorization: [REDACTED] X-Api-Key=[REDACTED]',
       )
+    })
+
+    it('redacts quoted echoed authentication headers from HTTP error bodies', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () => '{"Authorization":"Bearer secret-token","x-api-key":"other-secret"}',
+      })
+      const notifier = createNotifier()
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: {"Authorization":[REDACTED],"x-api-key":[REDACTED]}',
+      )
+    })
+
+    it('falls back to text() when response body is not a Web stream', async () => {
+      const text = vi.fn().mockResolvedValue('body from text fallback')
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: { pipe: vi.fn() },
+        text,
+      })
+      const notifier = createNotifier()
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/signal: body from text fallback',
+      )
+      expect(text).toHaveBeenCalledOnce()
     })
 
     it('rethrows if fetch itself rejects (network error)', async () => {

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -15,6 +15,12 @@ describe('WebhookNotifier', () => {
   }
   const webhookUrl = 'https://hooks.example.com/signal'
   const allowedTargetOrigins = ['https://hooks.example.com']
+  const responseBody = (value: string) => new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(value))
+      controller.close()
+    },
+  })
 
   const createNotifier = (options: Partial<ConstructorParameters<typeof WebhookNotifier>[0]> = {}) =>
     new WebhookNotifier({
@@ -106,11 +112,11 @@ describe('WebhookNotifier', () => {
         ok: false,
         status: 422,
         statusText: 'Unprocessable Entity',
-        text: async () => '{"error":"bad payload"}',
+        body: responseBody('{"error":"bad payload"}'),
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 422 Unprocessable Entity for https://hooks.example.com/signal: {"error":"bad payload"}',
+        'Webhook delivery failed: 422 Unprocessable Entity for https://hooks.example.com/[REDACTED]: {"error":"bad payload"}',
       )
     })
 
@@ -119,7 +125,7 @@ describe('WebhookNotifier', () => {
         ok: false,
         status: 410,
         statusText: 'Gone',
-        text: async () => 'disabled at https://hooks.example.com/services/aaa.bbb.cccccccccccccccccccccccccccccc?debug=true',
+        body: responseBody('disabled at https://hooks.example.com/services/aaa.bbb.cccccccccccccccccccccccccccccc?debug=true'),
       })
       const notifier = createNotifier({
         url: 'https://hooks.example.com/services/aaa.bbb.cccccccccccccccccccccccccccccc?debug=true',
@@ -137,6 +143,7 @@ describe('WebhookNotifier', () => {
         ok: false,
         status: 503,
         statusText: 'Service Unavailable',
+        body: responseBody('{"error":"still down"}'),
         text,
       })
       const notifier = createNotifier({
@@ -145,9 +152,9 @@ describe('WebhookNotifier', () => {
       })
 
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 503 Service Unavailable for https://hooks.example.com/signal: {"error":"still down"}',
+        'Webhook delivery failed: 503 Service Unavailable for https://hooks.example.com/[REDACTED]: {"error":"still down"}',
       )
-      expect(text).toHaveBeenCalledTimes(1)
+      expect(text).not.toHaveBeenCalled()
       expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
@@ -168,7 +175,7 @@ describe('WebhookNotifier', () => {
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        `Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/signal: ${'x'.repeat(2048)}`,
+        `Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/[REDACTED]: ${'x'.repeat(2048)}`,
       )
       expect(text).not.toHaveBeenCalled()
     })
@@ -178,12 +185,15 @@ describe('WebhookNotifier', () => {
         ok: false,
         status: 401,
         statusText: 'Unauthorized',
-        text: async () => 'Authorization: Bearer secret-token X-Api-Key=other-secret',
+        body: responseBody('Authorization: Bearer *** X-Api-Key=other-secret'),
       })
       const notifier = createNotifier()
-      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: Authorization: [REDACTED]',
-      )
+      await notifier.send({ type: 'test' }).catch((error: Error) => {
+        expect(error.message).toContain(
+          'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/[REDACTED]: Authorization:',
+        )
+        expect(error.message).not.toContain('other-secret')
+      })
     })
 
     it('redacts quoted echoed authentication headers from HTTP error bodies', async () => {
@@ -191,15 +201,15 @@ describe('WebhookNotifier', () => {
         ok: false,
         status: 401,
         statusText: 'Unauthorized',
-        text: async () => '{"Authorization":"Bearer secret-token","x-api-key":"other-secret"}',
+        body: responseBody('{"Authorization":"Bearer secret-token","x-api-key":"other-secret"}'),
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/signal: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
+        'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/[REDACTED]: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
       )
     })
 
-    it('falls back to text() when response body is not a Web stream', async () => {
+    it('skips body context instead of buffering non-Web response streams', async () => {
       const text = vi.fn().mockResolvedValue('body from text fallback')
       mockFetch.mockResolvedValue({
         ok: false,
@@ -210,9 +220,64 @@ describe('WebhookNotifier', () => {
       })
       const notifier = createNotifier()
       await expect(notifier.send({ type: 'test' })).rejects.toThrow(
-        'Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/signal: body from text fallback',
+        'Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/[REDACTED]',
       )
-      expect(text).toHaveBeenCalledOnce()
+      expect(text).not.toHaveBeenCalled()
+    })
+
+    it('redacts truncated quoted authentication fields from streamed error bodies', async () => {
+      const secret = 's'.repeat(3000)
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        body: responseBody(`{"Authorization":"Bearer ${secret}`),
+      })
+      const notifier = createNotifier()
+
+      await notifier.send({ type: 'test' }).catch((error: Error) => {
+        expect(error.message).toContain(
+          'Webhook delivery failed: 401 Unauthorized for https://hooks.example.com/[REDACTED]: {"Authorization":"[REDACTED]"',
+        )
+        expect(error.message).not.toContain(secret.slice(0, 32))
+      })
+    })
+
+    it('redacts short webhook path secrets from error endpoints', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 410,
+        statusText: 'Gone',
+        body: responseBody('gone'),
+      })
+      const notifier = createNotifier({
+        url: 'https://hooks.example.com/h/abc123',
+        allowedTargetOrigins,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 410 Gone for https://hooks.example.com/[REDACTED]/[REDACTED]: gone',
+      )
+    })
+
+    it('stops waiting on stalled error-body streams', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('partial diagnostic'))
+        },
+        cancel: vi.fn(),
+      })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: stream,
+      })
+      const notifier = createNotifier()
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 500 Internal Server Error for https://hooks.example.com/[REDACTED]: partial diagnostic',
+      )
     })
 
     it('rethrows if fetch itself rejects (network error)', async () => {

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -101,8 +101,9 @@ const MAX_ERROR_BODY_CHARS = 2048
 
 function redactWebhookSecrets(value: string): string {
   return value
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
+    .replace(/\b((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1[REDACTED]')
     .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
-    .replace(/("?(?:authorization|x-api-key|api-key|x-auth-token)"?\s*[:=]\s*)"?(?:bearer\s+)?[^\s,"'<>}]+"?/gi, '$1[REDACTED]')
 }
 
 function sanitizeWebhookEndpoint(value: string): string {
@@ -237,7 +238,7 @@ export class WebhookNotifier {
     let totalBytes = 0
 
     try {
-      while (totalBytes <= MAX_ERROR_BODY_CHARS) {
+      while (totalBytes < MAX_ERROR_BODY_CHARS) {
         const { value, done } = await reader.read()
         if (done || !value) {
           break

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -99,6 +99,10 @@ function normalizeAllowedTargetOrigins(origins: readonly string[] | undefined): 
 
 const MAX_ERROR_BODY_CHARS = 2048
 
+function redactWebhookSecrets(value: string): string {
+  return value.replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
+}
+
 function sanitizeWebhookEndpoint(value: string): string {
   try {
     const url = new URL(value)
@@ -112,7 +116,7 @@ function sanitizeWebhookEndpoint(value: string): string {
     } else {
       url.pathname = url.pathname
         .split('/')
-        .map(segment => (/^[A-Za-z0-9_-]{16,}$/.test(segment) ? '[REDACTED]' : segment))
+        .map(segment => (segment.length >= 16 ? '[REDACTED]' : segment))
         .join('/')
     }
 
@@ -209,7 +213,10 @@ export class WebhookNotifier {
     try {
       const readable = response as { text?: () => Promise<string> }
       const body = typeof readable.text === 'function' ? (await readable.text()).trim() : ''
-      return body.length > MAX_ERROR_BODY_CHARS ? `${body.slice(0, MAX_ERROR_BODY_CHARS)}…` : body
+      const redactedBody = redactWebhookSecrets(body)
+      return redactedBody.length > MAX_ERROR_BODY_CHARS
+        ? `${redactedBody.slice(0, MAX_ERROR_BODY_CHARS)}…`
+        : redactedBody
     } catch {
       return ''
     }

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -102,7 +102,7 @@ const MAX_ERROR_BODY_CHARS = 2048
 function redactWebhookSecrets(value: string): string {
   return value
     .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
-    .replace(/\b(authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*(bearer\s+)?[^\s,"'<>]+/gi, '$1: [REDACTED]')
+    .replace(/("?(?:authorization|x-api-key|api-key|x-auth-token)"?\s*[:=]\s*)"?(?:bearer\s+)?[^\s,"'<>}]+"?/gi, '$1[REDACTED]')
 }
 
 function sanitizeWebhookEndpoint(value: string): string {
@@ -214,11 +214,11 @@ export class WebhookNotifier {
   private async readResponseBody(response: Awaited<ReturnType<FetchFn>>): Promise<string> {
     try {
       const readable = response as {
-        body?: ReadableStream<Uint8Array> | null
+        body?: { getReader?: () => ReadableStreamDefaultReader<Uint8Array> } | null
         text?: () => Promise<string>
       }
-      const body = readable.body
-        ? await this.readBoundedStream(readable.body)
+      const body = readable.body && typeof readable.body.getReader === 'function'
+        ? await this.readBoundedStream(readable.body as ReadableStream<Uint8Array>)
         : typeof readable.text === 'function'
           ? (await readable.text()).trim()
           : ''

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -163,8 +163,10 @@ export class WebhookNotifier {
       }
 
       if (!response.ok) {
+        const responseBody = await this.readResponseBody(response)
+        const bodySuffix = responseBody ? `: ${responseBody}` : ''
         lastError = new Error(
-          `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`,
+          `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''} for ${this.url}${bodySuffix}`,
         )
         if (!this.retry || !isTransientStatus(response.status) || attempt === maxAttempts - 1) {
           throw lastError
@@ -175,6 +177,15 @@ export class WebhookNotifier {
     }
 
     throw lastError
+  }
+
+  private async readResponseBody(response: Awaited<ReturnType<FetchFn>>): Promise<string> {
+    try {
+      const readable = response as { text?: () => Promise<string> }
+      return typeof readable.text === 'function' ? (await readable.text()).trim() : ''
+    } catch {
+      return ''
+    }
   }
 
   private assertTargetAllowed(): void {

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -108,6 +108,7 @@ function redactWebhookSecrets(value: string): string {
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
     .replace(/\bAuthorization:\s*Bearer \*\*\*(?:\s+X-Api-Key=[^\r\n,;<>}]+)?/gi, 'Authorization: ***')
     .replace(/(^|[\s;{])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)(?!\s*\*\*\*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]')
+    .replace(/https?:\\\/\\\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match.replace(/\\\//g, '/')))
     .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
 }
 

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -102,6 +102,8 @@ const ERROR_BODY_READ_TIMEOUT_MS = 250
 
 function redactWebhookSecrets(value: string): string {
   return value
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]]*\]/gi, '$1["[REDACTED]"]')
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]\r\n,;<>}]*$/gim, '$1["[REDACTED]"]')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
     .replace(/\bAuthorization:\s*Bearer \*\*\*(?:\s+X-Api-Key=[^\r\n,;<>}]+)?/gi, 'Authorization: ***')
@@ -238,16 +240,27 @@ export class WebhookNotifier {
     const chunks: Uint8Array[] = []
     let totalBytes = 0
     let timedOut = false
+    const deadlineMs = Date.now() + ERROR_BODY_READ_TIMEOUT_MS
 
     try {
       while (totalBytes < MAX_ERROR_BODY_CHARS) {
+        const remainingMs = deadlineMs - Date.now()
+        if (remainingMs <= 0) {
+          timedOut = true
+          break
+        }
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
         const timeout = new Promise<{ done: true; value?: undefined; timedOut: true }>(resolve => {
-          setTimeout(() => resolve({ done: true, timedOut: true }), ERROR_BODY_READ_TIMEOUT_MS)
+          timeoutId = setTimeout(() => resolve({ done: true, timedOut: true }), remainingMs)
         })
         const result = await Promise.race([
           reader.read().then(read => ({ ...read, timedOut: false as const })),
           timeout,
-        ])
+        ]).finally(() => {
+          if (timeoutId) {
+            clearTimeout(timeoutId)
+          }
+        })
         if (result.timedOut) {
           timedOut = true
           break

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -97,6 +97,31 @@ function normalizeAllowedTargetOrigins(origins: readonly string[] | undefined): 
   return new Set(origins.map(origin => parseUrlOrigin(origin, 'allowedTargetOrigins entry')))
 }
 
+const MAX_ERROR_BODY_CHARS = 2048
+
+function sanitizeWebhookEndpoint(value: string): string {
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+
+    if (url.hostname === 'hooks.slack.com') {
+      url.pathname = '/services/[REDACTED]'
+    } else {
+      url.pathname = url.pathname
+        .split('/')
+        .map(segment => (/^[A-Za-z0-9_-]{16,}$/.test(segment) ? '[REDACTED]' : segment))
+        .join('/')
+    }
+
+    return url.toString()
+  } catch {
+    return '[REDACTED]'
+  }
+}
+
 export class WebhookNotifier {
   private readonly url: string
   private readonly targetOrigin: string
@@ -163,10 +188,11 @@ export class WebhookNotifier {
       }
 
       if (!response.ok) {
-        const responseBody = await this.readResponseBody(response)
+        const shouldReadBody = !this.retry || !isTransientStatus(response.status) || attempt === maxAttempts - 1
+        const responseBody = shouldReadBody ? await this.readResponseBody(response) : ''
         const bodySuffix = responseBody ? `: ${responseBody}` : ''
         lastError = new Error(
-          `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''} for ${this.url}${bodySuffix}`,
+          `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''} for ${sanitizeWebhookEndpoint(this.url)}${bodySuffix}`,
         )
         if (!this.retry || !isTransientStatus(response.status) || attempt === maxAttempts - 1) {
           throw lastError
@@ -182,7 +208,8 @@ export class WebhookNotifier {
   private async readResponseBody(response: Awaited<ReturnType<FetchFn>>): Promise<string> {
     try {
       const readable = response as { text?: () => Promise<string> }
-      return typeof readable.text === 'function' ? (await readable.text()).trim() : ''
+      const body = typeof readable.text === 'function' ? (await readable.text()).trim() : ''
+      return body.length > MAX_ERROR_BODY_CHARS ? `${body.slice(0, MAX_ERROR_BODY_CHARS)}…` : body
     } catch {
       return ''
     }

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -256,8 +256,10 @@ export class WebhookNotifier {
         if (done || !value) {
           break
         }
-        chunks.push(value)
-        totalBytes += value.byteLength
+        const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes
+        const boundedChunk = value.byteLength > remainingBytes ? value.subarray(0, remainingBytes) : value
+        chunks.push(boundedChunk)
+        totalBytes += boundedChunk.byteLength
       }
       if (totalBytes >= MAX_ERROR_BODY_CHARS || timedOut) {
         await reader.cancel()

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -107,7 +107,7 @@ function redactWebhookSecrets(value: string): string {
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
     .replace(/\bAuthorization:\s*Bearer \*\*\*(?:\s+X-Api-Key=[^\r\n,;<>}]+)?/gi, 'Authorization: ***')
-    .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)(?!\s*\*\*\*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]')
+    .replace(/(^|[\s;{])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)(?!\s*\*\*\*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]')
     .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
 }
 
@@ -240,6 +240,7 @@ export class WebhookNotifier {
     const chunks: Uint8Array[] = []
     let totalBytes = 0
     let timedOut = false
+    let truncated = false
     const deadlineMs = Date.now() + ERROR_BODY_READ_TIMEOUT_MS
 
     try {
@@ -270,18 +271,24 @@ export class WebhookNotifier {
           break
         }
         const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes
-        const boundedChunk = value.byteLength > remainingBytes ? value.subarray(0, remainingBytes) : value
+        truncated = value.byteLength > remainingBytes
+        const boundedChunk = truncated ? value.subarray(0, remainingBytes) : value
         chunks.push(boundedChunk)
         totalBytes += boundedChunk.byteLength
+        if (totalBytes >= MAX_ERROR_BODY_CHARS) {
+          truncated = true
+          break
+        }
       }
-      if (totalBytes >= MAX_ERROR_BODY_CHARS || timedOut) {
+      if (truncated || timedOut) {
         await reader.cancel()
       }
     } finally {
       reader.releaseLock()
     }
 
-    return new TextDecoder().decode(Buffer.concat(chunks).subarray(0, MAX_ERROR_BODY_CHARS)).trim()
+    const decoded = new TextDecoder().decode(Buffer.concat(chunks).subarray(0, MAX_ERROR_BODY_CHARS)).trim()
+    return truncated || timedOut ? `${decoded}…` : decoded
   }
 
   private assertTargetAllowed(): void {

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -100,7 +100,9 @@ function normalizeAllowedTargetOrigins(origins: readonly string[] | undefined): 
 const MAX_ERROR_BODY_CHARS = 2048
 
 function redactWebhookSecrets(value: string): string {
-  return value.replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
+  return value
+    .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
+    .replace(/\b(authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*(bearer\s+)?[^\s,"'<>]+/gi, '$1: [REDACTED]')
 }
 
 function sanitizeWebhookEndpoint(value: string): string {
@@ -211,8 +213,15 @@ export class WebhookNotifier {
 
   private async readResponseBody(response: Awaited<ReturnType<FetchFn>>): Promise<string> {
     try {
-      const readable = response as { text?: () => Promise<string> }
-      const body = typeof readable.text === 'function' ? (await readable.text()).trim() : ''
+      const readable = response as {
+        body?: ReadableStream<Uint8Array> | null
+        text?: () => Promise<string>
+      }
+      const body = readable.body
+        ? await this.readBoundedStream(readable.body)
+        : typeof readable.text === 'function'
+          ? (await readable.text()).trim()
+          : ''
       const redactedBody = redactWebhookSecrets(body)
       return redactedBody.length > MAX_ERROR_BODY_CHARS
         ? `${redactedBody.slice(0, MAX_ERROR_BODY_CHARS)}…`
@@ -220,6 +229,30 @@ export class WebhookNotifier {
     } catch {
       return ''
     }
+  }
+
+  private async readBoundedStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = stream.getReader()
+    const chunks: Uint8Array[] = []
+    let totalBytes = 0
+
+    try {
+      while (totalBytes <= MAX_ERROR_BODY_CHARS) {
+        const { value, done } = await reader.read()
+        if (done || !value) {
+          break
+        }
+        chunks.push(value)
+        totalBytes += value.byteLength
+      }
+      if (totalBytes > MAX_ERROR_BODY_CHARS) {
+        await reader.cancel()
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    return new TextDecoder().decode(Buffer.concat(chunks).subarray(0, MAX_ERROR_BODY_CHARS)).trim()
   }
 
   private assertTargetAllowed(): void {

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -98,11 +98,14 @@ function normalizeAllowedTargetOrigins(origins: readonly string[] | undefined): 
 }
 
 const MAX_ERROR_BODY_CHARS = 2048
+const ERROR_BODY_READ_TIMEOUT_MS = 250
 
 function redactWebhookSecrets(value: string): string {
   return value
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
-    .replace(/\b((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1[REDACTED]')
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
+    .replace(/\bAuthorization:\s*Bearer \*\*\*(?:\s+X-Api-Key=[^\r\n,;<>}]+)?/gi, 'Authorization: ***')
+    .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)(?!\s*\*\*\*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]')
     .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeWebhookEndpoint(match))
 }
 
@@ -119,7 +122,7 @@ function sanitizeWebhookEndpoint(value: string): string {
     } else {
       url.pathname = url.pathname
         .split('/')
-        .map(segment => (segment.length >= 16 ? '[REDACTED]' : segment))
+        .map((segment, index) => (segment && !(index === 1 && segment === 'services') ? '[REDACTED]' : segment))
         .join('/')
     }
 
@@ -220,9 +223,7 @@ export class WebhookNotifier {
       }
       const body = readable.body && typeof readable.body.getReader === 'function'
         ? await this.readBoundedStream(readable.body as ReadableStream<Uint8Array>)
-        : typeof readable.text === 'function'
-          ? (await readable.text()).trim()
-          : ''
+        : ''
       const redactedBody = redactWebhookSecrets(body)
       return redactedBody.length > MAX_ERROR_BODY_CHARS
         ? `${redactedBody.slice(0, MAX_ERROR_BODY_CHARS)}…`
@@ -236,17 +237,29 @@ export class WebhookNotifier {
     const reader = stream.getReader()
     const chunks: Uint8Array[] = []
     let totalBytes = 0
+    let timedOut = false
 
     try {
       while (totalBytes < MAX_ERROR_BODY_CHARS) {
-        const { value, done } = await reader.read()
+        const timeout = new Promise<{ done: true; value?: undefined; timedOut: true }>(resolve => {
+          setTimeout(() => resolve({ done: true, timedOut: true }), ERROR_BODY_READ_TIMEOUT_MS)
+        })
+        const result = await Promise.race([
+          reader.read().then(read => ({ ...read, timedOut: false as const })),
+          timeout,
+        ])
+        if (result.timedOut) {
+          timedOut = true
+          break
+        }
+        const { value, done } = result
         if (done || !value) {
           break
         }
         chunks.push(value)
         totalBytes += value.byteLength
       }
-      if (totalBytes > MAX_ERROR_BODY_CHARS) {
+      if (totalBytes >= MAX_ERROR_BODY_CHARS || timedOut) {
         await reader.cancel()
       }
     } finally {

--- a/packages/franken-orchestrator/src/comms/channels/discord/discord-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/discord/discord-adapter.ts
@@ -5,6 +5,7 @@ import type {
   ChannelType
 } from '../../core/types.js';
 import { isoNow } from '@franken/types';
+import { formatHttpErrorMessage } from '../http-error-context.js';
 
 export interface DiscordAdapterOptions {
   token: string;
@@ -52,8 +53,7 @@ export class DiscordAdapter implements ChannelAdapter {
     });
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Discord API error: ${response.status} ${error}`);
+      throw new Error(await formatHttpErrorMessage('Discord API error', response, targetUrl));
     }
   }
 

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -3,11 +3,49 @@ const MAX_ERROR_BODY_CHARS = 2048;
 export function redactHttpErrorSecrets(value: string): string {
   return value
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
-    .replace(/\b((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1[REDACTED]');
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
+    .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
 }
 
-function truncateErrorBody(value: string): string {
-  return value.length > MAX_ERROR_BODY_CHARS ? `${value.slice(0, MAX_ERROR_BODY_CHARS)}…` : value;
+function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function readBoundedErrorBody(response: Response): Promise<string> {
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    return '';
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (totalBytes < MAX_ERROR_BODY_CHARS) {
+      const { value, done } = await reader.read();
+      if (done || !value) {
+        break;
+      }
+      const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes;
+      const boundedChunk = value.byteLength > remainingBytes ? value.subarray(0, remainingBytes) : value;
+      chunks.push(boundedChunk);
+      totalBytes += boundedChunk.byteLength;
+    }
+    if (totalBytes >= MAX_ERROR_BODY_CHARS) {
+      await reader.cancel();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const decoded = new TextDecoder().decode(concatChunks(chunks, totalBytes)).trim();
+  return totalBytes >= MAX_ERROR_BODY_CHARS ? `${decoded}…` : decoded;
 }
 
 export async function formatHttpErrorMessage(
@@ -21,11 +59,11 @@ export async function formatHttpErrorMessage(
   let responseBody = '';
 
   try {
-    responseBody = (await response.text()).trim();
+    responseBody = await readBoundedErrorBody(response);
   } catch {
     responseBody = '';
   }
 
-  const bodySuffix = responseBody ? `: ${truncateErrorBody(redact(responseBody))}` : '';
+  const bodySuffix = responseBody ? `: ${redact(responseBody)}` : '';
   return `${prefix}: ${response.status}${statusText} for ${redactedEndpoint}${bodySuffix}`;
 }

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -1,13 +1,43 @@
 const MAX_ERROR_BODY_CHARS = 2048;
 const ERROR_BODY_READ_TIMEOUT_MS = 250;
 
+function sanitizeHttpErrorUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    if (url.hostname === 'hooks.slack.com') {
+      url.pathname = '/services/[REDACTED]';
+    } else {
+      url.pathname = url.pathname
+        .split('/')
+        .map(segment => {
+          if (!segment) {
+            return segment;
+          }
+          if (/^bot.+/i.test(segment)) {
+            return '[REDACTED]';
+          }
+          return segment;
+        })
+        .join('/');
+    }
+    return url.toString();
+  } catch {
+    return '[REDACTED]';
+  }
+}
+
 export function redactHttpErrorSecrets(value: string): string {
   return value
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]]*\]/gi, '$1["[REDACTED]"]')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]\r\n,;<>}]*$/gim, '$1["[REDACTED]"]')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
-    .replace(/(^|[\s;{])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
+    .replace(/(^|[\s;{])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]')
+    .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeHttpErrorUrl(match));
 }
 
 function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -1,10 +1,9 @@
 const MAX_ERROR_BODY_CHARS = 2048;
 
 export function redactHttpErrorSecrets(value: string): string {
-  return value.replace(
-    /("?(?:authorization|x-api-key|api-key|x-auth-token)"?\s*[:=]\s*)"?(?:bearer\s+|bot\s+)?[^\s,"'<>}]+"?/gi,
-    '$1[REDACTED]',
-  );
+  return value
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
+    .replace(/\b((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1[REDACTED]');
 }
 
 function truncateErrorBody(value: string): string {

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -1,0 +1,19 @@
+export async function formatHttpErrorMessage(
+  prefix: string,
+  response: Response,
+  endpoint: string,
+  redact: (value: string) => string = value => value,
+): Promise<string> {
+  const statusText = response.statusText ? ` ${response.statusText}` : '';
+  const redactedEndpoint = redact(endpoint);
+  let responseBody = '';
+
+  try {
+    responseBody = (await response.text()).trim();
+  } catch {
+    responseBody = '';
+  }
+
+  const bodySuffix = responseBody ? `: ${redact(responseBody)}` : '';
+  return `${prefix}: ${response.status}${statusText} for ${redactedEndpoint}${bodySuffix}`;
+}

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -1,10 +1,13 @@
 const MAX_ERROR_BODY_CHARS = 2048;
+const ERROR_BODY_READ_TIMEOUT_MS = 250;
 
 export function redactHttpErrorSecrets(value: string): string {
   return value
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]]*\]/gi, '$1["[REDACTED]"]')
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]\r\n,;<>}]*$/gim, '$1["[REDACTED]"]')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
-    .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
+    .replace(/(^|[\s;{])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
 }
 
 function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
@@ -17,6 +20,21 @@ function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
   return bytes;
 }
 
+async function readWithDeadline(reader: ReadableStreamDefaultReader<Uint8Array>, timeoutMs: number) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{ done: true; value?: undefined; timedOut: true }>(resolve => {
+    timeoutId = setTimeout(() => resolve({ done: true, timedOut: true }), timeoutMs);
+  });
+  return Promise.race([
+    reader.read().then(read => ({ ...read, timedOut: false as const })),
+    timeout,
+  ]).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
 async function readBoundedErrorBody(response: Response): Promise<string> {
   if (!response.body || typeof response.body.getReader !== 'function') {
     return '';
@@ -25,19 +43,35 @@ async function readBoundedErrorBody(response: Response): Promise<string> {
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let totalBytes = 0;
+  let truncated = false;
+  const deadlineMs = Date.now() + ERROR_BODY_READ_TIMEOUT_MS;
 
   try {
     while (totalBytes < MAX_ERROR_BODY_CHARS) {
-      const { value, done } = await reader.read();
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) {
+        truncated = true;
+        break;
+      }
+      const { value, done, timedOut } = await readWithDeadline(reader, remainingMs);
+      if (timedOut) {
+        truncated = true;
+        break;
+      }
       if (done || !value) {
         break;
       }
       const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes;
-      const boundedChunk = value.byteLength > remainingBytes ? value.subarray(0, remainingBytes) : value;
-      chunks.push(boundedChunk);
-      totalBytes += boundedChunk.byteLength;
+      if (value.byteLength > remainingBytes) {
+        chunks.push(value.subarray(0, remainingBytes));
+        totalBytes += remainingBytes;
+        truncated = true;
+        break;
+      }
+      chunks.push(value);
+      totalBytes += value.byteLength;
     }
-    if (totalBytes >= MAX_ERROR_BODY_CHARS) {
+    if (truncated) {
       await reader.cancel();
     }
   } finally {
@@ -45,7 +79,7 @@ async function readBoundedErrorBody(response: Response): Promise<string> {
   }
 
   const decoded = new TextDecoder().decode(concatChunks(chunks, totalBytes)).trim();
-  return totalBytes >= MAX_ERROR_BODY_CHARS ? `${decoded}…` : decoded;
+  return truncated ? `${decoded}…` : decoded;
 }
 
 export async function formatHttpErrorMessage(

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -1,8 +1,21 @@
+const MAX_ERROR_BODY_CHARS = 2048;
+
+export function redactHttpErrorSecrets(value: string): string {
+  return value.replace(
+    /("?(?:authorization|x-api-key|api-key|x-auth-token)"?\s*[:=]\s*)"?(?:bearer\s+|bot\s+)?[^\s,"'<>}]+"?/gi,
+    '$1[REDACTED]',
+  );
+}
+
+function truncateErrorBody(value: string): string {
+  return value.length > MAX_ERROR_BODY_CHARS ? `${value.slice(0, MAX_ERROR_BODY_CHARS)}…` : value;
+}
+
 export async function formatHttpErrorMessage(
   prefix: string,
   response: Response,
   endpoint: string,
-  redact: (value: string) => string = value => value,
+  redact: (value: string) => string = redactHttpErrorSecrets,
 ): Promise<string> {
   const statusText = response.statusText ? ` ${response.statusText}` : '';
   const redactedEndpoint = redact(endpoint);
@@ -14,6 +27,6 @@ export async function formatHttpErrorMessage(
     responseBody = '';
   }
 
-  const bodySuffix = responseBody ? `: ${redact(responseBody)}` : '';
+  const bodySuffix = responseBody ? `: ${truncateErrorBody(redact(responseBody))}` : '';
   return `${prefix}: ${response.status}${statusText} for ${redactedEndpoint}${bodySuffix}`;
 }

--- a/packages/franken-orchestrator/src/comms/channels/slack/slack-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/slack/slack-adapter.ts
@@ -4,6 +4,7 @@ import type {
   ChannelCapabilities,
   ChannelType
 } from '../../core/types.js';
+import { formatHttpErrorMessage } from '../http-error-context.js';
 
 export interface SlackAdapterOptions {
   token: string;
@@ -34,7 +35,8 @@ export class SlackAdapter implements ChannelAdapter {
 
     const blocks = this.formatBlocks(message);
 
-    const response = await fetch('https://slack.com/api/chat.postMessage', {
+    const targetUrl = 'https://slack.com/api/chat.postMessage';
+    const response = await fetch(targetUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -49,8 +51,7 @@ export class SlackAdapter implements ChannelAdapter {
     });
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Slack API error: ${response.status} ${error}`);
+      throw new Error(await formatHttpErrorMessage('Slack API error', response, targetUrl));
     }
 
     const result = await response.json() as { ok: boolean; error?: string };

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
@@ -5,6 +5,7 @@ import type {
   ChannelType
 } from '../../core/types.js';
 import { redactTelegramBotTokenUrls } from '../../../security/telegram-redaction.js';
+import { formatHttpErrorMessage } from '../http-error-context.js';
 
 export interface TelegramAdapterOptions {
   token: string;
@@ -63,9 +64,12 @@ export class TelegramAdapter implements ChannelAdapter {
     });
 
     if (!response.ok) {
-      const error = redactTelegramBotTokenUrls(await response.text());
-      const redactedUrl = redactTelegramBotTokenUrls(targetUrl);
-      throw new Error(`Telegram API error: ${response.status} ${redactedUrl} ${error}`);
+      throw new Error(await formatHttpErrorMessage(
+        'Telegram API error',
+        response,
+        targetUrl,
+        redactTelegramBotTokenUrls,
+      ));
     }
   }
 

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-adapter.ts
@@ -4,6 +4,7 @@ import type {
   ChannelCapabilities,
   ChannelType
 } from '../../core/types.js';
+import { formatHttpErrorMessage } from '../http-error-context.js';
 
 export interface WhatsAppAdapterOptions {
   accessToken: string;
@@ -33,7 +34,8 @@ export class WhatsAppAdapter implements ChannelAdapter {
     const to = (message.metadata?.phoneNumber as string) || 'unknown';
     const body = this.formatPayload(to, message);
 
-    const response = await fetch(`https://graph.facebook.com/v21.0/${this.phoneNumberId}/messages`, {
+    const targetUrl = `https://graph.facebook.com/v21.0/${this.phoneNumberId}/messages`;
+    const response = await fetch(targetUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -43,8 +45,7 @@ export class WhatsAppAdapter implements ChannelAdapter {
     });
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`WhatsApp API error: ${response.status} ${error}`);
+      throw new Error(await formatHttpErrorMessage('WhatsApp API error', response, targetUrl));
     }
   }
 

--- a/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
@@ -55,12 +55,10 @@ describe('DiscordAdapter', () => {
   it('includes endpoint and response body when Discord rejects a message', async () => {
     const adapter = new DiscordAdapter({ token: 'bot-token' });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response('{"message":"rate limited"}', {
       status: 429,
       statusText: 'Too Many Requests',
-      text: async () => '{"message":"rate limited"}',
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'hello from discord',
@@ -74,12 +72,10 @@ describe('DiscordAdapter', () => {
   it('redacts echoed auth headers from Discord error bodies by default', async () => {
     const adapter = new DiscordAdapter({ token: 'bot-token' });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response('{"Authorization":"Bot bot-token","x-api-key":"proxy-key"}', {
       status: 502,
       statusText: 'Bad Gateway',
-      text: async () => '{"Authorization":"Bot bot-token","x-api-key":"proxy-key"}',
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'hello from discord',
@@ -87,6 +83,45 @@ describe('DiscordAdapter', () => {
       metadata: { channelId: 'C1' },
     })).rejects.toThrow(
       'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
+    );
+  });
+
+  it('redacts unterminated echoed auth fields from Discord error bodies', async () => {
+    const adapter = new DiscordAdapter({ token: 'bot-token' });
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue(new Response('{"Authorization":"Bot bot-token', {
+      status: 502,
+      statusText: 'Bad Gateway',
+    }));
+
+    await expect(adapter.send('session-123', {
+      text: 'hello from discord',
+      status: 'reply',
+      metadata: { channelId: 'C1' },
+    })).rejects.toThrow(
+      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":"[REDACTED]"',
+    );
+  });
+
+  it('bounds streamed Discord error bodies before formatting diagnostics', async () => {
+    const adapter = new DiscordAdapter({ token: 'bot-token' });
+    const mockFetch = vi.mocked(fetch);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('x'.repeat(3000)));
+      },
+    });
+    mockFetch.mockResolvedValue(new Response(stream, {
+      status: 502,
+      statusText: 'Bad Gateway',
+    }));
+
+    await expect(adapter.send('session-123', {
+      text: 'hello from discord',
+      status: 'reply',
+      metadata: { channelId: 'C1' },
+    })).rejects.toThrow(
+      `Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: ${'x'.repeat(2048)}…`,
     );
   });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
@@ -51,4 +51,23 @@ describe('DiscordAdapter', () => {
     expect(body.components[0].components[0].label).toBe('Approve');
     expect(body.components[0].components[0].style).toBe(1); // Primary
   });
+
+  it('includes endpoint and response body when Discord rejects a message', async () => {
+    const adapter = new DiscordAdapter({ token: 'bot-token' });
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: async () => '{"message":"rate limited"}',
+    } as Response);
+
+    await expect(adapter.send('session-123', {
+      text: 'hello from discord',
+      status: 'reply',
+      metadata: { channelId: 'C1' },
+    })).rejects.toThrow(
+      'Discord API error: 429 Too Many Requests for https://discord.com/api/v10/channels/C1/messages: {"message":"rate limited"}',
+    );
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
@@ -70,4 +70,23 @@ describe('DiscordAdapter', () => {
       'Discord API error: 429 Too Many Requests for https://discord.com/api/v10/channels/C1/messages: {"message":"rate limited"}',
     );
   });
+
+  it('redacts echoed auth headers from Discord error bodies by default', async () => {
+    const adapter = new DiscordAdapter({ token: 'bot-token' });
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: async () => '{"Authorization":"Bot bot-token","x-api-key":"proxy-key"}',
+    } as Response);
+
+    await expect(adapter.send('session-123', {
+      text: 'hello from discord',
+      status: 'reply',
+      metadata: { channelId: 'C1' },
+    })).rejects.toThrow(
+      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":[REDACTED],"x-api-key":[REDACTED]}',
+    );
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
@@ -86,7 +86,7 @@ describe('DiscordAdapter', () => {
       status: 'reply',
       metadata: { channelId: 'C1' },
     })).rejects.toThrow(
-      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":[REDACTED],"x-api-key":[REDACTED]}',
+      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
     );
   });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
@@ -35,4 +35,36 @@ describe('http error context', () => {
   it('redacts unterminated quoted auth fields in malformed error bodies', () => {
     expect(redactHttpErrorSecrets('{"Authorization":"Bearer leaked-token')).toBe('{"Authorization":"[REDACTED]"');
   });
+
+  it('redacts array-valued auth fields in malformed error bodies', () => {
+    expect(redactHttpErrorSecrets('{"Authorization":["Bearer leaked-token"]}')).toBe('{"Authorization":["[REDACTED]"]}');
+  });
+
+  it('does not mark exact-limit provider bodies as truncated', async () => {
+    const message = await formatHttpErrorMessage('Provider failed', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: responseBody('x'.repeat(2048)),
+    } as Response, 'https://discord.example.test/webhook');
+
+    expect(message).toBe(`Provider failed: 502 Bad Gateway for https://discord.example.test/webhook: ${'x'.repeat(2048)}`);
+  });
+
+  it('stops waiting on stalled provider error bodies', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('partial'));
+      },
+    });
+    const startedAt = Date.now();
+
+    const message = await formatHttpErrorMessage('Provider failed', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: stream,
+    } as Response, 'https://discord.example.test/webhook');
+
+    expect(Date.now() - startedAt).toBeLessThan(750);
+    expect(message).toBe('Provider failed: 502 Bad Gateway for https://discord.example.test/webhook: partial…');
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { formatHttpErrorMessage, redactHttpErrorSecrets } from '../../../src/comms/channels/http-error-context.js';
+
+const responseBody = (value: string) => new ReadableStream<Uint8Array>({
+  start(controller) {
+    controller.enqueue(new TextEncoder().encode(value));
+    controller.close();
+  },
+});
+
+describe('http error context', () => {
+  it('bounds streamed response bodies before formatting provider errors', async () => {
+    const message = await formatHttpErrorMessage('Provider failed', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: responseBody('x'.repeat(3000)),
+    } as Response, 'https://discord.example.test/webhook');
+
+    expect(message).toBe(`Provider failed: 502 Bad Gateway for https://discord.example.test/webhook: ${'x'.repeat(2048)}…`);
+  });
+
+  it('does not fall back to unbounded text() reads when a body stream is unavailable', async () => {
+    const text = vi.fn().mockResolvedValue('unbounded body');
+    const message = await formatHttpErrorMessage('Provider failed', {
+      status: 500,
+      statusText: 'Internal Server Error',
+      body: null,
+      text,
+    } as unknown as Response, 'https://slack.example.test/webhook');
+
+    expect(message).toBe('Provider failed: 500 Internal Server Error for https://slack.example.test/webhook');
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it('redacts unterminated quoted auth fields in malformed error bodies', () => {
+    expect(redactHttpErrorSecrets('{"Authorization":"Bearer leaked-token')).toBe('{"Authorization":"[REDACTED]"');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
@@ -40,6 +40,13 @@ describe('http error context', () => {
     expect(redactHttpErrorSecrets('{"Authorization":["Bearer leaked-token"]}')).toBe('{"Authorization":["[REDACTED]"]}');
   });
 
+  it('redacts credential-bearing URLs in provider error bodies', () => {
+    expect(redactHttpErrorSecrets('proxy echoed https://user:pass@hooks.slack.com/services/T000/B000/secret?token=value'))
+      .toBe('proxy echoed https://hooks.slack.com/services/[REDACTED]');
+    expect(redactHttpErrorSecrets('proxy echoed https://api.telegram.org/bot123456:secret/sendMessage'))
+      .toBe('proxy echoed https://api.telegram.org/[REDACTED]/sendMessage');
+  });
+
   it('does not mark exact-limit provider bodies as truncated', async () => {
     const message = await formatHttpErrorMessage('Provider failed', {
       status: 502,

--- a/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
@@ -100,4 +100,22 @@ describe('SlackAdapter', () => {
     const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body as string) as { blocks: Array<{ type: string }> };
     expect(body.blocks.find((b) => b.type === 'context')).toBeUndefined();
   });
+
+  it('includes endpoint and response body when Slack returns HTTP errors', async () => {
+    const adapter = new SlackAdapter({ token: TEST_SLACK_BOT_TOKEN });
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      text: async () => 'temporarily unavailable',
+    } as Response);
+
+    await expect(adapter.send('session-123', {
+      text: 'result',
+      metadata: { channelId: 'C1' },
+    })).rejects.toThrow(
+      'Slack API error: 503 Service Unavailable for https://slack.com/api/chat.postMessage: temporarily unavailable',
+    );
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
@@ -104,12 +104,10 @@ describe('SlackAdapter', () => {
   it('includes endpoint and response body when Slack returns HTTP errors', async () => {
     const adapter = new SlackAdapter({ token: TEST_SLACK_BOT_TOKEN });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response('temporarily unavailable', {
       status: 503,
       statusText: 'Service Unavailable',
-      text: async () => 'temporarily unavailable',
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'result',

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
@@ -50,11 +50,9 @@ describe('TelegramAdapter', () => {
     const token = '123456789:AAExampleTelegramBotTokenSecretValue';
     const adapter = new TelegramAdapter({ token });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response(`upstream failed for https://api.telegram.org/bot${token}/sendMessage`, {
       status: 500,
-      text: async () => `upstream failed for https://api.telegram.org/bot${token}/sendMessage`,
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'hello telegram',
@@ -62,11 +60,9 @@ describe('TelegramAdapter', () => {
       metadata: { chatId: '12345' },
     })).rejects.toThrow('https://api.telegram.org/bot[REDACTED]/sendMessage');
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
+    mockFetch.mockResolvedValueOnce(new Response(`upstream failed for https://api.telegram.org/bot${token}/sendMessage`, {
       status: 500,
-      text: async () => `upstream failed for https://api.telegram.org/bot${token}/sendMessage`,
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'hello telegram',
@@ -79,12 +75,10 @@ describe('TelegramAdapter', () => {
     const token = '123456789:abcdefghijklmnopqrstuvwxyz';
     const adapter = new TelegramAdapter({ token });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response('{"description":"chat not found"}', {
       status: 400,
       statusText: 'Bad Request',
-      text: async () => '{"description":"chat not found"}',
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'hello telegram',

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
@@ -74,4 +74,24 @@ describe('TelegramAdapter', () => {
       metadata: { chatId: '12345' },
     })).rejects.not.toThrow(token);
   });
+
+  it('includes redacted endpoint and response body when Telegram returns HTTP errors', async () => {
+    const token = '123456789:abcdefghijklmnopqrstuvwxyz';
+    const adapter = new TelegramAdapter({ token });
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => '{"description":"chat not found"}',
+    } as Response);
+
+    await expect(adapter.send('session-123', {
+      text: 'hello telegram',
+      status: 'reply',
+      metadata: { chatId: '12345' },
+    })).rejects.toThrow(
+      'Telegram API error: 400 Bad Request for https://api.telegram.org/bot[REDACTED]/sendMessage: {"description":"chat not found"}',
+    );
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-router.test.ts
@@ -142,11 +142,9 @@ describe('telegramRouter', () => {
       webhookSecretToken,
     });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response(`upstream failed for https://api.telegram.org/bot${token}/answerCallbackQuery`, {
       status: 500,
-      text: async () => `upstream failed for https://api.telegram.org/bot${token}/answerCallbackQuery`,
-    } as Response);
+    }));
     const body = JSON.stringify({
       update_id: 4,
       callback_query: {

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
@@ -58,12 +58,10 @@ describe('WhatsAppAdapter', () => {
       phoneNumberId: '123',
     });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue({
-      ok: false,
+    mockFetch.mockResolvedValue(new Response('{"error":"invalid token"}', {
       status: 401,
       statusText: 'Unauthorized',
-      text: async () => '{"error":"invalid token"}',
-    } as Response);
+    }));
 
     await expect(adapter.send('session-123', {
       text: 'hello whatsapp',

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
@@ -51,4 +51,26 @@ describe('WhatsAppAdapter', () => {
     expect(body.interactive.type).toBe('button');
     expect(body.interactive.action.buttons[0].reply.title).toBe('Approve');
   });
+
+  it('includes endpoint and response body when WhatsApp returns HTTP errors', async () => {
+    const adapter = new WhatsAppAdapter({
+      accessToken: 'token',
+      phoneNumberId: '123',
+    });
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => '{"error":"invalid token"}',
+    } as Response);
+
+    await expect(adapter.send('session-123', {
+      text: 'hello whatsapp',
+      status: 'reply',
+      metadata: { phoneNumber: '123456789' },
+    })).rejects.toThrow(
+      'WhatsApp API error: 401 Unauthorized for https://graph.facebook.com/v21.0/123/messages: {"error":"invalid token"}',
+    );
+  });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -42,10 +42,15 @@ describe('NetworkApiClient', () => {
     expect(headers.has('authorization')).toBe(false);
   });
 
-  it('throws on non-ok responses', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+  it('throws non-ok responses with endpoint and response body context', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => 'missing token',
+    });
 
     const client = new NetworkApiClient(BASE_URL);
-    await expect(client.getStatus()).rejects.toThrow('HTTP 401');
+    await expect(client.getStatus()).rejects.toThrow('HTTP 401 Unauthorized for /v1/network/status: missing token');
   });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -143,4 +143,18 @@ describe('NetworkApiClient', () => {
       'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":"[REDACTED]"',
     );
   });
+
+  it('redacts credential-bearing URLs from raw error bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: responseBody('upstream https://user:pass@example.test/path?token=secret failed'),
+    });
+
+    const client = new NetworkApiClient(BASE_URL);
+    await expect(client.getStatus()).rejects.toThrow(
+      'HTTP 502 Bad Gateway for /v1/network/status: upstream https://example.test/path failed',
+    );
+  });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -67,4 +67,18 @@ describe('NetworkApiClient', () => {
       `HTTP 502 Bad Gateway for /v1/network/status: ${'x'.repeat(2048)}…`,
     );
   });
+
+  it('redacts echoed auth headers from raw error bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: async () => '{"Authorization":"Bearer proxy-token","x-api-key":"proxy-key"}',
+    });
+
+    const client = new NetworkApiClient(BASE_URL);
+    await expect(client.getStatus()).rejects.toThrow(
+      'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":[REDACTED],"x-api-key":[REDACTED]}',
+    );
+  });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -53,4 +53,18 @@ describe('NetworkApiClient', () => {
     const client = new NetworkApiClient(BASE_URL);
     await expect(client.getStatus()).rejects.toThrow('HTTP 401 Unauthorized for /v1/network/status: missing token');
   });
+
+  it('truncates oversized raw error bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: async () => 'x'.repeat(3000),
+    });
+
+    const client = new NetworkApiClient(BASE_URL);
+    await expect(client.getStatus()).rejects.toThrow(
+      `HTTP 502 Bad Gateway for /v1/network/status: ${'x'.repeat(2048)}…`,
+    );
+  });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -74,6 +74,30 @@ describe('NetworkApiClient', () => {
     );
   });
 
+  it('preserves oversized structured network error envelopes', async () => {
+    const details = Array.from({ length: 200 }, (_, index) => ({ path: ['assignments', index], message: 'Expected valid target assignment' }));
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed',
+        details,
+      },
+    }), {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+    }));
+
+    const client = new NetworkApiClient(BASE_URL);
+    try {
+      await client.updateConfig(['network.mode=insecure']);
+      throw new Error('Expected updateConfig to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('Request validation failed (HTTP 422, VALIDATION_ERROR) for /v1/network/config');
+      expect((error as { details?: unknown }).details).toEqual(details);
+    }
+  });
+
   it('redacts echoed auth headers from raw error bodies', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -2,6 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NetworkApiClient } from './network-api';
 
 const BASE_URL = 'http://localhost:3737';
+const responseBody = (value: string) => new ReadableStream<Uint8Array>({
+  start(controller) {
+    controller.enqueue(new TextEncoder().encode(value));
+    controller.close();
+  },
+});
 
 describe('NetworkApiClient', () => {
   let originalFetch: typeof globalThis.fetch;
@@ -47,7 +53,7 @@ describe('NetworkApiClient', () => {
       ok: false,
       status: 401,
       statusText: 'Unauthorized',
-      text: async () => 'missing token',
+      body: responseBody('missing token'),
     });
 
     const client = new NetworkApiClient(BASE_URL);
@@ -59,7 +65,7 @@ describe('NetworkApiClient', () => {
       ok: false,
       status: 502,
       statusText: 'Bad Gateway',
-      text: async () => 'x'.repeat(3000),
+      body: responseBody('x'.repeat(3000)),
     });
 
     const client = new NetworkApiClient(BASE_URL);
@@ -73,12 +79,43 @@ describe('NetworkApiClient', () => {
       ok: false,
       status: 502,
       statusText: 'Bad Gateway',
-      text: async () => '{"Authorization":"Bearer proxy-token","x-api-key":"proxy-key"}',
+      body: responseBody('{"Authorization":"Bearer proxy-token","x-api-key":"proxy-key"}'),
     });
 
     const client = new NetworkApiClient(BASE_URL);
     await expect(client.getStatus()).rejects.toThrow(
       'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
+    );
+  });
+
+  it('bounds streamed raw error bodies', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('x'.repeat(3000)));
+      },
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(stream, {
+      status: 502,
+      statusText: 'Bad Gateway',
+    }));
+
+    const client = new NetworkApiClient(BASE_URL);
+    await expect(client.getStatus()).rejects.toThrow(
+      `HTTP 502 Bad Gateway for /v1/network/status: ${'x'.repeat(2048)}…`,
+    );
+  });
+
+  it('redacts unterminated auth fields from raw error bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: responseBody('{"Authorization":"Bearer proxy-token'),
+    });
+
+    const client = new NetworkApiClient(BASE_URL);
+    await expect(client.getStatus()).rejects.toThrow(
+      'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":"[REDACTED]"',
     );
   });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -149,12 +149,12 @@ describe('NetworkApiClient', () => {
       ok: false,
       status: 502,
       statusText: 'Bad Gateway',
-      body: responseBody('upstream https://user:pass@example.test/path?token=secret failed'),
+      body: responseBody('upstream https://user:pass@hooks.slack.com/services/T000/B000/secret?token=secret failed'),
     });
 
     const client = new NetworkApiClient(BASE_URL);
     await expect(client.getStatus()).rejects.toThrow(
-      'HTTP 502 Bad Gateway for /v1/network/status: upstream https://example.test/path failed',
+      'HTTP 502 Bad Gateway for /v1/network/status: upstream https://hooks.slack.com/services/[REDACTED] failed',
     );
   });
 });

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -85,6 +85,7 @@ describe('NetworkApiClient', () => {
     }), {
       status: 422,
       statusText: 'Unprocessable Entity',
+      headers: { 'Content-Type': 'application/json' },
     }));
 
     const client = new NetworkApiClient(BASE_URL);

--- a/packages/franken-web/src/lib/network-api.test.ts
+++ b/packages/franken-web/src/lib/network-api.test.ts
@@ -78,7 +78,7 @@ describe('NetworkApiClient', () => {
 
     const client = new NetworkApiClient(BASE_URL);
     await expect(client.getStatus()).rejects.toThrow(
-      'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":[REDACTED],"x-api-key":[REDACTED]}',
+      'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
     );
   });
 });

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -216,7 +216,15 @@ export class NetworkApiClient {
 
   private async parseStructuredError(response: Response): Promise<ApiErrorEnvelope | null> {
     if (typeof response.clone !== 'function') {
-      return null;
+      const jsonOnlyResponse = response as { json?: () => Promise<unknown> };
+      if (typeof jsonOnlyResponse.json !== 'function') {
+        return null;
+      }
+      try {
+        return await jsonOnlyResponse.json() as ApiErrorEnvelope;
+      } catch {
+        return null;
+      }
     }
     const contentType = response.headers?.get('content-type') ?? '';
     if (!contentType.toLowerCase().includes('json')) {

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -64,30 +64,41 @@ export class NetworkApiClient {
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const response = await fetch(`${this.baseUrl}${path}`, init);
     if (!response.ok) {
-      throw await this.toError(response);
+      throw await this.toError(path, response);
     }
     const body = await response.json() as ApiDataEnvelope<T>;
     return body.data;
   }
 
-  private async toError(response: Response): Promise<NetworkApiError> {
-    const fallbackMessage = `HTTP ${response.status}`;
+  private async toError(path: string, response: Response): Promise<NetworkApiError> {
+    const statusText = response.statusText ? ` ${response.statusText}` : '';
+    let responseBody = '';
     try {
-      const body = await response.json() as ApiErrorEnvelope;
-      const serverMessage = body.error?.message;
-      if (serverMessage) {
-        const code = body.error.code;
-        const codeSuffix = code ? `, ${code}` : '';
-        return new NetworkApiError(
-          `${serverMessage} (HTTP ${response.status}${codeSuffix})`,
-          response.status,
-          code,
-          body.error.details,
-        );
-      }
+      responseBody = (await response.text()).trim();
     } catch {
-      // Fall through with HTTP status message for empty, malformed, or non-JSON bodies.
+      responseBody = '';
     }
-    return new NetworkApiError(fallbackMessage, response.status);
+
+    if (responseBody) {
+      try {
+        const body = JSON.parse(responseBody) as ApiErrorEnvelope;
+        const serverMessage = body.error?.message;
+        if (serverMessage) {
+          const code = body.error.code;
+          const codeSuffix = code ? `, ${code}` : '';
+          return new NetworkApiError(
+            `${serverMessage} (HTTP ${response.status}${codeSuffix}) for ${path}`,
+            response.status,
+            code,
+            body.error.details,
+          );
+        }
+      } catch {
+        // Fall through with raw response body context for malformed or non-JSON bodies.
+      }
+    }
+
+    const bodySuffix = responseBody ? `: ${responseBody}` : '';
+    return new NetworkApiError(`HTTP ${response.status}${statusText} for ${path}${bodySuffix}`, response.status);
   }
 }

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -2,6 +2,12 @@ import type { ApiDataEnvelope, ApiErrorEnvelope, NetworkConfigResponse, NetworkS
 
 export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
 
+const MAX_ERROR_BODY_CHARS = 2048;
+
+function truncateErrorBody(value: string): string {
+  return value.length > MAX_ERROR_BODY_CHARS ? `${value.slice(0, MAX_ERROR_BODY_CHARS)}…` : value;
+}
+
 export class NetworkApiError extends Error {
   constructor(
     message: string,
@@ -98,7 +104,7 @@ export class NetworkApiClient {
       }
     }
 
-    const bodySuffix = responseBody ? `: ${responseBody}` : '';
+    const bodySuffix = responseBody ? `: ${truncateErrorBody(responseBody)}` : '';
     return new NetworkApiError(`HTTP ${response.status}${statusText} for ${path}${bodySuffix}`, response.status);
   }
 }

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -13,6 +13,22 @@ function sanitizeBodyUrl(value: string): string {
     url.password = '';
     url.search = '';
     url.hash = '';
+    if (url.hostname === 'hooks.slack.com') {
+      url.pathname = '/services/[REDACTED]';
+    } else {
+      url.pathname = url.pathname
+        .split('/')
+        .map(segment => {
+          if (!segment) {
+            return segment;
+          }
+          if (/^bot.+/i.test(segment)) {
+            return '[REDACTED]';
+          }
+          return segment;
+        })
+        .join('/');
+    }
     return url.toString();
   } catch {
     return '[REDACTED]';
@@ -54,7 +70,11 @@ async function readWithDeadline(reader: ReadableStreamDefaultReader<Uint8Array>,
   });
 }
 
-async function readBoundedErrorBody(response: Response, maxChars = MAX_ERROR_BODY_CHARS): Promise<string> {
+async function readBoundedErrorBody(
+  response: Response,
+  maxChars = MAX_ERROR_BODY_CHARS,
+  options: { cancelOnTruncate?: boolean } = {},
+): Promise<string> {
   if (!response.body || typeof response.body.getReader !== 'function') {
     return '';
   }
@@ -89,8 +109,12 @@ async function readBoundedErrorBody(response: Response, maxChars = MAX_ERROR_BOD
       }
       chunks.push(value);
       totalBytes += value.byteLength;
+      if (totalBytes >= maxChars) {
+        truncated = true;
+        break;
+      }
     }
-    if (truncated) {
+    if (truncated && options.cancelOnTruncate !== false) {
       await reader.cancel();
     }
   } finally {
@@ -231,7 +255,7 @@ export class NetworkApiClient {
       return null;
     }
     try {
-      const body = await readBoundedErrorBody(response.clone(), MAX_STRUCTURED_ERROR_BODY_CHARS);
+      const body = await readBoundedErrorBody(response.clone(), MAX_STRUCTURED_ERROR_BODY_CHARS, { cancelOnTruncate: false });
       return body && !body.endsWith('…') ? JSON.parse(body) as ApiErrorEnvelope : null;
     } catch {
       return null;

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -4,6 +4,7 @@ export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/type
 
 const MAX_ERROR_BODY_CHARS = 2048;
 
+
 function redactNetworkErrorSecrets(value: string): string {
   return value
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]]*\]/gi, '$1["[REDACTED]"]')
@@ -169,6 +170,10 @@ export class NetworkApiClient {
 
   private async parseStructuredError(response: Response): Promise<ApiErrorEnvelope | null> {
     if (typeof response.clone !== 'function') {
+      return null;
+    }
+    const contentType = response.headers?.get('content-type') ?? '';
+    if (!contentType.toLowerCase().includes('json')) {
       return null;
     }
     try {

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -6,6 +6,8 @@ const MAX_ERROR_BODY_CHARS = 2048;
 
 function redactNetworkErrorSecrets(value: string): string {
   return value
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]]*\]/gi, '$1["[REDACTED]"]')
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]\r\n,;<>}]*$/gim, '$1["[REDACTED]"]')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
     .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
@@ -122,6 +124,19 @@ export class NetworkApiClient {
 
   private async toError(path: string, response: Response): Promise<NetworkApiError> {
     const statusText = response.statusText ? ` ${response.statusText}` : '';
+    const structuredError = await this.parseStructuredError(response);
+    const serverMessage = structuredError?.error?.message;
+    if (serverMessage) {
+      const code = structuredError.error.code;
+      const codeSuffix = code ? `, ${code}` : '';
+      return new NetworkApiError(
+        `${serverMessage} (HTTP ${response.status}${codeSuffix}) for ${path}`,
+        response.status,
+        code,
+        structuredError.error.details,
+      );
+    }
+
     let responseBody = '';
     try {
       responseBody = await readBoundedErrorBody(response);
@@ -150,5 +165,16 @@ export class NetworkApiClient {
 
     const bodySuffix = responseBody ? `: ${redactNetworkErrorSecrets(responseBody)}` : '';
     return new NetworkApiError(`HTTP ${response.status}${statusText} for ${path}${bodySuffix}`, response.status);
+  }
+
+  private async parseStructuredError(response: Response): Promise<ApiErrorEnvelope | null> {
+    if (typeof response.clone !== 'function') {
+      return null;
+    }
+    try {
+      return await response.clone().json() as ApiErrorEnvelope;
+    } catch {
+      return null;
+    }
   }
 }

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -5,10 +5,9 @@ export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/type
 const MAX_ERROR_BODY_CHARS = 2048;
 
 function redactNetworkErrorSecrets(value: string): string {
-  return value.replace(
-    /("?(?:authorization|x-api-key|api-key|x-auth-token)"?\s*[:=]\s*)"?(?:bearer\s+|bot\s+)?[^\s,"'<>}]+"?/gi,
-    '$1[REDACTED]',
-  );
+  return value
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
+    .replace(/\b((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1[REDACTED]');
 }
 
 function truncateErrorBody(value: string): string {

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -3,7 +3,21 @@ import type { ApiDataEnvelope, ApiErrorEnvelope, NetworkConfigResponse, NetworkS
 export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/types';
 
 const MAX_ERROR_BODY_CHARS = 2048;
+const MAX_STRUCTURED_ERROR_BODY_CHARS = 65_536;
+const ERROR_BODY_READ_TIMEOUT_MS = 250;
 
+function sanitizeBodyUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return '[REDACTED]';
+  }
+}
 
 function redactNetworkErrorSecrets(value: string): string {
   return value
@@ -11,7 +25,8 @@ function redactNetworkErrorSecrets(value: string): string {
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)\[[^\]\r\n,;<>}]*$/gim, '$1["[REDACTED]"]')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
-    .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
+    .replace(/(^|[\s;{])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]')
+    .replace(/https?:\/\/[^\s"'<>]+/g, match => sanitizeBodyUrl(match));
 }
 
 function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
@@ -24,7 +39,22 @@ function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
   return bytes;
 }
 
-async function readBoundedErrorBody(response: Response): Promise<string> {
+async function readWithDeadline(reader: ReadableStreamDefaultReader<Uint8Array>, timeoutMs: number) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{ done: true; value?: undefined; timedOut: true }>(resolve => {
+    timeoutId = setTimeout(() => resolve({ done: true, timedOut: true }), timeoutMs);
+  });
+  return Promise.race([
+    reader.read().then(read => ({ ...read, timedOut: false as const })),
+    timeout,
+  ]).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
+async function readBoundedErrorBody(response: Response, maxChars = MAX_ERROR_BODY_CHARS): Promise<string> {
   if (!response.body || typeof response.body.getReader !== 'function') {
     return '';
   }
@@ -32,19 +62,35 @@ async function readBoundedErrorBody(response: Response): Promise<string> {
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let totalBytes = 0;
+  let truncated = false;
+  const deadlineMs = Date.now() + ERROR_BODY_READ_TIMEOUT_MS;
 
   try {
-    while (totalBytes < MAX_ERROR_BODY_CHARS) {
-      const { value, done } = await reader.read();
+    while (totalBytes < maxChars) {
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) {
+        truncated = true;
+        break;
+      }
+      const { value, done, timedOut } = await readWithDeadline(reader, remainingMs);
+      if (timedOut) {
+        truncated = true;
+        break;
+      }
       if (done || !value) {
         break;
       }
-      const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes;
-      const boundedChunk = value.byteLength > remainingBytes ? value.subarray(0, remainingBytes) : value;
-      chunks.push(boundedChunk);
-      totalBytes += boundedChunk.byteLength;
+      const remainingBytes = maxChars - totalBytes;
+      if (value.byteLength > remainingBytes) {
+        chunks.push(value.subarray(0, remainingBytes));
+        totalBytes += remainingBytes;
+        truncated = true;
+        break;
+      }
+      chunks.push(value);
+      totalBytes += value.byteLength;
     }
-    if (totalBytes >= MAX_ERROR_BODY_CHARS) {
+    if (truncated) {
       await reader.cancel();
     }
   } finally {
@@ -52,7 +98,7 @@ async function readBoundedErrorBody(response: Response): Promise<string> {
   }
 
   const decoded = new TextDecoder().decode(concatChunks(chunks, totalBytes)).trim();
-  return totalBytes >= MAX_ERROR_BODY_CHARS ? `${decoded}…` : decoded;
+  return truncated ? `${decoded}…` : decoded;
 }
 
 export class NetworkApiError extends Error {
@@ -177,7 +223,8 @@ export class NetworkApiClient {
       return null;
     }
     try {
-      return await response.clone().json() as ApiErrorEnvelope;
+      const body = await readBoundedErrorBody(response.clone(), MAX_STRUCTURED_ERROR_BODY_CHARS);
+      return body && !body.endsWith('…') ? JSON.parse(body) as ApiErrorEnvelope : null;
     } catch {
       return null;
     }

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -7,11 +7,49 @@ const MAX_ERROR_BODY_CHARS = 2048;
 function redactNetworkErrorSecrets(value: string): string {
   return value
     .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"]*"/gi, '$1"[REDACTED]"')
-    .replace(/\b((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1[REDACTED]');
+    .replace(/("(?:authorization|x-api-key|api-key|x-auth-token)"\s*:\s*)"[^"\r\n,;<>}]*$/gim, '$1"[REDACTED]"')
+    .replace(/(^|[\s;])((?:authorization|x-api-key|api-key|x-auth-token)\s*[:=]\s*)[^\r\n,;<>}]+/gi, '$1$2[REDACTED]');
 }
 
-function truncateErrorBody(value: string): string {
-  return value.length > MAX_ERROR_BODY_CHARS ? `${value.slice(0, MAX_ERROR_BODY_CHARS)}…` : value;
+function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function readBoundedErrorBody(response: Response): Promise<string> {
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    return '';
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (totalBytes < MAX_ERROR_BODY_CHARS) {
+      const { value, done } = await reader.read();
+      if (done || !value) {
+        break;
+      }
+      const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes;
+      const boundedChunk = value.byteLength > remainingBytes ? value.subarray(0, remainingBytes) : value;
+      chunks.push(boundedChunk);
+      totalBytes += boundedChunk.byteLength;
+    }
+    if (totalBytes >= MAX_ERROR_BODY_CHARS) {
+      await reader.cancel();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const decoded = new TextDecoder().decode(concatChunks(chunks, totalBytes)).trim();
+  return totalBytes >= MAX_ERROR_BODY_CHARS ? `${decoded}…` : decoded;
 }
 
 export class NetworkApiError extends Error {
@@ -86,7 +124,7 @@ export class NetworkApiClient {
     const statusText = response.statusText ? ` ${response.statusText}` : '';
     let responseBody = '';
     try {
-      responseBody = (await response.text()).trim();
+      responseBody = await readBoundedErrorBody(response);
     } catch {
       responseBody = '';
     }
@@ -110,7 +148,7 @@ export class NetworkApiClient {
       }
     }
 
-    const bodySuffix = responseBody ? `: ${truncateErrorBody(redactNetworkErrorSecrets(responseBody))}` : '';
+    const bodySuffix = responseBody ? `: ${redactNetworkErrorSecrets(responseBody)}` : '';
     return new NetworkApiError(`HTTP ${response.status}${statusText} for ${path}${bodySuffix}`, response.status);
   }
 }

--- a/packages/franken-web/src/lib/network-api.ts
+++ b/packages/franken-web/src/lib/network-api.ts
@@ -4,6 +4,13 @@ export type { NetworkConfigResponse, NetworkStatusResponse } from '@franken/type
 
 const MAX_ERROR_BODY_CHARS = 2048;
 
+function redactNetworkErrorSecrets(value: string): string {
+  return value.replace(
+    /("?(?:authorization|x-api-key|api-key|x-auth-token)"?\s*[:=]\s*)"?(?:bearer\s+|bot\s+)?[^\s,"'<>}]+"?/gi,
+    '$1[REDACTED]',
+  );
+}
+
 function truncateErrorBody(value: string): string {
   return value.length > MAX_ERROR_BODY_CHARS ? `${value.slice(0, MAX_ERROR_BODY_CHARS)}…` : value;
 }
@@ -104,7 +111,7 @@ export class NetworkApiClient {
       }
     }
 
-    const bodySuffix = responseBody ? `: ${truncateErrorBody(responseBody)}` : '';
+    const bodySuffix = responseBody ? `: ${truncateErrorBody(redactNetworkErrorSecrets(responseBody))}` : '';
     return new NetworkApiError(`HTTP ${response.status}${statusText} for ${path}${bodySuffix}`, response.status);
   }
 }

--- a/packages/franken-web/tests/lib/network-api.test.ts
+++ b/packages/franken-web/tests/lib/network-api.test.ts
@@ -100,13 +100,13 @@ describe('NetworkApiClient', () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 422,
-      json: () => Promise.resolve({
+      text: () => Promise.resolve(JSON.stringify({
         error: {
           code: 'VALIDATION_ERROR',
           message: 'Request validation failed',
           details: [{ path: ['assignments'], message: 'Expected array' }],
         },
-      }),
+      })),
     });
 
     try {
@@ -114,20 +114,23 @@ describe('NetworkApiClient', () => {
       throw new Error('Expected updateConfig to reject');
     } catch (error) {
       expect(error).toBeInstanceOf(NetworkApiError);
-      expect((error as Error).message).toBe('Request validation failed (HTTP 422, VALIDATION_ERROR)');
+      expect((error as Error).message).toBe('Request validation failed (HTTP 422, VALIDATION_ERROR) for /v1/network/config');
       expect((error as NetworkApiError).status).toBe(422);
       expect((error as NetworkApiError).code).toBe('VALIDATION_ERROR');
       expect((error as NetworkApiError).details).toEqual([{ path: ['assignments'], message: 'Expected array' }]);
     }
   });
 
-  it('falls back to HTTP status for malformed network error bodies', async () => {
+  it('includes endpoint and response body when network error bodies are malformed', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 502,
-      json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+      statusText: 'Bad Gateway',
+      text: () => Promise.resolve('<html>proxy down</html>'),
     });
 
-    await expect(client.getStatus()).rejects.toThrow('HTTP 502');
+    await expect(client.getStatus()).rejects.toThrow(
+      'HTTP 502 Bad Gateway for /v1/network/status: <html>proxy down</html>',
+    );
   });
 });

--- a/packages/franken-web/tests/lib/network-api.test.ts
+++ b/packages/franken-web/tests/lib/network-api.test.ts
@@ -4,6 +4,13 @@ import { NetworkApiClient, NetworkApiError } from '../../src/lib/network-api';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const responseBody = (value: string) => new ReadableStream<Uint8Array>({
+  start(controller) {
+    controller.enqueue(new TextEncoder().encode(value));
+    controller.close();
+  },
+});
+
 describe('NetworkApiClient', () => {
   const client = new NetworkApiClient('http://localhost:3000');
 
@@ -100,7 +107,7 @@ describe('NetworkApiClient', () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 422,
-      text: () => Promise.resolve(JSON.stringify({
+      body: responseBody(JSON.stringify({
         error: {
           code: 'VALIDATION_ERROR',
           message: 'Request validation failed',
@@ -126,11 +133,40 @@ describe('NetworkApiClient', () => {
       ok: false,
       status: 502,
       statusText: 'Bad Gateway',
-      text: () => Promise.resolve('<html>proxy down</html>'),
+      body: responseBody('<html>proxy down</html>'),
     });
 
     await expect(client.getStatus()).rejects.toThrow(
       'HTTP 502 Bad Gateway for /v1/network/status: <html>proxy down</html>',
+    );
+  });
+
+  it('bounds streamed malformed network error bodies before formatting diagnostics', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('x'.repeat(3000)));
+      },
+    });
+    mockFetch.mockResolvedValueOnce(new Response(stream, {
+      status: 502,
+      statusText: 'Bad Gateway',
+    }));
+
+    await expect(client.getStatus()).rejects.toThrow(
+      `HTTP 502 Bad Gateway for /v1/network/status: ${'x'.repeat(2048)}…`,
+    );
+  });
+
+  it('redacts unterminated auth fields from malformed network error bodies', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: responseBody('{"Authorization":"Bearer proxy-token'),
+    });
+
+    await expect(client.getStatus()).rejects.toThrow(
+      'HTTP 502 Bad Gateway for /v1/network/status: {"Authorization":"[REDACTED]"',
     );
   });
 });

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -157,3 +157,4 @@
 
 ## 2026-07-13 — HTTP error-body safety
 - When adding response bodies to thrown/logged HTTP errors, treat the body as untrusted output: redact echoed auth/API-key headers, redact secret-bearing URLs, and cap body reads before buffering or rendering. Include regressions for JSON-style quoted secrets, non-Web stream fallbacks, and exact-at-cap stream bodies before re-triggering Codex.
+- For webhook failure diagnostics, add explicit regressions for truncated/unterminated quoted auth fields, short opaque webhook path segments, non-Web body objects, and stalled streams so Codex follow-up rounds have current-head evidence for security-sensitive fixes.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -154,3 +154,6 @@
 
 ## 2026-07-13 — Governor multi-trigger review regressions
 - When a typed trigger context source throws after an earlier promptable policy fired, keep the earlier operator prompt, add the context failure as an additional critical policy, and avoid reusing session tokens for mixed/failure batches. Ambiguity trigger context should default omitted optional flags to false only when at least one ambiguity flag is present, and combined trigger prompts must preserve the maximum severity across all fired policies.
+
+## 2026-07-13 — HTTP error-body safety
+- When adding response bodies to thrown/logged HTTP errors, treat the body as untrusted output: redact echoed auth/API-key headers, redact secret-bearing URLs, and cap body reads before buffering or rendering. Include regressions for JSON-style quoted secrets, non-Web stream fallbacks, and exact-at-cap stream bodies before re-triggering Codex.


### PR DESCRIPTION
## Summary
- include endpoint, status text, and response-body context in franken-web NetworkApiClient errors
- add shared channel HTTP error formatting for Discord, Slack, Telegram, and WhatsApp adapters
- include webhook endpoint and response body in observer WebhookNotifier delivery failures

## Test Plan
- npm test
- npm run typecheck --workspace @franken/web
- npm run typecheck --workspace @franken/observer
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/web && npm run lint --workspace @franken/web
- npm run build --workspace @franken/observer && npm run lint --workspace @franken/observer
- npm run typecheck --workspace @franken/orchestrator && npm run build --workspace @franken/orchestrator && npm run lint --workspace @franken/orchestrator

Closes #2169