### PR TITLE
fix(web): clarify dashboard SSE snapshot parse errors

### DIFF
--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -277,6 +277,13 @@ describe('DashboardApiClient', () => {
         expect(() => listeners['snapshot']!({ data: '{not-json' })).not.toThrow();
         expect(onSnapshot).not.toHaveBeenCalled();
         expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onError.mock.calls[0]![0].message).toContain(
+          'Dashboard stream snapshot payload could not be parsed.',
+        );
+
+        const snapshot = makeMockSnapshot();
+        expect(() => listeners['snapshot']!({ data: JSON.stringify(snapshot) })).not.toThrow();
+        expect(onSnapshot).toHaveBeenCalledWith(snapshot);
 
         unsub();
       } finally {

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -296,6 +296,51 @@ describe('DashboardApiClient', () => {
       }
     });
 
+    it('reports snapshot callback failures without labeling them as parse errors', async () => {
+      const listeners: Record<string, (event: { data: string }) => void> = {};
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data: string }) => void) => void;
+        close?: () => void;
+      }) {
+        this.addEventListener = vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          listeners[type] = handler;
+        });
+        this.close = vi.fn();
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ticket: 'dashboard-ticket' }),
+      });
+
+      try {
+        const callbackError = new Error('snapshot consumer failed');
+        const onSnapshot = vi.fn(() => {
+          throw callbackError;
+        });
+        const onError = vi.fn();
+        const client = new DashboardApiClient(BASE_URL);
+        const unsub = await client.subscribeToDashboard(onSnapshot, onError);
+
+        expect(() => listeners['snapshot']!({ data: JSON.stringify(makeMockSnapshot()) })).not.toThrow();
+        expect(onError).toHaveBeenCalledWith(callbackError);
+        expect(onError.mock.calls[0]![0].message).not.toContain('could not be parsed');
+
+        unsub();
+      } finally {
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
     it('mints a fresh one-shot ticket after EventSource errors', async () => {
       vi.useFakeTimers();
       const closeFns = [vi.fn(), vi.fn()];

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -106,12 +106,19 @@ export class DashboardApiClient {
       }
       eventSource = nextEventSource;
       nextEventSource.addEventListener('snapshot', (event: any) => {
+        let snapshot: DashboardSnapshot;
         try {
-          const snapshot = JSON.parse(event.data) as DashboardSnapshot;
-          onSnapshot(snapshot);
+          snapshot = JSON.parse(event.data) as DashboardSnapshot;
         } catch (error) {
           const parseError = toError(error);
           onError?.(new Error(`Dashboard stream snapshot payload could not be parsed. ${parseError.message}`));
+          return;
+        }
+
+        try {
+          onSnapshot(snapshot);
+        } catch (error) {
+          onError?.(toError(error));
         }
       });
       nextEventSource.addEventListener('error', () => {

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -110,7 +110,8 @@ export class DashboardApiClient {
           const snapshot = JSON.parse(event.data) as DashboardSnapshot;
           onSnapshot(snapshot);
         } catch (error) {
-          onError?.(toError(error));
+          const parseError = toError(error);
+          onError?.(new Error(`Dashboard stream snapshot payload could not be parsed. ${parseError.message}`));
         }
       });
       nextEventSource.addEventListener('error', () => {


### PR DESCRIPTION
## Summary
- wrap malformed dashboard SSE snapshot parse failures in a dashboard-specific controlled error
- extend the dashboard SSE regression test to prove malformed payloads do not throw, do not call `onSnapshot`, and keep later valid snapshots flowing

## Test Plan
- `npm --workspace @franken/web test -- --run src/lib/dashboard-api.test.ts`
- `npm --workspace @franken/types run build`
- `npm --workspace @franken/web run typecheck`
- `npm --workspace @franken/web run lint` (passes with existing warnings)
- `npm --workspace @franken/web run build`

Closes #2205
