### PR TITLE
feat(dr): add restore preview conflict detector

### DIFF
--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -123,7 +123,7 @@ function compareRecords(
         area,
         id,
         type: 'backup-only',
-        severity: 'info',
+        severity: area === 'approvals' ? 'blocker' : 'info',
         backup,
         recommendation: recommendationFor(area, 'backup-only'),
       });
@@ -162,9 +162,9 @@ function recordsEqual(backup: RestorePreviewRecord, live: RestorePreviewRecord):
 }
 
 function recordFingerprint(record: RestorePreviewRecord): string {
-  if (record.digest !== undefined) return `digest:${record.digest}`;
   return stableStringify({
     id: record.id,
+    digest: record.digest,
     state: record.state,
     updatedAt: record.updatedAt,
     value: record.value,

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -1,0 +1,221 @@
+export type RestorePreviewArea = 'schema' | 'tasks' | 'approvals' | 'memory' | 'cron';
+
+export type RestorePreviewConflictType =
+  | 'schema-mismatch'
+  | 'changed'
+  | 'newer-live'
+  | 'backup-only'
+  | 'live-only';
+
+export type RestorePreviewSeverity = 'info' | 'warning' | 'blocker';
+
+export interface RestorePreviewRecord {
+  readonly id: string;
+  readonly digest?: string;
+  readonly state?: string;
+  readonly updatedAt?: string;
+  readonly value?: unknown;
+}
+
+export interface RestorePreviewManifest {
+  readonly schemaVersion: number;
+  readonly tasks?: readonly RestorePreviewRecord[];
+  readonly approvals?: readonly RestorePreviewRecord[];
+  readonly memory?: readonly RestorePreviewRecord[];
+  readonly cron?: readonly RestorePreviewRecord[];
+}
+
+export interface RestorePreviewConflict {
+  readonly area: RestorePreviewArea;
+  readonly id: string;
+  readonly type: RestorePreviewConflictType;
+  readonly severity: RestorePreviewSeverity;
+  readonly backup?: RestorePreviewRecord | { readonly schemaVersion: number };
+  readonly live?: RestorePreviewRecord | { readonly schemaVersion: number };
+  readonly recommendation: string;
+}
+
+export interface RestorePreviewResult {
+  /** Explicitly records that preview calculation is read-only and performs no restore writes. */
+  readonly wouldWrite: false;
+  readonly safeToRestore: boolean;
+  readonly schema: {
+    readonly backupVersion: number;
+    readonly liveVersion: number;
+    readonly compatible: boolean;
+  };
+  readonly conflicts: readonly RestorePreviewConflict[];
+}
+
+type ComparableArea = Exclude<RestorePreviewArea, 'schema'>;
+
+const AREA_ACCESSORS = {
+  tasks: (manifest: RestorePreviewManifest) => manifest.tasks ?? [],
+  approvals: (manifest: RestorePreviewManifest) => manifest.approvals ?? [],
+  memory: (manifest: RestorePreviewManifest) => manifest.memory ?? [],
+  cron: (manifest: RestorePreviewManifest) => manifest.cron ?? [],
+} satisfies Record<ComparableArea, (manifest: RestorePreviewManifest) => readonly RestorePreviewRecord[]>;
+
+export function detectRestorePreviewConflicts(
+  backup: RestorePreviewManifest,
+  live: RestorePreviewManifest,
+): RestorePreviewResult {
+  const conflicts: RestorePreviewConflict[] = [];
+  const schemaCompatible = backup.schemaVersion === live.schemaVersion;
+
+  if (!schemaCompatible) {
+    conflicts.push({
+      area: 'schema',
+      id: 'schema-version',
+      type: 'schema-mismatch',
+      severity: 'blocker',
+      backup: { schemaVersion: backup.schemaVersion },
+      live: { schemaVersion: live.schemaVersion },
+      recommendation:
+        'Do not restore blindly; run a schema migration or use a backup produced by the live schema version before restoring.',
+    });
+  }
+
+  for (const area of Object.keys(AREA_ACCESSORS) as ComparableArea[]) {
+    conflicts.push(...compareRecords(area, AREA_ACCESSORS[area](backup), AREA_ACCESSORS[area](live)));
+  }
+
+  return {
+    wouldWrite: false,
+    safeToRestore: conflicts.length === 0,
+    schema: {
+      backupVersion: backup.schemaVersion,
+      liveVersion: live.schemaVersion,
+      compatible: schemaCompatible,
+    },
+    conflicts,
+  };
+}
+
+function compareRecords(
+  area: ComparableArea,
+  backupRecords: readonly RestorePreviewRecord[],
+  liveRecords: readonly RestorePreviewRecord[],
+): RestorePreviewConflict[] {
+  const conflicts: RestorePreviewConflict[] = [];
+  const backupById = indexById(backupRecords);
+  const liveById = indexById(liveRecords);
+  const ids = new Set([...backupById.keys(), ...liveById.keys()]);
+
+  for (const id of [...ids].sort()) {
+    const backup = backupById.get(id);
+    const live = liveById.get(id);
+
+    if (backup === undefined && live !== undefined) {
+      conflicts.push({
+        area,
+        id,
+        type: 'live-only',
+        severity: area === 'approvals' ? 'warning' : 'info',
+        live,
+        recommendation: recommendationFor(area, 'live-only'),
+      });
+      continue;
+    }
+
+    if (backup !== undefined && live === undefined) {
+      conflicts.push({
+        area,
+        id,
+        type: 'backup-only',
+        severity: 'info',
+        backup,
+        recommendation: recommendationFor(area, 'backup-only'),
+      });
+      continue;
+    }
+
+    if (backup === undefined || live === undefined || recordsEqual(backup, live)) {
+      continue;
+    }
+
+    const type = liveIsNewer(backup, live) ? 'newer-live' : 'changed';
+    conflicts.push({
+      area,
+      id,
+      type,
+      severity: severityFor(area, type),
+      backup,
+      live,
+      recommendation: recommendationFor(area, type),
+    });
+  }
+
+  return conflicts;
+}
+
+function indexById(records: readonly RestorePreviewRecord[]): Map<string, RestorePreviewRecord> {
+  const byId = new Map<string, RestorePreviewRecord>();
+  for (const record of records) {
+    byId.set(record.id, record);
+  }
+  return byId;
+}
+
+function recordsEqual(backup: RestorePreviewRecord, live: RestorePreviewRecord): boolean {
+  return recordFingerprint(backup) === recordFingerprint(live);
+}
+
+function recordFingerprint(record: RestorePreviewRecord): string {
+  if (record.digest !== undefined) return `digest:${record.digest}`;
+  return stableStringify({
+    id: record.id,
+    state: record.state,
+    updatedAt: record.updatedAt,
+    value: record.value,
+  });
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object)
+    .sort()
+    .filter((key) => object[key] !== undefined)
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`)
+    .join(',')}}`;
+}
+
+function liveIsNewer(backup: RestorePreviewRecord, live: RestorePreviewRecord): boolean {
+  if (backup.updatedAt === undefined || live.updatedAt === undefined) return false;
+  const backupTime = Date.parse(backup.updatedAt);
+  const liveTime = Date.parse(live.updatedAt);
+  return Number.isFinite(backupTime) && Number.isFinite(liveTime) && liveTime > backupTime;
+}
+
+function severityFor(area: ComparableArea, type: RestorePreviewConflictType): RestorePreviewSeverity {
+  if (area === 'approvals') return 'blocker';
+  if (type === 'newer-live') return 'warning';
+  return 'warning';
+}
+
+function recommendationFor(area: ComparableArea, type: RestorePreviewConflictType): string {
+  switch (area) {
+    case 'tasks':
+      return type === 'newer-live'
+        ? 'Review and merge task/card changes or restore only selected stale fields; do not overwrite newer live task state blindly.'
+        : type === 'live-only'
+          ? 'preserve the live task/card unless the operator explicitly chooses to delete or archive it during restore.'
+          : 'Review task/card delta and choose overwrite, merge, or skip for this item.';
+    case 'approvals':
+      return 'Skip approval token restore and require re-approval so stale or changed approval state cannot authorize live actions.';
+    case 'memory':
+      return type === 'live-only'
+        ? 'Preserve the live memory entry unless the operator explicitly prunes it.'
+        : 'Review and merge memory differences, or skip restore for this entry to avoid losing live context.';
+    case 'cron':
+      return type === 'live-only'
+        ? 'preserve the live cron job unless the operator explicitly removes it.'
+        : 'Review cron drift and explicitly restore, merge, or skip this job; do not overwrite schedules blindly.';
+  }
+}

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -188,6 +188,18 @@ export type { ShutdownHandler } from './resilience/graceful-shutdown.js';
 export { checkModuleHealth, allHealthy } from './resilience/module-initializer.js';
 export type { ModuleHealth } from './resilience/module-initializer.js';
 
+// Disaster recovery
+export { detectRestorePreviewConflicts } from './dr/restore-preview.js';
+export type {
+  RestorePreviewArea,
+  RestorePreviewConflict,
+  RestorePreviewConflictType,
+  RestorePreviewManifest,
+  RestorePreviewRecord,
+  RestorePreviewResult,
+  RestorePreviewSeverity,
+} from './dr/restore-preview.js';
+
 // CLI — file writer
 export { writeDesignDoc, readDesignDoc } from './cli/file-writer.js';
 

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -67,6 +67,57 @@ describe('restore preview conflict detector', () => {
     );
   });
 
+  it('treats backup-only approval tokens as blockers', () => {
+    const preview = detectRestorePreviewConflicts(
+      {
+        schemaVersion: 1,
+        tasks: [],
+        approvals: [{ id: 'approval-cleared-live', state: 'approved', digest: 'stale-token' }],
+        memory: [],
+        cron: [],
+      },
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+    );
+
+    expect(preview.safeToRestore).toBe(false);
+    expect(preview.conflicts).toContainEqual(
+      expect.objectContaining({
+        area: 'approvals',
+        id: 'approval-cleared-live',
+        type: 'backup-only',
+        severity: 'blocker',
+        recommendation: expect.stringContaining('re-approval'),
+      }),
+    );
+  });
+
+  it('compares digest, state, and timestamps so metadata drift is not hidden', () => {
+    const preview = detectRestorePreviewConflicts(
+      {
+        schemaVersion: 1,
+        tasks: [{ id: 'task-1', digest: 'same-task-body', updatedAt: '2026-07-14T10:00:00.000Z' }],
+        approvals: [{ id: 'approval-1', state: 'pending', digest: 'same-token' }],
+        memory: [],
+        cron: [],
+      },
+      {
+        schemaVersion: 1,
+        tasks: [{ id: 'task-1', digest: 'same-task-body', updatedAt: '2026-07-14T11:00:00.000Z' }],
+        approvals: [{ id: 'approval-1', state: 'approved', digest: 'same-token' }],
+        memory: [],
+        cron: [],
+      },
+    );
+
+    expect(preview.safeToRestore).toBe(false);
+    expect(preview.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ area: 'tasks', id: 'task-1', type: 'newer-live' }),
+        expect.objectContaining({ area: 'approvals', id: 'approval-1', type: 'changed', severity: 'blocker' }),
+      ]),
+    );
+  });
+
   it('blocks preview when backup and live schema versions differ', () => {
     const preview = detectRestorePreviewConflicts(
       { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectRestorePreviewConflicts,
+  type RestorePreviewManifest,
+} from '../../../src/dr/restore-preview.js';
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe('restore preview conflict detector', () => {
+  it('returns a clean no-write preview when backup manifest matches live state', () => {
+    const backup: RestorePreviewManifest = {
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', digest: 'task-digest', updatedAt: '2026-07-14T10:00:00.000Z' }],
+      approvals: [{ id: 'approval-1', state: 'pending', digest: 'approval-digest' }],
+      memory: [{ id: 'memory:user', digest: 'memory-digest' }],
+      cron: [{ id: 'daily-brief', digest: 'cron-digest' }],
+    };
+    const live = clone(backup);
+    const beforeBackup = clone(backup);
+    const beforeLive = clone(live);
+
+    const preview = detectRestorePreviewConflicts(backup, live);
+
+    expect(preview.safeToRestore).toBe(true);
+    expect(preview.wouldWrite).toBe(false);
+    expect(preview.conflicts).toEqual([]);
+    expect(backup).toEqual(beforeBackup);
+    expect(live).toEqual(beforeLive);
+  });
+
+  it('reports task, approval, memory, and cron conflicts with recommended actions', () => {
+    const backup: RestorePreviewManifest = {
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', digest: 'old-task', updatedAt: '2026-07-14T10:00:00.000Z' }],
+      approvals: [{ id: 'approval-1', state: 'pending', digest: 'pending-token' }],
+      memory: [{ id: 'memory:user', digest: 'old-memory' }],
+      cron: [{ id: 'daily-brief', digest: 'old-cron' }],
+    };
+    const live: RestorePreviewManifest = {
+      schemaVersion: 1,
+      tasks: [
+        { id: 'task-1', digest: 'new-task', updatedAt: '2026-07-14T11:00:00.000Z' },
+        { id: 'task-2', digest: 'live-only', updatedAt: '2026-07-14T11:30:00.000Z' },
+      ],
+      approvals: [{ id: 'approval-1', state: 'approved', digest: 'approved-token' }],
+      memory: [{ id: 'memory:user', digest: 'new-memory' }],
+      cron: [
+        { id: 'daily-brief', digest: 'new-cron' },
+        { id: 'hourly-watchdog', digest: 'live-only-cron' },
+      ],
+    };
+
+    const preview = detectRestorePreviewConflicts(backup, live);
+
+    expect(preview.safeToRestore).toBe(false);
+    expect(preview.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ area: 'tasks', id: 'task-1', type: 'newer-live', recommendation: expect.stringContaining('merge') }),
+        expect.objectContaining({ area: 'tasks', id: 'task-2', type: 'live-only', recommendation: expect.stringContaining('preserve') }),
+        expect.objectContaining({ area: 'approvals', id: 'approval-1', type: 'changed', recommendation: expect.stringContaining('re-approval') }),
+        expect.objectContaining({ area: 'memory', id: 'memory:user', type: 'changed', recommendation: expect.stringContaining('merge') }),
+        expect.objectContaining({ area: 'cron', id: 'daily-brief', type: 'changed', recommendation: expect.stringContaining('explicitly restore') }),
+        expect.objectContaining({ area: 'cron', id: 'hourly-watchdog', type: 'live-only', recommendation: expect.stringContaining('preserve') }),
+      ]),
+    );
+  });
+
+  it('blocks preview when backup and live schema versions differ', () => {
+    const preview = detectRestorePreviewConflicts(
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+      { schemaVersion: 2, tasks: [], approvals: [], memory: [], cron: [] },
+    );
+
+    expect(preview.safeToRestore).toBe(false);
+    expect(preview.schema.compatible).toBe(false);
+    expect(preview.conflicts).toContainEqual(
+      expect.objectContaining({
+        area: 'schema',
+        id: 'schema-version',
+        type: 'schema-mismatch',
+        severity: 'blocker',
+        recommendation: expect.stringContaining('Do not restore'),
+      }),
+    );
+  });
+});

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-14 — Restore preview conflict detector drift coverage
+- Restore preview comparisons must include record metadata (`state`, `updatedAt`) alongside content digests; digest-only equality can hide approval-state or task-timestamp drift that a restore would roll back.
+- Treat backup-only approval/session-token records as blocker-severity conflicts, not informational drift, because restoring them can reintroduce stale authorization state that live has already cleared.
+
 ## 2026-07-13 — Lesson contradiction detector Codex edge cases
 - For lesson-contradiction heuristics, compare negation per corrective/directive guidance fragment rather than across a whole lesson blob; multi-finding lessons can otherwise mask one reversed clause with an unrelated negated clause.
 - Keep high-signal short technical tokens such as `log`, `PII`, `JWT`, `API`, `CLI`, `SQL`, `URL`, and `env` in overlap matching, but avoid ambiguous negation words such as standalone `block` that also appear in affirmative guidance like code blocks.


### PR DESCRIPTION
## Summary
- Adds a read-only restore preview conflict detector for backup-vs-live manifests.
- Detects schema mismatch, task/card drift, approval token drift, memory drift, and cron drift.
- Returns per-conflict recommendations so operators can choose preserve/merge/skip/restore decisions before mutation.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/dr/restore-preview.test.ts
- npm run lint --workspace @franken/orchestrator
- npm run build
- npm run typecheck --workspace @franken/orchestrator
- npm run lint:security

Closes #1752
