### PR TITLE
fix(web): surface dashboard response errors

### DIFF
--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -95,6 +95,17 @@ describe('DashboardApiClient', () => {
       const client = new DashboardApiClient(BASE_URL);
       await expect(client.toggleSkill('missing', true)).rejects.toThrow('HTTP 404');
     });
+
+    it('prefers flat server error messages over bare HTTP status codes', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Skill "missing" was not found' }),
+      });
+
+      const client = new DashboardApiClient(BASE_URL);
+      await expect(client.toggleSkill('missing', true)).rejects.toThrow('Skill "missing" was not found');
+    });
   });
 
   describe('updateSecurityProfile', () => {
@@ -124,6 +135,30 @@ describe('DashboardApiClient', () => {
 
       const client = new DashboardApiClient(BASE_URL);
       await expect(client.updateSecurityProfile('strict')).rejects.toThrow('HTTP 403');
+    });
+
+    it('surfaces strict-profile server guidance in the thrown error', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'Security profile "strict" requires allowedDomains to be configured' }),
+      });
+
+      const client = new DashboardApiClient(BASE_URL);
+      await expect(client.updateSecurityProfile('strict')).rejects.toThrow(
+        'Security profile "strict" requires allowedDomains to be configured',
+      );
+    });
+
+    it('also accepts enveloped server error messages', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: { message: 'Profile update failed' } }),
+      });
+
+      const client = new DashboardApiClient(BASE_URL);
+      await expect(client.updateSecurityProfile('strict')).rejects.toThrow('Profile update failed');
     });
   });
 

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -32,7 +32,7 @@ export class DashboardApiClient {
 
   async fetchSnapshot(): Promise<DashboardSnapshot> {
     const res = await fetch(`${this.baseUrl}/api/dashboard`);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) throw await createResponseError(res);
     return (await res.json()) as DashboardSnapshot;
   }
 
@@ -42,7 +42,7 @@ export class DashboardApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ enabled }),
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) throw await createResponseError(res);
   }
 
   async updateSecurityProfile(profile: string): Promise<DashboardSecurity> {
@@ -51,7 +51,7 @@ export class DashboardApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ profile }),
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) throw await createResponseError(res);
     return (await res.json()) as DashboardSecurity;
   }
 
@@ -134,4 +134,26 @@ export class DashboardApiClient {
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+async function createResponseError(res: Response): Promise<Error> {
+  const message = await extractResponseErrorMessage(res);
+  return new Error(message ?? `HTTP ${res.status}`);
+}
+
+async function extractResponseErrorMessage(res: Response): Promise<string | undefined> {
+  try {
+    const body = await res.json() as unknown;
+    if (!body || typeof body !== 'object') return undefined;
+    const error = (body as { error?: unknown }).error;
+    if (typeof error === 'string' && error.trim()) return error;
+    if (error && typeof error === 'object') {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim()) return message;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Read dashboard mutation/fetch error response bodies before throwing
- Prefer flat server `{ error: string }` and enveloped `{ error: { message } }` messages over bare HTTP status codes
- Add regression coverage for skill toggle and strict security-profile failures

## Test Plan
- npm run build --workspace @franken/types
- npm run test -- src/lib/dashboard-api.test.ts
- npm run test -- src/pages/dashboard-page.test.tsx src/lib/dashboard-api.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #1695