### PR TITLE
fix(mcp-suite): avoid forced exits in server startup

### DIFF
--- a/packages/franken-mcp-suite/src/beast.ts
+++ b/packages/franken-mcp-suite/src/beast.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type ToolDef } from './shared/server-factory.js';
 import { createGovernanceGate } from './shared/governance-gate.js';
 import { createAuditSink } from './shared/central-enforcement.js';
 import { isMain } from './shared/is-main.js';
+import { handleStartupFailure } from './shared/shutdown.js';
 import { createBrainAdapter } from './adapters/brain-adapter.js';
 import { createObserverAdapter } from './adapters/observer-adapter.js';
 import { createGovernorAdapter } from './adapters/governor-adapter.js';
@@ -54,7 +55,6 @@ if (isMain(import.meta.url)) {
 
   const server = createCombinedMcpServer(values['db']!);
   server.start().catch((err) => {
-    console.error('fbeast-mcp failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-mcp', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/critique.ts
+++ b/packages/franken-mcp-suite/src/servers/critique.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createCritiqueAdapter, type CritiqueAdapter } from '../adapters/critique-adapter.js';
 import { parseArgs } from 'node:util';
 import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -24,7 +25,6 @@ if (isMain(import.meta.url)) {
   const critique = createCritiqueAdapter();
   const server = createCritiqueServer({ critique }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-critique failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-critique', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/firewall.ts
+++ b/packages/franken-mcp-suite/src/servers/firewall.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createFirewallAdapter, type FirewallAdapter } from '../adapters/firewall-adapter.js';
 import { parseArgs } from 'node:util';
 import { deriveProjectRootFromDbPath, resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -30,7 +31,6 @@ if (isMain(import.meta.url)) {
   const firewall = createFirewallAdapter(dbPath, tier, { root, configPath: values['config'] });
   const server = createFirewallServer({ firewall }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-firewall failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-firewall', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/governor.ts
+++ b/packages/franken-mcp-suite/src/servers/governor.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createGovernorAdapter, type GovernorAdapter } from '../adapters/governor-adapter.js';
 import { parseArgs } from 'node:util';
 import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -24,7 +25,6 @@ if (isMain(import.meta.url)) {
   const governor = createGovernorAdapter(dbPath);
   const server = createGovernorServer({ governor }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-governor failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-governor', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/memory.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createBrainAdapter, type BrainAdapter } from '../adapters/brain-adapter.js';
 import { parseArgs } from 'node:util';
 import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -24,7 +25,6 @@ if (isMain(import.meta.url)) {
   const brain = createBrainAdapter(dbPath);
   const server = createMemoryServer({ brain }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-memory failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-memory', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/observer.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createObserverAdapter, type ObserverAdapter } from '../adapters/observer-adapter.js';
 import { parseArgs } from 'node:util';
 import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -24,7 +25,6 @@ if (isMain(import.meta.url)) {
   const observer = createObserverAdapter(dbPath);
   const server = createObserverServer({ observer }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-observer failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-observer', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/planner.ts
+++ b/packages/franken-mcp-suite/src/servers/planner.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
 import { parseArgs } from 'node:util';
 import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -24,7 +25,6 @@ if (isMain(import.meta.url)) {
   const planner = createPlannerAdapter(dbPath);
   const server = createPlannerServer({ planner }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-planner failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-planner', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createMcpServer, sanitizeToolArgumentsForAudit, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef, type ToolResult } from '../shared/server-factory.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
 import { createGovernanceGate } from '../shared/governance-gate.js';
 import { createAuditSink } from '../shared/central-enforcement.js';
@@ -177,7 +178,6 @@ if (isMain(import.meta.url)) {
   });
   const server = createProxyServer({ dbPath: values['db']!, root: values['root'], configPath: values['config'] });
   server.start().catch((err) => {
-    console.error('fbeast-proxy failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-proxy', err);
   });
 }

--- a/packages/franken-mcp-suite/src/servers/skills.ts
+++ b/packages/franken-mcp-suite/src/servers/skills.ts
@@ -3,6 +3,7 @@ import { createMcpServer, type CreateMcpServerOptions, type FbeastMcpServer } fr
 import { createToolDefsForServer } from '../shared/tool-registry.js';
 import { createCentralOptions } from '../shared/central-enforcement.js';
 import { isMain } from '../shared/is-main.js';
+import { handleStartupFailure } from '../shared/shutdown.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
 import { parseArgs } from 'node:util';
 import { resolveProjectDbPath } from '../shared/resolve-db-path.js';
@@ -24,7 +25,6 @@ if (isMain(import.meta.url)) {
   const skills = createSkillsAdapter(dbPath);
   const server = createSkillsServer({ skills }, createCentralOptions(dbPath));
   server.start().catch((err) => {
-    console.error('fbeast-skills failed to start:', err);
-    process.exit(1);
+    handleStartupFailure('fbeast-skills', err);
   });
 }

--- a/packages/franken-mcp-suite/src/shared/shutdown.test.ts
+++ b/packages/franken-mcp-suite/src/shared/shutdown.test.ts
@@ -4,15 +4,16 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { handleStartupFailure } from './shutdown.js';
 
-const serverEntrypoints = [
-  'planner.ts',
-  'memory.ts',
-  'proxy.ts',
-  'critique.ts',
-  'skills.ts',
-  'firewall.ts',
-  'governor.ts',
-  'observer.ts',
+const entrypointPaths = [
+  ['servers', 'planner.ts'],
+  ['servers', 'memory.ts'],
+  ['servers', 'proxy.ts'],
+  ['servers', 'critique.ts'],
+  ['servers', 'skills.ts'],
+  ['servers', 'firewall.ts'],
+  ['servers', 'governor.ts'],
+  ['servers', 'observer.ts'],
+  ['beast.ts'],
 ] as const;
 
 describe('server shutdown handling', () => {
@@ -23,16 +24,19 @@ describe('server shutdown handling', () => {
       process: { exitCode: undefined as number | undefined },
     };
 
-    handleStartupFailure('fbeast-planner', new Error('bind failed'), runtime);
+    const error = new Error('bind failed');
+    handleStartupFailure('fbeast-planner', error, runtime);
 
     expect(runtime.process.exitCode).toBe(1);
-    expect(write).toHaveBeenCalledWith('fbeast-planner failed to start: bind failed\n');
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('fbeast-planner failed to start: Error: bind failed'));
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('at '));
   });
 
-  it('removes direct process.exit calls from standalone server entrypoints', () => {
-    for (const file of serverEntrypoints) {
-      const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'servers', file), 'utf8');
-      expect(source, `${file} should use shared shutdown helper instead of process.exit`).not.toMatch(/\bprocess\.exit\s*\(/);
+  it('removes direct process.exit calls from MCP server entrypoints', () => {
+    for (const pathParts of entrypointPaths) {
+      const filePath = join(dirname(fileURLToPath(import.meta.url)), '..', ...pathParts);
+      const source = readFileSync(filePath, 'utf8');
+      expect(source, `${pathParts.join('/')} should use shared shutdown helper instead of process.exit`).not.toMatch(/\bprocess\.exit\s*\(/);
     }
   });
 });

--- a/packages/franken-mcp-suite/src/shared/shutdown.test.ts
+++ b/packages/franken-mcp-suite/src/shared/shutdown.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { handleStartupFailure } from './shutdown.js';
+
+const serverEntrypoints = [
+  'planner.ts',
+  'memory.ts',
+  'proxy.ts',
+  'critique.ts',
+  'skills.ts',
+  'firewall.ts',
+  'governor.ts',
+  'observer.ts',
+] as const;
+
+describe('server shutdown handling', () => {
+  it('reports startup failures without forcing process.exit', () => {
+    const write = vi.fn();
+    const runtime = {
+      stderr: { write },
+      process: { exitCode: undefined as number | undefined },
+    };
+
+    handleStartupFailure('fbeast-planner', new Error('bind failed'), runtime);
+
+    expect(runtime.process.exitCode).toBe(1);
+    expect(write).toHaveBeenCalledWith('fbeast-planner failed to start: bind failed\n');
+  });
+
+  it('removes direct process.exit calls from standalone server entrypoints', () => {
+    for (const file of serverEntrypoints) {
+      const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'servers', file), 'utf8');
+      expect(source, `${file} should use shared shutdown helper instead of process.exit`).not.toMatch(/\bprocess\.exit\s*\(/);
+    }
+  });
+});

--- a/packages/franken-mcp-suite/src/shared/shutdown.ts
+++ b/packages/franken-mcp-suite/src/shared/shutdown.ts
@@ -1,0 +1,20 @@
+export interface StartupFailureRuntime {
+  readonly stderr: Pick<NodeJS.WriteStream, 'write'>;
+  readonly process: Pick<NodeJS.Process, 'exitCode'>;
+}
+
+export function describeStartupError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+  return String(error);
+}
+
+export function handleStartupFailure(
+  serviceName: string,
+  error: unknown,
+  runtime: StartupFailureRuntime = { stderr: process.stderr, process },
+): void {
+  runtime.stderr.write(`${serviceName} failed to start: ${describeStartupError(error)}\n`);
+  runtime.process.exitCode = 1;
+}

--- a/packages/franken-mcp-suite/src/shared/shutdown.ts
+++ b/packages/franken-mcp-suite/src/shared/shutdown.ts
@@ -1,13 +1,12 @@
+import { inspect } from 'node:util';
+
 export interface StartupFailureRuntime {
   readonly stderr: Pick<NodeJS.WriteStream, 'write'>;
   readonly process: Pick<NodeJS.Process, 'exitCode'>;
 }
 
 export function describeStartupError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message || error.name;
-  }
-  return String(error);
+  return inspect(error, { depth: 4 });
 }
 
 export function handleStartupFailure(


### PR DESCRIPTION
## Summary
- Add a shared startup-failure shutdown helper that reports errors and sets process.exitCode instead of forcing process.exit.
- Update standalone MCP server entrypoints to use the helper.
- Add regression coverage asserting startup failures avoid direct process.exit calls in server components.

## Test Plan
- npm --prefix packages/franken-mcp-suite test -- src/shared/shutdown.test.ts
- npm --prefix packages/franken-mcp-suite test -- src/servers/planner.test.ts src/servers/memory.test.ts src/servers/proxy.test.ts src/servers/critique.test.ts src/servers/skills.test.ts src/servers/firewall.test.ts src/servers/governor.test.ts src/servers/observer.test.ts src/shared/shutdown.test.ts
- npx turbo run build --filter=@franken/mcp-suite...
- npm --prefix packages/franken-mcp-suite run typecheck
- npm --prefix packages/franken-mcp-suite run lint
- npm --prefix packages/franken-mcp-suite test

Closes #2095