### PR TITLE
test(observer): cover missing rate limit header

### DIFF
--- a/packages/franken-observer/src/export/httpRetry.test.ts
+++ b/packages/franken-observer/src/export/httpRetry.test.ts
@@ -52,6 +52,17 @@ describe('fetchWithRetry (issue #68)', () => {
     expect(sleep).toHaveBeenCalledTimes(1)
   })
 
+  it('retries 429 responses without rate-limit headers using default backoff', async () => {
+    const sleep = noSleep()
+    const rateLimitedWithoutHeaders = { ok: false, status: 429, statusText: 'Too Many Requests' }
+    const attempt = vi.fn().mockResolvedValueOnce(rateLimitedWithoutHeaders).mockResolvedValueOnce(ok)
+
+    await expect(fetchWithRetry(attempt, { maxRetries: 1, jitter: false, sleep })).resolves.toEqual(ok)
+
+    expect(attempt).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(200)
+  })
+
   it('does NOT retry a 4xx — returns it immediately', async () => {
     const sleep = noSleep()
     const attempt = vi.fn().mockResolvedValue(badRequest)


### PR DESCRIPTION
## Summary
- Add observer retry coverage for a 429 response that has no rate-limit headers.
- Assert the retry path falls back to the default safe backoff and succeeds without throwing.

Closes #2198

## Test plan
- npm test --workspace @franken/observer -- --run src/export/httpRetry.test.ts

Note: fbeast MCP tools referenced by AGENTS.md were not available in this tool schema, so I used normal git/GitHub/terminal verification.