### PR TITLE
feat(observer): add transcript retention controls

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -311,6 +311,31 @@ const recovered = await adapter2.queryByTraceId(trace.id)
 adapter.close() // release the SQLite handle
 ```
 
+### `TranscriptRetentionAdapter`
+
+Prompt and tool transcripts can contain private user data, secrets, and operator context. Wrap any trace backend with `TranscriptRetentionAdapter` to control whether transcript fields are retained, how long they remain readable, how they are redacted, and what access level operators should treat the retained data as.
+
+Safe defaults use `mode: 'redacted'`, `redactionLevel: 'mask'`, `ttlMs: 24h`, and `accessLevel: 'restricted'`. The policy covers trace goals/prompts, tool inputs, tool outputs, span errors, summaries, and thought blocks.
+
+```ts
+import { SQLiteAdapter, TranscriptRetentionAdapter } from '@franken/observer'
+
+const db = new SQLiteAdapter('./traces.db')
+const adapter = new TranscriptRetentionAdapter({
+  adapter: db,
+  ttlMs: 6 * 60 * 60 * 1000,
+  retainedFields: {
+    toolOutputs: false, // keep debugging shape without retaining raw tool output
+  },
+})
+
+await adapter.flush(trace)
+console.log(adapter.describePolicy()) // mode, ttlMs, accessLevel, retainedFields
+await adapter.cleanupExpired()
+```
+
+Use `mode: 'disabled'` for sensitive lanes that should not persist transcripts at all. Use `mode: 'raw'` with `redactionLevel: 'none'` only as an explicit operator override for short-lived local debugging.
+
 ### Stacking adapters
 
 ```ts

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -111,6 +111,27 @@ describe('SQLiteAdapter', () => {
       expect(result).toBeNull()
     })
 
+    it('deletes traces and spans by trace id', async () => {
+      const trace = TraceContext.createTrace('delete me')
+      const span = TraceContext.startSpan(trace, { name: 'step' })
+      SpanLifecycle.setMetadata(span, { prompt: 'private prompt' })
+      TraceContext.endSpan(span)
+      TraceContext.endTrace(trace)
+      await adapter.flush(trace)
+
+      await adapter.deleteTrace(trace.id)
+
+      expect(await adapter.queryByTraceId(trace.id)).toBeNull()
+      expect(await adapter.listTraceIds()).toEqual([])
+      const raw = new Database(dbPath)
+      try {
+        expect(raw.prepare('SELECT COUNT(*) AS count FROM spans WHERE traceId = ?').get(trace.id)).toMatchObject({ count: 0 })
+        expect(raw.prepare('SELECT COUNT(*) AS count FROM traces WHERE id = ?').get(trace.id)).toMatchObject({ count: 0 })
+      } finally {
+        raw.close()
+      }
+    })
+
     it('upserts — re-flushing a trace overwrites the stored version', async () => {
       const trace = TraceContext.createTrace('original')
       TraceContext.endTrace(trace)

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -12,6 +12,8 @@ import {
   SELECT_SPANS,
   SELECT_ALL_TRACE_IDS,
   SELECT_TRACE_SUMMARIES,
+  DELETE_SPANS_BY_TRACE,
+  DELETE_TRACE,
 } from './schema.js'
 
 interface TraceRow {
@@ -264,6 +266,22 @@ export class SQLiteAdapter implements ExportAdapter {
       spanCount: row.spanCount,
       startedAt: row.startedAt,
     }))
+  }
+
+  async deleteTrace(traceId: string): Promise<void> {
+    const deleteSpans = this.db.prepare(DELETE_SPANS_BY_TRACE)
+    const deleteTrace = this.db.prepare(DELETE_TRACE)
+    const transaction = this.db.transaction((id: string) => {
+      deleteSpans.run(id)
+      deleteTrace.run(id)
+    })
+
+    transaction(traceId)
+    const flushed = this.flushedSpans.get(traceId)
+    if (flushed !== undefined) {
+      this.flushedSpanSnapshotCount -= flushed.size
+      this.flushedSpans.delete(traceId)
+    }
   }
 
   /** Release the DB connection. Call when shutting down. */

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -67,3 +67,6 @@ export const SELECT_TRACE_SUMMARIES = `
   GROUP BY traces.id
   ORDER BY traces.startedAt ASC
 `
+
+export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
+export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -47,6 +47,10 @@ export class InMemoryAdapter implements ExportAdapter {
     return Array.from(this.store.keys())
   }
 
+  async deleteTrace(traceId: string): Promise<void> {
+    this.store.delete(traceId)
+  }
+
   clear(): void {
     this.store.clear()
   }

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -43,6 +43,12 @@ export {
   enforceRuntimeArtifactExportPolicy,
   isHighSensitivityClassification,
 } from './security/data-classification.js'
+export {
+  TranscriptRetentionAdapter,
+  applyRetentionPolicy,
+  describeTranscriptRetentionPolicy,
+  resolveTranscriptRetentionPolicy,
+} from './security/transcript-retention.js'
 export { TraceServer } from './ui/TraceServer.js'
 export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
 
@@ -67,6 +73,17 @@ export type {
   RuntimeArtifactExportPolicyOptions,
   RuntimeArtifactType,
 } from './security/data-classification.js'
+export type {
+  ResolvedTranscriptRetentionPolicy,
+  TranscriptAccessLevel,
+  TranscriptField,
+  TranscriptRedactionLevel,
+  TranscriptRetainedFields,
+  TranscriptRetentionAdapterOptions,
+  TranscriptRetentionMode,
+  TranscriptRetentionPolicy,
+  TranscriptRetentionPolicyReport,
+} from './security/transcript-retention.js'
 export type { TraceServerOptions } from './ui/TraceServer.js'
 export type {
   GrafanaDashboard,

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -325,6 +325,8 @@ describe('transcript retention controls', () => {
           promptText: 'raw prompt text',
           systemPromptAddition: 'raw system prompt',
           tool_input_json: 'raw tool input',
+          input_json: 'raw serialized input',
+          argsJson: 'raw args json',
           toolResultPayload: 'raw tool output',
           safeCounter: 1,
         },
@@ -335,6 +337,8 @@ describe('transcript retention controls', () => {
       promptText: '[REDACTED_TRANSCRIPT]',
       systemPromptAddition: '[REDACTED_TRANSCRIPT]',
       tool_input_json: '[REDACTED_TRANSCRIPT]',
+      input_json: '[REDACTED_TRANSCRIPT]',
+      argsJson: '[REDACTED_TRANSCRIPT]',
       toolResultPayload: '[REDACTED_TRANSCRIPT]',
       safeCounter: 1,
     })
@@ -708,6 +712,58 @@ describe('transcript retention controls', () => {
       type: 'tool_result',
       tool_call_id: 'call-1',
     })
+  })
+
+  it('honors tool output opt-outs for root metadata tool result envelopes', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: { role: 'tool', content: 'private root tool result', tool_call_id: 'call-1' },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata).toEqual({ role: 'tool', tool_call_id: 'call-1' })
+  })
+
+  it('retains allowed tool outputs inside raw message containers when prompts are disabled', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          messages: [
+            { role: 'user', content: 'private prompt' },
+            { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+          ],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolOutputs: true },
+    })
+
+    expect(retained.spans[0].metadata['messages']).toEqual([
+      { role: 'user' },
+      { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+    ])
+  })
+
+  it('filters raw object-valued transcript fields before cloning shared metadata', () => {
+    const metadata: Record<string, unknown> = { prompt: 'private prompt' }
+    metadata['toolInput'] = metadata
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolInputs: true },
+    })
+
+    expect(retained.spans[0].metadata).toHaveProperty('toolInput')
+    expect(retained.spans[0].metadata).not.toHaveProperty('prompt')
+    expect(retained.spans[0].metadata['toolInput']).toBe(retained.spans[0].metadata)
   })
 
   it('walks Map and Set metadata before preserving their container types', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest'
+import type { Span, Trace } from '../core/types.js'
+import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
+import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
+import {
+  TranscriptRetentionAdapter,
+  applyRetentionPolicy,
+  describeTranscriptRetentionPolicy,
+} from './transcript-retention.js'
+
+function makeSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'span-1',
+    traceId: 'trace-1',
+    name: 'tool-call',
+    status: 'completed',
+    startedAt: 1,
+    endedAt: 2,
+    durationMs: 1,
+    errorMessage: 'raw failure with private context',
+    metadata: {
+      prompt: 'raw prompt text',
+      toolInput: { query: 'private input', nested: { args: 'secret args' } },
+      toolOutput: 'private output',
+      summary: 'private summary',
+      safeCounter: 1,
+    },
+    thoughtBlocks: ['private reasoning'],
+    ...overrides,
+  }
+}
+
+function makeTrace(overrides: Partial<Trace> = {}): Trace {
+  return {
+    id: 'trace-1',
+    goal: 'user prompt with secret context',
+    status: 'completed',
+    startedAt: 1,
+    endedAt: 2,
+    spans: [makeSpan()],
+    ...overrides,
+  }
+}
+
+class NonDeletingAdapter implements ExportAdapter {
+  private readonly inner = new InMemoryAdapter()
+
+  flush(trace: Trace): Promise<void> {
+    return this.inner.flush(trace)
+  }
+
+  queryByTraceId(traceId: string): Promise<Trace | null> {
+    return this.inner.queryByTraceId(traceId)
+  }
+
+  listTraceIds(): Promise<string[]> {
+    return this.inner.listTraceIds()
+  }
+
+  async listTraceSummaries(): Promise<TraceSummary[]> {
+    const summaries: TraceSummary[] = []
+    for (const id of await this.inner.listTraceIds()) {
+      const trace = await this.inner.queryByTraceId(id)
+      if (!trace) continue
+      summaries.push({
+        id: trace.id,
+        goal: trace.goal,
+        status: trace.status,
+        spanCount: trace.spans.length,
+        startedAt: trace.startedAt,
+      })
+    }
+    return summaries
+  }
+}
+
+describe('transcript retention controls', () => {
+  it('defaults to redacted retention for prompts, tool I/O, errors, and summaries', async () => {
+    const inner = new InMemoryAdapter()
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, now: () => 3 })
+
+    await adapter.flush(makeTrace())
+
+    const stored = await inner.queryByTraceId('trace-1')
+    expect(stored?.goal).toBe('[REDACTED_TRANSCRIPT]')
+    expect(stored?.spans[0].metadata['prompt']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(stored?.spans[0].metadata['toolInput']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(stored?.spans[0].metadata['toolOutput']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(stored?.spans[0].metadata['summary']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(stored?.spans[0].errorMessage).toBe('[REDACTED_TRANSCRIPT]')
+    expect(stored?.spans[0].thoughtBlocks).toEqual(['[REDACTED_TRANSCRIPT]'])
+    expect(stored?.spans[0].metadata['safeCounter']).toBe(1)
+  })
+
+  it('supports disabled retention by avoiding writes entirely', async () => {
+    const inner = new InMemoryAdapter()
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, mode: 'disabled' })
+
+    await adapter.flush(makeTrace())
+
+    expect(await inner.listTraceIds()).toEqual([])
+    expect(await adapter.listTraceIds()).toEqual([])
+  })
+
+  it('can drop selected transcript fields while retaining non-transcript metadata', () => {
+    const retained = applyRetentionPolicy(makeTrace(), {
+      retainedFields: {
+        prompts: false,
+        toolInputs: false,
+        toolOutputs: false,
+        errors: false,
+        summaries: false,
+      },
+    })
+
+    expect(retained.goal).toBe('[TRANSCRIPT_NOT_RETAINED]')
+    expect(retained.spans[0].metadata).toEqual({ safeCounter: 1 })
+    expect(retained.spans[0].errorMessage).toBeUndefined()
+    expect(retained.spans[0].thoughtBlocks).toEqual([])
+  })
+
+  it('honors explicit raw operator retention without redacting transcript fields', async () => {
+    const inner = new InMemoryAdapter()
+    const adapter = new TranscriptRetentionAdapter({
+      adapter: inner,
+      mode: 'raw',
+      redactionLevel: 'none',
+      accessLevel: 'operator',
+      now: () => 3,
+    })
+
+    await adapter.flush(makeTrace())
+
+    const stored = await adapter.queryByTraceId('trace-1')
+    expect(stored?.goal).toBe('user prompt with secret context')
+    expect(stored?.spans[0].metadata['toolOutput']).toBe('private output')
+    expect(adapter.describePolicy()).toMatchObject({
+      mode: 'raw',
+      redactionLevel: 'none',
+      accessLevel: 'operator',
+      storesRawTranscriptContent: true,
+    })
+  })
+
+  it('reports access policy and retained transcript fields for operator visibility', () => {
+    const report = describeTranscriptRetentionPolicy({
+      ttlMs: 60_000,
+      accessLevel: 'restricted',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(report).toMatchObject({
+      mode: 'redacted',
+      ttlMs: 60_000,
+      redactionLevel: 'mask',
+      accessLevel: 'restricted',
+      retainedFields: {
+        prompts: true,
+        toolInputs: true,
+        toolOutputs: false,
+        errors: true,
+        summaries: true,
+      },
+      storesRawTranscriptContent: false,
+    })
+  })
+
+  it('cleans up expired retained traces and hides them from reads', async () => {
+    let now = 10
+    const inner = new InMemoryAdapter()
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    expect(await adapter.listTraceIds()).toEqual(['trace-1'])
+
+    now = 16
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+    expect(await inner.listTraceIds()).toEqual([])
+  })
+
+  it('keeps expired traces hidden when the wrapped backend cannot delete them', async () => {
+    let now = 10
+    const adapter = new TranscriptRetentionAdapter({ adapter: new NonDeletingAdapter(), ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    expect(await adapter.listTraceIds()).toEqual([])
+    expect(await adapter.listTraceSummaries()).toEqual([])
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+  })
+
+  it('filters expired persisted summaries after wrapping an existing backend', async () => {
+    let now = 10
+    const backend = new InMemoryAdapter()
+    await backend.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+
+    now = 16
+    const adapter = new TranscriptRetentionAdapter({ adapter: backend, ttlMs: 5, now: () => now })
+
+    expect(await adapter.listTraceSummaries()).toEqual([])
+    expect(await adapter.listTraceIds()).toEqual([])
+  })
+
+  it('honors per-field opt-outs even when raw transcript retention is enabled', () => {
+    const retained = applyRetentionPolicy(makeTrace(), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.goal).toBe('user prompt with secret context')
+    expect(retained.spans[0].metadata['toolInput']).toEqual({ query: 'private input', nested: { args: 'secret args' } })
+    expect(retained.spans[0].metadata).not.toHaveProperty('toolOutput')
+  })
+
+  it('reports raw storage whenever redaction is disabled', () => {
+    expect(describeTranscriptRetentionPolicy({ redactionLevel: 'none' })).toMatchObject({
+      mode: 'redacted',
+      redactionLevel: 'none',
+      storesRawTranscriptContent: true,
+    })
+  })
+
+  it('redacts common snake_case transcript metadata keys', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          system_prompt: 'raw system prompt',
+          tool_input: 'raw input',
+          tool_output: 'raw output',
+          error_message: 'raw error',
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      system_prompt: '[REDACTED_TRANSCRIPT]',
+      tool_input: '[REDACTED_TRANSCRIPT]',
+      tool_output: '[REDACTED_TRANSCRIPT]',
+      error_message: '[REDACTED_TRANSCRIPT]',
+    })
+  })
+
+  it('handles cyclic metadata while redacting nested transcript fields', () => {
+    const metadata: Record<string, unknown> = { nested: { tool_output: 'raw output' } }
+    metadata['self'] = metadata
+
+    const retained = applyRetentionPolicy(makeTrace({ spans: [makeSpan({ metadata })] }))
+    const retainedMetadata = retained.spans[0].metadata
+
+    expect((retainedMetadata['nested'] as Record<string, unknown>)['tool_output']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retainedMetadata['self']).toBe(retainedMetadata)
+  })
+
+  it('preserves non-transcript metadata object types', () => {
+    const map = new Map([['key', 'value']])
+    const set = new Set(['value'])
+    const pattern = /abc/u
+    const bytes = new Uint8Array([1, 2, 3])
+
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: { map, set, pattern, bytes },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['map']).toEqual(map)
+    expect(retained.spans[0].metadata['set']).toEqual(set)
+    expect(retained.spans[0].metadata['pattern']).toBe(pattern)
+    expect(retained.spans[0].metadata['bytes']).toEqual(bytes)
+  })
+})

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Span, Trace } from '../core/types.js'
+import { BatchAdapter } from '../adapters/batch/BatchAdapter.js'
+import { MultiAdapter } from '../adapters/multi/MultiAdapter.js'
 import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
 import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
 import {
@@ -242,6 +244,74 @@ describe('transcript retention controls', () => {
       tool_output: '[REDACTED_TRANSCRIPT]',
       error_message: '[REDACTED_TRANSCRIPT]',
     })
+  })
+
+  it('redacts common suffixed transcript metadata keys', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          promptText: 'raw prompt text',
+          systemPromptAddition: 'raw system prompt',
+          tool_input_json: 'raw tool input',
+          toolResultPayload: 'raw tool output',
+          safeCounter: 1,
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      promptText: '[REDACTED_TRANSCRIPT]',
+      systemPromptAddition: '[REDACTED_TRANSCRIPT]',
+      tool_input_json: '[REDACTED_TRANSCRIPT]',
+      toolResultPayload: '[REDACTED_TRANSCRIPT]',
+      safeCounter: 1,
+    })
+  })
+
+  it('redacts Error objects stored under opaque metadata keys', () => {
+    const cause = new Error('nested private cause')
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          payload: new Error('private prompt stack', { cause }),
+          safeCounter: 1,
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      payload: '[REDACTED_TRANSCRIPT]',
+      safeCounter: 1,
+    })
+  })
+
+  it('removes expired traces from batch and multi adapter wrappers', async () => {
+    let now = 10
+    const primary = new InMemoryAdapter()
+    const secondary = new InMemoryAdapter()
+    const batch = new BatchAdapter({ adapter: primary, maxBatchSize: 10 })
+    const multi = new MultiAdapter({ adapters: [batch, secondary] })
+    const adapter = new TranscriptRetentionAdapter({ adapter: multi, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    await batch.drain()
+
+    expect(await primary.listTraceIds()).toEqual([])
+    expect(await secondary.listTraceIds()).toEqual([])
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+  })
+
+  it('keeps internal-slot objects intact instead of cloning them with fake prototypes', () => {
+    const url = new URL('https://example.test/path')
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { url } })],
+    }))
+
+    expect(retained.spans[0].metadata['url']).toBe(url)
+    expect(String(retained.spans[0].metadata['url'])).toBe('https://example.test/path')
   })
 
   it('handles cyclic metadata while redacting nested transcript fields', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1152,7 +1152,12 @@ describe('transcript retention controls', () => {
 
   it('honors tool input opt-outs for raw tool_use input blocks', () => {
     const retained = applyRetentionPolicy(makeTrace({
-      spans: [makeSpan({ metadata: { block: { type: 'tool_use', input: { location: '123 Main St' } } } })],
+      spans: [makeSpan({
+        metadata: {
+          block: { type: 'tool_use', input: { location: '123 Main St' } },
+          serverBlock: { type: 'server_tool_use', input: { location: '456 Main St' } },
+        },
+      })],
     }), {
       mode: 'raw',
       redactionLevel: 'none',
@@ -1160,6 +1165,7 @@ describe('transcript retention controls', () => {
     })
 
     expect(retained.spans[0].metadata['block']).toEqual({ type: 'tool_use' })
+    expect(retained.spans[0].metadata['serverBlock']).toEqual({ type: 'server_tool_use' })
   })
 
   it('redacts final thinking and completion payloads by default', () => {
@@ -1167,6 +1173,9 @@ describe('transcript retention controls', () => {
       spans: [makeSpan({
         metadata: {
           thinkingBlock: { type: 'thinking', thinking: 'private chain of thought' },
+          reasoning_content: 'private provider reasoning',
+          reasoning: 'private reasoning alias',
+          thinking: 'private thinking alias',
           completion: 'private assistant completion',
           generations: [{ text: 'private generated text' }],
         },
@@ -1174,8 +1183,25 @@ describe('transcript retention controls', () => {
     }))
 
     expect(retained.spans[0].metadata['thinkingBlock']).toEqual({ type: 'thinking', thinking: '[REDACTED_TRANSCRIPT]' })
+    expect(retained.spans[0].metadata['reasoning_content']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['reasoning']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['thinking']).toBe('[REDACTED_TRANSCRIPT]')
     expect(retained.spans[0].metadata['completion']).toBe('[REDACTED_TRANSCRIPT]')
     expect(retained.spans[0].metadata['generations']).toBe('[REDACTED_TRANSCRIPT]')
+  })
+
+  it('redacts provider-qualified stream delta payloads', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          event: { type: 'response.output_text.delta', delta: 'private streamed reply' },
+          doneEvent: { type: 'response.output_text.done', text: 'private final reply' },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['event']).toEqual({ type: 'response.output_text.delta', delta: '[REDACTED_TRANSCRIPT]' })
+    expect(retained.spans[0].metadata['doneEvent']).toEqual({ type: 'response.output_text.done', text: '[REDACTED_TRANSCRIPT]' })
   })
 
   it('redacts standalone inline multimodal payloads by default', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -211,6 +211,21 @@ describe('transcript retention controls', () => {
       redactionLevel: 'none',
       accessLevel: 'operator',
       storesRawTranscriptContent: true,
+      cleanupRemovesStoredTraces: true,
+    })
+  })
+
+  it('surfaces raw retention cleanup gaps for non-deleting adapters', () => {
+    const adapter = new TranscriptRetentionAdapter({
+      adapter: new NonDeletingAdapter(),
+      mode: 'raw',
+      redactionLevel: 'none',
+    })
+
+    expect(adapter.describePolicy()).toMatchObject({
+      storesRawTranscriptContent: true,
+      cleanupRemovesStoredTraces: false,
+      cleanupWarning: expect.stringContaining('does not support deleteTrace'),
     })
   })
 
@@ -235,6 +250,7 @@ describe('transcript retention controls', () => {
         summaries: true,
       },
       storesRawTranscriptContent: false,
+      cleanupRemovesStoredTraces: true,
       expiresAt: 61_000,
     })
   })
@@ -768,6 +784,10 @@ describe('transcript retention controls', () => {
             type: 'content_block_delta',
             delta: { type: 'text_delta', text: 'private streamed prompt' },
           },
+          untypedStreamEvent: {
+            type: 'content_block_delta',
+            delta: { text: 'private untyped streamed prompt' },
+          },
           toolEvent: {
             type: 'content_block_delta',
             delta: { type: 'input_json_delta', partial_json: '{"secret":"tool args"}' },
@@ -783,6 +803,10 @@ describe('transcript retention controls', () => {
     expect(retained.spans[0].metadata['streamEvent']).toEqual({
       type: 'content_block_delta',
       delta: { type: 'text_delta', text: '[REDACTED_TRANSCRIPT]' },
+    })
+    expect(retained.spans[0].metadata['untypedStreamEvent']).toEqual({
+      type: 'content_block_delta',
+      delta: { text: '[REDACTED_TRANSCRIPT]' },
     })
     expect(retained.spans[0].metadata['toolEvent']).toEqual({
       type: 'content_block_delta',
@@ -839,6 +863,25 @@ describe('transcript retention controls', () => {
     expect(retained.spans[0].metadata['document']).toEqual({
       type: 'file',
       file_data: '[REDACTED_TRANSCRIPT]',
+    })
+  })
+
+  it('redacts output text blocks and injected operator context fields', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          block: { type: 'output_text', text: 'private assistant transcript' },
+          hookSpecificOutput: { additionalContext: 'private operator context' },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['block']).toEqual({
+      type: 'output_text',
+      text: '[REDACTED_TRANSCRIPT]',
+    })
+    expect(retained.spans[0].metadata['hookSpecificOutput']).toEqual({
+      additionalContext: '[REDACTED_TRANSCRIPT]',
     })
   })
 

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1087,6 +1087,74 @@ describe('transcript retention controls', () => {
     expect([...records]).toEqual([{ transcript: '[REDACTED_TRANSCRIPT]' }, { safeCounter: 2 }])
   })
 
+  it('redacts untyped stream delta transcript fields using their content block parent', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          textDelta: {
+            type: 'content_block_delta',
+            delta: { text: 'private untyped stream text' },
+          },
+          toolDelta: {
+            type: 'content_block_delta',
+            delta: { partial_json: '{"private":"tool args"}' },
+          },
+          thinkingDelta: {
+            type: 'content_block_delta',
+            delta: { thinking: 'private chain of thought' },
+          },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['textDelta']).toEqual({
+      type: 'content_block_delta',
+      delta: { text: '[REDACTED_TRANSCRIPT]' },
+    })
+    expect(retained.spans[0].metadata['toolDelta']).toEqual({
+      type: 'content_block_delta',
+      delta: { partial_json: '[REDACTED_TRANSCRIPT]' },
+    })
+    expect(retained.spans[0].metadata['thinkingDelta']).toEqual({
+      type: 'content_block_delta',
+      delta: { thinking: '[REDACTED_TRANSCRIPT]' },
+    })
+  })
+
+  it('redacts output text blocks and injected operator context fields', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          payload: { type: 'output_text', text: 'private assistant transcript' },
+          hookSpecificOutput: { additionalContext: 'private operator context' },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['payload']).toEqual({
+      type: 'output_text',
+      text: '[REDACTED_TRANSCRIPT]',
+    })
+    expect(retained.spans[0].metadata['hookSpecificOutput']).toEqual({
+      additionalContext: '[REDACTED_TRANSCRIPT]',
+    })
+  })
+
+  it('reuses retained custom toJSON clones for repeated metadata references', () => {
+    class Payload {
+      toJSON(): Record<string, unknown> {
+        return { safeCounter: 1 }
+      }
+    }
+    const payload = new Payload()
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { first: payload, second: payload } })],
+    }))
+
+    expect(retained.spans[0].metadata['first']).toEqual({ safeCounter: 1 })
+    expect(retained.spans[0].metadata['second']).toBe(retained.spans[0].metadata['first'])
+  })
+
   it('preserves own __proto__ metadata keys as data properties', () => {
     const metadata: Record<string, unknown> = { safeCounter: 1 }
     Object.defineProperty(metadata, '__proto__', {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -76,6 +76,39 @@ class ThrowingDeleteAdapter extends NonDeletingAdapter {
   }
 }
 
+class SlowFlushingAdapter implements ExportAdapter {
+  private readonly inner = new InMemoryAdapter()
+  private releaseFlush: (() => void) | null = null
+  readonly flushStarted = new Promise<void>(resolve => {
+    this.releaseFlush = resolve
+  })
+
+  async flush(trace: Trace): Promise<void> {
+    await this.flushStarted
+    await this.inner.flush(trace)
+  }
+
+  release(): void {
+    this.releaseFlush?.()
+  }
+
+  queryByTraceId(traceId: string): Promise<Trace | null> {
+    return this.inner.queryByTraceId(traceId)
+  }
+
+  listTraceIds(): Promise<string[]> {
+    return this.inner.listTraceIds()
+  }
+
+  listTraceSummaries(): Promise<TraceSummary[]> {
+    return this.inner.listTraceSummaries()
+  }
+
+  deleteTrace(traceId: string): Promise<void> {
+    return this.inner.deleteTrace(traceId)
+  }
+}
+
 describe('transcript retention controls', () => {
   it('defaults to redacted retention for prompts, tool I/O, errors, and summaries', async () => {
     const inner = new InMemoryAdapter()
@@ -402,6 +435,43 @@ describe('transcript retention controls', () => {
     warn.mockRestore()
   })
 
+  it('continues deleting from later child adapters when one child delete throws', async () => {
+    let now = 10
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const throwing = new ThrowingDeleteAdapter()
+    const deletable = new InMemoryAdapter()
+    const multi = new MultiAdapter({ adapters: [throwing, deletable] })
+    const adapter = new TranscriptRetentionAdapter({ adapter: multi, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    await expect(adapter.cleanupExpired()).resolves.toEqual(['trace-1'])
+    expect(await throwing.listTraceIds()).toEqual(['trace-1'])
+    expect(await deletable.listTraceIds()).toEqual([])
+    expect(await adapter.listTraceIds()).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('deletes from the inner adapter after an in-flight batch drain persists an expired trace', async () => {
+    let now = 10
+    const slow = new SlowFlushingAdapter()
+    const batch = new BatchAdapter({ adapter: slow, maxBatchSize: 10 })
+    const adapter = new TranscriptRetentionAdapter({ adapter: batch, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    const drain = batch.drain()
+    now = 16
+    const cleanup = adapter.cleanupExpired()
+
+    slow.release()
+    await drain
+    await expect(cleanup).resolves.toEqual(['trace-1'])
+    expect(await slow.listTraceIds()).toEqual([])
+    expect(await adapter.listTraceIds()).toEqual([])
+  })
+
   it('retains active traces from flush time instead of expiring them by start time', async () => {
     let now = 100
     const adapter = new TranscriptRetentionAdapter({ adapter: new InMemoryAdapter(), ttlMs: 5, now: () => now })
@@ -410,6 +480,16 @@ describe('transcript retention controls', () => {
     expect(await adapter.listTraceIds()).toEqual(['trace-1'])
 
     now = 106
+    expect(await adapter.listTraceIds()).toEqual([])
+  })
+
+  it('expires restarted active traces from their original start time when no retained timestamp is available', async () => {
+    const inner = new InMemoryAdapter()
+    await inner.flush(makeTrace({ startedAt: 1, endedAt: undefined }))
+
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, ttlMs: 5, now: () => 100 })
+
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
     expect(await adapter.listTraceIds()).toEqual([])
   })
 
@@ -513,6 +593,32 @@ describe('transcript retention controls', () => {
       { role: 'user', content: 'private prompt' },
       { role: 'tool', type: 'tool_result', tool_call_id: 'call-1' },
     ])
+  })
+
+  it('honors tool output opt-outs inside raw prompt envelopes', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          prompt: {
+            messages: [
+              { role: 'user', content: 'private prompt' },
+              { role: 'tool', type: 'tool_result', content: 'private tool result' },
+            ],
+          },
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata['prompt']).toEqual({
+      messages: [
+        { role: 'user', content: 'private prompt' },
+        { role: 'tool', type: 'tool_result' },
+      ],
+    })
   })
 
   it('walks Map and Set metadata before preserving their container types', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -700,6 +700,28 @@ describe('transcript retention controls', () => {
     ])
   })
 
+  it('drops raw provider text blocks when prompt retention is disabled', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          messages: [
+            { type: 'text', text: 'private prompt text' },
+            { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+          ],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolOutputs: true },
+    })
+
+    expect(retained.spans[0].metadata['messages']).toEqual([
+      { type: 'text' },
+      { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+    ])
+  })
+
   it('honors tool output opt-outs inside raw prompt envelopes', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({
@@ -757,6 +779,24 @@ describe('transcript retention controls', () => {
     })
 
     expect(retained.spans[0].metadata).toEqual({ role: 'tool', tool_call_id: 'call-1' })
+  })
+
+  it('honors tool output opt-outs for enumerable raw provider payload objects', () => {
+    class ToolPayload {
+      role = 'tool'
+      content = 'private enumerable tool result'
+      tool_call_id = 'call-1'
+    }
+
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { payload: new ToolPayload() } })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata['payload']).toEqual({ role: 'tool', tool_call_id: 'call-1' })
   })
 
   it('retains allowed tool outputs inside raw message containers when prompts are disabled', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -412,6 +412,34 @@ describe('transcript retention controls', () => {
     })
   })
 
+  it('preserves binary views instead of applying custom JSON serialization', () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { bytes } })],
+    }))
+
+    expect(retained.spans[0].metadata['bytes']).toBe(bytes)
+  })
+
+  it('reuses retained custom JSON clones for repeated metadata references', () => {
+    class SharedPayload {
+      toJSON(): Record<string, unknown> {
+        return { safeCounter: 1 }
+      }
+    }
+    const payload = new SharedPayload()
+
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { first: payload, second: payload } })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      first: { safeCounter: 1 },
+      second: { safeCounter: 1 },
+    })
+    expect(retained.spans[0].metadata['second']).toBe(retained.spans[0].metadata['first'])
+  })
+
   it('redacts delegated summary goals nested under opaque metadata keys', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({
@@ -661,6 +689,8 @@ describe('transcript retention controls', () => {
       spans: [makeSpan({
         metadata: {
           promptTokens: 12,
+          promptTokenCount: 13,
+          prompt_tokens_details: { cached_tokens: 4 },
           completionTokens: 3,
           messages: [{ role: 'user', content: 'private chat prompt' }],
           transcript: ['private transcript line'],
@@ -670,6 +700,8 @@ describe('transcript retention controls', () => {
     }))
 
     expect(retained.spans[0].metadata['promptTokens']).toBe(12)
+    expect(retained.spans[0].metadata['promptTokenCount']).toBe(13)
+    expect(retained.spans[0].metadata['prompt_tokens_details']).toEqual({ cached_tokens: 4 })
     expect(retained.spans[0].metadata['completionTokens']).toBe(3)
     expect(retained.spans[0].metadata['messages']).toBe('[REDACTED_TRANSCRIPT]')
     expect(retained.spans[0].metadata['transcript']).toBe('[REDACTED_TRANSCRIPT]')
@@ -706,6 +738,7 @@ describe('transcript retention controls', () => {
         metadata: {
           messages: [
             { type: 'text', text: 'private prompt text' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,private' } },
             { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
           ],
         },
@@ -718,6 +751,7 @@ describe('transcript retention controls', () => {
 
     expect(retained.spans[0].metadata['messages']).toEqual([
       { type: 'text' },
+      { type: 'image_url' },
       { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
     ])
   })

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1138,12 +1138,16 @@ describe('transcript retention controls', () => {
         metadata: {
           messages: [{ role: 'user', text: 'private prompt' }, { role: 'assistant', text: 'private reply' }],
           opaque: { role: 'user', text: 'private opaque prompt' },
+          input_text: 'private provider prompt',
+          outputText: 'private provider completion',
         },
       })],
     }))
 
     expect(retained.spans[0].metadata['messages']).toBe('[REDACTED_TRANSCRIPT]')
     expect(retained.spans[0].metadata['opaque']).toEqual({ role: 'user', text: '[REDACTED_TRANSCRIPT]' })
+    expect(retained.spans[0].metadata['input_text']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['outputText']).toBe('[REDACTED_TRANSCRIPT]')
   })
 
   it('honors tool input opt-outs for raw tool_use input blocks', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -229,6 +229,20 @@ describe('transcript retention controls', () => {
     })
   })
 
+  it('surfaces raw retention cleanup gaps when any fan-out backend cannot delete', () => {
+    const adapter = new TranscriptRetentionAdapter({
+      adapter: new MultiAdapter({ adapters: [new InMemoryAdapter(), new NonDeletingAdapter()] }),
+      mode: 'raw',
+      redactionLevel: 'none',
+    })
+
+    expect(adapter.describePolicy()).toMatchObject({
+      storesRawTranscriptContent: true,
+      cleanupRemovesStoredTraces: false,
+      cleanupWarning: expect.stringContaining('does not support deleteTrace'),
+    })
+  })
+
   it('reports access policy and retained transcript fields for operator visibility', () => {
     const report = describeTranscriptRetentionPolicy({
       ttlMs: 60_000,

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -407,4 +407,58 @@ describe('transcript retention controls', () => {
     expect(retained.spans[0].metadata['pattern']).toBe(pattern)
     expect(retained.spans[0].metadata['bytes']).toEqual(bytes)
   })
+
+  it('reapplies the active policy to backend traces and summaries', async () => {
+    const inner = new InMemoryAdapter()
+    await inner.flush(makeTrace())
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, now: () => 3 })
+
+    const trace = await adapter.queryByTraceId('trace-1')
+    const summaries = await adapter.listTraceSummaries()
+
+    expect(trace?.goal).toBe('[REDACTED_TRANSCRIPT]')
+    expect(trace?.spans[0].metadata['prompt']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(summaries).toEqual([
+      {
+        id: 'trace-1',
+        goal: '[REDACTED_TRANSCRIPT]',
+        status: 'completed',
+        spanCount: 1,
+        startedAt: 1,
+      },
+    ])
+  })
+
+  it('keeps token counters numeric while redacting chat transcript shapes', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          promptTokens: 12,
+          completionTokens: 3,
+          messages: [{ role: 'user', content: 'private chat prompt' }],
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['promptTokens']).toBe(12)
+    expect(retained.spans[0].metadata['completionTokens']).toBe(3)
+    expect(retained.spans[0].metadata['messages']).toBe('[REDACTED_TRANSCRIPT]')
+  })
+
+  it('preserves own __proto__ metadata keys as data properties', () => {
+    const metadata: Record<string, unknown> = { safeCounter: 1 }
+    Object.defineProperty(metadata, '__proto__', {
+      value: { tool_output: 'private output' },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+
+    const retained = applyRetentionPolicy(makeTrace({ spans: [makeSpan({ metadata })] }))
+    const retainedMetadata = retained.spans[0].metadata
+
+    expect(Object.prototype.hasOwnProperty.call(retainedMetadata, '__proto__')).toBe(true)
+    expect(retainedMetadata['__proto__']).toEqual({ tool_output: '[REDACTED_TRANSCRIPT]' })
+    expect(Object.getPrototypeOf(retainedMetadata)).toBe(Object.prototype)
+  })
 })

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1132,6 +1132,62 @@ describe('transcript retention controls', () => {
     ])
   })
 
+  it('redacts role-scoped provider text fields as prompts', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          messages: [{ role: 'user', text: 'private prompt' }, { role: 'assistant', text: 'private reply' }],
+          opaque: { role: 'user', text: 'private opaque prompt' },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['messages']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['opaque']).toEqual({ role: 'user', text: '[REDACTED_TRANSCRIPT]' })
+  })
+
+  it('honors tool input opt-outs for raw tool_use input blocks', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { block: { type: 'tool_use', input: { location: '123 Main St' } } } })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolInputs: false },
+    })
+
+    expect(retained.spans[0].metadata['block']).toEqual({ type: 'tool_use' })
+  })
+
+  it('redacts final thinking and completion payloads by default', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          thinkingBlock: { type: 'thinking', thinking: 'private chain of thought' },
+          completion: 'private assistant completion',
+          generations: [{ text: 'private generated text' }],
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['thinkingBlock']).toEqual({ type: 'thinking', thinking: '[REDACTED_TRANSCRIPT]' })
+    expect(retained.spans[0].metadata['completion']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['generations']).toBe('[REDACTED_TRANSCRIPT]')
+  })
+
+  it('redacts standalone inline multimodal payloads by default', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          inlineData: { data: 'base64-private-image', mimeType: 'image/png' },
+          inline_data: { data: 'base64-private-audio', mimeType: 'audio/wav' },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['inlineData']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['inline_data']).toBe('[REDACTED_TRANSCRIPT]')
+  })
+
   it('drops object-valued prompt fields when raw prompt retention is disabled', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1039,6 +1039,48 @@ describe('transcript retention controls', () => {
     ])
   })
 
+  it('drops raw provider message parts when prompt retention is disabled', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          contents: [
+            { role: 'user', parts: [{ text: 'private Gemini prompt' }] },
+            { role: 'model', parts: [{ text: 'private Gemini response' }] },
+          ],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolOutputs: true },
+    })
+
+    expect(retained.spans[0].metadata['contents']).toEqual([
+      { role: 'user' },
+      { role: 'model' },
+    ])
+  })
+
+  it('retains raw provider tool output content-block arrays when prompts are disabled', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          messages: [
+            { role: 'tool', content: [{ type: 'text', text: 'private tool result' }], tool_call_id: 'call-1' },
+          ],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolOutputs: true },
+    })
+
+    expect(retained.spans[0].metadata['messages']).toEqual([
+      { role: 'tool', content: [{ type: 'text', text: 'private tool result' }], tool_call_id: 'call-1' },
+    ])
+  })
+
   it('drops object-valued prompt fields when raw prompt retention is disabled', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -764,25 +764,55 @@ describe('transcript retention controls', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({
         metadata: {
-          event: {
+          streamEvent: {
             type: 'content_block_delta',
-            delta: { type: 'text_delta', text: 'private streamed prompt text' },
+            delta: { type: 'text_delta', text: 'private streamed prompt' },
           },
           toolEvent: {
             type: 'content_block_delta',
-            delta: { type: 'input_json_delta', partial_json: '{"secret":"tool input"}' },
+            delta: { type: 'input_json_delta', partial_json: '{"secret":"tool args"}' },
+          },
+          thinkingEvent: {
+            type: 'content_block_delta',
+            delta: { type: 'thinking_delta', thinking: 'private chain of thought' },
           },
         },
       })],
     }))
 
-    expect(retained.spans[0].metadata['event']).toEqual({
+    expect(retained.spans[0].metadata['streamEvent']).toEqual({
       type: 'content_block_delta',
       delta: { type: 'text_delta', text: '[REDACTED_TRANSCRIPT]' },
     })
     expect(retained.spans[0].metadata['toolEvent']).toEqual({
       type: 'content_block_delta',
       delta: { type: 'input_json_delta', partial_json: '[REDACTED_TRANSCRIPT]' },
+    })
+    expect(retained.spans[0].metadata['thinkingEvent']).toEqual({
+      type: 'content_block_delta',
+      delta: { type: 'thinking_delta', thinking: '[REDACTED_TRANSCRIPT]' },
+    })
+  })
+
+  it('honors tool input opt-outs for raw provider stream deltas', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          toolEvent: {
+            type: 'content_block_delta',
+            delta: { type: 'input_json_delta', partial_json: '{"secret":"tool args"}' },
+          },
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolInputs: false },
+    })
+
+    expect(retained.spans[0].metadata['toolEvent']).toEqual({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta' },
     })
   })
 
@@ -993,6 +1023,7 @@ describe('transcript retention controls', () => {
             ['safeCounter', 1],
             ['nested', { tool_output: 'private nested output' }],
           ]),
+          keyedPayload: new Map<object, string>([[{ prompt: 'private key prompt' }, 'safe value']]),
           records: new Set<unknown>([{ transcript: 'private set transcript' }, { safeCounter: 2 }]),
         },
       })],
@@ -1005,6 +1036,10 @@ describe('transcript retention controls', () => {
     expect(payload.get('prompt')).toBe('[REDACTED_TRANSCRIPT]')
     expect(payload.get('safeCounter')).toBe(1)
     expect(payload.get('nested')).toEqual({ tool_output: '[REDACTED_TRANSCRIPT]' })
+    const keyedPayload = retained.spans[0].metadata['keyedPayload'] as Map<Record<string, unknown>, string>
+    expect(keyedPayload).toBeInstanceOf(Map)
+    expect([...keyedPayload.keys()]).toEqual([{ prompt: '[REDACTED_TRANSCRIPT]' }])
+    expect([...keyedPayload.values()]).toEqual(['safe value'])
     expect(records).toBeInstanceOf(Set)
     expect([...records]).toEqual([{ transcript: '[REDACTED_TRANSCRIPT]' }, { safeCounter: 2 }])
   })

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1081,6 +1081,57 @@ describe('transcript retention controls', () => {
     ])
   })
 
+  it('recurses through raw response envelopes when prompt retention is disabled', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          response: {
+            candidates: [{ content: { parts: [{ text: 'private model transcript' }] } }],
+          },
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolOutputs: true },
+    })
+
+    expect(retained.spans[0].metadata['response']).toEqual({
+      candidates: [{}],
+    })
+  })
+
+  it('treats generic raw input envelopes as prompts instead of tool inputs', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { input: 'private user prompt', inputs: ['private user prompt'] } })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolInputs: true },
+    })
+
+    expect(retained.spans[0].metadata).not.toHaveProperty('input')
+    expect(retained.spans[0].metadata).not.toHaveProperty('inputs')
+  })
+
+  it('honors tool output opt-outs for raw tool result parts', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          messages: [{ role: 'tool', parts: [{ text: 'private parts tool result' }], tool_call_id: 'call-1' }],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata['messages']).toEqual([
+      { role: 'tool', tool_call_id: 'call-1' },
+    ])
+  })
+
   it('drops object-valued prompt fields when raw prompt retention is disabled', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { Span, Trace } from '../core/types.js'
 import { BatchAdapter } from '../adapters/batch/BatchAdapter.js'
 import { MultiAdapter } from '../adapters/multi/MultiAdapter.js'
@@ -67,6 +67,12 @@ class NonDeletingAdapter implements ExportAdapter {
       spanCount: trace.spans.length,
       startedAt: trace.startedAt,
     }))
+  }
+}
+
+class ThrowingDeleteAdapter extends NonDeletingAdapter {
+  deleteTrace(): void {
+    throw new Error('delete failed')
   }
 }
 
@@ -381,6 +387,32 @@ describe('transcript retention controls', () => {
     expect(await adapter.queryByTraceId('trace-1')).toBeNull()
   })
 
+  it('keeps expired traces hidden even when backend deletion throws', async () => {
+    let now = 10
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const adapter = new TranscriptRetentionAdapter({ adapter: new ThrowingDeleteAdapter(), ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    await expect(adapter.cleanupExpired()).resolves.toEqual(['trace-1'])
+    expect(await adapter.listTraceIds()).toEqual([])
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('retains active traces from flush time instead of expiring them by start time', async () => {
+    let now = 100
+    const adapter = new TranscriptRetentionAdapter({ adapter: new InMemoryAdapter(), ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 1, endedAt: undefined }))
+    expect(await adapter.listTraceIds()).toEqual(['trace-1'])
+
+    now = 106
+    expect(await adapter.listTraceIds()).toEqual([])
+  })
+
   it('keeps internal-slot objects intact instead of cloning them with fake prototypes', () => {
     const url = new URL('https://example.test/path')
     const retained = applyRetentionPolicy(makeTrace({
@@ -459,6 +491,28 @@ describe('transcript retention controls', () => {
     expect(retained.spans[0].metadata['messages']).toBe('[REDACTED_TRANSCRIPT]')
     expect(retained.spans[0].metadata['transcript']).toBe('[REDACTED_TRANSCRIPT]')
     expect(retained.spans[0].metadata['stdin']).toBe('[REDACTED_TRANSCRIPT]')
+  })
+
+  it('honors tool output opt-outs inside raw provider message arrays', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          messages: [
+            { role: 'user', content: 'private prompt' },
+            { role: 'tool', type: 'tool_result', content: 'private tool result', tool_call_id: 'call-1' },
+          ],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata['messages']).toEqual([
+      { role: 'user', content: 'private prompt' },
+      { role: 'tool', type: 'tool_result', tool_call_id: 'call-1' },
+    ])
   })
 
   it('walks Map and Set metadata before preserving their container types', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -253,6 +253,18 @@ describe('transcript retention controls', () => {
     expect(await inner.listTraceIds()).toEqual([])
   })
 
+  it('does not retain expired IDs after successful backend deletes', async () => {
+    let now = 10
+    const inner = new InMemoryAdapter()
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    expect((adapter as unknown as { expiredTraceIds: Set<string> }).expiredTraceIds.has('trace-1')).toBe(false)
+  })
+
   it('keeps expired traces hidden when the wrapped backend cannot delete them', async () => {
     let now = 10
     const adapter = new TranscriptRetentionAdapter({ adapter: new NonDeletingAdapter(), ttlMs: 5, now: () => now })
@@ -377,6 +389,25 @@ describe('transcript retention controls', () => {
 
     expect(retained.spans[0].metadata).toEqual({
       payload: '[REDACTED_TRANSCRIPT]',
+      safeCounter: 1,
+    })
+  })
+
+  it('redacts transcript fields exposed only through custom JSON serialization', () => {
+    class ProviderPayload {
+      toJSON(): Record<string, unknown> {
+        return { prompt: 'private serialized prompt', safeCounter: 1 }
+      }
+    }
+
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: { payload: new ProviderPayload() },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['payload']).toEqual({
+      prompt: '[REDACTED_TRANSCRIPT]',
       safeCounter: 1,
     })
   })
@@ -746,6 +777,26 @@ describe('transcript retention controls', () => {
 
     expect(retained.spans[0].metadata['messages']).toEqual([
       { role: 'user' },
+      { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+    ])
+  })
+
+  it('drops object-valued prompt fields when raw prompt retention is disabled', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          prompt: { text: 'private prompt text', safeCounter: 1 },
+          messages: [{ role: 'tool', content: 'private tool result', tool_call_id: 'call-1' }],
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false, toolOutputs: true },
+    })
+
+    expect(retained.spans[0].metadata).not.toHaveProperty('prompt')
+    expect(retained.spans[0].metadata['messages']).toEqual([
       { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
     ])
   })

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -3,7 +3,7 @@ import type { Span, Trace } from '../core/types.js'
 import { BatchAdapter } from '../adapters/batch/BatchAdapter.js'
 import { MultiAdapter } from '../adapters/multi/MultiAdapter.js'
 import { InMemoryAdapter } from '../export/InMemoryAdapter.js'
-import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
+import type { ExportAdapter } from '../export/ExportAdapter.js'
 import {
   TranscriptRetentionAdapter,
   applyRetentionPolicy,
@@ -76,6 +76,29 @@ class ThrowingDeleteAdapter extends NonDeletingAdapter {
   }
 }
 
+class FailingOnceDeleteAdapter implements ExportAdapter {
+  private readonly traces = new Map<string, Trace>()
+  deleteAttempts = 0
+
+  async flush(trace: Trace): Promise<void> {
+    this.traces.set(trace.id, trace)
+  }
+
+  async queryByTraceId(traceId: string): Promise<Trace | null> {
+    return this.traces.get(traceId) ?? null
+  }
+
+  async listTraceIds(): Promise<string[]> {
+    return [...this.traces.keys()]
+  }
+
+  async deleteTrace(traceId: string): Promise<void> {
+    this.deleteAttempts += 1
+    if (this.deleteAttempts === 1) throw new Error('transient delete failure')
+    this.traces.delete(traceId)
+  }
+}
+
 class SlowFlushingAdapter implements ExportAdapter {
   private readonly inner = new InMemoryAdapter()
   private releaseFlush: (() => void) | null = null
@@ -98,10 +121,6 @@ class SlowFlushingAdapter implements ExportAdapter {
 
   listTraceIds(): Promise<string[]> {
     return this.inner.listTraceIds()
-  }
-
-  listTraceSummaries(): Promise<TraceSummary[]> {
-    return this.inner.listTraceSummaries()
   }
 
   deleteTrace(traceId: string): Promise<void> {
@@ -135,6 +154,12 @@ describe('transcript retention controls', () => {
 
     expect(await inner.listTraceIds()).toEqual([])
     expect(await adapter.listTraceIds()).toEqual([])
+  })
+
+  it('does not report raw transcript storage when retention is disabled', () => {
+    const report = describeTranscriptRetentionPolicy({ mode: 'disabled', redactionLevel: 'none' })
+
+    expect(report.storesRawTranscriptContent).toBe(false)
   })
 
   it('hides pre-existing backend traces and summaries when retention is disabled', async () => {
@@ -450,10 +475,31 @@ describe('transcript retention controls', () => {
     await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
     now = 16
 
-    await expect(adapter.cleanupExpired()).resolves.toEqual(['trace-1'])
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
     expect(await adapter.listTraceIds()).toEqual([])
     expect(await adapter.queryByTraceId('trace-1')).toBeNull()
-    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(
+      '[TranscriptRetentionAdapter] Failed to delete expired trace trace-1:',
+      expect.any(Error),
+    )
+    warn.mockRestore()
+  })
+
+  it('retries transient backend delete failures on later cleanup passes', async () => {
+    let now = 10
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const inner = new FailingOnceDeleteAdapter()
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+    expect(await inner.listTraceIds()).toEqual(['trace-1'])
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    expect(await inner.listTraceIds()).toEqual([])
+    expect(inner.deleteAttempts).toBe(2)
     warn.mockRestore()
   })
 
@@ -472,7 +518,7 @@ describe('transcript retention controls', () => {
     expect(await throwing.listTraceIds()).toEqual(['trace-1'])
     expect(await deletable.listTraceIds()).toEqual([])
     expect(await adapter.listTraceIds()).toEqual([])
-    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalled()
     warn.mockRestore()
   })
 
@@ -623,10 +669,10 @@ describe('transcript retention controls', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({
         metadata: {
-          prompt: {
+          llmPayload: {
             messages: [
               { role: 'user', content: 'private prompt' },
-              { role: 'tool', type: 'tool_result', content: 'private tool result' },
+              { role: 'tool', type: 'tool_result', content: 'private tool result', tool_call_id: 'call-1' },
             ],
           },
         },
@@ -637,11 +683,30 @@ describe('transcript retention controls', () => {
       retainedFields: { toolOutputs: false },
     })
 
-    expect(retained.spans[0].metadata['prompt']).toEqual({
+    expect(retained.spans[0].metadata['llmPayload']).toEqual({
       messages: [
         { role: 'user', content: 'private prompt' },
-        { role: 'tool', type: 'tool_result' },
+        { role: 'tool', type: 'tool_result', tool_call_id: 'call-1' },
       ],
+    })
+  })
+
+  it('honors tool output opt-outs for standalone raw tool result objects', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          payload: { type: 'tool_result', content: 'private tool result', tool_call_id: 'call-1' },
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata['payload']).toEqual({
+      type: 'tool_result',
+      tool_call_id: 'call-1',
     })
   })
 

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -45,34 +45,28 @@ function makeTrace(overrides: Partial<Trace> = {}): Trace {
 }
 
 class NonDeletingAdapter implements ExportAdapter {
-  private readonly inner = new InMemoryAdapter()
+  private readonly traces = new Map<string, Trace>()
 
-  flush(trace: Trace): Promise<void> {
-    return this.inner.flush(trace)
+  async flush(trace: Trace): Promise<void> {
+    this.traces.set(trace.id, trace)
   }
 
-  queryByTraceId(traceId: string): Promise<Trace | null> {
-    return this.inner.queryByTraceId(traceId)
+  async queryByTraceId(traceId: string): Promise<Trace | null> {
+    return this.traces.get(traceId) ?? null
   }
 
-  listTraceIds(): Promise<string[]> {
-    return this.inner.listTraceIds()
+  async listTraceIds(): Promise<string[]> {
+    return [...this.traces.keys()]
   }
 
   async listTraceSummaries(): Promise<TraceSummary[]> {
-    const summaries: TraceSummary[] = []
-    for (const id of await this.inner.listTraceIds()) {
-      const trace = await this.inner.queryByTraceId(id)
-      if (!trace) continue
-      summaries.push({
-        id: trace.id,
-        goal: trace.goal,
-        status: trace.status,
-        spanCount: trace.spans.length,
-        startedAt: trace.startedAt,
-      })
-    }
-    return summaries
+    return [...this.traces.values()].map(trace => ({
+      id: trace.id,
+      goal: trace.goal,
+      status: trace.status,
+      spanCount: trace.spans.length,
+      startedAt: trace.startedAt,
+    }))
   }
 }
 
@@ -369,6 +363,24 @@ describe('transcript retention controls', () => {
     expect(await adapter.queryByTraceId('trace-1')).toBeNull()
   })
 
+  it('keeps partially deleted expired traces hidden across multi-adapter children', async () => {
+    let now = 10
+    const deletable = new InMemoryAdapter()
+    const nonDeleting = new NonDeletingAdapter()
+    const multi = new MultiAdapter({ adapters: [deletable, nonDeleting] })
+    const adapter = new TranscriptRetentionAdapter({ adapter: multi, ttlMs: 5, now: () => now })
+
+    await adapter.flush(makeTrace({ startedAt: 8, endedAt: 10 }))
+    now = 16
+
+    expect(await adapter.cleanupExpired()).toEqual(['trace-1'])
+    expect(await deletable.listTraceIds()).toEqual([])
+    expect(await nonDeleting.listTraceIds()).toEqual(['trace-1'])
+    expect(await adapter.listTraceIds()).toEqual([])
+    expect(await adapter.listTraceSummaries()).toEqual([])
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+  })
+
   it('keeps internal-slot objects intact instead of cloning them with fake prototypes', () => {
     const url = new URL('https://example.test/path')
     const retained = applyRetentionPolicy(makeTrace({
@@ -436,6 +448,8 @@ describe('transcript retention controls', () => {
           promptTokens: 12,
           completionTokens: 3,
           messages: [{ role: 'user', content: 'private chat prompt' }],
+          transcript: ['private transcript line'],
+          stdin: 'private standard input',
         },
       })],
     }))
@@ -443,6 +457,33 @@ describe('transcript retention controls', () => {
     expect(retained.spans[0].metadata['promptTokens']).toBe(12)
     expect(retained.spans[0].metadata['completionTokens']).toBe(3)
     expect(retained.spans[0].metadata['messages']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['transcript']).toBe('[REDACTED_TRANSCRIPT]')
+    expect(retained.spans[0].metadata['stdin']).toBe('[REDACTED_TRANSCRIPT]')
+  })
+
+  it('walks Map and Set metadata before preserving their container types', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          payload: new Map<string, unknown>([
+            ['prompt', 'private map prompt'],
+            ['safeCounter', 1],
+            ['nested', { tool_output: 'private nested output' }],
+          ]),
+          records: new Set<unknown>([{ transcript: 'private set transcript' }, { safeCounter: 2 }]),
+        },
+      })],
+    }))
+
+    const payload = retained.spans[0].metadata['payload'] as Map<string, unknown>
+    const records = retained.spans[0].metadata['records'] as Set<Record<string, unknown>>
+
+    expect(payload).toBeInstanceOf(Map)
+    expect(payload.get('prompt')).toBe('[REDACTED_TRANSCRIPT]')
+    expect(payload.get('safeCounter')).toBe(1)
+    expect(payload.get('nested')).toEqual({ tool_output: '[REDACTED_TRANSCRIPT]' })
+    expect(records).toBeInstanceOf(Set)
+    expect([...records]).toEqual([{ transcript: '[REDACTED_TRANSCRIPT]' }, { safeCounter: 2 }])
   })
 
   it('preserves own __proto__ metadata keys as data properties', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -737,8 +737,10 @@ describe('transcript retention controls', () => {
       spans: [makeSpan({
         metadata: {
           messages: [
+            'private primitive prompt',
             { type: 'text', text: 'private prompt text' },
             { type: 'image_url', image_url: { url: 'data:image/png;base64,private' } },
+            { type: 'input_audio', input_audio: { data: 'private-base64-audio' } },
             { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
           ],
         },
@@ -750,10 +752,64 @@ describe('transcript retention controls', () => {
     })
 
     expect(retained.spans[0].metadata['messages']).toEqual([
+      '[TRANSCRIPT_NOT_RETAINED]',
       { type: 'text' },
       { type: 'image_url' },
+      { type: 'input_audio' },
       { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
     ])
+  })
+
+  it('redacts provider stream deltas stored under opaque metadata keys', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          event: {
+            type: 'content_block_delta',
+            delta: { type: 'text_delta', text: 'private streamed prompt text' },
+          },
+          toolEvent: {
+            type: 'content_block_delta',
+            delta: { type: 'input_json_delta', partial_json: '{"secret":"tool input"}' },
+          },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['event']).toEqual({
+      type: 'content_block_delta',
+      delta: { type: 'text_delta', text: '[REDACTED_TRANSCRIPT]' },
+    })
+    expect(retained.spans[0].metadata['toolEvent']).toEqual({
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: '[REDACTED_TRANSCRIPT]' },
+    })
+  })
+
+  it('redacts multimodal prompt block payloads stored under opaque metadata keys', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          payload: {
+            type: 'input_audio',
+            input_audio: { data: 'private-base64-audio' },
+          },
+          document: {
+            type: 'file',
+            file_data: 'private-file-bytes',
+          },
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata['payload']).toEqual({
+      type: 'input_audio',
+      input_audio: '[REDACTED_TRANSCRIPT]',
+    })
+    expect(retained.spans[0].metadata['document']).toEqual({
+      type: 'file',
+      file_data: '[REDACTED_TRANSCRIPT]',
+    })
   })
 
   it('honors tool output opt-outs inside raw prompt envelopes', () => {

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -748,6 +748,43 @@ describe('transcript retention controls', () => {
     })
   })
 
+  it('honors prompt opt-outs for standalone raw provider text blocks', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          message: { type: 'text', text: 'private standalone prompt', safeCounter: 1 },
+          system: 'private system prompt',
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { prompts: false },
+    })
+
+    expect(retained.spans[0].metadata['message']).toEqual({ type: 'text', safeCounter: 1 })
+    expect(retained.spans[0].metadata).not.toHaveProperty('system')
+  })
+
+  it('honors tool output opt-outs for standalone raw tool result text blocks', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          payload: { type: 'tool_result', text: 'private standalone tool result', tool_call_id: 'call-1' },
+        },
+      })],
+    }), {
+      mode: 'raw',
+      redactionLevel: 'none',
+      retainedFields: { toolOutputs: false },
+    })
+
+    expect(retained.spans[0].metadata['payload']).toEqual({
+      type: 'tool_result',
+      tool_call_id: 'call-1',
+    })
+  })
+
   it('honors tool output opt-outs for standalone raw tool result objects', () => {
     const retained = applyRetentionPolicy(makeTrace({
       spans: [makeSpan({

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -194,6 +194,7 @@ describe('transcript retention controls', () => {
       ttlMs: 60_000,
       accessLevel: 'restricted',
       retainedFields: { toolOutputs: false },
+      now: () => 1_000,
     })
 
     expect(report).toMatchObject({
@@ -209,6 +210,7 @@ describe('transcript retention controls', () => {
         summaries: true,
       },
       storesRawTranscriptContent: false,
+      expiresAt: 61_000,
     })
   })
 
@@ -309,6 +311,26 @@ describe('transcript retention controls', () => {
       systemPromptAddition: '[REDACTED_TRANSCRIPT]',
       tool_input_json: '[REDACTED_TRANSCRIPT]',
       toolResultPayload: '[REDACTED_TRANSCRIPT]',
+      safeCounter: 1,
+    })
+  })
+
+  it('redacts instruction and transcript variant metadata keys', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          systemInstruction: 'private system instruction',
+          custom_instructions: 'private custom instructions',
+          transcriptText: 'private transcript text',
+          safeCounter: 1,
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      systemInstruction: '[REDACTED_TRANSCRIPT]',
+      custom_instructions: '[REDACTED_TRANSCRIPT]',
+      transcriptText: '[REDACTED_TRANSCRIPT]',
       safeCounter: 1,
     })
   })
@@ -579,6 +601,7 @@ describe('transcript retention controls', () => {
         metadata: {
           messages: [
             { role: 'user', content: 'private prompt' },
+            { role: 'tool', content: 'private role-only tool result', tool_call_id: 'call-0' },
             { role: 'tool', type: 'tool_result', content: 'private tool result', tool_call_id: 'call-1' },
           ],
         },
@@ -591,6 +614,7 @@ describe('transcript retention controls', () => {
 
     expect(retained.spans[0].metadata['messages']).toEqual([
       { role: 'user', content: 'private prompt' },
+      { role: 'tool', tool_call_id: 'call-0' },
       { role: 'tool', type: 'tool_result', tool_call_id: 'call-1' },
     ])
   })

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -104,6 +104,18 @@ describe('transcript retention controls', () => {
     expect(await adapter.listTraceIds()).toEqual([])
   })
 
+  it('hides pre-existing backend traces and summaries when retention is disabled', async () => {
+    const inner = new InMemoryAdapter()
+    await inner.flush(makeTrace())
+
+    const adapter = new TranscriptRetentionAdapter({ adapter: inner, mode: 'disabled' })
+
+    expect(await adapter.queryByTraceId('trace-1')).toBeNull()
+    expect(await adapter.listTraceIds()).toEqual([])
+    expect(await adapter.listTraceSummaries()).toEqual([])
+    expect(await inner.listTraceIds()).toEqual(['trace-1'])
+  })
+
   it('can drop selected transcript fields while retaining non-transcript metadata', () => {
     const retained = applyRetentionPolicy(makeTrace(), {
       retainedFields: {
@@ -282,6 +294,59 @@ describe('transcript retention controls', () => {
     expect(retained.spans[0].metadata).toEqual({
       payload: '[REDACTED_TRANSCRIPT]',
       safeCounter: 1,
+    })
+  })
+
+  it('redacts delegated summary goals nested under opaque metadata keys', () => {
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({
+        metadata: {
+          delegation: {
+            delegatedTask: {
+              goal: 'private delegated task goal',
+              status: 'completed',
+            },
+            delegatedSummary: {
+              goal: 'private delegated task goal',
+              summary: 'private delegated summary',
+            },
+            childGoals: ['private child goal'],
+          },
+          safeCounter: 1,
+        },
+      })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      delegation: {
+        delegatedTask: {
+          goal: '[REDACTED_TRANSCRIPT]',
+          status: 'completed',
+        },
+        delegatedSummary: '[REDACTED_TRANSCRIPT]',
+        childGoals: '[REDACTED_TRANSCRIPT]',
+      },
+      safeCounter: 1,
+    })
+  })
+
+  it('redacts transcript fields inside enumerable non-plain metadata objects', () => {
+    class ToolPayload {
+      promptText = 'private class prompt'
+      stdout = 'private class output'
+      safeCounter = 1
+    }
+
+    const retained = applyRetentionPolicy(makeTrace({
+      spans: [makeSpan({ metadata: { payload: new ToolPayload() } })],
+    }))
+
+    expect(retained.spans[0].metadata).toEqual({
+      payload: {
+        promptText: '[REDACTED_TRANSCRIPT]',
+        stdout: '[REDACTED_TRANSCRIPT]',
+        safeCounter: 1,
+      },
     })
   })
 

--- a/packages/franken-observer/src/security/transcript-retention.test.ts
+++ b/packages/franken-observer/src/security/transcript-retention.test.ts
@@ -1019,7 +1019,9 @@ describe('transcript retention controls', () => {
         metadata: {
           messages: [
             { role: 'user', content: 'private prompt' },
+            { role: 'user', parts: [{ text: 'private gemini prompt' }] },
             { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+            { role: 'tool', content: [{ type: 'text', text: 'private block tool result' }], tool_call_id: 'call-2' },
           ],
         },
       })],
@@ -1031,7 +1033,9 @@ describe('transcript retention controls', () => {
 
     expect(retained.spans[0].metadata['messages']).toEqual([
       { role: 'user' },
+      { role: 'user' },
       { role: 'tool', content: 'private tool result', tool_call_id: 'call-1' },
+      { role: 'tool', content: [{ type: 'text', text: 'private block tool result' }], tool_call_id: 'call-2' },
     ])
   })
 

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -69,7 +69,7 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
   summaries: true,
 })
 
-const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions'])
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'goal', 'goals'])
 const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', 'arguments', 'args', 'parameters', 'params'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
@@ -99,6 +99,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   async queryByTraceId(traceId: string): Promise<Trace | null> {
+    if (this.policy.mode === 'disabled') return null
     if (this.expiredTraceIds.has(traceId)) return null
     if (await this.expireStoredTraceIfNeeded(traceId)) return null
 
@@ -112,6 +113,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   async listTraceIds(): Promise<string[]> {
+    if (this.policy.mode === 'disabled') return []
     await this.cleanupExpired()
     const ids = await this.inner.listTraceIds()
     const result: string[] = []
@@ -123,6 +125,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   async listTraceSummaries(): Promise<TraceSummary[]> {
+    if (this.policy.mode === 'disabled') return []
     await this.cleanupExpired()
     const summaries = this.inner.listTraceSummaries
       ? await this.inner.listTraceSummaries()
@@ -288,7 +291,11 @@ function redactNestedTranscriptValues(
     return retained
   }
   if (value instanceof Date) return new Date(value.getTime())
-  if (!isPlainRecord(value)) return cloneValue(value)
+  if (!isPlainRecord(value)) {
+    return shouldRedactEnumerableObject(value)
+      ? redactEnumerableObject(value, policy, seen)
+      : cloneValue(value)
+  }
 
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
@@ -302,7 +309,7 @@ function redactNestedTranscriptValues(
 
 function classifyTranscriptField(key: string): TranscriptField | undefined {
   const normalized = key.replace(/[_-]/g, '').toLowerCase()
-  if (PROMPT_KEYS.has(normalized) || normalized.includes('prompt')) return 'prompts'
+  if (PROMPT_KEYS.has(normalized) || normalized.includes('prompt') || normalized.endsWith('goal') || normalized.endsWith('goals')) return 'prompts'
   if (
     TOOL_INPUT_KEYS.has(normalized) ||
     normalized === 'query' ||
@@ -332,6 +339,33 @@ function redactValue(value: unknown, policy: ResolvedTranscriptRetentionPolicy):
   if (policy.mode === 'raw' || policy.redactionLevel === 'none') return cloneValue(value)
   if (policy.redactionLevel === 'drop') return DROPPED
   return MASK
+}
+
+function redactEnumerableObject(
+  value: object,
+  policy: ResolvedTranscriptRetentionPolicy,
+  seen: WeakMap<object, unknown>,
+): Record<string, unknown> {
+  const retained: Record<string, unknown> = {}
+  seen.set(value, retained)
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const field = classifyTranscriptField(key)
+    if (field && !policy.retainedFields[field]) continue
+    retained[key] = field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen)
+  }
+  return retained
+}
+
+function shouldRedactEnumerableObject(value: object): boolean {
+  return Object.keys(value).length > 0 &&
+    !(value instanceof RegExp) &&
+    !(value instanceof ArrayBuffer) &&
+    !ArrayBuffer.isView(value) &&
+    !(value instanceof Map) &&
+    !(value instanceof Set) &&
+    !(value instanceof Promise) &&
+    !(value instanceof WeakMap) &&
+    !(value instanceof WeakSet)
 }
 
 function redactString(value: string | undefined, policy: ResolvedTranscriptRetentionPolicy): string | undefined {

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -74,7 +74,7 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
 })
 
 const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts'])
-const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
+const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
 const SUMMARY_KEYS = new Set(['summary', 'summaries'])
@@ -377,6 +377,7 @@ function redactNestedTranscriptValues(
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
   const recordType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
+  const recordRole = typeof value['role'] === 'string' ? value['role'].replace(/[_-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
     if (recordType === 'contentblockdelta' && key.replace(/[_-]/g, '').toLowerCase() === 'delta') {
       setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
@@ -384,7 +385,12 @@ function redactNestedTranscriptValues(
     }
     const field = classifyContextualTranscriptField(value, key)
     if (field && !policy.retainedFields[field]) continue
-    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
+    const retainedValue = field === 'toolOutputs' && isRawRetention(policy) && isToolOutputMessageField(recordType, recordRole, key)
+      ? cloneValue(nestedValue, seen)
+      : field
+        ? redactFieldValue(nestedValue, field, policy, seen)
+        : redactNestedTranscriptValues(nestedValue, policy, seen)
+    setRecordValue(retained, key, retainedValue)
   }
   return retained
 }
@@ -393,7 +399,7 @@ function classifyContextualTranscriptField(record: Record<string, unknown>, key:
   const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
-  if ((recordType === 'toolresult' || recordRole === 'tool') && (normalizedKey === 'content' || normalizedKey === 'text')) return 'toolOutputs'
+  if (isToolOutputMessageField(recordType, recordRole, key)) return 'toolOutputs'
   if (recordType === 'inputjsondelta' && normalizedKey === 'partialjson') return 'toolInputs'
   if (isPromptBlockContentField(recordType, key)) return 'prompts'
   return classifyTranscriptField(key)
@@ -410,7 +416,9 @@ function classifyTranscriptField(key: string): TranscriptField | undefined {
     normalized.includes('instruction') ||
     normalized.includes('transcript') ||
     normalized.endsWith('goal') ||
-    normalized.endsWith('goals')
+    normalized.endsWith('goals') ||
+    normalized === 'input' ||
+    normalized === 'inputs'
   ) return 'prompts'
   if (
     TOOL_INPUT_KEYS.has(normalized) ||
@@ -466,11 +474,7 @@ function redactFieldValue(
     }
     if (value !== null && typeof value === 'object') return redactNestedTranscriptValues(value, policy, seen)
   }
-  if (field === 'toolOutputs' && (policy.mode === 'raw' || policy.redactionLevel === 'none')) {
-    return cloneValue(value, seen)
-  }
   if ((policy.mode === 'raw' || policy.redactionLevel === 'none') && value !== null && typeof value === 'object') {
-    if (field === 'toolOutputs') return cloneValue(value)
     return redactNestedTranscriptValues(value, policy, seen)
   }
   return redactValue(value, policy)
@@ -495,11 +499,12 @@ function redactProviderMessageValue(
     }
     const contextualField = classifyProviderMessageField(messageType, messageRole, key)
     if (contextualField && !policy.retainedFields[contextualField]) continue
-    setRecordValue(
-      retained,
-      key,
-      contextualField ? redactFieldValue(nestedValue, contextualField, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen),
-    )
+    const retainedValue = contextualField === 'toolOutputs' && isRawRetention(policy) && isToolOutputMessageField(messageType, messageRole, key)
+      ? cloneValue(nestedValue, seen)
+      : contextualField
+        ? redactFieldValue(nestedValue, contextualField, policy, seen)
+        : redactNestedTranscriptValues(nestedValue, policy, seen)
+    setRecordValue(retained, key, retainedValue)
   }
   return retained
 }
@@ -537,11 +542,21 @@ function classifyProviderStreamDeltaField(deltaType: string, key: string): Trans
 
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
-  if ((messageType === 'toolresult' || messageRole === 'tool') && (normalizedKey === 'content' || normalizedKey === 'text' || normalizedKey === 'parts')) return 'toolOutputs'
+  if (isToolOutputMessageField(messageType, messageRole, key)) return 'toolOutputs'
   if (messageType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
   if ((messageRole === 'user' || messageRole === 'system' || messageRole === 'assistant' || messageRole === 'model') && normalizedKey === 'parts') return 'prompts'
   if (isPromptBlockContentField(messageType, key)) return 'prompts'
   return classifyTranscriptField(key)
+}
+
+function isToolOutputMessageField(messageType: string, messageRole: string, key: string): boolean {
+  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  return (messageType === 'toolresult' || messageRole === 'tool' || messageRole === 'function') &&
+    (normalizedKey === 'content' || normalizedKey === 'text' || normalizedKey === 'parts')
+}
+
+function isRawRetention(policy: ResolvedTranscriptRetentionPolicy): boolean {
+  return policy.mode === 'raw' || policy.redactionLevel === 'none'
 }
 
 function isPromptBlockContentField(messageType: string, key: string): boolean {
@@ -595,7 +610,14 @@ function redactEnumerableObject(
   for (const [key, nestedValue] of Object.entries(value)) {
     const field = classifyContextualTranscriptField(record, key)
     if (field && !policy.retainedFields[field]) continue
-    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
+    const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
+    const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
+    const retainedValue = field === 'toolOutputs' && isRawRetention(policy) && isToolOutputMessageField(recordType, recordRole, key)
+      ? cloneValue(nestedValue, seen)
+      : field
+        ? redactFieldValue(nestedValue, field, policy, seen)
+        : redactNestedTranscriptValues(nestedValue, policy, seen)
+    setRecordValue(retained, key, retainedValue)
   }
   return retained
 }

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -95,7 +95,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
     if (this.isExpired(trace)) return
 
     const retainedTrace = applyRetentionPolicy(trace, this.policy)
-    this.retained.set(retainedTrace.id, getTraceExpiry(retainedTrace, this.policy.ttlMs))
+    this.retained.set(retainedTrace.id, getTraceExpiry(retainedTrace, this.policy.ttlMs, this.now()))
     this.expiredTraceIds.delete(retainedTrace.id)
     await this.inner.flush(retainedTrace)
   }
@@ -136,10 +136,6 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
     const result: TraceSummary[] = []
     for (const summary of summaries) {
       if (this.expiredTraceIds.has(summary.id)) continue
-      if (summary.startedAt + this.policy.ttlMs <= this.now()) {
-        const trace = await this.queryByTraceId(summary.id)
-        if (!trace) continue
-      }
       if (await this.expireStoredTraceIfNeeded(summary.id)) continue
       const trace = await this.queryByTraceId(summary.id)
       if (!trace) continue
@@ -196,7 +192,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   private isExpired(trace: Trace): boolean {
-    return getTraceExpiry(trace, this.policy.ttlMs) <= this.now()
+    return getTraceExpiry(trace, this.policy.ttlMs, this.now()) <= this.now()
   }
 
   private async expireStoredTraceIfNeeded(traceId: string): Promise<boolean> {
@@ -208,8 +204,12 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
 
   private async markExpired(traceId: string): Promise<void> {
     this.retained.delete(traceId)
-    await deleteTraceFromAdapter(this.inner, traceId)
     this.expiredTraceIds.add(traceId)
+    try {
+      await deleteTraceFromAdapter(this.inner, traceId)
+    } catch (error) {
+      console.warn(`[TranscriptRetentionAdapter] Failed to delete expired trace ${traceId}; keeping it hidden`, error)
+    }
   }
 }
 
@@ -288,7 +288,7 @@ function retainMetadata(
   for (const [key, value] of Object.entries(metadata)) {
     const field = classifyTranscriptField(key)
     if (field && !policy.retainedFields[field]) continue
-    setRecordValue(retained, key, field ? redactValue(value, policy) : redactNestedTranscriptValues(value, policy, seen))
+    setRecordValue(retained, key, field ? redactFieldValue(value, field, policy, seen) : redactNestedTranscriptValues(value, policy, seen))
   }
   return retained
 }
@@ -313,7 +313,7 @@ function redactNestedTranscriptValues(
     for (const [key, nestedValue] of value.entries()) {
       const field = typeof key === 'string' ? classifyTranscriptField(key) : undefined
       if (field && !policy.retainedFields[field]) continue
-      retained.set(cloneValue(key), field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen))
+      retained.set(cloneValue(key), field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
     }
     return retained
   }
@@ -335,7 +335,7 @@ function redactNestedTranscriptValues(
   for (const [key, nestedValue] of Object.entries(value)) {
     const field = classifyTranscriptField(key)
     if (field && !policy.retainedFields[field]) continue
-    setRecordValue(retained, key, field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen))
+    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }
   return retained
 }
@@ -376,6 +376,44 @@ function redactValue(value: unknown, policy: ResolvedTranscriptRetentionPolicy):
   return MASK
 }
 
+function redactFieldValue(
+  value: unknown,
+  field: TranscriptField,
+  policy: ResolvedTranscriptRetentionPolicy,
+  seen: WeakMap<object, unknown>,
+): unknown {
+  if (field === 'prompts' && Array.isArray(value) && (policy.mode === 'raw' || policy.redactionLevel === 'none')) {
+    const retained: unknown[] = []
+    seen.set(value, retained)
+    for (const item of value) retained.push(redactProviderMessageValue(item, policy, seen))
+    return retained
+  }
+  return redactValue(value, policy)
+}
+
+function redactProviderMessageValue(
+  value: unknown,
+  policy: ResolvedTranscriptRetentionPolicy,
+  seen: WeakMap<object, unknown>,
+): unknown {
+  if (!isPlainRecordValue(value)) return redactNestedTranscriptValues(value, policy, seen)
+  if (seen.has(value)) return seen.get(value)
+
+  const retained: Record<string, unknown> = {}
+  seen.set(value, retained)
+  const messageType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const contextualField = messageType === 'toolresult' && key === 'content' ? 'toolOutputs' : classifyTranscriptField(key)
+    if (contextualField && !policy.retainedFields[contextualField]) continue
+    setRecordValue(
+      retained,
+      key,
+      contextualField ? redactFieldValue(nestedValue, contextualField, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen),
+    )
+  }
+  return retained
+}
+
 function redactEnumerableObject(
   value: object,
   policy: ResolvedTranscriptRetentionPolicy,
@@ -386,7 +424,7 @@ function redactEnumerableObject(
   for (const [key, nestedValue] of Object.entries(value)) {
     const field = classifyTranscriptField(key)
     if (field && !policy.retainedFields[field]) continue
-    setRecordValue(retained, key, field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen))
+    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }
   return retained
 }
@@ -417,8 +455,8 @@ function redactString(value: string | undefined, policy: ResolvedTranscriptReten
   return redactValue(value, policy) as string
 }
 
-function getTraceExpiry(trace: Trace, ttlMs: number): number {
-  const anchor = trace.endedAt ?? trace.startedAt
+function getTraceExpiry(trace: Trace, ttlMs: number, retainedAt?: number): number {
+  const anchor = trace.endedAt ?? retainedAt ?? trace.startedAt
   return anchor + ttlMs
 }
 
@@ -506,4 +544,8 @@ function cloneValue(value: unknown, seen = new WeakMap<object, unknown>()): unkn
 function isPlainRecord(value: object): value is Record<string, unknown> {
   const prototype = Object.getPrototypeOf(value)
   return prototype === Object.prototype || prototype === null
+}
+
+function isPlainRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && isPlainRecord(value)
 }

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -55,6 +55,8 @@ type AdapterWrapperShape = Partial<{
   adapter: ExportAdapter
   adapters: ExportAdapter[]
   buffer: Trace[]
+  drain?: () => Promise<void>
+  drainPromise: Promise<void> | null
 }>
 
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
@@ -92,7 +94,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
 
   async flush(trace: Trace): Promise<void> {
     if (this.policy.mode === 'disabled') return
-    if (this.isExpired(trace)) return
+    if (trace.endedAt !== undefined && this.isExpired(trace)) return
 
     const retainedTrace = applyRetentionPolicy(trace, this.policy)
     this.retained.set(retainedTrace.id, getTraceExpiry(retainedTrace, this.policy.ttlMs, this.now()))
@@ -107,7 +109,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
 
     const trace = await this.inner.queryByTraceId(traceId)
     if (!trace) return null
-    if (this.isExpired(trace)) {
+    if (trace.endedAt !== undefined ? this.isExpired(trace) : (!this.retained.has(traceId) && this.isExpired(trace))) {
       await this.markExpired(traceId)
       return null
     }
@@ -166,7 +168,9 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
     for (const traceId of await this.inner.listTraceIds()) {
       if (this.expiredTraceIds.has(traceId)) continue
       const trace = await this.inner.queryByTraceId(traceId)
-      if (!trace || !this.isExpired(trace)) continue
+      if (!trace) continue
+      if (trace.endedAt === undefined && this.retained.has(traceId)) continue
+      if (!this.isExpired(trace)) continue
       expired.push(traceId)
       await this.markExpired(traceId)
     }
@@ -192,7 +196,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   private isExpired(trace: Trace): boolean {
-    return getTraceExpiry(trace, this.policy.ttlMs, this.now()) <= this.now()
+    return getTraceExpiry(trace, this.policy.ttlMs) <= this.now()
   }
 
   private async expireStoredTraceIfNeeded(traceId: string): Promise<boolean> {
@@ -382,11 +386,14 @@ function redactFieldValue(
   policy: ResolvedTranscriptRetentionPolicy,
   seen: WeakMap<object, unknown>,
 ): unknown {
-  if (field === 'prompts' && Array.isArray(value) && (policy.mode === 'raw' || policy.redactionLevel === 'none')) {
-    const retained: unknown[] = []
-    seen.set(value, retained)
-    for (const item of value) retained.push(redactProviderMessageValue(item, policy, seen))
-    return retained
+  if (field === 'prompts' && (policy.mode === 'raw' || policy.redactionLevel === 'none')) {
+    if (Array.isArray(value)) {
+      const retained: unknown[] = []
+      seen.set(value, retained)
+      for (const item of value) retained.push(redactProviderMessageValue(item, policy, seen))
+      return retained
+    }
+    if (value !== null && typeof value === 'object') return redactNestedTranscriptValues(value, policy, seen)
   }
   return redactValue(value, policy)
 }
@@ -474,6 +481,7 @@ async function deleteTraceFromAdapter(
 
   const wrapper = adapter as AdapterWrapperShape
   let deleted = false
+  let firstFailure: unknown = null
 
   if (Array.isArray(wrapper.buffer)) {
     for (let i = wrapper.buffer.length - 1; i >= 0; i--) {
@@ -484,15 +492,32 @@ async function deleteTraceFromAdapter(
     }
   }
 
+  if (wrapper.drainPromise !== null && wrapper.drainPromise !== undefined) {
+    try {
+      await wrapper.drainPromise
+    } catch (error) {
+      firstFailure ??= error
+    }
+  }
+
   if (hasDeleteTrace(adapter)) {
-    await adapter.deleteTrace(traceId)
-    deleted = true
+    try {
+      await adapter.deleteTrace(traceId)
+      deleted = true
+    } catch (error) {
+      firstFailure ??= error
+    }
   }
 
   for (const child of childAdapters(wrapper)) {
-    if (await deleteTraceFromAdapter(child, traceId, seen)) deleted = true
+    try {
+      if (await deleteTraceFromAdapter(child, traceId, seen)) deleted = true
+    } catch (error) {
+      firstFailure ??= error
+    }
   }
 
+  if (firstFailure !== null) throw firstFailure instanceof Error ? firstFailure : new Error(String(firstFailure))
   return deleted
 }
 

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -69,8 +69,8 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
   summaries: true,
 })
 
-const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'goal', 'goals'])
-const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', 'arguments', 'args', 'parameters', 'params'])
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'goal', 'goals', 'transcript', 'transcripts'])
+const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
 const SUMMARY_KEYS = new Set(['summary', 'summaries'])
@@ -208,11 +208,8 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
 
   private async markExpired(traceId: string): Promise<void> {
     this.retained.delete(traceId)
-    if (await deleteTraceFromAdapter(this.inner, traceId)) {
-      this.expiredTraceIds.delete(traceId)
-    } else {
-      this.expiredTraceIds.add(traceId)
-    }
+    await deleteTraceFromAdapter(this.inner, traceId)
+    this.expiredTraceIds.add(traceId)
   }
 }
 
@@ -308,6 +305,22 @@ function redactNestedTranscriptValues(
     const retained: unknown[] = []
     seen.set(value, retained)
     for (const item of value) retained.push(redactNestedTranscriptValues(item, policy, seen))
+    return retained
+  }
+  if (value instanceof Map) {
+    const retained = new Map<unknown, unknown>()
+    seen.set(value, retained)
+    for (const [key, nestedValue] of value.entries()) {
+      const field = typeof key === 'string' ? classifyTranscriptField(key) : undefined
+      if (field && !policy.retainedFields[field]) continue
+      retained.set(cloneValue(key), field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen))
+    }
+    return retained
+  }
+  if (value instanceof Set) {
+    const retained = new Set<unknown>()
+    seen.set(value, retained)
+    for (const nestedValue of value.values()) retained.add(redactNestedTranscriptValues(nestedValue, policy, seen))
     return retained
   }
   if (value instanceof Date) return new Date(value.getTime())

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -50,6 +50,13 @@ interface DeletableAdapter extends ExportAdapter {
   deleteTrace(traceId: string): Promise<void> | void
 }
 
+type AdapterWrapperShape = Partial<{
+  inner: ExportAdapter
+  adapter: ExportAdapter
+  adapters: ExportAdapter[]
+  buffer: Trace[]
+}>
+
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 const MASK = '[REDACTED_TRANSCRIPT]'
 const DROPPED = '[TRANSCRIPT_NOT_RETAINED]'
@@ -178,8 +185,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
 
   private async markExpired(traceId: string): Promise<void> {
     this.retained.delete(traceId)
-    if (hasDeleteTrace(this.inner)) {
-      await this.inner.deleteTrace(traceId)
+    if (await deleteTraceFromAdapter(this.inner, traceId)) {
       this.expiredTraceIds.delete(traceId)
     } else {
       this.expiredTraceIds.add(traceId)
@@ -273,6 +279,7 @@ function redactNestedTranscriptValues(
   seen: WeakMap<object, unknown>,
 ): unknown {
   if (value === null || typeof value !== 'object') return value
+  if (value instanceof Error) return policy.retainedFields.errors ? redactValue(value, policy) : DROPPED
   if (seen.has(value)) return seen.get(value)
   if (Array.isArray(value)) {
     const retained: unknown[] = []
@@ -295,11 +302,29 @@ function redactNestedTranscriptValues(
 
 function classifyTranscriptField(key: string): TranscriptField | undefined {
   const normalized = key.replace(/[_-]/g, '').toLowerCase()
-  if (PROMPT_KEYS.has(normalized)) return 'prompts'
-  if (TOOL_INPUT_KEYS.has(normalized)) return 'toolInputs'
-  if (TOOL_OUTPUT_KEYS.has(normalized)) return 'toolOutputs'
-  if (ERROR_KEYS.has(normalized)) return 'errors'
-  if (SUMMARY_KEYS.has(normalized)) return 'summaries'
+  if (PROMPT_KEYS.has(normalized) || normalized.includes('prompt')) return 'prompts'
+  if (
+    TOOL_INPUT_KEYS.has(normalized) ||
+    normalized === 'query' ||
+    normalized.includes('toolinput') ||
+    normalized.includes('toolarg') ||
+    normalized.includes('toolparam')
+  ) return 'toolInputs'
+  if (
+    TOOL_OUTPUT_KEYS.has(normalized) ||
+    normalized.includes('tooloutput') ||
+    normalized.includes('toolresult') ||
+    normalized.includes('toolresponse') ||
+    normalized.endsWith('stdout') ||
+    normalized.endsWith('stderr')
+  ) return 'toolOutputs'
+  if (
+    ERROR_KEYS.has(normalized) ||
+    normalized.includes('error') ||
+    normalized.includes('exception') ||
+    normalized.includes('stacktrace')
+  ) return 'errors'
+  if (SUMMARY_KEYS.has(normalized) || normalized.includes('summary')) return 'summaries'
   return undefined
 }
 
@@ -321,6 +346,53 @@ function getTraceExpiry(trace: Trace, ttlMs: number): number {
 
 function hasDeleteTrace(adapter: ExportAdapter): adapter is DeletableAdapter {
   return typeof (adapter as Partial<DeletableAdapter>).deleteTrace === 'function'
+}
+
+async function deleteTraceFromAdapter(
+  adapter: ExportAdapter,
+  traceId: string,
+  seen = new WeakSet<object>(),
+): Promise<boolean> {
+  if (seen.has(adapter)) return false
+  seen.add(adapter)
+
+  const wrapper = adapter as AdapterWrapperShape
+  let deleted = false
+
+  if (Array.isArray(wrapper.buffer)) {
+    for (let i = wrapper.buffer.length - 1; i >= 0; i--) {
+      if (wrapper.buffer[i]?.id === traceId) {
+        wrapper.buffer.splice(i, 1)
+        deleted = true
+      }
+    }
+  }
+
+  if (hasDeleteTrace(adapter)) {
+    await adapter.deleteTrace(traceId)
+    deleted = true
+  }
+
+  for (const child of childAdapters(wrapper)) {
+    if (await deleteTraceFromAdapter(child, traceId, seen)) deleted = true
+  }
+
+  return deleted
+}
+
+function childAdapters(wrapper: AdapterWrapperShape): ExportAdapter[] {
+  const children: ExportAdapter[] = []
+  if (isExportAdapter(wrapper.inner)) children.push(wrapper.inner)
+  if (isExportAdapter(wrapper.adapter)) children.push(wrapper.adapter)
+  if (Array.isArray(wrapper.adapters)) children.push(...wrapper.adapters.filter(isExportAdapter))
+  return children
+}
+
+function isExportAdapter(value: unknown): value is ExportAdapter {
+  return typeof value === 'object' && value !== null &&
+    typeof (value as ExportAdapter).flush === 'function' &&
+    typeof (value as ExportAdapter).queryByTraceId === 'function' &&
+    typeof (value as ExportAdapter).listTraceIds === 'function'
 }
 
 function cloneValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -461,7 +461,7 @@ function redactProviderMessageValue(
   policy: ResolvedTranscriptRetentionPolicy,
   seen: WeakMap<object, unknown>,
 ): unknown {
-  if (!isPlainRecordValue(value)) return redactNestedTranscriptValues(value, policy, seen)
+  if (!isPlainRecordValue(value)) return policy.retainedFields.prompts ? redactNestedTranscriptValues(value, policy, seen) : DROPPED
   if (seen.has(value)) return seen.get(value)
 
   const retained: Record<string, unknown> = {}
@@ -488,10 +488,42 @@ function classifyProviderMessageField(messageType: string, messageRole: string, 
 
 function isPromptBlockContentField(messageType: string, key: string): boolean {
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  if ((messageType === 'textdelta' || messageType === 'outputtextdelta') && normalizedKey === 'text') return true
+  if (messageType === 'inputjsondelta' && normalizedKey === 'partialjson') return true
+  if (
+    isMultimodalPromptBlockType(messageType) &&
+    MULTIMODAL_PROMPT_CONTENT_KEYS.has(normalizedKey)
+  ) return true
   return (
     ((messageType === 'text' || messageType === 'inputtext') && normalizedKey === 'text') ||
     ((messageType === 'imageurl' || messageType === 'inputimage') && (normalizedKey === 'imageurl' || normalizedKey === 'url'))
   )
+}
+
+const MULTIMODAL_PROMPT_CONTENT_KEYS = new Set([
+  'audio',
+  'data',
+  'document',
+  'file',
+  'filedata',
+  'image',
+  'imageurl',
+  'inputaudio',
+  'inputimage',
+  'source',
+  'url',
+])
+
+function isMultimodalPromptBlockType(messageType: string): boolean {
+  return messageType === 'inputaudio' ||
+    messageType === 'audio' ||
+    messageType === 'inputfile' ||
+    messageType === 'file' ||
+    messageType === 'document' ||
+    messageType === 'inputdocument' ||
+    messageType === 'image' ||
+    messageType === 'inputimage' ||
+    messageType === 'imageurl'
 }
 
 function redactEnumerableObject(

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -1,0 +1,359 @@
+import type { Trace, Span } from '../core/types.js'
+import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
+
+export type TranscriptRetentionMode = 'disabled' | 'redacted' | 'raw'
+export type TranscriptRedactionLevel = 'mask' | 'drop' | 'none'
+export type TranscriptAccessLevel = 'local' | 'operator' | 'restricted'
+export type TranscriptField = 'prompts' | 'toolInputs' | 'toolOutputs' | 'errors' | 'summaries'
+
+export interface TranscriptRetainedFields {
+  readonly prompts: boolean
+  readonly toolInputs: boolean
+  readonly toolOutputs: boolean
+  readonly errors: boolean
+  readonly summaries: boolean
+}
+
+export interface TranscriptRetentionPolicy {
+  /** Disabled drops transcript traces entirely; redacted is the safe default; raw requires an explicit operator choice. */
+  readonly mode?: TranscriptRetentionMode
+  /** How long flushed transcript traces can be read back. Defaults to 24 hours. */
+  readonly ttlMs?: number
+  /** Redaction applied when mode is redacted. Defaults to masking sensitive transcript fields. */
+  readonly redactionLevel?: TranscriptRedactionLevel
+  /** Minimum audience expected to access retained transcripts. Defaults to restricted. */
+  readonly accessLevel?: TranscriptAccessLevel
+  /** Per-field controls for prompts, tool I/O, errors, and summaries. */
+  readonly retainedFields?: Partial<TranscriptRetainedFields>
+  /** Clock override for deterministic tests. */
+  readonly now?: () => number
+}
+
+export interface ResolvedTranscriptRetentionPolicy {
+  readonly mode: TranscriptRetentionMode
+  readonly ttlMs: number
+  readonly redactionLevel: TranscriptRedactionLevel
+  readonly accessLevel: TranscriptAccessLevel
+  readonly retainedFields: TranscriptRetainedFields
+}
+
+export interface TranscriptRetentionPolicyReport extends ResolvedTranscriptRetentionPolicy {
+  readonly storesRawTranscriptContent: boolean
+  readonly expiresAt?: number
+}
+
+export interface TranscriptRetentionAdapterOptions extends TranscriptRetentionPolicy {
+  readonly adapter: ExportAdapter
+}
+
+interface DeletableAdapter extends ExportAdapter {
+  deleteTrace(traceId: string): Promise<void> | void
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+const MASK = '[REDACTED_TRANSCRIPT]'
+const DROPPED = '[TRANSCRIPT_NOT_RETAINED]'
+
+const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
+  prompts: true,
+  toolInputs: true,
+  toolOutputs: true,
+  errors: true,
+  summaries: true,
+})
+
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions'])
+const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', 'arguments', 'args', 'parameters', 'params'])
+const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
+const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
+const SUMMARY_KEYS = new Set(['summary', 'summaries'])
+
+export class TranscriptRetentionAdapter implements ExportAdapter {
+  private readonly inner: ExportAdapter
+  private readonly policy: ResolvedTranscriptRetentionPolicy
+  private readonly now: () => number
+  private readonly retained = new Map<string, number>()
+  private readonly expiredTraceIds = new Set<string>()
+
+  constructor(options: TranscriptRetentionAdapterOptions) {
+    this.inner = options.adapter
+    this.policy = resolveTranscriptRetentionPolicy(options)
+    this.now = options.now ?? Date.now
+  }
+
+  async flush(trace: Trace): Promise<void> {
+    if (this.policy.mode === 'disabled') return
+    if (this.isExpired(trace)) return
+
+    const retainedTrace = applyRetentionPolicy(trace, this.policy)
+    this.retained.set(retainedTrace.id, getTraceExpiry(retainedTrace, this.policy.ttlMs))
+    this.expiredTraceIds.delete(retainedTrace.id)
+    await this.inner.flush(retainedTrace)
+  }
+
+  async queryByTraceId(traceId: string): Promise<Trace | null> {
+    if (this.expiredTraceIds.has(traceId)) return null
+    if (await this.expireStoredTraceIfNeeded(traceId)) return null
+
+    const trace = await this.inner.queryByTraceId(traceId)
+    if (!trace) return null
+    if (this.isExpired(trace)) {
+      await this.markExpired(traceId)
+      return null
+    }
+    return trace
+  }
+
+  async listTraceIds(): Promise<string[]> {
+    await this.cleanupExpired()
+    const ids = await this.inner.listTraceIds()
+    const result: string[] = []
+    for (const id of ids) {
+      const trace = await this.queryByTraceId(id)
+      if (trace) result.push(id)
+    }
+    return result
+  }
+
+  async listTraceSummaries(): Promise<TraceSummary[]> {
+    await this.cleanupExpired()
+    const summaries = this.inner.listTraceSummaries
+      ? await this.inner.listTraceSummaries()
+      : await this.fallbackTraceSummaries()
+
+    const result: TraceSummary[] = []
+    for (const summary of summaries) {
+      if (this.expiredTraceIds.has(summary.id)) continue
+      if (summary.startedAt + this.policy.ttlMs <= this.now()) {
+        const trace = await this.queryByTraceId(summary.id)
+        if (!trace) continue
+      }
+      if (!(await this.expireStoredTraceIfNeeded(summary.id))) result.push(summary)
+    }
+    return result
+  }
+
+  describePolicy(): TranscriptRetentionPolicyReport {
+    return describeTranscriptRetentionPolicy(this.policy)
+  }
+
+  async cleanupExpired(): Promise<string[]> {
+    const expired: string[] = []
+    const now = this.now()
+    for (const [traceId, expiresAt] of this.retained.entries()) {
+      if (expiresAt > now) continue
+      expired.push(traceId)
+      await this.markExpired(traceId)
+    }
+    return expired
+  }
+
+  private async fallbackTraceSummaries(): Promise<TraceSummary[]> {
+    const ids = await this.inner.listTraceIds()
+    const summaries: TraceSummary[] = []
+    for (const id of ids) {
+      const trace = await this.queryByTraceId(id)
+      if (!trace) continue
+      summaries.push({
+        id: trace.id,
+        goal: trace.goal,
+        status: trace.status,
+        spanCount: trace.spans.length,
+        startedAt: trace.startedAt,
+      })
+    }
+    return summaries
+  }
+
+  private isExpired(trace: Trace): boolean {
+    return getTraceExpiry(trace, this.policy.ttlMs) <= this.now()
+  }
+
+  private async expireStoredTraceIfNeeded(traceId: string): Promise<boolean> {
+    const expiresAt = this.retained.get(traceId)
+    if (expiresAt === undefined || expiresAt > this.now()) return false
+    await this.markExpired(traceId)
+    return true
+  }
+
+  private async markExpired(traceId: string): Promise<void> {
+    this.retained.delete(traceId)
+    if (hasDeleteTrace(this.inner)) {
+      await this.inner.deleteTrace(traceId)
+      this.expiredTraceIds.delete(traceId)
+    } else {
+      this.expiredTraceIds.add(traceId)
+    }
+  }
+}
+
+export function resolveTranscriptRetentionPolicy(
+  policy: TranscriptRetentionPolicy = {},
+): ResolvedTranscriptRetentionPolicy {
+  const ttlMs = policy.ttlMs ?? DEFAULT_TTL_MS
+  if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+    throw new RangeError('Transcript retention ttlMs must be a non-negative finite number')
+  }
+
+  return Object.freeze({
+    mode: policy.mode ?? 'redacted',
+    ttlMs,
+    redactionLevel: policy.redactionLevel ?? (policy.mode === 'raw' ? 'none' : 'mask'),
+    accessLevel: policy.accessLevel ?? 'restricted',
+    retainedFields: Object.freeze({ ...DEFAULT_FIELDS, ...policy.retainedFields }),
+  })
+}
+
+export function describeTranscriptRetentionPolicy(
+  policy: TranscriptRetentionPolicy = {},
+): TranscriptRetentionPolicyReport {
+  const resolved = resolveTranscriptRetentionPolicy(policy)
+  return Object.freeze({
+    ...resolved,
+    storesRawTranscriptContent: resolved.mode === 'raw' || resolved.redactionLevel === 'none',
+    ...(resolved.ttlMs > 0 ? { expiresAt: Date.now() + resolved.ttlMs } : {}),
+  })
+}
+
+export function applyRetentionPolicy(trace: Trace, policy: TranscriptRetentionPolicy = {}): Trace {
+  const resolved = resolveTranscriptRetentionPolicy(policy)
+  if (resolved.mode === 'disabled') {
+    return { ...trace, goal: DROPPED, spans: [] }
+  }
+
+  return {
+    ...trace,
+    goal: retainTraceGoal(trace.goal, resolved),
+    spans: trace.spans.map(span => retainSpan(span, resolved)),
+  }
+}
+
+function retainTraceGoal(goal: string, policy: ResolvedTranscriptRetentionPolicy): string {
+  if (!policy.retainedFields.prompts) return DROPPED
+  return redactString(goal, policy) ?? MASK
+}
+
+function retainSpan(span: Span, policy: ResolvedTranscriptRetentionPolicy): Span {
+  const retained: Span = {
+    ...span,
+    metadata: retainMetadata(span.metadata, policy),
+    thoughtBlocks: policy.retainedFields.prompts
+      ? span.thoughtBlocks.map(block => redactString(block, policy) ?? MASK)
+      : [],
+  }
+
+  if (policy.retainedFields.errors) {
+    const errorMessage = redactString(span.errorMessage, policy)
+    if (errorMessage !== undefined) retained.errorMessage = errorMessage
+  } else {
+    delete retained.errorMessage
+  }
+
+  return retained
+}
+
+function retainMetadata(
+  metadata: Record<string, unknown>,
+  policy: ResolvedTranscriptRetentionPolicy,
+): Record<string, unknown> {
+  const retained: Record<string, unknown> = {}
+  const seen = new WeakMap<object, unknown>()
+  seen.set(metadata, retained)
+  for (const [key, value] of Object.entries(metadata)) {
+    const field = classifyTranscriptField(key)
+    if (field && !policy.retainedFields[field]) continue
+    retained[key] = field ? redactValue(value, policy) : redactNestedTranscriptValues(value, policy, seen)
+  }
+  return retained
+}
+
+function redactNestedTranscriptValues(
+  value: unknown,
+  policy: ResolvedTranscriptRetentionPolicy,
+  seen: WeakMap<object, unknown>,
+): unknown {
+  if (value === null || typeof value !== 'object') return value
+  if (seen.has(value)) return seen.get(value)
+  if (Array.isArray(value)) {
+    const retained: unknown[] = []
+    seen.set(value, retained)
+    for (const item of value) retained.push(redactNestedTranscriptValues(item, policy, seen))
+    return retained
+  }
+  if (value instanceof Date) return new Date(value.getTime())
+  if (!isPlainRecord(value)) return cloneValue(value)
+
+  const retained: Record<string, unknown> = {}
+  seen.set(value, retained)
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const field = classifyTranscriptField(key)
+    if (field && !policy.retainedFields[field]) continue
+    retained[key] = field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen)
+  }
+  return retained
+}
+
+function classifyTranscriptField(key: string): TranscriptField | undefined {
+  const normalized = key.replace(/[_-]/g, '').toLowerCase()
+  if (PROMPT_KEYS.has(normalized)) return 'prompts'
+  if (TOOL_INPUT_KEYS.has(normalized)) return 'toolInputs'
+  if (TOOL_OUTPUT_KEYS.has(normalized)) return 'toolOutputs'
+  if (ERROR_KEYS.has(normalized)) return 'errors'
+  if (SUMMARY_KEYS.has(normalized)) return 'summaries'
+  return undefined
+}
+
+function redactValue(value: unknown, policy: ResolvedTranscriptRetentionPolicy): unknown {
+  if (policy.mode === 'raw' || policy.redactionLevel === 'none') return cloneValue(value)
+  if (policy.redactionLevel === 'drop') return DROPPED
+  return MASK
+}
+
+function redactString(value: string | undefined, policy: ResolvedTranscriptRetentionPolicy): string | undefined {
+  if (value === undefined) return undefined
+  return redactValue(value, policy) as string
+}
+
+function getTraceExpiry(trace: Trace, ttlMs: number): number {
+  const anchor = trace.endedAt ?? trace.startedAt
+  return anchor + ttlMs
+}
+
+function hasDeleteTrace(adapter: ExportAdapter): adapter is DeletableAdapter {
+  return typeof (adapter as Partial<DeletableAdapter>).deleteTrace === 'function'
+}
+
+function cloneValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
+  if (value === null || typeof value !== 'object') return value
+  if (seen.has(value)) return seen.get(value)
+  if (Array.isArray(value)) {
+    const cloned: unknown[] = []
+    seen.set(value, cloned)
+    for (const item of value) cloned.push(cloneValue(item, seen))
+    return cloned
+  }
+  if (value instanceof Date) return new Date(value.getTime())
+  if (value instanceof Map) {
+    const cloned = new Map<unknown, unknown>()
+    seen.set(value, cloned)
+    for (const [key, nested] of value.entries()) cloned.set(cloneValue(key, seen), cloneValue(nested, seen))
+    return cloned
+  }
+  if (value instanceof Set) {
+    const cloned = new Set<unknown>()
+    seen.set(value, cloned)
+    for (const nested of value.values()) cloned.add(cloneValue(nested, seen))
+    return cloned
+  }
+  if (!isPlainRecord(value)) return value
+
+  const cloned: Record<string, unknown> = {}
+  seen.set(value, cloned)
+  for (const [key, nested] of Object.entries(value)) cloned[key] = cloneValue(nested, seen)
+  return cloned
+}
+
+function isPlainRecord(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -452,7 +452,7 @@ function redactProviderMessageValue(
   const messageType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const messageRole = typeof value['role'] === 'string' ? value['role'].replace(/[_-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
-    const contextualField = (messageType === 'toolresult' || messageRole === 'tool') && key === 'content' ? 'toolOutputs' : classifyTranscriptField(key)
+    const contextualField = classifyProviderMessageField(messageType, messageRole, key)
     if (contextualField && !policy.retainedFields[contextualField]) continue
     setRecordValue(
       retained,
@@ -463,6 +463,12 @@ function redactProviderMessageValue(
   return retained
 }
 
+function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
+  if ((messageType === 'toolresult' || messageRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
+  if (messageType === 'text' && key === 'text') return 'prompts'
+  return classifyTranscriptField(key)
+}
+
 function redactEnumerableObject(
   value: object,
   policy: ResolvedTranscriptRetentionPolicy,
@@ -470,8 +476,9 @@ function redactEnumerableObject(
 ): Record<string, unknown> {
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
+  const record = value as Record<string, unknown>
   for (const [key, nestedValue] of Object.entries(value)) {
-    const field = classifyTranscriptField(key)
+    const field = classifyContextualTranscriptField(record, key)
     if (field && !policy.retainedFields[field]) continue
     setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -636,8 +636,9 @@ function hasDeleteTrace(adapter: ExportAdapter): adapter is DeletableAdapter {
 function hasDeleteTraceSupport(adapter: ExportAdapter, seen = new WeakSet<object>()): boolean {
   if (seen.has(adapter)) return false
   seen.add(adapter)
-  if (hasDeleteTrace(adapter)) return true
-  return childAdapters(adapter as AdapterWrapperShape).some(child => hasDeleteTraceSupport(child, seen))
+  const children = childAdapters(adapter as AdapterWrapperShape)
+  if (children.length > 0) return children.every(child => hasDeleteTraceSupport(child, seen))
+  return hasDeleteTrace(adapter)
 }
 
 async function deleteTraceFromAdapter(

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -340,7 +340,8 @@ function redactNestedTranscriptValues(
     for (const [key, nestedValue] of value.entries()) {
       const field = typeof key === 'string' ? classifyTranscriptField(key) : undefined
       if (field && !policy.retainedFields[field]) continue
-      retained.set(cloneValue(key), field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
+      const retainedKey = typeof key === 'string' ? cloneValue(key) : redactNestedTranscriptValues(key, policy, seen)
+      retained.set(retainedKey, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
     }
     return retained
   }
@@ -379,6 +380,7 @@ function classifyContextualTranscriptField(record: Record<string, unknown>, key:
   const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
   if ((recordType === 'toolresult' || recordRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
+  if (recordType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
   if (isPromptBlockContentField(recordType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }
@@ -482,6 +484,7 @@ function redactProviderMessageValue(
 
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
   if ((messageType === 'toolresult' || messageRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
+  if (messageType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
   if (isPromptBlockContentField(messageType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }
@@ -489,7 +492,7 @@ function classifyProviderMessageField(messageType: string, messageRole: string, 
 function isPromptBlockContentField(messageType: string, key: string): boolean {
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
   if ((messageType === 'textdelta' || messageType === 'outputtextdelta') && normalizedKey === 'text') return true
-  if (messageType === 'inputjsondelta' && normalizedKey === 'partialjson') return true
+  if (messageType === 'thinkingdelta' && normalizedKey === 'thinking') return true
   if (
     isMultimodalPromptBlockType(messageType) &&
     MULTIMODAL_PROMPT_CONTENT_KEYS.has(normalizedKey)

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -76,7 +76,19 @@ const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', '
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
 const SUMMARY_KEYS = new Set(['summary', 'summaries'])
-const NON_TRANSCRIPT_TOKEN_KEYS = new Set(['prompttokens', 'completiontokens', 'totaltokens'])
+const NON_TRANSCRIPT_TOKEN_KEYS = new Set([
+  'prompttokens',
+  'prompttokencount',
+  'prompttokenscount',
+  'prompttokensdetails',
+  'completiontokens',
+  'completiontokencount',
+  'completiontokenscount',
+  'completiontokensdetails',
+  'totaltokens',
+  'totaltokencount',
+  'totaltokenscount',
+])
 const CHAT_TRANSCRIPT_KEYS = new Set(['message', 'messages', 'content', 'contents'])
 
 export class TranscriptRetentionAdapter implements ExportAdapter {
@@ -340,10 +352,13 @@ function redactNestedTranscriptValues(
   }
   if (value instanceof Date) return new Date(value.getTime())
   if (value instanceof URL) return cloneValue(value)
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return cloneValue(value)
   if (!isPlainRecord(value)) {
     if (hasCustomToJSON(value)) {
       seen.set(value, DROPPED)
-      return redactNestedTranscriptValues(value.toJSON(), policy, seen)
+      const retained = redactNestedTranscriptValues(value.toJSON(), policy, seen)
+      seen.set(value, retained)
+      return retained
     }
     return shouldRedactEnumerableObject(value)
       ? redactEnumerableObject(value, policy, seen)
@@ -364,7 +379,7 @@ function classifyContextualTranscriptField(record: Record<string, unknown>, key:
   const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
   if ((recordType === 'toolresult' || recordRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
-  if (recordType === 'text' && key === 'text') return 'prompts'
+  if (isPromptBlockContentField(recordType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }
 
@@ -467,8 +482,16 @@ function redactProviderMessageValue(
 
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
   if ((messageType === 'toolresult' || messageRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
-  if (messageType === 'text' && key === 'text') return 'prompts'
+  if (isPromptBlockContentField(messageType, key)) return 'prompts'
   return classifyTranscriptField(key)
+}
+
+function isPromptBlockContentField(messageType: string, key: string): boolean {
+  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  return (
+    ((messageType === 'text' || messageType === 'inputtext') && normalizedKey === 'text') ||
+    ((messageType === 'imageurl' || messageType === 'inputimage') && (normalizedKey === 'imageurl' || normalizedKey === 'url'))
+  )
 }
 
 function redactEnumerableObject(

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -73,7 +73,7 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
   summaries: true,
 })
 
-const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts', 'inputtext', 'outputtext', 'completion', 'completions', 'generation', 'generations', 'inlinedata'])
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts', 'inputtext', 'outputtext', 'completion', 'completions', 'generation', 'generations', 'inlinedata', 'reasoning', 'reasoningcontent', 'thinking'])
 const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
@@ -376,10 +376,10 @@ function redactNestedTranscriptValues(
 
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
-  const recordType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
-  const recordRole = typeof value['role'] === 'string' ? value['role'].replace(/[_-]/g, '').toLowerCase() : ''
+  const recordType = typeof value['type'] === 'string' ? value['type'].replace(/[_.-]/g, '').toLowerCase() : ''
+  const recordRole = typeof value['role'] === 'string' ? value['role'].replace(/[_.-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
-    if (recordType === 'contentblockdelta' && key.replace(/[_-]/g, '').toLowerCase() === 'delta') {
+    if (recordType === 'contentblockdelta' && key.replace(/[_.-]/g, '').toLowerCase() === 'delta') {
       setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
       continue
     }
@@ -396,11 +396,11 @@ function redactNestedTranscriptValues(
 }
 
 function classifyContextualTranscriptField(record: Record<string, unknown>, key: string): TranscriptField | undefined {
-  const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
-  const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
-  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_.-]/g, '').toLowerCase() : ''
+  const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_.-]/g, '').toLowerCase() : ''
+  const normalizedKey = key.replace(/[_.-]/g, '').toLowerCase()
   if (isToolOutputMessageField(recordType, recordRole, key)) return 'toolOutputs'
-  if ((recordType === 'tooluse' || recordType === 'functioncall') && normalizedKey === 'input') return 'toolInputs'
+  if (isToolUseType(recordType) && normalizedKey === 'input') return 'toolInputs'
   if ((recordRole === 'user' || recordRole === 'system' || recordRole === 'assistant' || recordRole === 'model') && (normalizedKey === 'text' || normalizedKey === 'parts')) return 'prompts'
   if (recordType === 'inputjsondelta' && normalizedKey === 'partialjson') return 'toolInputs'
   if (isPromptBlockContentField(recordType, key)) return 'prompts'
@@ -408,7 +408,7 @@ function classifyContextualTranscriptField(record: Record<string, unknown>, key:
 }
 
 function classifyTranscriptField(key: string): TranscriptField | undefined {
-  const normalized = key.replace(/[_-]/g, '').toLowerCase()
+  const normalized = key.replace(/[_.-]/g, '').toLowerCase()
   if (NON_TRANSCRIPT_TOKEN_KEYS.has(normalized)) return undefined
   if (CHAT_TRANSCRIPT_KEYS.has(normalized)) return 'prompts'
   if (
@@ -452,7 +452,7 @@ function classifyTranscriptField(key: string): TranscriptField | undefined {
 }
 
 function isChatTranscriptContainerKey(key: string): boolean {
-  return CHAT_TRANSCRIPT_KEYS.has(key.replace(/[_-]/g, '').toLowerCase())
+  return CHAT_TRANSCRIPT_KEYS.has(key.replace(/[_.-]/g, '').toLowerCase())
 }
 
 function redactValue(value: unknown, policy: ResolvedTranscriptRetentionPolicy): unknown {
@@ -492,10 +492,10 @@ function redactProviderMessageValue(
 
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
-  const messageType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
-  const messageRole = typeof value['role'] === 'string' ? value['role'].replace(/[_-]/g, '').toLowerCase() : ''
+  const messageType = typeof value['type'] === 'string' ? value['type'].replace(/[_.-]/g, '').toLowerCase() : ''
+  const messageRole = typeof value['role'] === 'string' ? value['role'].replace(/[_.-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
-    if (messageType === 'contentblockdelta' && key.replace(/[_-]/g, '').toLowerCase() === 'delta') {
+    if (messageType === 'contentblockdelta' && key.replace(/[_.-]/g, '').toLowerCase() === 'delta') {
       setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
       continue
     }
@@ -521,7 +521,7 @@ function redactProviderStreamDeltaValue(
 
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
-  const deltaType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
+  const deltaType = typeof value['type'] === 'string' ? value['type'].replace(/[_.-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
     const contextualField = classifyProviderStreamDeltaField(deltaType, key)
     if (contextualField && !policy.retainedFields[contextualField]) continue
@@ -535,7 +535,7 @@ function redactProviderStreamDeltaValue(
 }
 
 function classifyProviderStreamDeltaField(deltaType: string, key: string): TranscriptField | undefined {
-  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  const normalizedKey = key.replace(/[_.-]/g, '').toLowerCase()
   if ((deltaType === '' || deltaType === 'textdelta' || deltaType === 'outputtextdelta') && normalizedKey === 'text') return 'prompts'
   if ((deltaType === '' || deltaType === 'inputjsondelta') && normalizedKey === 'partialjson') return 'toolInputs'
   if ((deltaType === '' || deltaType === 'thinkingdelta') && normalizedKey === 'thinking') return 'prompts'
@@ -543,19 +543,23 @@ function classifyProviderStreamDeltaField(deltaType: string, key: string): Trans
 }
 
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
-  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  const normalizedKey = key.replace(/[_.-]/g, '').toLowerCase()
   if (isToolOutputMessageField(messageType, messageRole, key)) return 'toolOutputs'
-  if ((messageType === 'tooluse' || messageType === 'functioncall') && normalizedKey === 'input') return 'toolInputs'
-  if (messageType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
+  if (isToolUseType(messageType) && normalizedKey === 'input') return 'toolInputs'
+  if (messageType === 'inputjsondelta' && key.replace(/[_.-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
   if ((messageRole === 'user' || messageRole === 'system' || messageRole === 'assistant' || messageRole === 'model') && (normalizedKey === 'parts' || normalizedKey === 'text')) return 'prompts'
   if (isPromptBlockContentField(messageType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }
 
 function isToolOutputMessageField(messageType: string, messageRole: string, key: string): boolean {
-  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  const normalizedKey = key.replace(/[_.-]/g, '').toLowerCase()
   return (messageType === 'toolresult' || messageRole === 'tool' || messageRole === 'function') &&
     (normalizedKey === 'content' || normalizedKey === 'text' || normalizedKey === 'parts')
+}
+
+function isToolUseType(messageType: string): boolean {
+  return messageType === 'functioncall' || messageType.endsWith('tooluse') || messageType.includes('tooluse')
 }
 
 function isRawRetention(policy: ResolvedTranscriptRetentionPolicy): boolean {
@@ -563,8 +567,8 @@ function isRawRetention(policy: ResolvedTranscriptRetentionPolicy): boolean {
 }
 
 function isPromptBlockContentField(messageType: string, key: string): boolean {
-  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
-  if ((messageType === 'textdelta' || messageType === 'outputtextdelta') && normalizedKey === 'text') return true
+  const normalizedKey = key.replace(/[_.-]/g, '').toLowerCase()
+  if (((messageType === 'textdelta' || messageType === 'outputtextdelta' || messageType.endsWith('textdelta') || messageType.includes('outputtext')) && (normalizedKey === 'text' || normalizedKey === 'delta'))) return true
   if ((messageType === 'thinkingdelta' || messageType === 'thinking') && normalizedKey === 'thinking') return true
   if (
     isMultimodalPromptBlockType(messageType) &&
@@ -613,8 +617,8 @@ function redactEnumerableObject(
   for (const [key, nestedValue] of Object.entries(value)) {
     const field = classifyContextualTranscriptField(record, key)
     if (field && !policy.retainedFields[field]) continue
-    const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
-    const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
+    const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_.-]/g, '').toLowerCase() : ''
+    const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_.-]/g, '').toLowerCase() : ''
     const retainedValue = field === 'toolOutputs' && isRawRetention(policy) && isToolOutputMessageField(recordType, recordRole, key)
       ? cloneValue(nestedValue, seen)
       : field

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -91,7 +91,7 @@ const NON_TRANSCRIPT_TOKEN_KEYS = new Set([
   'totaltokencount',
   'totaltokenscount',
 ])
-const CHAT_TRANSCRIPT_KEYS = new Set(['message', 'messages', 'content', 'contents'])
+const CHAT_TRANSCRIPT_KEYS = new Set(['message', 'messages', 'content', 'contents', 'parts'])
 
 export class TranscriptRetentionAdapter implements ExportAdapter {
   private readonly inner: ExportAdapter
@@ -465,6 +465,9 @@ function redactFieldValue(
       return retained
     }
     if (value !== null && typeof value === 'object') return redactNestedTranscriptValues(value, policy, seen)
+  }
+  if (field === 'toolOutputs' && (policy.mode === 'raw' || policy.redactionLevel === 'none')) {
+    return cloneValue(value, seen)
   }
   if ((policy.mode === 'raw' || policy.redactionLevel === 'none') && value !== null && typeof value === 'object') {
     if (field === 'toolOutputs') return cloneValue(value)

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -73,7 +73,7 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
   summaries: true,
 })
 
-const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts'])
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts', 'completion', 'completions', 'generation', 'generations', 'inlinedata'])
 const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
@@ -400,6 +400,8 @@ function classifyContextualTranscriptField(record: Record<string, unknown>, key:
   const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
   if (isToolOutputMessageField(recordType, recordRole, key)) return 'toolOutputs'
+  if ((recordType === 'tooluse' || recordType === 'functioncall') && normalizedKey === 'input') return 'toolInputs'
+  if ((recordRole === 'user' || recordRole === 'system' || recordRole === 'assistant' || recordRole === 'model') && (normalizedKey === 'text' || normalizedKey === 'parts')) return 'prompts'
   if (recordType === 'inputjsondelta' && normalizedKey === 'partialjson') return 'toolInputs'
   if (isPromptBlockContentField(recordType, key)) return 'prompts'
   return classifyTranscriptField(key)
@@ -543,8 +545,9 @@ function classifyProviderStreamDeltaField(deltaType: string, key: string): Trans
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
   if (isToolOutputMessageField(messageType, messageRole, key)) return 'toolOutputs'
+  if ((messageType === 'tooluse' || messageType === 'functioncall') && normalizedKey === 'input') return 'toolInputs'
   if (messageType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
-  if ((messageRole === 'user' || messageRole === 'system' || messageRole === 'assistant' || messageRole === 'model') && normalizedKey === 'parts') return 'prompts'
+  if ((messageRole === 'user' || messageRole === 'system' || messageRole === 'assistant' || messageRole === 'model') && (normalizedKey === 'parts' || normalizedKey === 'text')) return 'prompts'
   if (isPromptBlockContentField(messageType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }
@@ -562,7 +565,7 @@ function isRawRetention(policy: ResolvedTranscriptRetentionPolicy): boolean {
 function isPromptBlockContentField(messageType: string, key: string): boolean {
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
   if ((messageType === 'textdelta' || messageType === 'outputtextdelta') && normalizedKey === 'text') return true
-  if (messageType === 'thinkingdelta' && normalizedKey === 'thinking') return true
+  if ((messageType === 'thinkingdelta' || messageType === 'thinking') && normalizedKey === 'thinking') return true
   if (
     isMultimodalPromptBlockType(messageType) &&
     MULTIMODAL_PROMPT_CONTENT_KEYS.has(normalizedKey)

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -39,6 +39,8 @@ export interface ResolvedTranscriptRetentionPolicy {
 
 export interface TranscriptRetentionPolicyReport extends ResolvedTranscriptRetentionPolicy {
   readonly storesRawTranscriptContent: boolean
+  readonly cleanupRemovesStoredTraces: boolean
+  readonly cleanupWarning?: string
   readonly expiresAt?: number
 }
 
@@ -71,7 +73,7 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
   summaries: true,
 })
 
-const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'goal', 'goals', 'transcript', 'transcripts'])
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts'])
 const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
@@ -166,7 +168,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   describePolicy(): TranscriptRetentionPolicyReport {
-    return describeTranscriptRetentionPolicy(this.policy, this.now)
+    return describeTranscriptRetentionPolicy(this.policy, this.now, hasDeleteTraceSupport(this.inner))
   }
 
   async cleanupExpired(): Promise<string[]> {
@@ -254,11 +256,17 @@ export function resolveTranscriptRetentionPolicy(
 export function describeTranscriptRetentionPolicy(
   policy: TranscriptRetentionPolicy = {},
   now: () => number = policy.now ?? Date.now,
+  cleanupRemovesStoredTraces = true,
 ): TranscriptRetentionPolicyReport {
   const resolved = resolveTranscriptRetentionPolicy(policy)
+  const storesRawTranscriptContent = resolved.mode !== 'disabled' && (resolved.mode === 'raw' || resolved.redactionLevel === 'none')
   return Object.freeze({
     ...resolved,
-    storesRawTranscriptContent: resolved.mode !== 'disabled' && (resolved.mode === 'raw' || resolved.redactionLevel === 'none'),
+    storesRawTranscriptContent,
+    cleanupRemovesStoredTraces,
+    ...(storesRawTranscriptContent && !cleanupRemovesStoredTraces
+      ? { cleanupWarning: 'Wrapped adapter does not support deleteTrace; TTL cleanup only hides traces through this retention wrapper and cannot remove already-exported raw transcripts from that backend.' }
+      : {}),
     ...(resolved.ttlMs > 0 ? { expiresAt: now() + resolved.ttlMs } : {}),
   })
 }
@@ -368,7 +376,12 @@ function redactNestedTranscriptValues(
 
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
+  const recordType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
+    if (recordType === 'contentblockdelta' && key.replace(/[_-]/g, '').toLowerCase() === 'delta') {
+      setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
+      continue
+    }
     const field = classifyContextualTranscriptField(value, key)
     if (field && !policy.retainedFields[field]) continue
     setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
@@ -471,6 +484,10 @@ function redactProviderMessageValue(
   const messageType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const messageRole = typeof value['role'] === 'string' ? value['role'].replace(/[_-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
+    if (messageType === 'contentblockdelta' && key.replace(/[_-]/g, '').toLowerCase() === 'delta') {
+      setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
+      continue
+    }
     const contextualField = classifyProviderMessageField(messageType, messageRole, key)
     if (contextualField && !policy.retainedFields[contextualField]) continue
     setRecordValue(
@@ -480,6 +497,37 @@ function redactProviderMessageValue(
     )
   }
   return retained
+}
+
+function redactProviderStreamDeltaValue(
+  value: unknown,
+  policy: ResolvedTranscriptRetentionPolicy,
+  seen: WeakMap<object, unknown>,
+): unknown {
+  if (!isPlainRecordValue(value)) return redactNestedTranscriptValues(value, policy, seen)
+  if (seen.has(value)) return seen.get(value)
+
+  const retained: Record<string, unknown> = {}
+  seen.set(value, retained)
+  const deltaType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const contextualField = classifyProviderStreamDeltaField(deltaType, key)
+    if (contextualField && !policy.retainedFields[contextualField]) continue
+    setRecordValue(
+      retained,
+      key,
+      contextualField ? redactFieldValue(nestedValue, contextualField, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen),
+    )
+  }
+  return retained
+}
+
+function classifyProviderStreamDeltaField(deltaType: string, key: string): TranscriptField | undefined {
+  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  if ((deltaType === '' || deltaType === 'textdelta' || deltaType === 'outputtextdelta') && normalizedKey === 'text') return 'prompts'
+  if (deltaType === 'inputjsondelta' && normalizedKey === 'partialjson') return 'toolInputs'
+  if (deltaType === 'thinkingdelta' && normalizedKey === 'thinking') return 'prompts'
+  return classifyProviderMessageField(deltaType, '', key)
 }
 
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
@@ -498,7 +546,7 @@ function isPromptBlockContentField(messageType: string, key: string): boolean {
     MULTIMODAL_PROMPT_CONTENT_KEYS.has(normalizedKey)
   ) return true
   return (
-    ((messageType === 'text' || messageType === 'inputtext') && normalizedKey === 'text') ||
+    ((messageType === 'text' || messageType === 'inputtext' || messageType === 'outputtext') && normalizedKey === 'text') ||
     ((messageType === 'imageurl' || messageType === 'inputimage') && (normalizedKey === 'imageurl' || normalizedKey === 'url'))
   )
 }
@@ -582,6 +630,13 @@ function getTraceExpiry(trace: Trace, ttlMs: number, retainedAt?: number): numbe
 
 function hasDeleteTrace(adapter: ExportAdapter): adapter is DeletableAdapter {
   return typeof (adapter as Partial<DeletableAdapter>).deleteTrace === 'function'
+}
+
+function hasDeleteTraceSupport(adapter: ExportAdapter, seen = new WeakSet<object>()): boolean {
+  if (seen.has(adapter)) return false
+  seen.add(adapter)
+  if (hasDeleteTrace(adapter)) return true
+  return childAdapters(adapter as AdapterWrapperShape).some(child => hasDeleteTraceSupport(child, seen))
 }
 
 async function deleteTraceFromAdapter(

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -332,6 +332,7 @@ function redactNestedTranscriptValues(
   value: unknown,
   policy: ResolvedTranscriptRetentionPolicy,
   seen: WeakMap<object, unknown>,
+  parentType = '',
 ): unknown {
   if (value === null || typeof value !== 'object') return value
   if (value instanceof Error) return policy.retainedFields.errors ? redactValue(value, policy) : DROPPED
@@ -382,9 +383,10 @@ function redactNestedTranscriptValues(
       setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
       continue
     }
-    const field = classifyContextualTranscriptField(value, key)
+    const field = classifyContextualTranscriptField(value, key, parentType)
     if (field && !policy.retainedFields[field]) continue
-    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
+    const nestedParentType = key.replace(/[_-]/g, '').toLowerCase() === 'delta' ? recordType : ''
+    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen, nestedParentType))
   }
   return retained
 }
@@ -392,8 +394,9 @@ function redactNestedTranscriptValues(
 function classifyContextualTranscriptField(record: Record<string, unknown>, key: string): TranscriptField | undefined {
   const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
-  if ((recordType === 'toolresult' || recordRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
-  if (recordType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
+  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  if ((recordType === 'toolresult' || recordRole === 'tool') && (normalizedKey === 'content' || normalizedKey === 'text')) return 'toolOutputs'
+  if (recordType === 'inputjsondelta' && normalizedKey === 'partialjson') return 'toolInputs'
   if (isPromptBlockContentField(recordType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }
@@ -525,8 +528,8 @@ function redactProviderStreamDeltaValue(
 function classifyProviderStreamDeltaField(deltaType: string, key: string): TranscriptField | undefined {
   const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
   if ((deltaType === '' || deltaType === 'textdelta' || deltaType === 'outputtextdelta') && normalizedKey === 'text') return 'prompts'
-  if (deltaType === 'inputjsondelta' && normalizedKey === 'partialjson') return 'toolInputs'
-  if (deltaType === 'thinkingdelta' && normalizedKey === 'thinking') return 'prompts'
+  if ((deltaType === '' || deltaType === 'inputjsondelta') && normalizedKey === 'partialjson') return 'toolInputs'
+  if ((deltaType === '' || deltaType === 'thinkingdelta') && normalizedKey === 'thinking') return 'prompts'
   return classifyProviderMessageField(deltaType, '', key)
 }
 

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -153,7 +153,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   describePolicy(): TranscriptRetentionPolicyReport {
-    return describeTranscriptRetentionPolicy(this.policy)
+    return describeTranscriptRetentionPolicy(this.policy, this.now)
   }
 
   async cleanupExpired(): Promise<string[]> {
@@ -236,12 +236,13 @@ export function resolveTranscriptRetentionPolicy(
 
 export function describeTranscriptRetentionPolicy(
   policy: TranscriptRetentionPolicy = {},
+  now: () => number = policy.now ?? Date.now,
 ): TranscriptRetentionPolicyReport {
   const resolved = resolveTranscriptRetentionPolicy(policy)
   return Object.freeze({
     ...resolved,
     storesRawTranscriptContent: resolved.mode === 'raw' || resolved.redactionLevel === 'none',
-    ...(resolved.ttlMs > 0 ? { expiresAt: Date.now() + resolved.ttlMs } : {}),
+    ...(resolved.ttlMs > 0 ? { expiresAt: now() + resolved.ttlMs } : {}),
   })
 }
 
@@ -348,7 +349,14 @@ function classifyTranscriptField(key: string): TranscriptField | undefined {
   const normalized = key.replace(/[_-]/g, '').toLowerCase()
   if (NON_TRANSCRIPT_TOKEN_KEYS.has(normalized)) return undefined
   if (CHAT_TRANSCRIPT_KEYS.has(normalized)) return 'prompts'
-  if (PROMPT_KEYS.has(normalized) || normalized.includes('prompt') || normalized.endsWith('goal') || normalized.endsWith('goals')) return 'prompts'
+  if (
+    PROMPT_KEYS.has(normalized) ||
+    normalized.includes('prompt') ||
+    normalized.includes('instruction') ||
+    normalized.includes('transcript') ||
+    normalized.endsWith('goal') ||
+    normalized.endsWith('goals')
+  ) return 'prompts'
   if (
     TOOL_INPUT_KEYS.has(normalized) ||
     normalized === 'query' ||
@@ -409,8 +417,9 @@ function redactProviderMessageValue(
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
   const messageType = typeof value['type'] === 'string' ? value['type'].replace(/[_-]/g, '').toLowerCase() : ''
+  const messageRole = typeof value['role'] === 'string' ? value['role'].replace(/[_-]/g, '').toLowerCase() : ''
   for (const [key, nestedValue] of Object.entries(value)) {
-    const contextualField = messageType === 'toolresult' && key === 'content' ? 'toolOutputs' : classifyTranscriptField(key)
+    const contextualField = (messageType === 'toolresult' || messageRole === 'tool') && key === 'content' ? 'toolOutputs' : classifyTranscriptField(key)
     if (contextualField && !policy.retainedFields[contextualField]) continue
     setRecordValue(
       retained,

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -73,7 +73,7 @@ const DEFAULT_FIELDS: TranscriptRetainedFields = Object.freeze({
   summaries: true,
 })
 
-const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts', 'completion', 'completions', 'generation', 'generations', 'inlinedata'])
+const PROMPT_KEYS = new Set(['prompt', 'prompts', 'systemprompt', 'userprompt', 'developerprompt', 'instructions', 'additionalcontext', 'operatorcontext', 'context', 'goal', 'goals', 'transcript', 'transcripts', 'inputtext', 'outputtext', 'completion', 'completions', 'generation', 'generations', 'inlinedata'])
 const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'arguments', 'args', 'parameters', 'params', 'stdin'])
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -212,7 +212,8 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
     this.retained.delete(traceId)
     this.expiredTraceIds.add(traceId)
     try {
-      await deleteTraceFromAdapter(this.inner, traceId)
+      const deleted = await deleteTraceFromAdapter(this.inner, traceId)
+      if (deleted) this.expiredTraceIds.delete(traceId)
       this.deleteFailedTraceIds.delete(traceId)
     } catch (error) {
       this.deleteFailedTraceIds.add(traceId)
@@ -297,7 +298,7 @@ function retainMetadata(
   for (const [key, value] of Object.entries(metadata)) {
     const field = classifyContextualTranscriptField(metadata, key)
     if (field && !policy.retainedFields[field]) {
-      if (field === 'prompts' && value !== null && typeof value === 'object') {
+      if (field === 'prompts' && isChatTranscriptContainerKey(key) && value !== null && typeof value === 'object') {
         setRecordValue(retained, key, redactFieldValue(value, field, policy, seen))
       }
       continue
@@ -338,7 +339,12 @@ function redactNestedTranscriptValues(
     return retained
   }
   if (value instanceof Date) return new Date(value.getTime())
+  if (value instanceof URL) return cloneValue(value)
   if (!isPlainRecord(value)) {
+    if (hasCustomToJSON(value)) {
+      seen.set(value, DROPPED)
+      return redactNestedTranscriptValues(value.toJSON(), policy, seen)
+    }
     return shouldRedactEnumerableObject(value)
       ? redactEnumerableObject(value, policy, seen)
       : cloneValue(value)
@@ -400,6 +406,10 @@ function classifyTranscriptField(key: string): TranscriptField | undefined {
   ) return 'errors'
   if (SUMMARY_KEYS.has(normalized) || normalized.includes('summary')) return 'summaries'
   return undefined
+}
+
+function isChatTranscriptContainerKey(key: string): boolean {
+  return CHAT_TRANSCRIPT_KEYS.has(key.replace(/[_-]/g, '').toLowerCase())
 }
 
 function redactValue(value: unknown, policy: ResolvedTranscriptRetentionPolicy): unknown {
@@ -487,6 +497,10 @@ function shouldRedactEnumerableObject(value: object): boolean {
     !(value instanceof Promise) &&
     !(value instanceof WeakMap) &&
     !(value instanceof WeakSet)
+}
+
+function hasCustomToJSON(value: object): value is { toJSON: () => unknown } {
+  return typeof (value as { toJSON?: unknown }).toJSON === 'function'
 }
 
 function redactString(value: string | undefined, policy: ResolvedTranscriptRetentionPolicy): string | undefined {

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -295,8 +295,13 @@ function retainMetadata(
   const seen = new WeakMap<object, unknown>()
   seen.set(metadata, retained)
   for (const [key, value] of Object.entries(metadata)) {
-    const field = classifyTranscriptField(key)
-    if (field && !policy.retainedFields[field]) continue
+    const field = classifyContextualTranscriptField(metadata, key)
+    if (field && !policy.retainedFields[field]) {
+      if (field === 'prompts' && value !== null && typeof value === 'object') {
+        setRecordValue(retained, key, redactFieldValue(value, field, policy, seen))
+      }
+      continue
+    }
     setRecordValue(retained, key, field ? redactFieldValue(value, field, policy, seen) : redactNestedTranscriptValues(value, policy, seen))
   }
   return retained
@@ -373,7 +378,11 @@ function classifyTranscriptField(key: string): TranscriptField | undefined {
     normalized === 'query' ||
     normalized.includes('toolinput') ||
     normalized.includes('toolarg') ||
-    normalized.includes('toolparam')
+    normalized.includes('toolparam') ||
+    normalized === 'inputjson' ||
+    normalized === 'argsjson' ||
+    normalized.endsWith('inputjson') ||
+    normalized.endsWith('argsjson')
   ) return 'toolInputs'
   if (
     TOOL_OUTPUT_KEYS.has(normalized) ||
@@ -413,6 +422,9 @@ function redactFieldValue(
       return retained
     }
     if (value !== null && typeof value === 'object') return redactNestedTranscriptValues(value, policy, seen)
+  }
+  if ((policy.mode === 'raw' || policy.redactionLevel === 'none') && value !== null && typeof value === 'object') {
+    return redactNestedTranscriptValues(value, policy, seen)
   }
   return redactValue(value, policy)
 }

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -332,7 +332,6 @@ function redactNestedTranscriptValues(
   value: unknown,
   policy: ResolvedTranscriptRetentionPolicy,
   seen: WeakMap<object, unknown>,
-  parentType = '',
 ): unknown {
   if (value === null || typeof value !== 'object') return value
   if (value instanceof Error) return policy.retainedFields.errors ? redactValue(value, policy) : DROPPED
@@ -383,10 +382,9 @@ function redactNestedTranscriptValues(
       setRecordValue(retained, key, redactProviderStreamDeltaValue(nestedValue, policy, seen))
       continue
     }
-    const field = classifyContextualTranscriptField(value, key, parentType)
+    const field = classifyContextualTranscriptField(value, key)
     if (field && !policy.retainedFields[field]) continue
-    const nestedParentType = key.replace(/[_-]/g, '').toLowerCase() === 'delta' ? recordType : ''
-    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen, nestedParentType))
+    setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }
   return retained
 }

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -85,6 +85,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   private readonly now: () => number
   private readonly retained = new Map<string, number>()
   private readonly expiredTraceIds = new Set<string>()
+  private readonly deleteFailedTraceIds = new Set<string>()
 
   constructor(options: TranscriptRetentionAdapterOptions) {
     this.inner = options.adapter
@@ -157,25 +158,26 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
   }
 
   async cleanupExpired(): Promise<string[]> {
-    const expired: string[] = []
+    const expired = new Set<string>()
     const now = this.now()
     for (const [traceId, expiresAt] of this.retained.entries()) {
       if (expiresAt > now) continue
-      expired.push(traceId)
+      expired.add(traceId)
       await this.markExpired(traceId)
     }
 
     for (const traceId of await this.inner.listTraceIds()) {
-      if (this.expiredTraceIds.has(traceId)) continue
+      if (expired.has(traceId)) continue
+      if (this.expiredTraceIds.has(traceId) && !this.deleteFailedTraceIds.has(traceId)) continue
       const trace = await this.inner.queryByTraceId(traceId)
       if (!trace) continue
       if (trace.endedAt === undefined && this.retained.has(traceId)) continue
       if (!this.isExpired(trace)) continue
-      expired.push(traceId)
+      expired.add(traceId)
       await this.markExpired(traceId)
     }
 
-    return expired
+    return [...expired]
   }
 
   private async fallbackTraceSummaries(): Promise<TraceSummary[]> {
@@ -211,8 +213,10 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
     this.expiredTraceIds.add(traceId)
     try {
       await deleteTraceFromAdapter(this.inner, traceId)
+      this.deleteFailedTraceIds.delete(traceId)
     } catch (error) {
-      console.warn(`[TranscriptRetentionAdapter] Failed to delete expired trace ${traceId}; keeping it hidden`, error)
+      this.deleteFailedTraceIds.add(traceId)
+      console.warn?.(`[TranscriptRetentionAdapter] Failed to delete expired trace ${traceId}:`, error)
     }
   }
 }
@@ -241,7 +245,7 @@ export function describeTranscriptRetentionPolicy(
   const resolved = resolveTranscriptRetentionPolicy(policy)
   return Object.freeze({
     ...resolved,
-    storesRawTranscriptContent: resolved.mode === 'raw' || resolved.redactionLevel === 'none',
+    storesRawTranscriptContent: resolved.mode !== 'disabled' && (resolved.mode === 'raw' || resolved.redactionLevel === 'none'),
     ...(resolved.ttlMs > 0 ? { expiresAt: now() + resolved.ttlMs } : {}),
   })
 }
@@ -338,11 +342,18 @@ function redactNestedTranscriptValues(
   const retained: Record<string, unknown> = {}
   seen.set(value, retained)
   for (const [key, nestedValue] of Object.entries(value)) {
-    const field = classifyTranscriptField(key)
+    const field = classifyContextualTranscriptField(value, key)
     if (field && !policy.retainedFields[field]) continue
     setRecordValue(retained, key, field ? redactFieldValue(nestedValue, field, policy, seen) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }
   return retained
+}
+
+function classifyContextualTranscriptField(record: Record<string, unknown>, key: string): TranscriptField | undefined {
+  const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
+  const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
+  if ((recordType === 'toolresult' || recordRole === 'tool') && key === 'content') return 'toolOutputs'
+  return classifyTranscriptField(key)
 }
 
 function classifyTranscriptField(key: string): TranscriptField | undefined {

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -467,6 +467,7 @@ function redactFieldValue(
     if (value !== null && typeof value === 'object') return redactNestedTranscriptValues(value, policy, seen)
   }
   if ((policy.mode === 'raw' || policy.redactionLevel === 'none') && value !== null && typeof value === 'object') {
+    if (field === 'toolOutputs') return cloneValue(value)
     return redactNestedTranscriptValues(value, policy, seen)
   }
   return redactValue(value, policy)
@@ -532,8 +533,10 @@ function classifyProviderStreamDeltaField(deltaType: string, key: string): Trans
 }
 
 function classifyProviderMessageField(messageType: string, messageRole: string, key: string): TranscriptField | undefined {
-  if ((messageType === 'toolresult' || messageRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
+  const normalizedKey = key.replace(/[_-]/g, '').toLowerCase()
+  if ((messageType === 'toolresult' || messageRole === 'tool') && (normalizedKey === 'content' || normalizedKey === 'text' || normalizedKey === 'parts')) return 'toolOutputs'
   if (messageType === 'inputjsondelta' && key.replace(/[_-]/g, '').toLowerCase() === 'partialjson') return 'toolInputs'
+  if ((messageRole === 'user' || messageRole === 'system' || messageRole === 'assistant' || messageRole === 'model') && normalizedKey === 'parts') return 'prompts'
   if (isPromptBlockContentField(messageType, key)) return 'prompts'
   return classifyTranscriptField(key)
 }

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -363,7 +363,8 @@ function redactNestedTranscriptValues(
 function classifyContextualTranscriptField(record: Record<string, unknown>, key: string): TranscriptField | undefined {
   const recordType = typeof record['type'] === 'string' ? record['type'].replace(/[_-]/g, '').toLowerCase() : ''
   const recordRole = typeof record['role'] === 'string' ? record['role'].replace(/[_-]/g, '').toLowerCase() : ''
-  if ((recordType === 'toolresult' || recordRole === 'tool') && key === 'content') return 'toolOutputs'
+  if ((recordType === 'toolresult' || recordRole === 'tool') && (key === 'content' || key === 'text')) return 'toolOutputs'
+  if (recordType === 'text' && key === 'text') return 'prompts'
   return classifyTranscriptField(key)
 }
 
@@ -374,6 +375,7 @@ function classifyTranscriptField(key: string): TranscriptField | undefined {
   if (
     PROMPT_KEYS.has(normalized) ||
     normalized.includes('prompt') ||
+    normalized === 'system' ||
     normalized.includes('instruction') ||
     normalized.includes('transcript') ||
     normalized.endsWith('goal') ||

--- a/packages/franken-observer/src/security/transcript-retention.ts
+++ b/packages/franken-observer/src/security/transcript-retention.ts
@@ -74,6 +74,8 @@ const TOOL_INPUT_KEYS = new Set(['toolinput', 'toolinputs', 'input', 'inputs', '
 const TOOL_OUTPUT_KEYS = new Set(['tooloutput', 'tooloutputs', 'output', 'outputs', 'result', 'results', 'response', 'responses', 'stdout', 'stderr'])
 const ERROR_KEYS = new Set(['error', 'errors', 'exception', 'exceptions', 'stack', 'stacktrace', 'errormessage', 'stderr'])
 const SUMMARY_KEYS = new Set(['summary', 'summaries'])
+const NON_TRANSCRIPT_TOKEN_KEYS = new Set(['prompttokens', 'completiontokens', 'totaltokens'])
+const CHAT_TRANSCRIPT_KEYS = new Set(['message', 'messages', 'content', 'contents'])
 
 export class TranscriptRetentionAdapter implements ExportAdapter {
   private readonly inner: ExportAdapter
@@ -109,7 +111,7 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
       await this.markExpired(traceId)
       return null
     }
-    return trace
+    return applyRetentionPolicy(trace, this.policy)
   }
 
   async listTraceIds(): Promise<string[]> {
@@ -138,7 +140,16 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
         const trace = await this.queryByTraceId(summary.id)
         if (!trace) continue
       }
-      if (!(await this.expireStoredTraceIfNeeded(summary.id))) result.push(summary)
+      if (await this.expireStoredTraceIfNeeded(summary.id)) continue
+      const trace = await this.queryByTraceId(summary.id)
+      if (!trace) continue
+      result.push({
+        id: trace.id,
+        goal: trace.goal,
+        status: trace.status,
+        spanCount: trace.spans.length,
+        startedAt: trace.startedAt,
+      })
     }
     return result
   }
@@ -155,6 +166,15 @@ export class TranscriptRetentionAdapter implements ExportAdapter {
       expired.push(traceId)
       await this.markExpired(traceId)
     }
+
+    for (const traceId of await this.inner.listTraceIds()) {
+      if (this.expiredTraceIds.has(traceId)) continue
+      const trace = await this.inner.queryByTraceId(traceId)
+      if (!trace || !this.isExpired(trace)) continue
+      expired.push(traceId)
+      await this.markExpired(traceId)
+    }
+
     return expired
   }
 
@@ -271,7 +291,7 @@ function retainMetadata(
   for (const [key, value] of Object.entries(metadata)) {
     const field = classifyTranscriptField(key)
     if (field && !policy.retainedFields[field]) continue
-    retained[key] = field ? redactValue(value, policy) : redactNestedTranscriptValues(value, policy, seen)
+    setRecordValue(retained, key, field ? redactValue(value, policy) : redactNestedTranscriptValues(value, policy, seen))
   }
   return retained
 }
@@ -302,13 +322,15 @@ function redactNestedTranscriptValues(
   for (const [key, nestedValue] of Object.entries(value)) {
     const field = classifyTranscriptField(key)
     if (field && !policy.retainedFields[field]) continue
-    retained[key] = field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen)
+    setRecordValue(retained, key, field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }
   return retained
 }
 
 function classifyTranscriptField(key: string): TranscriptField | undefined {
   const normalized = key.replace(/[_-]/g, '').toLowerCase()
+  if (NON_TRANSCRIPT_TOKEN_KEYS.has(normalized)) return undefined
+  if (CHAT_TRANSCRIPT_KEYS.has(normalized)) return 'prompts'
   if (PROMPT_KEYS.has(normalized) || normalized.includes('prompt') || normalized.endsWith('goal') || normalized.endsWith('goals')) return 'prompts'
   if (
     TOOL_INPUT_KEYS.has(normalized) ||
@@ -351,9 +373,18 @@ function redactEnumerableObject(
   for (const [key, nestedValue] of Object.entries(value)) {
     const field = classifyTranscriptField(key)
     if (field && !policy.retainedFields[field]) continue
-    retained[key] = field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen)
+    setRecordValue(retained, key, field ? redactValue(nestedValue, policy) : redactNestedTranscriptValues(nestedValue, policy, seen))
   }
   return retained
+}
+
+function setRecordValue(record: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(record, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  })
 }
 
 function shouldRedactEnumerableObject(value: object): boolean {
@@ -455,7 +486,7 @@ function cloneValue(value: unknown, seen = new WeakMap<object, unknown>()): unkn
 
   const cloned: Record<string, unknown> = {}
   seen.set(value, cloned)
-  for (const [key, nested] of Object.entries(value)) cloned[key] = cloneValue(nested, seen)
+  for (const [key, nested] of Object.entries(value)) setRecordValue(cloned, key, cloneValue(nested, seen))
   return cloned
 }
 

--- a/tasks/pr-2237-closeout-progress.md
+++ b/tasks/pr-2237-closeout-progress.md
@@ -2,10 +2,10 @@
 
 - [x] Inspect live PR state and current Codex findings.
 - [x] Create isolated closeout worktree at `/home/pfkagent/dev/closeout-pr-2237` and set git identity.
-- [x] Fix minimal actionable transcript retention redaction/deletion findings.
+- [x] Fix actionable transcript retention redaction/deletion findings from both Codex passes.
 - [x] Add or update regression tests for each fixed behavior.
 - [x] Run targeted franken-observer tests/typecheck/lint/build checks.
-- [ ] Commit and push to PR branch.
+- [ ] Commit and push latest fixes to PR branch.
 - [ ] Trigger/poll fresh Codex review and verify unresolved threads/checks/mergeability.
 - [ ] Merge if gates pass, otherwise block with exact metadata.
 - [ ] Update Kanban worker card with final machine-readable metadata.

--- a/tasks/pr-2237-closeout-progress.md
+++ b/tasks/pr-2237-closeout-progress.md
@@ -1,0 +1,11 @@
+# PR 2237 closeout progress
+
+- [x] Inspect live PR state and current Codex findings.
+- [x] Create isolated closeout worktree at `/home/pfkagent/dev/closeout-pr-2237` and set git identity.
+- [x] Fix minimal actionable transcript retention redaction/deletion findings.
+- [x] Add or update regression tests for each fixed behavior.
+- [x] Run targeted franken-observer tests/typecheck/lint/build checks.
+- [ ] Commit and push to PR branch.
+- [ ] Trigger/poll fresh Codex review and verify unresolved threads/checks/mergeability.
+- [ ] Merge if gates pass, otherwise block with exact metadata.
+- [ ] Update Kanban worker card with final machine-readable metadata.


### PR DESCRIPTION
## Summary
- Add `TranscriptRetentionAdapter` with safe redacted defaults, disabled/raw modes, per-field retention controls, TTL cleanup, and operator-visible policy reporting.
- Cover prompts, tool inputs, tool outputs, errors, summaries, and thought blocks in the retention policy.
- Document the observer retention wrapper and add in-memory trace deletion support for cleanup.

## Test Plan
- `npm run build --workspace @franken/types`
- `npm test --workspace @franken/observer -- src/security/transcript-retention.test.ts`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (passes with 6 pre-existing warnings)
- `npm test --workspace @franken/observer`

Closes #1737
