### PR TITLE
fix(orchestrator): reject unknown beast status runs

### DIFF
--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -1,6 +1,7 @@
 import type { CliArgs } from './args.js';
 import type { InterviewIO } from '../planning/interview-loop.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
+import { UnknownBeastRunError } from '../beasts/services/beast-run-service.js';
 import { collectBeastConfig } from './beast-prompts.js';
 import type { ProjectPaths } from './project-root.js';
 import { createBeastControlClient } from './beast-control-client.js';
@@ -150,8 +151,11 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           throw new Error('beasts status requires a run id');
         }
         const run = services.runs.getRun(args.beastTarget);
-        const attempts = run ? services.runs.listAttempts(args.beastTarget) : [];
-        print(JSON.stringify(run ? statusPayload(run, attempts) : undefined, null, 2));
+        if (!run) {
+          throw new UnknownBeastRunError(args.beastTarget);
+        }
+        const attempts = services.runs.listAttempts(args.beastTarget);
+        print(JSON.stringify(statusPayload(run, attempts), null, 2));
         return;
       }
       case 'logs': {

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -204,6 +204,18 @@ describe('handleBeastCommand() spawn', () => {
 });
 
 describe('handleBeastCommand() status and logs', () => {
+  it('throws for an unknown status run id instead of printing undefined', async () => {
+    mockServices.runs.getRun.mockReturnValue(undefined);
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'status', beastTarget: 'missing-run' } as CliArgs,
+    });
+
+    await expect(handleBeastCommand(deps)).rejects.toThrow('Unknown Beast run: missing-run');
+    expect(deps.print).not.toHaveBeenCalled();
+    expect(mockServices.runs.listAttempts).not.toHaveBeenCalled();
+    expect(mockServices.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it('renders current attempt container metadata in status output', async () => {
     mockServices.runs.getRun.mockReturnValue({
       id: 'run-1',


### PR DESCRIPTION
## Summary
- Make `beasts status <run-id>` throw `UnknownBeastRunError` when the run id is missing instead of printing JSON.stringify(undefined)
- Add a regression test that verifies unknown status ids reject, print nothing, skip attempt lookup, and dispose services

## Test Plan
- TMPDIR="$PWD/.tmp" npm run test --workspace @franken/orchestrator -- tests/unit/cli/beast-cli.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1698
