### PR TITLE
feat(brain): add memory schema migrations

### DIFF
--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -1,6 +1,6 @@
 # @franken/brain — MOD-03: Memory Systems
 
-Current public API: `SqliteBrain`, `WorkingMemoryLimitError`, `DEFAULT_WORKING_MEMORY_LIMITS`, and the `WorkingMemoryLimits` type.
+Current public API: `SqliteBrain`, `WorkingMemoryLimitError`, `UnsupportedMemorySchemaVersionError`, `DEFAULT_WORKING_MEMORY_LIMITS`, `CURRENT_MEMORY_SCHEMA_VERSION`, and the `WorkingMemoryLimits`, `MemorySchemaMetadata`, `MemorySchemaStoreMetadata`, `MemorySchemaMigrationOptions`, `MemorySchemaMigrationOperation`, and `MemorySchemaMigrationResult` types.
 
 `@franken/brain` provides SQLite-backed working memory, episodic event recall, and recovery checkpoints for the Frankenbeast runtime. Older design docs described a `MemoryOrchestrator` with ChromaDB-backed semantic memory and PII-decorator stores; those classes are not exported by the current package.
 

--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -77,6 +77,26 @@ SqliteBrain
 
 The package creates the required SQLite schema in its constructor and enables WAL mode. Use `:memory:` for tests or pass a file path for persistent state.
 
+## Memory schema versioning and migrations
+
+Durable memory stores are explicitly versioned. `working_memory`, `episodic_events`, and `checkpoints` rows include a `schema_version` column, and the `memory_schema_versions` table records the current schema version for each store. `SqliteBrain#getMemorySchemaMetadata()` returns the active store versions and record counts so callers can audit what is on disk.
+
+`SqliteBrain` automatically upgrades version-0/legacy SQLite files that have the old tables but no version metadata. Use the migration helper before opening a database when you want an audit plan or a backup:
+
+```typescript
+import { SqliteBrain } from '@franken/brain';
+
+const plan = SqliteBrain.migrateMemorySchema('.fbeast/beast.db', { dryRun: true });
+// inspect plan.operations
+
+SqliteBrain.migrateMemorySchema('.fbeast/beast.db', {
+  backupBeforeMigrate: true,
+  backupPath: '.fbeast/beast.db.before-memory-schema-v1',
+});
+```
+
+Future schema changes should increment `CURRENT_MEMORY_SCHEMA_VERSION`, add a forward-only migration in `migrateMemorySchemaDatabase`, and add fixtures that prove old databases upgrade and unsupported future versions fail closed with `UnsupportedMemorySchemaVersionError`. Do not silently ignore unknown future store or record versions.
+
 ## Project structure
 
 ```text

--- a/packages/franken-brain/src/index.ts
+++ b/packages/franken-brain/src/index.ts
@@ -1,6 +1,13 @@
 export {
   SqliteBrain,
   WorkingMemoryLimitError,
+  UnsupportedMemorySchemaVersionError,
   DEFAULT_WORKING_MEMORY_LIMITS,
+  CURRENT_MEMORY_SCHEMA_VERSION,
   type WorkingMemoryLimits,
+  type MemorySchemaMetadata,
+  type MemorySchemaStoreMetadata,
+  type MemorySchemaMigrationOptions,
+  type MemorySchemaMigrationOperation,
+  type MemorySchemaMigrationResult,
 } from './sqlite-brain.js';

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1,4 +1,3 @@
-import { copyFileSync } from 'node:fs';
 import Database from 'better-sqlite3';
 import type {
   IBrain,
@@ -617,6 +616,7 @@ export class SqliteBrain implements IBrain {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');
+    assertSupportedMemorySchema(this.db);
     this.initSchema();
     migrateMemorySchemaDatabase(this.db, dbPath, { dryRun: false });
     this.working = new SqliteWorkingMemory(this.db, {
@@ -667,9 +667,11 @@ export class SqliteBrain implements IBrain {
     dbPath: string,
     options: MemorySchemaMigrationOptions = {},
   ): MemorySchemaMigrationResult {
-    const db = new Database(dbPath);
-    db.pragma('journal_mode = WAL');
-    db.pragma('busy_timeout = 5000');
+    const db = new Database(dbPath, options.dryRun ? { readonly: true, fileMustExist: true } : {});
+    if (!options.dryRun) {
+      db.pragma('journal_mode = WAL');
+      db.pragma('busy_timeout = 5000');
+    }
     try {
       return migrateMemorySchemaDatabase(db, dbPath, options);
     } finally {
@@ -821,7 +823,7 @@ function migrateMemorySchemaDatabase(
       throw new Error('Cannot create a backup for an in-memory SQLite database');
     }
     backupPath ??= `${dbPath}.backup-${Date.now()}`;
-    copyFileSync(dbPath, backupPath);
+    db.exec(`VACUUM INTO ${sqliteStringLiteral(backupPath)}`);
   }
 
   if (!dryRun && migrated) {
@@ -872,6 +874,44 @@ function readMemorySchemaMetadata(db: Database.Database): MemorySchemaMetadata {
       recordCount: (db.prepare(`SELECT COUNT(*) AS count FROM ${store}`).get() as { count: number }).count,
     })),
   };
+}
+
+function assertSupportedMemorySchema(db: Database.Database): void {
+  const tableRows = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all() as Array<{
+    name: string;
+  }>;
+  const existingTables = new Set(tableRows.map(row => row.name));
+  if (existingTables.has('memory_schema_versions')) {
+    const rows = db.prepare(`SELECT store, version FROM memory_schema_versions`).all() as Array<{
+      store: string;
+      version: number;
+    }>;
+    for (const row of rows) {
+      if (row.version > CURRENT_MEMORY_SCHEMA_VERSION) {
+        throw new UnsupportedMemorySchemaVersionError(
+          `Memory store ${row.store} uses schema version ${row.version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+        );
+      }
+    }
+  }
+
+  for (const store of ['working_memory', 'episodic_events', 'checkpoints']) {
+    if (!existingTables.has(store)) continue;
+    const columnRows = db.prepare(`PRAGMA table_info(${store})`).all() as Array<{ name: string }>;
+    if (!columnRows.some(row => row.name === 'schema_version')) continue;
+    const future = db
+      .prepare(`SELECT schema_version FROM ${store} WHERE schema_version > ? LIMIT 1`)
+      .get(CURRENT_MEMORY_SCHEMA_VERSION) as { schema_version: number } | undefined;
+    if (future) {
+      throw new UnsupportedMemorySchemaVersionError(
+        `Memory table ${store} contains record schema version ${future.schema_version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+      );
+    }
+  }
+}
+
+function sqliteStringLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 // --- Constants ---

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -670,6 +670,8 @@ export class SqliteBrain implements IBrain {
   ): MemorySchemaMigrationResult {
     const db = new Database(dbPath, options.dryRun ? { readonly: true, fileMustExist: true } : {});
     if (!options.dryRun) {
+      db.pragma('busy_timeout = 5000');
+      assertSupportedMemorySchema(db);
       db.pragma('journal_mode = WAL');
       db.pragma('busy_timeout = 5000');
     }
@@ -781,6 +783,12 @@ function migrateMemorySchemaDatabase(
         throw new UnsupportedMemorySchemaVersionError(
           `Memory store ${row.store} uses schema version ${row.version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
         );
+      }
+      if (row.version < CURRENT_MEMORY_SCHEMA_VERSION) {
+        operations.push({
+          table: 'memory_schema_versions',
+          action: `update ${row.store} registry version from ${row.version} to ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+        });
       }
       fromVersion = Math.min(fromVersion, row.version);
     }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -669,13 +669,13 @@ export class SqliteBrain implements IBrain {
     options: MemorySchemaMigrationOptions = {},
   ): MemorySchemaMigrationResult {
     const db = new Database(dbPath, options.dryRun ? { readonly: true, fileMustExist: true } : {});
-    if (!options.dryRun) {
-      db.pragma('busy_timeout = 5000');
-      assertSupportedMemorySchema(db);
-      db.pragma('journal_mode = WAL');
-      db.pragma('busy_timeout = 5000');
-    }
     try {
+      if (!options.dryRun) {
+        db.pragma('busy_timeout = 5000');
+        assertSupportedMemorySchema(db);
+        db.pragma('journal_mode = WAL');
+        db.pragma('busy_timeout = 5000');
+      }
       return migrateMemorySchemaDatabase(db, dbPath, options);
     } finally {
       db.close();

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -614,9 +614,9 @@ export class SqliteBrain implements IBrain {
     options: { hydrateWorkingMemoryFromDb?: boolean } = {},
   ) {
     this.db = new Database(dbPath);
+    assertSupportedMemorySchema(this.db);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');
-    assertSupportedMemorySchema(this.db);
     this.initSchema();
     migrateMemorySchemaDatabase(this.db, dbPath, { dryRun: false });
     this.working = new SqliteWorkingMemory(this.db, {
@@ -818,12 +818,14 @@ function migrateMemorySchemaDatabase(
 
   const migrated = operations.length > 0;
   let backupPath = options.backupPath;
+  let createdBackupPath: string | undefined;
   if (!dryRun && migrated && options.backupBeforeMigrate) {
     if (dbPath === ':memory:') {
       throw new Error('Cannot create a backup for an in-memory SQLite database');
     }
     backupPath ??= `${dbPath}.backup-${Date.now()}`;
     db.exec(`VACUUM INTO ${sqliteStringLiteral(backupPath)}`);
+    createdBackupPath = backupPath;
   }
 
   if (!dryRun && migrated) {
@@ -854,7 +856,7 @@ function migrateMemorySchemaDatabase(
     toVersion: CURRENT_MEMORY_SCHEMA_VERSION,
     dryRun,
     migrated,
-    ...(backupPath ? { backupPath } : {}),
+    ...(createdBackupPath ? { backupPath: createdBackupPath } : {}),
     operations,
   };
 }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1,3 +1,4 @@
+import { copyFileSync } from 'node:fs';
 import Database from 'better-sqlite3';
 import type {
   IBrain,
@@ -27,6 +28,46 @@ export const DEFAULT_WORKING_MEMORY_LIMITS: WorkingMemoryLimits = {
   maxValueBytes: 5 * 1024 * 1024,
   maxTotalBytes: 64 * 1024 * 1024,
 };
+
+export const CURRENT_MEMORY_SCHEMA_VERSION = 1;
+
+export interface MemorySchemaStoreMetadata {
+  store: string;
+  version: number;
+  recordCount: number;
+}
+
+export interface MemorySchemaMetadata {
+  version: number;
+  stores: MemorySchemaStoreMetadata[];
+}
+
+export interface MemorySchemaMigrationOperation {
+  table: string;
+  action: string;
+}
+
+export interface MemorySchemaMigrationResult {
+  fromVersion: number;
+  toVersion: number;
+  dryRun: boolean;
+  migrated: boolean;
+  backupPath?: string;
+  operations: MemorySchemaMigrationOperation[];
+}
+
+export interface MemorySchemaMigrationOptions {
+  dryRun?: boolean;
+  backupBeforeMigrate?: boolean;
+  backupPath?: string;
+}
+
+export class UnsupportedMemorySchemaVersionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedMemorySchemaVersionError';
+  }
+}
 
 export class WorkingMemoryLimitError extends Error {
   constructor(message: string) {
@@ -129,8 +170,8 @@ class SqliteWorkingMemory implements IWorkingMemory {
   flushToDb(): (() => void) | void {
     const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
     const upsert = this.db.prepare(
-      `INSERT INTO working_memory (key, value, updated_at) VALUES (?, ?, ?)
-       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+      `INSERT INTO working_memory (key, value, updated_at, schema_version) VALUES (?, ?, ?, ${CURRENT_MEMORY_SCHEMA_VERSION})
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at, schema_version = excluded.schema_version
        WHERE working_memory.value IS NOT excluded.value`,
     );
     const now = isoNow();
@@ -389,8 +430,8 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
   record(event: EpisodicEvent): void {
     this.db
       .prepare(
-        `INSERT INTO episodic_events (type, step, summary, details, created_at)
-         VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO episodic_events (type, step, summary, details, created_at, schema_version)
+         VALUES (?, ?, ?, ?, ?, ${CURRENT_MEMORY_SCHEMA_VERSION})`,
       )
       .run(
         event.type,
@@ -521,7 +562,7 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
     const tx = this.db.transaction(() => {
       finalizeWorkingMemoryFlush.current = this.flushWorkingMemory?.() ?? undefined;
       const result = this.db
-        .prepare(`INSERT INTO checkpoints (state, created_at) VALUES (?, ?)`)
+        .prepare(`INSERT INTO checkpoints (state, created_at, schema_version) VALUES (?, ?, ${CURRENT_MEMORY_SCHEMA_VERSION})`)
         .run(JSON.stringify(state), state.timestamp);
       return { id: String(result.lastInsertRowid) };
     });
@@ -577,6 +618,7 @@ export class SqliteBrain implements IBrain {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');
     this.initSchema();
+    migrateMemorySchemaDatabase(this.db, dbPath, { dryRun: false });
     this.working = new SqliteWorkingMemory(this.db, {
       ...DEFAULT_WORKING_MEMORY_LIMITS,
       ...workingMemoryLimits,
@@ -587,10 +629,16 @@ export class SqliteBrain implements IBrain {
 
   private initSchema(): void {
     this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_schema_versions (
+        store TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        migrated_at TEXT NOT NULL
+      );
       CREATE TABLE IF NOT EXISTS working_memory (
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL,
-        updated_at TEXT NOT NULL
+        updated_at TEXT NOT NULL,
+        schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}
       );
       CREATE TABLE IF NOT EXISTS episodic_events (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -599,14 +647,34 @@ export class SqliteBrain implements IBrain {
         summary TEXT NOT NULL,
         details TEXT,
         embedding BLOB,
-        created_at TEXT NOT NULL
+        created_at TEXT NOT NULL,
+        schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}
       );
       CREATE TABLE IF NOT EXISTS checkpoints (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         state TEXT NOT NULL,
-        created_at TEXT NOT NULL
+        created_at TEXT NOT NULL,
+        schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}
       );
     `);
+  }
+
+  getMemorySchemaMetadata(): MemorySchemaMetadata {
+    return readMemorySchemaMetadata(this.db);
+  }
+
+  static migrateMemorySchema(
+    dbPath: string,
+    options: MemorySchemaMigrationOptions = {},
+  ): MemorySchemaMigrationResult {
+    const db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    db.pragma('busy_timeout = 5000');
+    try {
+      return migrateMemorySchemaDatabase(db, dbPath, options);
+    } finally {
+      db.close();
+    }
   }
 
   /** Flush working memory to SQLite before serialization or checkpoint. */
@@ -643,7 +711,7 @@ export class SqliteBrain implements IBrain {
          VALUES (?, ?, ?, ?, ?, ?)`,
       );
       const insertCheckpoint = brain.db.prepare(
-        `INSERT INTO checkpoints (state, created_at) VALUES (?, ?)`,
+        `INSERT INTO checkpoints (state, created_at, schema_version) VALUES (?, ?, ${CURRENT_MEMORY_SCHEMA_VERSION})`,
       );
 
       const finalizeWorkingMemoryFlush: { current: (() => void) | undefined } = { current: undefined };
@@ -683,6 +751,127 @@ export class SqliteBrain implements IBrain {
   close(): void {
     this.db.close();
   }
+}
+
+
+function migrateMemorySchemaDatabase(
+  db: Database.Database,
+  dbPath: string,
+  options: MemorySchemaMigrationOptions = {},
+): MemorySchemaMigrationResult {
+  const dryRun = options.dryRun ?? false;
+  const stores = ['working_memory', 'episodic_events', 'checkpoints'];
+  const tableRows = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all() as Array<{
+    name: string;
+  }>;
+  const existingTables = new Set(tableRows.map(row => row.name));
+  const operations: MemorySchemaMigrationOperation[] = [];
+  let fromVersion = CURRENT_MEMORY_SCHEMA_VERSION;
+
+  if (!existingTables.has('memory_schema_versions')) {
+    operations.push({ table: 'memory_schema_versions', action: 'create store schema-version registry' });
+    fromVersion = 0;
+  } else {
+    const rows = db.prepare(`SELECT store, version FROM memory_schema_versions`).all() as Array<{ store: string; version: number }>;
+    for (const row of rows) {
+      if (row.version > CURRENT_MEMORY_SCHEMA_VERSION) {
+        throw new UnsupportedMemorySchemaVersionError(
+          `Memory store ${row.store} uses schema version ${row.version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+        );
+      }
+      fromVersion = Math.min(fromVersion, row.version);
+    }
+  }
+
+  for (const store of stores) {
+    if (!existingTables.has(store)) continue;
+    const columnRows = db.prepare(`PRAGMA table_info(${store})`).all() as Array<{ name: string }>;
+    const columns = new Set(columnRows.map(row => row.name));
+    if (!columns.has('schema_version')) {
+      operations.push({ table: store, action: `add schema_version column defaulting to ${CURRENT_MEMORY_SCHEMA_VERSION}` });
+      fromVersion = 0;
+    } else {
+      const future = db
+        .prepare(`SELECT schema_version FROM ${store} WHERE schema_version > ? LIMIT 1`)
+        .get(CURRENT_MEMORY_SCHEMA_VERSION) as { schema_version: number } | undefined;
+      if (future) {
+        throw new UnsupportedMemorySchemaVersionError(
+          `Memory table ${store} contains record schema version ${future.schema_version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+        );
+      }
+    }
+  }
+
+  for (const store of stores) {
+    if (existingTables.has(store)) {
+      const hasRegistryRow = existingTables.has('memory_schema_versions')
+        ? db.prepare(`SELECT 1 FROM memory_schema_versions WHERE store = ?`).get(store)
+        : undefined;
+      if (!hasRegistryRow) {
+        operations.push({ table: 'memory_schema_versions', action: `record ${store} store schema version` });
+        fromVersion = 0;
+      }
+    }
+  }
+
+  const migrated = operations.length > 0;
+  let backupPath = options.backupPath;
+  if (!dryRun && migrated && options.backupBeforeMigrate) {
+    if (dbPath === ':memory:') {
+      throw new Error('Cannot create a backup for an in-memory SQLite database');
+    }
+    backupPath ??= `${dbPath}.backup-${Date.now()}`;
+    copyFileSync(dbPath, backupPath);
+  }
+
+  if (!dryRun && migrated) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_schema_versions (
+        store TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        migrated_at TEXT NOT NULL
+      );
+    `);
+    for (const store of stores) {
+      if (!existingTables.has(store)) continue;
+      const columnRows = db.prepare(`PRAGMA table_info(${store})`).all() as Array<{ name: string }>;
+      const columns = new Set(columnRows.map(row => row.name));
+      if (!columns.has('schema_version')) {
+        db.exec(`ALTER TABLE ${store} ADD COLUMN schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}`);
+      }
+      const now = isoNow();
+      db.prepare(
+        `INSERT INTO memory_schema_versions (store, version, migrated_at) VALUES (?, ?, ?)
+         ON CONFLICT(store) DO UPDATE SET version = excluded.version, migrated_at = excluded.migrated_at`,
+      ).run(store, CURRENT_MEMORY_SCHEMA_VERSION, now);
+    }
+  }
+
+  return {
+    fromVersion,
+    toVersion: CURRENT_MEMORY_SCHEMA_VERSION,
+    dryRun,
+    migrated,
+    ...(backupPath ? { backupPath } : {}),
+    operations,
+  };
+}
+
+function readMemorySchemaMetadata(db: Database.Database): MemorySchemaMetadata {
+  const stores = ['working_memory', 'episodic_events', 'checkpoints'];
+  const rows = db.prepare(`SELECT store, version FROM memory_schema_versions ORDER BY store ASC`).all() as Array<{
+    store: string;
+    version: number;
+  }>;
+  const versionByStore = new Map(rows.map(row => [row.store, row.version]));
+  return {
+    version: CURRENT_MEMORY_SCHEMA_VERSION,
+    stores: stores.map(store => ({
+      store,
+      version: versionByStore.get(store) ?? CURRENT_MEMORY_SCHEMA_VERSION,
+      recordCount: (db.prepare(`SELECT COUNT(*) AS count FROM ${store}`).get() as { count: number }).count,
+    })),
+  };
 }
 
 // --- Constants ---

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -614,6 +614,7 @@ export class SqliteBrain implements IBrain {
     options: { hydrateWorkingMemoryFromDb?: boolean } = {},
   ) {
     this.db = new Database(dbPath);
+    this.db.pragma('busy_timeout = 5000');
     assertSupportedMemorySchema(this.db);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1,12 +1,15 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import Database from 'better-sqlite3';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BrainSnapshotSchema } from '@franken/types';
 import type { EpisodicEvent, ExecutionState, BrainSnapshot } from '@franken/types';
 import {
   SqliteBrain,
   WorkingMemoryLimitError,
+  UnsupportedMemorySchemaVersionError,
+  CURRENT_MEMORY_SCHEMA_VERSION,
   DEFAULT_WORKING_MEMORY_LIMITS,
 } from '../../src/sqlite-brain.js';
 
@@ -259,6 +262,132 @@ describe('SqliteBrain', () => {
       expect(brain.working.snapshot()).toEqual({ rules: validated });
       expect(brain.working.get('rules')).toEqual(validated);
       expect(brain.working.usage().totalBytes).toBe(accountedBytes);
+    });
+  });
+
+
+  describe('memory schema versioning and migrations', () => {
+    it('exposes store-level and record-level schema version metadata', () => {
+      brain.working.set('goal', 'ship migrations');
+      brain.flush();
+      brain.episodic.record({
+        type: 'decision',
+        summary: 'use explicit schema versions',
+        createdAt: '2026-07-13T00:00:00.000Z',
+      });
+      brain.recovery.checkpoint({
+        runId: 'run-1',
+        phase: 'migration',
+        step: 1,
+        context: {},
+        timestamp: '2026-07-13T00:00:01.000Z',
+      });
+
+      const metadata = brain.getMemorySchemaMetadata();
+      expect(metadata.version).toBe(CURRENT_MEMORY_SCHEMA_VERSION);
+      expect(metadata.stores).toEqual([
+        { store: 'working_memory', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 1 },
+        { store: 'episodic_events', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 1 },
+        { store: 'checkpoints', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 1 },
+      ]);
+
+      const db = (brain as unknown as {
+        db: { prepare: (sql: string) => { get: () => { schema_version: number } | undefined } };
+      }).db;
+      expect(db.prepare('SELECT schema_version FROM working_memory').get()?.schema_version).toBe(
+        CURRENT_MEMORY_SCHEMA_VERSION,
+      );
+      expect(db.prepare('SELECT schema_version FROM episodic_events').get()?.schema_version).toBe(
+        CURRENT_MEMORY_SCHEMA_VERSION,
+      );
+      expect(db.prepare('SELECT schema_version FROM checkpoints').get()?.schema_version).toBe(
+        CURRENT_MEMORY_SCHEMA_VERSION,
+      );
+    });
+
+    it('dry-runs and then migrates an old fixture with a backup before opening', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-migration-'));
+      const dbPath = join(dir, 'brain.db');
+      const backupPath = join(dir, 'brain.backup.db');
+
+      try {
+        const legacy = new Database(dbPath);
+        legacy.exec(`
+          CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+          CREATE TABLE episodic_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            type TEXT NOT NULL,
+            step TEXT,
+            summary TEXT NOT NULL,
+            details TEXT,
+            embedding BLOB,
+            created_at TEXT NOT NULL
+          );
+          CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+          INSERT INTO working_memory (key, value, updated_at) VALUES ('legacy', '"value"', '2026-07-13T00:00:00.000Z');
+        `);
+        legacy.close();
+
+        const dryRun = SqliteBrain.migrateMemorySchema(dbPath, { dryRun: true });
+        expect(dryRun.dryRun).toBe(true);
+        expect(dryRun.migrated).toBe(true);
+        expect(dryRun.operations.map(op => op.table)).toContain('working_memory');
+        const afterDryRun = new Database(dbPath);
+        expect(
+          afterDryRun.prepare(`PRAGMA table_info(working_memory)`).all().some(row => (row as { name: string }).name === 'schema_version'),
+        ).toBe(false);
+        afterDryRun.close();
+
+        const migrated = SqliteBrain.migrateMemorySchema(dbPath, { backupBeforeMigrate: true, backupPath });
+        expect(migrated.dryRun).toBe(false);
+        expect(migrated.backupPath).toBe(backupPath);
+        expect(existsSync(backupPath)).toBe(true);
+
+        const reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.get('legacy')).toBe('value');
+        expect(reopened.getMemorySchemaMetadata().stores).toEqual([
+          { store: 'working_memory', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 1 },
+          { store: 'episodic_events', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 0 },
+          { store: 'checkpoints', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 0 },
+        ]);
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects unsupported future store and record schema versions', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-future-version-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const created = new SqliteBrain(dbPath);
+        created.working.set('future', 'blocked');
+        created.flush();
+        created.close();
+
+        const db = new Database(dbPath);
+        db.prepare(`UPDATE memory_schema_versions SET version = ? WHERE store = ?`).run(
+          CURRENT_MEMORY_SCHEMA_VERSION + 1,
+          'working_memory',
+        );
+        db.close();
+        expect(() => new SqliteBrain(dbPath)).toThrow(UnsupportedMemorySchemaVersionError);
+
+        const rowFutureDb = new Database(dbPath);
+        rowFutureDb.prepare(`UPDATE memory_schema_versions SET version = ? WHERE store = ?`).run(
+          CURRENT_MEMORY_SCHEMA_VERSION,
+          'working_memory',
+        );
+        rowFutureDb.prepare(`UPDATE working_memory SET schema_version = ? WHERE key = ?`).run(
+          CURRENT_MEMORY_SCHEMA_VERSION + 1,
+          'future',
+        );
+        rowFutureDb.close();
+        expect(() => new SqliteBrain(dbPath)).toThrow(UnsupportedMemorySchemaVersionError);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -364,6 +364,23 @@ describe('SqliteBrain', () => {
           { store: 'checkpoints', version: CURRENT_MEMORY_SCHEMA_VERSION, recordCount: 0 },
         ]);
         reopened.close();
+
+        const staleRegistryDb = new Database(dbPath);
+        staleRegistryDb.prepare(`UPDATE memory_schema_versions SET version = ? WHERE store = ?`).run(
+          CURRENT_MEMORY_SCHEMA_VERSION - 1,
+          'working_memory',
+        );
+        staleRegistryDb.close();
+        const registryMigration = SqliteBrain.migrateMemorySchema(dbPath);
+        expect(registryMigration.migrated).toBe(true);
+        expect(registryMigration.operations.map(op => op.table)).toContain('memory_schema_versions');
+        const afterRegistryMigration = new SqliteBrain(dbPath);
+        expect(afterRegistryMigration.getMemorySchemaMetadata().stores[0]).toEqual({
+          store: 'working_memory',
+          version: CURRENT_MEMORY_SCHEMA_VERSION,
+          recordCount: 1,
+        });
+        afterRegistryMigration.close();
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
@@ -411,6 +428,7 @@ describe('SqliteBrain', () => {
           futureShapeDb.close();
 
           expect(() => new SqliteBrain(futureShapePath)).toThrow(UnsupportedMemorySchemaVersionError);
+          expect(() => SqliteBrain.migrateMemorySchema(futureShapePath)).toThrow(UnsupportedMemorySchemaVersionError);
           const afterRejectedOpen = new Database(futureShapePath, { readonly: true });
           const tables = afterRejectedOpen
             .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name ASC`)

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -332,6 +332,9 @@ describe('SqliteBrain', () => {
         expect(dryRun.dryRun).toBe(true);
         expect(dryRun.migrated).toBe(true);
         expect(dryRun.operations.map(op => op.table)).toContain('working_memory');
+        expect(dryRun.backupPath).toBeUndefined();
+        const dryRunWithBackupPath = SqliteBrain.migrateMemorySchema(dbPath, { dryRun: true, backupPath });
+        expect(dryRunWithBackupPath.backupPath).toBeUndefined();
         const afterDryRun = new Database(dbPath);
         expect(
           afterDryRun.prepare(`PRAGMA table_info(working_memory)`).all().some(row => (row as { name: string }).name === 'schema_version'),
@@ -415,6 +418,8 @@ describe('SqliteBrain', () => {
             .map(row => (row as { name: string }).name);
           expect(tables).toEqual(['memory_schema_versions']);
           afterRejectedOpen.close();
+          expect(existsSync(`${futureShapePath}-wal`)).toBe(false);
+          expect(existsSync(`${futureShapePath}-shm`)).toBe(false);
         } finally {
           rmSync(futureShapeDir, { recursive: true, force: true });
         }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -337,11 +337,21 @@ describe('SqliteBrain', () => {
           afterDryRun.prepare(`PRAGMA table_info(working_memory)`).all().some(row => (row as { name: string }).name === 'schema_version'),
         ).toBe(false);
         afterDryRun.close();
+        expect(existsSync(`${dbPath}-wal`)).toBe(false);
+        expect(existsSync(`${dbPath}-shm`)).toBe(false);
 
         const migrated = SqliteBrain.migrateMemorySchema(dbPath, { backupBeforeMigrate: true, backupPath });
         expect(migrated.dryRun).toBe(false);
         expect(migrated.backupPath).toBe(backupPath);
         expect(existsSync(backupPath)).toBe(true);
+        const backup = new Database(backupPath, { readonly: true });
+        expect(backup.prepare(`SELECT value FROM working_memory WHERE key = ?`).get('legacy')).toEqual({
+          value: '"value"',
+        });
+        expect(
+          backup.prepare(`PRAGMA table_info(working_memory)`).all().some(row => (row as { name: string }).name === 'schema_version'),
+        ).toBe(false);
+        backup.close();
 
         const reopened = new SqliteBrain(dbPath);
         expect(reopened.working.get('legacy')).toBe('value');
@@ -385,6 +395,29 @@ describe('SqliteBrain', () => {
         );
         rowFutureDb.close();
         expect(() => new SqliteBrain(dbPath)).toThrow(UnsupportedMemorySchemaVersionError);
+
+        const futureShapeDir = mkdtempSync(join(tmpdir(), 'sqlite-brain-future-shape-'));
+        const futureShapePath = join(futureShapeDir, 'brain.db');
+        try {
+          const futureShapeDb = new Database(futureShapePath);
+          futureShapeDb.exec(`
+            CREATE TABLE memory_schema_versions (store TEXT PRIMARY KEY, version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+            INSERT INTO memory_schema_versions (store, version, migrated_at)
+            VALUES ('semantic_memory', ${CURRENT_MEMORY_SCHEMA_VERSION + 1}, '2026-07-13T00:00:00.000Z');
+          `);
+          futureShapeDb.close();
+
+          expect(() => new SqliteBrain(futureShapePath)).toThrow(UnsupportedMemorySchemaVersionError);
+          const afterRejectedOpen = new Database(futureShapePath, { readonly: true });
+          const tables = afterRejectedOpen
+            .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name ASC`)
+            .all()
+            .map(row => (row as { name: string }).name);
+          expect(tables).toEqual(['memory_schema_versions']);
+          afterRejectedOpen.close();
+        } finally {
+          rmSync(futureShapeDir, { recursive: true, force: true });
+        }
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary
- add explicit schema_version metadata for SQLite memory stores and records
- add dry-run/backup migration runner plus future-version fail-closed checks
- document the developer workflow for adding memory schema changes

## Test Plan
- npm test --workspace @franken/brain
- npm run lint --workspace @franken/brain
- npm run typecheck --workspace @franken/brain
- npm run build --workspace @franken/brain
- npm run typecheck
- npm run build

Closes #1687