### PR TITLE
fix(governor): consume approval session tokens atomically

### DIFF
--- a/packages/franken-governor/src/gateway/governor-critique-adapter.ts
+++ b/packages/franken-governor/src/gateway/governor-critique-adapter.ts
@@ -251,8 +251,8 @@ export class GovernorCritiqueAdapter {
     const scope = formatApprovalSessionTokenScope(request);
     for (const tokenId of this.getApprovalSessionTokenCandidates(rationale)) {
       try {
-        const token = this.sessionTokenStore.get(tokenId);
-        if (token?.scope === scope) return token;
+        const result = this.sessionTokenStore.consume(tokenId, scope);
+        if (result.status === 'consumed') return result.token;
       } catch {
         return undefined;
       }

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -32,6 +32,12 @@ export interface SweepExpiredSessionTokenOptions {
   readonly nowMs?: number;
 }
 
+export type ConsumeSessionTokenResult =
+  | { readonly status: 'consumed'; readonly token: SessionToken }
+  | { readonly status: 'missing' }
+  | { readonly status: 'expired' }
+  | { readonly status: 'scope_mismatch' };
+
 interface SerializedSessionToken {
   readonly tokenId: string;
   readonly approvalId: string;
@@ -116,6 +122,38 @@ export class SessionTokenStore {
     const token = this.get(tokenId);
     if (!token) return false;
     return scope === undefined || token.scope === scope;
+  }
+
+  consume(tokenId: string, scope?: string): ConsumeSessionTokenResult {
+    const consumeLoadedToken = (): ConsumeSessionTokenResult => {
+      const token = this.tokens.get(tokenId);
+      if (token === undefined) return { status: 'missing' };
+
+      if (this.isExpired(token)) {
+        this.tokens.delete(tokenId);
+        return { status: 'expired' };
+      }
+
+      if (scope !== undefined && token.scope !== scope) {
+        return { status: 'scope_mismatch' };
+      }
+
+      this.tokens.delete(tokenId);
+      return { status: 'consumed', token };
+    };
+
+    if (!this.persistenceFile) {
+      return consumeLoadedToken();
+    }
+
+    return this.withFileLock(() => {
+      this.loadPersistedTokens();
+      const result = consumeLoadedToken();
+      if (result.status === 'consumed' || result.status === 'expired') {
+        this.persist();
+      }
+      return result;
+    });
   }
 
   private pruneExpiredTokens(nowMs: number = wallClockNow()): number {

--- a/packages/franken-governor/src/security/session-token-store.ts
+++ b/packages/franken-governor/src/security/session-token-store.ts
@@ -147,12 +147,16 @@ export class SessionTokenStore {
     }
 
     return this.withFileLock(() => {
-      this.loadPersistedTokens();
+      const expiredTokenIds = new Set<string>();
+      this.loadPersistedTokens(expiredTokenIds);
       const result = consumeLoadedToken();
-      if (result.status === 'consumed' || result.status === 'expired') {
+      const effectiveResult = result.status === 'missing' && expiredTokenIds.has(tokenId)
+        ? { status: 'expired' as const }
+        : result;
+      if (effectiveResult.status === 'consumed' || effectiveResult.status === 'expired') {
         this.persist();
       }
-      return result;
+      return effectiveResult;
     });
   }
 
@@ -167,7 +171,7 @@ export class SessionTokenStore {
     return pruned;
   }
 
-  private loadPersistedTokens(): number {
+  private loadPersistedTokens(expiredTokenIds?: Set<string>): number {
     if (!this.persistenceFile) return 0;
 
     let raw: string;
@@ -200,6 +204,7 @@ export class SessionTokenStore {
       if (token && !this.isExpired(token)) {
         this.tokens.set(token.tokenId, token);
       } else if (token) {
+        expiredTokenIds?.add(token.tokenId);
         expiredPersisted += 1;
       }
     }

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -353,11 +353,12 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
     let token: SessionToken | undefined;
     try {
-      token = sessionTokenStore.get(body.tokenId);
+      const result = sessionTokenStore.consume(body.tokenId, body.scope);
+      token = result.status === 'consumed' ? result.token : undefined;
     } catch {
       return c.json({ error: { message: 'Session token validation unavailable' } }, 503);
     }
-    if (!token || (body.scope !== undefined && token.scope !== body.scope)) {
+    if (!token) {
       return c.json({ valid: false }, 401);
     }
 

--- a/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
+++ b/packages/franken-governor/tests/unit/gateway/governor-critique-adapter.test.ts
@@ -491,6 +491,7 @@ describe('GovernorCritiqueAdapter per-trigger context construction (issue #490)'
       decision: 'APPROVE',
       respondedBy: 'operator-session-token',
     }));
+    expect(tokenStore.isValid(token.tokenId, makeScope())).toBe(false);
   });
 
   it('fails closed to a fresh operator prompt when the risky-action session token is expired', async () => {
@@ -584,7 +585,7 @@ describe('GovernorCritiqueAdapter per-trigger context construction (issue #490)'
 
   it('fails closed to a fresh operator prompt when token validation storage throws', async () => {
     const tokenStore = {
-      isValid: vi.fn(() => {
+      consume: vi.fn(() => {
         throw new Error('corrupt token store');
       }),
       store: vi.fn(),
@@ -613,7 +614,7 @@ describe('GovernorCritiqueAdapter per-trigger context construction (issue #490)'
 
   it('approves without issuing a replacement token when token persistence fails after fresh approval', async () => {
     const tokenStore = {
-      get: vi.fn(() => {
+      consume: vi.fn(() => {
         throw new Error('corrupt token store');
       }),
       store: vi.fn(() => {

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -125,6 +125,58 @@ describe('SessionTokenStore', () => {
     expect(store.isValid('unknown')).toBe(false);
   });
 
+  it('consume() returns the token once and removes it from the in-memory store', () => {
+    const store = new SessionTokenStore();
+    const token = makeToken(10_000);
+
+    store.store(token);
+
+    expect(store.consume(token.tokenId, 'deploy')).toEqual({ status: 'consumed', token });
+    expect(store.consume(token.tokenId, 'deploy')).toEqual({ status: 'missing' });
+    expect(store.isValid(token.tokenId, 'deploy')).toBe(false);
+  });
+
+  it('consume() preserves a valid token when the requested scope does not match', () => {
+    const store = new SessionTokenStore();
+    const token = makeToken(10_000);
+
+    store.store(token);
+
+    expect(store.consume(token.tokenId, 'other-scope')).toEqual({ status: 'scope_mismatch' });
+    expect(store.isValid(token.tokenId, 'deploy')).toBe(true);
+  });
+
+  it('consume() prunes expired tokens and reports the expired state', () => {
+    const store = new SessionTokenStore();
+    const token = makeToken(1000);
+
+    store.store(token);
+    vi.advanceTimersByTime(2000);
+
+    expect(store.consume(token.tokenId, 'deploy')).toEqual({ status: 'expired' });
+    expect(store.consume(token.tokenId, 'deploy')).toEqual({ status: 'missing' });
+  });
+
+  it('consume() atomically allows one persisted store instance to claim a token', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const issuer = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(10_000);
+      issuer.store(token);
+
+      const contenders = Array.from({ length: 8 }, () => new SessionTokenStore({ persistenceFile }));
+      const results = await Promise.all(contenders.map((store) => Promise.resolve().then(() => store.consume(token.tokenId, 'deploy'))));
+
+      expect(results.filter((result) => result.status === 'consumed')).toHaveLength(1);
+      expect(results.filter((result) => result.status === 'missing')).toHaveLength(7);
+      expect(new SessionTokenStore({ persistenceFile }).isValid(token.tokenId, 'deploy')).toBe(false);
+      expect(JSON.parse(readFileSync(persistenceFile, 'utf8'))).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('persists tokens so a new store instance can validate them', () => {
     const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
     const persistenceFile = join(dir, 'tokens.json');

--- a/packages/franken-governor/tests/unit/security/session-token-store.test.ts
+++ b/packages/franken-governor/tests/unit/security/session-token-store.test.ts
@@ -177,6 +177,22 @@ describe('SessionTokenStore', () => {
     }
   });
 
+  it('consume() reports and prunes an expired persisted token for the requested id', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
+    const persistenceFile = join(dir, 'tokens.json');
+    try {
+      const store = new SessionTokenStore({ persistenceFile });
+      const token = makeToken(1000);
+      store.store(token);
+      vi.advanceTimersByTime(2000);
+
+      expect(new SessionTokenStore({ persistenceFile }).consume(token.tokenId, 'deploy')).toEqual({ status: 'expired' });
+      expect(JSON.parse(readFileSync(persistenceFile, 'utf8'))).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('persists tokens so a new store instance can validate them', () => {
     const dir = mkdtempSync(join(tmpdir(), 'governor-session-token-store-'));
     const persistenceFile = join(dir, 'tokens.json');

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -387,6 +387,7 @@ describe('Governor Hono Server', () => {
         grantedBy: 'human',
       });
       expect(body.token.tokenId).toBeUndefined();
+      expect(store.isValid(token.tokenId, 'deploy-prod')).toBe(false);
     });
 
     it('validates tokens persisted by a separate store instance', async () => {
@@ -409,6 +410,34 @@ describe('Governor Hono Server', () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.valid).toBe(true);
+        expect(new SessionTokenStore({ persistenceFile }).isValid(token.tokenId)).toBe(false);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('allows only one concurrent validation request to claim a persisted token', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'governor-app-session-store-'));
+      const persistenceFile = join(dir, 'tokens.json');
+      try {
+        const issuingStore = new SessionTokenStore({ persistenceFile });
+        const token = makeStoredToken(issuingStore);
+        const app = createGovernorApp({
+          sessionTokenStorePath: persistenceFile,
+          allowUnsignedApprovalsForTests: true,
+        });
+
+        const requests = Array.from({ length: 6 }, () => app.request('/v1/approval/session/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tokenId: token.tokenId, scope: 'deploy-prod' }),
+        }));
+
+        const responses = await Promise.all(requests);
+        expect(responses.filter((response) => response.status === 200)).toHaveLength(1);
+        expect(responses.filter((response) => response.status === 401)).toHaveLength(5);
+        await Promise.all(responses.map((response) => response.json()));
+        expect(new SessionTokenStore({ persistenceFile }).isValid(token.tokenId)).toBe(false);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary
- add atomic consume semantics for persisted governor session tokens
- require operator-session token reuse to claim and remove the token before approving
- cover in-memory, persisted, expired, scope-mismatch, and concurrent contender consumption paths

## Test Plan
- TMPDIR=$PWD/.tmp-test npm run test --workspace @franken/governor -- tests/unit/security/session-token-store.test.ts tests/unit/gateway/governor-critique-adapter.test.ts
- TMPDIR=$PWD/.tmp-test npm run test --workspace @franken/governor
- TMPDIR=$PWD/.tmp-test npm run typecheck --workspace @franken/governor (after npm run build --workspace @franken/types)
- TMPDIR=$PWD/.tmp-test npm run build --workspace @franken/governor
- TMPDIR=$PWD/.tmp-test npm run lint --workspace @franken/governor

Note: local /tmp is inode-constrained on this runner, so tests were run with TMPDIR inside the worktree.

Closes #1743