### PR TITLE
refactor(orchestrator): decompose god functions

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -207,6 +207,15 @@ function remapRuntimePathArgs(
   });
 }
 
+
+type PreparedBeastStartResources = {
+  readonly processSpec: BeastProcessSpec;
+  readonly worktree: BeastWorktreeAllocation | undefined;
+  readonly configFilePath: string;
+  readonly spawnedSpec: BeastProcessSpec;
+  readonly configuredSecrets: readonly string[];
+};
+
 export interface ProcessBeastExecutorOptions {
   onRunStatusChange?: (runId: string) => void;
   eventBus?: BeastEventBus;
@@ -309,71 +318,13 @@ export class ProcessBeastExecutor implements BeastExecutor {
   ) {}
 
   async start(run: BeastRun, definition: BeastDefinition): Promise<BeastRunAttempt> {
-    const processSpec = definition.buildProcessSpec(run.configSnapshot);
-    const moduleEnv = moduleConfigToEnv(run.configSnapshot.modules as ModuleConfig | undefined);
-    this.supervisor.validateCwd?.(processSpec.cwd);
-    const worktree = run.trackedAgentId
-      ? createBeastWorktree(
-          this.options.worktreeIsolation,
-          run.trackedAgentId,
-          processSpec.cwd,
-        )
-      : undefined;
-    if (worktree) {
-      this.worktreeAllocations.set(run.id, worktree);
-    }
-    const isolatedConfigSnapshot = worktree
-      ? remapRuntimeConfigSnapshot(run.configSnapshot, processSpec.cwd, worktree.executionCwd)
-      : run.configSnapshot;
-    const isolatedSpec = worktree
-      ? {
-          ...processSpec,
-          args: remapRuntimePathArgs(processSpec.args, processSpec.cwd, worktree.executionCwd),
-          cwd: worktree.executionCwd,
-          env: {
-            ...processSpec.env,
-            FRANKENBEAST_WORKTREE_PATH: worktree.worktreePath,
-            FRANKENBEAST_WORKTREE_BRANCH: worktree.branchName,
-          },
-        }
-      : processSpec;
-
-    // Write configSnapshot to a JSON file for the spawned process to load
-    const runConfigRoot = resolve(this.options.runConfigRoot ?? isolatedSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd());
-    const configDir = resolve(this.options.runConfigDir ?? join(runConfigRoot, '.fbeast', '.build', 'run-configs'));
-    const runConfigOwner = resolveRunConfigOwner(this.options.runConfigOwner);
-    ensureSecureRunConfigDirectory(configDir, runConfigOwner, runConfigRoot);
-    const configFilePath = join(configDir, `${run.id}.json`);
-    try {
-      lstatSync(configFilePath);
-      unlinkSync(configFilePath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error;
-      }
-    }
-    this.pendingConfigFilePaths.set(run.id, configFilePath);
-
-    const mergedSpec = {
-      ...isolatedSpec,
-      env: {
-        ...isolatedSpec.env,
-        ...moduleEnv,
-        FRANKENBEAST_RUN_CONFIG: configFilePath,
-      },
-    };
-    const spawnedSpec = this.options.transformSpec?.(run, processSpec, mergedSpec) ?? mergedSpec;
-    const configuredSecrets = collectConfiguredSecretValues(
-      run.configSnapshot,
-      processSpec.env,
-      isolatedSpec.env,
-      mergedSpec.env,
-      spawnedSpec.env,
-    );
-    const redactedConfigSnapshot = redactRunConfigSnapshot(isolatedConfigSnapshot, configuredSecrets);
-    writeFileSync(configFilePath, JSON.stringify(redactedConfigSnapshot, null, 2), { mode: RUN_CONFIG_FILE_MODE });
-    applyRunConfigOwnership(configFilePath, runConfigOwner);
-    chmodSync(configFilePath, RUN_CONFIG_FILE_MODE);
+    const {
+      processSpec,
+      worktree,
+      configFilePath,
+      spawnedSpec,
+      configuredSecrets,
+    } = this.prepareStartResources(run, definition);
 
     // eslint-disable-next-line prefer-const -- reassigned after attempt creation (line 162)
     let attemptId: string | undefined;
@@ -557,6 +508,90 @@ export class ProcessBeastExecutor implements BeastExecutor {
       data: { runId: run.id, attemptId: attempt.id, stream: 'stdout', line: startLogLine, createdAt: startedAt },
     });
     return attempt;
+  }
+
+
+  private prepareStartResources(run: BeastRun, definition: BeastDefinition): PreparedBeastStartResources {
+    const processSpec = definition.buildProcessSpec(run.configSnapshot);
+    const moduleEnv = moduleConfigToEnv(run.configSnapshot.modules as ModuleConfig | undefined);
+    this.supervisor.validateCwd?.(processSpec.cwd);
+    const worktree = this.allocateWorktree(run, processSpec);
+    const isolatedConfigSnapshot = worktree
+      ? remapRuntimeConfigSnapshot(run.configSnapshot, processSpec.cwd, worktree.executionCwd)
+      : run.configSnapshot;
+    const isolatedSpec = this.buildIsolatedSpec(processSpec, worktree);
+    const configFilePath = this.prepareRunConfigFile(run, isolatedSpec);
+
+    const mergedSpec = {
+      ...isolatedSpec,
+      env: {
+        ...isolatedSpec.env,
+        ...moduleEnv,
+        FRANKENBEAST_RUN_CONFIG: configFilePath,
+      },
+    };
+    const spawnedSpec = this.options.transformSpec?.(run, processSpec, mergedSpec) ?? mergedSpec;
+    const configuredSecrets = collectConfiguredSecretValues(
+      run.configSnapshot,
+      processSpec.env,
+      isolatedSpec.env,
+      mergedSpec.env,
+      spawnedSpec.env,
+    );
+    const redactedConfigSnapshot = redactRunConfigSnapshot(isolatedConfigSnapshot, configuredSecrets);
+    writeFileSync(configFilePath, JSON.stringify(redactedConfigSnapshot, null, 2), { mode: RUN_CONFIG_FILE_MODE });
+    const runConfigOwner = resolveRunConfigOwner(this.options.runConfigOwner);
+    applyRunConfigOwnership(configFilePath, runConfigOwner);
+    chmodSync(configFilePath, RUN_CONFIG_FILE_MODE);
+
+    return { processSpec, worktree, configFilePath, spawnedSpec, configuredSecrets };
+  }
+
+  private allocateWorktree(run: BeastRun, processSpec: BeastProcessSpec): BeastWorktreeAllocation | undefined {
+    const worktree = run.trackedAgentId
+      ? createBeastWorktree(
+          this.options.worktreeIsolation,
+          run.trackedAgentId,
+          processSpec.cwd,
+        )
+      : undefined;
+    if (worktree) {
+      this.worktreeAllocations.set(run.id, worktree);
+    }
+    return worktree;
+  }
+
+  private buildIsolatedSpec(processSpec: BeastProcessSpec, worktree: BeastWorktreeAllocation | undefined): BeastProcessSpec {
+    return worktree
+      ? {
+          ...processSpec,
+          args: remapRuntimePathArgs(processSpec.args, processSpec.cwd, worktree.executionCwd),
+          cwd: worktree.executionCwd,
+          env: {
+            ...processSpec.env,
+            FRANKENBEAST_WORKTREE_PATH: worktree.worktreePath,
+            FRANKENBEAST_WORKTREE_BRANCH: worktree.branchName,
+          },
+        }
+      : processSpec;
+  }
+
+  private prepareRunConfigFile(run: BeastRun, isolatedSpec: BeastProcessSpec): string {
+    const runConfigRoot = resolve(this.options.runConfigRoot ?? isolatedSpec.cwd ?? process.env.FBEAST_ROOT ?? process.cwd());
+    const configDir = resolve(this.options.runConfigDir ?? join(runConfigRoot, '.fbeast', '.build', 'run-configs'));
+    const runConfigOwner = resolveRunConfigOwner(this.options.runConfigOwner);
+    ensureSecureRunConfigDirectory(configDir, runConfigOwner, runConfigRoot);
+    const configFilePath = join(configDir, `${run.id}.json`);
+    try {
+      lstatSync(configFilePath);
+      unlinkSync(configFilePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    this.pendingConfigFilePaths.set(run.id, configFilePath);
+    return configFilePath;
   }
 
   async stop(runId: string, attemptId: string, options?: StopOptions): Promise<BeastRunAttempt> {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -981,6 +981,266 @@ async function createChatSurfaceDeps(
   };
 }
 
+
+
+async function runNonSessionCommandIfRequested(options: {
+  readonly args: CliArgs;
+  readonly config: OrchestratorConfig;
+  readonly configLoadFallback: boolean;
+  readonly root: string;
+  readonly paths: ReturnType<typeof getProjectPaths>;
+}): Promise<boolean> {
+  const { args, config, configLoadFallback, root, paths } = options;
+  if (args.subcommand === 'beasts-daemon') {
+  await runBeastDaemonCommand(args, config, root, paths);
+  return true;
+  }
+
+  if (args.subcommand === 'network') {
+  await runNetworkCommand(args, config, root, paths);
+  return true;
+  }
+
+  if (args.subcommand === 'beasts') {
+  const io = createStdinIO();
+  try {
+    await handleBeastCommand({
+      args,
+      io,
+      paths,
+      print: printLine,
+    });
+  } finally {
+    io.close();
+  }
+  return true;
+  }
+
+  if (args.subcommand === 'init') {
+  const io = createStdinIO();
+  try {
+    await handleInitCommand({
+      args,
+      config,
+      configLoadFallback,
+      io,
+      paths,
+      print: printLine,
+    });
+  } finally {
+    io.close();
+  }
+  return true;
+  }
+
+  if (args.subcommand === 'skill') {
+  try {
+    const { SkillManager } = await import('../skills/skill-manager.js');
+    const skillsDir = join(paths.frankenbeastDir, 'skills');
+    const skillManager = new SkillManager(skillsDir, new Set());
+    await handleSkillCommand({
+      skillManager,
+      action: args.skillAction,
+      target: args.skillTarget,
+      command: args.skillCommand,
+      commandArgs: args.skillCommandArgs,
+      print: printLine,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  }
+  return true;
+  }
+
+  if (args.subcommand === 'security') {
+  try {
+    await handleSecurityCommand({
+      action: args.securityAction,
+      target: args.securityTarget,
+      configPath: args.config ?? paths.configFile,
+      ...(config.security?.profile ? { currentProfile: config.security.profile } : {}),
+      ...(config.security ? { currentSecurity: config.security } : {}),
+      print: printLine,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  }
+  return true;
+  }
+
+  return false;
+}
+
+async function runChatCommandIfRequested(
+  args: CliArgs,
+  config: OrchestratorConfig,
+  root: string,
+  paths: ReturnType<typeof getProjectPaths>,
+  logger: BeastLogger,
+): Promise<boolean> {
+  if (args.subcommand !== 'chat' && args.subcommand !== 'chat-server') {
+    return false;
+  }
+  if (args.subcommand === 'chat') {
+    // Resolve the operator token so the attach client can authenticate
+    // when the managed chat-server has it configured (which it must, when
+    // exposed). Mirror chat-server's boot: try the configured secret
+    // store first (so deployments that keep the token only in the secure
+    // backend still work), then fall through to env / .env via
+    // resolveBeastOperatorToken.
+    let attachSecretStore: ISecretStore | undefined;
+    try {
+      const secureBackend = config.network.secureBackend ?? 'local-encrypted';
+      attachSecretStore = createSecretStore(secureBackend, {
+        projectRoot: root,
+        passphrase: process.env.FRANKENBEAST_PASSPHRASE,
+      });
+    } catch {
+      attachSecretStore = undefined;
+    }
+    const attachOperatorToken = await resolveBeastOperatorToken(root, {
+      ...(attachSecretStore ? { secretStore: attachSecretStore } : {}),
+      config,
+    }).catch(() => undefined);
+    const managedAttachment = await resolveManagedChatAttachment({
+      config,
+      frankenbeastDir: paths.frankenbeastDir,
+      ...(attachOperatorToken ? { operatorToken: attachOperatorToken } : {}),
+    });
+    if (managedAttachment) {
+      await runManagedChatRepl({
+        attachment: managedAttachment,
+        projectId: paths.root.split('/').pop() ?? 'unknown',
+        verbose: args.verbose,
+      });
+      return true;
+    }
+  }
+
+  const { chatLlm, execLlm, finalize, projectId, sessionStoreDir, skillManager, providerRegistry } = await createChatSurfaceDeps(args, config, paths);
+
+  if (args.subcommand === 'chat-server') {
+    let mutableConfig = config;
+    // Attempt to create a secret store for operator token resolution.
+    // Only succeeds when a passphrase is available (non-interactive boot path).
+    let bootSecretStore: import('../network/secret-store.js').ISecretStore | undefined;
+    try {
+      const secureBackend = config.network.secureBackend ?? 'local-encrypted';
+      bootSecretStore = createSecretStore(secureBackend, {
+        projectRoot: root,
+        passphrase: process.env.FRANKENBEAST_PASSPHRASE,
+      });
+    } catch {
+      // No passphrase available — fall through to env var / .env file resolution
+      bootSecretStore = undefined;
+    }
+    const beastOperatorToken = await resolveBeastOperatorToken(root, {
+      secretStore: bootSecretStore,
+      config,
+    });
+    const analytics = createSqliteAnalyticsService({
+      dbPath: join(paths.frankenbeastDir, 'beast.db'),
+    });
+    const commsConfig = await buildChatServerCommsConfig(config, bootSecretStore, root);
+    const explicitBeastDaemonUrl = process.env.FRANKENBEAST_BEAST_DAEMON_URL
+      ? assertLocalPlaintextOrSecureHttpUrl(
+          process.env.FRANKENBEAST_BEAST_DAEMON_URL,
+          'FRANKENBEAST_BEAST_DAEMON_URL',
+        )
+      : undefined;
+    const detectedBeastDaemonUrl = !explicitBeastDaemonUrl && beastOperatorToken
+      ? await resolveDetectedBeastsDaemonUrl(root, config, logger)
+      : undefined;
+    const beastDaemonUrl = explicitBeastDaemonUrl ?? detectedBeastDaemonUrl;
+    const localBeastServices = beastOperatorToken && !beastDaemonUrl
+      ? createBeastServices({
+          beastsDb: join(paths.frankenbeastDir, 'beast.db'),
+          beastLogsDir: paths.beastLogsDir,
+          root,
+        })
+      : undefined;
+    const allowedOrigins = Array.from(new Set([
+      ...(args.allowOrigin ? [args.allowOrigin] : []),
+      ...resolveDashboardAllowedOrigins(config),
+    ]));
+    const server = await startChatServer({
+      sessionStoreDir,
+      llm: chatLlm,
+      executionLlm: execLlm,
+      projectName: projectId,
+      ...(beastOperatorToken ? { operatorToken: beastOperatorToken } : {}),
+      ...(localBeastServices && beastOperatorToken
+        ? {
+            beastControl: {
+              ...localBeastServices,
+              operatorToken: beastOperatorToken,
+              security: new TransportSecurityService(),
+              rateLimit: { windowMs: 60_000, max: 20 },
+            },
+            disposeBeastControl: localBeastServices.dispose,
+          }
+        : {}),
+      ...(beastOperatorToken && beastDaemonUrl
+        ? {
+            beastDaemon: {
+              baseUrl: beastDaemonUrl,
+              operatorToken: beastOperatorToken,
+            },
+          }
+        : {}),
+      networkControl: {
+        root,
+        frankenbeastDir: paths.frankenbeastDir,
+        configFile: paths.configFile,
+        allowTrustedProviderCommandOverrides: args.trustProviderCommandOverrides,
+        getConfig: () => mutableConfig,
+        setConfig: (nextConfig) => {
+          mutableConfig = nextConfig;
+        },
+      },
+      ...(commsConfig ? { commsConfig } : {}),
+      ...(args.host ? { host: args.host } : {}),
+      ...(args.port !== undefined ? { port: args.port } : {}),
+      ...(allowedOrigins.length > 0 ? { allowedOrigins } : {}),
+      // Consolidated deps — skill/dashboard routes activate when providers are configured
+      ...(skillManager ? { skillManager } : {}),
+      ...(providerRegistry ? { providerRegistry } : {}),
+      ...(skillManager && providerRegistry
+        ? {
+            dashboardDeps: {
+              skillManager,
+              getSecurityConfig: () => resolveConfigSecurity(mutableConfig),
+              getProviders: () => buildDashboardProviderSnapshot(mutableConfig, providerRegistry, [resolveSelectedProvider(args, mutableConfig), ...(args.providers ?? [])]),
+            },
+          }
+        : {}),
+      analyticsDeps: { analytics },
+    });
+    printLine(`Chat server listening on ${server.url}`);
+    return true;
+  }
+
+  const sessionStore = new FileSessionStore(sessionStoreDir);
+  const runtime = createChatRuntime({
+    chatLlm,
+    executionLlm: execLlm,
+    projectName: projectId,
+    sessionContinuation: true,
+  });
+  const repl = new ChatRepl({
+    engine: runtime.engine,
+    turnRunner: runtime.turnRunner,
+    projectId,
+    sessionStore,
+    verbose: args.verbose,
+  });
+  await repl.start();
+  await finalize();
+  return true;
+}
+
 export async function main(): Promise<void> {
   const args = parseArgs();
 
@@ -1094,241 +1354,11 @@ export async function main(): Promise<void> {
   validateStateDirBeforeScaffold(config, scaffoldPaths);
   scaffoldFrankenbeast(scaffoldPaths);
 
-  if (args.subcommand === 'beasts-daemon') {
-    await runBeastDaemonCommand(args, config, root, paths);
+  if (await runNonSessionCommandIfRequested({ args, config, configLoadFallback, root, paths })) {
     return;
   }
 
-  if (args.subcommand === 'network') {
-    await runNetworkCommand(args, config, root, paths);
-    return;
-  }
-
-  if (args.subcommand === 'beasts') {
-    const io = createStdinIO();
-    try {
-      await handleBeastCommand({
-        args,
-        io,
-        paths,
-        print: printLine,
-      });
-    } finally {
-      io.close();
-    }
-    return;
-  }
-
-  if (args.subcommand === 'init') {
-    const io = createStdinIO();
-    try {
-      await handleInitCommand({
-        args,
-        config,
-        configLoadFallback,
-        io,
-        paths,
-        print: printLine,
-      });
-    } finally {
-      io.close();
-    }
-    return;
-  }
-
-  if (args.subcommand === 'skill') {
-    try {
-      const { SkillManager } = await import('../skills/skill-manager.js');
-      const skillsDir = join(paths.frankenbeastDir, 'skills');
-      const skillManager = new SkillManager(skillsDir, new Set());
-      await handleSkillCommand({
-        skillManager,
-        action: args.skillAction,
-        target: args.skillTarget,
-        command: args.skillCommand,
-        commandArgs: args.skillCommandArgs,
-        print: printLine,
-      });
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exitCode = 1;
-    }
-    return;
-  }
-
-  if (args.subcommand === 'security') {
-    try {
-      await handleSecurityCommand({
-        action: args.securityAction,
-        target: args.securityTarget,
-        configPath: args.config ?? paths.configFile,
-        ...(config.security?.profile ? { currentProfile: config.security.profile } : {}),
-        ...(config.security ? { currentSecurity: config.security } : {}),
-        print: printLine,
-      });
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exitCode = 1;
-    }
-    return;
-  }
-
-  if (args.subcommand === 'chat' || args.subcommand === 'chat-server') {
-    if (args.subcommand === 'chat') {
-      // Resolve the operator token so the attach client can authenticate
-      // when the managed chat-server has it configured (which it must, when
-      // exposed). Mirror chat-server's boot: try the configured secret
-      // store first (so deployments that keep the token only in the secure
-      // backend still work), then fall through to env / .env via
-      // resolveBeastOperatorToken.
-      let attachSecretStore: ISecretStore | undefined;
-      try {
-        const secureBackend = config.network.secureBackend ?? 'local-encrypted';
-        attachSecretStore = createSecretStore(secureBackend, {
-          projectRoot: root,
-          passphrase: process.env.FRANKENBEAST_PASSPHRASE,
-        });
-      } catch {
-        attachSecretStore = undefined;
-      }
-      const attachOperatorToken = await resolveBeastOperatorToken(root, {
-        ...(attachSecretStore ? { secretStore: attachSecretStore } : {}),
-        config,
-      }).catch(() => undefined);
-      const managedAttachment = await resolveManagedChatAttachment({
-        config,
-        frankenbeastDir: paths.frankenbeastDir,
-        ...(attachOperatorToken ? { operatorToken: attachOperatorToken } : {}),
-      });
-      if (managedAttachment) {
-        await runManagedChatRepl({
-          attachment: managedAttachment,
-          projectId: paths.root.split('/').pop() ?? 'unknown',
-          verbose: args.verbose,
-        });
-        return;
-      }
-    }
-
-    const { chatLlm, execLlm, finalize, projectId, sessionStoreDir, skillManager, providerRegistry } = await createChatSurfaceDeps(args, config, paths);
-
-    if (args.subcommand === 'chat-server') {
-      let mutableConfig = config;
-      // Attempt to create a secret store for operator token resolution.
-      // Only succeeds when a passphrase is available (non-interactive boot path).
-      let bootSecretStore: import('../network/secret-store.js').ISecretStore | undefined;
-      try {
-        const secureBackend = config.network.secureBackend ?? 'local-encrypted';
-        bootSecretStore = createSecretStore(secureBackend, {
-          projectRoot: root,
-          passphrase: process.env.FRANKENBEAST_PASSPHRASE,
-        });
-      } catch {
-        // No passphrase available — fall through to env var / .env file resolution
-        bootSecretStore = undefined;
-      }
-      const beastOperatorToken = await resolveBeastOperatorToken(root, {
-        secretStore: bootSecretStore,
-        config,
-      });
-      const analytics = createSqliteAnalyticsService({
-        dbPath: join(paths.frankenbeastDir, 'beast.db'),
-      });
-      const commsConfig = await buildChatServerCommsConfig(config, bootSecretStore, root);
-      const explicitBeastDaemonUrl = process.env.FRANKENBEAST_BEAST_DAEMON_URL
-        ? assertLocalPlaintextOrSecureHttpUrl(
-            process.env.FRANKENBEAST_BEAST_DAEMON_URL,
-            'FRANKENBEAST_BEAST_DAEMON_URL',
-          )
-        : undefined;
-      const detectedBeastDaemonUrl = !explicitBeastDaemonUrl && beastOperatorToken
-        ? await resolveDetectedBeastsDaemonUrl(root, config, logger)
-        : undefined;
-      const beastDaemonUrl = explicitBeastDaemonUrl ?? detectedBeastDaemonUrl;
-      const localBeastServices = beastOperatorToken && !beastDaemonUrl
-        ? createBeastServices({
-            beastsDb: join(paths.frankenbeastDir, 'beast.db'),
-            beastLogsDir: paths.beastLogsDir,
-            root,
-          })
-        : undefined;
-      const allowedOrigins = Array.from(new Set([
-        ...(args.allowOrigin ? [args.allowOrigin] : []),
-        ...resolveDashboardAllowedOrigins(config),
-      ]));
-      const server = await startChatServer({
-        sessionStoreDir,
-        llm: chatLlm,
-        executionLlm: execLlm,
-        projectName: projectId,
-        ...(beastOperatorToken ? { operatorToken: beastOperatorToken } : {}),
-        ...(localBeastServices && beastOperatorToken
-          ? {
-              beastControl: {
-                ...localBeastServices,
-                operatorToken: beastOperatorToken,
-                security: new TransportSecurityService(),
-                rateLimit: { windowMs: 60_000, max: 20 },
-              },
-              disposeBeastControl: localBeastServices.dispose,
-            }
-          : {}),
-        ...(beastOperatorToken && beastDaemonUrl
-          ? {
-              beastDaemon: {
-                baseUrl: beastDaemonUrl,
-                operatorToken: beastOperatorToken,
-              },
-            }
-          : {}),
-        networkControl: {
-          root,
-          frankenbeastDir: paths.frankenbeastDir,
-          configFile: paths.configFile,
-          allowTrustedProviderCommandOverrides: args.trustProviderCommandOverrides,
-          getConfig: () => mutableConfig,
-          setConfig: (nextConfig) => {
-            mutableConfig = nextConfig;
-          },
-        },
-        ...(commsConfig ? { commsConfig } : {}),
-        ...(args.host ? { host: args.host } : {}),
-        ...(args.port !== undefined ? { port: args.port } : {}),
-        ...(allowedOrigins.length > 0 ? { allowedOrigins } : {}),
-        // Consolidated deps — skill/dashboard routes activate when providers are configured
-        ...(skillManager ? { skillManager } : {}),
-        ...(providerRegistry ? { providerRegistry } : {}),
-        ...(skillManager && providerRegistry
-          ? {
-              dashboardDeps: {
-                skillManager,
-                getSecurityConfig: () => resolveConfigSecurity(mutableConfig),
-                getProviders: () => buildDashboardProviderSnapshot(mutableConfig, providerRegistry, [resolveSelectedProvider(args, mutableConfig), ...(args.providers ?? [])]),
-              },
-            }
-          : {}),
-        analyticsDeps: { analytics },
-      });
-      printLine(`Chat server listening on ${server.url}`);
-      return;
-    }
-
-    const sessionStore = new FileSessionStore(sessionStoreDir);
-    const runtime = createChatRuntime({
-      chatLlm,
-      executionLlm: execLlm,
-      projectName: projectId,
-      sessionContinuation: true,
-    });
-    const repl = new ChatRepl({
-      engine: runtime.engine,
-      turnRunner: runtime.turnRunner,
-      projectId,
-      sessionStore,
-      verbose: args.verbose,
-    });
-    await repl.start();
-    await finalize();
+  if (await runChatCommandIfRequested(args, config, root, paths, logger)) {
     return;
   }
 

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -171,6 +171,32 @@ type VerifyCommandSpec = {
   readonly args: readonly string[];
 };
 
+
+type BudgetAbortWiring = {
+  readonly controller: AbortController;
+  readonly abortForBudget: (result: CircuitBreakerResult) => void;
+  readonly cleanup: () => void;
+  readonly getResult: () => CircuitBreakerResult | undefined;
+};
+
+type StaleMateState = {
+  lastSignature: string;
+  stalledIterations: number;
+};
+
+type BuildMartinConfigOptions = {
+  readonly chunkId: string;
+  readonly config: Partial<CliSkillConfig>;
+  readonly input: SkillInput;
+  readonly taskId: string | undefined;
+  readonly defaultPromiseTag: string;
+  readonly executionStage: string;
+  readonly budgetWiring: BudgetAbortWiring;
+  readonly checkpoint: ICheckpointStore | undefined;
+  readonly chunkSpan: Span;
+  readonly staleMateState: StaleMateState;
+};
+
 const ALLOWED_VERIFY_COMMANDS = new Map<string, VerifyCommandSpec>([
   ['npx tsc --noEmit', { command: process.platform === 'win32' ? 'npx.cmd' : 'npx', args: ['tsc', '--noEmit'] }],
   ['npm run typecheck', { command: process.platform === 'win32' ? 'npm.cmd' : 'npm', args: ['run', 'typecheck'] }],
@@ -279,31 +305,10 @@ export class CliSkillExecutor {
     }
 
     const chunkId = this.extractChunkId(skillId);
-    const budgetAbortController = new AbortController();
-    let budgetAbortResult: CircuitBreakerResult | undefined;
-
-    const abortForBudget = (result: CircuitBreakerResult): void => {
-      budgetAbortResult = result;
-      if (!budgetAbortController.signal.aborted) {
-        budgetAbortController.abort(new BudgetExceededError(result.spendUsd, result.limitUsd));
-      }
-    };
-    const upstreamAbortSignal = config.martin?.abortSignal;
-    let upstreamAbortHandler: (() => void) | undefined;
-    const cleanupUpstreamAbortHandler = (): void => {
-      if (upstreamAbortSignal && upstreamAbortHandler) {
-        upstreamAbortSignal.removeEventListener('abort', upstreamAbortHandler);
-        upstreamAbortHandler = undefined;
-      }
-    };
-    if (upstreamAbortSignal?.aborted) {
-      budgetAbortController.abort(upstreamAbortSignal.reason);
-    } else if (upstreamAbortSignal) {
-      upstreamAbortHandler = () => {
-        budgetAbortController.abort(upstreamAbortSignal.reason);
-      };
-      upstreamAbortSignal.addEventListener('abort', upstreamAbortHandler, { once: true });
-    }
+    const isImpl = taskId ? !this.isHardenTaskId(taskId) : true;
+    const executionStage = isImpl ? 'impl' : 'harden';
+    const defaultPromiseTag = isImpl ? `IMPL_${chunkId}_DONE` : `HARDEN_${chunkId}_DONE`;
+    const budgetWiring = this.createBudgetAbortWiring(config.martin?.abortSignal);
 
     this.observer.recordReplay?.({
       kind: 'tool.call',
@@ -320,7 +325,7 @@ export class CliSkillExecutor {
     const preCost = this.computeCurrentCost();
     const preCheck = this.observer.breaker.check(preCost);
     if (preCheck.tripped) {
-      cleanupUpstreamAbortHandler();
+      budgetWiring.cleanup();
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
       return {
         output: `Budget exceeded: $${preCheck.spendUsd.toFixed(2)} / $${preCheck.limitUsd.toFixed(2)}`,
@@ -332,7 +337,7 @@ export class CliSkillExecutor {
     try {
       this.git.isolate(chunkId);
     } catch (err) {
-      cleanupUpstreamAbortHandler();
+      budgetWiring.cleanup();
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: String(err) });
       throw new Error(
         `Git isolation failed for chunk "${chunkId}": ${err instanceof Error ? err.message : String(err)}`,
@@ -341,187 +346,34 @@ export class CliSkillExecutor {
     const preMartinStatus = this.git.getStatus();
     const preMartinTrackedChanges = this.trackedChangesFromStatus(preMartinStatus);
     if (preMartinTrackedChanges.length > 0) {
-      cleanupUpstreamAbortHandler();
+      budgetWiring.cleanup();
       const errorMessage = 'git worktree has pre-existing tracked changes after isolation; refusing budget-managed execution';
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage });
       throw new Error(`${errorMessage}: ${preMartinTrackedChanges.join(', ')}`);
     }
     const preMartinUntrackedFiles = this.untrackedFilesFromStatus(preMartinStatus);
 
-    // Build martin config with defaults from input when not explicitly provided
-    const isImpl = taskId ? !this.isHardenTaskId(taskId) : true;
-    const executionStage = isImpl ? 'impl' : 'harden';
-    const defaultPromiseTag = isImpl ? `IMPL_${chunkId}_DONE` : `HARDEN_${chunkId}_DONE`;
-    const martinDefaults: MartinLoopConfig = {
-      prompt: input.objective,
-      promiseTag: defaultPromiseTag,
-      maxIterations: 10,
-      maxTurns: 25,
-      timeoutMs: 600_000,
-      workingDir: this.git.getWorkingDir(),
-      taskId,
+    const staleMateState: StaleMateState = { lastSignature: '', stalledIterations: 0 };
+    const wrappedConfig = this.buildMartinConfig({
       chunkId,
-      ...this.defaultMartinConfig,
-    };
-
-    // Wire onIteration for observer integration
-    const wrappedConfig: MartinLoopConfig = {
-      ...martinDefaults,
-      ...config.martin,
-      abortSignal: budgetAbortController.signal,
-      onRateLimit: (provider: string) => {
-        this.logger?.warn('MartinLoop: provider rate limited', { chunkId, provider }, 'martin');
-        return config.martin?.onRateLimit?.(provider);
-      },
-      onProviderAttempt: (provider: string, iteration: number, renderedPrompt?: string) => {
-        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, provider, renderedPrompt);
-        const estimatedBudgetResult = this.observer.breaker.check(estimatedSpend);
-        if (estimatedBudgetResult.tripped) {
-          abortForBudget(estimatedBudgetResult);
-          throw new BudgetExceededError(estimatedBudgetResult.spendUsd, estimatedBudgetResult.limitUsd);
-        }
-
-        this.logger?.info('MartinLoop: provider attempt', { chunkId, provider, iteration }, 'martin');
-        // Show in-place progress line (overwritten by next update or final summary)
-        writeProgress(
-          formatIterationProgress({ chunkId, iteration, maxIterations: wrappedConfig.maxIterations }),
-          { final: false },
-        );
-        config.martin?.onProviderAttempt?.(provider, iteration, renderedPrompt);
-      },
-      onProviderSwitch: (fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset' | 'spawn-error') => {
-        this.logger?.warn('MartinLoop: provider switch', { chunkId, fromProvider, toProvider, reason }, 'martin');
-        config.martin?.onProviderSwitch?.(fromProvider, toProvider, reason);
-      },
-      onSpawnError: (provider: string, error: string) => {
-        this.logger?.error('MartinLoop: provider spawn error', { chunkId, provider, error }, 'martin');
-        const currentCost = this.computeCurrentCost();
-        const budgetResult = this.observer.breaker.check(currentCost);
-        if (budgetResult.tripped) {
-          abortForBudget(budgetResult);
-        }
-        config.martin?.onSpawnError?.(provider, error);
-      },
-      onProviderTimeout: (provider: string, timeoutMs: number) => {
-        this.logger?.warn('MartinLoop: provider iteration timeout', { chunkId, provider, timeoutMs }, 'martin');
-        config.martin?.onProviderTimeout?.(provider, timeoutMs);
-      },
-      onSleep: (durationMs: number, source: string) => {
-        this.logger?.warn('MartinLoop: sleeping for rate limit reset', {
-          chunkId,
-          durationMs,
-          source,
-        }, 'martin');
-        config.martin?.onSleep?.(durationMs, source);
-      },
-      onIteration: (iteration: number, result: IterationResult) => {
-        // Print final summary line (not overwritten)
-        writeProgress(
-          formatIterationProgress({
-            chunkId,
-            iteration,
-            maxIterations: wrappedConfig.maxIterations,
-            durationMs: result.durationMs,
-            tokensEstimated: result.tokensEstimated,
-          }),
-          { final: true },
-        );
-        this.logger?.info('MartinLoop: iteration complete', {
-          chunkId,
-          iteration,
-          exitCode: result.exitCode,
-          rateLimited: result.rateLimited,
-          promiseDetected: result.promiseDetected,
-          ...(result.emittedPromiseTags && result.emittedPromiseTags.length > 0
-            ? { emittedPromiseTags: result.emittedPromiseTags }
-            : {}),
-          sleepMs: result.sleepMs,
-        }, 'martin');
-        // Full raw output -> build.log only (via debug, always captured)
-        // Embed as multi-line text (not JSON) so newlines are preserved in build.log
-        if (result.stderr) {
-          this.logger?.debug(`MartinLoop: iter ${iteration} stderr [${chunkId}]:\n${result.stderr}`, undefined, 'martin');
-        }
-        if (result.stdout) {
-          this.logger?.debug(`MartinLoop: iter ${iteration} stdout [${chunkId}] (${result.stdout.length} chars):\n${result.stdout.slice(0, 4000)}`, undefined, 'martin');
-        }
-        // Surface errors on terminal when iteration fails (non-rate-limit)
-        if (result.exitCode !== 0 && !result.rateLimited) {
-          this.logger?.error(
-            `MartinLoop: iter ${iteration} failed (exit ${result.exitCode})`,
-            result.failure ?? {
-              chunkId,
-              exitCode: result.exitCode,
-              stderr: result.stderr?.trim().split('\n').slice(-5).join('\n') ?? '',
-            },
-            'martin',
-          );
-        }
-        // Create iteration span
-        const iterSpan = this.observer.startSpan(this.observer.trace, {
-          name: `cli:${chunkId}:iter-${iteration}`,
-          parentSpanId: chunkSpan.id,
-        });
-
-        // Record token usage
-        this.observer.recordTokenUsage(
-          iterSpan,
-          {
-            model: result.provider,
-            promptTokens: Math.ceil((config.martin?.prompt?.length ?? 0) / 4),
-            completionTokens: result.tokensEstimated,
-          },
-          this.observer.counter,
-        );
-
-        // End iteration span
-        this.observer.endSpan(iterSpan, { status: 'completed' }, this.observer.loopDetector);
-
-        // Auto-commit + per-commit checkpoint recording
-        const committed = this.git.autoCommit(chunkId, executionStage, iteration);
-        if (committed && checkpoint && taskId) {
-          const commitHash = this.git.getCurrentHead();
-          checkpoint.recordCommit(taskId, executionStage, iteration, commitHash);
-        }
-
-        if (wrappedConfig.staleMateLimit !== undefined && !result.rateLimited) {
-          const signature = normalizeStaleMateSignature(result.stdout);
-          const outputChanged = signature.length > 0 && signature !== lastStaleMateSignature;
-          if (committed || outputChanged || result.promiseDetected) {
-            stalledIterations = 0;
-          } else {
-            stalledIterations++;
-          }
-          lastStaleMateSignature = signature;
-
-          if (stalledIterations >= wrappedConfig.staleMateLimit) {
-            throw new Error(
-              `MartinLoop stale mate for chunk "${chunkId}" after ${stalledIterations} non-progress iterations`,
-            );
-          }
-        }
-
-        // Budget check — stops before NEXT iteration
-        const currentCost = this.computeCurrentCost();
-        const budgetResult = this.observer.breaker.check(currentCost);
-        if (budgetResult.tripped) {
-          throw new BudgetExceededError(currentCost, budgetResult.limitUsd);
-        }
-
-        // Forward to original callback if provided
-        config.martin?.onIteration?.(iteration, result);
-      },
-    };
+      config,
+      input,
+      taskId,
+      defaultPromiseTag,
+      executionStage,
+      budgetWiring,
+      checkpoint,
+      chunkSpan,
+      staleMateState,
+    });
 
     // Run Martin loop
     let martinResult: MartinLoopResult;
-    let lastStaleMateSignature = '';
-    let stalledIterations = 0;
     const budgetPoll = setInterval(() => {
       const currentCost = this.computeCurrentCost();
       const budgetResult = this.observer.breaker.check(currentCost);
       if (budgetResult.tripped) {
-        abortForBudget(budgetResult);
+        budgetWiring.abortForBudget(budgetResult);
       }
     }, BUDGET_POLL_INTERVAL_MS);
     budgetPoll.unref?.();
@@ -531,8 +383,8 @@ export class CliSkillExecutor {
     } catch (err) {
       const budgetError = err instanceof BudgetExceededError
         ? err
-        : budgetAbortResult
-          ? new BudgetExceededError(budgetAbortResult.spendUsd, budgetAbortResult.limitUsd)
+        : budgetWiring.getResult()
+          ? new BudgetExceededError(budgetWiring.getResult()!.spendUsd, budgetWiring.getResult()!.limitUsd)
           : undefined;
 
       if (budgetError) {
@@ -551,9 +403,10 @@ export class CliSkillExecutor {
       );
     } finally {
       clearInterval(budgetPoll);
-      cleanupUpstreamAbortHandler();
+      budgetWiring.cleanup();
     }
 
+    const budgetAbortResult = budgetWiring.getResult();
     if (budgetAbortResult) {
       this.resetBudgetAbortedWorktree(preMartinUntrackedFiles);
       this.observer.setMetadata(chunkSpan, {
@@ -654,6 +507,241 @@ export class CliSkillExecutor {
       output: martinResult.output,
       tokensUsed: chunkTokensUsed,
     };
+  }
+
+
+  private createBudgetAbortWiring(upstreamAbortSignal?: AbortSignal): BudgetAbortWiring {
+    const controller = new AbortController();
+    let budgetAbortResult: CircuitBreakerResult | undefined;
+    let upstreamAbortHandler: (() => void) | undefined;
+
+    const abortForBudget = (result: CircuitBreakerResult): void => {
+      budgetAbortResult = result;
+      if (!controller.signal.aborted) {
+        controller.abort(new BudgetExceededError(result.spendUsd, result.limitUsd));
+      }
+    };
+
+    const cleanup = (): void => {
+      if (upstreamAbortSignal && upstreamAbortHandler) {
+        upstreamAbortSignal.removeEventListener('abort', upstreamAbortHandler);
+        upstreamAbortHandler = undefined;
+      }
+    };
+
+    if (upstreamAbortSignal?.aborted) {
+      controller.abort(upstreamAbortSignal.reason);
+    } else if (upstreamAbortSignal) {
+      upstreamAbortHandler = () => {
+        controller.abort(upstreamAbortSignal.reason);
+      };
+      upstreamAbortSignal.addEventListener('abort', upstreamAbortHandler, { once: true });
+    }
+
+    return {
+      controller,
+      abortForBudget,
+      cleanup,
+      getResult: () => budgetAbortResult,
+    };
+  }
+
+  private buildMartinConfig(options: BuildMartinConfigOptions): MartinLoopConfig {
+    const {
+      chunkId,
+      config,
+      input,
+      taskId,
+      defaultPromiseTag,
+      executionStage,
+      budgetWiring,
+      checkpoint,
+      chunkSpan,
+      staleMateState,
+    } = options;
+    const martinDefaults: MartinLoopConfig = {
+      prompt: input.objective,
+      promiseTag: defaultPromiseTag,
+      maxIterations: 10,
+      maxTurns: 25,
+      timeoutMs: 600_000,
+      workingDir: this.git.getWorkingDir(),
+      taskId,
+      chunkId,
+      ...this.defaultMartinConfig,
+    };
+
+    const wrappedConfig: MartinLoopConfig = {
+      ...martinDefaults,
+      ...config.martin,
+      abortSignal: budgetWiring.controller.signal,
+      onRateLimit: (provider: string) => {
+        this.logger?.warn('MartinLoop: provider rate limited', { chunkId, provider }, 'martin');
+        return config.martin?.onRateLimit?.(provider);
+      },
+      onProviderAttempt: (provider: string, iteration: number, renderedPrompt?: string) => {
+        const estimatedSpend = this.computeCurrentCost() + this.estimateUpcomingIterationCost(wrappedConfig, provider, renderedPrompt);
+        const estimatedBudgetResult = this.observer.breaker.check(estimatedSpend);
+        if (estimatedBudgetResult.tripped) {
+          budgetWiring.abortForBudget(estimatedBudgetResult);
+          throw new BudgetExceededError(estimatedBudgetResult.spendUsd, estimatedBudgetResult.limitUsd);
+        }
+
+        this.logger?.info('MartinLoop: provider attempt', { chunkId, provider, iteration }, 'martin');
+        writeProgress(
+          formatIterationProgress({ chunkId, iteration, maxIterations: wrappedConfig.maxIterations }),
+          { final: false },
+        );
+        config.martin?.onProviderAttempt?.(provider, iteration, renderedPrompt);
+      },
+      onProviderSwitch: (fromProvider: string, toProvider: string, reason: 'rate-limit' | 'post-sleep-reset' | 'spawn-error') => {
+        this.logger?.warn('MartinLoop: provider switch', { chunkId, fromProvider, toProvider, reason }, 'martin');
+        config.martin?.onProviderSwitch?.(fromProvider, toProvider, reason);
+      },
+      onSpawnError: (provider: string, error: string) => {
+        this.logger?.error('MartinLoop: provider spawn error', { chunkId, provider, error }, 'martin');
+        const currentCost = this.computeCurrentCost();
+        const budgetResult = this.observer.breaker.check(currentCost);
+        if (budgetResult.tripped) {
+          budgetWiring.abortForBudget(budgetResult);
+        }
+        config.martin?.onSpawnError?.(provider, error);
+      },
+      onProviderTimeout: (provider: string, timeoutMs: number) => {
+        this.logger?.warn('MartinLoop: provider iteration timeout', { chunkId, provider, timeoutMs }, 'martin');
+        config.martin?.onProviderTimeout?.(provider, timeoutMs);
+      },
+      onSleep: (durationMs: number, source: string) => {
+        this.logger?.warn('MartinLoop: sleeping for rate limit reset', { chunkId, durationMs, source }, 'martin');
+        config.martin?.onSleep?.(durationMs, source);
+      },
+      onIteration: (iteration: number, result: IterationResult) => {
+        this.recordMartinIteration({
+          chunkId,
+          iteration,
+          result,
+          wrappedConfig,
+          config,
+          executionStage,
+          checkpoint,
+          taskId,
+          chunkSpan,
+          staleMateState,
+        });
+      },
+    };
+
+    return wrappedConfig;
+  }
+
+  private recordMartinIteration(options: {
+    readonly chunkId: string;
+    readonly iteration: number;
+    readonly result: IterationResult;
+    readonly wrappedConfig: MartinLoopConfig;
+    readonly config: Partial<CliSkillConfig>;
+    readonly executionStage: string;
+    readonly checkpoint: ICheckpointStore | undefined;
+    readonly taskId: string | undefined;
+    readonly chunkSpan: Span;
+    readonly staleMateState: StaleMateState;
+  }): void {
+    const { chunkId, iteration, result, wrappedConfig, config, executionStage, checkpoint, taskId, chunkSpan, staleMateState } = options;
+    writeProgress(
+      formatIterationProgress({
+        chunkId,
+        iteration,
+        maxIterations: wrappedConfig.maxIterations,
+        durationMs: result.durationMs,
+        tokensEstimated: result.tokensEstimated,
+      }),
+      { final: true },
+    );
+    this.logger?.info('MartinLoop: iteration complete', {
+      chunkId,
+      iteration,
+      exitCode: result.exitCode,
+      rateLimited: result.rateLimited,
+      promiseDetected: result.promiseDetected,
+      ...(result.emittedPromiseTags && result.emittedPromiseTags.length > 0
+        ? { emittedPromiseTags: result.emittedPromiseTags }
+        : {}),
+      sleepMs: result.sleepMs,
+    }, 'martin');
+    if (result.stderr) {
+      this.logger?.debug(`MartinLoop: iter ${iteration} stderr [${chunkId}]:\n${result.stderr}`, undefined, 'martin');
+    }
+    if (result.stdout) {
+      this.logger?.debug(`MartinLoop: iter ${iteration} stdout [${chunkId}] (${result.stdout.length} chars):\n${result.stdout.slice(0, 4000)}`, undefined, 'martin');
+    }
+    if (result.exitCode !== 0 && !result.rateLimited) {
+      this.logger?.error(
+        `MartinLoop: iter ${iteration} failed (exit ${result.exitCode})`,
+        result.failure ?? {
+          chunkId,
+          exitCode: result.exitCode,
+          stderr: result.stderr?.trim().split('\n').slice(-5).join('\n') ?? '',
+        },
+        'martin',
+      );
+    }
+
+    const iterSpan = this.observer.startSpan(this.observer.trace, {
+      name: `cli:${chunkId}:iter-${iteration}`,
+      parentSpanId: chunkSpan.id,
+    });
+    this.observer.recordTokenUsage(
+      iterSpan,
+      {
+        model: result.provider,
+        promptTokens: Math.ceil((config.martin?.prompt?.length ?? 0) / 4),
+        completionTokens: result.tokensEstimated,
+      },
+      this.observer.counter,
+    );
+    this.observer.endSpan(iterSpan, { status: 'completed' }, this.observer.loopDetector);
+
+    const committed = this.git.autoCommit(chunkId, executionStage, iteration);
+    if (committed && checkpoint && taskId) {
+      const commitHash = this.git.getCurrentHead();
+      checkpoint.recordCommit(taskId, executionStage, iteration, commitHash);
+    }
+
+    this.checkStaleMate({ chunkId, result, wrappedConfig, committed, staleMateState });
+
+    const currentCost = this.computeCurrentCost();
+    const budgetResult = this.observer.breaker.check(currentCost);
+    if (budgetResult.tripped) {
+      throw new BudgetExceededError(currentCost, budgetResult.limitUsd);
+    }
+
+    config.martin?.onIteration?.(iteration, result);
+  }
+
+  private checkStaleMate(options: {
+    readonly chunkId: string;
+    readonly result: IterationResult;
+    readonly wrappedConfig: MartinLoopConfig;
+    readonly committed: boolean;
+    readonly staleMateState: StaleMateState;
+  }): void {
+    const { chunkId, result, wrappedConfig, committed, staleMateState } = options;
+    if (wrappedConfig.staleMateLimit === undefined || result.rateLimited) return;
+
+    const signature = normalizeStaleMateSignature(result.stdout);
+    const outputChanged = signature.length > 0 && signature !== staleMateState.lastSignature;
+    if (committed || outputChanged || result.promiseDetected) {
+      staleMateState.stalledIterations = 0;
+    } else {
+      staleMateState.stalledIterations++;
+    }
+    staleMateState.lastSignature = signature;
+
+    if (staleMateState.stalledIterations >= wrappedConfig.staleMateLimit) {
+      throw new Error(
+        `MartinLoop stale mate for chunk "${chunkId}" after ${staleMateState.stalledIterations} non-progress iterations`,
+      );
+    }
   }
 
   private async attemptConflictResolution(

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -25,6 +25,12 @@ import { tryExtractTextFromNode } from './providers/index.js';
 import { createChunkSession, createChunkTranscriptEntry, type ChunkSession } from '../session/chunk-session.js';
 import { classifyCommandFailure, commandFailureFromExecError, parseResetTimeText, type CommandFailure } from '../errors/command-failure.js';
 
+type RunLoopRateLimitState = {
+  readonly activeProvider: string;
+  readonly pendingSleepMs: number;
+  readonly chunkSession: ChunkSession | undefined;
+};
+
 export function parseResetTime(stderr: string, stdout: string): { sleepSeconds: number; source: string } {
   return parseResetTimeText(`${stderr}\n${stdout}`);
 }
@@ -623,151 +629,45 @@ export class MartinLoop {
 
       config.onIteration?.(iteration, iterResult);
 
-      if (chunkSession) {
-        chunkSession = this.appendIterationOutput(chunkSession, activeProvider, normalizedStdout, iteration);
-
-        if (config.contextUsage) {
-          const usage = config.contextUsage(renderedPrompt, activeProvider, resolved.defaultContextWindowTokens());
-          chunkSession = {
-            ...chunkSession,
-            contextWindow: {
-              ...chunkSession.contextWindow,
-              provider: activeProvider,
-              usedTokens: usage.usedTokens,
-              maxTokens: usage.maxTokens,
-              usageRatio: usage.usageRatio,
-              compactThreshold: usage.threshold,
-            },
-            updatedAt: isoNow(),
-          };
-        }
-
-        config.sessionStore?.save(chunkSession);
-
-        if (
-          config.contextUsage &&
-          config.snapshotStore &&
-          config.compactor &&
-          chunkSession.contextWindow.usageRatio >= chunkSession.contextWindow.compactThreshold
-        ) {
-          config.snapshotStore.writeSnapshot(chunkSession, 'pre-compaction');
-          chunkSession = await config.compactor.compact(chunkSession);
-          config.sessionStore?.save(chunkSession);
-        }
-      }
+      chunkSession = await this.persistIterationSession({
+        chunkSession,
+        activeProvider,
+        normalizedStdout,
+        iteration,
+        renderedPrompt,
+        resolved,
+        config,
+      });
 
       // Rate limit: provider fallback chain
       if (rateLimited) {
         iteration--;
-
-        // Notify via legacy callback (non-controlling)
-        config.onRateLimit?.(activeProvider);
-
-        // Track this provider as exhausted
-        exhaustedProviders.set(activeProvider, failure!);
-
-        // Find next non-exhausted provider
-        const nextProvider = providers.find(p => !exhaustedProviders.has(p));
-
-        if (nextProvider) {
-          // Switch to next provider, retry immediately
-          config.onProviderSwitch?.(activeProvider, nextProvider, 'rate-limit');
-          activeProvider = nextProvider;
-          if (chunkSession) {
-            chunkSession = {
-              ...chunkSession,
-              activeProvider,
-              updatedAt: isoNow(),
-            };
-            config.sessionStore?.save(chunkSession);
-          }
-          continue;
-        }
-
-        // All providers exhausted — parse reset times and sleep
-        let shortestSleep = Infinity;
-        let shortestSource = 'unknown';
-
-        for (const [providerName, data] of exhaustedProviders) {
-          if (data.retryAfterMs !== undefined) {
-            const sleepSeconds = data.retryAfterMs / 1000;
-            if (sleepSeconds >= 0 && sleepSeconds < shortestSleep) {
-              shortestSleep = sleepSeconds;
-              shortestSource = `${providerName} parseRetryAfter`;
-            }
-            continue;
-          }
-
-          const parsed = parseResetTime(data.stderr, data.stdout);
-          if (parsed.sleepSeconds >= 0 && parsed.sleepSeconds < shortestSleep) {
-            shortestSleep = parsed.sleepSeconds;
-            shortestSource = parsed.source;
-          }
-        }
-
-        let sleepMs: number;
-        let sleepSource: string;
-
-        if (shortestSleep === Infinity) {
-          // No parseable reset time — fallback to 120s
-          sleepMs = 120_000;
-          sleepSource = 'unknown';
-          // Log warning with raw stderr so user can see what the API said
-          const rawStderrs = [...exhaustedProviders.entries()]
-            .map(([p, d]) => `${p}: ${d.stderr}`)
-            .join(' | ');
-          console.warn(`[MartinLoop] Rate limit reset time could not be determined. Raw stderr: ${rawStderrs}`);
-        } else {
-          sleepMs = shortestSleep * 1000;
-          sleepSource = shortestSource;
-        }
-
-        // Fire onSleep before sleeping
-        config.onSleep?.(sleepMs, sleepSource);
-
-        // Sleep until reset (abort-aware so SIGINT can interrupt long waits)
-        await sleepWithAbort(sleepMs, sleepFn, config.abortSignal);
-
-        // Track the sleep duration for the next iteration's report
-        pendingSleepMs = sleepMs;
-
-        // Clear exhausted state, reset to original provider
-        exhaustedProviders.clear();
-        if (activeProvider !== initialProvider) {
-          config.onProviderSwitch?.(activeProvider, initialProvider, 'post-sleep-reset');
-        }
-        activeProvider = initialProvider;
-        if (chunkSession) {
-          chunkSession = {
-            ...chunkSession,
-            activeProvider,
-            updatedAt: isoNow(),
-          };
-          config.sessionStore?.save(chunkSession);
-        }
+        const nextState = await this.handleRateLimitedIteration({
+          config,
+          providers,
+          initialProvider,
+          activeProvider,
+          failure: failure!,
+          exhaustedProviders,
+          chunkSession,
+          sleepFn,
+        });
+        activeProvider = nextState.activeProvider;
+        pendingSleepMs = nextState.pendingSleepMs;
+        chunkSession = nextState.chunkSession;
         continue;
       }
 
       // Promise detected — verify meaningful output
       if (promiseDetected) {
-        const stripped = normalizedStdout.replace(promiseRegex, '').trim();
-        if (stripped.length === 0) {
-          // Promise without meaningful changes — reject
-          return {
-            completed: false,
-            iterations: iteration,
-            output: lastOutput,
-            tokensUsed: totalTokens,
-            emittedPromiseTags: lastEmittedPromiseTags,
-          };
-        }
-        return {
-          completed: true,
-          iterations: iteration,
-          output: lastOutput,
-          tokensUsed: totalTokens,
-          emittedPromiseTags: lastEmittedPromiseTags,
-        };
+        return this.finalizePromiseDetectedIteration({
+          normalizedStdout,
+          promiseRegex,
+          iteration,
+          lastOutput,
+          totalTokens,
+          lastEmittedPromiseTags,
+        });
       }
     }
 
@@ -778,6 +678,183 @@ export class MartinLoop {
       tokensUsed: totalTokens,
       emittedPromiseTags: lastEmittedPromiseTags,
     };
+  }
+
+
+
+
+  private finalizePromiseDetectedIteration(options: {
+    readonly normalizedStdout: string;
+    readonly promiseRegex: RegExp;
+    readonly iteration: number;
+    readonly lastOutput: string;
+    readonly totalTokens: number;
+    readonly lastEmittedPromiseTags: readonly string[];
+  }): MartinLoopResult {
+    const { normalizedStdout, promiseRegex, iteration, lastOutput, totalTokens, lastEmittedPromiseTags } = options;
+    const stripped = normalizedStdout.replace(promiseRegex, '').trim();
+    if (stripped.length === 0) {
+      return {
+        completed: false,
+        iterations: iteration,
+        output: lastOutput,
+        tokensUsed: totalTokens,
+        emittedPromiseTags: lastEmittedPromiseTags,
+      };
+    }
+    return {
+      completed: true,
+      iterations: iteration,
+      output: lastOutput,
+      tokensUsed: totalTokens,
+      emittedPromiseTags: lastEmittedPromiseTags,
+    };
+  }
+
+  private async persistIterationSession(options: {
+    readonly chunkSession: ChunkSession | undefined;
+    readonly activeProvider: string;
+    readonly normalizedStdout: string;
+    readonly iteration: number;
+    readonly renderedPrompt: string;
+    readonly resolved: ICliProvider;
+    readonly config: MartinLoopConfig;
+  }): Promise<ChunkSession | undefined> {
+    const { chunkSession, activeProvider, normalizedStdout, iteration, renderedPrompt, resolved, config } = options;
+    if (!chunkSession) return undefined;
+
+    let nextSession = this.appendIterationOutput(chunkSession, activeProvider, normalizedStdout, iteration);
+
+    if (config.contextUsage) {
+      const usage = config.contextUsage(renderedPrompt, activeProvider, resolved.defaultContextWindowTokens());
+      nextSession = {
+        ...nextSession,
+        contextWindow: {
+          ...nextSession.contextWindow,
+          provider: activeProvider,
+          usedTokens: usage.usedTokens,
+          maxTokens: usage.maxTokens,
+          usageRatio: usage.usageRatio,
+          compactThreshold: usage.threshold,
+        },
+        updatedAt: isoNow(),
+      };
+    }
+
+    config.sessionStore?.save(nextSession);
+
+    if (
+      config.contextUsage &&
+      config.snapshotStore &&
+      config.compactor &&
+      nextSession.contextWindow.usageRatio >= nextSession.contextWindow.compactThreshold
+    ) {
+      config.snapshotStore.writeSnapshot(nextSession, 'pre-compaction');
+      nextSession = await config.compactor.compact(nextSession);
+      config.sessionStore?.save(nextSession);
+    }
+
+    return nextSession;
+  }
+
+  private async handleRateLimitedIteration(options: {
+    readonly config: MartinLoopConfig;
+    readonly providers: readonly string[];
+    readonly initialProvider: string;
+    readonly activeProvider: string;
+    readonly failure: CommandFailure;
+    readonly exhaustedProviders: Map<string, CommandFailure>;
+    readonly chunkSession: ChunkSession | undefined;
+    readonly sleepFn: (durationMs: number) => Promise<void>;
+  }): Promise<RunLoopRateLimitState> {
+    const {
+      config,
+      providers,
+      initialProvider,
+      activeProvider,
+      failure,
+      exhaustedProviders,
+      chunkSession,
+      sleepFn,
+    } = options;
+
+    config.onRateLimit?.(activeProvider);
+    exhaustedProviders.set(activeProvider, failure);
+
+    const nextProvider = providers.find(p => !exhaustedProviders.has(p));
+    if (nextProvider) {
+      config.onProviderSwitch?.(activeProvider, nextProvider, 'rate-limit');
+      return {
+        activeProvider: nextProvider,
+        pendingSleepMs: 0,
+        chunkSession: this.updateChunkSessionProvider(chunkSession, nextProvider, config),
+      };
+    }
+
+    const { sleepMs, sleepSource } = this.resolveProviderExhaustionSleep(exhaustedProviders);
+    config.onSleep?.(sleepMs, sleepSource);
+    await sleepWithAbort(sleepMs, sleepFn, config.abortSignal);
+
+    exhaustedProviders.clear();
+    if (activeProvider !== initialProvider) {
+      config.onProviderSwitch?.(activeProvider, initialProvider, 'post-sleep-reset');
+    }
+
+    return {
+      activeProvider: initialProvider,
+      pendingSleepMs: sleepMs,
+      chunkSession: this.updateChunkSessionProvider(chunkSession, initialProvider, config),
+    };
+  }
+
+  private resolveProviderExhaustionSleep(exhaustedProviders: Map<string, CommandFailure>): {
+    readonly sleepMs: number;
+    readonly sleepSource: string;
+  } {
+    let shortestSleep = Infinity;
+    let shortestSource = 'unknown';
+
+    for (const [providerName, data] of exhaustedProviders) {
+      if (data.retryAfterMs !== undefined) {
+        const sleepSeconds = data.retryAfterMs / 1000;
+        if (sleepSeconds >= 0 && sleepSeconds < shortestSleep) {
+          shortestSleep = sleepSeconds;
+          shortestSource = `${providerName} parseRetryAfter`;
+        }
+        continue;
+      }
+
+      const parsed = parseResetTime(data.stderr, data.stdout);
+      if (parsed.sleepSeconds >= 0 && parsed.sleepSeconds < shortestSleep) {
+        shortestSleep = parsed.sleepSeconds;
+        shortestSource = parsed.source;
+      }
+    }
+
+    if (shortestSleep !== Infinity) {
+      return { sleepMs: shortestSleep * 1000, sleepSource: shortestSource };
+    }
+
+    const rawStderrs = [...exhaustedProviders.entries()]
+      .map(([p, d]) => `${p}: ${d.stderr}`)
+      .join(' | ');
+    console.warn(`[MartinLoop] Rate limit reset time could not be determined. Raw stderr: ${rawStderrs}`);
+    return { sleepMs: 120_000, sleepSource: 'unknown' };
+  }
+
+  private updateChunkSessionProvider(
+    chunkSession: ChunkSession | undefined,
+    activeProvider: string,
+    config: MartinLoopConfig,
+  ): ChunkSession | undefined {
+    if (!chunkSession) return undefined;
+    const updated = {
+      ...chunkSession,
+      activeProvider,
+      updatedAt: isoNow(),
+    };
+    config.sessionStore?.save(updated);
+    return updated;
   }
 
   private loadOrCreateChunkSession(config: MartinLoopConfig, providerName: string): ChunkSession | undefined {


### PR DESCRIPTION
## Summary
- extracts setup, iteration, replay, merge-conflict, and cost helpers from CliSkillExecutor.execute
- splits MartinLoop session persistence, promise-finalization, rate-limit sleep/reset handling, and chunk provider updates into focused helpers
- extracts ProcessBeastExecutor.start resource preparation, worktree allocation, isolated spec building, and secure run-config path preparation
- moves non-session and chat CLI command handling out of main so the entrypoint is a thinner coordinator

## Function size check
- CliSkillExecutor.execute: 209 lines
- MartinLoop.run: 247 lines
- ProcessBeastExecutor.start: 192 lines
- main: 212 lines

## Test plan
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator test -- --run tests/unit/beasts/process-beast-executor.test.ts tests/unit/skills/martin-loop.test.ts tests/unit/skills/cli-skill-executor.test.ts
- npm --prefix packages/franken-orchestrator run lint
- npm --prefix packages/franken-orchestrator run build

Closes #2227