### PR TITLE
docs(dr): add disaster tabletop template

### DIFF
--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -14,3 +14,7 @@ Expected interpretation:
 - recovery guidance: review the cron drift and explicitly restore, merge, or skip the job; do not silently drop it and do not overwrite live schedules blindly.
 
 This fixture is covered by `packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts` so future restore-preview changes keep missing cron jobs visible in deterministic test output.
+
+## Tabletop exercises
+
+Use `docs/dr/tabletop-exercise-template.md` when operators need to rehearse a restore-preview scenario before executing any recovery work. The template keeps disaster-recovery practice read-only, requires at least one fail-closed edge case such as corrupt backup input, and records explicit restore/merge/skip/quarantine decisions for every drift item.

--- a/docs/dr/tabletop-exercise-template.md
+++ b/docs/dr/tabletop-exercise-template.md
@@ -34,7 +34,7 @@ Run at least one success-path inject and one negative/edge inject. Add issue-spe
 | Inject | Expected operator action | Evidence to capture |
 | --- | --- | --- |
 | Backup-only cron job | Identify the missing scheduled job and choose restore, merge, or skip explicitly. | Restore-preview output showing `area: cron`, `type: backup-only`, severity, and final decision. |
-| Live-only approval/session token | Treat restoration as blocker-risk until an approver confirms the token is safe to revive or should remain absent. | Decision log naming the approver, token class, and why restore was allowed or rejected. |
+| Live-only approval/session token | Preserve live approval state and skip token restore; require a fresh approval if the backup lacks the live token. | Decision log naming the approver or owner, token class, and why restore was skipped or re-approval was required. |
 | Corrupt backup manifest | Stop before restore, quarantine or replace the corrupt artifact, and record the failed validation path. | Validation error, quarantined artifact path or replacement source, and owner for backup repair. |
 | Partial worker state | Compare task id, branch, PR, and latest heartbeat before overwriting or merging worker state. | Current worker evidence plus the chosen recovery action. |
 

--- a/docs/dr/tabletop-exercise-template.md
+++ b/docs/dr/tabletop-exercise-template.md
@@ -1,0 +1,77 @@
+# Disaster tabletop exercise template
+
+Use this template to run a deterministic disaster-recovery tabletop before changing restore tooling, rotating critical operators, or exercising backup/restore confidence. The exercise is deliberately non-destructive: operators inspect manifests, compare live state, and record decisions without restoring or overwriting production data.
+
+## Exercise metadata
+
+| Field | Value |
+| --- | --- |
+| Exercise name | `<short incident name>` |
+| Date / window | `<YYYY-MM-DD HH:MM UTC>` |
+| Facilitator | `<name>` |
+| Participants | `<operator, PM, worker owner, approver>` |
+| Systems in scope | `<cron jobs, worker queues, approvals, state manifests>` |
+| Systems out of scope | `<anything that must not be touched>` |
+| Backup manifest | `<path, URI, or snapshot id>` |
+| Live manifest | `<path, URI, or environment>` |
+| Communication channel | `<incident room / kanban card / ticket>` |
+
+## Preconditions
+
+- Confirm the exercise runs in dry-run/read-only mode and no restore command will be executed.
+- Capture the current live manifest reference and the backup manifest reference before discussion starts.
+- Assign one scribe to record every decision, unknown, and follow-up owner.
+- Define a stop condition: any participant can halt the exercise if a step would mutate production, expose secrets, or require credentials outside the approved scope.
+
+## Scenario prompt
+
+> A critical operator reports that a restore may be required because live orchestration state is incomplete, stale, or partially corrupt. The team must decide whether to restore, merge, quarantine, or skip each drifted item while preserving evidence and avoiding silent destructive changes.
+
+## Injects
+
+Run at least one success-path inject and one negative/edge inject. Add issue-specific injects when exercising a new restore fixture.
+
+| Inject | Expected operator action | Evidence to capture |
+| --- | --- | --- |
+| Backup-only cron job | Identify the missing scheduled job and choose restore, merge, or skip explicitly. | Restore-preview output showing `area: cron`, `type: backup-only`, severity, and final decision. |
+| Live-only approval/session token | Treat restoration as blocker-risk until an approver confirms the token is safe to revive or should remain absent. | Decision log naming the approver, token class, and why restore was allowed or rejected. |
+| Corrupt backup manifest | Stop before restore, quarantine or replace the corrupt artifact, and record the failed validation path. | Validation error, quarantined artifact path or replacement source, and owner for backup repair. |
+| Partial worker state | Compare task id, branch, PR, and latest heartbeat before overwriting or merging worker state. | Current worker evidence plus the chosen recovery action. |
+
+## Facilitation steps
+
+1. Read the scenario aloud and confirm the exercise scope.
+2. Open the backup manifest and live manifest in read-only mode.
+3. Generate or inspect restore-preview output for each drifted item.
+4. For every item, classify the action as `restore`, `merge`, `skip`, or `quarantine`.
+5. For every `restore` or `merge` decision, name the approver and the exact approval artifact before any follow-up implementation work starts.
+6. For every `skip` or `quarantine` decision, record the reason and the owner for cleanup.
+7. End the exercise by reviewing unresolved blockers and turning each into a tracked follow-up.
+
+## Decision log
+
+| Time (UTC) | Drift item | Action | Approver / owner | Evidence link | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `<HH:MM>` | `<manifest key>` | `restore \| merge \| skip \| quarantine` | `<name>` | `<link/path>` | `<why>` |
+
+## Edge-case checklist
+
+- [ ] The team demonstrated that corrupt or unreadable backup input fails closed.
+- [ ] Backup-only credentials, approvals, and session tokens were treated as blocker-risk, not informational drift.
+- [ ] Live-only state was not deleted solely because it was absent from backup.
+- [ ] Cron or scheduled work changes were reviewed for timezone, cadence, and owner before restore.
+- [ ] Every decision has an owner and evidence reference.
+- [ ] No production restore, force-push, branch deletion, or secret export occurred during the tabletop.
+
+## After-action summary
+
+Complete this section before closing the tabletop card.
+
+- What failed or surprised the team?
+- Which restore-preview output was ambiguous?
+- Which runbook, fixture, or alert should change before the next exercise?
+- Which follow-up tickets were created, and who owns them?
+
+## Pass/fail criteria
+
+The tabletop passes only when the team can explain every drift item, demonstrate at least one fail-closed edge case, and leave behind enough evidence for a later worker to reproduce the reasoning. If any step requires undocumented tribal knowledge or an untracked manual command, the exercise fails until that gap is documented or ticketed.

--- a/tests/docs-issue-1838.test.ts
+++ b/tests/docs-issue-1838.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+describe('issue #1838 disaster tabletop exercise template', () => {
+  const template = () => read('docs/dr/tabletop-exercise-template.md');
+
+  it('documents a complete operator tabletop workflow for restore-preview exercises', () => {
+    const doc = template();
+
+    for (const section of [
+      '# Disaster tabletop exercise template',
+      '## Exercise metadata',
+      '## Preconditions',
+      '## Scenario prompt',
+      '## Injects',
+      '## Facilitation steps',
+      '## Decision log',
+      '## Edge-case checklist',
+      '## After-action summary',
+      '## Pass/fail criteria',
+    ]) {
+      expect(doc).toContain(section);
+    }
+
+    for (const requiredField of [
+      'Backup manifest',
+      'Live manifest',
+      'Communication channel',
+      'restore',
+      'merge',
+      'skip',
+      'quarantine',
+    ]) {
+      expect(doc).toContain(requiredField);
+    }
+  });
+
+  it('covers success and fail-closed edge cases without allowing destructive restore practice', () => {
+    const doc = template();
+
+    expect(doc).toContain('Backup-only cron job');
+    expect(doc).toContain('Corrupt backup manifest');
+    expect(doc).toContain('fails closed');
+    expect(doc).toContain('No production restore, force-push, branch deletion, or secret export occurred during the tabletop.');
+    expect(doc).toContain('no restore command will be executed');
+    expect(doc).not.toContain('run the restore command against production');
+  });
+
+  it('links the template from the restore-preview disaster-recovery documentation', () => {
+    const restorePreview = read('docs/dr/restore-preview.md');
+
+    expect(restorePreview).toContain('docs/dr/tabletop-exercise-template.md');
+    expect(restorePreview).toContain('read-only');
+    expect(restorePreview).toContain('fail-closed edge case');
+  });
+});

--- a/tests/docs-issue-1838.test.ts
+++ b/tests/docs-issue-1838.test.ts
@@ -45,10 +45,14 @@ describe('issue #1838 disaster tabletop exercise template', () => {
 
     expect(doc).toContain('Backup-only cron job');
     expect(doc).toContain('Corrupt backup manifest');
+    expect(doc).toContain('Live-only approval/session token');
+    expect(doc).toContain('skip token restore');
+    expect(doc).toContain('fresh approval');
     expect(doc).toContain('fails closed');
     expect(doc).toContain('No production restore, force-push, branch deletion, or secret export occurred during the tabletop.');
     expect(doc).toContain('no restore command will be executed');
     expect(doc).not.toContain('run the restore command against production');
+    expect(doc).not.toContain('revive');
   });
 
   it('links the template from the restore-preview disaster-recovery documentation', () => {


### PR DESCRIPTION
## Summary
- Add a disaster-recovery tabletop exercise template covering metadata, scenario prompt, injects, facilitation steps, decision log, edge-case checklist, and pass/fail criteria.
- Link the tabletop template from the restore-preview disaster-recovery docs.
- Add a deterministic docs regression test for the template structure, fail-closed edge cases, and restore-preview cross-link.

## Verification
- `npm ci`
- `npm run test:root -- tests/docs-issue-1838.test.ts`
- `npm run test:root`
- `npm run lint` (passes; existing warnings only)
- `npm run build`

Closes #1838
