### PR TITLE
chore(web): deduplicate API error helpers

### DIFF
--- a/packages/franken-web/src/lib/analytics-api.ts
+++ b/packages/franken-web/src/lib/analytics-api.ts
@@ -1,3 +1,5 @@
+import { extractResponseErrorMessage } from './http-error';
+
 export type AnalyticsSource = 'observer' | 'governor' | 'security' | 'cost' | 'beast';
 export type AnalyticsOutcome = 'approved' | 'denied' | 'review_recommended' | 'failed' | 'error' | 'detected';
 export type AnalyticsSeverity = 'info' | 'warning' | 'error';
@@ -91,24 +93,6 @@ export class AnalyticsApiClient {
   }
 }
 
-async function extractResponseErrorMessage(res: Response): Promise<string | undefined> {
-  try {
-    const body = await res.json() as unknown;
-    if (!body || typeof body !== 'object') return undefined;
-
-    const error = (body as { error?: unknown }).error;
-    if (typeof error === 'string' && error.trim()) return error;
-
-    if (error && typeof error === 'object') {
-      const message = (error as { message?: unknown }).message;
-      if (typeof message === 'string' && message.trim()) return message;
-    }
-  } catch {
-    return undefined;
-  }
-
-  return undefined;
-}
 
 function queryString(filters: AnalyticsEventFilters): string {
   const params = new URLSearchParams();

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -21,6 +21,7 @@ import type {
   TrackedAgentInitAction,
   TrackedAgentSummary,
 } from '@franken/types';
+import { toError } from './http-error';
 
 export { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 export type {
@@ -472,6 +473,3 @@ function normalizeHeaders(headers: HeadersInit | undefined): Record<string, stri
   return { ...headers };
 }
 
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -1,3 +1,5 @@
+import { extractResponseErrorMessage, toError } from './http-error';
+
 export interface DashboardSkill {
   name: string;
   enabled: boolean;
@@ -140,28 +142,9 @@ export class DashboardApiClient {
 
 }
 
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}
 
 async function createResponseError(res: Response): Promise<Error> {
   const message = await extractResponseErrorMessage(res);
   return new Error(message ?? `HTTP ${res.status}`);
 }
 
-async function extractResponseErrorMessage(res: Response): Promise<string | undefined> {
-  try {
-    const body = await res.json() as unknown;
-    if (!body || typeof body !== 'object') return undefined;
-    const error = (body as { error?: unknown }).error;
-    if (typeof error === 'string' && error.trim()) return error;
-    if (error && typeof error === 'object') {
-      const message = (error as { message?: unknown }).message;
-      if (typeof message === 'string' && message.trim()) return message;
-    }
-  } catch {
-    return undefined;
-  }
-
-  return undefined;
-}

--- a/packages/franken-web/src/lib/http-error.test.ts
+++ b/packages/franken-web/src/lib/http-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { extractResponseErrorMessage, toError } from './http-error';
+
+describe('http-error helpers', () => {
+  it('extracts shared response error message shapes', async () => {
+    await expect(extractResponseErrorMessage(new Response(JSON.stringify({
+      error: 'Flat failure',
+    })))).resolves.toBe('Flat failure');
+
+    await expect(extractResponseErrorMessage(new Response(JSON.stringify({
+      error: { message: 'Nested failure' },
+    })))).resolves.toBe('Nested failure');
+  });
+
+  it('returns undefined for unusable response bodies', async () => {
+    await expect(extractResponseErrorMessage(new Response(JSON.stringify({
+      error: { code: 'NO_MESSAGE' },
+    })))).resolves.toBeUndefined();
+
+    await expect(extractResponseErrorMessage(new Response('<not-json>'))).resolves.toBeUndefined();
+  });
+
+  it('normalizes unknown thrown values into Error instances', () => {
+    const existing = new Error('Already an Error');
+    expect(toError(existing)).toBe(existing);
+    expect(toError('string failure')).toMatchObject({ message: 'string failure' });
+  });
+});

--- a/packages/franken-web/src/lib/http-error.ts
+++ b/packages/franken-web/src/lib/http-error.ts
@@ -1,0 +1,22 @@
+export function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export async function extractResponseErrorMessage(res: Response): Promise<string | undefined> {
+  try {
+    const body = await res.json() as unknown;
+    if (!body || typeof body !== 'object') return undefined;
+
+    const error = (body as { error?: unknown }).error;
+    if (typeof error === 'string' && error.trim()) return error;
+
+    if (error && typeof error === 'object') {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim()) return message;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Add shared franken-web HTTP error helpers for response error messages and unknown-to-Error conversion
- Update analytics, dashboard, and beast API clients to reuse the shared helpers
- Add focused helper regression coverage

## Test Plan
- npm test --workspace @franken/web -- src/lib/http-error.test.ts src/lib/analytics-api.test.ts src/lib/dashboard-api.test.ts src/lib/beast-api.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/web

Closes #2229