### PR TITLE
test(dr): add missing cron job recovery fixture

### DIFF
--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -1,0 +1,16 @@
+# Restore preview disaster-recovery fixtures
+
+Restore preview is a read-only comparison between a backup manifest and the current live manifest. It is intended to make disaster-recovery drift explicit before an operator restores any state.
+
+## Missing cron job recovery
+
+The fixture at `packages/franken-orchestrator/tests/unit/dr/fixtures/missing-cron-job-recovery.json` captures a backup manifest that contains the `nightly-dr-check` cron job while the live manifest has no matching cron entry.
+
+Expected interpretation:
+
+- `area`: `cron`
+- `type`: `backup-only`
+- `severity`: `info`
+- recovery guidance: review the cron drift and explicitly restore, merge, or skip the job; do not silently drop it and do not overwrite live schedules blindly.
+
+This fixture is covered by `packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts` so future restore-preview changes keep missing cron jobs visible in deterministic test output.

--- a/packages/franken-orchestrator/tests/unit/dr/fixtures/missing-cron-job-recovery.json
+++ b/packages/franken-orchestrator/tests/unit/dr/fixtures/missing-cron-job-recovery.json
@@ -1,0 +1,36 @@
+{
+  "description": "Restore preview fixture for a cron job that exists in the backup manifest but is missing from live state. Operators should review and explicitly restore, merge, or skip the job instead of silently dropping it.",
+  "backup": {
+    "schemaVersion": 1,
+    "tasks": [],
+    "approvals": [],
+    "memory": [],
+    "cron": [
+      {
+        "id": "nightly-dr-check",
+        "digest": "sha256:backup-nightly-dr-check",
+        "state": "enabled",
+        "updatedAt": "2026-07-14T02:00:00.000Z",
+        "value": {
+          "schedule": "0 2 * * *",
+          "command": "frankenbeast dr verify --manifest latest",
+          "owner": "ops"
+        }
+      }
+    ]
+  },
+  "live": {
+    "schemaVersion": 1,
+    "tasks": [],
+    "approvals": [],
+    "memory": [],
+    "cron": []
+  },
+  "expectedConflict": {
+    "area": "cron",
+    "id": "nightly-dr-check",
+    "type": "backup-only",
+    "severity": "info",
+    "recommendationIncludes": "Review cron drift and explicitly restore, merge, or skip this job"
+  }
+}

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -1,11 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 import {
   detectRestorePreviewConflicts,
   type RestorePreviewManifest,
 } from '../../../src/dr/restore-preview.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+interface MissingCronJobRecoveryFixture {
+  readonly description: string;
+  readonly backup: RestorePreviewManifest;
+  readonly live: RestorePreviewManifest;
+  readonly expectedConflict: {
+    readonly area: 'cron';
+    readonly id: string;
+    readonly type: 'backup-only';
+    readonly severity: 'info';
+    readonly recommendationIncludes: string;
+  };
+}
+
+function readMissingCronJobRecoveryFixture(): MissingCronJobRecoveryFixture {
+  return JSON.parse(
+    readFileSync(join(__dirname, 'fixtures', 'missing-cron-job-recovery.json'), 'utf8'),
+  ) as MissingCronJobRecoveryFixture;
 }
 
 describe('restore preview conflict detector', () => {
@@ -89,6 +114,26 @@ describe('restore preview conflict detector', () => {
         recommendation: expect.stringContaining('re-approval'),
       }),
     );
+  });
+
+  it('loads the missing cron job recovery fixture as an explicit backup-only cron conflict', () => {
+    const fixture = readMissingCronJobRecoveryFixture();
+    const preview = detectRestorePreviewConflicts(fixture.backup, fixture.live);
+
+    expect(fixture.description).toContain('missing from live state');
+    expect(preview.safeToRestore).toBe(false);
+    expect(preview.wouldWrite).toBe(false);
+    expect(preview.conflicts).toContainEqual(
+      expect.objectContaining({
+        area: fixture.expectedConflict.area,
+        id: fixture.expectedConflict.id,
+        type: fixture.expectedConflict.type,
+        severity: fixture.expectedConflict.severity,
+        backup: expect.objectContaining({ state: 'enabled' }),
+        recommendation: expect.stringContaining(fixture.expectedConflict.recommendationIncludes),
+      }),
+    );
+    expect(preview.conflicts).not.toContainEqual(expect.objectContaining({ type: 'live-only' }));
   });
 
   it('compares digest, state, and timestamps so metadata drift is not hidden', () => {


### PR DESCRIPTION
## Summary
- Adds a deterministic restore-preview fixture for a backup-only cron job missing from live state.
- Covers the fixture in the restore-preview unit test so missing cron jobs remain explicit recovery conflicts.
- Documents the operator interpretation for the missing cron recovery fixture.

## Verification
- npm test --workspace @franken/orchestrator -- tests/unit/dr/restore-preview.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)
- git diff --check

Closes #1836