### PR TITLE
test(memory): add injection budget coverage

### DIFF
--- a/packages/franken-orchestrator/src/skills/llm-skill-handler.ts
+++ b/packages/franken-orchestrator/src/skills/llm-skill-handler.ts
@@ -63,36 +63,26 @@ export class LlmSkillHandler {
     const selectedLines: string[] = [];
     let omitted = 0;
 
-    for (const entry of entries) {
+    for (let index = 0; index < entries.length; index += 1) {
+      const entry = entries[index]!;
       const line = this.formatMemoryEntry(entry);
-      const nextLines = [...selectedLines, line];
-      const remainingAfterThis = entries.length - selectedLines.length - 1;
-      const needsMarker = omitted + remainingAfterThis > 0;
-      const candidate = this.renderMemoryContextBlock(nextLines, needsMarker ? omitted + remainingAfterThis : 0);
+      const omittedAfterThis = entries.length - index - 1;
+      const candidate = this.renderMemoryContextBlock([...selectedLines, line], omittedAfterThis);
 
       if (candidate.length <= this.memoryContextBudgetChars) {
         selectedLines.push(line);
-      } else {
-        omitted += 1;
+        continue;
       }
+
+      const truncated = this.fitTruncatedLine(selectedLines, line, omittedAfterThis);
+      if (truncated) {
+        selectedLines.push(truncated);
+      }
+      omitted = entries.length - selectedLines.length;
+      break;
     }
 
-    if (selectedLines.length === 0) {
-      const first = entries[0]!;
-      const marker = this.truncationMarker(entries.length - 1);
-      const budgetForLine = this.memoryContextBudgetChars - MEMORY_CONTEXT_HEADER.length - marker.length - 4;
-      selectedLines.push(this.truncateLine(this.formatMemoryEntry(first), budgetForLine));
-      omitted = entries.length - 1;
-    }
-
-    let block = this.renderMemoryContextBlock(selectedLines, omitted);
-    while (block.length > this.memoryContextBudgetChars && selectedLines.length > 1) {
-      selectedLines.pop();
-      omitted += 1;
-      block = this.renderMemoryContextBlock(selectedLines, omitted);
-    }
-
-    return block;
+    return this.renderMemoryContextBlock(selectedLines, omitted);
   }
 
   private rankMemoryEntries(context: MemoryContext): RankedMemoryEntry[] {
@@ -119,19 +109,18 @@ export class LlmSkillHandler {
     return entries.sort((left, right) =>
       left.priority - right.priority ||
       this.sectionPriority(left.section) - this.sectionPriority(right.section) ||
-      left.text.localeCompare(right.text) ||
       left.originalIndex - right.originalIndex,
     );
   }
 
   private memoryPriority(value: string, section: MemorySection): number {
     const normalized = value.toLowerCase();
+    if (normalized.includes('stale')) return 20;
+    if (normalized.includes('archived')) return 19;
     if (normalized.includes('user preference')) return 0;
     if (normalized.includes('project convention') || normalized.includes('active project')) return 1;
     if (normalized.includes('environment memory')) return 2;
     if (normalized.includes('procedure memory')) return 3;
-    if (normalized.includes('stale')) return 20;
-    if (normalized.includes('archived')) return 19;
 
     switch (section) {
       case 'rules':
@@ -165,6 +154,30 @@ export class LlmSkillHandler {
 
   private truncationMarker(omitted: number): string {
     return `[memory truncated: ${omitted} lower-priority entr${omitted === 1 ? 'y' : 'ies'} omitted]`;
+  }
+
+  private fitTruncatedLine(
+    selectedLines: readonly string[],
+    line: string,
+    omittedAfterThis: number,
+  ): string | undefined {
+    let low = 1;
+    let high = line.length;
+    let best: string | undefined;
+
+    while (low <= high) {
+      const midpoint = Math.floor((low + high) / 2);
+      const truncated = this.truncateLine(line, midpoint);
+      const candidate = this.renderMemoryContextBlock([...selectedLines, truncated], omittedAfterThis);
+      if (candidate.length <= this.memoryContextBudgetChars) {
+        best = truncated;
+        low = midpoint + 1;
+      } else {
+        high = midpoint - 1;
+      }
+    }
+
+    return best;
   }
 
   private truncateLine(line: string, budget: number): string {

--- a/packages/franken-orchestrator/src/skills/llm-skill-handler.ts
+++ b/packages/franken-orchestrator/src/skills/llm-skill-handler.ts
@@ -3,11 +3,31 @@ import type { MemoryContext } from '../deps.js';
 
 type LlmSkillResult = { output: string; tokensUsed: number };
 
+export interface LlmSkillHandlerOptions {
+  /** Maximum characters reserved for injected memory context in the prompt. */
+  readonly memoryContextBudgetChars?: number | undefined;
+}
+
+type MemorySection = 'adrs' | 'rules' | 'knownErrors';
+
+type RankedMemoryEntry = {
+  readonly section: MemorySection;
+  readonly label: string;
+  readonly text: string;
+  readonly priority: number;
+  readonly originalIndex: number;
+};
+
+const DEFAULT_MEMORY_CONTEXT_BUDGET_CHARS = 6_000;
+const MEMORY_CONTEXT_HEADER = 'Memory Context:';
+
 export class LlmSkillHandler {
   private readonly llmClient: ILlmClient;
+  private readonly memoryContextBudgetChars: number;
 
-  constructor(llmClient: ILlmClient) {
+  constructor(llmClient: ILlmClient, options: LlmSkillHandlerOptions = {}) {
     this.llmClient = llmClient;
+    this.memoryContextBudgetChars = Math.max(120, options.memoryContextBudgetChars ?? DEFAULT_MEMORY_CONTEXT_BUDGET_CHARS);
   }
 
   async execute(objective: string, context: MemoryContext): Promise<LlmSkillResult> {
@@ -30,23 +50,127 @@ export class LlmSkillHandler {
       'Objective:',
       objective,
       '',
-      'ADRs:',
-      ...this.formatSection(context.adrs),
-      '',
-      'Rules:',
-      ...this.formatSection(context.rules),
-      '',
-      'Known Errors:',
-      ...this.formatSection(context.knownErrors),
+      this.buildMemoryContextBlock(context),
     ].join('\n');
   }
 
-  private formatSection(entries: readonly string[]): string[] {
+  private buildMemoryContextBlock(context: MemoryContext): string {
+    const entries = this.rankMemoryEntries(context);
     if (entries.length === 0) {
-      return ['(none)'];
+      return `${MEMORY_CONTEXT_HEADER}\n(none)`;
     }
 
-    return entries.map(entry => `- ${entry}`);
+    const selectedLines: string[] = [];
+    let omitted = 0;
+
+    for (const entry of entries) {
+      const line = this.formatMemoryEntry(entry);
+      const nextLines = [...selectedLines, line];
+      const remainingAfterThis = entries.length - selectedLines.length - 1;
+      const needsMarker = omitted + remainingAfterThis > 0;
+      const candidate = this.renderMemoryContextBlock(nextLines, needsMarker ? omitted + remainingAfterThis : 0);
+
+      if (candidate.length <= this.memoryContextBudgetChars) {
+        selectedLines.push(line);
+      } else {
+        omitted += 1;
+      }
+    }
+
+    if (selectedLines.length === 0) {
+      const first = entries[0]!;
+      const marker = this.truncationMarker(entries.length - 1);
+      const budgetForLine = this.memoryContextBudgetChars - MEMORY_CONTEXT_HEADER.length - marker.length - 4;
+      selectedLines.push(this.truncateLine(this.formatMemoryEntry(first), budgetForLine));
+      omitted = entries.length - 1;
+    }
+
+    let block = this.renderMemoryContextBlock(selectedLines, omitted);
+    while (block.length > this.memoryContextBudgetChars && selectedLines.length > 1) {
+      selectedLines.pop();
+      omitted += 1;
+      block = this.renderMemoryContextBlock(selectedLines, omitted);
+    }
+
+    return block;
+  }
+
+  private rankMemoryEntries(context: MemoryContext): RankedMemoryEntry[] {
+    const entries: RankedMemoryEntry[] = [];
+    let originalIndex = 0;
+
+    const pushEntries = (section: MemorySection, label: string, values: readonly string[]) => {
+      for (const value of values) {
+        entries.push({
+          section,
+          label,
+          text: value,
+          priority: this.memoryPriority(value, section),
+          originalIndex,
+        });
+        originalIndex += 1;
+      }
+    };
+
+    pushEntries('rules', 'Rules', context.rules);
+    pushEntries('adrs', 'ADRs', context.adrs);
+    pushEntries('knownErrors', 'Known Errors', context.knownErrors);
+
+    return entries.sort((left, right) =>
+      left.priority - right.priority ||
+      this.sectionPriority(left.section) - this.sectionPriority(right.section) ||
+      left.text.localeCompare(right.text) ||
+      left.originalIndex - right.originalIndex,
+    );
+  }
+
+  private memoryPriority(value: string, section: MemorySection): number {
+    const normalized = value.toLowerCase();
+    if (normalized.includes('user preference')) return 0;
+    if (normalized.includes('project convention') || normalized.includes('active project')) return 1;
+    if (normalized.includes('environment memory')) return 2;
+    if (normalized.includes('procedure memory')) return 3;
+    if (normalized.includes('stale')) return 20;
+    if (normalized.includes('archived')) return 19;
+
+    switch (section) {
+      case 'rules':
+        return 4;
+      case 'adrs':
+        return 5;
+      case 'knownErrors':
+        return 10;
+    }
+  }
+
+  private sectionPriority(section: MemorySection): number {
+    switch (section) {
+      case 'rules':
+        return 0;
+      case 'adrs':
+        return 1;
+      case 'knownErrors':
+        return 2;
+    }
+  }
+
+  private formatMemoryEntry(entry: RankedMemoryEntry): string {
+    return `- [${entry.label}] ${entry.text}`;
+  }
+
+  private renderMemoryContextBlock(lines: readonly string[], omitted: number): string {
+    const body = omitted > 0 ? [...lines, this.truncationMarker(omitted)] : [...lines];
+    return [MEMORY_CONTEXT_HEADER, ...body].join('\n');
+  }
+
+  private truncationMarker(omitted: number): string {
+    return `[memory truncated: ${omitted} lower-priority entr${omitted === 1 ? 'y' : 'ies'} omitted]`;
+  }
+
+  private truncateLine(line: string, budget: number): string {
+    if (line.length <= budget) return line;
+    if (budget <= 1) return '…';
+    return `${line.slice(0, budget - 1)}…`;
   }
 
   private estimateTokens(prompt: string, response: string): number {

--- a/packages/franken-orchestrator/src/skills/llm-skill-handler.ts
+++ b/packages/franken-orchestrator/src/skills/llm-skill-handler.ts
@@ -60,6 +60,11 @@ export class LlmSkillHandler {
       return `${MEMORY_CONTEXT_HEADER}\n(none)`;
     }
 
+    const fullBlock = this.renderMemoryContextBlock(entries.map(entry => this.formatMemoryEntry(entry)), 0);
+    if (fullBlock.length <= this.memoryContextBudgetChars) {
+      return fullBlock;
+    }
+
     const selectedLines: string[] = [];
     let omitted = 0;
 
@@ -89,13 +94,14 @@ export class LlmSkillHandler {
     const entries: RankedMemoryEntry[] = [];
     let originalIndex = 0;
 
-    const pushEntries = (section: MemorySection, label: string, values: readonly string[]) => {
+    const pushEntries = (section: MemorySection, label: string, values: readonly unknown[]) => {
       for (const value of values) {
+        const text = String(value);
         entries.push({
           section,
           label,
-          text: value,
-          priority: this.memoryPriority(value, section),
+          text,
+          priority: this.memoryPriority(text, section),
           originalIndex,
         });
         originalIndex += 1;
@@ -114,9 +120,8 @@ export class LlmSkillHandler {
   }
 
   private memoryPriority(value: string, section: MemorySection): number {
-    const normalized = value.toLowerCase();
-    if (normalized.includes('stale')) return 20;
-    if (normalized.includes('archived')) return 19;
+    const normalized = value.toLowerCase().trimStart();
+    if (this.isExplicitlyStaleOrArchived(normalized)) return 20;
     if (normalized.includes('user preference')) return 0;
     if (normalized.includes('project convention') || normalized.includes('active project')) return 1;
     if (normalized.includes('environment memory')) return 2;
@@ -130,6 +135,10 @@ export class LlmSkillHandler {
       case 'knownErrors':
         return 10;
     }
+  }
+
+  private isExplicitlyStaleOrArchived(normalized: string): boolean {
+    return /^(stale|archived)\b/.test(normalized);
   }
 
   private sectionPriority(section: MemorySection): number {

--- a/packages/franken-orchestrator/tests/unit/skills/llm-skill-handler.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/llm-skill-handler.test.ts
@@ -108,4 +108,73 @@ describe('LlmSkillHandler', () => {
     expect(procedureMemory).toBeGreaterThan(environmentMemory);
     expect(staleObservation === -1 || staleObservation > procedureMemory).toBe(true);
   });
+
+  it('truncates an oversized priority memory instead of replacing it with lower-priority facts', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 180 });
+
+    await handler.execute('Keep top priority memory', {
+      rules: [
+        `User preference: ${'critical preference '.repeat(20)}`,
+        'Stale rule: tiny but outdated.',
+      ],
+      adrs: [],
+      knownErrors: [],
+    });
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    const memoryBlock = prompt.slice(prompt.indexOf('Memory Context:'));
+    expect(memoryBlock.length).toBeLessThanOrEqual(180);
+    expect(memoryBlock).toContain('User preference: critical preference');
+    expect(memoryBlock).toContain('…');
+    expect(memoryBlock).toContain('[memory truncated: 1 lower-priority entry omitted]');
+    expect(memoryBlock).not.toContain('Stale rule: tiny but outdated.');
+  });
+
+  it('preserves insertion order for same-priority known errors so newest failures stay first', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 230 });
+
+    await handler.execute('Recover from errors', {
+      adrs: [],
+      rules: [],
+      knownErrors: [
+        'Z newest failure from recentFailures should remain first.',
+        'A older failure sorts alphabetically first but is less recent.',
+        'M oldest failure should be omitted under the budget.',
+      ],
+    });
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    expect(prompt.indexOf('Z newest failure')).toBeLessThan(prompt.indexOf('A older failure'));
+  });
+
+  it('demotes stale category-labeled memories before active facts', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 260 });
+
+    await handler.execute('Ignore stale facts', {
+      adrs: ['Project convention: active TypeScript convention.'],
+      rules: [
+        'Stale user preference: outdated verbose status reports.',
+        'User preference: active concise status reports.',
+      ],
+      knownErrors: ['Stale environment memory: retired Node version.'],
+    });
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    const activePreference = prompt.indexOf('User preference: active concise status reports.');
+    const activeProject = prompt.indexOf('Project convention: active TypeScript convention.');
+    const stalePreference = prompt.indexOf('Stale user preference: outdated verbose status reports.');
+
+    expect(activePreference).toBeGreaterThan(-1);
+    expect(activeProject).toBeGreaterThan(activePreference);
+    expect(stalePreference === -1 || stalePreference > activeProject).toBe(true);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/llm-skill-handler.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/llm-skill-handler.test.ts
@@ -177,4 +177,65 @@ describe('LlmSkillHandler', () => {
     expect(activeProject).toBeGreaterThan(activePreference);
     expect(stalePreference === -1 || stalePreference > activeProject).toBe(true);
   });
+
+  it('does not demote active memories that mention stale resources', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 260 });
+
+    await handler.execute('Keep active stale-branch preference', {
+      adrs: ['ADR-002: generic architecture rule.'],
+      rules: [
+        'Generic rule that should come after preferences.',
+        'User preference: warn before deleting stale branches.',
+      ],
+      knownErrors: [],
+    });
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    expect(prompt.indexOf('User preference: warn before deleting stale branches.')).toBeLessThan(
+      prompt.indexOf('Generic rule that should come after preferences.'),
+    );
+  });
+
+  it('coerces restored non-string memory values before ranking', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient);
+    const restoredContext = {
+      adrs: [404],
+      rules: ['User preference: keep recovered facts visible.'],
+      knownErrors: [{ code: 'E_RESTORED' }],
+    } as unknown as MemoryContext;
+
+    await expect(handler.execute('Handle restored context', restoredContext)).resolves.toMatchObject({ output: 'ok' });
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('404');
+    expect(prompt).toContain('[object Object]');
+  });
+
+  it('does not reserve a truncation marker when all memory entries fit', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 145 });
+
+    await handler.execute('Render fitting memory', {
+      adrs: [],
+      rules: [
+        'User preference: keep this medium-sized preference in context.',
+        'Tiny rule.',
+      ],
+      knownErrors: [],
+    });
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    const memoryBlock = prompt.slice(prompt.indexOf('Memory Context:'));
+    expect(memoryBlock.length).toBeLessThanOrEqual(145);
+    expect(memoryBlock).toContain('User preference: keep this medium-sized preference in context.');
+    expect(memoryBlock).toContain('Tiny rule.');
+    expect(memoryBlock).not.toContain('[memory truncated:');
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/llm-skill-handler.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/llm-skill-handler.test.ts
@@ -38,4 +38,74 @@ describe('LlmSkillHandler', () => {
       'Skill execution failed for objective "Draft release notes": Service unavailable',
     );
   });
+
+  it('keeps oversized memory injection under the configured budget while preserving priority facts', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const oversizedContext: MemoryContext = {
+      rules: [
+        'User preference: keep responses concise and direct.',
+        'Procedure memory: run package tests from the package directory.',
+        ...Array.from({ length: 20 }, (_, index) => `Stale rule observation ${index}: ${'low-value '.repeat(10)}`),
+      ],
+      adrs: [
+        'Project convention: use Vitest for TypeScript unit coverage.',
+        ...Array.from({ length: 20 }, (_, index) => `Archived ADR note ${index}: ${'legacy '.repeat(12)}`),
+      ],
+      knownErrors: [
+        'Environment memory: CI runs Node 24 with npm workspaces.',
+        ...Array.from({ length: 20 }, (_, index) => `Stale observation ${index}: ${'outdated '.repeat(12)}`),
+      ],
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 900 });
+
+    await handler.execute('Use memory safely', oversizedContext);
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    const memoryBlock = prompt.slice(prompt.indexOf('Memory Context:'));
+    expect(memoryBlock.length).toBeLessThanOrEqual(900);
+    expect(memoryBlock).toContain('User preference: keep responses concise and direct.');
+    expect(memoryBlock).toContain('Project convention: use Vitest for TypeScript unit coverage.');
+    expect(memoryBlock).toContain('Environment memory: CI runs Node 24 with npm workspaces.');
+    expect(memoryBlock).toContain('Procedure memory: run package tests from the package directory.');
+    expect(memoryBlock).toContain('[memory truncated:');
+    expect(memoryBlock).not.toContain('Stale observation 19');
+  });
+
+  it('orders truncated memory deterministically by priority before stale observations', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue('ok'),
+    };
+    const handler = new LlmSkillHandler(llmClient, { memoryContextBudgetChars: 700 });
+
+    await handler.execute('Rank memory', {
+      adrs: [
+        'Archived ADR: previous migration note.',
+        'Project convention: conventional commits are required.',
+      ],
+      rules: [
+        'Stale rule: old status update wording.',
+        'User preference: report blockers explicitly.',
+        'Procedure memory: trigger @codex review after every PR update.',
+      ],
+      knownErrors: [
+        'Stale observation: old provider outage.',
+        'Environment memory: tests run with deterministic Vitest seed.',
+      ],
+    });
+
+    const prompt = llmClient.complete.mock.calls[0]?.[0] as string;
+    const userPreference = prompt.indexOf('User preference: report blockers explicitly.');
+    const projectConvention = prompt.indexOf('Project convention: conventional commits are required.');
+    const environmentMemory = prompt.indexOf('Environment memory: tests run with deterministic Vitest seed.');
+    const procedureMemory = prompt.indexOf('Procedure memory: trigger @codex review after every PR update.');
+    const staleObservation = prompt.indexOf('Stale observation: old provider outage.');
+
+    expect(userPreference).toBeGreaterThan(-1);
+    expect(projectConvention).toBeGreaterThan(userPreference);
+    expect(environmentMemory).toBeGreaterThan(projectConvention);
+    expect(procedureMemory).toBeGreaterThan(environmentMemory);
+    expect(staleObservation === -1 || staleObservation > procedureMemory).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds deterministic memory injection budgeting in the LLM skill prompt path.
- Preserves user preferences, project conventions, environment, and procedure facts before stale observations.
- Adds oversized memory fixtures that assert budget limits, deterministic ordering, and truncation markers.

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/skills/llm-skill-handler.test.ts
- npm --prefix packages/franken-orchestrator test -- tests/unit/skills/llm-skill-handler.test.ts tests/unit/phases/hydration.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint -- --quiet
- npm --prefix packages/franken-orchestrator run build

Closes #1759