### PR TITLE
fix(orchestrator): write skill credentials atomically

### DIFF
--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -39,13 +39,17 @@ function fsyncDir(dirPath: string): void {
  * torn/partial file, mirroring the pattern used by FileCheckpointStore.
  * The parent directory must already exist.
  */
-export function atomicWriteFileSync(filePath: string, contents: string): void {
+export function atomicWriteFileSync(
+  filePath: string,
+  contents: string,
+  options: { mode?: number } = {},
+): void {
   let tmpPath = `${filePath}.tmp.${writeCounter++}.${deterministicUuid('atomic-file-write')}`;
   try {
     let fd: number;
     for (;;) {
       try {
-        fd = openSync(tmpPath, 'wx');
+        fd = openSync(tmpPath, 'wx', options.mode);
         break;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {

--- a/packages/franken-orchestrator/src/skills/skill-credential-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-credential-store.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { atomicWriteFileSync } from '../session/atomic-file.js';
 
 /**
  * Manages credential storage in .fbeast/.env.
@@ -62,6 +63,6 @@ export class SkillCredentialStore {
     const lines = Object.entries(entries).map(
       ([key, value]) => `${key}=${value}`,
     );
-    writeFileSync(this.envPath, lines.join('\n') + '\n');
+    atomicWriteFileSync(this.envPath, lines.join('\n') + '\n', { mode: 0o600 });
   }
 }

--- a/packages/franken-orchestrator/tests/unit/skills/skill-credential-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-credential-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SkillCredentialStore } from '../../../src/skills/skill-credential-store.js';
@@ -29,6 +29,45 @@ describe('SkillCredentialStore', () => {
     );
     expect(content).toContain('GITHUB_TOKEN=ghp_abc');
     expect(content).toContain('LINEAR_KEY=lin_xyz');
+  });
+
+  it('creates the credential env file with owner-only permissions', () => {
+    store.setMany({ GITHUB_TOKEN: 'ghp_abc' });
+
+    const mode = statSync(join(tempDir, '.fbeast', '.env')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('persists credentials without the truncating writeFileSync path', async () => {
+    rmSync(tempDir, { recursive: true, force: true });
+    const isolatedDir = mkdtempSync(join(tmpdir(), 'cred-atomic-test-'));
+    tempDir = isolatedDir;
+    writeFileSync(join(isolatedDir, 'existing.txt'), 'keep fs import active');
+
+    vi.resetModules();
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        writeFileSync: vi.fn(() => {
+          throw new Error('non-atomic writeFileSync must not be used');
+        }),
+      };
+    });
+    try {
+      const { SkillCredentialStore: IsolatedStore } = await import(
+        '../../../src/skills/skill-credential-store.js'
+      );
+      const isolatedStore = new IsolatedStore(isolatedDir);
+
+      expect(() => isolatedStore.setMany({ API_KEY: 'secret' })).not.toThrow();
+      expect(readFileSync(join(isolatedDir, '.fbeast', '.env'), 'utf-8')).toBe(
+        'API_KEY=secret\n',
+      );
+    } finally {
+      vi.doUnmock('node:fs');
+      vi.resetModules();
+    }
   });
 
   it('setMany preserves existing credentials', () => {


### PR DESCRIPTION
## Summary
- Replace SkillCredentialStore's truncating .fbeast/.env rewrite with atomic temp-file + fsync + rename persistence.
- Extend atomicWriteFileSync with an optional mode and write credential env files as 0600.
- Add regression coverage proving SkillCredentialStore no longer depends on writeFileSync and creates owner-only env files.

## Test Plan
- npm test -- --run tests/unit/skills/skill-credential-store.test.ts tests/unit/session/atomic-file.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/observer && npm run build --workspace @franken/brain && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1697