### PR TITLE
feat(critique): quarantine stale lessons

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -30,6 +30,11 @@ export type {
   LessonTestTraceabilityEntry,
   LessonExperimentSandbox,
   LessonRollbackWorkflow,
+  LessonLifecycleStatus,
+  LessonQuarantineEvidence,
+  LessonQuarantineReviewItem,
+  LessonQuarantineMetadata,
+  LessonUnquarantineMetadata,
   LessonCooldownMetadata,
   LessonCooldownSuppression,
   CrossTaskBlockerPattern,
@@ -80,11 +85,21 @@ export type { CritiqueErrorOptions } from './errors/index.js';
 // Core components
 export { CritiquePipeline } from './pipeline/critique-pipeline.js';
 export { CritiqueLoop } from './loop/critique-loop.js';
-export { LessonRecorder } from './memory/lesson-recorder.js';
+export {
+  LessonRecorder,
+  isLessonApplicable,
+  quarantineLesson,
+  quarantineLessonForRepeatedFailures,
+  unquarantineLesson,
+} from './memory/lesson-recorder.js';
 export type {
   BlockerPatternObservation,
   BlockerPatternState,
   LessonRecorderOptions,
+  LessonQuarantineRequest,
+  LessonFailureSignal,
+  RepeatedFailureQuarantineRequest,
+  LessonUnquarantineRequest,
 } from './memory/lesson-recorder.js';
 
 // Evaluators

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -166,7 +166,10 @@ export interface RepeatedFailureQuarantineRequest {
 export type LessonUnquarantineRequest = LessonUnquarantineMetadata;
 
 export function isLessonApplicable(lesson: CritiqueLesson): boolean {
-  return lesson.lifecycleStatus === 'active' && lesson.quarantine === undefined;
+  if (lesson.quarantine !== undefined) {
+    return false;
+  }
+  return lesson.lifecycleStatus === undefined || lesson.lifecycleStatus === 'active';
 }
 
 export function quarantineLesson(
@@ -179,18 +182,25 @@ export function quarantineLesson(
     throw new RangeError('Lesson quarantine requires at least one evidence item.');
   }
   const evidence = request.evidence.map(normalizeQuarantineEvidence);
+  const previousQuarantine = lesson.quarantine;
+  const combinedEvidence = [...(previousQuarantine?.evidence ?? []), ...evidence];
   const reviewItem = createLessonQuarantineReviewItem(
     lesson,
     reason,
-    evidence,
+    combinedEvidence,
     quarantinedAt,
   );
+  const previousLifecycleStatus =
+    previousQuarantine?.previousLifecycleStatus ?? lesson.lifecycleStatus;
   const quarantine: LessonQuarantineMetadata = {
     trigger: request.trigger,
-    reason,
+    reason: previousQuarantine
+      ? `${previousQuarantine.reason}; ${reason}`
+      : reason,
     quarantinedAt,
-    evidence,
+    evidence: combinedEvidence,
     ...(request.threshold !== undefined ? { threshold: request.threshold } : {}),
+    ...(previousLifecycleStatus !== undefined ? { previousLifecycleStatus } : {}),
     reviewItem,
   };
   const { unquarantine, ...lessonWithoutUnquarantine } = lesson;
@@ -243,10 +253,10 @@ export function unquarantineLesson(
     reason: request.reason,
   };
   const { quarantine, ...lessonWithoutQuarantine } = lesson;
-  void quarantine;
+  const restoredLifecycleStatus = quarantine.previousLifecycleStatus ?? 'active';
   return {
     ...lessonWithoutQuarantine,
-    lifecycleStatus: 'active',
+    lifecycleStatus: restoredLifecycleStatus,
     unquarantine,
   };
 }

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -169,6 +169,9 @@ export function isLessonApplicable(lesson: CritiqueLesson): boolean {
   if (lesson.quarantine !== undefined) {
     return false;
   }
+  if (lesson.experimentSandbox?.promotionBlocked === true) {
+    return false;
+  }
   return lesson.lifecycleStatus === undefined || lesson.lifecycleStatus === 'active';
 }
 
@@ -190,8 +193,9 @@ export function quarantineLesson(
     combinedEvidence,
     quarantinedAt,
   );
-  const previousLifecycleStatus =
-    previousQuarantine?.previousLifecycleStatus ?? lesson.lifecycleStatus;
+  const previousLifecycleStatus = previousQuarantine?.previousLifecycleStatus ??
+    (lesson.lifecycleStatus === 'quarantined' ? undefined : lesson.lifecycleStatus);
+  const threshold = request.threshold ?? previousQuarantine?.threshold;
   const quarantine: LessonQuarantineMetadata = {
     trigger: request.trigger,
     reason: previousQuarantine
@@ -199,7 +203,7 @@ export function quarantineLesson(
       : reason,
     quarantinedAt,
     evidence: combinedEvidence,
-    ...(request.threshold !== undefined ? { threshold: request.threshold } : {}),
+    ...(threshold !== undefined ? { threshold } : {}),
     ...(previousLifecycleStatus !== undefined ? { previousLifecycleStatus } : {}),
     reviewItem,
   };

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -230,6 +230,9 @@ export function unquarantineLesson(
   lesson: CritiqueLesson,
   request: LessonUnquarantineRequest,
 ): CritiqueLesson {
+  if (lesson.lifecycleStatus !== 'quarantined' || lesson.quarantine === undefined) {
+    throw new RangeError('Only quarantined lessons can be unquarantined.');
+  }
   requireNonEmptyString(request.reviewer, 'unquarantine reviewer');
   requireNonEmptyString(request.reason, 'unquarantine reason');
   requireNonEmptyString(request.evidenceUrl, 'unquarantine evidenceUrl');

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -9,6 +9,9 @@ import type {
   CrossTaskBlockerPattern,
   LearningBacklogPrioritizationItem,
   AgentImprovementScorecard,
+  LessonQuarantineEvidence,
+  LessonQuarantineMetadata,
+  LessonUnquarantineMetadata,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
@@ -136,6 +139,114 @@ const POST_PR_LESSON_EXTRACTION_TEMPLATE: PostPrLessonExtractionTemplate = {
   insufficientEvidenceGuidance:
     'Do not promote a post-PR lesson until the issue/PR, source finding, correction, and verification evidence are all available.',
 };
+
+const LESSON_QUARANTINE_REVIEW_ACTION =
+  'Review rollback evidence, decide whether to retire or supersede the lesson, and keep it out of prompt injection until explicitly unquarantined.';
+
+export interface LessonQuarantineRequest {
+  readonly trigger: LessonQuarantineMetadata['trigger'];
+  readonly reason: string;
+  readonly evidence: readonly LessonQuarantineEvidence[];
+  readonly quarantinedAt: string;
+  readonly threshold?: number;
+}
+
+export interface LessonFailureSignal {
+  readonly taskId: TaskId;
+  readonly reason: string;
+  readonly evidenceUrl: string;
+}
+
+export interface RepeatedFailureQuarantineRequest {
+  readonly threshold: number;
+  readonly observedAt: string;
+  readonly failures: readonly LessonFailureSignal[];
+}
+
+export type LessonUnquarantineRequest = LessonUnquarantineMetadata;
+
+export function isLessonApplicable(lesson: CritiqueLesson): boolean {
+  return lesson.lifecycleStatus === 'active' && lesson.quarantine === undefined;
+}
+
+export function quarantineLesson(
+  lesson: CritiqueLesson,
+  request: LessonQuarantineRequest,
+): CritiqueLesson {
+  const reason = requireNonEmptyString(request.reason, 'quarantine reason');
+  const quarantinedAt = normalizeTimestamp(request.quarantinedAt);
+  if (request.evidence.length === 0) {
+    throw new RangeError('Lesson quarantine requires at least one evidence item.');
+  }
+  const evidence = request.evidence.map(normalizeQuarantineEvidence);
+  const reviewItem = createLessonQuarantineReviewItem(
+    lesson,
+    reason,
+    evidence,
+    quarantinedAt,
+  );
+  const quarantine: LessonQuarantineMetadata = {
+    trigger: request.trigger,
+    reason,
+    quarantinedAt,
+    evidence,
+    ...(request.threshold !== undefined ? { threshold: request.threshold } : {}),
+    reviewItem,
+  };
+  const { unquarantine, ...lessonWithoutUnquarantine } = lesson;
+  void unquarantine;
+  return {
+    ...lessonWithoutUnquarantine,
+    lifecycleStatus: 'quarantined',
+    quarantine,
+  };
+}
+
+export function quarantineLessonForRepeatedFailures(
+  lesson: CritiqueLesson,
+  request: RepeatedFailureQuarantineRequest,
+): CritiqueLesson {
+  if (!Number.isSafeInteger(request.threshold) || request.threshold < 1) {
+    throw new RangeError('Repeated failure quarantine threshold must be a positive integer.');
+  }
+  const distinctFailures = dedupeFailureSignals(request.failures);
+  if (distinctFailures.length < request.threshold) {
+    return lesson;
+  }
+  return quarantineLesson(lesson, {
+    trigger: 'repeated-failure-threshold',
+    reason: `Lesson caused ${distinctFailures.length} distinct failure signals, meeting the quarantine threshold of ${request.threshold}.`,
+    evidence: distinctFailures.map((failure) => ({
+      kind: 'failed-regression',
+      reference: failure.evidenceUrl,
+      note: `${failure.taskId}: ${failure.reason}`,
+    })),
+    quarantinedAt: request.observedAt,
+    threshold: request.threshold,
+  });
+}
+
+export function unquarantineLesson(
+  lesson: CritiqueLesson,
+  request: LessonUnquarantineRequest,
+): CritiqueLesson {
+  requireNonEmptyString(request.reviewer, 'unquarantine reviewer');
+  requireNonEmptyString(request.reason, 'unquarantine reason');
+  requireNonEmptyString(request.evidenceUrl, 'unquarantine evidenceUrl');
+  const unquarantine: LessonUnquarantineMetadata = {
+    reviewedAt: normalizeTimestamp(request.reviewedAt),
+    reviewer: request.reviewer,
+    evidenceUrl: request.evidenceUrl,
+    reason: request.reason,
+  };
+  const { quarantine, ...lessonWithoutQuarantine } = lesson;
+  void quarantine;
+  return {
+    ...lessonWithoutQuarantine,
+    lifecycleStatus: 'active',
+    unquarantine,
+  };
+}
 
 export class LessonRecorder {
   private readonly memory: MemoryPort;
@@ -362,6 +473,7 @@ export class LessonRecorder {
             : 'Unknown correction',
           taskId,
           timestamp: recordedAt,
+          lifecycleStatus: 'candidate',
           experimentSandbox: {
             state: 'experimental',
             promotionBlocked: true,
@@ -1100,6 +1212,70 @@ function addCooldownWindowMs(baseMs: number, cooldownMs: number): number {
     );
   }
   return suppressUntilMs;
+}
+
+function createLessonQuarantineReviewItem(
+  lesson: CritiqueLesson,
+  reason: string,
+  evidence: readonly LessonQuarantineEvidence[],
+  createdAt: string,
+): LessonQuarantineMetadata['reviewItem'] {
+  const lessonId = lesson.testTraceability?.[0]?.lessonId ??
+    `${sanitizeLessonIdPart(lesson.taskId)}:${sanitizeLessonIdPart(lesson.evaluatorName)}`;
+  return {
+    id: `lesson-quarantine:${stableHash(`${lessonId}:${reason}:${createdAt}`)}`,
+    status: 'open',
+    lessonId,
+    createdAt,
+    reason,
+    evidence,
+    recommendedAction: LESSON_QUARANTINE_REVIEW_ACTION,
+  };
+}
+
+function normalizeQuarantineEvidence(
+  evidence: LessonQuarantineEvidence,
+): LessonQuarantineEvidence {
+  const reference = requireNonEmptyString(
+    evidence.reference,
+    'quarantine evidence reference',
+  );
+  return {
+    kind: evidence.kind,
+    reference,
+    ...(evidence.note ? { note: evidence.note } : {}),
+  };
+}
+
+function requireNonEmptyString(value: string, fieldName: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new RangeError(`Lesson ${fieldName} must be a non-empty string.`);
+  }
+  return normalized;
+}
+
+function dedupeFailureSignals(
+  failures: readonly LessonFailureSignal[],
+): LessonFailureSignal[] {
+  const seenTaskIds = new Set<string>();
+  const uniqueFailures: LessonFailureSignal[] = [];
+  for (const failure of failures) {
+    const taskIdText = requireNonEmptyString(failure.taskId, 'failure taskId');
+    if (seenTaskIds.has(taskIdText)) {
+      continue;
+    }
+    seenTaskIds.add(taskIdText);
+    uniqueFailures.push({
+      taskId: failure.taskId,
+      reason: requireNonEmptyString(failure.reason, 'failure reason'),
+      evidenceUrl: requireNonEmptyString(
+        failure.evidenceUrl,
+        'failure evidenceUrl',
+      ),
+    });
+  }
+  return uniqueFailures;
 }
 
 function stableHash(value: string): string {

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -132,6 +132,8 @@ export interface LessonQuarantineMetadata {
   readonly quarantinedAt: string;
   readonly evidence: readonly LessonQuarantineEvidence[];
   readonly threshold?: number;
+  /** Lifecycle status before quarantine; missing means legacy active. */
+  readonly previousLifecycleStatus?: LessonLifecycleStatus;
   readonly reviewItem: LessonQuarantineReviewItem;
 }
 

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -91,6 +91,58 @@ export interface LessonRollbackWorkflow {
   readonly insufficientEvidenceGuidance: string;
 }
 
+/** Lifecycle states for learned critique guidance. */
+export type LessonLifecycleStatus =
+  | 'candidate'
+  | 'active'
+  | 'quarantined'
+  | 'retired'
+  | 'superseded';
+
+/** Evidence attached to lesson quarantine/rollback decisions. */
+export interface LessonQuarantineEvidence {
+  readonly kind:
+    | 'operator-report'
+    | 'failed-regression'
+    | 'review-comment'
+    | 'incident-link';
+  /** Stable URL, issue/PR reference, or operator report handle proving the lesson is harmful/stale. */
+  readonly reference: string;
+  readonly note?: string;
+}
+
+/** PM/liveness review item created whenever a lesson is quarantined. */
+export interface LessonQuarantineReviewItem {
+  readonly id: string;
+  readonly status: 'open';
+  readonly lessonId: string;
+  readonly createdAt: string;
+  readonly reason: string;
+  readonly evidence: readonly LessonQuarantineEvidence[];
+  readonly recommendedAction: string;
+}
+
+/** Metadata proving why a lesson was removed from future prompt/application paths. */
+export interface LessonQuarantineMetadata {
+  readonly trigger:
+    | 'explicit-user-correction'
+    | 'repeated-failure-threshold'
+    | 'manual-review';
+  readonly reason: string;
+  readonly quarantinedAt: string;
+  readonly evidence: readonly LessonQuarantineEvidence[];
+  readonly threshold?: number;
+  readonly reviewItem: LessonQuarantineReviewItem;
+}
+
+/** Evidence that a quarantined lesson was reviewed and may be applied again. */
+export interface LessonUnquarantineMetadata {
+  readonly reviewedAt: string;
+  readonly reviewer: string;
+  readonly evidenceUrl: string;
+  readonly reason: string;
+}
+
 /** A normalized reviewer finding captured alongside a learned critique lesson. */
 export interface ReviewerFeedbackLessonEntry {
   /** Iteration where the reviewer feedback was emitted. */
@@ -280,6 +332,12 @@ export interface CritiqueLesson {
   readonly correctionApplied: string;
   readonly taskId: TaskId;
   readonly timestamp: string;
+  /** Lifecycle status used by memory/frontload consumers before injecting learned guidance. */
+  readonly lifecycleStatus?: LessonLifecycleStatus;
+  /** Present when a bad/stale lesson has been quarantined and must not be applied. */
+  readonly quarantine?: LessonQuarantineMetadata;
+  /** Present after a reviewed manual unquarantine restores the lesson to active status. */
+  readonly unquarantine?: LessonUnquarantineMetadata;
   /** Present for lessons recorded by LessonRecorder; absent legacy lessons are unverified. */
   readonly testTraceability?: readonly LessonTestTraceabilityEntry[];
   /** Present for new lessons that must remain quarantined until independently verified. */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
-import { LessonRecorder } from '../../../src/memory/lesson-recorder.js';
+import {
+  LessonRecorder,
+  isLessonApplicable,
+  quarantineLesson,
+  quarantineLessonForRepeatedFailures,
+  unquarantineLesson,
+} from '../../../src/memory/lesson-recorder.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
 import type { MemoryPort } from '../../../src/types/contracts.js';
 import type {
@@ -689,6 +695,167 @@ describe('LessonRecorder', () => {
       insufficientEvidenceGuidance:
         'Do not roll back a lesson unless the rollback request names the lesson, explains the bad/stale guidance, links review or regression evidence, and includes a verification command for the replacement or retirement decision.',
     });
+  });
+
+  it('records new critique lessons with candidate lifecycle status', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message: 'fresh lesson needs review before active injection',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'lifecycle-task');
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(lesson.lifecycleStatus).toBe('candidate');
+    expect(isLessonApplicable(lesson)).toBe(false);
+  });
+
+  it('quarantines active lessons on explicit user correction and prevents future application', () => {
+    const activeLesson = {
+      evaluatorName: 'learning-reviewer',
+      failureDescription: 'prefer short-circuiting verifier output',
+      correctionApplied: 'Corrected in iteration 1',
+      taskId: 'task-with-bad-lesson',
+      timestamp: '2026-07-12T10:00:00.000Z',
+      lifecycleStatus: 'active' as const,
+    };
+
+    const quarantined = quarantineLesson(activeLesson, {
+      trigger: 'explicit-user-correction',
+      reason: 'User corrected this as unsafe because verifier output was skipped.',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1729',
+        },
+      ],
+      quarantinedAt: '2026-07-12T10:05:00.000Z',
+    });
+
+    expect(quarantined.lifecycleStatus).toBe('quarantined');
+    expect(quarantined.quarantine).toEqual({
+      trigger: 'explicit-user-correction',
+      reason: 'User corrected this as unsafe because verifier output was skipped.',
+      quarantinedAt: '2026-07-12T10:05:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1729',
+        },
+      ],
+      reviewItem: expect.objectContaining({
+        status: 'open',
+        recommendedAction:
+          'Review rollback evidence, decide whether to retire or supersede the lesson, and keep it out of prompt injection until explicitly unquarantined.',
+      }),
+    });
+    expect(isLessonApplicable(quarantined)).toBe(false);
+  });
+
+  it('quarantines active lessons after repeated failure signals cross the configured threshold', () => {
+    const activeLesson = {
+      evaluatorName: 'learning-reviewer',
+      failureDescription: 'always skip Codex gate after local tests pass',
+      correctionApplied: 'Corrected in iteration 1',
+      taskId: 'original-task',
+      timestamp: '2026-07-12T10:00:00.000Z',
+      lifecycleStatus: 'active' as const,
+    };
+
+    const belowThreshold = quarantineLessonForRepeatedFailures(activeLesson, {
+      threshold: 3,
+      observedAt: '2026-07-12T11:00:00.000Z',
+      failures: [
+        {
+          taskId: 'task-a',
+          reason: 'Codex finding proved the lesson harmful.',
+          evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/1',
+        },
+        {
+          taskId: 'task-b',
+          reason: 'Repeated merge gate failure.',
+          evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/2',
+        },
+      ],
+    });
+
+    expect(belowThreshold).toBe(activeLesson);
+
+    const quarantined = quarantineLessonForRepeatedFailures(activeLesson, {
+      threshold: 2,
+      observedAt: '2026-07-12T11:00:00.000Z',
+      failures: [
+        {
+          taskId: 'task-a',
+          reason: 'Codex finding proved the lesson harmful.',
+          evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/1',
+        },
+        {
+          taskId: 'task-b',
+          reason: 'Repeated merge gate failure.',
+          evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/2',
+        },
+      ],
+    });
+
+    expect(quarantined.lifecycleStatus).toBe('quarantined');
+    expect(quarantined.quarantine).toMatchObject({
+      trigger: 'repeated-failure-threshold',
+      threshold: 2,
+      evidence: [
+        { kind: 'failed-regression', reference: 'https://github.com/djm204/frankenbeast/pull/1' },
+        { kind: 'failed-regression', reference: 'https://github.com/djm204/frankenbeast/pull/2' },
+      ],
+    });
+    expect(isLessonApplicable(quarantined)).toBe(false);
+  });
+
+  it('allows manual unquarantine only with review evidence and restores active application', () => {
+    const quarantined = quarantineLesson(
+      {
+        evaluatorName: 'learning-reviewer',
+        failureDescription: 'require stale workaround',
+        correctionApplied: 'Corrected in iteration 1',
+        taskId: 'rollback-task',
+        timestamp: '2026-07-12T10:00:00.000Z',
+        lifecycleStatus: 'active' as const,
+      },
+      {
+        trigger: 'explicit-user-correction',
+        reason: 'User reported stale workaround.',
+        evidence: [{ kind: 'operator-report', reference: 'discord://operator-report' }],
+        quarantinedAt: '2026-07-12T10:05:00.000Z',
+      },
+    );
+
+    const unquarantined = unquarantineLesson(quarantined, {
+      reviewedAt: '2026-07-12T12:00:00.000Z',
+      reviewer: 'pm-reviewer',
+      evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/3',
+      reason: 'Replacement guidance has regression coverage.',
+    });
+
+    expect(unquarantined.lifecycleStatus).toBe('active');
+    expect(unquarantined.quarantine).toBeUndefined();
+    expect(unquarantined.unquarantine).toEqual({
+      reviewedAt: '2026-07-12T12:00:00.000Z',
+      reviewer: 'pm-reviewer',
+      evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/3',
+      reason: 'Replacement guidance has regression coverage.',
+    });
+    expect(isLessonApplicable(unquarantined)).toBe(true);
   });
 
   it('does not attach rollback workflow guidance when no actionable lesson is recorded', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -720,6 +720,15 @@ describe('LessonRecorder', () => {
       .calls[0]![0];
     expect(lesson.lifecycleStatus).toBe('candidate');
     expect(isLessonApplicable(lesson)).toBe(false);
+    expect(
+      isLessonApplicable({
+        evaluatorName: 'legacy-reviewer',
+        failureDescription: 'legacy lesson without lifecycle metadata',
+        correctionApplied: 'legacy correction',
+        taskId: 'legacy-task',
+        timestamp: '2026-07-12T08:00:00.000Z',
+      }),
+    ).toBe(true);
   });
 
   it('quarantines active lessons on explicit user correction and prevents future application', () => {
@@ -745,7 +754,7 @@ describe('LessonRecorder', () => {
     });
 
     expect(quarantined.lifecycleStatus).toBe('quarantined');
-    expect(quarantined.quarantine).toEqual({
+    expect(quarantined.quarantine).toMatchObject({
       trigger: 'explicit-user-correction',
       reason: 'User corrected this as unsafe because verifier output was skipped.',
       quarantinedAt: '2026-07-12T10:05:00.000Z',
@@ -820,6 +829,55 @@ describe('LessonRecorder', () => {
       ],
     });
     expect(isLessonApplicable(quarantined)).toBe(false);
+  });
+
+  it('preserves lifecycle and quarantine audit trail across repeated quarantine and unquarantine', () => {
+    const candidateLesson = {
+      evaluatorName: 'learning-reviewer',
+      failureDescription: 'candidate guidance may be stale',
+      correctionApplied: 'Corrected in iteration 1',
+      taskId: 'candidate-quarantine-task',
+      timestamp: '2026-07-12T10:00:00.000Z',
+      lifecycleStatus: 'candidate' as const,
+    };
+
+    const firstQuarantine = quarantineLesson(candidateLesson, {
+      trigger: 'explicit-user-correction',
+      reason: 'User reported this candidate as harmful.',
+      evidence: [{ kind: 'operator-report', reference: 'discord://first-report' }],
+      quarantinedAt: '2026-07-12T10:05:00.000Z',
+    });
+    const repeatedQuarantine = quarantineLesson(firstQuarantine, {
+      trigger: 'repeated-failure-threshold',
+      reason: 'Regression repeated after initial correction.',
+      evidence: [
+        {
+          kind: 'failed-regression',
+          reference: 'https://github.com/djm204/frankenbeast/pull/4',
+        },
+      ],
+      quarantinedAt: '2026-07-12T11:00:00.000Z',
+      threshold: 2,
+    });
+
+    expect(repeatedQuarantine.quarantine?.previousLifecycleStatus).toBe('candidate');
+    expect(repeatedQuarantine.quarantine?.evidence).toEqual([
+      { kind: 'operator-report', reference: 'discord://first-report' },
+      {
+        kind: 'failed-regression',
+        reference: 'https://github.com/djm204/frankenbeast/pull/4',
+      },
+    ]);
+
+    const unquarantined = unquarantineLesson(repeatedQuarantine, {
+      reviewedAt: '2026-07-12T12:00:00.000Z',
+      reviewer: 'pm-reviewer',
+      evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/5',
+      reason: 'Review complete but candidate still requires promotion.',
+    });
+
+    expect(unquarantined.lifecycleStatus).toBe('candidate');
+    expect(isLessonApplicable(unquarantined)).toBe(false);
   });
 
   it('allows manual unquarantine only with review evidence and restores active application', () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -823,6 +823,25 @@ describe('LessonRecorder', () => {
   });
 
   it('allows manual unquarantine only with review evidence and restores active application', () => {
+    expect(() =>
+      unquarantineLesson(
+        {
+          evaluatorName: 'learning-reviewer',
+          failureDescription: 'fresh candidate should not be activated',
+          correctionApplied: 'Corrected in iteration 1',
+          taskId: 'candidate-task',
+          timestamp: '2026-07-12T09:00:00.000Z',
+          lifecycleStatus: 'candidate' as const,
+        },
+        {
+          reviewedAt: '2026-07-12T12:00:00.000Z',
+          reviewer: 'pm-reviewer',
+          evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/3',
+          reason: 'Candidate cannot skip quarantine review.',
+        },
+      ),
+    ).toThrow('Only quarantined lessons can be unquarantined.');
+
     const quarantined = quarantineLesson(
       {
         evaluatorName: 'learning-reviewer',

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -729,6 +729,22 @@ describe('LessonRecorder', () => {
         timestamp: '2026-07-12T08:00:00.000Z',
       }),
     ).toBe(true);
+    expect(
+      isLessonApplicable({
+        evaluatorName: 'legacy-reviewer',
+        failureDescription: 'legacy sandboxed lesson',
+        correctionApplied: 'legacy correction',
+        taskId: 'legacy-sandbox-task',
+        timestamp: '2026-07-12T08:00:00.000Z',
+        experimentSandbox: {
+          state: 'experimental',
+          promotionBlocked: true,
+          requiredChecks: [],
+          promotionCriteria:
+            'Require independent verification before allowing lesson reuse.',
+        },
+      }),
+    ).toBe(false);
   });
 
   it('quarantines active lessons on explicit user correction and prevents future application', () => {
@@ -861,6 +877,7 @@ describe('LessonRecorder', () => {
     });
 
     expect(repeatedQuarantine.quarantine?.previousLifecycleStatus).toBe('candidate');
+    expect(repeatedQuarantine.quarantine?.threshold).toBe(2);
     expect(repeatedQuarantine.quarantine?.evidence).toEqual([
       { kind: 'operator-report', reference: 'discord://first-report' },
       {


### PR DESCRIPTION
## Summary
- add lesson lifecycle metadata for candidate, active, quarantined, retired, and superseded states
- add quarantine helpers for explicit corrections and repeated failure thresholds
- add manual unquarantine helper and applicability gate so quarantined/candidate lessons stay out of future application paths

## Test Plan
- npm install
- npm run build --workspace @franken/types
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run test --workspace @franken/critique -- --run tests/unit/types/public-contracts.test.ts
- npm run typecheck --workspace @franken/critique
- npm run build --workspace @franken/critique
- npm run lint --workspace @franken/critique

Closes #1729