### PR TITLE
fix(orchestrator): remove unsafe double casts

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -27,6 +27,29 @@ interface ReplayCaptureRecord {
   readonly content: string;
 }
 
+function createDisabledTrace(traceId: string): Trace {
+  return {
+    id: traceId,
+    goal: 'tracing-disabled',
+    status: 'completed',
+    startedAt: Date.now(),
+    spans: [],
+  };
+}
+
+function createDisabledSpan(traceId: string, opts: { name: string; parentSpanId?: string }): Span {
+  return {
+    id: `tracing-disabled:${opts.name}`,
+    traceId,
+    ...(opts.parentSpanId ? { parentSpanId: opts.parentSpanId } : {}),
+    name: opts.name,
+    status: 'completed',
+    startedAt: Date.now(),
+    metadata: {},
+    thoughtBlocks: [],
+  };
+}
+
 export class CliObserverBridge implements IObserverModule {
   private readonly counter: TokenCounter;
   private readonly costCalc: CostCalculator;
@@ -121,11 +144,8 @@ export class CliObserverBridge implements IObserverModule {
   }
 
   get disabledObserverDeps(): ObserverDeps {
-    const trace = {
-      id: this.activeSessionId ?? 'tracing-disabled',
-      sessionId: this.activeSessionId ?? 'tracing-disabled',
-      spans: [],
-    } as unknown as Trace;
+    const traceId = this.activeSessionId ?? 'tracing-disabled';
+    const trace = createDisabledTrace(traceId);
 
     return {
       trace,
@@ -134,10 +154,8 @@ export class CliObserverBridge implements IObserverModule {
       breaker: this.breaker,
       loopDetector: this.loopDet,
       estimateContextWindow: (input) => this.estimateContextWindow(input),
-      startSpan: (_t: Trace, opts: { name: string; parentSpanId?: string }) => ({
-        id: `tracing-disabled:${opts.name}`,
-        name: opts.name,
-      }) as unknown as Span,
+      startSpan: (_t: Trace, opts: { name: string; parentSpanId?: string }) =>
+        createDisabledSpan(traceId, opts),
       endSpan: () => {},
       recordTokenUsage: (_span: Span, usage: { promptTokens: number; completionTokens: number; model?: string }, counter?: TokenCounter) => {
         (counter ?? this.counter).record({

--- a/packages/franken-orchestrator/src/http/routes/comms-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/comms-routes.ts
@@ -45,7 +45,7 @@ const GenericCommsInboundBody = z.object({
   text: z.string().min(1),
   rawEvent: z.custom<unknown>((value) => value !== undefined, { message: 'Required' }),
   receivedAt: z.string().datetime({ offset: true }),
-}).strict();
+}).strict() satisfies z.ZodType<ChannelInboundMessage>;
 
 const GenericCommsActionBody = z.object({
   channelType: ChannelTypeSchema,
@@ -153,7 +153,7 @@ export function commsRoutes(options: CommsRoutesOptions): Hono {
   }
 
   app.post('/v1/comms/inbound', async (c) => {
-    const body = validateBody(GenericCommsInboundBody, await parseJsonBody(c)) as unknown as ChannelInboundMessage;
+    const body = validateBody(GenericCommsInboundBody, await parseJsonBody(c));
     await gateway.handleInbound(body);
     return c.json({ accepted: true });
   });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { describe, it, expect } from 'vitest';
 import {
   TokenCounter,
@@ -247,6 +248,36 @@ describe('CliObserverBridge', () => {
     it('observerDeps throws when startTrace has not been called', () => {
       const bridge = new CliObserverBridge(defaultConfig);
       expect(() => bridge.observerDeps).toThrow('No active trace');
+    });
+
+    it('returns fully shaped disabled observer trace and span null objects without double-casts', async () => {
+      const bridge = new CliObserverBridge(defaultConfig);
+      bridge.startTrace('session-disabled');
+
+      const deps = bridge.disabledObserverDeps;
+      expect(deps.trace).toMatchObject({
+        id: 'session-disabled',
+        goal: 'tracing-disabled',
+        status: 'completed',
+        spans: [],
+      });
+      expect(deps.trace.startedAt).toEqual(expect.any(Number));
+
+      const span = deps.startSpan(deps.trace, { name: 'disabled-span', parentSpanId: 'parent-span' });
+      expect(span).toMatchObject({
+        id: 'tracing-disabled:disabled-span',
+        traceId: 'session-disabled',
+        parentSpanId: 'parent-span',
+        name: 'disabled-span',
+        status: 'completed',
+        metadata: {},
+        thoughtBlocks: [],
+      });
+      expect(span.startedAt).toEqual(expect.any(Number));
+
+      const source = await readFile(new URL('../../../src/adapters/cli-observer-bridge.ts', import.meta.url), 'utf-8');
+      expect(source).not.toContain('as unknown as Trace');
+      expect(source).not.toContain('as unknown as Span');
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/comms-routes.test.ts
@@ -1,4 +1,5 @@
 import { generateKeyPairSync } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../src/comms/channels/slack/slack-adapter.js', () => ({
@@ -120,6 +121,13 @@ describe('commsRoutes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ accepted: true });
+  });
+
+  it('keeps generic inbound comms validation coupled to the ChannelInboundMessage type without double-casts', async () => {
+    const source = await readFile(new URL('../../../src/http/routes/comms-routes.ts', import.meta.url), 'utf-8');
+
+    expect(source).toContain('satisfies z.ZodType<ChannelInboundMessage>');
+    expect(source).not.toContain('as unknown as ChannelInboundMessage');
   });
 
   it('handles POST /v1/comms/action', async () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-14 — Type-safety hardening regressions
+- For removing unsafe TypeScript double-casts, pair the runtime regression with a source-inspection guard that names the exact bypass (`as unknown as ...`) and the intended type-coupling construct (`satisfies z.ZodType<...>` or typed null-object helpers) so future changes cannot silently reintroduce the cast while preserving behavior.
+- Disabled/null-object implementations should return structurally complete domain objects rather than partial objects cast through `unknown`; include required lifecycle/status/time fields in the helper so `tsc --noEmit` enforces drift against upstream type changes.
+
 ## 2026-07-14 — Right-to-forget privacy/code-review hardening
 - For deletion/right-to-forget flows, compare selectors against both persisted storage rows and the current in-memory overlay; avoid broad stale-instance flushes that can delete unrelated external rows, and keep persisted/runtime deletion finalization rollback-safe.
 - Redact destructive privacy selectors before every audit/governance sink, including proxy/envelope validation failures and governor logs; if a tool is destructive, route it through the same governance path as sibling deletion tools rather than exempting it as non-executing data.


### PR DESCRIPTION
## Summary
- Type-couple generic comms inbound validation to `ChannelInboundMessage` with `satisfies z.ZodType<...>` and remove the unsafe `as unknown as ChannelInboundMessage` cast.
- Replace disabled CLI observer bridge trace/span double-casts with structurally complete typed null-object helpers.
- Add regression tests that guard against reintroducing the specific unsafe double-cast patterns.

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/http/comms-routes.test.ts tests/unit/adapters/cli-observer-bridge.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- `npm run test --workspace @franken/orchestrator`

Closes #2226
