### PR TITLE
fix(orchestrator): validate replay content refs

### DIFF
--- a/packages/franken-orchestrator/src/replay/replay-content-store.ts
+++ b/packages/franken-orchestrator/src/replay/replay-content-store.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+const SHA256_HEX_REF = /^[a-f0-9]{64}$/;
+
 export type ReplayRecordKind = 'llm.request' | 'llm.response' | 'tool.call' | 'tool.result' | 'environment.snapshot';
 
 export interface ReplayRecord {
@@ -35,6 +37,10 @@ export class ReplayContentStore implements ReplayContentStoreLike {
   }
 
   get(contentRef: string): string {
+    if (!SHA256_HEX_REF.test(contentRef)) {
+      throw new Error('Replay content ref must be exactly 64 lowercase sha256 hex characters');
+    }
+
     return readFileSync(join(this.blobsDir, contentRef), 'utf8');
   }
 }

--- a/packages/franken-orchestrator/tests/unit/replay/replay-content-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/replay/replay-content-store.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ReplayContentStore } from '../../../src/replay/replay-content-store.js';
+
+function newStore(): ReplayContentStore {
+  return new ReplayContentStore(mkdtempSync(join(tmpdir(), 'orchestrator-replay-store-')));
+}
+
+describe('ReplayContentStore', () => {
+  it('round-trips content by generated sha256 content ref', () => {
+    const store = newStore();
+    const ref = store.put(JSON.stringify({ text: 'cached answer' }));
+
+    expect(ref).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.parse(store.get(ref))).toEqual({ text: 'cached answer' });
+  });
+
+  it.each([
+    '',
+    '../manifest.json',
+    '/tmp/manifest.json',
+    'ABCDEF'.padEnd(64, '0'),
+    'g'.repeat(64),
+    'a'.repeat(63),
+    'a'.repeat(65),
+  ])('rejects invalid replay content ref %j before reading blobs', (contentRef) => {
+    const store = newStore();
+
+    expect(() => store.get(contentRef)).toThrow(/replay content ref/i);
+  });
+});


### PR DESCRIPTION
## Summary
- validate orchestrator replay content refs before resolving blob paths
- reject traversal, empty, uppercase, non-hex, and wrong-length refs with a clear error
- add replay content store regression coverage for invalid refs and valid digest round-trip

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/replay/replay-content-store.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run test --workspace @franken/orchestrator

Closes #2066
