### PR TITLE
fix(orchestrator): bound JSON parsing inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ LLM-based agents routinely lose safety constraints when context windows compress
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for vulnerability reporting, dependency update expectations, secret handling, HTTPS guidance, and runtime hardening recommendations.
+See [SECURITY.md](SECURITY.md) for vulnerability reporting, dependency update expectations, secret handling, HTTPS guidance, and runtime hardening recommendations. See [docs/security-json-parsing-limits.md](docs/security-json-parsing-limits.md) for JSON input limits; Beast config, run config, GitHub issue payloads, and LLM issue decomposition payloads are size/depth/fan-out bounded, and YAML is not accepted on those surfaces.
 
 ## Architecture
 

--- a/docs/security-json-parsing-limits.md
+++ b/docs/security-json-parsing-limits.md
@@ -1,0 +1,17 @@
+# Safe JSON parsing limits
+
+Frankenbeast treats operator config files, run config files, GitHub issue payloads, and LLM-generated issue decomposition payloads as bounded JSON inputs. YAML is not accepted for these inputs; operators should convert YAML to JSON before passing it to the CLI.
+
+The default config/run-config limits are intentionally conservative for local operator files:
+
+- Maximum UTF-8 input size: 1 MiB
+- Maximum nested object/array depth: 64
+- Maximum object/array containers: 10,000
+- Maximum object keys across the document: 20,000
+- Maximum array items across the document: 50,000
+
+Issue ingestion uses a 2 MiB input cap with bounds on depth, containers, object keys, and array fan-out. LLM issue-decomposition responses use a smaller 256 KiB cap and tighter structure limits because they should contain only chunk definitions.
+
+When a document exceeds a limit, parsing fails before the value is trusted and the thrown error names the exceeded limit, for example `maxBytes`, `maxDepth`, `maxObjectKeys`, `maxArrayItems`, or `maxContainers`.
+
+Trusted admin contexts can override limits by calling `parseSafeJson(text, { ...limits })` directly from code that intentionally accepts larger local input. Do not raise limits for repository-controlled config or external issue/LLM payloads without adding targeted tests for the new bound.

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
@@ -58,6 +58,10 @@ function fromEnv(shadowedFields: ReadonlySet<keyof OrchestratorConfig> = new Set
 
 /** Load config from a JSON file. */
 async function fromFile(filePath: string): Promise<Partial<OrchestratorConfig>> {
+  const info = await stat(filePath);
+  if (info.size > 1_048_576) {
+    throw new RangeError(`Config file ${filePath} exceeds maxBytes: ${info.size} > 1048576`);
+  }
   const raw = await readFile(filePath, 'utf-8');
   const parsed = parseSafeJson(raw, {
     context: `Config file ${filePath}`,

--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { parseOrchestratorConfig, type OrchestratorConfig } from '../config/orchestrator-config.js';
 import { applyNetworkConfigSets } from '../network/network-config-paths.js';
+import { parseSafeJson } from '../utils/safe-json.js';
 import type { CliArgs } from './args.js';
 
 /** Environment variable prefix for orchestrator config. */
@@ -58,7 +59,14 @@ function fromEnv(shadowedFields: ReadonlySet<keyof OrchestratorConfig> = new Set
 /** Load config from a JSON file. */
 async function fromFile(filePath: string): Promise<Partial<OrchestratorConfig>> {
   const raw = await readFile(filePath, 'utf-8');
-  const parsed = JSON.parse(raw) as unknown;
+  const parsed = parseSafeJson(raw, {
+    context: `Config file ${filePath}`,
+    maxBytes: 1_048_576,
+    maxDepth: 64,
+    maxContainers: 10_000,
+    maxObjectKeys: 20_000,
+    maxArrayItems: 50_000,
+  });
   if (!isRecord(parsed)) {
     throw new TypeError('Config file must contain a JSON object');
   }

--- a/packages/franken-orchestrator/src/cli/run-config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/run-config-loader.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { z } from 'zod';
+import { parseSafeJson } from '../utils/safe-json.js';
 
 
 function printLine(...args: unknown[]): void {
@@ -77,7 +78,14 @@ export function loadRunConfig(filePath: string): RunConfig {
   const raw = readFileSync(filePath, 'utf-8');
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw) as unknown;
+    parsed = parseSafeJson(raw, {
+      context: `Run config ${filePath}`,
+      maxBytes: 1_048_576,
+      maxDepth: 64,
+      maxContainers: 10_000,
+      maxObjectKeys: 20_000,
+      maxArrayItems: 50_000,
+    });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new RunConfigParseError(filePath, reason, error instanceof Error ? { cause: error } : undefined);

--- a/packages/franken-orchestrator/src/cli/run-config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/run-config-loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { z } from 'zod';
 import { parseSafeJson } from '../utils/safe-json.js';
 
@@ -75,6 +75,10 @@ export class RunConfigParseError extends Error {
  * Throws if the file does not exist or the content fails Zod validation.
  */
 export function loadRunConfig(filePath: string): RunConfig {
+  const info = statSync(filePath);
+  if (info.size > 1_048_576) {
+    throw new RunConfigParseError(filePath, `Run config ${filePath} exceeds maxBytes: ${info.size} > 1048576`);
+  }
   const raw = readFileSync(filePath, 'utf-8');
   let parsed: unknown;
   try {

--- a/packages/franken-orchestrator/src/issues/issue-fetcher.ts
+++ b/packages/franken-orchestrator/src/issues/issue-fetcher.ts
@@ -56,7 +56,7 @@ export class IssueFetcher implements IIssueFetcher {
       maxDepth: 48,
       maxContainers: 20_000,
       maxObjectKeys: 100_000,
-      maxArrayItems: Math.max(limit * 8, 240),
+      maxArrayItems: Math.max(limit * 64, 2_000),
     }) as RawGithubIssue[];
 
     return raw.map((issue) => ({

--- a/packages/franken-orchestrator/src/issues/issue-fetcher.ts
+++ b/packages/franken-orchestrator/src/issues/issue-fetcher.ts
@@ -15,10 +15,10 @@ interface RawGithubIssue {
 }
 
 export class IssueFetcher implements IIssueFetcher {
-  private readonly execFn: ExecFn;
+  private readonly execFn: ExecFn | undefined;
 
   constructor(execFn?: ExecFn) {
-    this.execFn = execFn ?? defaultExecFile;
+    this.execFn = execFn;
   }
 
   async fetch(options: IssueFetchOptions): Promise<GithubIssue[]> {
@@ -49,7 +49,7 @@ export class IssueFetcher implements IIssueFetcher {
     const limit = options.limit ?? 30;
     args.push('--limit', String(limit));
 
-    const stdout = await this.run('gh', args);
+    const stdout = await this.run('gh', args, 2_097_152);
     const raw = parseSafeJson(stdout, {
       context: 'GitHub issue list payload',
       maxBytes: 2_097_152,
@@ -70,7 +70,7 @@ export class IssueFetcher implements IIssueFetcher {
   }
 
   async inferRepo(): Promise<string> {
-    const stdout = await this.run('gh', ['repo', 'view', '--json', 'nameWithOwner']);
+    const stdout = await this.run('gh', ['repo', 'view', '--json', 'nameWithOwner'], 16_384);
     const parsed = parseSafeJson(stdout, {
       context: 'GitHub repository payload',
       maxBytes: 16_384,
@@ -82,16 +82,23 @@ export class IssueFetcher implements IIssueFetcher {
     return parsed.nameWithOwner;
   }
 
-  private run(file: string, args: string[]): Promise<string> {
+  private run(file: string, args: string[], maxBuffer: number): Promise<string> {
     return new Promise((resolve, reject) => {
-      this.execFn(file, args, (error, stdout, stderr) => {
+      const callback = (error: Error | null, stdout: string, stderr: string): void => {
         if (error) {
           const message = this.describeError(stderr);
           reject(new Error(message, { cause: error }));
           return;
         }
         resolve(stdout);
-      });
+      };
+
+      if (this.execFn) {
+        this.execFn(file, args, callback);
+        return;
+      }
+
+      defaultExecFile(file, args, { maxBuffer }, callback);
     });
   }
 

--- a/packages/franken-orchestrator/src/issues/issue-fetcher.ts
+++ b/packages/franken-orchestrator/src/issues/issue-fetcher.ts
@@ -1,4 +1,5 @@
 import { execFile as defaultExecFile } from 'node:child_process';
+import { parseSafeJson } from '../utils/safe-json.js';
 import type { GithubIssue, IIssueFetcher, IssueFetchOptions } from './types.js';
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
@@ -49,7 +50,14 @@ export class IssueFetcher implements IIssueFetcher {
     args.push('--limit', String(limit));
 
     const stdout = await this.run('gh', args);
-    const raw: RawGithubIssue[] = JSON.parse(stdout) as RawGithubIssue[];
+    const raw = parseSafeJson(stdout, {
+      context: 'GitHub issue list payload',
+      maxBytes: 2_097_152,
+      maxDepth: 48,
+      maxContainers: 20_000,
+      maxObjectKeys: 100_000,
+      maxArrayItems: Math.max(limit * 8, 240),
+    }) as RawGithubIssue[];
 
     return raw.map((issue) => ({
       number: issue.number,
@@ -63,7 +71,14 @@ export class IssueFetcher implements IIssueFetcher {
 
   async inferRepo(): Promise<string> {
     const stdout = await this.run('gh', ['repo', 'view', '--json', 'nameWithOwner']);
-    const parsed = JSON.parse(stdout) as { nameWithOwner: string };
+    const parsed = parseSafeJson(stdout, {
+      context: 'GitHub repository payload',
+      maxBytes: 16_384,
+      maxDepth: 8,
+      maxContainers: 20,
+      maxObjectKeys: 50,
+      maxArrayItems: 10,
+    }) as { nameWithOwner: string };
     return parsed.nameWithOwner;
   }
 

--- a/packages/franken-orchestrator/src/issues/issue-graph-builder.ts
+++ b/packages/franken-orchestrator/src/issues/issue-graph-builder.ts
@@ -2,7 +2,7 @@ import type { PlanGraph, PlanTask } from '../deps.js';
 import type { GithubIssue, TriageResult } from './types.js';
 import type { ChunkDefinition } from '../cli/file-writer.js';
 import { cleanLlmJson } from '../skills/providers/stream-json-utils.js';
-import { parseSafeJson } from '../utils/safe-json.js';
+import { assertSafeJsonText, parseSafeJson } from '../utils/safe-json.js';
 
 type CompleteFn = (prompt: string, hint?: {
   operation?: string;
@@ -110,6 +110,10 @@ Respond with ONLY a JSON array. No explanation, no markdown — just the JSON ar
   }
 
   private parseResponse(raw: string): ChunkDefinition[] {
+    assertSafeJsonText(raw, {
+      context: 'Raw LLM issue decomposition response',
+      maxBytes: 262_144,
+    });
     const text = cleanLlmJson(raw, { parseFastPath: false });
 
     let parsed: unknown;

--- a/packages/franken-orchestrator/src/issues/issue-graph-builder.ts
+++ b/packages/franken-orchestrator/src/issues/issue-graph-builder.ts
@@ -110,7 +110,7 @@ Respond with ONLY a JSON array. No explanation, no markdown — just the JSON ar
   }
 
   private parseResponse(raw: string): ChunkDefinition[] {
-    const text = cleanLlmJson(raw);
+    const text = cleanLlmJson(raw, { parseFastPath: false });
 
     let parsed: unknown;
     try {

--- a/packages/franken-orchestrator/src/issues/issue-graph-builder.ts
+++ b/packages/franken-orchestrator/src/issues/issue-graph-builder.ts
@@ -2,6 +2,7 @@ import type { PlanGraph, PlanTask } from '../deps.js';
 import type { GithubIssue, TriageResult } from './types.js';
 import type { ChunkDefinition } from '../cli/file-writer.js';
 import { cleanLlmJson } from '../skills/providers/stream-json-utils.js';
+import { parseSafeJson } from '../utils/safe-json.js';
 
 type CompleteFn = (prompt: string, hint?: {
   operation?: string;
@@ -113,11 +114,19 @@ Respond with ONLY a JSON array. No explanation, no markdown — just the JSON ar
 
     let parsed: unknown;
     try {
-      parsed = JSON.parse(text);
-    } catch {
+      parsed = parseSafeJson(text, {
+        context: 'LLM issue decomposition response',
+        maxBytes: 262_144,
+        maxDepth: 24,
+        maxContainers: 1_000,
+        maxObjectKeys: 5_000,
+        maxArrayItems: 1_000,
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
       throw new Error(
         `Failed to parse LLM response as JSON. Expected a JSON array of chunk definitions. ` +
-          `Response starts with: "${raw.slice(0, 100)}..."`,
+          `${reason}. Response starts with: "${raw.slice(0, 100)}..."`,
       );
     }
 

--- a/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
+++ b/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
@@ -53,17 +53,23 @@ export function stripHookJson(text: string): string {
   return result.trim();
 }
 
+export interface CleanLlmJsonOptions {
+  readonly parseFastPath?: boolean;
+}
+
 /**
  * Clean raw LLM output so it can be JSON.parse()'d.
  * Uses bracket-depth matching to extract the JSON structure,
  * so it works regardless of markdown wrapping, code fences,
  * leading/trailing prose, or other LLM formatting quirks.
  */
-export function cleanLlmJson(raw: string): string {
+export function cleanLlmJson(raw: string, options: CleanLlmJsonOptions = {}): string {
   let text = stripHookJson(raw.trim());
 
   // Try parsing as-is first (fast path)
-  try { JSON.parse(text); return text; } catch { /* fall through */ }
+  if (options.parseFastPath !== false) {
+    try { JSON.parse(text); return text; } catch { /* fall through */ }
+  }
 
   // Find the first [ or { and extract the matching structure
   // using bracket-depth counting that respects quoted strings.

--- a/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
+++ b/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
@@ -76,15 +76,50 @@ export function cleanLlmJson(raw: string, options: CleanLlmJsonOptions = {}): st
   const extracted = extractJsonStructure(text);
   if (extracted !== null) {
     // Strip trailing commas before } or ] (common LLM artifact)
-    return extracted.replace(/,\s*([}\]])/g, '$1');
+    return stripTrailingJsonCommas(extracted);
   }
 
   // Last resort: strip fences and trailing commas, hope for the best
   text = text.replace(/^`{3,}\w*\s*\n?/, '');
   text = text.replace(/\n?\s*`{3,}\s*$/, '');
   text = text.trim();
-  text = text.replace(/,\s*([}\]])/g, '$1');
+  text = stripTrailingJsonCommas(text);
   return text;
+}
+
+function stripTrailingJsonCommas(text: string): string {
+  let result = '';
+  let inStr = false;
+  let esc = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+    if (esc) {
+      esc = false;
+      result += ch;
+      continue;
+    }
+    if (ch === '\\' && inStr) {
+      esc = true;
+      result += ch;
+      continue;
+    }
+    if (ch === '"') {
+      inStr = !inStr;
+      result += ch;
+      continue;
+    }
+    if (!inStr && ch === ',') {
+      let j = i + 1;
+      while (j < text.length && /\s/u.test(text[j]!)) j++;
+      if (text[j] === '}' || text[j] === ']') {
+        continue;
+      }
+    }
+    result += ch;
+  }
+
+  return result;
 }
 
 /**

--- a/packages/franken-orchestrator/src/utils/safe-json.ts
+++ b/packages/franken-orchestrator/src/utils/safe-json.ts
@@ -1,0 +1,123 @@
+export interface SafeJsonLimits {
+  readonly maxBytes?: number;
+  readonly maxDepth?: number;
+  readonly maxContainers?: number;
+  readonly maxObjectKeys?: number;
+  readonly maxArrayItems?: number;
+}
+
+export interface SafeJsonParseOptions extends SafeJsonLimits {
+  readonly context?: string;
+}
+
+export class SafeJsonParseError extends Error {
+  public readonly code = 'SAFE_JSON_PARSE_LIMIT_EXCEEDED';
+
+  constructor(
+    public readonly limit: keyof SafeJsonLimits,
+    public readonly actual: number,
+    public readonly maximum: number,
+    context: string,
+  ) {
+    super(`${context} exceeds ${limit}: ${actual} > ${maximum}`);
+    this.name = 'SafeJsonParseError';
+  }
+}
+
+export const DEFAULT_SAFE_JSON_LIMITS = {
+  maxBytes: 1_048_576,
+  maxDepth: 64,
+  maxContainers: 10_000,
+  maxObjectKeys: 20_000,
+  maxArrayItems: 50_000,
+} as const satisfies Required<SafeJsonLimits>;
+
+interface StackFrame {
+  readonly value: unknown;
+  readonly depth: number;
+}
+
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function throwLimit(
+  limit: keyof SafeJsonLimits,
+  actual: number,
+  maximum: number,
+  context: string,
+): never {
+  throw new SafeJsonParseError(limit, actual, maximum, context);
+}
+
+function mergedLimits(options: SafeJsonParseOptions): Required<SafeJsonLimits> {
+  return {
+    maxBytes: options.maxBytes ?? DEFAULT_SAFE_JSON_LIMITS.maxBytes,
+    maxDepth: options.maxDepth ?? DEFAULT_SAFE_JSON_LIMITS.maxDepth,
+    maxContainers: options.maxContainers ?? DEFAULT_SAFE_JSON_LIMITS.maxContainers,
+    maxObjectKeys: options.maxObjectKeys ?? DEFAULT_SAFE_JSON_LIMITS.maxObjectKeys,
+    maxArrayItems: options.maxArrayItems ?? DEFAULT_SAFE_JSON_LIMITS.maxArrayItems,
+  };
+}
+
+export function assertSafeJsonText(text: string, options: SafeJsonParseOptions = {}): void {
+  const limits = mergedLimits(options);
+  const context = options.context ?? 'JSON document';
+  const bytes = utf8ByteLength(text);
+  if (bytes > limits.maxBytes) {
+    throwLimit('maxBytes', bytes, limits.maxBytes, context);
+  }
+}
+
+export function assertSafeJsonValue(value: unknown, options: SafeJsonParseOptions = {}): void {
+  const limits = mergedLimits(options);
+  const context = options.context ?? 'JSON document';
+  const stack: StackFrame[] = [{ value, depth: 1 }];
+  let containers = 0;
+  let objectKeys = 0;
+  let arrayItems = 0;
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    const current = frame.value;
+    if (current === null || typeof current !== 'object') {
+      continue;
+    }
+
+    if (frame.depth > limits.maxDepth) {
+      throwLimit('maxDepth', frame.depth, limits.maxDepth, context);
+    }
+
+    containers += 1;
+    if (containers > limits.maxContainers) {
+      throwLimit('maxContainers', containers, limits.maxContainers, context);
+    }
+
+    if (Array.isArray(current)) {
+      arrayItems += current.length;
+      if (arrayItems > limits.maxArrayItems) {
+        throwLimit('maxArrayItems', arrayItems, limits.maxArrayItems, context);
+      }
+      for (const child of current) {
+        stack.push({ value: child, depth: frame.depth + 1 });
+      }
+      continue;
+    }
+
+    const values = Object.values(current as Record<string, unknown>);
+    objectKeys += values.length;
+    if (objectKeys > limits.maxObjectKeys) {
+      throwLimit('maxObjectKeys', objectKeys, limits.maxObjectKeys, context);
+    }
+    for (const child of values) {
+      stack.push({ value: child, depth: frame.depth + 1 });
+    }
+  }
+}
+
+export function parseSafeJson(text: string, options: SafeJsonParseOptions = {}): unknown {
+  assertSafeJsonText(text, options);
+  const parsed = JSON.parse(text) as unknown;
+  assertSafeJsonValue(parsed, options);
+  return parsed;
+}

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -92,6 +92,23 @@ describe('Config loader', () => {
     await expect(loadConfig(makeArgs({ subcommand: 'init', config: filePath }))).rejects.toThrow(SyntaxError);
   });
 
+  it('rejects config files that exceed the safe byte limit with an actionable error', async () => {
+    const filePath = join(tmpdir(), `beast-config-huge-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({ notes: 'x'.repeat(1_048_576) }));
+
+    await expect(loadConfig(makeArgs({ config: filePath }))).rejects.toThrow(/maxBytes/u);
+  });
+
+  it('rejects config files that exceed the safe nesting limit with an actionable error', async () => {
+    const filePath = join(tmpdir(), `beast-config-deep-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    const deep = '{' + '"a":{'.repeat(65) + '"value":true' + '}'.repeat(65) + '}';
+    await writeFile(filePath, deep);
+
+    await expect(loadConfig(makeArgs({ config: filePath }))).rejects.toThrow(/maxDepth/u);
+  });
+
   it('deep merges nested network config from file', async () => {
     const filePath = join(tmpdir(), `beast-network-config-${Date.now()}.json`);
     tmpFiles.push(filePath);

--- a/packages/franken-orchestrator/tests/unit/issues/issue-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-graph-builder.test.ts
@@ -293,6 +293,16 @@ describe('IssueGraphBuilder', () => {
       await expect(builder.buildForIssue(issue, triage)).rejects.toThrow(/missing required fields/i);
     });
 
+    it('throws when an LLM decomposition response exceeds safe JSON limits', async () => {
+      const oversized = JSON.stringify([{ id: 'huge', objective: 'x'.repeat(262_144), files: [], successCriteria: 'ok', verificationCommand: 'echo ok', dependencies: [] }]);
+      const completeFn = vi.fn<CompleteFn>(async () => oversized);
+      const builder = new IssueGraphBuilder(completeFn);
+      const issue = makeIssue({ number: 43 });
+      const triage = makeTriageResult(43, 'chunked');
+
+      await expect(builder.buildForIssue(issue, triage)).rejects.toThrow(/maxBytes/u);
+    });
+
     it('decomposition prompt is distinct from LlmGraphBuilder prompt (issue-focused, not design-doc)', async () => {
       const completeFn = vi.fn<CompleteFn>(async () => JSON.stringify(twoChunks));
       const builder = new IssueGraphBuilder(completeFn);

--- a/packages/franken-orchestrator/tests/unit/skills/providers/stream-json-utils.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/stream-json-utils.test.ts
@@ -162,6 +162,17 @@ describe('cleanLlmJson', () => {
     expect(result).toEqual([{ id: 'setup', objective: 'Set up project' }]);
   });
 
+  it('can skip the JSON.parse fast path for callers that must enforce limits first', () => {
+    const input = '[{"id":"chunk1"}]';
+    const originalParse = JSON.parse;
+    JSON.parse = (() => { throw new Error('fast path used'); }) as typeof JSON.parse;
+    try {
+      expect(cleanLlmJson(input, { parseFastPath: false })).toBe(input);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
   it('strips whitespace around fences', () => {
     const input = '  \n```json\n[1,2,3]\n```\n  ';
     expect(JSON.parse(cleanLlmJson(input))).toEqual([1, 2, 3]);

--- a/packages/franken-orchestrator/tests/unit/skills/providers/stream-json-utils.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/stream-json-utils.test.ts
@@ -162,6 +162,12 @@ describe('cleanLlmJson', () => {
     expect(result).toEqual([{ id: 'setup', objective: 'Set up project' }]);
   });
 
+  it('preserves comma-bracket text inside valid JSON strings when fast path is skipped', () => {
+    const input = '[{"id":"chunk1","objective":"Keep literal ,] and ,} text"}]';
+    const cleaned = cleanLlmJson(input, { parseFastPath: false });
+    expect(JSON.parse(cleaned)).toEqual([{ id: 'chunk1', objective: 'Keep literal ,] and ,} text' }]);
+  });
+
   it('can skip the JSON.parse fast path for callers that must enforce limits first', () => {
     const input = '[{"id":"chunk1"}]';
     const originalParse = JSON.parse;

--- a/packages/franken-orchestrator/tests/unit/utils/safe-json.test.ts
+++ b/packages/franken-orchestrator/tests/unit/utils/safe-json.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { parseSafeJson, SafeJsonParseError } from '../../../src/utils/safe-json.js';
+
+describe('parseSafeJson', () => {
+  it('parses safe JSON documents', () => {
+    expect(parseSafeJson('{"ok":[1,2,3]}')).toEqual({ ok: [1, 2, 3] });
+  });
+
+  it('rejects huge JSON before parsing and identifies the byte limit', () => {
+    expect(() => parseSafeJson(JSON.stringify({ data: 'x'.repeat(32) }), {
+      context: 'test payload',
+      maxBytes: 16,
+    })).toThrow(SafeJsonParseError);
+
+    expect(() => parseSafeJson(JSON.stringify({ data: 'x'.repeat(32) }), {
+      context: 'test payload',
+      maxBytes: 16,
+    })).toThrow(/test payload exceeds maxBytes/u);
+  });
+
+  it('rejects deeply nested JSON and identifies the depth limit', () => {
+    const deep = '{"a":{"b":{"c":{"d":1}}}}';
+
+    expect(() => parseSafeJson(deep, {
+      context: 'nested config',
+      maxDepth: 3,
+    })).toThrow(/nested config exceeds maxDepth/u);
+  });
+
+  it('rejects objects with too many keys and identifies the key limit', () => {
+    const manyKeys = JSON.stringify({ a: 1, b: 2, c: 3 });
+
+    expect(() => parseSafeJson(manyKeys, {
+      context: 'object config',
+      maxObjectKeys: 2,
+    })).toThrow(/object config exceeds maxObjectKeys/u);
+  });
+
+  it('rejects arrays with too many items and identifies the array-item limit', () => {
+    expect(() => parseSafeJson('[1,2,3,4]', {
+      context: 'issue payload',
+      maxArrayItems: 3,
+    })).toThrow(/issue payload exceeds maxArrayItems/u);
+  });
+
+  it('rejects alias-like JSON fanout through the same container count checks used after parsing', () => {
+    const fanout = JSON.stringify({
+      items: Array.from({ length: 4 }, (_, index) => ({ index })),
+    });
+
+    expect(() => parseSafeJson(fanout, {
+      context: 'fanout payload',
+      maxContainers: 4,
+    })).toThrow(/fanout payload exceeds maxContainers/u);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable safe JSON parser with input byte, nesting-depth, container-count, object-key, and array-item limits
- Apply bounded JSON parsing to Beast config files, run configs, GitHub issue payloads, repo metadata payloads, and LLM issue decomposition payloads
- Document JSON parsing limits and explicitly note YAML is not accepted on these surfaces

## Test Plan
- npm --workspace @franken/orchestrator exec -- vitest run tests/unit/utils/safe-json.test.ts tests/unit/cli/config-loader.test.ts tests/unit/cli/run-config-loader.test.ts tests/unit/issues/issue-graph-builder.test.ts
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator run lint
- npm --workspace @franken/orchestrator run build

Closes #1742