### PR TITLE
test(ci): assert CI branch filters explicitly

### DIFF
--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -134,16 +134,12 @@ on:
       expect(workflow.name).toBe('CI');
     });
 
-    it('triggers on push to main', () => {
+    it('explicitly limits CI push and pull_request triggers to the main branch', () => {
       const triggers = expectRecord(workflow.on, 'workflow.on');
-      const push = expectRecord(triggers.push, 'workflow.on.push');
-      expect(push.branches).toEqual(['main']);
-    });
 
-    it('triggers on pull_request to main', () => {
-      const triggers = expectRecord(workflow.on, 'workflow.on');
-      const pullRequest = expectRecord(triggers.pull_request, 'workflow.on.pull_request');
-      expect(pullRequest.branches).toEqual(['main']);
+      expect(Object.keys(triggers)).toEqual(['push', 'pull_request']);
+      expect(expectRecord(triggers.push, 'workflow.on.push')).toEqual({ branches: ['main'] });
+      expect(expectRecord(triggers.pull_request, 'workflow.on.pull_request')).toEqual({ branches: ['main'] });
     });
 
     it('uses the repository-pinned minimum supported Node.js version', () => {

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -137,7 +137,7 @@ on:
     it('explicitly limits CI push and pull_request triggers to the main branch', () => {
       const triggers = expectRecord(workflow.on, 'workflow.on');
 
-      expect(Object.keys(triggers)).toEqual(['push', 'pull_request']);
+      expect(Object.keys(triggers).sort()).toEqual(['pull_request', 'push']);
       expect(expectRecord(triggers.push, 'workflow.on.push')).toEqual({ branches: ['main'] });
       expect(expectRecord(triggers.pull_request, 'workflow.on.pull_request')).toEqual({ branches: ['main'] });
     });


### PR DESCRIPTION
## Summary
- Tighten the CI workflow test to assert the exact push and pull_request trigger objects.
- Verify CI is limited to push/pull_request events targeting the main branch, preventing silent trigger-scope drift.

Closes #2138

## Test plan
- npm exec -- vitest run tests/unit/ci-workflow.test.ts --reporter=verbose

## Notes
- fbeast MCP tools were not available in this worker, so I used standard git/GitHub CLI verification.