### PR TITLE
fix(orchestrator): validate init security mode

### DIFF
--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -75,6 +75,16 @@ async function askText(io: InterviewIO, prompt: string, defaultValue: string): P
   return trimmed.length > 0 ? trimmed : defaultValue;
 }
 
+async function askSecurityMode(io: InterviewIO, defaultValue: 'secure' | 'insecure'): Promise<'secure' | 'insecure'> {
+  while (true) {
+    const answer = (await askText(io, 'Security mode [secure/insecure] (default: secure)', defaultValue)).toLowerCase();
+    if (answer === 'secure' || answer === 'insecure') {
+      return answer;
+    }
+    io.display('Invalid security mode. Enter "secure" or "insecure".');
+  }
+}
+
 function buildConfig(
   baseConfig: OrchestratorConfig,
   state: InitState,
@@ -172,7 +182,7 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
     : currentProviderDefault;
 
   const securityMode = (!secretBackendOnly && scope.has('security'))
-    ? await askText(options.io, 'Security mode [secure/insecure] (default: secure)', options.initialState.securityMode) as 'secure' | 'insecure'
+    ? await askSecurityMode(options.io, options.initialState.securityMode)
     : options.initialState.securityMode;
 
   // Secret backend detection

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { InterviewIO } from '../../../src/planning/interview-loop.js';
 import type { ISecretStore, SecretStoreDetection } from '../../../src/network/secret-store.js';
 import { runInitWizard, type InitWizardScope } from '../../../src/init/init-wizard.js';
@@ -71,6 +71,19 @@ describe('runInitWizard – backward compatibility (no secretStore)', () => {
     expect(result.state).toBeDefined();
     // No secret-backend-selection in completedSteps (no secretStore)
     expect(result.state.completedSteps).not.toContain('secret-backend-selection');
+  });
+
+  it('re-prompts when the security mode answer is invalid before continuing', async () => {
+    const io = makeIO(['y', 'y', 'n', 'claude', 'high', 'insecure']);
+    const state = createEmptyInitState('/tmp/test-config.json');
+
+    const result = await runInitWizard({ io, initialState: state });
+
+    expect(result.config.network.mode).toBe('insecure');
+    expect(result.state.securityMode).toBe('insecure');
+    expect(io.display).toHaveBeenCalledWith('Invalid security mode. Enter "secure" or "insecure".');
+    expect(io.ask).toHaveBeenNthCalledWith(5, 'Security mode [secure/insecure] (default: secure)');
+    expect(io.ask).toHaveBeenNthCalledWith(6, 'Security mode [secure/insecure] (default: secure)');
   });
 });
 


### PR DESCRIPTION
## Summary
- Validate the init wizard security-mode prompt before continuing.
- Re-prompt with a plain-language error until the answer is `secure` or `insecure`.
- Add a regression test proving an invalid answer no longer reaches final config parsing as a raw Zod error.

## Test Plan
- [x] `npm run test --workspace @franken/orchestrator -- tests/unit/init/init-wizard.test.ts`
- [x] `npm run typecheck --workspace @franken/orchestrator`
- [x] `npm run build --workspace @franken/orchestrator`
- [x] `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)

Closes #1696
