### PR TITLE
fix(web): surface analytics API error messages

### DIFF
--- a/packages/franken-web/src/lib/analytics-api.test.ts
+++ b/packages/franken-web/src/lib/analytics-api.test.ts
@@ -60,6 +60,28 @@ describe('AnalyticsApiClient', () => {
     await expect(client.fetchEventDetail('missing-event-id')).rejects.toThrow('Analytics event not found');
   });
 
+  it('accepts flat analytics error messages before falling back to HTTP status', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'Analytics filter is invalid' }),
+    });
+
+    const client = new AnalyticsApiClient(BASE_URL);
+    await expect(client.fetchEvents({ outcome: 'failed' })).rejects.toThrow('Analytics filter is invalid');
+  });
+
+  it('falls back to HTTP status when failed responses have no error message', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: { code: 'ANALYTICS_UNAVAILABLE' } }),
+    });
+
+    const client = new AnalyticsApiClient(BASE_URL);
+    await expect(client.fetchSummary({})).rejects.toThrow('HTTP 503');
+  });
+
   it('falls back to HTTP status when failed responses have malformed JSON', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/franken-web/src/lib/analytics-api.ts
+++ b/packages/franken-web/src/lib/analytics-api.ts
@@ -62,12 +62,6 @@ export interface AnalyticsEventPage {
   pageSize: number;
 }
 
-interface AnalyticsApiErrorEnvelope {
-  error?: {
-    message?: string;
-  };
-}
-
 export class AnalyticsApiClient {
   constructor(private readonly baseUrl: string) {}
 
@@ -91,19 +85,29 @@ export class AnalyticsApiClient {
   private async fetchJson<T>(path: string): Promise<T> {
     const res = await fetch(`${this.baseUrl}${path}`);
     if (!res.ok) {
-      let message = `HTTP ${res.status}`;
-      try {
-        const body = (await res.json()) as AnalyticsApiErrorEnvelope;
-        if (body.error?.message) {
-          message = body.error.message;
-        }
-      } catch {
-        // Fall through with HTTP status message.
-      }
-      throw new Error(message);
+      throw new Error(await extractResponseErrorMessage(res) ?? `HTTP ${res.status}`);
     }
     return (await res.json()) as T;
   }
+}
+
+async function extractResponseErrorMessage(res: Response): Promise<string | undefined> {
+  try {
+    const body = await res.json() as unknown;
+    if (!body || typeof body !== 'object') return undefined;
+
+    const error = (body as { error?: unknown }).error;
+    if (typeof error === 'string' && error.trim()) return error;
+
+    if (error && typeof error === 'object') {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim()) return message;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
 }
 
 function queryString(filters: AnalyticsEventFilters): string {


### PR DESCRIPTION
## Summary
- Parse analytics API error responses through a reusable extractor before falling back to `HTTP <status>`.
- Preserve structured `{ error: { message } }` server messages such as `Analytics event not found` and align analytics with other web clients that also accept flat error strings.
- Add regression coverage for structured, flat, no-message, and malformed analytics error responses.

## Test Plan
- [x] npm ci
- [x] npm run build --workspace @franken/types
- [x] npm run test --workspace @franken/web -- analytics-api.test.ts
- [x] npm run test --workspace @franken/web
- [x] npm run typecheck --workspace @franken/web
- [x] npm run lint --workspace @franken/web
- [x] npm run build --workspace @franken/web

Closes #2182
