### PR TITLE
fix(orchestrator): log CLI process kill failures

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -493,7 +493,15 @@ export class CliLlmAdapter implements IAdapter {
 
       const timer = setTimeout(() => {
         timedOut = true;
-        child.kill('SIGTERM');
+        try {
+          child.kill('SIGTERM');
+        } catch (error) {
+          console.warn('[CliLlmAdapter] Failed to terminate timed-out CLI process', {
+            signal: 'SIGTERM',
+            pid: child.pid,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
         hardKillTimer = setTimeout(() => {
           try {
             child.kill('SIGKILL');

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -513,6 +513,51 @@ describe('CliLlmAdapter', () => {
           .rejects.toThrow(/timeout/i);
       });
 
+      it('warns and still rejects when the timeout SIGTERM fails', async () => {
+        vi.useFakeTimers();
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+          const killError = new Error('process already exited');
+          const spawnFn = (): ChildProcess => {
+            const proc = new EventEmitter() as ChildProcess;
+            Object.defineProperty(proc, 'stdin', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'stdout', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'stderr', { value: new PassThrough(), writable: false });
+            Object.defineProperty(proc, 'pid', { value: 13579, writable: false });
+            Object.defineProperty(proc, 'kill', {
+              value: vi.fn((signal?: NodeJS.Signals | number) => {
+                if (signal === 'SIGTERM') throw killError;
+                return true;
+              }),
+              writable: false,
+            });
+            return proc;
+          };
+          const adapter = new CliLlmAdapter(
+            claudeProvider,
+            { ...baseOpts, timeoutMs: 50 },
+            spawnFn,
+          );
+
+          const result = adapter.execute({ prompt: 'test', maxTurns: 1 });
+          const assertion = expect(result).rejects.toThrow('CLI timeout after 50ms');
+
+          await vi.advanceTimersByTimeAsync(50);
+          await assertion;
+          await vi.advanceTimersByTimeAsync(5_000);
+
+          expect(warnSpy).toHaveBeenCalledWith('[CliLlmAdapter] Failed to terminate timed-out CLI process', {
+            signal: 'SIGTERM',
+            pid: 13579,
+            error: 'process already exited',
+          });
+        } finally {
+          warnSpy.mockRestore();
+          vi.useRealTimers();
+        }
+      });
+
       it('settles the timeout path once when the child closes before hard kill', async () => {
         vi.useFakeTimers();
         const killSignals: NodeJS.Signals[] = [];


### PR DESCRIPTION
## Summary
- Log SIGTERM failures when timed-out CLI child process termination throws
- Preserve timeout rejection and existing hard-kill fallback behavior
- Add regression coverage for SIGTERM kill failures

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/adapters/cli-llm-adapter.test.ts
- npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build
- npm --prefix packages/franken-orchestrator run lint (warnings only; pre-existing)

Closes #2207