### PR TITLE
docs(dx): align setup runtime guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,9 @@ npm run bootstrap -- --services
 # Seed ChromaDB with initial collections. This uses CHROMA_URL from the environment.
 npm run local:seed
 
-# Verify everything is running. This probes the same CHROMA_URL endpoint.
+# Verify everything is running. This probes the same CHROMA_URL endpoint,
+# plus fixed compose defaults for Grafana (http://localhost:3000/api/health)
+# and Tempo readiness (http://localhost:3200/ready).
 npm run local:verify-setup
 ```
 

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -15,7 +15,7 @@ The dashboard talks to two local services when run through `frankenbeast network
 
 ## Prerequisites
 
-- Node.js `>=22.13.0 <23 || >=24.0.0 <26` and repo dependencies installed (`npm install`).
+- Node.js `>=22.13.0 <23 || >=24.0.0 <26`, Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`), and repo dependencies installed (`npm install`).
 - At least one supported CLI provider works locally for chat/execution.
 - An operator token is configured so Beast control routes are enabled.
 - For container mode: Docker is installed and the sandbox image exists locally (`fbeast/sandbox:latest` by default). Current main includes the in-repo `Dockerfile`, non-root user policy, resource-limit defaults, `no-new-privileges`, and optional read-only workspace support from #459.

--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -12,6 +12,7 @@ The beast harness is split across two CLIs. This guide covers both.
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26`
+- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)
 - For API-backed `frankenbeast` provider registry runs, an API key for at least one supported provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or either `GOOGLE_API_KEY` / `GEMINI_API_KEY` for `gemini-api`
 - For `fbeast mcp beast` preset activation, one of the supported Beast provider paths: `anthropic-api` with `ANTHROPIC_API_KEY`, or an installed/logged-in `claude` / `codex` CLI for `claude-cli` / `codex-cli`
 

--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -11,6 +11,7 @@ This guide starts the Frankenbeast dashboard chat with the real CLI-chat-compati
 ## Prerequisites
 
 - Node.js `>=22.13.0 <23 || >=24.0.0 <26`
+- Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)
 - `npm install` has already been run at the repo root
 - at least one supported CLI chat provider is configured locally
 

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -41,6 +41,9 @@ describe('local setup scripts', () => {
     expect(read('README.md')).toContain('Node.js** `>=22.13.0 <23 || >=24.0.0 <26`');
     expect(read('README.md')).toContain('local default is pinned in [.nvmrc](.nvmrc)');
     expect(read('README.md')).toContain('**npm** 11.5.1 via the root `packageManager` pin');
+    expect(read('docs/guides/run-cli-beast.md')).toContain('Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)');
+    expect(read('docs/guides/run-dashboard-chat.md')).toContain('Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)');
+    expect(read('docs/guides/deploy-beasts.md')).toContain('Corepack-enabled npm matching the root `packageManager` pin (`npm@11.5.1`)');
     expect(read('packages/franken-brain/README.md')).toContain('npm 11.5.1 via the repository `packageManager` setting');
     expect(read('docs/guides/quickstart.md')).toContain('npm run bootstrap -- --no-docker');
     expect(read('docs/guides/quickstart.md')).toContain('npm install -g corepack');
@@ -98,6 +101,9 @@ describe('local setup scripts', () => {
     expect(quickstart).toContain('**Grafana** (port 3000)');
     expect(quickstart).toContain('**Tempo** (ports 3200, 4317, 4318)');
     expect(quickstart).toContain('There is no `firewall` Docker service in the current compose file.');
+    expect(read('README.md')).toContain('fixed compose defaults for Grafana (http://localhost:3000/api/health)');
+    expect(read('README.md')).toContain('Tempo readiness (http://localhost:3200/ready)');
+    expect(read('README.md')).toContain('.env.example intentionally does not define a TEMPO_ENDPOINT override');
     expect(source).toContain("await checkHttp('ChromaDB', `${chromaUrl}/api/v2/heartbeat`)");
     expect(source).toContain("await checkHttp('Grafana', 'http://localhost:3000/api/health')");
     expect(source).toContain("await checkHttp('Tempo', 'http://localhost:3200/ready')");


### PR DESCRIPTION
## Summary
- Align CLI, dashboard, and deploy guide prerequisites with the repo Node support range and npm packageManager pin.
- Clarify README local verification probes CHROMA_URL plus fixed docker-compose Grafana and Tempo readiness endpoints.
- Extend local setup regression coverage for the guide npm requirement and verifier endpoint docs.

Closes #2174

## Test plan
- `git diff --check`
- `node - <<'NODE' ... NODE` static alignment smoke: Passed 17 Node/setup documentation alignment checks.
- `npx --no-install vitest run tests/local-setup-scripts.test.ts` (blocked: no repo node_modules/vitest in isolated worktree; did not install dependencies per task constraints)