### PR TITLE
docs(observer): document Langfuse environment variables

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -588,6 +588,10 @@ const adapter = new LangfuseAdapter({
 await adapter.flush(trace)
 ```
 
+`LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are caller-managed credentials; `LangfuseAdapter` does not read them automatically and has no default key values. `publicKey` identifies the Langfuse project, while `secretKey` is sent with it in the Basic Authorization header. Keep the secret key in local/CI secret stores, never commit it or expose it to browser bundles, and fail fast before constructing the adapter if a live-export job is missing either value. For local development, prefer an ignored `.env.local` or shell profile and use placeholder values only with a mocked `fetch`. CI should inject masked `LANGFUSE_*` secrets only into jobs that intentionally test live Langfuse export wiring; unit and documentation checks should continue to run without real credentials.
+
+See [`docs/adapters.md#langfuseadapter`](./docs/adapters.md#langfuseadapter) for the full environment-variable reference, local development example, and CI snippet.
+
 ### `TempoAdapter`
 
 Posts OTEL payloads to [Grafana Tempo](https://grafana.com/oss/tempo/) over OTLP/HTTP.

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -588,9 +588,9 @@ const adapter = new LangfuseAdapter({
 await adapter.flush(trace)
 ```
 
-`LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are caller-managed credentials; `LangfuseAdapter` does not read them automatically and has no default key values. `publicKey` identifies the Langfuse project, while `secretKey` is sent with it in the Basic Authorization header. Keep the secret key in local/CI secret stores, never commit it or expose it to browser bundles, and fail fast before constructing the adapter if a live-export job is missing either value. For local development, prefer an ignored `.env.local` or shell profile and use placeholder values only with a mocked `fetch`. CI should inject masked `LANGFUSE_*` secrets only into jobs that intentionally test live Langfuse export wiring; unit and documentation checks should continue to run without real credentials.
+`LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are caller-managed credentials; `LangfuseAdapter` does not read them automatically and has no default key values. `publicKey` identifies the Langfuse project, while `secretKey` is sent with it in the Basic Authorization header. Keep the secret key in local/CI secret stores, never commit it or expose it to browser bundles, and fail fast before constructing the adapter if a live-export job is missing either value. For local development, prefer an ignored `.env` file or shell profile and use placeholder values only with a mocked `fetch`. CI should inject masked `LANGFUSE_*` secrets only into jobs that intentionally test live Langfuse export wiring; unit and documentation checks should continue to run without real credentials.
 
-See [`docs/adapters.md#langfuseadapter`](./docs/adapters.md#langfuseadapter) for the full environment-variable reference, local development example, and CI snippet.
+See the repository copy of [`packages/franken-observer/docs/adapters.md`](https://github.com/djm204/frankenbeast/blob/main/packages/franken-observer/docs/adapters.md#langfuseadapter) for the full environment-variable reference, local development example, and CI snippet.
 
 ### `TempoAdapter`
 

--- a/packages/franken-observer/docs/adapters.md
+++ b/packages/franken-observer/docs/adapters.md
@@ -66,12 +66,34 @@ await adapter.flush(trace) // throws on non-2xx response
 
 **Options**
 
-| Option      | Type     | Default                          | Description                      |
-|-------------|----------|----------------------------------|----------------------------------|
-| `publicKey` | `string` | —                                | Langfuse project public key      |
-| `secretKey` | `string` | —                                | Langfuse project secret key      |
-| `baseUrl`   | `string` | `https://cloud.langfuse.com`     | Override for EU region or Phoenix|
-| `fetch`     | `FetchFn`| `globalThis.fetch`               | Injectable for testing           |
+| Option      | Type      | Default                      | Description                       |
+|-------------|-----------|------------------------------|-----------------------------------|
+| `publicKey` | `string`  | —                            | Langfuse project public key       |
+| `secretKey` | `string`  | —                            | Langfuse project secret key       |
+| `baseUrl`   | `string`  | `https://cloud.langfuse.com` | Override for EU region or Phoenix |
+| `fetch`     | `FetchFn` | `globalThis.fetch`           | Injectable for testing            |
+
+**Environment variables**
+
+`LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are the recommended application-level names for the two required Langfuse credentials. The adapter does not read environment variables by itself and does not provide default credential values: callers must pass both keys into `new LangfuseAdapter({ publicKey, secretKey })`. If either variable is missing, fail fast in the application or CI job that enables Langfuse export rather than constructing the adapter with an empty string.
+
+`LANGFUSE_PUBLIC_KEY` identifies the Langfuse project that receives the OTEL payloads. `LANGFUSE_SECRET_KEY` is paired with it and is sent as part of the adapter's HTTP Basic Authorization header (`publicKey:secretKey`). Keep the secret key in a password manager, CI secret store, or local uncommitted `.env` file; never commit it, print it in logs, or expose it to browser bundles.
+
+Local development usually keeps Langfuse export opt-in. Store real keys in an ignored `.env.local` (or equivalent shell profile), use placeholder values only when paired with a mocked `fetch`, and point `baseUrl` at the correct Langfuse region when you are testing live exports:
+
+```bash
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+# Optional: pass baseUrl: 'https://eu.cloud.langfuse.com' in code for EU projects.
+```
+
+CI pipelines should inject masked secrets only into jobs that intentionally exercise Langfuse export wiring. Documentation, unit, and mock-transport tests should not require real Langfuse credentials.
+
+```yaml
+env:
+  LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+  LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+```
 
 **Testing without a real Langfuse instance**
 

--- a/packages/franken-observer/docs/adapters.md
+++ b/packages/franken-observer/docs/adapters.md
@@ -79,7 +79,7 @@ await adapter.flush(trace) // throws on non-2xx response
 
 `LANGFUSE_PUBLIC_KEY` identifies the Langfuse project that receives the OTEL payloads. `LANGFUSE_SECRET_KEY` is paired with it and is sent as part of the adapter's HTTP Basic Authorization header (`publicKey:secretKey`). Keep the secret key in a password manager, CI secret store, or local uncommitted `.env` file; never commit it, print it in logs, or expose it to browser bundles.
 
-Local development usually keeps Langfuse export opt-in. Store real keys in an ignored `.env.local` (or equivalent shell profile), use placeholder values only when paired with a mocked `fetch`, and point `baseUrl` at the correct Langfuse region when you are testing live exports:
+Local development usually keeps Langfuse export opt-in. Store real keys in an ignored `.env` file (or equivalent shell profile), use placeholder values only when paired with a mocked `fetch`, and point `baseUrl` at the correct Langfuse region when you are testing live exports:
 
 ```bash
 export LANGFUSE_PUBLIC_KEY="pk-lf-..."

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,10 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-13 — Langfuse docs and env-var DX
+- For docs that include links from published package pages, prefer links to files that are shipped in the package (e.g., README, changelog). In `@franken/observer`, avoid package-relative links to `docs/` if that directory is not published.
+- For local secret setup guidance, recommend `.env`/ignored secret files that match repo policy to reduce accidental staging of keys like `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY`.
+- When running Codex review on a refreshed commit, resolve all `chatgpt-codex-connector` inline findings and verify `reviewThreads.isResolved` is true for the relevant threads before treating a second `@codex review` cycle as complete.
+
 ## 2026-07-13 — Operator session-token review hardening
 - Approval-session tokens must be scoped to the policy actually approved: skill triggers can use selected tool scope, but budget/custom/non-skill approvals should stay task-scoped even when a tool is selected so same-tool actions in other tasks do not bypass prompts.
 - Never reuse an approval-session token for fail-closed trigger-evaluation errors; even a valid same-scope token must fall back to a fresh operator prompt when evaluator context/logic throws.


### PR DESCRIPTION
## Summary
- Document `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` usage for `LangfuseAdapter`
- Clarify that credentials are caller-managed and have no package defaults
- Add local development, security, and CI secret-handling guidance

## Test Plan
- `npm ci`
- `npm run build --workspace @franken/types`
- `npm run lint --workspace @franken/observer` (passes with existing warnings)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run test --workspace @franken/observer`

Closes #2129
