### PR TITLE
docs: restore main CI documentation assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The repository currently contains the following 10 active packages:
 - `franken-web` – @franken/web: React dashboard
 - `live-bench` – @franken/live-bench: Live CLI benchmark tooling
 
-Historical packages such as `frankenfirewall`, `franken-skills`, `franken-heartbeat`, `franken-mcp`, and `franken-comms` have been consolidated into `@franken/orchestrator` and `@franken/mcp-suite` per [ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md).
+Historical packages such as `frankenfirewall`, `franken-skills`, `franken-heartbeat`, `franken-mcp`, and `franken-comms` are not standalone workspaces anymore; they have been consolidated into `@franken/orchestrator` and `@franken/mcp-suite` per [ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md).
 
 **Build commands** (all via Turborepo):
 - `npm run build` — runs `turbo run build` (dependency-ordered)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 ![Status](https://img.shields.io/badge/status-beta-blue)
-[![Latest release](https://img.shields.io/github/v/release/djm204/frankenbeast?label=release)](https://github.com/djm204/frankenbeast/releases/latest)
+[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases/latest)
 [![Daily security scan](https://github.com/djm204/frankenbeast/actions/workflows/daily-security-scan.yml/badge.svg)](https://github.com/djm204/frankenbeast/actions/workflows/daily-security-scan.yml)
 [![Dependabot](https://img.shields.io/badge/dependabot-configured-025E8C?logo=dependabot)](.github/dependabot.yml)
 


### PR DESCRIPTION
## Summary\n- Restore the README latest root release badge/link shape expected by root CI.\n- Restore the CLAUDE.md monorepo consolidation wording expected by the workspace package-map test.\n\n## Test Plan\n- npm run test:root -- tests/local-setup-scripts.test.ts tests/unit/readme-release-communication.test.ts\n- npm run test:ci (root/package CI reached one unrelated orchestrator timeout: tests/unit/cli/dep-factory-providers.test.ts; rerun of that exact test passed)\n- npm run test --workspace @franken/orchestrator -- tests/unit/cli/dep-factory-providers.test.ts\n\nFixes the shared main CI docs regression blocking unrelated issue PRs.