### PR TITLE
feat(dr): add worker push rollback runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 
 - [ADR-018](docs/adr/018-secret-store-architecture.md) — secret store design and backend selection rationale
 - [ADR-017](docs/adr/017-network-operator-control-plane.md) — network operator control plane and token auth
+- [Worker push rollback runbook](docs/runbooks/worker-push-rollback.md) — dry-run planning and approval-cop routing for failed or bad worker branch publishes
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,7 @@ When deploying Frankenbeast services, apply defense-in-depth controls around the
 - Run services with the least privileges and a dedicated service account.
 - Set explicit project roots (`--base-dir` where supported) so file access and generated artifacts stay inside the intended checkout.
 - Keep human-in-the-loop approval gateways enabled for destructive or high-risk actions.
+- Route worker branch rollback or force-with-lease recovery through the [worker push rollback runbook](docs/runbooks/worker-push-rollback.md) and approval-cop instead of ad-hoc force pushes.
 - Validate webhook signatures and operator tokens before processing privileged requests.
 - Use secure HTTP headers such as Helmet-compatible defaults at the edge or application layer.
 - Apply rate limits to authentication, webhook, chat, and operator-action endpoints.

--- a/docs/runbooks/worker-push-rollback.md
+++ b/docs/runbooks/worker-push-rollback.md
@@ -1,0 +1,133 @@
+# Worker push rollback runbook
+
+Use this runbook when a worker push fails midway, a force-with-lease update is denied, or a worker branch lands commits that must be rolled back before the PR can continue. The goal is to preserve evidence, identify the intended last-good commit, and route the risky rollback through approval-cop/HITL instead of running ad-hoc force pushes.
+
+## Scope and safety rules
+
+- Applies to worker-owned feature/issue branches, not `main` or release tags.
+- Treat branch rewrites as destructive. Never run `git push --force`, `git push --force-with-lease`, branch deletion, or equivalent GitHub mutation directly from a worker shell.
+- Use approval-cop/HITL for the rollback command after evidence and the last-good commit are reviewed.
+- Prefer a normal merge/revert commit when it preserves the PR history safely. Use branch rollback only when the remote branch itself needs to be restored to a prior commit.
+
+## 1. Diagnose the failure shape
+
+Record which case you are handling:
+
+- Push failed before the remote moved.
+- Push failed because the remote moved unexpectedly.
+- Push succeeded, but the branch contains bad commits.
+- PR state is inconsistent with the local worktree after a rebase or takeover.
+
+Capture the local state before making changes:
+
+```bash
+git status --short --branch
+git branch --show-current
+git log --oneline --decorate --graph -20
+```
+
+If a PR already exists, capture it too:
+
+```bash
+gh pr view <pr-number> --repo <owner>/<repo> \
+  --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url
+```
+
+## 2. Capture current remote evidence
+
+Create an evidence directory that can be attached to a handoff or postmortem:
+
+```bash
+mkdir -p rollback-evidence/<branch-slug>
+git ls-remote --heads origin <branch> | tee rollback-evidence/<branch-slug>/remote-head.txt
+gh pr view <pr-number> --repo <owner>/<repo> \
+  --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url \
+  > rollback-evidence/<branch-slug>/pr-state.json
+git log --oneline --decorate --graph <last-good>..origin/<branch> \
+  > rollback-evidence/<branch-slug>/commits-to-remove.txt
+```
+
+The SHA in `remote-head.txt` is the lease value. Do not proceed if it changes between evidence capture and approval.
+
+## 3. Select and verify the last-good ref
+
+Choose the last-good ref from one of these sources, in order of preference:
+
+1. The PR's last reviewed clean head.
+2. The last CI-green commit before the bad publish.
+3. The parent of the first bad commit on the worker branch.
+4. `origin/main` only when the correct recovery is to reset the branch back to the base.
+
+Verify it resolves to a commit:
+
+```bash
+git rev-parse --verify '<last-good>^{commit}'
+git merge-base --is-ancestor '<last-good>' HEAD || true
+```
+
+Keep the resolved SHA in the evidence bundle. If the last-good commit is ambiguous, stop and ask for a human decision on the Kanban card or PR.
+
+## 4. Generate a dry-run rollback plan
+
+The helper prints the exact read-only evidence commands, approval-gated rollback command, and post-rollback verification steps. It never executes the rollback.
+
+```bash
+node scripts/worker-push-rollback-plan.mjs \
+  --dry-run \
+  --branch <branch> \
+  --last-good <last-good-ref> \
+  --repo <owner>/<repo> \
+  --pr <pr-number>
+```
+
+When you already captured the two SHAs, include them so the printed force-with-lease command is concrete:
+
+```bash
+node scripts/worker-push-rollback-plan.mjs \
+  --dry-run \
+  --branch <branch> \
+  --last-good <last-good-ref> \
+  --repo <owner>/<repo> \
+  --pr <pr-number> \
+  --remote-head-oid <current-remote-head-sha> \
+  --last-good-oid <resolved-last-good-sha>
+```
+
+## 5. Route the dangerous command through approval-cop
+
+The dry-run helper will print a command shaped like this:
+
+```bash
+approval-cop run -- git push \
+  --force-with-lease=refs/heads/<branch>:<current-remote-head-sha> \
+  origin \
+  <resolved-last-good-sha>:refs/heads/<branch>
+```
+
+Only submit that command after the evidence bundle and last-good selection are reviewed. Do not reshape the command to bypass approval-cop if approval is denied or pending.
+
+## 6. Verify the rollback
+
+After approval-cop executes the rollback, verify the remote and PR state:
+
+```bash
+git ls-remote --heads origin <branch>
+gh pr view <pr-number> --repo <owner>/<repo> \
+  --json headRefOid,mergeStateStatus,statusCheckRollup,url
+gh pr checks <pr-number> --repo <owner>/<repo>
+```
+
+The remote head must match the resolved last-good SHA. If the PR head changed, any previous CI or Codex clean for the old head is stale; rerun the required gates for the current head.
+
+## 7. Update the PR and postmortem trail
+
+Post a concise PR comment with:
+
+- What failed.
+- The captured remote head before rollback.
+- The selected last-good SHA and why it was selected.
+- The approval-cop command outcome or approval token reference.
+- Verification commands and results.
+- Any follow-up CI/Codex review required for the new head.
+
+If the rollback is part of a Kanban worker recovery, also add a Kanban comment with the same evidence summary before blocking or completing the card.

--- a/docs/runbooks/worker-push-rollback.md
+++ b/docs/runbooks/worker-push-rollback.md
@@ -39,12 +39,13 @@ Create an evidence directory that can be attached to a handoff or postmortem:
 
 ```bash
 mkdir -p rollback-evidence/<branch-slug>
+set -o pipefail
 git ls-remote --heads origin refs/heads/<branch> | tee rollback-evidence/<branch-slug>/remote-head.txt
 gh pr view <pr-number> --repo <owner>/<repo> \
   --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url \
   > rollback-evidence/<branch-slug>/pr-state.json
-git fetch --no-tags origin refs/heads/<branch>:refs/remotes/origin/<branch>
-git log --oneline --decorate --graph <last-good>..refs/remotes/origin/<branch> \
+git fetch --force --no-tags origin +refs/heads/<branch>:refs/fbeast/rollback-evidence/<branch-slug>
+git log --oneline --decorate --graph <last-good>..refs/fbeast/rollback-evidence/<branch-slug> \
   > rollback-evidence/<branch-slug>/commits-to-remove.txt
 ```
 
@@ -62,11 +63,12 @@ Choose the last-good ref from one of these sources, in order of preference:
 Verify it resolves to a commit:
 
 ```bash
-git rev-parse --verify '<last-good>^{commit}'
-git merge-base --is-ancestor '<last-good>' HEAD
+set -o pipefail
+git rev-parse --verify '<last-good>^{commit}' | tee rollback-evidence/<branch-slug>/last-good-oid.txt
+git merge-base --is-ancestor '<last-good>' refs/fbeast/rollback-evidence/<branch-slug>
 ```
 
-If the ancestry check fails, stop: the selected last-good ref is not an ancestor of the current head and needs human review before any rollback command is submitted.
+If the ancestry check fails, stop: the selected last-good ref is not an ancestor of the freshly fetched remote branch head and needs human review before any rollback command is submitted.
 
 Keep the resolved SHA in the evidence bundle. If the last-good commit is ambiguous, stop and ask for a human decision on the Kanban card or PR.
 

--- a/docs/runbooks/worker-push-rollback.md
+++ b/docs/runbooks/worker-push-rollback.md
@@ -7,6 +7,7 @@ Use this runbook when a worker push fails midway, a force-with-lease update is d
 - Applies to worker-owned feature/issue branches, not `main` or release tags.
 - Treat branch rewrites as destructive. Never run `git push --force`, `git push --force-with-lease`, branch deletion, or equivalent GitHub mutation directly from a worker shell.
 - Use approval-cop/HITL for the rollback command after evidence and the last-good commit are reviewed.
+- Ensure `approval-cop` or the repository's approved HITL wrapper is installed and on `PATH` before generating or submitting a rollback plan.
 - Prefer a normal merge/revert commit when it preserves the PR history safely. Use branch rollback only when the remote branch itself needs to be restored to a prior commit.
 
 ## 1. Diagnose the failure shape
@@ -38,14 +39,18 @@ gh pr view <pr-number> --repo <owner>/<repo> \
 Create an evidence directory that can be attached to a handoff or postmortem:
 
 ```bash
+branch='<branch>'
+branch_slug='<branch-slug>'
+branch_ref="refs/heads/${branch}"
+evidence_ref="refs/fbeast/rollback-evidence/${branch_slug}"
 mkdir -p rollback-evidence/<branch-slug>
 set -o pipefail
-git ls-remote --heads origin refs/heads/<branch> | tee rollback-evidence/<branch-slug>/remote-head.txt
+git ls-remote --heads origin "${branch_ref}" | tee rollback-evidence/<branch-slug>/remote-head.txt
 gh pr view <pr-number> --repo <owner>/<repo> \
   --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url \
   > rollback-evidence/<branch-slug>/pr-state.json
-git fetch --force --no-tags origin +refs/heads/<branch>:refs/fbeast/rollback-evidence/<branch-slug>
-git log --oneline --decorate --graph <last-good>..refs/fbeast/rollback-evidence/<branch-slug> \
+git fetch --force --no-tags origin "+${branch_ref}:${evidence_ref}"
+git log --oneline --decorate --graph <last-good>.."${evidence_ref}" \
   > rollback-evidence/<branch-slug>/commits-to-remove.txt
 ```
 
@@ -65,7 +70,7 @@ Verify it resolves to a commit:
 ```bash
 set -o pipefail
 git rev-parse --verify '<last-good>^{commit}' | tee rollback-evidence/<branch-slug>/last-good-oid.txt
-git merge-base --is-ancestor '<last-good>' refs/fbeast/rollback-evidence/<branch-slug>
+git merge-base --is-ancestor '<last-good>' "${evidence_ref}"
 ```
 
 If the ancestry check fails, stop: the selected last-good ref is not an ancestor of the freshly fetched remote branch head and needs human review before any rollback command is submitted.
@@ -110,6 +115,7 @@ approval-cop run -- git push \
 ```
 
 Only submit that command after the evidence bundle and last-good selection are reviewed. Do not reshape the command to bypass approval-cop if approval is denied or pending.
+The helper refuses blank `--approval-cop` overrides because the approval/HITL wrapper is the safety boundary for the rendered force-with-lease command.
 
 ## 6. Verify the rollback
 
@@ -134,5 +140,7 @@ Post a concise PR comment with:
 - The approval-cop command outcome or approval token reference.
 - Verification commands and results.
 - Any follow-up CI/Codex review required for the new head.
+
+Do not post the generated `rollback-comment.md` while it still contains placeholder fields; fill in the approval-cop outcome and verification results first.
 
 If the rollback is part of a Kanban worker recovery, also add a Kanban comment with the same evidence summary before blocking or completing the card.

--- a/docs/runbooks/worker-push-rollback.md
+++ b/docs/runbooks/worker-push-rollback.md
@@ -39,11 +39,12 @@ Create an evidence directory that can be attached to a handoff or postmortem:
 
 ```bash
 mkdir -p rollback-evidence/<branch-slug>
-git ls-remote --heads origin <branch> | tee rollback-evidence/<branch-slug>/remote-head.txt
+git ls-remote --heads origin refs/heads/<branch> | tee rollback-evidence/<branch-slug>/remote-head.txt
 gh pr view <pr-number> --repo <owner>/<repo> \
   --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url \
   > rollback-evidence/<branch-slug>/pr-state.json
-git log --oneline --decorate --graph <last-good>..origin/<branch> \
+git fetch --no-tags origin refs/heads/<branch>:refs/remotes/origin/<branch>
+git log --oneline --decorate --graph <last-good>..refs/remotes/origin/<branch> \
   > rollback-evidence/<branch-slug>/commits-to-remove.txt
 ```
 
@@ -62,8 +63,10 @@ Verify it resolves to a commit:
 
 ```bash
 git rev-parse --verify '<last-good>^{commit}'
-git merge-base --is-ancestor '<last-good>' HEAD || true
+git merge-base --is-ancestor '<last-good>' HEAD
 ```
+
+If the ancestry check fails, stop: the selected last-good ref is not an ancestor of the current head and needs human review before any rollback command is submitted.
 
 Keep the resolved SHA in the evidence bundle. If the last-good commit is ambiguous, stop and ask for a human decision on the Kanban card or PR.
 
@@ -111,7 +114,7 @@ Only submit that command after the evidence bundle and last-good selection are r
 After approval-cop executes the rollback, verify the remote and PR state:
 
 ```bash
-git ls-remote --heads origin <branch>
+git ls-remote --heads origin refs/heads/<branch>
 gh pr view <pr-number> --repo <owner>/<repo> \
   --json headRefOid,mergeStateStatus,statusCheckRollup,url
 gh pr checks <pr-number> --repo <owner>/<repo>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "check:dependabot-supply-chain": "node scripts/check-dependabot-supply-chain.mjs",
+    "dr:worker-push-rollback:dry-run": "node scripts/worker-push-rollback-plan.mjs --dry-run",
     "create:project": "bash scripts/create-project.sh",
     "deps:outdated:major": "node scripts/check-major-outdated.mjs",
     "lint": "node scripts/check-workspace-lint-coverage.mjs && turbo run lint",

--- a/scripts/worker-push-rollback-plan.mjs
+++ b/scripts/worker-push-rollback-plan.mjs
@@ -82,7 +82,7 @@ export function buildRollbackPlan(options) {
   }
 
   const branchRef = `refs/heads/${branch}`;
-  const remoteTrackingRef = `refs/remotes/${remote}/${branch}`;
+  const evidenceRef = `refs/fbeast/rollback-evidence/${sanitizePathSegment(branch)}`;
   const remoteHead = remoteHeadOid?.toLowerCase() ?? '<captured-remote-head-oid>';
   const goodOid = lastGoodOid?.toLowerCase() ?? '<resolved-last-good-oid>';
   const prSelector = pr != null ? String(pr) : '<pr-number>';
@@ -99,10 +99,10 @@ export function buildRollbackPlan(options) {
     evidenceDir,
     readOnlyCapture: [
       ['mkdir', '-p', evidenceDir],
-      ['bash', '-lc', 'git ls-remote --heads "$1" "$2" | tee "$3"', '--', remote, branchRef, remoteHeadPath],
-      ['bash', '-lc', 'git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGood, lastGoodPath],
-      ['git', 'fetch', '--no-tags', remote, `${branchRef}:${remoteTrackingRef}`],
-      ['bash', '-lc', 'git log --oneline --decorate --graph "$1..$2" > "$3"', '--', lastGood, remoteTrackingRef, commitsPath],
+      ['bash', '-lc', 'set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3"', '--', remote, branchRef, remoteHeadPath],
+      ['bash', '-lc', 'set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGood, lastGoodPath],
+      ['git', 'fetch', '--force', '--no-tags', remote, `+${branchRef}:${evidenceRef}`],
+      ['bash', '-lc', 'git merge-base --is-ancestor "$1" "$2" && git log --oneline --decorate --graph "$1..$2" > "$3"', '--', lastGood, evidenceRef, commitsPath],
       ['bash', '-lc', 'gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2"', '--', prSelector, prStatePath, ...repoArgs],
       ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], `## Worker branch rollback postmortem\n\n- Branch: ${process.argv[2]}\n- Remote head before rollback: ${process.argv[3]}\n- Selected last-good commit: ${process.argv[4]}\n- Evidence directory: ${process.argv[5]}\n- Approval-cop outcome/token: <fill before posting>\n- Verification: rerun ls-remote, pr view, checks, and Codex on the new head before merging.\n`)', rollbackCommentPath, branchRef, remoteHead, goodOid, evidenceDir],
     ],

--- a/scripts/worker-push-rollback-plan.mjs
+++ b/scripts/worker-push-rollback-plan.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const SHA_RE = /^[0-9a-f]{40}$/iu;
@@ -63,14 +64,15 @@ export function buildRollbackPlan(options) {
     remote = 'origin',
     repo,
     pr,
-    evidenceDir = `rollback-evidence/${sanitizePathSegment(branch)}`,
+    evidenceDir: providedEvidenceDir,
     approvalCop = 'approval-cop run --',
     remoteHeadOid,
     lastGoodOid,
   } = options;
-
   assertRollbackBranch(branch);
   assertSafeRemote(remote);
+  const branchSlug = buildBranchEvidenceSlug(branch);
+  const evidenceDir = providedEvidenceDir ?? `rollback-evidence/${branchSlug}`;
   if (!lastGood || String(lastGood).startsWith('-')) {
     throw new Error('lastGood must be supplied as a ref or commit to roll back to');
   }
@@ -82,7 +84,7 @@ export function buildRollbackPlan(options) {
   }
 
   const branchRef = `refs/heads/${branch}`;
-  const evidenceRef = `refs/fbeast/rollback-evidence/${sanitizePathSegment(branch)}`;
+  const evidenceRef = `refs/fbeast/rollback-evidence/${branchSlug}`;
   const remoteHead = remoteHeadOid?.toLowerCase() ?? '<captured-remote-head-oid>';
   const goodOid = lastGoodOid?.toLowerCase() ?? '<resolved-last-good-oid>';
   const lastGoodEvidence = lastGoodOid?.toLowerCase() ?? lastGood;
@@ -104,8 +106,8 @@ export function buildRollbackPlan(options) {
     readOnlyCapture: [
       ['mkdir', '-p', evidenceDir],
       ['bash', '-lc', 'set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3"', '--', remote, branchRef, remoteHeadPath],
-      ['bash', '-lc', 'set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGoodEvidence, lastGoodPath],
       ['git', 'fetch', '--force', '--no-tags', remote, `+${branchRef}:${evidenceRef}`],
+      ['bash', '-lc', 'set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGoodEvidence, lastGoodPath],
       ['bash', '-lc', 'git merge-base --is-ancestor "$1" "$2" && git log --oneline --decorate --graph "$1..$2" > "$3"', '--', lastGoodEvidence, evidenceRef, commitsPath],
       ['bash', '-lc', 'gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2"', '--', prSelector, prStatePath, ...repoArgs],
       ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], `## Worker branch rollback postmortem\n\n- Branch: ${process.argv[2]}\n- Remote head before rollback: ${process.argv[3]}\n- Selected last-good commit: ${process.argv[4]}\n- Evidence directory: ${process.argv[5]}\n- Approval-cop outcome/token: <fill before posting>\n- Verification: rerun ls-remote, pr view, checks, and Codex on the new head before merging.\n`)', rollbackCommentPath, branchRef, remoteHead, goodOid, evidenceDir],
@@ -125,7 +127,8 @@ export function buildRollbackPlan(options) {
     postRollbackVerification: [
       ['git', 'ls-remote', '--heads', remote, branchRef],
       ['gh', 'pr', 'view', prSelector, ...repoArgs, '--json', 'headRefOid,mergeStateStatus,statusCheckRollup,url'],
-      ['bash', '-lc', '! grep -q "<fill before posting>" "$1" && gh pr comment "$2" "${@:4}" --body-file "$1"', '--', rollbackCommentPath, prSelector, ...repoArgs],
+      ['gh', 'pr', 'checks', prSelector, ...repoArgs],
+      ['bash', '-lc', '! grep -Eq "<(fill before posting|captured-remote-head-oid|resolved-last-good-oid)>" "$1" && gh pr comment "$2" "${@:3}" --body-file "$1"', '--', rollbackCommentPath, prSelector, ...repoArgs],
     ],
     notes: [
       'This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.',
@@ -170,6 +173,12 @@ function splitCommandPrefix(command) {
 
 function sanitizePathSegment(value) {
   return String(value).replace(/[^A-Za-z0-9._-]+/gu, '-').replace(/^-+|-+$/gu, '') || 'branch';
+}
+
+function buildBranchEvidenceSlug(branch) {
+  const safeBranch = sanitizePathSegment(branch);
+  const branchHash = createHash('sha256').update(branch).digest('hex').slice(0, 8);
+  return `${safeBranch}-${branchHash}`;
 }
 
 function quoteCommand(args) {

--- a/scripts/worker-push-rollback-plan.mjs
+++ b/scripts/worker-push-rollback-plan.mjs
@@ -85,9 +85,13 @@ export function buildRollbackPlan(options) {
   const evidenceRef = `refs/fbeast/rollback-evidence/${sanitizePathSegment(branch)}`;
   const remoteHead = remoteHeadOid?.toLowerCase() ?? '<captured-remote-head-oid>';
   const goodOid = lastGoodOid?.toLowerCase() ?? '<resolved-last-good-oid>';
+  const lastGoodEvidence = lastGoodOid?.toLowerCase() ?? lastGood;
   const prSelector = pr != null ? String(pr) : '<pr-number>';
   const repoArgs = repo ? ['--repo', repo] : [];
   const approvalPrefix = splitCommandPrefix(approvalCop);
+  if (approvalPrefix.length === 0) {
+    throw new Error('approvalCop must name the approval-cop/HITL command; blank overrides are not allowed');
+  }
   const remoteHeadPath = `${evidenceDir}/remote-head.txt`;
   const lastGoodPath = `${evidenceDir}/last-good-oid.txt`;
   const commitsPath = `${evidenceDir}/commits-to-remove.txt`;
@@ -100,9 +104,9 @@ export function buildRollbackPlan(options) {
     readOnlyCapture: [
       ['mkdir', '-p', evidenceDir],
       ['bash', '-lc', 'set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3"', '--', remote, branchRef, remoteHeadPath],
-      ['bash', '-lc', 'set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGood, lastGoodPath],
+      ['bash', '-lc', 'set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGoodEvidence, lastGoodPath],
       ['git', 'fetch', '--force', '--no-tags', remote, `+${branchRef}:${evidenceRef}`],
-      ['bash', '-lc', 'git merge-base --is-ancestor "$1" "$2" && git log --oneline --decorate --graph "$1..$2" > "$3"', '--', lastGood, evidenceRef, commitsPath],
+      ['bash', '-lc', 'git merge-base --is-ancestor "$1" "$2" && git log --oneline --decorate --graph "$1..$2" > "$3"', '--', lastGoodEvidence, evidenceRef, commitsPath],
       ['bash', '-lc', 'gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2"', '--', prSelector, prStatePath, ...repoArgs],
       ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], `## Worker branch rollback postmortem\n\n- Branch: ${process.argv[2]}\n- Remote head before rollback: ${process.argv[3]}\n- Selected last-good commit: ${process.argv[4]}\n- Evidence directory: ${process.argv[5]}\n- Approval-cop outcome/token: <fill before posting>\n- Verification: rerun ls-remote, pr view, checks, and Codex on the new head before merging.\n`)', rollbackCommentPath, branchRef, remoteHead, goodOid, evidenceDir],
     ],
@@ -110,6 +114,7 @@ export function buildRollbackPlan(options) {
       `Confirm ${remoteHead} is the current remote head for ${branchRef}.`,
       `Confirm ${goodOid} is the intended last-good commit for ${lastGood}.`,
       'Preserve read-only command output in the evidence directory before requesting approval.',
+      `Fill ${rollbackCommentPath} with the approval-cop outcome and verification results before posting it to the PR.`,
     ],
     approvalGatedActions: [
       [
@@ -120,12 +125,13 @@ export function buildRollbackPlan(options) {
     postRollbackVerification: [
       ['git', 'ls-remote', '--heads', remote, branchRef],
       ['gh', 'pr', 'view', prSelector, ...repoArgs, '--json', 'headRefOid,mergeStateStatus,statusCheckRollup,url'],
-      ['gh', 'pr', 'comment', prSelector, ...repoArgs, '--body-file', rollbackCommentPath],
+      ['bash', '-lc', '! grep -q "<fill before posting>" "$1" && gh pr comment "$2" "${@:4}" --body-file "$1"', '--', rollbackCommentPath, prSelector, ...repoArgs],
     ],
     notes: [
       'This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.',
       'The force-with-lease value pins the expected remote head so concurrent worker pushes are not overwritten silently.',
       'Run the approval-gated command only through approval-cop/HITL after evidence and last-good selection are reviewed.',
+      'Requires approval-cop, or an equivalent HITL wrapper supplied with --approval-cop, to be installed in PATH; blank approval-cop overrides are rejected.',
     ],
   };
 }

--- a/scripts/worker-push-rollback-plan.mjs
+++ b/scripts/worker-push-rollback-plan.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 const SHA_RE = /^[0-9a-f]{40}$/iu;
 const REF_FORBIDDEN_CHAR_RE = /[\x00-\x20\x7f~^:?*[\\]/u;
 const REF_FORBIDDEN_SEQ_RE = /\.\.|@\{|\/{2,}|^[./]|[./]$|\/\.|\.lock(?:\/|$)/u;
+const PROTECTED_BRANCHES = new Set(['main', 'master', 'trunk', 'develop', 'development', 'staging', 'production']);
 
 export function parseLsRemoteHeads(output) {
   return String(output ?? '')
@@ -39,6 +40,13 @@ export function assertSafeBranch(value, label = 'branch') {
   }
 }
 
+export function assertRollbackBranch(value) {
+  assertSafeBranch(value, 'branch');
+  if (PROTECTED_BRANCHES.has(value) || value.startsWith('release/')) {
+    throw new Error(`branch is protected and cannot be rolled back by this helper: ${value}`);
+  }
+}
+
 export function assertSafeRemote(value) {
   if (typeof value !== 'string' || value.length === 0 || value.length > 2048) {
     throw new Error('remote must be a non-empty git remote name or URL');
@@ -61,7 +69,7 @@ export function buildRollbackPlan(options) {
     lastGoodOid,
   } = options;
 
-  assertSafeBranch(branch, 'branch');
+  assertRollbackBranch(branch);
   assertSafeRemote(remote);
   if (!lastGood || String(lastGood).startsWith('-')) {
     throw new Error('lastGood must be supplied as a ref or commit to roll back to');
@@ -74,21 +82,29 @@ export function buildRollbackPlan(options) {
   }
 
   const branchRef = `refs/heads/${branch}`;
+  const remoteTrackingRef = `refs/remotes/${remote}/${branch}`;
   const remoteHead = remoteHeadOid?.toLowerCase() ?? '<captured-remote-head-oid>';
   const goodOid = lastGoodOid?.toLowerCase() ?? '<resolved-last-good-oid>';
   const prSelector = pr != null ? String(pr) : '<pr-number>';
   const repoArgs = repo ? ['--repo', repo] : [];
   const approvalPrefix = splitCommandPrefix(approvalCop);
+  const remoteHeadPath = `${evidenceDir}/remote-head.txt`;
+  const lastGoodPath = `${evidenceDir}/last-good-oid.txt`;
+  const commitsPath = `${evidenceDir}/commits-to-remove.txt`;
+  const prStatePath = `${evidenceDir}/pr-state.json`;
+  const rollbackCommentPath = `${evidenceDir}/rollback-comment.md`;
 
   return {
     summary: `Dry-run rollback plan for ${branch}`,
     evidenceDir,
     readOnlyCapture: [
       ['mkdir', '-p', evidenceDir],
-      ['git', 'ls-remote', '--heads', remote, branch],
-      ['git', 'rev-parse', '--verify', `${lastGood}^{commit}`],
-      ['git', 'log', '--oneline', '--decorate', '--graph', `${lastGood}..${remote}/${branch}`],
-      ['gh', 'pr', 'view', prSelector, ...repoArgs, '--json', 'number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url'],
+      ['bash', '-lc', 'git ls-remote --heads "$1" "$2" | tee "$3"', '--', remote, branchRef, remoteHeadPath],
+      ['bash', '-lc', 'git rev-parse --verify "$1^{commit}" | tee "$2"', '--', lastGood, lastGoodPath],
+      ['git', 'fetch', '--no-tags', remote, `${branchRef}:${remoteTrackingRef}`],
+      ['bash', '-lc', 'git log --oneline --decorate --graph "$1..$2" > "$3"', '--', lastGood, remoteTrackingRef, commitsPath],
+      ['bash', '-lc', 'gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2"', '--', prSelector, prStatePath, ...repoArgs],
+      ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], `## Worker branch rollback postmortem\n\n- Branch: ${process.argv[2]}\n- Remote head before rollback: ${process.argv[3]}\n- Selected last-good commit: ${process.argv[4]}\n- Evidence directory: ${process.argv[5]}\n- Approval-cop outcome/token: <fill before posting>\n- Verification: rerun ls-remote, pr view, checks, and Codex on the new head before merging.\n`)', rollbackCommentPath, branchRef, remoteHead, goodOid, evidenceDir],
     ],
     requiredDecisions: [
       `Confirm ${remoteHead} is the current remote head for ${branchRef}.`,
@@ -102,9 +118,9 @@ export function buildRollbackPlan(options) {
       ],
     ],
     postRollbackVerification: [
-      ['git', 'ls-remote', '--heads', remote, branch],
+      ['git', 'ls-remote', '--heads', remote, branchRef],
       ['gh', 'pr', 'view', prSelector, ...repoArgs, '--json', 'headRefOid,mergeStateStatus,statusCheckRollup,url'],
-      ['gh', 'pr', 'comment', prSelector, ...repoArgs, '--body-file', `${evidenceDir}/rollback-comment.md`],
+      ['gh', 'pr', 'comment', prSelector, ...repoArgs, '--body-file', rollbackCommentPath],
     ],
     notes: [
       'This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.',

--- a/scripts/worker-push-rollback-plan.mjs
+++ b/scripts/worker-push-rollback-plan.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url';
+
+const SHA_RE = /^[0-9a-f]{40}$/iu;
+const REF_FORBIDDEN_CHAR_RE = /[\x00-\x20\x7f~^:?*[\\]/u;
+const REF_FORBIDDEN_SEQ_RE = /\.\.|@\{|\/{2,}|^[./]|[./]$|\/\.|\.lock(?:\/|$)/u;
+
+export function parseLsRemoteHeads(output) {
+  return String(output ?? '')
+    .split(/\r?\n/u)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [oid, ref, ...extra] = line.split(/\s+/u);
+      if (!SHA_RE.test(oid ?? '') || !ref?.startsWith('refs/heads/') || extra.length > 0) {
+        throw new Error(`Invalid ls-remote head line: ${line}`);
+      }
+      return {
+        oid: oid.toLowerCase(),
+        ref,
+        branch: ref.slice('refs/heads/'.length),
+      };
+    });
+}
+
+export function findRemoteHead(output, branch) {
+  assertSafeBranch(branch, 'branch');
+  const heads = parseLsRemoteHeads(output);
+  return heads.find(head => head.branch === branch) ?? null;
+}
+
+export function assertSafeBranch(value, label = 'branch') {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 255) {
+    throw new Error(`${label} must be a non-empty git branch name`);
+  }
+  if (value.startsWith('-') || REF_FORBIDDEN_CHAR_RE.test(value) || REF_FORBIDDEN_SEQ_RE.test(value)) {
+    throw new Error(`${label} is not a safe git branch name: ${value}`);
+  }
+}
+
+export function assertSafeRemote(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 2048) {
+    throw new Error('remote must be a non-empty git remote name or URL');
+  }
+  if (value.startsWith('-') || /[\x00-\x20\x7f]/u.test(value) || /^[A-Za-z][A-Za-z0-9+.-]*::/u.test(value)) {
+    throw new Error(`remote is not safe for git argv usage: ${value}`);
+  }
+}
+
+export function buildRollbackPlan(options) {
+  const {
+    branch,
+    lastGood,
+    remote = 'origin',
+    repo,
+    pr,
+    evidenceDir = `rollback-evidence/${sanitizePathSegment(branch)}`,
+    approvalCop = 'approval-cop run --',
+    remoteHeadOid,
+    lastGoodOid,
+  } = options;
+
+  assertSafeBranch(branch, 'branch');
+  assertSafeRemote(remote);
+  if (!lastGood || String(lastGood).startsWith('-')) {
+    throw new Error('lastGood must be supplied as a ref or commit to roll back to');
+  }
+  if (remoteHeadOid != null && !SHA_RE.test(remoteHeadOid)) {
+    throw new Error('remoteHeadOid must be a 40-character SHA-1');
+  }
+  if (lastGoodOid != null && !SHA_RE.test(lastGoodOid)) {
+    throw new Error('lastGoodOid must be a 40-character SHA-1');
+  }
+
+  const branchRef = `refs/heads/${branch}`;
+  const remoteHead = remoteHeadOid?.toLowerCase() ?? '<captured-remote-head-oid>';
+  const goodOid = lastGoodOid?.toLowerCase() ?? '<resolved-last-good-oid>';
+  const prSelector = pr != null ? String(pr) : '<pr-number>';
+  const repoArgs = repo ? ['--repo', repo] : [];
+  const approvalPrefix = splitCommandPrefix(approvalCop);
+
+  return {
+    summary: `Dry-run rollback plan for ${branch}`,
+    evidenceDir,
+    readOnlyCapture: [
+      ['mkdir', '-p', evidenceDir],
+      ['git', 'ls-remote', '--heads', remote, branch],
+      ['git', 'rev-parse', '--verify', `${lastGood}^{commit}`],
+      ['git', 'log', '--oneline', '--decorate', '--graph', `${lastGood}..${remote}/${branch}`],
+      ['gh', 'pr', 'view', prSelector, ...repoArgs, '--json', 'number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url'],
+    ],
+    requiredDecisions: [
+      `Confirm ${remoteHead} is the current remote head for ${branchRef}.`,
+      `Confirm ${goodOid} is the intended last-good commit for ${lastGood}.`,
+      'Preserve read-only command output in the evidence directory before requesting approval.',
+    ],
+    approvalGatedActions: [
+      [
+        ...approvalPrefix,
+        'git', 'push', `--force-with-lease=${branchRef}:${remoteHead}`, remote, `${goodOid}:${branchRef}`,
+      ],
+    ],
+    postRollbackVerification: [
+      ['git', 'ls-remote', '--heads', remote, branch],
+      ['gh', 'pr', 'view', prSelector, ...repoArgs, '--json', 'headRefOid,mergeStateStatus,statusCheckRollup,url'],
+      ['gh', 'pr', 'comment', prSelector, ...repoArgs, '--body-file', `${evidenceDir}/rollback-comment.md`],
+    ],
+    notes: [
+      'This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.',
+      'The force-with-lease value pins the expected remote head so concurrent worker pushes are not overwritten silently.',
+      'Run the approval-gated command only through approval-cop/HITL after evidence and last-good selection are reviewed.',
+    ],
+  };
+}
+
+export function renderPlan(plan) {
+  const lines = [
+    `# ${plan.summary}`,
+    '',
+    `Evidence directory: ${plan.evidenceDir}`,
+    '',
+    '## 1. Capture read-only evidence',
+    ...plan.readOnlyCapture.map(command => `- ${quoteCommand(command)}`),
+    '',
+    '## 2. Operator decisions before rollback',
+    ...plan.requiredDecisions.map(item => `- ${item}`),
+    '',
+    '## 3. Approval-gated rollback action',
+    ...plan.approvalGatedActions.map(command => `- ${quoteCommand(command)}`),
+    '',
+    '## 4. Verify and update the PR',
+    ...plan.postRollbackVerification.map(command => `- ${quoteCommand(command)}`),
+    '',
+    '## Safety notes',
+    ...plan.notes.map(item => `- ${item}`),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function splitCommandPrefix(command) {
+  return String(command ?? '')
+    .trim()
+    .split(/\s+/u)
+    .filter(Boolean);
+}
+
+function sanitizePathSegment(value) {
+  return String(value).replace(/[^A-Za-z0-9._-]+/gu, '-').replace(/^-+|-+$/gu, '') || 'branch';
+}
+
+function quoteCommand(args) {
+  return args.map(quoteArg).join(' ');
+}
+
+function quoteArg(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@+,-]+$/u.test(text)) return text;
+  return `'${text.replace(/'/gu, `'"'"'`)}'`;
+}
+
+function parseArgs(argv) {
+  const options = { dryRun: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (value == null || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    switch (arg) {
+      case '--dry-run': options.dryRun = true; break;
+      case '--branch': options.branch = readValue(); break;
+      case '--remote': options.remote = readValue(); break;
+      case '--last-good': options.lastGood = readValue(); break;
+      case '--repo': options.repo = readValue(); break;
+      case '--pr': options.pr = readValue(); break;
+      case '--evidence-dir': options.evidenceDir = readValue(); break;
+      case '--approval-cop': options.approvalCop = readValue(); break;
+      case '--remote-head-oid': options.remoteHeadOid = readValue(); break;
+      case '--last-good-oid': options.lastGoodOid = readValue(); break;
+      case '--help': options.help = true; break;
+      default: throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function usage() {
+  return `Usage: node scripts/worker-push-rollback-plan.mjs --dry-run --branch <branch> --last-good <ref> [--remote origin] [--repo OWNER/REPO] [--pr N]\n\nPrints a rollback runbook plan only. It does not execute git push, force-with-lease, gh comment, or approval-cop commands.`;
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(usage());
+      return;
+    }
+    if (!options.dryRun) {
+      throw new Error('Refusing to run without --dry-run; rollback side effects must go through approval-cop/HITL manually.');
+    }
+    if (!options.branch || !options.lastGood) {
+      throw new Error('--branch and --last-good are required');
+    }
+    const plan = buildRollbackPlan(options);
+    console.log(renderPlan(plan));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(usage());
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/unit/worker-push-rollback-plan.test.ts
+++ b/tests/unit/worker-push-rollback-plan.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  assertRollbackBranch,
   buildRollbackPlan,
   findRemoteHead,
   parseLsRemoteHeads,
@@ -42,6 +43,12 @@ describe('worker push rollback dry-run helper', () => {
     expect(() => parseLsRemoteHeads(`${REMOTE_HEAD}\trefs/tags/v1`)).toThrow(/Invalid ls-remote/u);
   });
 
+  it('rejects protected rollback targets', () => {
+    expect(() => assertRollbackBranch('main')).toThrow(/protected/u);
+    expect(() => assertRollbackBranch('release/2026-07-14')).toThrow(/protected/u);
+    expect(() => assertRollbackBranch('resolve/issue-1720-feat-dr')).not.toThrow();
+  });
+
   it('builds a dry-run plan that routes the dangerous rollback through approval-cop', () => {
     const plan = buildRollbackPlan({
       branch: 'resolve/issue-1720-feat-dr',
@@ -54,7 +61,13 @@ describe('worker push rollback dry-run helper', () => {
     });
 
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'git ls-remote --heads origin resolve/issue-1720-feat-dr',
+      'bash -lc git ls-remote --heads "$1" "$2" | tee "$3" -- origin refs/heads/resolve/issue-1720-feat-dr rollback-evidence/resolve-issue-1720-feat-dr/remote-head.txt',
+    );
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'git fetch --no-tags origin refs/heads/resolve/issue-1720-feat-dr:refs/remotes/origin/resolve/issue-1720-feat-dr',
+    );
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'bash -lc gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2" -- 1720 rollback-evidence/resolve-issue-1720-feat-dr/pr-state.json --repo djm204/frankenbeast',
     );
     expect(plan.approvalGatedActions).toEqual([
       [
@@ -90,7 +103,9 @@ describe('worker push rollback dry-run helper', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('## 1. Capture read-only evidence');
-    expect(result.stdout).toContain('git ls-remote --heads origin resolve/issue-1720-feat-dr');
+    expect(result.stdout).toContain('git ls-remote --heads "$1" "$2" | tee "$3"');
+    expect(result.stdout).toContain('refs/heads/resolve/issue-1720-feat-dr');
+    expect(result.stdout).toContain('rollback-comment.md');
     expect(result.stdout).toContain('approval-cop run -- git push --force-with-lease=refs/heads/resolve/issue-1720-feat-dr:1111111111111111111111111111111111111111 origin 2222222222222222222222222222222222222222:refs/heads/resolve/issue-1720-feat-dr');
     expect(result.stdout).toContain('This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.');
   });

--- a/tests/unit/worker-push-rollback-plan.test.ts
+++ b/tests/unit/worker-push-rollback-plan.test.ts
@@ -13,6 +13,7 @@ const ROOT = resolve(import.meta.dirname, '..', '..');
 const SCRIPT = resolve(ROOT, 'scripts/worker-push-rollback-plan.mjs');
 const REMOTE_HEAD = '1111111111111111111111111111111111111111';
 const LAST_GOOD = '2222222222222222222222222222222222222222';
+const BRANCH_SLUG = 'resolve-issue-1720-feat-dr-42ef95ea';
 
 describe('worker push rollback dry-run helper', () => {
   it('parses ls-remote branch heads and selects the requested branch', () => {
@@ -61,16 +62,22 @@ describe('worker push rollback dry-run helper', () => {
     });
 
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'bash -lc set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3" -- origin refs/heads/resolve/issue-1720-feat-dr rollback-evidence/resolve-issue-1720-feat-dr/remote-head.txt',
+      `bash -lc set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3" -- origin refs/heads/resolve/issue-1720-feat-dr rollback-evidence/${BRANCH_SLUG}/remote-head.txt`,
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'git fetch --force --no-tags origin +refs/heads/resolve/issue-1720-feat-dr:refs/fbeast/rollback-evidence/resolve-issue-1720-feat-dr',
+      `git fetch --force --no-tags origin +refs/heads/resolve/issue-1720-feat-dr:refs/fbeast/rollback-evidence/${BRANCH_SLUG}`,
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      `bash -lc set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2" -- ${LAST_GOOD} rollback-evidence/resolve-issue-1720-feat-dr/last-good-oid.txt`,
+      `bash -lc set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2" -- ${LAST_GOOD} rollback-evidence/${BRANCH_SLUG}/last-good-oid.txt`,
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'bash -lc gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2" -- 1720 rollback-evidence/resolve-issue-1720-feat-dr/pr-state.json --repo djm204/frankenbeast',
+      'bash -lc gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2" -- 1720 rollback-evidence/'
+        + `${BRANCH_SLUG}/pr-state.json --repo djm204/frankenbeast`,
+    );
+    const captureCommands = plan.readOnlyCapture.map(command => command[0] === 'bash' ? command[2] : command.join(' '));
+    expect(captureCommands.indexOf('git fetch --force --no-tags origin +refs/heads/resolve/issue-1720-feat-dr:refs/fbeast/rollback-evidence/resolve-issue-1720-feat-dr')).toBe(-1);
+    expect(plan.readOnlyCapture.findIndex(command => command[0] === 'git' && command[1] === 'fetch')).toBeLessThan(
+      plan.readOnlyCapture.findIndex(command => command[0] === 'bash' && command[2].includes('git rev-parse')),
     );
     expect(plan.approvalGatedActions).toEqual([
       [
@@ -85,7 +92,21 @@ describe('worker push rollback dry-run helper', () => {
       ],
     ]);
     expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
-      'bash -lc ! grep -q "<fill before posting>" "$1" && gh pr comment "$2" "${@:4}" --body-file "$1" -- rollback-evidence/resolve-issue-1720-feat-dr/rollback-comment.md 1720 --repo djm204/frankenbeast',
+      'gh pr checks 1720 --repo djm204/frankenbeast',
+    );
+    expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
+      'bash -lc ! grep -Eq "<(fill before posting|captured-remote-head-oid|resolved-last-good-oid)>" "$1" && gh pr comment "$2" "${@:3}" --body-file "$1" -- rollback-evidence/'
+        + `${BRANCH_SLUG}/rollback-comment.md 1720 --repo djm204/frankenbeast`,
+    );
+  });
+
+  it('uses distinct evidence slugs for branches that sanitize to the same path segment', () => {
+    const slashPlan = buildRollbackPlan({ branch: 'feature/foo/bar', lastGood: 'origin/main' });
+    const dashPlan = buildRollbackPlan({ branch: 'feature/foo-bar', lastGood: 'origin/main' });
+
+    expect(slashPlan.evidenceDir).not.toBe(dashPlan.evidenceDir);
+    expect(slashPlan.readOnlyCapture.map(command => command.join(' ')).join('\n')).not.toContain(
+      'refs/fbeast/rollback-evidence/feature-foo-bar ',
     );
   });
 
@@ -116,8 +137,9 @@ describe('worker push rollback dry-run helper', () => {
     expect(result.stdout).toContain('## 1. Capture read-only evidence');
     expect(result.stdout).toContain('set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3"');
     expect(result.stdout).toContain('refs/heads/resolve/issue-1720-feat-dr');
-    expect(result.stdout).toContain('refs/fbeast/rollback-evidence/resolve-issue-1720-feat-dr');
+    expect(result.stdout).toContain(`refs/fbeast/rollback-evidence/${BRANCH_SLUG}`);
     expect(result.stdout).toContain('rollback-comment.md');
+    expect(result.stdout).toContain('gh pr checks 1720 --repo djm204/frankenbeast');
     expect(result.stdout).toContain('approval-cop run -- git push --force-with-lease=refs/heads/resolve/issue-1720-feat-dr:1111111111111111111111111111111111111111 origin 2222222222222222222222222222222222222222:refs/heads/resolve/issue-1720-feat-dr');
     expect(result.stdout).toContain('This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.');
   });

--- a/tests/unit/worker-push-rollback-plan.test.ts
+++ b/tests/unit/worker-push-rollback-plan.test.ts
@@ -1,0 +1,111 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRollbackPlan,
+  findRemoteHead,
+  parseLsRemoteHeads,
+} from '../../scripts/worker-push-rollback-plan.mjs';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/worker-push-rollback-plan.mjs');
+const REMOTE_HEAD = '1111111111111111111111111111111111111111';
+const LAST_GOOD = '2222222222222222222222222222222222222222';
+
+describe('worker push rollback dry-run helper', () => {
+  it('parses ls-remote branch heads and selects the requested branch', () => {
+    const output = [
+      `${REMOTE_HEAD}\trefs/heads/resolve/issue-1720-feat-dr`,
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/main',
+      '',
+    ].join('\n');
+
+    expect(parseLsRemoteHeads(output)).toEqual([
+      {
+        oid: REMOTE_HEAD,
+        ref: 'refs/heads/resolve/issue-1720-feat-dr',
+        branch: 'resolve/issue-1720-feat-dr',
+      },
+      {
+        oid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ref: 'refs/heads/main',
+        branch: 'main',
+      },
+    ]);
+    expect(findRemoteHead(output, 'resolve/issue-1720-feat-dr')?.oid).toBe(REMOTE_HEAD);
+    expect(findRemoteHead(output, 'missing')).toBeNull();
+  });
+
+  it('rejects malformed remote-ref evidence', () => {
+    expect(() => parseLsRemoteHeads('not-a-sha refs/heads/main')).toThrow(/Invalid ls-remote/u);
+    expect(() => parseLsRemoteHeads(`${REMOTE_HEAD}\trefs/tags/v1`)).toThrow(/Invalid ls-remote/u);
+  });
+
+  it('builds a dry-run plan that routes the dangerous rollback through approval-cop', () => {
+    const plan = buildRollbackPlan({
+      branch: 'resolve/issue-1720-feat-dr',
+      lastGood: 'origin/main',
+      remote: 'origin',
+      repo: 'djm204/frankenbeast',
+      pr: 1720,
+      remoteHeadOid: REMOTE_HEAD,
+      lastGoodOid: LAST_GOOD,
+    });
+
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'git ls-remote --heads origin resolve/issue-1720-feat-dr',
+    );
+    expect(plan.approvalGatedActions).toEqual([
+      [
+        'approval-cop',
+        'run',
+        '--',
+        'git',
+        'push',
+        `--force-with-lease=refs/heads/resolve/issue-1720-feat-dr:${REMOTE_HEAD}`,
+        'origin',
+        `${LAST_GOOD}:refs/heads/resolve/issue-1720-feat-dr`,
+      ],
+    ]);
+    expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
+      'gh pr comment 1720 --repo djm204/frankenbeast --body-file rollback-evidence/resolve-issue-1720-feat-dr/rollback-comment.md',
+    );
+  });
+
+  it('prints planned actions in dry-run mode without executing side effects', () => {
+    const result = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--branch', 'resolve/issue-1720-feat-dr',
+      '--last-good', 'origin/main',
+      '--repo', 'djm204/frankenbeast',
+      '--pr', '1720',
+      '--remote-head-oid', REMOTE_HEAD,
+      '--last-good-oid', LAST_GOOD,
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('## 1. Capture read-only evidence');
+    expect(result.stdout).toContain('git ls-remote --heads origin resolve/issue-1720-feat-dr');
+    expect(result.stdout).toContain('approval-cop run -- git push --force-with-lease=refs/heads/resolve/issue-1720-feat-dr:1111111111111111111111111111111111111111 origin 2222222222222222222222222222222222222222:refs/heads/resolve/issue-1720-feat-dr');
+    expect(result.stdout).toContain('This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.');
+  });
+
+  it('refuses non-dry-run rollback execution', () => {
+    const result = spawnSync(process.execPath, [
+      SCRIPT,
+      '--branch', 'resolve/issue-1720-feat-dr',
+      '--last-good', 'origin/main',
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to run without --dry-run');
+  });
+});

--- a/tests/unit/worker-push-rollback-plan.test.ts
+++ b/tests/unit/worker-push-rollback-plan.test.ts
@@ -67,6 +67,9 @@ describe('worker push rollback dry-run helper', () => {
       'git fetch --force --no-tags origin +refs/heads/resolve/issue-1720-feat-dr:refs/fbeast/rollback-evidence/resolve-issue-1720-feat-dr',
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      `bash -lc set -o pipefail; git rev-parse --verify "$1^{commit}" | tee "$2" -- ${LAST_GOOD} rollback-evidence/resolve-issue-1720-feat-dr/last-good-oid.txt`,
+    );
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
       'bash -lc gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2" -- 1720 rollback-evidence/resolve-issue-1720-feat-dr/pr-state.json --repo djm204/frankenbeast',
     );
     expect(plan.approvalGatedActions).toEqual([
@@ -82,8 +85,16 @@ describe('worker push rollback dry-run helper', () => {
       ],
     ]);
     expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
-      'gh pr comment 1720 --repo djm204/frankenbeast --body-file rollback-evidence/resolve-issue-1720-feat-dr/rollback-comment.md',
+      'bash -lc ! grep -q "<fill before posting>" "$1" && gh pr comment "$2" "${@:4}" --body-file "$1" -- rollback-evidence/resolve-issue-1720-feat-dr/rollback-comment.md 1720 --repo djm204/frankenbeast',
     );
+  });
+
+  it('rejects blank approval-cop overrides', () => {
+    expect(() => buildRollbackPlan({
+      branch: 'resolve/issue-1720-feat-dr',
+      lastGood: 'origin/main',
+      approvalCop: '   ',
+    })).toThrow(/approvalCop/u);
   });
 
   it('prints planned actions in dry-run mode without executing side effects', () => {

--- a/tests/unit/worker-push-rollback-plan.test.ts
+++ b/tests/unit/worker-push-rollback-plan.test.ts
@@ -61,10 +61,10 @@ describe('worker push rollback dry-run helper', () => {
     });
 
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'bash -lc git ls-remote --heads "$1" "$2" | tee "$3" -- origin refs/heads/resolve/issue-1720-feat-dr rollback-evidence/resolve-issue-1720-feat-dr/remote-head.txt',
+      'bash -lc set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3" -- origin refs/heads/resolve/issue-1720-feat-dr rollback-evidence/resolve-issue-1720-feat-dr/remote-head.txt',
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'git fetch --no-tags origin refs/heads/resolve/issue-1720-feat-dr:refs/remotes/origin/resolve/issue-1720-feat-dr',
+      'git fetch --force --no-tags origin +refs/heads/resolve/issue-1720-feat-dr:refs/fbeast/rollback-evidence/resolve-issue-1720-feat-dr',
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
       'bash -lc gh pr view "$1" "${@:3}" --json number,title,state,headRefName,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup,url > "$2" -- 1720 rollback-evidence/resolve-issue-1720-feat-dr/pr-state.json --repo djm204/frankenbeast',
@@ -103,8 +103,9 @@ describe('worker push rollback dry-run helper', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('## 1. Capture read-only evidence');
-    expect(result.stdout).toContain('git ls-remote --heads "$1" "$2" | tee "$3"');
+    expect(result.stdout).toContain('set -o pipefail; git ls-remote --heads "$1" "$2" | tee "$3"');
     expect(result.stdout).toContain('refs/heads/resolve/issue-1720-feat-dr');
+    expect(result.stdout).toContain('refs/fbeast/rollback-evidence/resolve-issue-1720-feat-dr');
     expect(result.stdout).toContain('rollback-comment.md');
     expect(result.stdout).toContain('approval-cop run -- git push --force-with-lease=refs/heads/resolve/issue-1720-feat-dr:1111111111111111111111111111111111111111 origin 2222222222222222222222222222222222222222:refs/heads/resolve/issue-1720-feat-dr');
     expect(result.stdout).toContain('This helper is dry-run only; it never executes push, force-push, or GitHub mutation commands.');


### PR DESCRIPTION
## Summary
- Add a worker push rollback runbook covering diagnosis, remote ref capture, last-good selection, approval routing, verification, and PR update steps.
- Add a dry-run-only helper that prints evidence capture, approval-cop-gated force-with-lease rollback, and post-rollback verification commands without executing mutations.
- Add parser/dry-run tests and link the runbook from README/security guidance.

## Test Plan
- [x] node scripts/worker-push-rollback-plan.mjs --dry-run --branch resolve/issue-1720-feat-dr --last-good origin/main --repo djm204/frankenbeast --pr 1720 --remote-head-oid 1111111111111111111111111111111111111111 --last-good-oid 2222222222222222222222222222222222222222
- [x] npx vitest run tests/unit/worker-push-rollback-plan.test.ts
- [x] npm run test:root
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run build

Closes #1720