### PR TITLE
fix(web): clear Beast SSE reconnect errors

### DIFF
--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -238,6 +238,7 @@ export interface BeastSseRunEvent {
 }
 
 export interface BeastEventHandlers {
+  connected?: () => void;
   snapshot?: (snapshot: BeastSseSnapshot) => void;
   agentStatus?: (event: BeastSseAgentStatusEvent) => void;
   agentEvent?: (event: BeastSseAgentEvent) => void;

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -609,6 +609,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     const requestBeastRefresh = () => setBeastRefreshNonce((current) => current + 1);
 
     void beastClient.subscribeToEvents({
+      connected: () => {
+        if (!cancelled) {
+          setBeastError(null);
+        }
+      },
       snapshot: (snapshot) => {
         if (cancelled || !snapshot.agents) return;
         const currentAgents = beastAgentsRef.current;

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -303,6 +303,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   const beastAgentsRef = useRef<TrackedAgentSummary[]>([]);
   const beastAgentDetailRef = useRef<(TrackedAgentDetail & { run?: BeastRunDetail | null }) | null>(null);
   const [beastError, setBeastError] = useState<string | null>(null);
+  const beastStreamErrorRef = useRef<string | null>(null);
   const [beastCreationUnavailableReason, setBeastCreationUnavailableReason] = useState<string | null>(null);
   const [beastRefreshNonce, setBeastRefreshNonce] = useState(0);
   const [pendingBeastAgentActions, setPendingBeastAgentActions] = useState<Record<string, AgentLifecycleAction | undefined>>({});
@@ -549,12 +550,14 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       } catch (error) {
         if (!cancelled) {
           const message = error instanceof Error ? error.message : 'Unable to load Beast dispatch state.';
+          beastStreamErrorRef.current = null;
           setBeastError(message);
           setBeastCreationUnavailableReason(message);
         }
         return;
       }
 
+      beastStreamErrorRef.current = null;
       setBeastError(null);
       setBeastCreationUnavailableReason(null);
       setBeastCatalog(catalog);
@@ -587,6 +590,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       } catch (error) {
         if (!cancelled) {
           const message = error instanceof Error ? error.message : 'Unable to load Beast dispatch state.';
+          beastStreamErrorRef.current = null;
           setBeastError(message);
         }
       }
@@ -611,7 +615,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     void beastClient.subscribeToEvents({
       connected: () => {
         if (!cancelled) {
-          setBeastError(null);
+          setBeastError((current) => {
+            if (current && beastStreamErrorRef.current === current) {
+              beastStreamErrorRef.current = null;
+              return null;
+            }
+            return current;
+          });
         }
       },
       snapshot: (snapshot) => {
@@ -744,6 +754,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       },
       error: (error) => {
         if (!cancelled) {
+          beastStreamErrorRef.current = error.message;
           setBeastError(error.message);
         }
       },
@@ -755,6 +766,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       }
     }).catch((error: unknown) => {
       if (!cancelled) {
+        beastStreamErrorRef.current = null;
         setBeastError(error instanceof Error ? error.message : 'Unable to subscribe to Beast events.');
       }
     });
@@ -871,6 +883,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
   }) {
     if (!beastClient || pendingBeastAgentActionsRef.current[agentId]) return;
 
+    beastStreamErrorRef.current = null;
     setBeastError(null);
     setPendingBeastAgentAction(agentId, action);
     void request()
@@ -879,6 +892,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         setBeastRefreshNonce((current) => current + 1);
       })
       .catch((err) => {
+        beastStreamErrorRef.current = null;
         setBeastError(err instanceof Error ? err.message : errorMessage);
       })
       .finally(() => {

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -257,6 +257,11 @@ export class BeastApiClient {
       );
       eventSource = nextSource;
 
+      nextSource.addEventListener('open', () => {
+        if (closed || eventSource !== nextSource) return;
+        handlers.connected?.();
+      });
+
       nextSource.addEventListener('snapshot', (event) => {
         if (eventSource !== nextSource) return;
         try {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1539,6 +1539,29 @@ describe('ChatShell', () => {
     });
   });
 
+  it('keeps non-stream Beast errors visible after the SSE connection opens', async () => {
+    window.location.hash = '#/beasts';
+    mockGetAgent.mockRejectedValue(new Error('Agent detail unavailable'));
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent detail unavailable')).toBeDefined();
+    });
+
+    latestBeastEventHandlers?.connected?.({});
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent detail unavailable')).toBeDefined();
+    });
+  });
+
   it('keeps create-agent enabled when selected agent detail fails after state loads', async () => {
     window.location.hash = '#/beasts';
     mockGetAgent.mockRejectedValue(new Error('Agent detail unavailable'));

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1498,7 +1498,7 @@ describe('ChatShell', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('agent-1')).toBeDefined();
+      expect(screen.getAllByText('agent-1').length).toBeGreaterThan(0);
     });
 
     latestBeastEventHandlers?.error?.(new Error('SSE disconnected'));
@@ -1509,6 +1509,34 @@ describe('ChatShell', () => {
 
     const headerCreateButton = screen.getByRole('button', { name: /^\+ create agent$/i });
     expect(headerCreateButton.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('clears transient Beast stream disconnect errors after the SSE connection recovers', async () => {
+    window.location.hash = '#/beasts';
+
+    render(
+      <ChatShell
+        baseUrl="http://localhost:3000"
+        projectId="test-project"
+        version="0.9.0"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('agent-1').length).toBeGreaterThan(0);
+    });
+
+    latestBeastEventHandlers?.error?.(new Error('Beast event stream disconnected; reconnecting'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Beast event stream disconnected; reconnecting')).toBeDefined();
+    });
+
+    latestBeastEventHandlers?.connected?.({});
+
+    await waitFor(() => {
+      expect(screen.queryByText('Beast event stream disconnected; reconnecting')).toBeNull();
+    });
   });
 
   it('keeps create-agent enabled when selected agent detail fails after state loads', async () => {

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -471,6 +471,54 @@ describe('BeastApiClient', () => {
     }
   });
 
+  it('notifies handlers when the Beast event stream reconnects successfully', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+
+    try {
+      const onConnected = vi.fn();
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ connected: onConnected, error: onError });
+
+      listeners[0]?.open?.({ data: '' });
+      expect(onConnected).toHaveBeenCalledTimes(1);
+
+      listeners[0]?.error?.({ data: '' });
+      await vi.advanceTimersByTimeAsync(1_000);
+      listeners[1]?.open?.({ data: '' });
+
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('reconnecting') }));
+      expect(onConnected).toHaveBeenCalledTimes(2);
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
   it('passes the last successfully parsed SSE event id when reconnecting with a fresh ticket', async () => {
     vi.useFakeTimers();
     const listeners: Array<Record<string, (event: { data: string; lastEventId?: string }) => void>> = [];


### PR DESCRIPTION
## Summary
- emit a Beast SSE connected callback on EventSource open/reopen
- clear transient Beast event stream errors once the SSE connection recovers
- add Beast API and ChatShell regression coverage for reconnect recovery

## Test Plan
- npm --prefix packages/franken-web test -- tests/lib/beast-api.test.ts -t "notifies handlers when the Beast event stream reconnects successfully|requests a fresh single-use ticket"
- npm --prefix packages/franken-web test -- tests/components/chat-shell.test.tsx -t "clears transient Beast stream disconnect errors|keeps create-agent enabled for non-creation Beast event errors"
- npm --prefix packages/franken-types run typecheck
- npm --prefix packages/franken-types run build && npm --prefix packages/franken-web run typecheck
- npm --prefix packages/franken-web run lint
- npm --prefix packages/franken-web test -- tests/lib/beast-api.test.ts tests/components/chat-shell.test.tsx
- npm --prefix packages/franken-web run build

Closes #1699