### PR TITLE
feat(availability): add issue runner backpressure

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -113,3 +113,7 @@ Prompts: `Approve all? [Y/n/edit]`
 ## Budget
 
 The `--budget` flag sets a USD spending cap across all issues (default: $10). When the budget is exhausted, remaining issues are skipped with status `skipped`. Budget tracking converts USD to tokens at 1 USD = 1,000,000 tokens.
+
+## Backpressure
+
+Issue execution has a programmatic backpressure policy for orchestrator/refill callers that need to pause fresh issue starts before they create an availability incident. Callers can pass capacity signals for active processes, failed starts, in-flight backlog, pending queue depth, oldest queue age, provider budget remaining, and system load. When a configured threshold is exceeded, the runner skips the fresh issue start with status `skipped`, logs `[issues] Backpressure paused issue #<n>`, and includes a `backpressure: ...` reason in the issue outcome so refill/liveness output explains why work was paused. Once later signals fall below threshold, the next eligible issue is allowed automatically; no manual reset is required.

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -48,6 +48,18 @@ export type {
   TaskOutcome,
 } from './types.js';
 
+// Issues
+export { IssueRunner, evaluateIssueBackpressure } from './issues/index.js';
+export type {
+  IssueRunnerConfig,
+  IssueBackpressureConfig,
+  IssueBackpressureDecision,
+  IssueBackpressureSignalContext,
+  IssueBackpressureSignals,
+  IssueBackpressureSignalSource,
+  IssueBackpressureThresholds,
+} from './issues/index.js';
+
 // Config
 export { OrchestratorConfigSchema, defaultConfig, parseOrchestratorConfig } from './config/orchestrator-config.js';
 export type { OrchestratorConfig, OrchestratorConfigParseOptions } from './config/orchestrator-config.js';

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,15 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner } from './issue-runner.js';
-export type { IssueRunnerConfig } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure } from './issue-runner.js';
+export type {
+  IssueRunnerConfig,
+  IssueBackpressureConfig,
+  IssueBackpressureDecision,
+  IssueBackpressureSignalContext,
+  IssueBackpressureSignals,
+  IssueBackpressureSignalSource,
+  IssueBackpressureThresholds,
+} from './issue-runner.js';
 export { IssueReview } from './issue-review.js';
 export type { ReviewIO, ReviewDecision, IssueReviewOptions } from './issue-review.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -1,4 +1,5 @@
 import { appendFileSync, mkdirSync } from 'node:fs';
+import { loadavg } from 'node:os';
 import { basename, dirname, resolve } from 'node:path';
 import { BeastLoop } from '../beast-loop.js';
 import { ChunkFileGraphBuilder } from '../planning/chunk-file-graph-builder.js';
@@ -34,6 +35,51 @@ export interface IssueRuntimeSupport {
   artifactsForIssue(issueNumber: number): IssueRuntimeArtifacts;
 }
 
+export interface IssueBackpressureSignals {
+  readonly activeProcesses: number;
+  readonly failedStarts: number;
+  readonly inFlightBacklog: number;
+  readonly oldestQueueAgeMs?: number | undefined;
+  readonly systemLoadAverage?: number | undefined;
+  readonly providerBudgetTokensRemaining?: number | undefined;
+  readonly pendingIssueCount?: number | undefined;
+}
+
+export interface IssueBackpressureSignalContext {
+  readonly issue: GithubIssue;
+  readonly index: number;
+  readonly totalIssues: number;
+  readonly pendingIssueCount: number;
+  readonly cumulativeTokens: number;
+  readonly budgetTokens: number;
+  readonly providerBudgetTokensRemaining: number;
+}
+
+export type IssueBackpressureSignalSource = (
+  context: IssueBackpressureSignalContext,
+) => IssueBackpressureSignals | Promise<IssueBackpressureSignals>;
+
+export interface IssueBackpressureThresholds {
+  readonly maxActiveProcesses?: number | undefined;
+  readonly maxFailedStarts?: number | undefined;
+  readonly maxInFlightBacklog?: number | undefined;
+  readonly maxPendingIssueCount?: number | undefined;
+  readonly maxOldestQueueAgeMs?: number | undefined;
+  readonly maxSystemLoadAverage?: number | undefined;
+  readonly minProviderBudgetTokensRemaining?: number | undefined;
+}
+
+export interface IssueBackpressureConfig {
+  readonly thresholds?: IssueBackpressureThresholds | undefined;
+  readonly signals?: IssueBackpressureSignalSource | undefined;
+}
+
+export interface IssueBackpressureDecision {
+  readonly allowed: boolean;
+  readonly reasons: readonly string[];
+  readonly signals: IssueBackpressureSignals;
+}
+
 export interface IssueRunnerConfig {
   readonly issues: readonly GithubIssue[];
   readonly triageResults: readonly TriageResult[];
@@ -47,6 +93,7 @@ export interface IssueRunnerConfig {
   readonly checkpoint?: ICheckpointStore | undefined;
   readonly timeoutMs?: number | undefined;
   readonly enableTracing?: boolean | undefined;
+  readonly backpressure?: IssueBackpressureConfig | undefined;
 }
 
 const SEVERITY_ORDER: Record<string, number> = {
@@ -60,6 +107,71 @@ const NO_SEVERITY = 4;
 const TOKENS_PER_DOLLAR = 1_000_000;
 const ONE_SHOT_MAX_ITERATIONS = 50;
 const ONE_SHOT_STALE_MATE_LIMIT = 3;
+
+function limitExceeded(value: number | undefined, limit: number | undefined): value is number {
+  return limit !== undefined && value !== undefined && value > limit;
+}
+
+function providerBudgetAtReserve(value: number | undefined, reserve: number | undefined): value is number {
+  return reserve !== undefined && value !== undefined && value <= reserve;
+}
+
+function defaultBackpressureSignals(context: IssueBackpressureSignalContext): IssueBackpressureSignals {
+  return {
+    activeProcesses: 0,
+    failedStarts: 0,
+    inFlightBacklog: 0,
+    pendingIssueCount: context.pendingIssueCount,
+    providerBudgetTokensRemaining: context.providerBudgetTokensRemaining,
+    systemLoadAverage: loadavg()[0],
+  };
+}
+
+export async function evaluateIssueBackpressure(
+  backpressure: IssueBackpressureConfig | undefined,
+  context: IssueBackpressureSignalContext,
+): Promise<IssueBackpressureDecision> {
+  const rawSignals = await (backpressure?.signals?.(context) ?? defaultBackpressureSignals(context));
+  const signals: IssueBackpressureSignals = {
+    ...rawSignals,
+    providerBudgetTokensRemaining: rawSignals.providerBudgetTokensRemaining ?? context.providerBudgetTokensRemaining,
+    pendingIssueCount: rawSignals.pendingIssueCount ?? context.pendingIssueCount,
+  };
+  const thresholds = backpressure?.thresholds ?? {};
+  const reasons: string[] = [];
+
+  if (limitExceeded(signals.activeProcesses, thresholds.maxActiveProcesses)) {
+    reasons.push(`active processes ${signals.activeProcesses} exceeds limit ${thresholds.maxActiveProcesses}`);
+  }
+  if (limitExceeded(signals.failedStarts, thresholds.maxFailedStarts)) {
+    reasons.push(`failed starts ${signals.failedStarts} exceeds limit ${thresholds.maxFailedStarts}`);
+  }
+  if (limitExceeded(signals.inFlightBacklog, thresholds.maxInFlightBacklog)) {
+    reasons.push(
+      `fresh ticket creation blocked while in-flight backlog ${signals.inFlightBacklog} exceeds limit ${thresholds.maxInFlightBacklog}`,
+    );
+  }
+  if (limitExceeded(signals.pendingIssueCount, thresholds.maxPendingIssueCount)) {
+    reasons.push(`queue depth ${signals.pendingIssueCount} exceeds limit ${thresholds.maxPendingIssueCount}`);
+  }
+  if (limitExceeded(signals.oldestQueueAgeMs, thresholds.maxOldestQueueAgeMs)) {
+    reasons.push(`oldest queue age ${signals.oldestQueueAgeMs}ms exceeds limit ${thresholds.maxOldestQueueAgeMs}ms`);
+  }
+  if (limitExceeded(signals.systemLoadAverage, thresholds.maxSystemLoadAverage)) {
+    reasons.push(`system load ${signals.systemLoadAverage} exceeds limit ${thresholds.maxSystemLoadAverage}`);
+  }
+  if (providerBudgetAtReserve(signals.providerBudgetTokensRemaining, thresholds.minProviderBudgetTokensRemaining)) {
+    reasons.push(
+      `provider budget remaining ${signals.providerBudgetTokensRemaining} tokens is at or below reserve ${thresholds.minProviderBudgetTokensRemaining}`,
+    );
+  }
+
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    signals,
+  };
+}
 
 function extractSeverity(labels: readonly string[]): number {
   for (const label of labels) {
@@ -202,6 +314,38 @@ export class IssueRunner {
         continue;
       }
 
+      const providerBudgetTokensRemaining = Math.max(0, budgetTokens - cumulativeTokens);
+      const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
+        issue,
+        index: i,
+        totalIssues: sorted.length,
+        pendingIssueCount: sorted.length - i,
+        cumulativeTokens,
+        budgetTokens,
+        providerBudgetTokensRemaining,
+      });
+
+      if (!backpressureDecision.allowed) {
+        const reason = `backpressure: ${backpressureDecision.reasons.join('; ')}`;
+        logger?.warn(
+          `[issues] Backpressure paused issue #${issue.number}: ${backpressureDecision.reasons.join('; ')}`,
+          {
+            issueNumber: issue.number,
+            reasons: backpressureDecision.reasons,
+            signals: backpressureDecision.signals,
+          },
+          'issues',
+        );
+        outcomes.push({
+          issueNumber: issue.number,
+          issueTitle: issue.title,
+          status: 'skipped',
+          tokensUsed: 0,
+          error: reason,
+        });
+        continue;
+      }
+
       logger?.info(`[issues] Starting issue #${issue.number} (${position})`, undefined, 'issues');
 
       const triage = findTriage(triageResults, issue.number);
@@ -217,7 +361,7 @@ export class IssueRunner {
       }
 
       try {
-        const outcome = await this.processIssue(issue, triage, config, cumulativeTokens, budgetTokens);
+        const outcome = await this.processIssue(issue, triage, config);
         cumulativeTokens += outcome.tokensUsed;
         outcomes.push(outcome);
 
@@ -242,8 +386,6 @@ export class IssueRunner {
     issue: GithubIssue,
     triage: TriageResult,
     config: IssueRunnerConfig,
-    cumulativeTokens: number,
-    budgetTokens: number,
   ): Promise<IssueOutcome> {
     const {
       graphBuilder,

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -228,7 +228,8 @@ function checkpointEntriesHavePlanProgress(
   issueNumber: number,
   planDir: string,
 ): boolean {
-  for (const chunkPath of listPlanChunkPaths(planDir)) {
+  const chunkPaths = listPlanChunkPaths(planDir);
+  for (const chunkPath of chunkPaths) {
     const chunkId = basename(chunkPath, '.md');
     if (
       entries.has(issueTaskProgressKey(issueNumber, `impl:${chunkId}`)) ||
@@ -236,6 +237,16 @@ function checkpointEntriesHavePlanProgress(
     ) {
       return true;
     }
+  }
+
+  if (chunkPaths.length > 0) {
+    return chunkPaths.every((chunkPath) => {
+      const chunkId = basename(chunkPath, '.md');
+      return (
+        entries.has(issueCompletionKey(`impl:${chunkId}`)) &&
+        entries.has(issueCompletionKey(`harden:${chunkId}`))
+      );
+    });
   }
 
   return false;

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -1,6 +1,6 @@
-import { appendFileSync, mkdirSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { loadavg } from 'node:os';
-import { basename, dirname, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { BeastLoop } from '../beast-loop.js';
 import { ChunkFileGraphBuilder } from '../planning/chunk-file-graph-builder.js';
 import { ChunkFileWriter } from '../planning/chunk-file-writer.js';
@@ -203,10 +203,37 @@ function issueCompletionKey(taskId: string): string {
   return `${taskId}:done`;
 }
 
+function listPlanChunkPaths(planDir: string): string[] {
+  try {
+    if (!existsSync(planDir)) return [];
+    return readdirSync(planDir)
+      .filter((fileName) => fileName.endsWith('.md') && !fileName.startsWith('00_') && /^\d{2}/.test(fileName))
+      .sort()
+      .map((fileName) => join(planDir, fileName));
+  } catch {
+    return [];
+  }
+}
+
+function checkpointEntriesHavePlanProgress(entries: ReadonlySet<string>, planDir: string): boolean {
+  for (const chunkPath of listPlanChunkPaths(planDir)) {
+    const chunkId = basename(chunkPath, '.md');
+    if (
+      entries.has(issueCompletionKey(`impl:${chunkId}`)) ||
+      entries.has(issueCompletionKey(`harden:${chunkId}`))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function checkpointEntriesHaveIssueProgress(
   entries: ReadonlySet<string> | undefined,
   issueNumber: number,
   issueSpecificCheckpoint: boolean,
+  planDir: string,
 ): boolean {
   if (!entries) return false;
   if (issueSpecificCheckpoint) return entries.size > 0;
@@ -223,7 +250,7 @@ function checkpointEntriesHaveIssueProgress(
     if (!hasNumericPrefix && !hasNumericSuffix) return true;
   }
 
-  return false;
+  return checkpointEntriesHavePlanProgress(entries, planDir);
 }
 
 function issueSkillDescriptor(id: string): SkillDescriptor {
@@ -417,7 +444,9 @@ export class IssueRunner {
       checkpointEntries,
       issue.number,
       issueRuntime !== undefined,
+      planDir,
     );
+    const checkpointedPlanChunkPaths = checkpointHasIssueProgress ? listPlanChunkPaths(planDir) : [];
 
     const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
       const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
@@ -446,7 +475,7 @@ export class IssueRunner {
       };
     };
 
-    if (backpressureContext.stopRemainingReason && issueRuntime !== undefined && !checkpointHasIssueProgress) {
+    if (backpressureContext.stopRemainingReason && !checkpointHasIssueProgress) {
       return {
         issueNumber: issue.number,
         issueTitle: issue.title,
@@ -468,9 +497,10 @@ export class IssueRunner {
     let refreshPlanTasks: BeastLoopDeps['refreshPlanTasks'];
     let skillIds: readonly string[];
     try {
-      const chunks = await graphBuilder.buildChunkDefinitionsForIssue(issue, triage);
-      const chunkPaths = new ChunkFileWriter(planDir).write(chunks);
       const realGraphBuilder = new ChunkFileGraphBuilder(planDir);
+      const chunkPaths = checkpointedPlanChunkPaths.length > 0
+        ? checkpointedPlanChunkPaths
+        : new ChunkFileWriter(planDir).write(await graphBuilder.buildChunkDefinitionsForIssue(issue, triage));
       graph = await realGraphBuilder.build({ goal: `Process issue #${issue.number}` });
       executionGraphBuilder = realGraphBuilder;
       skillIds = chunkPaths.map((chunkPath) => `cli:${basename(chunkPath, '.md')}`);
@@ -485,6 +515,9 @@ export class IssueRunner {
       };
     }
 
+    const graphHasCheckpointProgress =
+      issueCheckpoint !== undefined && graph.tasks.some((task) => issueCheckpoint.has(issueCompletionKey(task.id)));
+
     if (issueCheckpoint && graph.tasks.every((task) => issueCheckpoint.has(issueCompletionKey(task.id)))) {
       logger?.info(`[issues] Issue #${issue.number} already completed (checkpoint)`, undefined, 'issues');
       appendIssueLog(logFile, `Issue #${issue.number} already complete from checkpoint`);
@@ -496,7 +529,7 @@ export class IssueRunner {
       };
     }
 
-    if (backpressureContext.stopRemainingReason) {
+    if (backpressureContext.stopRemainingReason && !graphHasCheckpointProgress) {
       return {
         issueNumber: issue.number,
         issueTitle: issue.title,
@@ -506,7 +539,7 @@ export class IssueRunner {
       };
     }
 
-    if (requiresCheckpointCompletionCheckBeforeBackpressure) {
+    if (requiresCheckpointCompletionCheckBeforeBackpressure && !graphHasCheckpointProgress) {
       const paused = await pauseForBackpressure();
       if (paused) return paused;
     }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -302,18 +302,20 @@ export class IssueRunner {
     const budgetTokens = budget * TOKENS_PER_DOLLAR;
     let cumulativeTokens = 0;
     let budgetExceeded = false;
+    let stopRemainingReason: string | undefined;
     const outcomes: IssueOutcome[] = [];
 
     for (let i = 0; i < sorted.length; i++) {
       const issue = sorted[i]!;
       const position = `${i + 1}/${sorted.length}`;
 
-      if (budgetExceeded) {
+      if (budgetExceeded || stopRemainingReason) {
         outcomes.push({
           issueNumber: issue.number,
           issueTitle: issue.title,
           status: 'skipped',
           tokensUsed: 0,
+          ...(stopRemainingReason ? { error: stopRemainingReason } : {}),
         });
         continue;
       }
@@ -345,7 +347,7 @@ export class IssueRunner {
         outcomes.push(outcome);
 
         if (outcome.status === 'skipped' && outcome.error?.includes('queue depth')) {
-          budgetExceeded = true;
+          stopRemainingReason = outcome.error;
         }
 
         if (cumulativeTokens >= budgetTokens) {
@@ -386,6 +388,38 @@ export class IssueRunner {
     const logFile = runtimeArtifacts?.logFile;
     const planDir = runtimeArtifacts?.planDir ?? resolve(getProjectPaths('.').plansDir, planName);
 
+    const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
+      const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
+        issue,
+        ...backpressureContext,
+      });
+
+      if (backpressureDecision.allowed) return undefined;
+
+      const reason = `backpressure: ${backpressureDecision.reasons.join('; ')}`;
+      logger?.warn(
+        `[issues] Backpressure paused issue #${issue.number}: ${backpressureDecision.reasons.join('; ')}`,
+        {
+          issueNumber: issue.number,
+          reasons: backpressureDecision.reasons,
+          signals: backpressureDecision.signals,
+        },
+        'issues',
+      );
+      return {
+        issueNumber: issue.number,
+        issueTitle: issue.title,
+        status: 'skipped',
+        tokensUsed: 0,
+        error: reason,
+      };
+    };
+
+    if (!issueCheckpoint) {
+      const paused = await pauseForBackpressure();
+      if (paused) return paused;
+    }
+
     let graph: PlanGraph;
     let executionGraphBuilder: BeastLoopDeps['graphBuilder'];
     let refreshPlanTasks: BeastLoopDeps['refreshPlanTasks'];
@@ -419,30 +453,8 @@ export class IssueRunner {
       };
     }
 
-    const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
-      issue,
-      ...backpressureContext,
-    });
-
-    if (!backpressureDecision.allowed) {
-      const reason = `backpressure: ${backpressureDecision.reasons.join('; ')}`;
-      logger?.warn(
-        `[issues] Backpressure paused issue #${issue.number}: ${backpressureDecision.reasons.join('; ')}`,
-        {
-          issueNumber: issue.number,
-          reasons: backpressureDecision.reasons,
-          signals: backpressureDecision.signals,
-        },
-        'issues',
-      );
-      return {
-        issueNumber: issue.number,
-        issueTitle: issue.title,
-        status: 'skipped',
-        tokensUsed: 0,
-        error: reason,
-      };
-    }
+    const paused = await pauseForBackpressure();
+    if (paused) return paused;
 
     git.isolate(`issue-${issue.number}`);
 

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -526,7 +526,10 @@ export class IssueRunner {
       refreshPlanTasks = async () => (await realGraphBuilder.build({ goal: 'refresh issue tasks' })).tasks;
       if (issueCheckpoint && issueRuntime === undefined) {
         for (const task of graph.tasks) {
-          issueCheckpoint.write(issueTaskProgressKey(issue.number, task.id));
+          const progressKey = issueTaskProgressKey(issue.number, task.id);
+          if (!issueCheckpoint.has(progressKey)) {
+            issueCheckpoint.write(progressKey);
+          }
         }
       }
     } catch (err) {

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -309,7 +309,10 @@ export class IssueRunner {
       const issue = sorted[i]!;
       const position = `${i + 1}/${sorted.length}`;
 
-      if (budgetExceeded || stopRemainingReason) {
+      const hasIssueSpecificCheckpointProgress =
+        (config.issueRuntime?.checkpointForIssue(issue.number).readAll().size ?? 0) > 0;
+
+      if (budgetExceeded || (stopRemainingReason && !hasIssueSpecificCheckpointProgress)) {
         outcomes.push({
           issueNumber: issue.number,
           issueTitle: issue.title,
@@ -387,7 +390,7 @@ export class IssueRunner {
     const planName = runtimeArtifacts?.planName ?? issueRuntime?.planNameForIssue(issue.number) ?? `issue-${issue.number}`;
     const logFile = runtimeArtifacts?.logFile;
     const planDir = runtimeArtifacts?.planDir ?? resolve(getProjectPaths('.').plansDir, planName);
-    const checkpointHasProgress = (issueCheckpoint?.readAll().size ?? 0) > 0;
+    const checkpointHasProgress = issueRuntime !== undefined && (issueCheckpoint?.readAll().size ?? 0) > 0;
 
     const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
       const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -203,6 +203,29 @@ function issueCompletionKey(taskId: string): string {
   return `${taskId}:done`;
 }
 
+function checkpointEntriesHaveIssueProgress(
+  entries: ReadonlySet<string> | undefined,
+  issueNumber: number,
+  issueSpecificCheckpoint: boolean,
+): boolean {
+  if (!entries) return false;
+  if (issueSpecificCheckpoint) return entries.size > 0;
+
+  const issueToken = `issue-${issueNumber}`;
+  for (const entry of entries) {
+    const index = entry.indexOf(issueToken);
+    if (index < 0) continue;
+
+    const before = entry[index - 1];
+    const after = entry[index + issueToken.length];
+    const hasNumericPrefix = before !== undefined && /\d/.test(before);
+    const hasNumericSuffix = after !== undefined && /\d/.test(after);
+    if (!hasNumericPrefix && !hasNumericSuffix) return true;
+  }
+
+  return false;
+}
+
 function issueSkillDescriptor(id: string): SkillDescriptor {
   return {
     id,
@@ -309,16 +332,12 @@ export class IssueRunner {
       const issue = sorted[i]!;
       const position = `${i + 1}/${sorted.length}`;
 
-      const hasIssueSpecificCheckpointProgress =
-        (config.issueRuntime?.checkpointForIssue(issue.number).readAll().size ?? 0) > 0;
-
-      if (budgetExceeded || (stopRemainingReason && !hasIssueSpecificCheckpointProgress)) {
+      if (budgetExceeded) {
         outcomes.push({
           issueNumber: issue.number,
           issueTitle: issue.title,
           status: 'skipped',
           tokensUsed: 0,
-          ...(stopRemainingReason ? { error: stopRemainingReason } : {}),
         });
         continue;
       }
@@ -345,6 +364,7 @@ export class IssueRunner {
           cumulativeTokens,
           budgetTokens,
           providerBudgetTokensRemaining: Math.max(0, budgetTokens - cumulativeTokens),
+          stopRemainingReason,
         });
         cumulativeTokens += outcome.tokensUsed;
         outcomes.push(outcome);
@@ -374,7 +394,9 @@ export class IssueRunner {
     issue: GithubIssue,
     triage: TriageResult,
     config: IssueRunnerConfig,
-    backpressureContext: Omit<IssueBackpressureSignalContext, 'issue'>,
+    backpressureContext: Omit<IssueBackpressureSignalContext, 'issue'> & {
+      readonly stopRemainingReason?: string | undefined;
+    },
   ): Promise<IssueOutcome> {
     const {
       graphBuilder,
@@ -390,7 +412,12 @@ export class IssueRunner {
     const planName = runtimeArtifacts?.planName ?? issueRuntime?.planNameForIssue(issue.number) ?? `issue-${issue.number}`;
     const logFile = runtimeArtifacts?.logFile;
     const planDir = runtimeArtifacts?.planDir ?? resolve(getProjectPaths('.').plansDir, planName);
-    const checkpointHasProgress = issueRuntime !== undefined && (issueCheckpoint?.readAll().size ?? 0) > 0;
+    const checkpointEntries = issueCheckpoint?.readAll();
+    const checkpointHasIssueProgress = checkpointEntriesHaveIssueProgress(
+      checkpointEntries,
+      issue.number,
+      issueRuntime !== undefined,
+    );
 
     const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
       const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
@@ -419,7 +446,19 @@ export class IssueRunner {
       };
     };
 
-    if (!checkpointHasProgress) {
+    if (backpressureContext.stopRemainingReason && issueRuntime !== undefined && !checkpointHasIssueProgress) {
+      return {
+        issueNumber: issue.number,
+        issueTitle: issue.title,
+        status: 'skipped',
+        tokensUsed: 0,
+        error: backpressureContext.stopRemainingReason,
+      };
+    }
+
+    const requiresCheckpointCompletionCheckBeforeBackpressure =
+      issueRuntime === undefined && issueCheckpoint !== undefined && checkpointHasIssueProgress;
+    if (!checkpointHasIssueProgress && !requiresCheckpointCompletionCheckBeforeBackpressure) {
       const paused = await pauseForBackpressure();
       if (paused) return paused;
     }
@@ -455,6 +494,21 @@ export class IssueRunner {
         status: 'fixed',
         tokensUsed: 0,
       };
+    }
+
+    if (backpressureContext.stopRemainingReason) {
+      return {
+        issueNumber: issue.number,
+        issueTitle: issue.title,
+        status: 'skipped',
+        tokensUsed: 0,
+        error: backpressureContext.stopRemainingReason,
+      };
+    }
+
+    if (requiresCheckpointCompletionCheckBeforeBackpressure) {
+      const paused = await pauseForBackpressure();
+      if (paused) return paused;
     }
 
     git.isolate(`issue-${issue.number}`);

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -203,6 +203,14 @@ function issueCompletionKey(taskId: string): string {
   return `${taskId}:done`;
 }
 
+function issueTaskProgressKey(issueNumber: number, taskId: string): string {
+  return `issue:${issueNumber}:${taskId}`;
+}
+
+function taskRecoveryStage(taskId: string): 'impl' | 'harden' {
+  return taskId.startsWith('harden:') || taskId.startsWith('fix-harden:') ? 'harden' : 'impl';
+}
+
 function listPlanChunkPaths(planDir: string): string[] {
   try {
     if (!existsSync(planDir)) return [];
@@ -215,15 +223,39 @@ function listPlanChunkPaths(planDir: string): string[] {
   }
 }
 
-function checkpointEntriesHavePlanProgress(entries: ReadonlySet<string>, planDir: string): boolean {
+function checkpointEntriesHavePlanProgress(
+  entries: ReadonlySet<string>,
+  issueNumber: number,
+  planDir: string,
+): boolean {
   for (const chunkPath of listPlanChunkPaths(planDir)) {
     const chunkId = basename(chunkPath, '.md');
     if (
-      entries.has(issueCompletionKey(`impl:${chunkId}`)) ||
-      entries.has(issueCompletionKey(`harden:${chunkId}`))
+      entries.has(issueTaskProgressKey(issueNumber, `impl:${chunkId}`)) ||
+      entries.has(issueTaskProgressKey(issueNumber, `harden:${chunkId}`))
     ) {
       return true;
     }
+  }
+
+  return false;
+}
+
+function checkpointEntryTaskId(entry: string): string | undefined {
+  const match = /^(?:impl|harden):(.+):done$/.exec(entry);
+  return match?.[1];
+}
+
+function taskIdContainsIssueToken(taskId: string): boolean {
+  return /(?:^|[^\d])issue-\d+(?:$|[^\d])/.test(taskId);
+}
+
+function checkpointEntriesMayHaveUnscopedPlanProgress(entries: ReadonlySet<string> | undefined): boolean {
+  if (!entries) return false;
+
+  for (const entry of entries) {
+    const taskId = checkpointEntryTaskId(entry);
+    if (taskId !== undefined && !taskIdContainsIssueToken(taskId)) return true;
   }
 
   return false;
@@ -250,7 +282,14 @@ function checkpointEntriesHaveIssueProgress(
     if (!hasNumericPrefix && !hasNumericSuffix) return true;
   }
 
-  return checkpointEntriesHavePlanProgress(entries, planDir);
+  return checkpointEntriesHavePlanProgress(entries, issueNumber, planDir);
+}
+
+function checkpointHasTaskProgress(issueCheckpoint: ICheckpointStore, taskId: string): boolean {
+  return (
+    issueCheckpoint.has(issueCompletionKey(taskId)) ||
+    issueCheckpoint.lastCommit(taskId, taskRecoveryStage(taskId)) !== undefined
+  );
 }
 
 function issueSkillDescriptor(id: string): SkillDescriptor {
@@ -446,6 +485,9 @@ export class IssueRunner {
       issueRuntime !== undefined,
       planDir,
     );
+    const checkpointMayHaveIssueProgress =
+      checkpointHasIssueProgress ||
+      (issueRuntime === undefined && checkpointEntriesMayHaveUnscopedPlanProgress(checkpointEntries));
     const checkpointedPlanChunkPaths = checkpointHasIssueProgress ? listPlanChunkPaths(planDir) : [];
 
     const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
@@ -475,7 +517,7 @@ export class IssueRunner {
       };
     };
 
-    if (backpressureContext.stopRemainingReason && !checkpointHasIssueProgress) {
+    if (backpressureContext.stopRemainingReason && !checkpointMayHaveIssueProgress) {
       return {
         issueNumber: issue.number,
         issueTitle: issue.title,
@@ -486,8 +528,8 @@ export class IssueRunner {
     }
 
     const requiresCheckpointCompletionCheckBeforeBackpressure =
-      issueRuntime === undefined && issueCheckpoint !== undefined && checkpointHasIssueProgress;
-    if (!checkpointHasIssueProgress && !requiresCheckpointCompletionCheckBeforeBackpressure) {
+      issueRuntime === undefined && issueCheckpoint !== undefined && checkpointMayHaveIssueProgress;
+    if (!checkpointMayHaveIssueProgress && !requiresCheckpointCompletionCheckBeforeBackpressure) {
       const paused = await pauseForBackpressure();
       if (paused) return paused;
     }
@@ -505,6 +547,11 @@ export class IssueRunner {
       executionGraphBuilder = realGraphBuilder;
       skillIds = chunkPaths.map((chunkPath) => `cli:${basename(chunkPath, '.md')}`);
       refreshPlanTasks = async () => (await realGraphBuilder.build({ goal: 'refresh issue tasks' })).tasks;
+      if (issueCheckpoint && issueRuntime === undefined) {
+        for (const task of graph.tasks) {
+          issueCheckpoint.write(issueTaskProgressKey(issue.number, task.id));
+        }
+      }
     } catch (err) {
       return {
         issueNumber: issue.number,
@@ -516,7 +563,7 @@ export class IssueRunner {
     }
 
     const graphHasCheckpointProgress =
-      issueCheckpoint !== undefined && graph.tasks.some((task) => issueCheckpoint.has(issueCompletionKey(task.id)));
+      issueCheckpoint !== undefined && graph.tasks.some((task) => checkpointHasTaskProgress(issueCheckpoint, task.id));
 
     if (issueCheckpoint && graph.tasks.every((task) => issueCheckpoint.has(issueCompletionKey(task.id)))) {
       logger?.info(`[issues] Issue #${issue.number} already completed (checkpoint)`, undefined, 'issues');

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -387,6 +387,7 @@ export class IssueRunner {
     const planName = runtimeArtifacts?.planName ?? issueRuntime?.planNameForIssue(issue.number) ?? `issue-${issue.number}`;
     const logFile = runtimeArtifacts?.logFile;
     const planDir = runtimeArtifacts?.planDir ?? resolve(getProjectPaths('.').plansDir, planName);
+    const checkpointHasProgress = (issueCheckpoint?.readAll().size ?? 0) > 0;
 
     const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
       const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
@@ -415,7 +416,7 @@ export class IssueRunner {
       };
     };
 
-    if (!issueCheckpoint) {
+    if (!checkpointHasProgress) {
       const paused = await pauseForBackpressure();
       if (paused) return paused;
     }
@@ -452,9 +453,6 @@ export class IssueRunner {
         tokensUsed: 0,
       };
     }
-
-    const paused = await pauseForBackpressure();
-    if (paused) return paused;
 
     git.isolate(`issue-${issue.number}`);
 

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -241,26 +241,6 @@ function checkpointEntriesHavePlanProgress(
   return false;
 }
 
-function checkpointEntryTaskId(entry: string): string | undefined {
-  const match = /^(?:impl|harden):(.+):done$/.exec(entry);
-  return match?.[1];
-}
-
-function taskIdContainsIssueToken(taskId: string): boolean {
-  return /(?:^|[^\d])issue-\d+(?:$|[^\d])/.test(taskId);
-}
-
-function checkpointEntriesMayHaveUnscopedPlanProgress(entries: ReadonlySet<string> | undefined): boolean {
-  if (!entries) return false;
-
-  for (const entry of entries) {
-    const taskId = checkpointEntryTaskId(entry);
-    if (taskId !== undefined && !taskIdContainsIssueToken(taskId)) return true;
-  }
-
-  return false;
-}
-
 function checkpointEntriesHaveIssueProgress(
   entries: ReadonlySet<string> | undefined,
   issueNumber: number,
@@ -485,9 +465,6 @@ export class IssueRunner {
       issueRuntime !== undefined,
       planDir,
     );
-    const checkpointMayHaveIssueProgress =
-      checkpointHasIssueProgress ||
-      (issueRuntime === undefined && checkpointEntriesMayHaveUnscopedPlanProgress(checkpointEntries));
     const checkpointedPlanChunkPaths = checkpointHasIssueProgress ? listPlanChunkPaths(planDir) : [];
 
     const pauseForBackpressure = async (): Promise<IssueOutcome | undefined> => {
@@ -517,7 +494,7 @@ export class IssueRunner {
       };
     };
 
-    if (backpressureContext.stopRemainingReason && !checkpointMayHaveIssueProgress) {
+    if (backpressureContext.stopRemainingReason && !checkpointHasIssueProgress) {
       return {
         issueNumber: issue.number,
         issueTitle: issue.title,
@@ -528,8 +505,8 @@ export class IssueRunner {
     }
 
     const requiresCheckpointCompletionCheckBeforeBackpressure =
-      issueRuntime === undefined && issueCheckpoint !== undefined && checkpointMayHaveIssueProgress;
-    if (!checkpointMayHaveIssueProgress && !requiresCheckpointCompletionCheckBeforeBackpressure) {
+      issueRuntime === undefined && issueCheckpoint !== undefined && checkpointHasIssueProgress;
+    if (!checkpointHasIssueProgress && !requiresCheckpointCompletionCheckBeforeBackpressure) {
       const paused = await pauseForBackpressure();
       if (paused) return paused;
     }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -112,6 +112,10 @@ function limitExceeded(value: number | undefined, limit: number | undefined): va
   return limit !== undefined && value !== undefined && value > limit;
 }
 
+function limitReached(value: number | undefined, limit: number | undefined): value is number {
+  return limit !== undefined && value !== undefined && value >= limit;
+}
+
 function providerBudgetAtReserve(value: number | undefined, reserve: number | undefined): value is number {
   return reserve !== undefined && value !== undefined && value <= reserve;
 }
@@ -140,8 +144,8 @@ export async function evaluateIssueBackpressure(
   const thresholds = backpressure?.thresholds ?? {};
   const reasons: string[] = [];
 
-  if (limitExceeded(signals.activeProcesses, thresholds.maxActiveProcesses)) {
-    reasons.push(`active processes ${signals.activeProcesses} exceeds limit ${thresholds.maxActiveProcesses}`);
+  if (limitReached(signals.activeProcesses, thresholds.maxActiveProcesses)) {
+    reasons.push(`active processes ${signals.activeProcesses} reached limit ${thresholds.maxActiveProcesses}`);
   }
   if (limitExceeded(signals.failedStarts, thresholds.maxFailedStarts)) {
     reasons.push(`failed starts ${signals.failedStarts} exceeds limit ${thresholds.maxFailedStarts}`);
@@ -314,38 +318,6 @@ export class IssueRunner {
         continue;
       }
 
-      const providerBudgetTokensRemaining = Math.max(0, budgetTokens - cumulativeTokens);
-      const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
-        issue,
-        index: i,
-        totalIssues: sorted.length,
-        pendingIssueCount: sorted.length - i,
-        cumulativeTokens,
-        budgetTokens,
-        providerBudgetTokensRemaining,
-      });
-
-      if (!backpressureDecision.allowed) {
-        const reason = `backpressure: ${backpressureDecision.reasons.join('; ')}`;
-        logger?.warn(
-          `[issues] Backpressure paused issue #${issue.number}: ${backpressureDecision.reasons.join('; ')}`,
-          {
-            issueNumber: issue.number,
-            reasons: backpressureDecision.reasons,
-            signals: backpressureDecision.signals,
-          },
-          'issues',
-        );
-        outcomes.push({
-          issueNumber: issue.number,
-          issueTitle: issue.title,
-          status: 'skipped',
-          tokensUsed: 0,
-          error: reason,
-        });
-        continue;
-      }
-
       logger?.info(`[issues] Starting issue #${issue.number} (${position})`, undefined, 'issues');
 
       const triage = findTriage(triageResults, issue.number);
@@ -361,9 +333,20 @@ export class IssueRunner {
       }
 
       try {
-        const outcome = await this.processIssue(issue, triage, config);
+        const outcome = await this.processIssue(issue, triage, config, {
+          index: i,
+          totalIssues: sorted.length,
+          pendingIssueCount: sorted.length - i,
+          cumulativeTokens,
+          budgetTokens,
+          providerBudgetTokensRemaining: Math.max(0, budgetTokens - cumulativeTokens),
+        });
         cumulativeTokens += outcome.tokensUsed;
         outcomes.push(outcome);
+
+        if (outcome.status === 'skipped' && outcome.error?.includes('queue depth')) {
+          budgetExceeded = true;
+        }
 
         if (cumulativeTokens >= budgetTokens) {
           budgetExceeded = true;
@@ -386,6 +369,7 @@ export class IssueRunner {
     issue: GithubIssue,
     triage: TriageResult,
     config: IssueRunnerConfig,
+    backpressureContext: Omit<IssueBackpressureSignalContext, 'issue'>,
   ): Promise<IssueOutcome> {
     const {
       graphBuilder,
@@ -432,6 +416,31 @@ export class IssueRunner {
         issueTitle: issue.title,
         status: 'fixed',
         tokensUsed: 0,
+      };
+    }
+
+    const backpressureDecision = await evaluateIssueBackpressure(config.backpressure, {
+      issue,
+      ...backpressureContext,
+    });
+
+    if (!backpressureDecision.allowed) {
+      const reason = `backpressure: ${backpressureDecision.reasons.join('; ')}`;
+      logger?.warn(
+        `[issues] Backpressure paused issue #${issue.number}: ${backpressureDecision.reasons.join('; ')}`,
+        {
+          issueNumber: issue.number,
+          reasons: backpressureDecision.reasons,
+          signals: backpressureDecision.signals,
+        },
+        'issues',
+      );
+      return {
+        issueNumber: issue.number,
+        issueTitle: issue.title,
+        status: 'skipped',
+        tokensUsed: 0,
+        error: reason,
       };
     }
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -577,7 +577,8 @@ describe('IssueRunner', () => {
     });
 
     it('does not treat unrelated shared checkpoint entries as progress for fresh starts', async () => {
-      const checkpoint = mockCheckpoint(new Set(['impl:01_issue-150:done', 'harden:01_issue-150:done']));
+      writePlanChunks('issue-15', ['api']);
+      const checkpoint = mockCheckpoint(new Set(['impl:01_api:done', 'harden:01_api:done']));
       const graphBuilder = mockGraphBuilder();
       const config = makeConfig({
         issues: [makeIssue({ number: 15 })],
@@ -600,6 +601,37 @@ describe('IssueRunner', () => {
       expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'skipped' });
       expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
       expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it('resumes issue-scoped shared-checkpoint commit recovery under backpressure', async () => {
+      writePlanChunks('issue-9916', ['checkpointed-api']);
+      const checkpoint = {
+        ...mockCheckpoint(new Set(['issue:9916:impl:01_checkpointed-api'])),
+        lastCommit: vi.fn((taskId: string, stage: string) =>
+          taskId === 'impl:01_checkpointed-api' && stage === 'impl' ? 'abc123' : undefined,
+        ),
+      };
+      const signals = vi.fn(() => ({
+        activeProcesses: 1,
+        failedStarts: 0,
+        inFlightBacklog: 0,
+        oldestQueueAgeMs: 0,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 9916 })],
+        triageResults: [makeTriage(9916, 'chunked')],
+        checkpoint,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals,
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 9916, status: 'fixed' });
+      expect(signals).not.toHaveBeenCalled();
+      expect(mockRun).toHaveBeenCalledOnce();
     });
 
     it('stops iteration after queue depth backpressure to avoid priority inversion', async () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { IssueRunner } from '../../../src/issues/issue-runner.js';
 import type { IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
@@ -12,6 +14,7 @@ import type { ChunkDefinition } from '../../../src/cli/file-writer.js';
 // ── Mocks ──
 
 const mockLoopConstructions: Array<{ deps: BeastLoopDeps; config: unknown }> = [];
+const tempPlanDirs: string[] = [];
 
 const mockRun = vi.fn(async (deps?: BeastLoopDeps) => {
   // Default mock behavior: success with some tokens used
@@ -146,6 +149,23 @@ function mockCheckpoint(completed: Set<string> = new Set()): ICheckpointStore {
   };
 }
 
+function writePlanChunks(planName: string, chunkIds: readonly string[]): string {
+  const planDir = resolve(process.cwd(), '.fbeast', 'plans', planName);
+  mkdirSync(planDir, { recursive: true });
+  tempPlanDirs.push(planDir);
+
+  chunkIds.forEach((chunkId, index) => {
+    const chunkNumber = String(index + 1).padStart(2, '0');
+    writeFileSync(
+      resolve(planDir, `${chunkNumber}_${chunkId}.md`),
+      `# Chunk ${chunkNumber}: ${chunkId}\n\n## Objective\n\nResume ${chunkId}\n\n## Files\n\n- test.ts\n\n## Success Criteria\n\nDone\n\n## Verification Command\n\n\`\`\`bash\nnpm test\n\`\`\`\n`,
+      'utf8',
+    );
+  });
+
+  return planDir;
+}
+
 function makeConfig(overrides: Partial<IssueRunnerConfig> = {}): IssueRunnerConfig {
   return {
     issues: [],
@@ -193,6 +213,12 @@ describe('IssueRunner', () => {
       return result;
     });
     runner = new IssueRunner();
+  });
+
+  afterEach(() => {
+    for (const dir of tempPlanDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   describe('run() basic contract', () => {
@@ -463,6 +489,8 @@ describe('IssueRunner', () => {
       vi.mocked(issueRuntime.artifactsForIssue).mockReturnValue({
         planName: 'issue-15',
         planDir: '.tmp/test-issue-15',
+        checkpointFile: '.tmp/test-issue-15.checkpoint',
+        logFile: '.tmp/test-issue-15.log',
       });
       const signals = vi.fn(() => ({
         activeProcesses: 1,
@@ -513,6 +541,35 @@ describe('IssueRunner', () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
+    it('recognizes shared-checkpoint progress from existing arbitrary chunk plans before pausing', async () => {
+      writePlanChunks('issue-15', ['api', 'ui']);
+      const checkpoint = mockCheckpoint(new Set(['impl:01_api:done', 'harden:01_api:done']));
+      const graphBuilder = mockGraphBuilder();
+      const signals = vi.fn(() => ({
+        activeProcesses: 1,
+        failedStarts: 0,
+        inFlightBacklog: 0,
+        oldestQueueAgeMs: 0,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 15 })],
+        triageResults: [makeTriage(15, 'chunked')],
+        checkpoint,
+        graphBuilder,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals,
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'fixed' });
+      expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
+      expect(signals).not.toHaveBeenCalled();
+      expect(mockRun).toHaveBeenCalledOnce();
+    });
+
     it('does not treat unrelated shared checkpoint entries as progress for fresh starts', async () => {
       const checkpoint = mockCheckpoint(new Set(['impl:01_issue-150:done', 'harden:01_issue-150:done']));
       const graphBuilder = mockGraphBuilder();
@@ -540,9 +597,11 @@ describe('IssueRunner', () => {
     });
 
     it('stops iteration after queue depth backpressure to avoid priority inversion', async () => {
+      const graphBuilder = mockGraphBuilder();
       const config = makeConfig({
         issues: [makeIssue({ number: 16 }), makeIssue({ number: 17 })],
         triageResults: [makeTriage(16), makeTriage(17)],
+        graphBuilder,
         backpressure: {
           thresholds: { maxPendingIssueCount: 1 },
         },
@@ -564,6 +623,34 @@ describe('IssueRunner', () => {
         }),
       ]);
       expect(mockRun).not.toHaveBeenCalled();
+      expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
+    });
+
+    it('resumes partially checkpointed issueRuntime work after queue-depth stops fresh starts', async () => {
+      const issueRuntime = makeIssueRuntimeSupport();
+      vi.mocked(issueRuntime.checkpointForIssue).mockImplementation((issueNumber: number) =>
+        issueNumber === 17 ? mockCheckpoint(new Set(['impl:01_issue-17:done'])) : mockCheckpoint(),
+      );
+      vi.mocked(issueRuntime.artifactsForIssue).mockImplementation((issueNumber: number): IssueRuntimeArtifacts => ({
+        planName: `issue-${issueNumber}`,
+        planDir: `.tmp/test-issue-${issueNumber}`,
+        checkpointFile: `.tmp/test-issue-${issueNumber}.checkpoint`,
+        logFile: `.tmp/test-issue-${issueNumber}.log`,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 16 }), makeIssue({ number: 17 })],
+        triageResults: [makeTriage(16), makeTriage(17)],
+        issueRuntime,
+        backpressure: {
+          thresholds: { maxPendingIssueCount: 1 },
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 16, status: 'skipped' });
+      expect(outcomes[1]).toMatchObject({ issueNumber: 17, status: 'fixed' });
+      expect(mockRun).toHaveBeenCalledOnce();
     });
 
     it('contains issue-runtime checkpoint read failures to one issue outcome', async () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -488,6 +488,57 @@ describe('IssueRunner', () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
+    it('preserves shared-checkpoint completions before evaluating backpressure', async () => {
+      const checkpoint = mockCheckpoint(new Set(['impl:01_issue-15:done', 'harden:01_issue-15:done']));
+      const signals = vi.fn(() => ({
+        activeProcesses: 1,
+        failedStarts: 0,
+        inFlightBacklog: 0,
+        oldestQueueAgeMs: 0,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 15 })],
+        triageResults: [makeTriage(15)],
+        checkpoint,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals,
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'fixed' });
+      expect(signals).not.toHaveBeenCalled();
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it('does not treat unrelated shared checkpoint entries as progress for fresh starts', async () => {
+      const checkpoint = mockCheckpoint(new Set(['impl:01_issue-150:done', 'harden:01_issue-150:done']));
+      const graphBuilder = mockGraphBuilder();
+      const config = makeConfig({
+        issues: [makeIssue({ number: 15 })],
+        triageResults: [makeTriage(15)],
+        checkpoint,
+        graphBuilder,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals: () => ({
+            activeProcesses: 1,
+            failedStarts: 0,
+            inFlightBacklog: 0,
+            oldestQueueAgeMs: 0,
+          }),
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'skipped' });
+      expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
     it('stops iteration after queue depth backpressure to avoid priority inversion', async () => {
       const config = makeConfig({
         issues: [makeIssue({ number: 16 }), makeIssue({ number: 17 })],

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -14,7 +14,7 @@ import type { ChunkDefinition } from '../../../src/cli/file-writer.js';
 // ── Mocks ──
 
 const mockLoopConstructions: Array<{ deps: BeastLoopDeps; config: unknown }> = [];
-const tempPlanDirs: string[] = [];
+const tempPlanFiles: string[] = [];
 
 const mockRun = vi.fn(async (deps?: BeastLoopDeps) => {
   // Default mock behavior: success with some tokens used
@@ -152,15 +152,16 @@ function mockCheckpoint(completed: Set<string> = new Set()): ICheckpointStore {
 function writePlanChunks(planName: string, chunkIds: readonly string[]): string {
   const planDir = resolve(process.cwd(), '.fbeast', 'plans', planName);
   mkdirSync(planDir, { recursive: true });
-  tempPlanDirs.push(planDir);
 
   chunkIds.forEach((chunkId, index) => {
     const chunkNumber = String(index + 1).padStart(2, '0');
+    const filePath = resolve(planDir, `${chunkNumber}_${chunkId}.md`);
     writeFileSync(
-      resolve(planDir, `${chunkNumber}_${chunkId}.md`),
+      filePath,
       `# Chunk ${chunkNumber}: ${chunkId}\n\n## Objective\n\nResume ${chunkId}\n\n## Files\n\n- test.ts\n\n## Success Criteria\n\nDone\n\n## Verification Command\n\n\`\`\`bash\nnpm test\n\`\`\`\n`,
       'utf8',
     );
+    tempPlanFiles.push(filePath);
   });
 
   return planDir;
@@ -216,8 +217,8 @@ describe('IssueRunner', () => {
   });
 
   afterEach(() => {
-    for (const dir of tempPlanDirs.splice(0)) {
-      rmSync(dir, { recursive: true, force: true });
+    for (const file of tempPlanFiles.splice(0)) {
+      rmSync(file, { force: true });
     }
   });
 
@@ -541,9 +542,14 @@ describe('IssueRunner', () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
-    it('recognizes shared-checkpoint progress from existing arbitrary chunk plans before pausing', async () => {
-      writePlanChunks('issue-15', ['api', 'ui']);
-      const checkpoint = mockCheckpoint(new Set(['impl:01_api:done', 'harden:01_api:done']));
+    it('recognizes issue-scoped shared-checkpoint progress from existing arbitrary chunk plans before pausing', async () => {
+      writePlanChunks('issue-9915', ['checkpointed-api', 'checkpointed-ui']);
+      const checkpoint = mockCheckpoint(new Set([
+        'issue:9915:impl:01_checkpointed-api',
+        'issue:9915:harden:01_checkpointed-api',
+        'impl:01_checkpointed-api:done',
+        'harden:01_checkpointed-api:done',
+      ]));
       const graphBuilder = mockGraphBuilder();
       const signals = vi.fn(() => ({
         activeProcesses: 1,
@@ -552,8 +558,8 @@ describe('IssueRunner', () => {
         oldestQueueAgeMs: 0,
       }));
       const config = makeConfig({
-        issues: [makeIssue({ number: 15 })],
-        triageResults: [makeTriage(15, 'chunked')],
+        issues: [makeIssue({ number: 9915 })],
+        triageResults: [makeTriage(9915, 'chunked')],
         checkpoint,
         graphBuilder,
         backpressure: {
@@ -564,7 +570,7 @@ describe('IssueRunner', () => {
 
       const outcomes = await runner.run(config);
 
-      expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'fixed' });
+      expect(outcomes[0]).toMatchObject({ issueNumber: 9915, status: 'fixed' });
       expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
       expect(signals).not.toHaveBeenCalled();
       expect(mockRun).toHaveBeenCalledOnce();

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -578,8 +578,8 @@ describe('IssueRunner', () => {
       expect(mockRun).toHaveBeenCalledOnce();
     });
 
-    it('does not treat unrelated shared checkpoint entries as progress for fresh starts', async () => {
-      writePlanChunks('issue-15', ['api']);
+    it('does not treat partial legacy shared checkpoint entries as progress for fresh starts', async () => {
+      writePlanChunks('issue-15', ['api', 'ui']);
       const checkpoint = mockCheckpoint(new Set(['impl:01_api:done', 'harden:01_api:done']));
       const graphBuilder = mockGraphBuilder();
       const config = makeConfig({
@@ -602,6 +602,38 @@ describe('IssueRunner', () => {
 
       expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'skipped' });
       expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it('recognizes completed legacy shared-checkpoint chunk plans before pausing', async () => {
+      writePlanChunks('issue-9917', ['legacy-api']);
+      const checkpoint = mockCheckpoint(new Set([
+        'impl:01_legacy-api:done',
+        'harden:01_legacy-api:done',
+      ]));
+      const graphBuilder = mockGraphBuilder();
+      const signals = vi.fn(() => ({
+        activeProcesses: 1,
+        failedStarts: 0,
+        inFlightBacklog: 0,
+        oldestQueueAgeMs: 0,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 9917 })],
+        triageResults: [makeTriage(9917, 'chunked')],
+        checkpoint,
+        graphBuilder,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals,
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 9917, status: 'fixed' });
+      expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
+      expect(signals).not.toHaveBeenCalled();
       expect(mockRun).not.toHaveBeenCalled();
     });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -363,6 +363,97 @@ describe('IssueRunner', () => {
     });
   });
 
+  describe('backpressure controls', () => {
+    it('skips fresh issue starts when active process capacity is exhausted and explains the throttle', async () => {
+      const logger = mockLogger();
+      const issues = [makeIssue({ number: 11 })];
+      const triages = [makeTriage(11)];
+      const config = makeConfig({
+        issues,
+        triageResults: triages,
+        logger,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals: () => ({
+            activeProcesses: 2,
+            failedStarts: 0,
+            inFlightBacklog: 0,
+            oldestQueueAgeMs: 0,
+          }),
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(mockRun).not.toHaveBeenCalled();
+      expect(outcomes).toEqual([
+        expect.objectContaining({
+          issueNumber: 11,
+          status: 'skipped',
+          error: expect.stringContaining('backpressure: active processes 2 exceeds limit 1'),
+        }),
+      ]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[issues] Backpressure paused issue #11'),
+        expect.objectContaining({
+          reasons: expect.arrayContaining(['active processes 2 exceeds limit 1']),
+        }),
+        'issues',
+      );
+    });
+
+    it('blocks fresh ticket creation while in-flight backlog remains above threshold', async () => {
+      const issues = [makeIssue({ number: 12 })];
+      const triages = [makeTriage(12)];
+      const config = makeConfig({
+        issues,
+        triageResults: triages,
+        backpressure: {
+          thresholds: { maxInFlightBacklog: 1 },
+          signals: () => ({
+            activeProcesses: 0,
+            failedStarts: 0,
+            inFlightBacklog: 2,
+            oldestQueueAgeMs: 5_000,
+          }),
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(mockRun).not.toHaveBeenCalled();
+      expect(outcomes[0]).toMatchObject({
+        issueNumber: 12,
+        status: 'skipped',
+        error: expect.stringContaining('fresh ticket creation blocked while in-flight backlog 2 exceeds limit 1'),
+      });
+    });
+
+    it('recovers automatically when backpressure signals return to normal on the next issue', async () => {
+      const snapshots = [
+        { activeProcesses: 0, failedStarts: 3, inFlightBacklog: 0, oldestQueueAgeMs: 0 },
+        { activeProcesses: 0, failedStarts: 0, inFlightBacklog: 0, oldestQueueAgeMs: 0 },
+      ];
+      const issues = [makeIssue({ number: 13 }), makeIssue({ number: 14 })];
+      const triages = [makeTriage(13), makeTriage(14)];
+      const config = makeConfig({
+        issues,
+        triageResults: triages,
+        backpressure: {
+          thresholds: { maxFailedStarts: 1 },
+          signals: () => snapshots.shift()!,
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 13, status: 'skipped' });
+      expect(outcomes[0]!.error).toContain('failed starts 3 exceeds limit 1');
+      expect(outcomes[1]).toMatchObject({ issueNumber: 14, status: 'fixed' });
+      expect(mockRun).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('checkpoint integration', () => {
     it('skips issues where all tasks already checkpointed', async () => {
       const checkpoint = mockCheckpoint(

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -458,6 +458,12 @@ describe('IssueRunner', () => {
 
     it('preserves checkpoint-complete outcomes before evaluating backpressure', async () => {
       const checkpoint = mockCheckpoint(new Set(['impl:01_issue-15:done', 'harden:01_issue-15:done']));
+      const issueRuntime = makeIssueRuntimeSupport();
+      vi.mocked(issueRuntime.checkpointForIssue).mockReturnValue(checkpoint);
+      vi.mocked(issueRuntime.artifactsForIssue).mockReturnValue({
+        planName: 'issue-15',
+        planDir: '.tmp/test-issue-15',
+      });
       const signals = vi.fn(() => ({
         activeProcesses: 1,
         failedStarts: 0,
@@ -468,6 +474,7 @@ describe('IssueRunner', () => {
         issues: [makeIssue({ number: 15 })],
         triageResults: [makeTriage(15)],
         checkpoint,
+        issueRuntime,
         backpressure: {
           thresholds: { maxActiveProcesses: 1 },
           signals,

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -375,7 +375,7 @@ describe('IssueRunner', () => {
         backpressure: {
           thresholds: { maxActiveProcesses: 1 },
           signals: () => ({
-            activeProcesses: 2,
+            activeProcesses: 1,
             failedStarts: 0,
             inFlightBacklog: 0,
             oldestQueueAgeMs: 0,
@@ -390,13 +390,13 @@ describe('IssueRunner', () => {
         expect.objectContaining({
           issueNumber: 11,
           status: 'skipped',
-          error: expect.stringContaining('backpressure: active processes 2 exceeds limit 1'),
+          error: expect.stringContaining('backpressure: active processes 1 reached limit 1'),
         }),
       ]);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('[issues] Backpressure paused issue #11'),
         expect.objectContaining({
-          reasons: expect.arrayContaining(['active processes 2 exceeds limit 1']),
+          reasons: expect.arrayContaining(['active processes 1 reached limit 1']),
         }),
         'issues',
       );
@@ -450,6 +450,85 @@ describe('IssueRunner', () => {
       expect(outcomes[0]).toMatchObject({ issueNumber: 13, status: 'skipped' });
       expect(outcomes[0]!.error).toContain('failed starts 3 exceeds limit 1');
       expect(outcomes[1]).toMatchObject({ issueNumber: 14, status: 'fixed' });
+      expect(mockRun).toHaveBeenCalledOnce();
+    });
+
+    it('preserves checkpoint-complete outcomes before evaluating backpressure', async () => {
+      const checkpoint = mockCheckpoint(new Set(['impl:01_issue-15:done', 'harden:01_issue-15:done']));
+      const signals = vi.fn(() => ({
+        activeProcesses: 1,
+        failedStarts: 0,
+        inFlightBacklog: 0,
+        oldestQueueAgeMs: 0,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 15 })],
+        triageResults: [makeTriage(15)],
+        checkpoint,
+        backpressure: {
+          thresholds: { maxActiveProcesses: 1 },
+          signals,
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({ issueNumber: 15, status: 'fixed' });
+      expect(signals).not.toHaveBeenCalled();
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it('stops iteration after queue depth backpressure to avoid priority inversion', async () => {
+      const config = makeConfig({
+        issues: [makeIssue({ number: 16 }), makeIssue({ number: 17 })],
+        triageResults: [makeTriage(16), makeTriage(17)],
+        backpressure: {
+          thresholds: { maxPendingIssueCount: 1 },
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes).toEqual([
+        expect.objectContaining({
+          issueNumber: 16,
+          status: 'skipped',
+          error: expect.stringContaining('queue depth 2 exceeds limit 1'),
+        }),
+        expect.objectContaining({
+          issueNumber: 17,
+          status: 'skipped',
+          tokensUsed: 0,
+        }),
+      ]);
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it('contains failing signal sources to a failed issue outcome', async () => {
+      const config = makeConfig({
+        issues: [makeIssue({ number: 18 }), makeIssue({ number: 19 })],
+        triageResults: [makeTriage(18), makeTriage(19)],
+        backpressure: {
+          signals: vi
+            .fn()
+            .mockRejectedValueOnce(new Error('metrics unavailable'))
+            .mockResolvedValue({
+              activeProcesses: 0,
+              failedStarts: 0,
+              inFlightBacklog: 0,
+              oldestQueueAgeMs: 0,
+            }),
+        },
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({
+        issueNumber: 18,
+        status: 'failed',
+        error: 'metrics unavailable',
+      });
+      expect(outcomes[1]).toMatchObject({ issueNumber: 19, status: 'fixed' });
       expect(mockRun).toHaveBeenCalledOnce();
     });
   });

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -573,6 +573,8 @@ describe('IssueRunner', () => {
       expect(outcomes[0]).toMatchObject({ issueNumber: 9915, status: 'fixed' });
       expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
       expect(signals).not.toHaveBeenCalled();
+      expect(checkpoint.write).not.toHaveBeenCalledWith('issue:9915:impl:01_checkpointed-api');
+      expect(checkpoint.write).not.toHaveBeenCalledWith('issue:9915:harden:01_checkpointed-api');
       expect(mockRun).toHaveBeenCalledOnce();
     });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -368,10 +368,12 @@ describe('IssueRunner', () => {
       const logger = mockLogger();
       const issues = [makeIssue({ number: 11 })];
       const triages = [makeTriage(11)];
+      const graphBuilder = mockGraphBuilder();
       const config = makeConfig({
         issues,
         triageResults: triages,
         logger,
+        graphBuilder,
         backpressure: {
           thresholds: { maxActiveProcesses: 1 },
           signals: () => ({
@@ -386,6 +388,7 @@ describe('IssueRunner', () => {
       const outcomes = await runner.run(config);
 
       expect(mockRun).not.toHaveBeenCalled();
+      expect(graphBuilder.buildChunkDefinitionsForIssue).not.toHaveBeenCalled();
       expect(outcomes).toEqual([
         expect.objectContaining({
           issueNumber: 11,
@@ -499,6 +502,7 @@ describe('IssueRunner', () => {
           issueNumber: 17,
           status: 'skipped',
           tokensUsed: 0,
+          error: expect.stringContaining('queue depth 2 exceeds limit 1'),
         }),
       ]);
       expect(mockRun).not.toHaveBeenCalled();

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -566,6 +566,40 @@ describe('IssueRunner', () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
+    it('contains issue-runtime checkpoint read failures to one issue outcome', async () => {
+      const throwingCheckpoint = {
+        ...mockCheckpoint(),
+        readAll: vi.fn(() => {
+          throw new Error('checkpoint unreadable');
+        }),
+      };
+      const issueRuntime = makeIssueRuntimeSupport();
+      vi.mocked(issueRuntime.checkpointForIssue).mockImplementation((issueNumber: number) =>
+        issueNumber === 21 ? throwingCheckpoint : mockCheckpoint(),
+      );
+      vi.mocked(issueRuntime.artifactsForIssue).mockImplementation((issueNumber: number): IssueRuntimeArtifacts => ({
+        planName: `issue-${issueNumber}`,
+        planDir: `.tmp/test-issue-${issueNumber}`,
+        checkpointFile: `.tmp/test-issue-${issueNumber}.checkpoint`,
+        logFile: `.tmp/test-issue-${issueNumber}.log`,
+      }));
+      const config = makeConfig({
+        issues: [makeIssue({ number: 21 }), makeIssue({ number: 22 })],
+        triageResults: [makeTriage(21), makeTriage(22)],
+        issueRuntime,
+      });
+
+      const outcomes = await runner.run(config);
+
+      expect(outcomes[0]).toMatchObject({
+        issueNumber: 21,
+        status: 'failed',
+        error: 'checkpoint unreadable',
+      });
+      expect(outcomes[1]).toMatchObject({ issueNumber: 22, status: 'fixed' });
+      expect(mockRun).toHaveBeenCalledOnce();
+    });
+
     it('contains failing signal sources to a failed issue outcome', async () => {
       const config = makeConfig({
         issues: [makeIssue({ number: 18 }), makeIssue({ number: 19 })],


### PR DESCRIPTION
## Summary
- adds IssueRunner backpressure configuration with active-process, failed-start, backlog, queue-age, load, queue-depth, and provider-budget threshold checks
- skips fresh issue starts with explicit backpressure reasons and warning logs while allowing later issues to resume when signals recover
- documents the programmatic backpressure behavior for issue/refill orchestration callers

## Test Plan
- TMPDIR=$PWD/.tmp npm test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts
- TMPDIR=$PWD/.tmp npm run typecheck --workspace @franken/orchestrator
- TMPDIR=$PWD/.tmp npm run build --workspace @franken/orchestrator

Closes #1680