### PR TITLE
fix(orchestrator): reject stale approval decisions

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -259,14 +259,22 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const session = getSessionOrThrow(sessionStore, id);
 
     return withChatMutationAdmission(c, session.id, async () => {
-      if (!session.pendingApproval && session.state !== 'pending_approval') {
+      if (!session.pendingApproval) {
+        if (session.state === 'pending_approval') {
+          return c.json({
+            error: {
+              code: 'APPROVAL_NOT_PENDING',
+              message: 'No pending approval metadata exists for this session. Reject or recreate the stale approval state before responding.',
+            },
+          }, 409);
+        }
         return c.json({ data: { id: session.id, approved, state: session.state, pendingApproval: null } });
       }
 
       let result: Awaited<ReturnType<ChatRuntime['run']>> | null = null;
       if (approved) {
-        const pendingApproval = session.pendingApproval ?? null;
-        const wasPendingApproval = Boolean(pendingApproval) || session.state === 'pending_approval';
+        const pendingApproval = session.pendingApproval;
+        const wasPendingApproval = true;
         let runtimeInput: string;
         try {
           runtimeInput = approvalRuntimeInput(pendingApproval);

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -396,6 +396,24 @@ export class ChatSocketController {
     session: ChatSession,
     approved: boolean,
   ): Promise<void> {
+    if (!session.pendingApproval) {
+      if (session.state === 'pending_approval') {
+        this.emit(peer, {
+          type: 'turn.error',
+          code: 'APPROVAL_NOT_PENDING',
+          message: 'No pending approval metadata exists for this session. Reject or recreate the stale approval state before responding.',
+          timestamp: nowIso(),
+        });
+        return;
+      }
+      this.emit(peer, {
+        type: 'turn.approval.resolved',
+        approved: session.state !== 'rejected',
+        timestamp: nowIso(),
+      });
+      return;
+    }
+
     if (!approved) {
       session.pendingApproval = null;
       session.state = 'rejected';
@@ -415,16 +433,7 @@ export class ChatSocketController {
       return;
     }
 
-    if (!session.pendingApproval && session.state !== 'pending_approval') {
-      this.emit(peer, {
-        type: 'turn.approval.resolved',
-        approved: session.state !== 'rejected',
-        timestamp: nowIso(),
-      });
-      return;
-    }
-
-    const pendingApproval = session.pendingApproval ?? null;
+    const pendingApproval = session.pendingApproval;
     const originalState = session.state;
     let runtimeInput: string;
     try {
@@ -469,7 +478,7 @@ export class ChatSocketController {
     try {
       result = await this.runtime.run(runtimeInput, {
         sessionId: session.id,
-        pendingApproval: Boolean(pendingApproval) || originalState === 'pending_approval',
+        pendingApproval: true,
         approvalResolved: true,
         projectId: session.projectId,
         transcript: session.transcript,

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -1032,10 +1032,10 @@ describe('Chat HTTP Routes', () => {
     expect(sessionStore.save).not.toHaveBeenCalled();
   });
 
-  it('POST /v1/chat/sessions/:id/approve handles state-only pending approvals', async () => {
+  it.each([true, false])('POST /v1/chat/sessions/:id/approve rejects state-only pending approvals (approved=%s)', async (approved) => {
     const now = new Date().toISOString();
     const session: ChatSession = {
-      id: 'chat-state-only-pending',
+      id: `chat-state-only-pending-${approved ? 'approve' : 'reject'}`,
       projectId: 'proj',
       transcript: [],
       state: 'pending_approval',
@@ -1054,14 +1054,7 @@ describe('Chat HTTP Routes', () => {
       delete: vi.fn(),
     };
     const runtime = {
-      run: vi.fn(async () => ({
-        displayMessages: [{ kind: 'approval' as const, content: 'Approved.' }],
-        events: [],
-        pendingApproval: false,
-        state: 'approved',
-        tier: null,
-        transcript: [],
-      })),
+      run: vi.fn(),
     };
 
     app = createChatApp({
@@ -1075,15 +1068,16 @@ describe('Chat HTTP Routes', () => {
     const res = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ approved: true }),
+      body: JSON.stringify({ approved }),
     });
 
-    expect(res.status).toBe(200);
-    expect((await res.json()).data.state).toBe('approved');
-    expect(runtime.run).toHaveBeenCalledWith('/approve', expect.objectContaining({
-      pendingApproval: true,
-    }));
-    expect(session.state).toBe('approved');
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatchObject({
+      code: 'APPROVAL_NOT_PENDING',
+    });
+    expect(runtime.run).not.toHaveBeenCalled();
+    expect(sessionStore.save).not.toHaveBeenCalled();
+    expect(session.state).toBe('pending_approval');
     expect(session.pendingApproval).toBeNull();
   });
 

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -760,6 +760,54 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it.each([true, false])('rejects WebSocket approval decisions without pending approval metadata (approved=%s)', async (approved) => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = null;
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const execute = vi.fn();
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await expect(controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved,
+    }))).resolves.toBeUndefined();
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(store.get(session.id)?.state).toBe('pending_approval');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'APPROVAL_NOT_PENDING',
+      message: expect.stringContaining('No pending approval'),
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'turn.approval.resolved',
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('restores pending approval and notifies clients when approved execution throws', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -160,6 +160,36 @@ describe('chat approval route persistence', () => {
     expect(stored?.pendingApproval).toBeNull();
   });
 
+  it.each([true, false])('rejects HTTP approval decisions without pending approval metadata (approved=%s)', async (approved) => {
+    const llm = { complete: vi.fn().mockResolvedValue('should not run') };
+    const app = createChatApp({
+      sessionStore,
+      llm,
+      projectName: 'chat-approval-route-test',
+    });
+    const session = sessionStore.create('project-1');
+    session.state = 'pending_approval';
+    session.pendingApproval = null;
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json() as { error: { code: string; message: string } };
+    expect(body.error).toMatchObject({
+      code: 'APPROVAL_NOT_PENDING',
+      message: expect.stringContaining('No pending approval'),
+    });
+    expect(llm.complete).not.toHaveBeenCalled();
+    const stored = sessionStore.get(session.id);
+    expect(stored?.state).toBe('pending_approval');
+    expect(stored?.pendingApproval).toBeNull();
+  });
+
   it('blocks unsafe model-derived approval commands and preserves pending approval', async () => {
     const llm = { complete: vi.fn().mockResolvedValue('should not run') };
     const app = createChatApp({


### PR DESCRIPTION
## Summary
- require stored pending approval metadata before accepting HTTP approve/reject decisions
- preserve stale state-only pending sessions and return a 409 instead of replaying /approve or falsely rejecting
- add regression coverage for both approve and reject decisions with missing approval metadata

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/http/chat-routes-approval.test.ts
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm test --workspace @franken/orchestrator

Closes #2145