### PR TITLE
fix(mcp-suite): restore observer cost input validation

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -4,6 +4,7 @@ import {
   createAuditEvent,
   hashContent,
 } from '@franken/observer';
+import { validateObserverCostNumbers } from '../shared/observer-cost-validation.js';
 import { createSqliteStore } from '../shared/sqlite-store.js';
 
 export interface ObserverLogInput {
@@ -85,18 +86,6 @@ function shouldRepriceStoredCost(row: { cost_source: string; cost_usd: number; m
   return true;
 }
 
-function validateCostInput(input: ObserverCostInput): void {
-  if (!Number.isFinite(input.promptTokens) || !Number.isSafeInteger(input.promptTokens) || input.promptTokens < 0) {
-    throw new Error('promptTokens must be a finite safe non-negative integer');
-  }
-  if (!Number.isFinite(input.completionTokens) || !Number.isSafeInteger(input.completionTokens) || input.completionTokens < 0) {
-    throw new Error('completionTokens must be a finite safe non-negative integer');
-  }
-  if (input.costUsd !== undefined && (!Number.isFinite(input.costUsd) || input.costUsd < 0)) {
-    throw new Error('costUsd must be a finite non-negative number');
-  }
-}
-
 export function createObserverAdapter(dbPath: string): ObserverAdapter {
   const store = createSqliteStore(dbPath);
   const costCalculator = new CostCalculator(DEFAULT_PRICING, {
@@ -143,7 +132,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
     },
 
     async logCost(input) {
-      validateCostInput(input);
+      validateObserverCostNumbers(input);
       const unknownModel = input.costUsd === undefined && !hasDefaultPricing(input.model);
       const costUsd = input.costUsd ?? costCalculator.calculate({
         model: input.model,

--- a/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
+++ b/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
@@ -1,0 +1,82 @@
+export interface ObserverCostNumbers {
+  promptTokens: number;
+  completionTokens: number;
+  costUsd?: number;
+}
+
+export interface ParsedObserverCostArgs extends ObserverCostNumbers {
+  sessionId: string;
+  model: string;
+}
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; message: string };
+
+function parseNonNegativeIntegerArg(name: string, value: unknown): ParseResult<number> {
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return { ok: false, message: `${name} must be a finite safe non-negative integer` };
+  }
+  const raw = typeof value === 'string' ? value.trim() : String(value);
+  if (raw.length === 0) {
+    return { ok: false, message: `${name} must be a finite safe non-negative integer` };
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed < 0) {
+    return { ok: false, message: `${name} must be a finite safe non-negative integer` };
+  }
+  return { ok: true, value: parsed };
+}
+
+function parseOptionalNonNegativeNumberArg(name: string, value: unknown): ParseResult<number | undefined> {
+  if (value == null) {
+    return { ok: true, value: undefined };
+  }
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return { ok: false, message: `${name} must be a finite non-negative number` };
+  }
+  const raw = typeof value === 'string' ? value.trim() : String(value);
+  if (raw.length === 0) {
+    return { ok: false, message: `${name} must be a finite non-negative number` };
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { ok: false, message: `${name} must be a finite non-negative number` };
+  }
+  return { ok: true, value: parsed };
+}
+
+export function validateObserverCostNumbers(input: ObserverCostNumbers): void {
+  if (!Number.isFinite(input.promptTokens) || !Number.isSafeInteger(input.promptTokens) || input.promptTokens < 0) {
+    throw new Error('promptTokens must be a finite safe non-negative integer');
+  }
+  if (!Number.isFinite(input.completionTokens) || !Number.isSafeInteger(input.completionTokens) || input.completionTokens < 0) {
+    throw new Error('completionTokens must be a finite safe non-negative integer');
+  }
+  if (input.costUsd !== undefined && (!Number.isFinite(input.costUsd) || input.costUsd < 0)) {
+    throw new Error('costUsd must be a finite non-negative number');
+  }
+}
+
+export function parseObserverCostArgs(args: Record<string, unknown>): ParseResult<ParsedObserverCostArgs> {
+  const promptTokensArg = parseNonNegativeIntegerArg('promptTokens', args['promptTokens']);
+  if (!promptTokensArg.ok) {
+    return promptTokensArg;
+  }
+  const completionTokensArg = parseNonNegativeIntegerArg('completionTokens', args['completionTokens']);
+  if (!completionTokensArg.ok) {
+    return completionTokensArg;
+  }
+  const costUsdArg = parseOptionalNonNegativeNumberArg('costUsd', args['costUsd']);
+  if (!costUsdArg.ok) {
+    return costUsdArg;
+  }
+
+  const parsed = {
+    sessionId: String(args['sessionId']),
+    model: String(args['model']),
+    promptTokens: promptTokensArg.value,
+    completionTokens: completionTokensArg.value,
+    ...(costUsdArg.value !== undefined ? { costUsd: costUsdArg.value } : {}),
+  };
+  validateObserverCostNumbers(parsed);
+  return { ok: true, value: parsed };
+}

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -5,6 +5,7 @@ import { createGovernorAdapter, type GovernorAdapter } from '../adapters/governo
 import { createObserverAdapter, type ObserverAdapter } from '../adapters/observer-adapter.js';
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
+import { parseObserverCostArgs } from './observer-cost-validation.js';
 import type { ToolDef, ToolInputSchema, ToolResult } from './server-factory.js';
 
 export interface AdapterSet {
@@ -53,39 +54,6 @@ function parseMemoryQueryLimit(value: unknown): { ok: true; value: number } | { 
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_MEMORY_QUERY_LIMIT) {
     return { ok: false, message: `limit must be a positive integer between 1 and ${MAX_MEMORY_QUERY_LIMIT}` };
-  }
-  return { ok: true, value: parsed };
-}
-
-function parseNonNegativeIntegerArg(name: string, value: unknown): { ok: true; value: number } | { ok: false; message: string } {
-  if (typeof value !== 'number' && typeof value !== 'string') {
-    return { ok: false, message: `${name} must be a finite safe non-negative integer` };
-  }
-  const raw = typeof value === 'string' ? value.trim() : String(value);
-  if (raw.length === 0) {
-    return { ok: false, message: `${name} must be a finite safe non-negative integer` };
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed < 0) {
-    return { ok: false, message: `${name} must be a finite safe non-negative integer` };
-  }
-  return { ok: true, value: parsed };
-}
-
-function parseOptionalNonNegativeNumberArg(name: string, value: unknown): { ok: true; value: number | undefined } | { ok: false; message: string } {
-  if (value == null) {
-    return { ok: true, value: undefined };
-  }
-  if (typeof value !== 'number' && typeof value !== 'string') {
-    return { ok: false, message: `${name} must be a finite non-negative number` };
-  }
-  const raw = typeof value === 'string' ? value.trim() : String(value);
-  if (raw.length === 0) {
-    return { ok: false, message: `${name} must be a finite non-negative number` };
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return { ok: false, message: `${name} must be a finite non-negative number` };
   }
   return { ok: true, value: parsed };
 }
@@ -432,23 +400,12 @@ const TOOLS: ToolFull[] = [
       required: ['sessionId', 'model', 'promptTokens', 'completionTokens'],
     },
     makeHandler: ({ observer }) => async (args) => {
-      const sessionId = String(args['sessionId']);
-      const model = String(args['model']);
-      const promptTokensArg = parseNonNegativeIntegerArg('promptTokens', args['promptTokens']);
-      if (!promptTokensArg.ok) {
-        return { content: [{ type: 'text', text: `Error: fbeast_observer_log_cost ${promptTokensArg.message}` }], isError: true };
+      const parsedArgs = parseObserverCostArgs(args);
+      if (!parsedArgs.ok) {
+        return { content: [{ type: 'text', text: `Error: fbeast_observer_log_cost ${parsedArgs.message}` }], isError: true };
       }
-      const completionTokensArg = parseNonNegativeIntegerArg('completionTokens', args['completionTokens']);
-      if (!completionTokensArg.ok) {
-        return { content: [{ type: 'text', text: `Error: fbeast_observer_log_cost ${completionTokensArg.message}` }], isError: true };
-      }
-      const costUsdArg = parseOptionalNonNegativeNumberArg('costUsd', args['costUsd']);
-      if (!costUsdArg.ok) {
-        return { content: [{ type: 'text', text: `Error: fbeast_observer_log_cost ${costUsdArg.message}` }], isError: true };
-      }
-      const promptTokens = promptTokensArg.value;
-      const completionTokens = completionTokensArg.value;
-      const result = await observer.logCost({ sessionId, model, promptTokens, completionTokens, ...(costUsdArg.value !== undefined ? { costUsd: costUsdArg.value } : {}) });
+      const { sessionId, model, promptTokens, completionTokens } = parsedArgs.value;
+      const result = await observer.logCost(parsedArgs.value);
       const pricingNote = result.unknownModel ? ' (unknown model — not priced)' : '';
       return { content: [{ type: 'text', text: `Logged cost: ${promptTokens}+${completionTokens} tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}` }] };
     },


### PR DESCRIPTION
## Summary
- Add a shared observer cost validation/parser helper for MCP tool arguments and adapter-level persistence checks.
- Route fbeast_observer_log_cost through the shared validator before calling observer.logCost.
- Keep adapter-level finite, safe, non-negative token and non-negative cost guards before ledger insertion.

Fixes #2181

## Test plan
- npm test --workspace @franken/mcp-suite -- --run src/servers/observer.test.ts src/shared/tool-registry.test.ts src/adapters/observer-adapter.test.ts
- git diff --check

## Notes
- fbeast MCP tools were not available in this worker tool schema, so verification used normal terminal/git/gh tooling.
- npm run typecheck --workspace @franken/mcp-suite is currently blocked in this isolated worktree because local workspace package declarations/dist are not built/resolved (e.g. @franken/brain, @franken/types, @franken/observer).