### PR TITLE
refactor(web): decompose chat shell and session helpers

### DIFF
--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import brandMark from '../../../../assets/img/frankenbeast-github-logo-478x72.png';
-import { useChatSession, type ChatErrorBanner } from '../hooks/use-chat-session';
+import { useChatSession } from '../hooks/use-chat-session';
 import { TranscriptPane } from './transcript-pane';
 import { Composer } from './composer';
 import { ActivityPane } from './activity-pane';
@@ -27,203 +27,19 @@ import { AnalyticsApiClient } from '../lib/analytics-api';
 import { AnalyticsPage } from '../pages/analytics-page';
 import { DashboardApiClient } from '../lib/dashboard-api';
 import { DashboardPage } from '../pages/dashboard-page';
+import { ChatErrorBanners } from './chat-shell/chat-error-banners';
+import { PlaceholderPage } from './chat-shell/placeholder-page';
+import { PRIMARY_NAV_ROUTES, ROUTES, routeFromHash, type RouteId } from './chat-shell/route-model';
+import { formatSessionOptionLabel } from './chat-shell/session-labels';
+import { getSidebarFocusableElements } from './chat-shell/sidebar-focus';
+import { appendUniqueLogLine, formatStreamedLogLine, getAgentEventRunId } from './chat-shell/beast-log-utils';
+import { networkErrorMessage } from './chat-shell/network-error';
 
 export interface ChatShellProps {
   baseUrl: string;
   projectId: string;
   sessionId?: string;
   version: string;
-}
-
-type RouteId = 'dashboard' | 'chat' | 'beasts' | 'network' | 'sessions' | 'analytics' | 'costs' | 'safety' | 'settings';
-type PlaceholderRouteId = Exclude<RouteId, 'dashboard' | 'chat' | 'beasts' | 'network' | 'analytics'>;
-
-const ROUTES: Array<{ id: RouteId; label: string; summary: string; live: boolean }> = [
-  { id: 'dashboard', label: 'Overview', summary: 'Snapshot controls for skills, security, and providers', live: true },
-  { id: 'chat', label: 'Chat', summary: 'Live CLI-parity operator console', live: true },
-  { id: 'beasts', label: 'Beasts', summary: 'Dispatch, inspect, and control tracked beast runs', live: true },
-  { id: 'network', label: 'Network', summary: 'Service controls and operator config', live: true },
-  { id: 'sessions', label: 'Sessions', summary: 'Coming online once session explorer lands', live: false },
-  { id: 'analytics', label: 'Analytics', summary: 'Observer, governor, security, and cost telemetry', live: true },
-  { id: 'costs', label: 'Costs', summary: 'Token and provider reporting will live here', live: false },
-  { id: 'safety', label: 'Safety', summary: 'Approvals, policy, and injection telemetry', live: false },
-  { id: 'settings', label: 'Settings', summary: 'Operator configuration and launch profiles', live: false },
-];
-
-const PRIMARY_NAV_ROUTES = ROUTES.filter((route) => route.live);
-
-function formatSessionCount(count: number): string {
-  return `${count} ${count === 1 ? 'message' : 'messages'}`;
-}
-
-function formatRelativeUpdatedTime(value: string): string {
-  const updatedAt = new Date(value).getTime();
-  if (!Number.isFinite(updatedAt)) {
-    return 'updated time unknown';
-  }
-
-  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - updatedAt) / 1000));
-  if (elapsedSeconds < 60) {
-    return 'updated just now';
-  }
-
-  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
-  if (elapsedMinutes < 60) {
-    return `updated ${elapsedMinutes}m ago`;
-  }
-
-  const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24) {
-    return `updated ${elapsedHours}h ago`;
-  }
-
-  const elapsedDays = Math.floor(elapsedHours / 24);
-  if (elapsedDays < 30) {
-    return `updated ${elapsedDays}d ago`;
-  }
-
-  return `updated ${new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
-}
-
-function shortenSessionId(id: string): string {
-  if (id.length <= 14) {
-    return id;
-  }
-
-  return `${id.slice(0, 8)}…${id.slice(-4)}`;
-}
-
-function getSidebarFocusableElements(sidebar: HTMLElement): HTMLElement[] {
-  return Array.from(
-    sidebar.querySelectorAll<HTMLElement>('a[href]:not(.sidebar__focus-guard), button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not(.sidebar__focus-guard)'),
-  );
-}
-
-function formatSessionOptionLabel(session: ChatSessionSummary): string {
-  const preview = session.preview.trim();
-  const details = [
-    session.state,
-    formatSessionCount(session.messageCount),
-    formatRelativeUpdatedTime(session.updatedAt),
-    shortenSessionId(session.id),
-  ];
-
-  return preview ? `${preview} — ${details.join(' · ')}` : details.join(' · ');
-}
-
-function routeFromHash(hash: string): RouteId {
-  const candidate = hash.replace(/^#\/?/, '') as RouteId;
-  return PRIMARY_NAV_ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
-}
-
-function networkErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
-}
-
-function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {
-  const route = ROUTES.find((item) => item.id === routeId)!;
-
-  return (
-    <section className="placeholder-page">
-      <p className="eyebrow">Dashboard Module</p>
-      <h2>{route.label}</h2>
-      <p>{route.summary}</p>
-    </section>
-  );
-}
-
-function ChatErrorBanners({
-  banners = [],
-  onDismiss = () => undefined,
-  onRetry = () => undefined,
-}: {
-  banners?: ChatErrorBanner[];
-  onDismiss?: (id: string) => void;
-  onRetry?: (id: string) => void | Promise<unknown>;
-}) {
-  if (banners.length === 0) {
-    return null;
-  }
-
-  return (
-    <section className="chat-alerts" aria-label="Chat errors" aria-live="assertive">
-      {banners.map((banner) => (
-        <article key={banner.id} className="chat-alert" role="alert">
-          <div className="chat-alert__body">
-            <p className="eyebrow">{banner.code ?? 'chat_error'}</p>
-            <h2>{banner.title}</h2>
-            <p>{banner.message}</p>
-          </div>
-          <div className="chat-alert__actions">
-            <button className="button button--secondary" type="button" onClick={() => onRetry(banner.id)}>
-              {banner.actionLabel}
-            </button>
-            <button className="button button--ghost" type="button" onClick={() => onDismiss(banner.id)}>
-              Dismiss
-            </button>
-          </div>
-        </article>
-      ))}
-    </section>
-  );
-}
-
-function appendUniqueLogLine(logs: string[], nextLine: string): string[] {
-  const nextIdentity = parseLogIdentity(nextLine);
-  if (nextIdentity?.eventId && logs.some((line) => parseLogIdentity(line)?.eventId === nextIdentity.eventId)) {
-    return logs;
-  }
-  if (nextIdentity?.createdAt && logs.some((line) => {
-    const identity = parseLogIdentity(line);
-    return identity
-      && (!identity.eventId || !nextIdentity.eventId)
-      && identity.stream === nextIdentity.stream
-      && identity.message === nextIdentity.message
-      && identity.createdAt === nextIdentity.createdAt;
-  })) {
-    return logs;
-  }
-  return logs[logs.length - 1] === nextLine ? logs : [...logs, nextLine];
-}
-
-function parseLogIdentity(line: string): { eventId?: string; stream?: string; message?: string; createdAt?: string } | null {
-  try {
-    const parsed = JSON.parse(line) as unknown;
-    if (typeof parsed !== 'object' || parsed === null) {
-      return null;
-    }
-    const candidate = parsed as { eventId?: unknown; stream?: unknown; message?: unknown; createdAt?: unknown };
-    const identity = {
-      ...(typeof candidate.eventId === 'string' && candidate.eventId.length > 0 ? { eventId: candidate.eventId } : {}),
-      ...(typeof candidate.stream === 'string' ? { stream: candidate.stream } : {}),
-      ...(typeof candidate.message === 'string' ? { message: candidate.message } : {}),
-      ...(typeof candidate.createdAt === 'string' ? { createdAt: candidate.createdAt } : {}),
-    };
-    return identity.eventId || (identity.message && identity.createdAt) ? identity : null;
-  } catch {
-    return null;
-  }
-}
-
-function getAgentEventRunId(payload: unknown): string | null {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'runId' in payload
-    && typeof (payload as { runId?: unknown }).runId === 'string'
-    ? (payload as { runId: string }).runId
-    : null;
-}
-
-function formatStreamedLogLine(event: { eventId?: string; stream?: string; line: string; createdAt?: string }): string {
-  if (event.eventId || event.createdAt || event.stream) {
-    return JSON.stringify({
-      ...(event.eventId ? { eventId: event.eventId } : {}),
-      ...(event.stream ? { stream: event.stream } : {}),
-      message: event.line,
-      ...(event.createdAt ? { createdAt: event.createdAt } : {}),
-    });
-  }
-  return event.line;
 }
 
 export function buildInitAction(

--- a/packages/franken-web/src/components/chat-shell/beast-log-utils.ts
+++ b/packages/franken-web/src/components/chat-shell/beast-log-utils.ts
@@ -1,0 +1,57 @@
+export function appendUniqueLogLine(logs: string[], nextLine: string): string[] {
+  const nextIdentity = parseLogIdentity(nextLine);
+  if (nextIdentity?.eventId && logs.some((line) => parseLogIdentity(line)?.eventId === nextIdentity.eventId)) {
+    return logs;
+  }
+  if (nextIdentity?.createdAt && logs.some((line) => {
+    const identity = parseLogIdentity(line);
+    return identity
+      && (!identity.eventId || !nextIdentity.eventId)
+      && identity.stream === nextIdentity.stream
+      && identity.message === nextIdentity.message
+      && identity.createdAt === nextIdentity.createdAt;
+  })) {
+    return logs;
+  }
+  return logs[logs.length - 1] === nextLine ? logs : [...logs, nextLine];
+}
+
+function parseLogIdentity(line: string): { eventId?: string; stream?: string; message?: string; createdAt?: string } | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null;
+    }
+    const candidate = parsed as { eventId?: unknown; stream?: unknown; message?: unknown; createdAt?: unknown };
+    const identity = {
+      ...(typeof candidate.eventId === 'string' && candidate.eventId.length > 0 ? { eventId: candidate.eventId } : {}),
+      ...(typeof candidate.stream === 'string' ? { stream: candidate.stream } : {}),
+      ...(typeof candidate.message === 'string' ? { message: candidate.message } : {}),
+      ...(typeof candidate.createdAt === 'string' ? { createdAt: candidate.createdAt } : {}),
+    };
+    return identity.eventId || (identity.message && identity.createdAt) ? identity : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getAgentEventRunId(payload: unknown): string | null {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'runId' in payload
+    && typeof (payload as { runId?: unknown }).runId === 'string'
+    ? (payload as { runId: string }).runId
+    : null;
+}
+
+export function formatStreamedLogLine(event: { eventId?: string; stream?: string; line: string; createdAt?: string }): string {
+  if (event.eventId || event.createdAt || event.stream) {
+    return JSON.stringify({
+      ...(event.eventId ? { eventId: event.eventId } : {}),
+      ...(event.stream ? { stream: event.stream } : {}),
+      message: event.line,
+      ...(event.createdAt ? { createdAt: event.createdAt } : {}),
+    });
+  }
+  return event.line;
+}

--- a/packages/franken-web/src/components/chat-shell/chat-error-banners.tsx
+++ b/packages/franken-web/src/components/chat-shell/chat-error-banners.tsx
@@ -1,0 +1,37 @@
+import type { ChatErrorBanner } from '../../hooks/use-chat-session';
+
+export function ChatErrorBanners({
+  banners = [],
+  onDismiss = () => undefined,
+  onRetry = () => undefined,
+}: {
+  banners?: ChatErrorBanner[];
+  onDismiss?: (id: string) => void;
+  onRetry?: (id: string) => void | Promise<unknown>;
+}) {
+  if (banners.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="chat-alerts" aria-label="Chat errors" aria-live="assertive">
+      {banners.map((banner) => (
+        <article key={banner.id} className="chat-alert" role="alert">
+          <div className="chat-alert__body">
+            <p className="eyebrow">{banner.code ?? 'chat_error'}</p>
+            <h2>{banner.title}</h2>
+            <p>{banner.message}</p>
+          </div>
+          <div className="chat-alert__actions">
+            <button className="button button--secondary" type="button" onClick={() => onRetry(banner.id)}>
+              {banner.actionLabel}
+            </button>
+            <button className="button button--ghost" type="button" onClick={() => onDismiss(banner.id)}>
+              Dismiss
+            </button>
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/packages/franken-web/src/components/chat-shell/network-error.ts
+++ b/packages/franken-web/src/components/chat-shell/network-error.ts
@@ -1,0 +1,3 @@
+export function networkErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}

--- a/packages/franken-web/src/components/chat-shell/placeholder-page.tsx
+++ b/packages/franken-web/src/components/chat-shell/placeholder-page.tsx
@@ -1,0 +1,13 @@
+import { ROUTES, type PlaceholderRouteId } from './route-model';
+
+export function PlaceholderPage({ routeId }: { routeId: PlaceholderRouteId }) {
+  const route = ROUTES.find((item) => item.id === routeId)!;
+
+  return (
+    <section className="placeholder-page">
+      <p className="eyebrow">Dashboard Module</p>
+      <h2>{route.label}</h2>
+      <p>{route.summary}</p>
+    </section>
+  );
+}

--- a/packages/franken-web/src/components/chat-shell/route-model.ts
+++ b/packages/franken-web/src/components/chat-shell/route-model.ts
@@ -1,0 +1,28 @@
+export type RouteId = 'dashboard' | 'chat' | 'beasts' | 'network' | 'sessions' | 'analytics' | 'costs' | 'safety' | 'settings';
+export type PlaceholderRouteId = Exclude<RouteId, 'dashboard' | 'chat' | 'beasts' | 'network' | 'analytics'>;
+
+export interface DashboardRoute {
+  id: RouteId;
+  label: string;
+  summary: string;
+  live: boolean;
+}
+
+export const ROUTES: DashboardRoute[] = [
+  { id: 'dashboard', label: 'Overview', summary: 'Snapshot controls for skills, security, and providers', live: true },
+  { id: 'chat', label: 'Chat', summary: 'Live CLI-parity operator console', live: true },
+  { id: 'beasts', label: 'Beasts', summary: 'Dispatch, inspect, and control tracked beast runs', live: true },
+  { id: 'network', label: 'Network', summary: 'Service controls and operator config', live: true },
+  { id: 'sessions', label: 'Sessions', summary: 'Coming online once session explorer lands', live: false },
+  { id: 'analytics', label: 'Analytics', summary: 'Observer, governor, security, and cost telemetry', live: true },
+  { id: 'costs', label: 'Costs', summary: 'Token and provider reporting will live here', live: false },
+  { id: 'safety', label: 'Safety', summary: 'Approvals, policy, and injection telemetry', live: false },
+  { id: 'settings', label: 'Settings', summary: 'Operator configuration and launch profiles', live: false },
+];
+
+export const PRIMARY_NAV_ROUTES = ROUTES.filter((route) => route.live);
+
+export function routeFromHash(hash: string): RouteId {
+  const candidate = hash.replace(/^#\/?/, '') as RouteId;
+  return PRIMARY_NAV_ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
+}

--- a/packages/franken-web/src/components/chat-shell/session-labels.ts
+++ b/packages/franken-web/src/components/chat-shell/session-labels.ts
@@ -1,0 +1,54 @@
+import type { ChatSessionSummary } from '../../lib/api';
+
+function formatSessionCount(count: number): string {
+  return `${count} ${count === 1 ? 'message' : 'messages'}`;
+}
+
+function formatRelativeUpdatedTime(value: string): string {
+  const updatedAt = new Date(value).getTime();
+  if (!Number.isFinite(updatedAt)) {
+    return 'updated time unknown';
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - updatedAt) / 1000));
+  if (elapsedSeconds < 60) {
+    return 'updated just now';
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) {
+    return `updated ${elapsedMinutes}m ago`;
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) {
+    return `updated ${elapsedHours}h ago`;
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 30) {
+    return `updated ${elapsedDays}d ago`;
+  }
+
+  return `updated ${new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
+}
+
+function shortenSessionId(id: string): string {
+  if (id.length <= 14) {
+    return id;
+  }
+
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+export function formatSessionOptionLabel(session: ChatSessionSummary): string {
+  const preview = session.preview.trim();
+  const details = [
+    session.state,
+    formatSessionCount(session.messageCount),
+    formatRelativeUpdatedTime(session.updatedAt),
+    shortenSessionId(session.id),
+  ];
+
+  return preview ? `${preview} — ${details.join(' · ')}` : details.join(' · ');
+}

--- a/packages/franken-web/src/components/chat-shell/sidebar-focus.ts
+++ b/packages/franken-web/src/components/chat-shell/sidebar-focus.ts
@@ -1,0 +1,5 @@
+export function getSidebarFocusableElements(sidebar: HTMLElement): HTMLElement[] {
+  return Array.from(
+    sidebar.querySelectorAll<HTMLElement>('a[href]:not(.sidebar__focus-guard), button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not(.sidebar__focus-guard)'),
+  );
+}

--- a/packages/franken-web/src/hooks/chat-session-state.ts
+++ b/packages/franken-web/src/hooks/chat-session-state.ts
@@ -1,0 +1,278 @@
+import {
+  type ApproveResult,
+  type ChatSession,
+  type TokenTotals,
+  type TranscriptMessage,
+} from '../lib/api';
+import {
+  type ServerSocketEvent,
+  deterministicUuid,
+  isoNow,
+  seededRandom,
+} from '@franken/types';
+import type { ActivityEvent, ChatErrorAction, ChatErrorBanner, ChatMessage, MessageReceipt } from './use-chat-session';
+
+export const EMPTY_TOKEN_TOTALS: TokenTotals = {
+  cheap: 0,
+  premiumReasoning: 0,
+  premiumExecution: 0,
+};
+
+export const SOCKET_SEND_ACK_TIMEOUT_MS = 15_000;
+
+export interface PendingSend {
+  timeoutId: ReturnType<typeof setTimeout>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export class NonRetryableSendError extends Error {
+  readonly retryableSend = false;
+}
+
+export function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+export function makeBanner(
+  title: string,
+  message: string,
+  action: ChatErrorAction,
+  actionLabel: string,
+  code?: string,
+): ChatErrorBanner {
+  return {
+    id: makeId('chat-error'),
+    title,
+    message,
+    action,
+    actionLabel,
+    ...(code ? { code } : {}),
+  };
+}
+
+function hasDeterministicSeed(): boolean {
+  const globalWithProcess = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+  };
+  return Boolean(globalWithProcess.process?.env?.['FRANKENBEAST_SEED']);
+}
+
+export function makeId(prefix: string): string {
+  if (hasDeterministicSeed()) {
+    return deterministicUuid('packages/franken-web/src/hooks/use-chat-session.ts');
+  }
+
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+
+  return `${prefix}-${seededRandom.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeTranscript(messages: TranscriptMessage[]): ChatMessage[] {
+  return messages.map((message) => ({
+    id: message.id ?? makeId(message.role),
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    ...(message.modelTier ? { modelTier: message.modelTier } : {}),
+  }));
+}
+
+export function appendOrUpdateAssistantMessage(
+  messages: ChatMessage[],
+  event: Extract<ServerSocketEvent, { type: 'assistant.message.delta' | 'assistant.message.complete' }>,
+): ChatMessage[] {
+  const existingIndex = messages.findIndex((message) => message.id === event.messageId);
+  const nextMessage: ChatMessage = {
+    id: event.messageId,
+    role: 'assistant',
+    content: event.type === 'assistant.message.delta'
+      ? (existingIndex >= 0 ? `${messages[existingIndex]!.content}${event.chunk}` : event.chunk)
+      : event.content,
+    timestamp: event.type === 'assistant.message.complete'
+      ? event.timestamp
+      : (existingIndex >= 0 ? messages[existingIndex]!.timestamp : isoNow()),
+    ...(event.modelTier ? { modelTier: event.modelTier } : {}),
+    streaming: event.type === 'assistant.message.delta',
+  };
+
+  if (existingIndex >= 0) {
+    return messages.map((message, index) => (index === existingIndex ? nextMessage : message));
+  }
+
+  return [...messages, nextMessage];
+}
+
+export function activityEventsFromApproveResult(result: ApproveResult, approved: boolean): ActivityEvent[] {
+  const timestamp = isoNow();
+  return [
+    {
+      type: 'turn.approval.resolved',
+      data: { approved },
+      timestamp,
+    },
+    ...(result.events ?? []).flatMap((event): ActivityEvent[] => {
+      if (!event || typeof event !== 'object' || !('type' in event)) {
+        return [];
+      }
+      const turnEvent = event as { type: unknown; data?: Record<string, unknown> };
+      if (turnEvent.type !== 'start' && turnEvent.type !== 'progress' && turnEvent.type !== 'complete') {
+        return [];
+      }
+      return [{
+        type: `turn.execution.${turnEvent.type}`,
+        ...(turnEvent.data !== undefined ? { data: turnEvent.data } : {}),
+        timestamp,
+      }];
+    }),
+  ];
+}
+
+export function updateReceipt(
+  messages: ChatMessage[],
+  messageId: string,
+  receipt: MessageReceipt,
+): ChatMessage[] {
+  return messages.map((message) => (
+    message.id === messageId
+      ? { ...message, receipt, ...(receipt !== 'failed' ? { error: undefined } : {}) }
+      : message
+  ));
+}
+
+export function markMessageFailed(messages: ChatMessage[], messageId: string, error: string, canRetry = true): ChatMessage[] {
+  return messages.map((message) => (
+    message.id === messageId
+      ? { ...message, receipt: 'failed', error, canRetry }
+      : message
+  ));
+}
+
+export function isFailedUserDraftForContent(message: ChatMessage, content: string): boolean {
+  return message.role === 'user' && message.receipt === 'failed' && message.content === content;
+}
+
+export function applySessionSnapshot(session: ChatSession): ChatMessage[] {
+  return normalizeTranscript(session.transcript);
+}
+
+export function sessionHasTokenTelemetry(session: ChatSession): boolean {
+  if (session.tokenTotals.cheap > 0
+    || session.tokenTotals.premiumReasoning > 0
+    || session.tokenTotals.premiumExecution > 0) {
+    return true;
+  }
+
+  return session.transcript.some((message) => message.tokens !== undefined);
+}
+
+export function sessionHasCostTelemetry(session: ChatSession): boolean {
+  if (session.costUsd > 0) {
+    return true;
+  }
+
+  return session.transcript.some((message) => message.costUsd !== undefined);
+}
+
+export function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): ChatMessage[] {
+  const snapshot = applySessionSnapshot(session);
+  const snapshotById = new Map(snapshot.map((message) => [message.id, message]));
+  const snapshotEquivalentMessages = new Map<string, ChatMessage[]>();
+  for (const message of snapshot) {
+    const key = `${message.role}\u0000${message.content}`;
+    snapshotEquivalentMessages.set(key, [...(snapshotEquivalentMessages.get(key) ?? []), message]);
+  }
+  const seen = new Set<string>();
+  const merged = current.flatMap((message) => {
+    const snapshotMessage = snapshotById.get(message.id);
+    if (snapshotMessage) {
+      seen.add(message.id);
+      return [snapshotMessage];
+    }
+
+    const key = `${message.role}\u0000${message.content}`;
+    const equivalentMessages = snapshotEquivalentMessages.get(key) ?? [];
+    const equivalentMessage = equivalentMessages.shift();
+    if (equivalentMessage) {
+      seen.add(equivalentMessage.id);
+      return [equivalentMessage];
+    }
+
+    return [message];
+  });
+
+  return [
+    ...merged,
+    ...snapshot.filter((message) => !seen.has(message.id)),
+  ];
+}
+
+export function preserveLocalRecoveryMessages(
+  current: ChatMessage[],
+  transcript: TranscriptMessage[],
+): { messages: ChatMessage[]; clearedFailedDrafts: string[] } {
+  const snapshot = normalizeTranscript(transcript);
+  const snapshotIds = new Set(snapshot.map((message) => message.id));
+  const unmatchedSnapshotContentCounts = new Map<string, number>();
+  const clearedFailedDrafts: string[] = [];
+
+  for (const message of snapshot) {
+    const key = `${message.role}\u0000${message.content}`;
+    unmatchedSnapshotContentCounts.set(key, (unmatchedSnapshotContentCounts.get(key) ?? 0) + 1);
+  }
+
+  const consumeSnapshotMatch = (message: ChatMessage): boolean => {
+    const key = `${message.role}\u0000${message.content}`;
+    const snapshotMatchCount = unmatchedSnapshotContentCounts.get(key) ?? 0;
+    if (snapshotMatchCount === 0) {
+      return false;
+    }
+    if (snapshotMatchCount === 1) {
+      unmatchedSnapshotContentCounts.delete(key);
+    } else {
+      unmatchedSnapshotContentCounts.set(key, snapshotMatchCount - 1);
+    }
+    return true;
+  };
+
+  const localRecoveryMessages = current.flatMap((message): ChatMessage[] => {
+    if (snapshotIds.has(message.id)) {
+      consumeSnapshotMatch(message);
+      return [];
+    }
+
+    if (consumeSnapshotMatch(message)) {
+      if (message.role === 'user' && (message.receipt === 'failed' || (message.receipt === 'accepted' && message.canRetry === false))) {
+        clearedFailedDrafts.push(message.content);
+      }
+      return [];
+    }
+
+    if (message.role === 'user' && message.receipt === 'accepted' && message.canRetry === false) {
+      return [message];
+    }
+
+    if (message.role !== 'user' || !message.receipt || message.canRetry === false) {
+      return [];
+    }
+
+    if (message.receipt === 'failed') {
+      return [message];
+    }
+
+    if (message.content.trim().startsWith('/')) {
+      return [];
+    }
+
+    return [{
+      ...message,
+      receipt: 'failed',
+      error: message.error ?? 'The server acknowledged this message but did not include it in the refreshed transcript. Resend to recover it.',
+      canRetry: true,
+    }];
+  });
+
+  return { messages: [...snapshot, ...localRecoveryMessages], clearedFailedDrafts };
+}

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -1,19 +1,33 @@
 import { useEffect, useRef, useState } from 'react';
 import {
-  type ApproveResult,
   ChatApiClient,
-  type ChatSession,
   type PendingApproval,
   type TokenTotals,
   type TranscriptMessage,
 } from '../lib/api';
 import {
   ServerSocketEventSchema,
-  type ServerSocketEvent,
-  deterministicUuid,
   isoNow,
-  seededRandom,
 } from '@franken/types';
+import {
+  EMPTY_TOKEN_TOTALS,
+  SOCKET_SEND_ACK_TIMEOUT_MS,
+  NonRetryableSendError,
+  activityEventsFromApproveResult,
+  appendOrUpdateAssistantMessage,
+  applySessionSnapshot,
+  errorMessage,
+  isFailedUserDraftForContent,
+  makeBanner,
+  makeId,
+  markMessageFailed,
+  mergeSessionSnapshot,
+  preserveLocalRecoveryMessages,
+  sessionHasCostTelemetry,
+  sessionHasTokenTelemetry,
+  updateReceipt,
+  type PendingSend,
+} from './chat-session-state';
 
 export type SessionStatus = 'idle' | 'connecting' | 'sending' | 'streaming' | 'error';
 export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'offline' | 'error';
@@ -82,271 +96,6 @@ export interface UseChatSessionResult {
   status: SessionStatus;
   tier: string | null;
   tokenTotals: TokenTotals;
-}
-
-const EMPTY_TOKEN_TOTALS: TokenTotals = {
-  cheap: 0,
-  premiumReasoning: 0,
-  premiumExecution: 0,
-};
-
-const SOCKET_SEND_ACK_TIMEOUT_MS = 15_000;
-
-interface PendingSend {
-  timeoutId: ReturnType<typeof setTimeout>;
-  resolve: () => void;
-  reject: (error: Error) => void;
-}
-
-class NonRetryableSendError extends Error {
-  readonly retryableSend = false;
-}
-
-function errorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error && error.message ? error.message : fallback;
-}
-
-function makeBanner(
-  title: string,
-  message: string,
-  action: ChatErrorAction,
-  actionLabel: string,
-  code?: string,
-): ChatErrorBanner {
-  return {
-    id: makeId('chat-error'),
-    title,
-    message,
-    action,
-    actionLabel,
-    ...(code ? { code } : {}),
-  };
-}
-
-function hasDeterministicSeed(): boolean {
-  const globalWithProcess = globalThis as typeof globalThis & {
-    process?: { env?: Record<string, string | undefined> };
-  };
-  return Boolean(globalWithProcess.process?.env?.['FRANKENBEAST_SEED']);
-}
-
-function makeId(prefix: string): string {
-  if (hasDeterministicSeed()) {
-    return deterministicUuid('packages/franken-web/src/hooks/use-chat-session.ts');
-  }
-
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return `${prefix}-${crypto.randomUUID()}`;
-  }
-
-  return `${prefix}-${seededRandom.random().toString(36).slice(2, 10)}`;
-}
-
-function normalizeTranscript(messages: TranscriptMessage[]): ChatMessage[] {
-  return messages.map((message) => ({
-    id: message.id ?? makeId(message.role),
-    role: message.role,
-    content: message.content,
-    timestamp: message.timestamp,
-    ...(message.modelTier ? { modelTier: message.modelTier } : {}),
-  }));
-}
-
-function appendOrUpdateAssistantMessage(
-  messages: ChatMessage[],
-  event: Extract<ServerSocketEvent, { type: 'assistant.message.delta' | 'assistant.message.complete' }>,
-): ChatMessage[] {
-  const existingIndex = messages.findIndex((message) => message.id === event.messageId);
-  const nextMessage: ChatMessage = {
-    id: event.messageId,
-    role: 'assistant',
-    content: event.type === 'assistant.message.delta'
-      ? (existingIndex >= 0 ? `${messages[existingIndex]!.content}${event.chunk}` : event.chunk)
-      : event.content,
-    timestamp: event.type === 'assistant.message.complete'
-      ? event.timestamp
-      : (existingIndex >= 0 ? messages[existingIndex]!.timestamp : isoNow()),
-    ...(event.modelTier ? { modelTier: event.modelTier } : {}),
-    streaming: event.type === 'assistant.message.delta',
-  };
-
-  if (existingIndex >= 0) {
-    return messages.map((message, index) => (index === existingIndex ? nextMessage : message));
-  }
-
-  return [...messages, nextMessage];
-}
-
-function activityEventsFromApproveResult(result: ApproveResult, approved: boolean): ActivityEvent[] {
-  const timestamp = isoNow();
-  return [
-    {
-      type: 'turn.approval.resolved',
-      data: { approved },
-      timestamp,
-    },
-    ...(result.events ?? []).flatMap((event): ActivityEvent[] => {
-      if (!event || typeof event !== 'object' || !('type' in event)) {
-        return [];
-      }
-      const turnEvent = event as { type: unknown; data?: Record<string, unknown> };
-      if (turnEvent.type !== 'start' && turnEvent.type !== 'progress' && turnEvent.type !== 'complete') {
-        return [];
-      }
-      return [{
-        type: `turn.execution.${turnEvent.type}`,
-        ...(turnEvent.data !== undefined ? { data: turnEvent.data } : {}),
-        timestamp,
-      }];
-    }),
-  ];
-}
-
-function updateReceipt(
-  messages: ChatMessage[],
-  messageId: string,
-  receipt: MessageReceipt,
-): ChatMessage[] {
-  return messages.map((message) => (
-    message.id === messageId
-      ? { ...message, receipt, ...(receipt !== 'failed' ? { error: undefined } : {}) }
-      : message
-  ));
-}
-
-function markMessageFailed(messages: ChatMessage[], messageId: string, error: string, canRetry = true): ChatMessage[] {
-  return messages.map((message) => (
-    message.id === messageId
-      ? { ...message, receipt: 'failed', error, canRetry }
-      : message
-  ));
-}
-
-function isFailedUserDraftForContent(message: ChatMessage, content: string): boolean {
-  return message.role === 'user' && message.receipt === 'failed' && message.content === content;
-}
-
-function applySessionSnapshot(session: ChatSession): ChatMessage[] {
-  return normalizeTranscript(session.transcript);
-}
-
-function sessionHasTokenTelemetry(session: ChatSession): boolean {
-  if (session.tokenTotals.cheap > 0
-    || session.tokenTotals.premiumReasoning > 0
-    || session.tokenTotals.premiumExecution > 0) {
-    return true;
-  }
-
-  return session.transcript.some((message) => message.tokens !== undefined);
-}
-
-function sessionHasCostTelemetry(session: ChatSession): boolean {
-  if (session.costUsd > 0) {
-    return true;
-  }
-
-  return session.transcript.some((message) => message.costUsd !== undefined);
-}
-
-function mergeSessionSnapshot(current: ChatMessage[], session: ChatSession): ChatMessage[] {
-  const snapshot = applySessionSnapshot(session);
-  const snapshotById = new Map(snapshot.map((message) => [message.id, message]));
-  const snapshotEquivalentMessages = new Map<string, ChatMessage[]>();
-  for (const message of snapshot) {
-    const key = `${message.role}\u0000${message.content}`;
-    snapshotEquivalentMessages.set(key, [...(snapshotEquivalentMessages.get(key) ?? []), message]);
-  }
-  const seen = new Set<string>();
-  const merged = current.flatMap((message) => {
-    const snapshotMessage = snapshotById.get(message.id);
-    if (snapshotMessage) {
-      seen.add(message.id);
-      return [snapshotMessage];
-    }
-
-    const key = `${message.role}\u0000${message.content}`;
-    const equivalentMessages = snapshotEquivalentMessages.get(key) ?? [];
-    const equivalentMessage = equivalentMessages.shift();
-    if (equivalentMessage) {
-      seen.add(equivalentMessage.id);
-      return [equivalentMessage];
-    }
-
-    return [message];
-  });
-
-  return [
-    ...merged,
-    ...snapshot.filter((message) => !seen.has(message.id)),
-  ];
-}
-
-function preserveLocalRecoveryMessages(
-  current: ChatMessage[],
-  transcript: TranscriptMessage[],
-): { messages: ChatMessage[]; clearedFailedDrafts: string[] } {
-  const snapshot = normalizeTranscript(transcript);
-  const snapshotIds = new Set(snapshot.map((message) => message.id));
-  const unmatchedSnapshotContentCounts = new Map<string, number>();
-  const clearedFailedDrafts: string[] = [];
-
-  for (const message of snapshot) {
-    const key = `${message.role}\u0000${message.content}`;
-    unmatchedSnapshotContentCounts.set(key, (unmatchedSnapshotContentCounts.get(key) ?? 0) + 1);
-  }
-
-  const consumeSnapshotMatch = (message: ChatMessage): boolean => {
-    const key = `${message.role}\u0000${message.content}`;
-    const snapshotMatchCount = unmatchedSnapshotContentCounts.get(key) ?? 0;
-    if (snapshotMatchCount === 0) {
-      return false;
-    }
-    if (snapshotMatchCount === 1) {
-      unmatchedSnapshotContentCounts.delete(key);
-    } else {
-      unmatchedSnapshotContentCounts.set(key, snapshotMatchCount - 1);
-    }
-    return true;
-  };
-
-  const localRecoveryMessages = current.flatMap((message): ChatMessage[] => {
-    if (snapshotIds.has(message.id)) {
-      consumeSnapshotMatch(message);
-      return [];
-    }
-
-    if (consumeSnapshotMatch(message)) {
-      if (message.role === 'user' && (message.receipt === 'failed' || (message.receipt === 'accepted' && message.canRetry === false))) {
-        clearedFailedDrafts.push(message.content);
-      }
-      return [];
-    }
-
-    if (message.role === 'user' && message.receipt === 'accepted' && message.canRetry === false) {
-      return [message];
-    }
-
-    if (message.role !== 'user' || !message.receipt || message.canRetry === false) {
-      return [];
-    }
-
-    if (message.receipt === 'failed') {
-      return [message];
-    }
-
-    if (message.content.trim().startsWith('/')) {
-      return [];
-    }
-
-    return [{
-      ...message,
-      receipt: 'failed',
-      error: message.error ?? 'The server acknowledged this message but did not include it in the refreshed transcript. Resend to recover it.',
-      canRetry: true,
-    }];
-  });
-
-  return { messages: [...snapshot, ...localRecoveryMessages], clearedFailedDrafts };
 }
 
 export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResult {

--- a/packages/franken-web/tests/components/chat-shell-source.test.ts
+++ b/packages/franken-web/tests/components/chat-shell-source.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const chatShellSourcePath = resolve(process.cwd(), 'src/components/chat-shell.tsx');
+const chatShellSource = readFileSync(chatShellSourcePath, 'utf8');
+
+const extractedModules = [
+  'route-model.ts',
+  'session-labels.ts',
+  'sidebar-focus.ts',
+  'chat-error-banners.tsx',
+  'placeholder-page.tsx',
+  'beast-log-utils.ts',
+  'network-error.ts',
+];
+
+describe('ChatShell source decomposition', () => {
+  it('keeps extracted route, sidebar, alert, session-label, network, and Beast log concerns in small modules', () => {
+    for (const fileName of extractedModules) {
+      const modulePath = resolve(process.cwd(), 'src/components/chat-shell', fileName);
+      expect(existsSync(modulePath)).toBe(true);
+      const lineCount = readFileSync(modulePath, 'utf8').split('\n').length;
+      expect(lineCount).toBeLessThan(80);
+    }
+  });
+
+  it('keeps the ChatShell component below the historical god-component size', () => {
+    expect(chatShellSource.split('\n').length).toBeLessThan(1300);
+  });
+});

--- a/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
@@ -1,8 +1,9 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(resolve(process.cwd(), 'src/hooks/use-chat-session.ts'), 'utf8');
+const sourcePath = resolve(process.cwd(), 'src/hooks/use-chat-session.ts');
+const source = readFileSync(sourcePath, 'utf8');
 
 describe('useChatSession source hygiene', () => {
   const patchAdditionMarker = new RegExp(`^\\s*${'\\+'}\\s*(?:\\/\\/|const|if|try|catch|socket|set\\w*|return|throw|await|for|function)\\b`, 'm');
@@ -32,5 +33,12 @@ describe('useChatSession source hygiene', () => {
 
     const recoveryImplementation = source.slice(pendingSendStart, retryErrorStart);
     expect(recoveryImplementation).not.toMatch(patchAdditionMarker);
+  });
+
+  it('keeps pure transcript, receipt, telemetry, banner, and id helpers extracted from the hook body', () => {
+    const helperModulePath = resolve(process.cwd(), 'src/hooks/chat-session-state.ts');
+    expect(existsSync(helperModulePath)).toBe(true);
+    expect(source.split('\n').length).toBeLessThan(900);
+    expect(readFileSync(helperModulePath, 'utf8')).toContain('export function preserveLocalRecoveryMessages');
   });
 });


### PR DESCRIPTION
## Summary
- Extract ChatShell route/session-label/sidebar/error-banner/network-error/Beast-log helper concerns into focused modules
- Move useChatSession pure transcript, receipt, telemetry, banner, and id helpers into chat-session-state
- Add source decomposition tests to keep the refactor boundary from regressing

## Test Plan
- npm test -- src/components/chat-shell.test.tsx src/hooks/use-chat-session.test.tsx tests/hooks/use-chat-session-source.test.ts tests/components/chat-shell-source.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #2228