### PR TITLE
feat(observer): classify runtime artifacts

### DIFF
--- a/docs/runtime-artifact-data-classification.md
+++ b/docs/runtime-artifact-data-classification.md
@@ -1,0 +1,59 @@
+# Runtime Artifact Data Classification
+
+Frankenbeast runtime artifacts must carry a sensitivity label before they are stored, exported, or delivered outside the local process. The observer package exposes the canonical labels and default artifact mapping via `RUNTIME_ARTIFACT_CLASSIFICATIONS`, `classifyRuntimeArtifact()`, and `ClassificationGuardAdapter`.
+
+## Classification labels
+
+- `public`: safe to publish; contains no tenant, operator, user, or runtime-private context.
+- `internal`: implementation or operational metadata that should stay inside the project/operator boundary.
+- `sensitive`: may include trace metadata, errors, destinations, cost/spend, or incident details. Redact before broad sharing.
+- `secret`: credentials, backups, bundled state, tokens, or material that could grant access if disclosed.
+- `user-private`: prompts, memory, user-provided content, and tenant-specific private context.
+
+## Default runtime artifact mapping
+
+| Artifact type | Default class | Why |
+|---|---:|---|
+| Logs | `sensitive` | Logs can include prompts, tool arguments, URLs, stack traces, and identifiers. |
+| Memory | `user-private` | Durable memory can contain personal preferences, tenant-scoped environment facts, or private context. |
+| Backups | `secret` | Backups can bundle config, credentials, approvals, memory, cron jobs, and historical runtime artifacts. |
+| Exports | `sensitive` | Generic exports are cross-boundary copies and may include traces, prompts, metadata, or audit details. |
+| Prompts | `user-private` | Prompts often contain user requests, retrieved context, and private operator intent. |
+| Webhooks | `sensitive` | Webhook payloads leave the process boundary and may include incidents, spend, traces, or approval context. |
+| Traces | `sensitive` | Observer traces include goals, span metadata, errors, and thought-block placeholders. |
+| Audit trails | `sensitive` | Audit trails record decisions and runtime references needed for accountability. |
+| Post-mortems | `sensitive` | Post-mortems include failures, diagnostics, and operator decisions. |
+
+## Choosing a class for a new artifact type
+
+1. Start from the highest class of any field that may be present in the artifact.
+2. Use `secret` for credentials, access tokens, raw backups, or bundled state that may contain secrets.
+3. Use `user-private` for prompts, memories, tenant/user content, or anything the user did not explicitly intend to publish.
+4. Use `sensitive` for operational/runtime data that is not itself secret but can expose behavior, topology, or incident details.
+5. Downgrade only after the producer proves redaction strips the higher-class fields.
+6. For external export, call `enforceRuntimeArtifactExportPolicy()` or wrap the adapter with `ClassificationGuardAdapter` so `secret` and `user-private` artifacts cannot leave without redaction or an explicit operator override.
+
+## Export policy
+
+`secret` and `user-private` artifacts are blocked from export by default. Export is allowed only when the caller sets `redactionApplied: true` after masking/removing high-sensitivity fields, or `allowSensitiveExportOverride: true` for an explicit audited operator override.
+
+Example:
+
+```ts
+import { ClassificationGuardAdapter, SpanRedactor } from '@franken/observer'
+
+const redacted = new SpanRedactor({
+  adapter: thirdPartyAdapter,
+  rules: [{ key: /token|secret|password/i, action: 'mask' }],
+  redactThoughtBlocks: true,
+})
+
+const guarded = new ClassificationGuardAdapter({
+  adapter: redacted,
+  artifactType: 'prompt',
+  redactionApplied: true,
+  destination: 'third-party collector',
+})
+```
+
+Prefer redaction over overrides. When an override is unavoidable, record the destination, reason, operator, and retention expectation in the audit trail.

--- a/docs/runtime-artifact-data-classification.md
+++ b/docs/runtime-artifact-data-classification.md
@@ -42,15 +42,15 @@ Example:
 ```ts
 import { ClassificationGuardAdapter, SpanRedactor } from '@franken/observer'
 
-const redacted = new SpanRedactor({
+const redactedTraceAdapter = new SpanRedactor({
   adapter: thirdPartyAdapter,
   rules: [{ key: /token|secret|password/i, action: 'mask' }],
   redactThoughtBlocks: true,
 })
 
 const guarded = new ClassificationGuardAdapter({
-  adapter: redacted,
-  artifactType: 'prompt',
+  adapter: redactedTraceAdapter,
+  artifactType: 'trace',
   redactionApplied: true,
   destination: 'third-party collector',
 })

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -35,6 +35,14 @@ export { LangfuseAdapter } from './adapters/langfuse/LangfuseAdapter.js'
 export { PrometheusAdapter } from './adapters/prometheus/PrometheusAdapter.js'
 export { TempoAdapter } from './adapters/tempo/TempoAdapter.js'
 export { WebhookNotifier } from './notify/WebhookNotifier.js'
+export {
+  ClassificationGuardAdapter,
+  RUNTIME_ARTIFACT_CLASSIFICATIONS,
+  classifyRuntimeArtifact,
+  classificationAtLeast,
+  enforceRuntimeArtifactExportPolicy,
+  isHighSensitivityClassification,
+} from './security/data-classification.js'
 export { TraceServer } from './ui/TraceServer.js'
 export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
 
@@ -52,6 +60,13 @@ export type { SQLiteAdapterOptions } from './adapters/sqlite/SQLiteAdapter.js'
 export type { PrometheusAdapterOptions } from './adapters/prometheus/PrometheusAdapter.js'
 export type { TempoAdapterOptions, TempoBasicAuth } from './adapters/tempo/TempoAdapter.js'
 export type { WebhookNotifierOptions, WebhookRetryOptions } from './notify/WebhookNotifier.js'
+export type {
+  ClassificationGuardAdapterOptions,
+  DataClassification,
+  RuntimeArtifactClassification,
+  RuntimeArtifactExportPolicyOptions,
+  RuntimeArtifactType,
+} from './security/data-classification.js'
 export type { TraceServerOptions } from './ui/TraceServer.js'
 export type {
   GrafanaDashboard,

--- a/packages/franken-observer/src/security/data-classification.test.ts
+++ b/packages/franken-observer/src/security/data-classification.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { Trace } from '../core/types.js'
+import type { ExportAdapter } from '../export/ExportAdapter.js'
+import {
+  ClassificationGuardAdapter,
+  RUNTIME_ARTIFACT_CLASSIFICATIONS,
+  classifyRuntimeArtifact,
+  enforceRuntimeArtifactExportPolicy,
+} from './data-classification.js'
+
+describe('runtime artifact data classification', () => {
+  it('defines expected sensitivity labels for core runtime artifact types', () => {
+    expect(Object.keys(RUNTIME_ARTIFACT_CLASSIFICATIONS).sort()).toEqual(
+      [
+        'audit-trail',
+        'backup',
+        'export',
+        'log',
+        'memory',
+        'post-mortem',
+        'prompt',
+        'trace',
+        'webhook',
+      ].sort(),
+    )
+    expect(classifyRuntimeArtifact('log').classification).toBe('sensitive')
+    expect(classifyRuntimeArtifact('memory').classification).toBe('user-private')
+    expect(classifyRuntimeArtifact('backup').classification).toBe('secret')
+    expect(classifyRuntimeArtifact('export').classification).toBe('sensitive')
+    expect(classifyRuntimeArtifact('prompt').classification).toBe('user-private')
+    expect(classifyRuntimeArtifact('webhook').classification).toBe('sensitive')
+  })
+
+  it('blocks secret artifacts from export unless redacted or explicitly overridden', () => {
+    const backup = classifyRuntimeArtifact('backup')
+
+    expect(() => enforceRuntimeArtifactExportPolicy(backup, { destination: 'external archive' })).toThrow(
+      'Refusing to export secret backup artifact to external archive without redaction or explicit override',
+    )
+
+    expect(() => enforceRuntimeArtifactExportPolicy(backup, { redactionApplied: true })).not.toThrow()
+    expect(() => enforceRuntimeArtifactExportPolicy(backup, { allowSensitiveExportOverride: true })).not.toThrow()
+  })
+
+  it('blocks user-private artifacts from export unless redacted or explicitly overridden', () => {
+    const memory = classifyRuntimeArtifact('memory')
+
+    expect(() => enforceRuntimeArtifactExportPolicy(memory)).toThrow(
+      'Refusing to export user-private memory artifact without redaction or explicit override',
+    )
+
+    expect(() => enforceRuntimeArtifactExportPolicy(memory, { redactionApplied: true })).not.toThrow()
+    expect(() => enforceRuntimeArtifactExportPolicy(memory, { allowSensitiveExportOverride: true })).not.toThrow()
+  })
+
+  it('allows sensitive non-secret exports so redaction policy can be applied by destination wrappers', () => {
+    expect(() => enforceRuntimeArtifactExportPolicy(classifyRuntimeArtifact('trace'))).not.toThrow()
+    expect(() => enforceRuntimeArtifactExportPolicy(classifyRuntimeArtifact('webhook'))).not.toThrow()
+  })
+
+  it('prevents guarded secret trace exports before the wrapped adapter sees the trace', async () => {
+    const inner = new RecordingAdapter()
+    const guarded = new ClassificationGuardAdapter({
+      adapter: inner,
+      artifactType: 'trace',
+      classification: 'secret',
+      destination: 'third-party collector',
+    })
+
+    await expect(guarded.flush(exampleTrace)).rejects.toThrow(
+      'Refusing to export secret trace artifact to third-party collector without redaction or explicit override',
+    )
+    expect(inner.flushed).toHaveLength(0)
+  })
+
+  it('passes guarded private exports after redaction is applied', async () => {
+    const inner = new RecordingAdapter()
+    const guarded = new ClassificationGuardAdapter({
+      adapter: inner,
+      artifactType: 'prompt',
+      redactionApplied: true,
+    })
+
+    await guarded.flush(exampleTrace)
+
+    expect(inner.flushed).toEqual([exampleTrace])
+  })
+})
+
+const exampleTrace: Trace = {
+  id: 'trace-1',
+  goal: 'classify runtime artifacts',
+  status: 'completed',
+  startedAt: 1,
+  endedAt: 2,
+  spans: [],
+}
+
+class RecordingAdapter implements ExportAdapter {
+  readonly flushed: Trace[] = []
+
+  async flush(trace: Trace): Promise<void> {
+    this.flushed.push(trace)
+  }
+
+  async queryByTraceId(traceId: string): Promise<Trace | null> {
+    return this.flushed.find(trace => trace.id === traceId) ?? null
+  }
+
+  async listTraceIds(): Promise<string[]> {
+    return this.flushed.map(trace => trace.id)
+  }
+}

--- a/packages/franken-observer/src/security/data-classification.test.ts
+++ b/packages/franken-observer/src/security/data-classification.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { Trace } from '../core/types.js'
 import type { ExportAdapter } from '../export/ExportAdapter.js'
 import {
@@ -53,6 +53,29 @@ describe('runtime artifact data classification', () => {
     expect(() => enforceRuntimeArtifactExportPolicy(memory, { allowSensitiveExportOverride: true })).not.toThrow()
   })
 
+  it('keeps exported classification policy immutable at runtime', () => {
+    const mutablePolicy = RUNTIME_ARTIFACT_CLASSIFICATIONS as unknown as Record<string, { classification: string }>
+    expect(Object.isFrozen(RUNTIME_ARTIFACT_CLASSIFICATIONS)).toBe(true)
+    expect(Object.isFrozen(RUNTIME_ARTIFACT_CLASSIFICATIONS.backup)).toBe(true)
+    expect(Object.isFrozen(RUNTIME_ARTIFACT_CLASSIFICATIONS.backup.defaultControls)).toBe(true)
+
+    expect(() => {
+      mutablePolicy.backup.classification = 'sensitive'
+    }).toThrow()
+
+    expect(classifyRuntimeArtifact('backup').classification).toBe('secret')
+  })
+
+  it('returns defensive classification labels instead of live policy aliases', () => {
+    const backup = classifyRuntimeArtifact('backup') as unknown as { classification: string }
+
+    expect(() => {
+      backup.classification = 'sensitive'
+    }).toThrow()
+
+    expect(classifyRuntimeArtifact('backup').classification).toBe('secret')
+  })
+
   it('allows sensitive non-secret exports so redaction policy can be applied by destination wrappers', () => {
     expect(() => enforceRuntimeArtifactExportPolicy(classifyRuntimeArtifact('trace'))).not.toThrow()
     expect(() => enforceRuntimeArtifactExportPolicy(classifyRuntimeArtifact('webhook'))).not.toThrow()
@@ -69,6 +92,35 @@ describe('runtime artifact data classification', () => {
 
     await expect(guarded.flush(exampleTrace)).rejects.toThrow(
       'Refusing to export secret trace artifact to third-party collector without redaction or explicit override',
+    )
+    expect(inner.flushed).toHaveLength(0)
+  })
+
+  it('enforces policy before active-span warnings can leak rejected artifact details', async () => {
+    const inner = new RecordingAdapter()
+    const guarded = new ClassificationGuardAdapter({
+      adapter: inner,
+      artifactType: 'prompt',
+    })
+    const emitWarning = vi.spyOn(process, 'emitWarning').mockImplementation(() => true)
+
+    await expect(guarded.flush(activeTrace)).rejects.toThrow(
+      'Refusing to export user-private prompt artifact without redaction or explicit override',
+    )
+    expect(emitWarning).not.toHaveBeenCalled()
+    emitWarning.mockRestore()
+  })
+
+  it('prevents callers from downgrading a secret default classification', async () => {
+    const inner = new RecordingAdapter()
+    const guarded = new ClassificationGuardAdapter({
+      adapter: inner,
+      artifactType: 'backup',
+      classification: 'sensitive',
+    })
+
+    await expect(guarded.flush(exampleTrace)).rejects.toThrow(
+      'Refusing to export secret backup artifact without redaction or explicit override',
     )
     expect(inner.flushed).toHaveLength(0)
   })
@@ -94,6 +146,21 @@ const exampleTrace: Trace = {
   startedAt: 1,
   endedAt: 2,
   spans: [],
+}
+
+const activeTrace: Trace = {
+  ...exampleTrace,
+  spans: [
+    {
+      id: 'span-1',
+      traceId: 'trace-1',
+      name: 'collect private prompt',
+      status: 'active',
+      startedAt: 1,
+      metadata: {},
+      thoughtBlocks: [],
+    },
+  ],
 }
 
 class RecordingAdapter implements ExportAdapter {

--- a/packages/franken-observer/src/security/data-classification.ts
+++ b/packages/franken-observer/src/security/data-classification.ts
@@ -1,0 +1,194 @@
+import type { Trace } from '../core/types.js'
+import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
+import { warnIfTraceHasActiveSpans } from '../export/ExportAdapter.js'
+
+export type DataClassification = 'public' | 'internal' | 'sensitive' | 'secret' | 'user-private'
+
+export type RuntimeArtifactType =
+  | 'log'
+  | 'memory'
+  | 'backup'
+  | 'export'
+  | 'prompt'
+  | 'webhook'
+  | 'trace'
+  | 'audit-trail'
+  | 'post-mortem'
+
+export interface RuntimeArtifactClassification {
+  readonly artifactType: RuntimeArtifactType
+  readonly classification: DataClassification
+  readonly rationale: string
+  readonly defaultControls: readonly string[]
+}
+
+export interface RuntimeArtifactExportPolicyOptions {
+  /** True when a caller already stripped or masked secret/private payload fields. */
+  readonly redactionApplied?: boolean
+  /**
+   * Explicit operator override for controlled incident response or migration jobs.
+   * Callers should record the reason in their own audit trail.
+   */
+  readonly allowSensitiveExportOverride?: boolean
+  /** Optional human-readable destination for error messages and audit records. */
+  readonly destination?: string
+}
+
+export interface ClassificationGuardAdapterOptions extends RuntimeArtifactExportPolicyOptions {
+  readonly adapter: ExportAdapter
+  readonly artifactType?: RuntimeArtifactType
+  readonly classification?: DataClassification
+}
+
+const CLASSIFICATION_RANK: Record<DataClassification, number> = {
+  public: 0,
+  internal: 1,
+  sensitive: 2,
+  secret: 3,
+  'user-private': 3,
+}
+
+export const RUNTIME_ARTIFACT_CLASSIFICATIONS: Readonly<Record<RuntimeArtifactType, RuntimeArtifactClassification>> = {
+  log: {
+    artifactType: 'log',
+    classification: 'sensitive',
+    rationale: 'Logs can include prompts, tool arguments, URLs, stack traces, and operator/user identifiers.',
+    defaultControls: ['redact credentials and private user text before external export', 'retain only for operational need'],
+  },
+  memory: {
+    artifactType: 'memory',
+    classification: 'user-private',
+    rationale: 'Memory stores durable user preferences, environment facts, and potentially personal or tenant-scoped data.',
+    defaultControls: ['local/private storage by default', 'redact or require explicit override before export'],
+  },
+  backup: {
+    artifactType: 'backup',
+    classification: 'secret',
+    rationale: 'Backups can bundle config, credentials, approvals, memory, cron jobs, and historical runtime artifacts.',
+    defaultControls: ['encrypt at rest', 'do not share externally without explicit operator override'],
+  },
+  export: {
+    artifactType: 'export',
+    classification: 'sensitive',
+    rationale: 'Generic exports are cross-boundary copies and may contain traces, prompts, costs, metadata, or audit details.',
+    defaultControls: ['apply destination-specific redaction', 'audit destination and purpose'],
+  },
+  prompt: {
+    artifactType: 'prompt',
+    classification: 'user-private',
+    rationale: 'Prompts frequently contain user requests, private context, retrieved content, and hidden operator intent.',
+    defaultControls: ['avoid external export unless redacted', 'strip secrets and private user text'],
+  },
+  webhook: {
+    artifactType: 'webhook',
+    classification: 'sensitive',
+    rationale: 'Webhook payloads leave the process boundary and often include incident, spend, trace, or approval context.',
+    defaultControls: ['allowlist destinations', 'redact echoed credentials and high-sensitivity payloads'],
+  },
+  trace: {
+    artifactType: 'trace',
+    classification: 'sensitive',
+    rationale: 'Observer traces contain goals, span metadata, errors, and thought-block placeholders from runtime execution.',
+    defaultControls: ['redact span metadata/thought blocks before external export', 'warn on active spans'],
+  },
+  'audit-trail': {
+    artifactType: 'audit-trail',
+    classification: 'sensitive',
+    rationale: 'Audit trails include execution decisions and references needed for accountability.',
+    defaultControls: ['append-only storage', 'share only the minimum necessary fields'],
+  },
+  'post-mortem': {
+    artifactType: 'post-mortem',
+    classification: 'sensitive',
+    rationale: 'Post-mortems can contain trace goals, failures, operator decisions, and diagnostic details.',
+    defaultControls: ['sanitize filenames', 'redact before external publication'],
+  },
+}
+
+export function classifyRuntimeArtifact(artifactType: RuntimeArtifactType): RuntimeArtifactClassification {
+  return RUNTIME_ARTIFACT_CLASSIFICATIONS[artifactType]
+}
+
+export function isHighSensitivityClassification(classification: DataClassification): boolean {
+  return classification === 'secret' || classification === 'user-private'
+}
+
+export function classificationAtLeast(
+  classification: DataClassification,
+  minimum: DataClassification,
+): boolean {
+  return CLASSIFICATION_RANK[classification] >= CLASSIFICATION_RANK[minimum]
+}
+
+export function enforceRuntimeArtifactExportPolicy(
+  artifact: RuntimeArtifactClassification,
+  options: RuntimeArtifactExportPolicyOptions = {},
+): void {
+  if (!isHighSensitivityClassification(artifact.classification)) {
+    return
+  }
+
+  if (options.redactionApplied || options.allowSensitiveExportOverride) {
+    return
+  }
+
+  const destination = options.destination ? ` to ${options.destination}` : ''
+  throw new Error(
+    `Refusing to export ${artifact.classification} ${artifact.artifactType} artifact${destination} without redaction or explicit override`,
+  )
+}
+
+export class ClassificationGuardAdapter implements ExportAdapter {
+  private readonly inner: ExportAdapter
+  private readonly artifact: RuntimeArtifactClassification
+  private readonly policyOptions: RuntimeArtifactExportPolicyOptions
+
+  constructor(options: ClassificationGuardAdapterOptions) {
+    this.inner = options.adapter
+    this.artifact = options.classification
+      ? {
+          ...classifyRuntimeArtifact(options.artifactType ?? 'trace'),
+          classification: options.classification,
+        }
+      : classifyRuntimeArtifact(options.artifactType ?? 'trace')
+    this.policyOptions = {
+      redactionApplied: options.redactionApplied,
+      allowSensitiveExportOverride: options.allowSensitiveExportOverride,
+      destination: options.destination,
+    }
+  }
+
+  async flush(trace: Trace): Promise<void> {
+    warnIfTraceHasActiveSpans(trace, 'ClassificationGuardAdapter')
+    enforceRuntimeArtifactExportPolicy(this.artifact, this.policyOptions)
+    await this.inner.flush(trace)
+  }
+
+  async queryByTraceId(traceId: string): Promise<Trace | null> {
+    return this.inner.queryByTraceId(traceId)
+  }
+
+  async listTraceIds(): Promise<string[]> {
+    return this.inner.listTraceIds()
+  }
+
+  async listTraceSummaries(): Promise<TraceSummary[]> {
+    if (!this.inner.listTraceSummaries) {
+      const ids = await this.inner.listTraceIds()
+      const summaries: TraceSummary[] = []
+      for (const id of ids) {
+        const trace = await this.inner.queryByTraceId(id)
+        if (!trace) continue
+        summaries.push({
+          id: trace.id,
+          goal: trace.goal,
+          status: trace.status,
+          spanCount: trace.spans.length,
+          startedAt: trace.startedAt,
+        })
+      }
+      return summaries
+    }
+    return this.inner.listTraceSummaries()
+  }
+}

--- a/packages/franken-observer/src/security/data-classification.ts
+++ b/packages/franken-observer/src/security/data-classification.ts
@@ -37,6 +37,7 @@ export interface RuntimeArtifactExportPolicyOptions {
 export interface ClassificationGuardAdapterOptions extends RuntimeArtifactExportPolicyOptions {
   readonly adapter: ExportAdapter
   readonly artifactType?: RuntimeArtifactType
+  /** Optional stricter classification for a specific payload; never downgrades the default artifact class. */
   readonly classification?: DataClassification
 }
 
@@ -48,7 +49,7 @@ const CLASSIFICATION_RANK: Record<DataClassification, number> = {
   'user-private': 3,
 }
 
-export const RUNTIME_ARTIFACT_CLASSIFICATIONS: Readonly<Record<RuntimeArtifactType, RuntimeArtifactClassification>> = {
+const RUNTIME_ARTIFACT_CLASSIFICATION_DEFINITIONS = {
   log: {
     artifactType: 'log',
     classification: 'sensitive',
@@ -103,10 +104,13 @@ export const RUNTIME_ARTIFACT_CLASSIFICATIONS: Readonly<Record<RuntimeArtifactTy
     rationale: 'Post-mortems can contain trace goals, failures, operator decisions, and diagnostic details.',
     defaultControls: ['sanitize filenames', 'redact before external publication'],
   },
-}
+} satisfies Record<RuntimeArtifactType, RuntimeArtifactClassification>
+
+export const RUNTIME_ARTIFACT_CLASSIFICATIONS: Readonly<Record<RuntimeArtifactType, RuntimeArtifactClassification>> =
+  freezeClassificationMap(RUNTIME_ARTIFACT_CLASSIFICATION_DEFINITIONS)
 
 export function classifyRuntimeArtifact(artifactType: RuntimeArtifactType): RuntimeArtifactClassification {
-  return RUNTIME_ARTIFACT_CLASSIFICATIONS[artifactType]
+  return cloneClassification(RUNTIME_ARTIFACT_CLASSIFICATIONS[artifactType])
 }
 
 export function isHighSensitivityClassification(classification: DataClassification): boolean {
@@ -145,12 +149,7 @@ export class ClassificationGuardAdapter implements ExportAdapter {
 
   constructor(options: ClassificationGuardAdapterOptions) {
     this.inner = options.adapter
-    this.artifact = options.classification
-      ? {
-          ...classifyRuntimeArtifact(options.artifactType ?? 'trace'),
-          classification: options.classification,
-        }
-      : classifyRuntimeArtifact(options.artifactType ?? 'trace')
+    this.artifact = buildGuardClassification(options.artifactType ?? 'trace', options.classification)
     this.policyOptions = {
       redactionApplied: options.redactionApplied,
       allowSensitiveExportOverride: options.allowSensitiveExportOverride,
@@ -159,8 +158,8 @@ export class ClassificationGuardAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
-    warnIfTraceHasActiveSpans(trace, 'ClassificationGuardAdapter')
     enforceRuntimeArtifactExportPolicy(this.artifact, this.policyOptions)
+    warnIfTraceHasActiveSpans(trace, 'ClassificationGuardAdapter')
     await this.inner.flush(trace)
   }
 
@@ -191,4 +190,41 @@ export class ClassificationGuardAdapter implements ExportAdapter {
     }
     return this.inner.listTraceSummaries()
   }
+}
+
+function buildGuardClassification(
+  artifactType: RuntimeArtifactType,
+  overrideClassification: DataClassification | undefined,
+): RuntimeArtifactClassification {
+  const base = classifyRuntimeArtifact(artifactType)
+  if (!overrideClassification || classificationAtLeast(base.classification, overrideClassification)) {
+    return base
+  }
+
+  return Object.freeze({
+    ...base,
+    classification: overrideClassification,
+    defaultControls: Object.freeze([...base.defaultControls]),
+  })
+}
+
+function freezeClassificationMap(
+  value: Record<RuntimeArtifactType, RuntimeArtifactClassification>,
+): Readonly<Record<RuntimeArtifactType, RuntimeArtifactClassification>> {
+  const entries = Object.entries(value).map(([key, classification]) => [key, freezeClassification(classification)])
+  return Object.freeze(Object.fromEntries(entries)) as Readonly<Record<RuntimeArtifactType, RuntimeArtifactClassification>>
+}
+
+function freezeClassification(classification: RuntimeArtifactClassification): RuntimeArtifactClassification {
+  return Object.freeze({
+    ...classification,
+    defaultControls: Object.freeze([...classification.defaultControls]),
+  })
+}
+
+function cloneClassification(classification: RuntimeArtifactClassification): RuntimeArtifactClassification {
+  return Object.freeze({
+    ...classification,
+    defaultControls: Object.freeze([...classification.defaultControls]),
+  })
 }

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-14 — Observer classification verification
+- In fresh worktrees, build `@franken/types` before running `@franken/observer` typecheck/build because observer imports generated workspace package exports.
+- For runtime-artifact classification/security changes, cover runtime policy immutability, downgrade prevention, warning side effects before rejection, and docs examples that might overclaim redaction semantics before triggering Codex.
+
 ## 2026-07-14 — Restore preview conflict detector drift coverage
 - Restore preview comparisons must include record metadata (`state`, `updatedAt`) alongside content digests; digest-only equality can hide approval-state or task-timestamp drift that a restore would roll back.
 - Treat backup-only approval/session-token records as blocker-severity conflicts, not informational drift, because restoring them can reintroduce stale authorization state that live has already cleared.


### PR DESCRIPTION
## Summary
- add observer runtime artifact data classification labels and default mappings
- add export policy guards for secret/user-private artifacts requiring redaction or explicit override
- document how logs, memory, backups, exports, prompts, webhooks, traces, audit trails, and post-mortems choose classes

## Test Plan
- npm run test --workspace @franken/observer -- src/security/data-classification.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer
- npm run test --workspace @franken/observer

Closes #1736