### PR TITLE
feat(dr): add runtime config rollback plan generator

### DIFF
--- a/docs/dr/runtime-config-rollback-plan.md
+++ b/docs/dr/runtime-config-rollback-plan.md
@@ -10,6 +10,7 @@ The helper is intentionally conservative:
 - it prints deterministic JSON-pointer changed paths;
 - it JSON-encodes changed paths in Markdown so unusual config keys cannot forge headings or command bullets;
 - it redacts changed values from machine-readable plan output and evidence commands;
+- it rejects control characters in rendered file paths;
 - it never writes the target runtime config itself;
 - the default evidence directory is deterministic but unique per target path;
 - captured evidence commands use private directory/file modes (`0700`/`0600`);
@@ -38,9 +39,9 @@ npm run dr:runtime-config-rollback:dry-run -- \
 
 The plan has four sections:
 
-1. `Capture read-only rollback evidence` — create the evidence directory, force it to `0700`, copy the before snapshot into it with `0600` permissions, and write deterministic change metadata.
+1. `Capture read-only rollback evidence` — refuse symlinked evidence path components, create the evidence directory, force it to `0700`, copy the before/after snapshots into it with `0600` permissions, and write deterministic value-redacted change metadata.
 2. `Operator decisions before rollback` — confirm the before snapshot is the intended last-known-good state and the changed paths match the incident.
-3. `Approval-gated rollback action` — the single `approval-cop run -- node ...` command that refuses symlinked target paths, checks that the target still matches the captured after snapshot, and then restores the before snapshot to the target config.
+3. `Approval-gated rollback action` — the single `approval-cop run -- node ...` command that refuses symlinked target paths, checks that the target still matches the captured immutable after snapshot under the evidence directory, and then restores the before snapshot to the target config.
 4. `Verify rollback` — compare the restored target with the rollback snapshot and parse both JSON files before resuming the affected runtime.
 
 Do not run the approval-gated copy until the evidence is captured and the changed paths are reviewed. After approval-cop restores the config, rerun the affected Beast/runtime launch path and record the verification result in the generated `rollback-comment.md` before posting it to a PR, incident record, or Kanban card.

--- a/docs/dr/runtime-config-rollback-plan.md
+++ b/docs/dr/runtime-config-rollback-plan.md
@@ -8,7 +8,8 @@ The helper is intentionally conservative:
 - it enforces the same 1 MiB/depth/container safety budget as the runtime config loader;
 - it rejects no-op comparisons so operators do not approve an empty rollback;
 - it prints deterministic JSON-pointer changed paths;
-- it escapes changed paths in Markdown so unusual config keys cannot forge headings or command bullets;
+- it JSON-encodes changed paths in Markdown so unusual config keys cannot forge headings or command bullets;
+- it redacts changed values from machine-readable plan output and evidence commands;
 - it never writes the target runtime config itself;
 - the default evidence directory is deterministic but unique per target path;
 - captured evidence commands use private directory/file modes (`0700`/`0600`);
@@ -39,7 +40,7 @@ The plan has four sections:
 
 1. `Capture read-only rollback evidence` — create the evidence directory, force it to `0700`, copy the before snapshot into it with `0600` permissions, and write deterministic change metadata.
 2. `Operator decisions before rollback` — confirm the before snapshot is the intended last-known-good state and the changed paths match the incident.
-3. `Approval-gated rollback action` — the single `approval-cop run -- cp ...` command that restores the before snapshot to the target config.
+3. `Approval-gated rollback action` — the single `approval-cop run -- node ...` command that refuses symlinked target paths, checks that the target still matches the captured after snapshot, and then restores the before snapshot to the target config.
 4. `Verify rollback` — compare the restored target with the rollback snapshot and parse both JSON files before resuming the affected runtime.
 
 Do not run the approval-gated copy until the evidence is captured and the changed paths are reviewed. After approval-cop restores the config, rerun the affected Beast/runtime launch path and record the verification result in the generated `rollback-comment.md` before posting it to a PR, incident record, or Kanban card.

--- a/docs/dr/runtime-config-rollback-plan.md
+++ b/docs/dr/runtime-config-rollback-plan.md
@@ -1,0 +1,48 @@
+# Runtime config rollback plan generator
+
+Use the runtime config rollback plan generator when a Beast/runtime config change causes a failed launch, degraded behavior, or ambiguous rollback handoff. The helper compares a last-known-good JSON runtime config snapshot with the changed snapshot and prints a dry-run plan that operators can review before restoring the old config.
+
+The helper is intentionally conservative:
+
+- it only accepts JSON object snapshots;
+- it rejects no-op comparisons so operators do not approve an empty rollback;
+- it prints deterministic JSON-pointer changed paths;
+- it never writes the target runtime config itself;
+- the actual restore command is routed through `approval-cop` or an equivalent HITL wrapper.
+
+## Generate a plan
+
+```bash
+npm run dr:runtime-config-rollback:dry-run -- \
+  --before .fbeast/.build/run-configs/run-123.before.json \
+  --after .fbeast/.build/run-configs/run-123.after.json \
+  --target .fbeast/.build/run-configs/run-123.json \
+  --evidence-dir rollback-evidence/runtime-run-123
+```
+
+For automation, request structured output:
+
+```bash
+npm run dr:runtime-config-rollback:dry-run -- \
+  --format json \
+  --before snapshots/run-123.before.json \
+  --after snapshots/run-123.after.json \
+  --target .fbeast/.build/run-configs/run-123.json
+```
+
+## Operator interpretation
+
+The plan has four sections:
+
+1. `Capture read-only rollback evidence` — copy the before snapshot into the evidence directory and write deterministic change metadata.
+2. `Operator decisions before rollback` — confirm the before snapshot is the intended last-known-good state and the changed paths match the incident.
+3. `Approval-gated rollback action` — the single `approval-cop run -- cp ...` command that restores the before snapshot to the target config.
+4. `Verify rollback` — compare the restored target with the rollback snapshot and parse both JSON files before resuming the affected runtime.
+
+Do not run the approval-gated copy until the evidence is captured and the changed paths are reviewed. After approval-cop restores the config, rerun the affected Beast/runtime launch path and record the verification result in the generated `rollback-comment.md` before posting it to a PR, incident record, or Kanban card.
+
+## Failure modes
+
+- Invalid JSON or a non-object snapshot fails before a plan is printed.
+- Matching before/after snapshots fail with `No runtime config changes detected`.
+- Paths starting with `-` or containing NUL are rejected so generated argv commands cannot be interpreted as options.

--- a/docs/dr/runtime-config-rollback-plan.md
+++ b/docs/dr/runtime-config-rollback-plan.md
@@ -5,9 +5,12 @@ Use the runtime config rollback plan generator when a Beast/runtime config chang
 The helper is intentionally conservative:
 
 - it only accepts JSON object snapshots;
+- it enforces the same 1 MiB/depth/container safety budget as the runtime config loader;
 - it rejects no-op comparisons so operators do not approve an empty rollback;
 - it prints deterministic JSON-pointer changed paths;
 - it never writes the target runtime config itself;
+- the default evidence directory is deterministic but unique per target path;
+- captured evidence commands use private directory/file modes (`0700`/`0600`);
 - the actual restore command is routed through `approval-cop` or an equivalent HITL wrapper.
 
 ## Generate a plan
@@ -16,8 +19,7 @@ The helper is intentionally conservative:
 npm run dr:runtime-config-rollback:dry-run -- \
   --before .fbeast/.build/run-configs/run-123.before.json \
   --after .fbeast/.build/run-configs/run-123.after.json \
-  --target .fbeast/.build/run-configs/run-123.json \
-  --evidence-dir rollback-evidence/runtime-run-123
+  --target .fbeast/.build/run-configs/run-123.json
 ```
 
 For automation, request structured output:
@@ -34,7 +36,7 @@ npm run dr:runtime-config-rollback:dry-run -- \
 
 The plan has four sections:
 
-1. `Capture read-only rollback evidence` — copy the before snapshot into the evidence directory and write deterministic change metadata.
+1. `Capture read-only rollback evidence` — create a private evidence directory, copy the before snapshot into it with `0600` permissions, and write deterministic change metadata.
 2. `Operator decisions before rollback` — confirm the before snapshot is the intended last-known-good state and the changed paths match the incident.
 3. `Approval-gated rollback action` — the single `approval-cop run -- cp ...` command that restores the before snapshot to the target config.
 4. `Verify rollback` — compare the restored target with the rollback snapshot and parse both JSON files before resuming the affected runtime.
@@ -44,5 +46,6 @@ Do not run the approval-gated copy until the evidence is captured and the change
 ## Failure modes
 
 - Invalid JSON or a non-object snapshot fails before a plan is printed.
+- Snapshots larger than 1 MiB, deeper than 64 containers, or exceeding the configured container/key/item budgets fail before a plan is printed.
 - Matching before/after snapshots fail with `No runtime config changes detected`.
 - Paths starting with `-` or containing NUL are rejected so generated argv commands cannot be interpreted as options.

--- a/docs/dr/runtime-config-rollback-plan.md
+++ b/docs/dr/runtime-config-rollback-plan.md
@@ -8,6 +8,7 @@ The helper is intentionally conservative:
 - it enforces the same 1 MiB/depth/container safety budget as the runtime config loader;
 - it rejects no-op comparisons so operators do not approve an empty rollback;
 - it prints deterministic JSON-pointer changed paths;
+- it escapes changed paths in Markdown so unusual config keys cannot forge headings or command bullets;
 - it never writes the target runtime config itself;
 - the default evidence directory is deterministic but unique per target path;
 - captured evidence commands use private directory/file modes (`0700`/`0600`);
@@ -36,7 +37,7 @@ npm run dr:runtime-config-rollback:dry-run -- \
 
 The plan has four sections:
 
-1. `Capture read-only rollback evidence` — create a private evidence directory, copy the before snapshot into it with `0600` permissions, and write deterministic change metadata.
+1. `Capture read-only rollback evidence` — create the evidence directory, force it to `0700`, copy the before snapshot into it with `0600` permissions, and write deterministic change metadata.
 2. `Operator decisions before rollback` — confirm the before snapshot is the intended last-known-good state and the changed paths match the incident.
 3. `Approval-gated rollback action` — the single `approval-cop run -- cp ...` command that restores the before snapshot to the target config.
 4. `Verify rollback` — compare the restored target with the rollback snapshot and parse both JSON files before resuming the affected runtime.

--- a/docs/dr/runtime-config-rollback-plan.md
+++ b/docs/dr/runtime-config-rollback-plan.md
@@ -1,6 +1,6 @@
 # Runtime config rollback plan generator
 
-Use the runtime config rollback plan generator when a Beast/runtime config change causes a failed launch, degraded behavior, or ambiguous rollback handoff. The helper compares a last-known-good JSON runtime config snapshot with the changed snapshot and prints a dry-run plan that operators can review before restoring the old config.
+Use the runtime config rollback plan generator when a persistent Beast/runtime config change causes a failed launch, degraded behavior, or ambiguous rollback handoff. The helper compares a last-known-good JSON runtime config snapshot with the changed snapshot and prints a dry-run plan that operators can review before restoring the old config. It is a live-target rollback helper: point `--target` at the persistent config file that the next run will read, not an ephemeral `.fbeast/.build/run-configs/...` launch snapshot that may be cleaned up after process exit.
 
 The helper is intentionally conservative:
 
@@ -13,16 +13,16 @@ The helper is intentionally conservative:
 - it rejects control characters in rendered file paths;
 - it never writes the target runtime config itself;
 - the default evidence directory is deterministic but unique per target path;
-- captured evidence commands use private directory/file modes (`0700`/`0600`);
+- captured evidence commands reject symlinked evidence paths and leaf files, use private directory/file modes (`0700`/`0600`), and pin before/after snapshot digests before approval;
 - the actual restore command is routed through `approval-cop` or an equivalent HITL wrapper.
 
 ## Generate a plan
 
 ```bash
 npm run dr:runtime-config-rollback:dry-run -- \
-  --before .fbeast/.build/run-configs/run-123.before.json \
-  --after .fbeast/.build/run-configs/run-123.after.json \
-  --target .fbeast/.build/run-configs/run-123.json
+  --before snapshots/runtime.before.json \
+  --after snapshots/runtime.after.json \
+  --target config/runtime.json
 ```
 
 For automation, request structured output:
@@ -30,18 +30,18 @@ For automation, request structured output:
 ```bash
 npm run dr:runtime-config-rollback:dry-run -- \
   --format json \
-  --before snapshots/run-123.before.json \
-  --after snapshots/run-123.after.json \
-  --target .fbeast/.build/run-configs/run-123.json
+  --before snapshots/runtime.before.json \
+  --after snapshots/runtime.after.json \
+  --target config/runtime.json
 ```
 
 ## Operator interpretation
 
 The plan has four sections:
 
-1. `Capture read-only rollback evidence` — refuse symlinked evidence path components, create the evidence directory, force it to `0700`, copy the before/after snapshots into it with `0600` permissions, and write deterministic value-redacted change metadata.
+1. `Capture read-only rollback evidence` — refuse symlinked evidence path components, create the evidence directory, force it to `0700`, copy the before/after snapshots into it without following symlinked leaf files, and write deterministic value-redacted change metadata with `0600` permissions.
 2. `Operator decisions before rollback` — confirm the before snapshot is the intended last-known-good state and the changed paths match the incident.
-3. `Approval-gated rollback action` — the single `approval-cop run -- node ...` command that refuses symlinked target paths, checks that the target still matches the captured immutable after snapshot under the evidence directory, and then restores the before snapshot to the target config.
+3. `Approval-gated rollback action` — the single `approval-cop run -- node ...` command that refuses symlinked target paths, verifies the captured before/after snapshot digests still match the reviewed files, checks that the target still matches the captured immutable after snapshot under the evidence directory, and then restores the before snapshot to the target config.
 4. `Verify rollback` — compare the restored target with the rollback snapshot and parse both JSON files before resuming the affected runtime.
 
 Do not run the approval-gated copy until the evidence is captured and the changed paths are reviewed. After approval-cop restores the config, rerun the affected Beast/runtime launch path and record the verification result in the generated `rollback-comment.md` before posting it to a PR, incident record, or Kanban card.
@@ -51,4 +51,4 @@ Do not run the approval-gated copy until the evidence is captured and the change
 - Invalid JSON or a non-object snapshot fails before a plan is printed.
 - Snapshots larger than 1 MiB, deeper than 64 containers, or exceeding the configured container/key/item budgets fail before a plan is printed.
 - Matching before/after snapshots fail with `No runtime config changes detected`.
-- Paths starting with `-` or containing NUL are rejected so generated argv commands cannot be interpreted as options.
+- Paths starting with `-` or containing control characters are rejected so generated argv and Markdown cannot be interpreted as options or forged plan text.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "check:dependabot-supply-chain": "node scripts/check-dependabot-supply-chain.mjs",
     "dr:worker-push-rollback:dry-run": "node scripts/worker-push-rollback-plan.mjs --dry-run",
+    "dr:runtime-config-rollback:dry-run": "node scripts/runtime-config-rollback-plan.mjs --dry-run",
     "create:project": "bash scripts/create-project.sh",
     "deps:outdated:major": "node scripts/check-major-outdated.mjs",
     "lint": "node scripts/check-workspace-lint-coverage.mjs && turbo run lint",

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -83,7 +83,8 @@ export function buildRuntimeConfigRollbackPlan(options) {
     changedPaths,
     changes,
     readOnlyCapture: [
-      ['mkdir', '-m', '700', '-p', evidenceDir],
+      ['mkdir', '-p', evidenceDir],
+      ['chmod', '700', evidenceDir],
       ['install', '-m', '600', beforePath, rollbackConfigPath],
       [
         'node',
@@ -104,13 +105,13 @@ export function buildRuntimeConfigRollbackPlan(options) {
         targetPath,
         beforePath,
         afterPath,
-        changedPaths.join(', '),
+        changedPaths.map(path => JSON.stringify(path)).join(', '),
       ],
     ],
     requiredDecisions: [
       `Confirm ${beforePath} is the last-known-good runtime config snapshot.`,
       `Confirm ${afterPath} captures the currently deployed or failed runtime config state.`,
-      `Review changed paths before rollback: ${changedPaths.join(', ')}.`,
+      `Review changed paths before rollback: ${changedPaths.map(path => JSON.stringify(path)).join(', ')}.`,
       `Fill ${rollbackCommentPath} with the approval-cop outcome and verification results before posting it to a PR or Kanban card.`,
     ],
     approvalGatedActions: [
@@ -122,7 +123,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
     postRollbackVerification: [
       ['cmp', '-s', rollbackConfigPath, targetPath],
       ['node', '-e', 'const fs=require("node:fs"); JSON.parse(fs.readFileSync(process.argv[1], "utf8")); JSON.parse(fs.readFileSync(process.argv[2], "utf8"));', rollbackConfigPath, targetPath],
-      ['bash', '-lc', '! grep -Eq "<(fill before posting)>" "$1"', '--', rollbackCommentPath],
+      ['bash', '-lc', '[ -f "$1" ] && ! grep -Eq "<(fill before posting)>" "$1"', '--', rollbackCommentPath],
     ],
     notes: [
       'This helper is dry-run only; it never writes the target runtime config or executes approval-gated commands.',
@@ -144,7 +145,7 @@ export function renderPlan(plan) {
     `Target config: ${plan.targetPath}`,
     '',
     '## Changed runtime config paths',
-    ...plan.changes.map(change => `- ${change.path}: ${change.type}`),
+    ...plan.changes.map(change => `- \`${escapeMarkdownInlineCode(change.path)}\`: ${change.type}`),
     '',
     '## 1. Capture read-only rollback evidence',
     ...plan.readOnlyCapture.map(command => `- ${quoteCommand(command)}`),
@@ -196,7 +197,7 @@ function buildChange(path, before, after) {
 }
 
 function validateSnapshotShape(value, filePath) {
-  const stack = [{ value, depth: 0 }];
+  const stack = [{ value, depth: 1 }];
   let containers = 0;
   let objectKeys = 0;
   let arrayItems = 0;
@@ -256,6 +257,12 @@ function assertSafePath(value, label) {
   if (value.startsWith('-') || /\x00/u.test(value)) {
     throw new Error(`${label} is not safe for argv usage: ${value}`);
   }
+}
+
+function escapeMarkdownInlineCode(value) {
+  return String(value)
+    .replace(/`/gu, '\\`')
+    .replace(/[\r\n]+/gu, '\\n');
 }
 
 function quoteCommand(args) {

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -40,15 +40,17 @@ export async function writeFileNoFollow(filePath, data, mode = 0o600, owner) {
   } finally {
     await handle.close();
   }
-  await chmod(tempPath, mode);
-  if (owner && Number.isInteger(owner.uid) && Number.isInteger(owner.gid)) {
-    await chown(tempPath, owner.uid, owner.gid);
-  }
+  let renamed = false;
   try {
+    await chmod(tempPath, mode);
+    if (owner && Number.isInteger(owner.uid) && Number.isInteger(owner.gid)) {
+      await chown(tempPath, owner.uid, owner.gid);
+    }
     await rename(tempPath, resolvedFilePath);
+    renamed = true;
     await chmod(resolvedFilePath, mode);
   } catch (error) {
-    await unlink(tempPath).catch(() => undefined);
+    if (!renamed) await unlink(tempPath).catch(() => undefined);
     throw error;
   }
 }
@@ -83,18 +85,22 @@ export async function loadRuntimeConfigSnapshot(filePath) {
 
 export async function loadRuntimeConfigSnapshotWithDigest(filePath) {
   const info = await stat(filePath);
+  if (!info.isFile()) {
+    throw new Error(`Runtime config snapshot ${filePath} must be a regular file`);
+  }
   if (info.size > SNAPSHOT_LIMITS.maxBytes) {
     throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${info.size} > ${SNAPSHOT_LIMITS.maxBytes}`);
   }
-  const raw = await readFileNoFollow(filePath, 'utf8');
-  const rawBytes = Buffer.byteLength(raw, 'utf8');
+  const rawBuffer = await readFileNoFollow(filePath);
+  const rawBytes = rawBuffer.byteLength;
   if (rawBytes > SNAPSHOT_LIMITS.maxBytes) {
     throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${rawBytes} > ${SNAPSHOT_LIMITS.maxBytes}`);
   }
+  const raw = rawBuffer.toString('utf8');
   const snapshot = parseRuntimeConfigSnapshot(raw, filePath);
   return {
     snapshot,
-    sha256: createHash('sha256').update(raw).digest('hex'),
+    sha256: createHash('sha256').update(rawBuffer).digest('hex'),
   };
 }
 
@@ -178,7 +184,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { chmod, lstat, mkdir } from "node:fs/promises"; import { parse, relative, resolve, sep } from "node:path"; const [dir]=process.argv.slice(1); async function assertNoSymlinkExisting(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); try { const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked evidence path component: ${current}`); } catch (error) { if (error && error.code === "ENOENT") break; throw error; } } } await assertNoSymlinkExisting(dir); await mkdir(dir, { recursive: true }); await assertNoSymlinkExisting(dir); await chmod(dir, 0o700);',
+        'import { chmod, lstat, mkdir } from "node:fs/promises"; import { parse, relative, resolve, sep } from "node:path"; const [dir]=process.argv.slice(1); async function assertNoSymlinkExisting(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); try { const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked evidence path component: ${current}`); } catch (error) { if (error && error.code === "ENOENT") break; throw error; } } } await assertNoSymlinkExisting(dir); const created=await mkdir(dir, { recursive: true }); await assertNoSymlinkExisting(dir); const info=await lstat(dir); if (!info.isDirectory()) throw new Error(`Evidence path is not a directory: ${dir}`); if (created !== undefined) await chmod(dir, 0o700);',
         evidenceDir,
       ],
       [
@@ -217,13 +223,13 @@ export function buildRuntimeConfigRollbackPlan(options) {
         targetPath,
         beforePath,
         afterPath,
-        changedPaths.map(path => JSON.stringify(path)).join(', '),
+        changedPaths.map(formatChangedPath).join(', '),
       ],
     ],
     requiredDecisions: [
       `Confirm ${beforePath} is the last-known-good runtime config snapshot.`,
       `Confirm ${afterPath} captures the currently deployed or failed runtime config state.`,
-      `Review changed paths before rollback: ${changedPaths.map(path => JSON.stringify(path)).join(', ')}.`,
+      `Review changed paths before rollback: ${changedPaths.map(formatChangedPath).join(', ')}.`,
       `Fill ${rollbackCommentPath} with the approval-cop outcome and verification results before posting it to a PR or Kanban card.`,
     ],
     approvalGatedActions: [

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+export async function loadRuntimeConfigSnapshot(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Runtime config snapshot ${filePath} is not valid JSON: ${reason}`);
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Runtime config snapshot ${filePath} must contain a JSON object`);
+  }
+  return parsed;
+}
+
+export function diffRuntimeConfig(before, after) {
+  return diffValues(before, after, '').sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function buildRuntimeConfigRollbackPlan(options) {
+  const {
+    beforePath,
+    afterPath,
+    targetPath,
+    before,
+    after,
+    evidenceDir = 'rollback-evidence/runtime-config',
+    approvalCop = 'approval-cop run --',
+  } = options;
+
+  assertSafePath(beforePath, 'beforePath');
+  assertSafePath(afterPath, 'afterPath');
+  assertSafePath(targetPath, 'targetPath');
+  assertSafePath(evidenceDir, 'evidenceDir');
+  const approvalPrefix = splitCommandPrefix(approvalCop);
+  if (approvalPrefix.length === 0) {
+    throw new Error('approvalCop must name the approval-cop/HITL command; blank overrides are not allowed');
+  }
+
+  const changes = diffRuntimeConfig(before, after);
+  if (changes.length === 0) {
+    throw new Error('No runtime config changes detected; rollback plan would be a no-op');
+  }
+
+  const rollbackConfigPath = `${evidenceDir}/rollback-config.json`;
+  const changesPath = `${evidenceDir}/runtime-config-changes.json`;
+  const rollbackCommentPath = `${evidenceDir}/rollback-comment.md`;
+  const changedPaths = changes.map(change => change.path);
+
+  return {
+    summary: `Dry-run runtime config rollback plan for ${targetPath}`,
+    evidenceDir,
+    beforePath,
+    afterPath,
+    targetPath,
+    changedPaths,
+    changes,
+    readOnlyCapture: [
+      ['mkdir', '-p', evidenceDir],
+      ['cp', beforePath, rollbackConfigPath],
+      ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], JSON.stringify(JSON.parse(process.argv[2]), null, 2) + "\\n")', changesPath, JSON.stringify(changes)],
+      ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], `## Runtime config rollback postmortem\\n\\n- Target config: ${process.argv[2]}\\n- Before snapshot: ${process.argv[3]}\\n- After snapshot: ${process.argv[4]}\\n- Changed paths: ${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n`)', rollbackCommentPath, targetPath, beforePath, afterPath, changedPaths.join(', ')],
+    ],
+    requiredDecisions: [
+      `Confirm ${beforePath} is the last-known-good runtime config snapshot.`,
+      `Confirm ${afterPath} captures the currently deployed or failed runtime config state.`,
+      `Review changed paths before rollback: ${changedPaths.join(', ')}.`,
+      `Fill ${rollbackCommentPath} with the approval-cop outcome and verification results before posting it to a PR or Kanban card.`,
+    ],
+    approvalGatedActions: [
+      [
+        ...approvalPrefix,
+        'cp', rollbackConfigPath, targetPath,
+      ],
+    ],
+    postRollbackVerification: [
+      ['cmp', '-s', rollbackConfigPath, targetPath],
+      ['node', '-e', 'const fs=require("node:fs"); JSON.parse(fs.readFileSync(process.argv[1], "utf8")); JSON.parse(fs.readFileSync(process.argv[2], "utf8"));', rollbackConfigPath, targetPath],
+      ['bash', '-lc', '! grep -Eq "<(fill before posting)>" "$1"', '--', rollbackCommentPath],
+    ],
+    notes: [
+      'This helper is dry-run only; it never writes the target runtime config or executes approval-gated commands.',
+      'The generated rollback action copies the captured before snapshot back over the target config through approval-cop/HITL.',
+      'Treat runtime config rollback as operationally risky: verify the affected run/beast launch path after approval-cop applies the copy.',
+      'Use this for JSON runtime config snapshots, not arbitrary source-code rewrites or branch rollbacks.',
+    ],
+  };
+}
+
+export function renderPlan(plan) {
+  const lines = [
+    `# ${plan.summary}`,
+    '',
+    `Evidence directory: ${plan.evidenceDir}`,
+    `Before snapshot: ${plan.beforePath}`,
+    `After snapshot: ${plan.afterPath}`,
+    `Target config: ${plan.targetPath}`,
+    '',
+    '## Changed runtime config paths',
+    ...plan.changes.map(change => `- ${change.path}: ${change.type}`),
+    '',
+    '## 1. Capture read-only rollback evidence',
+    ...plan.readOnlyCapture.map(command => `- ${quoteCommand(command)}`),
+    '',
+    '## 2. Operator decisions before rollback',
+    ...plan.requiredDecisions.map(item => `- ${item}`),
+    '',
+    '## 3. Approval-gated rollback action',
+    ...plan.approvalGatedActions.map(command => `- ${quoteCommand(command)}`),
+    '',
+    '## 4. Verify rollback',
+    ...plan.postRollbackVerification.map(command => `- ${quoteCommand(command)}`),
+    '',
+    '## Safety notes',
+    ...plan.notes.map(item => `- ${item}`),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function diffValues(before, after, path) {
+  if (Object.is(before, after)) return [];
+
+  const beforeIsContainer = isContainer(before);
+  const afterIsContainer = isContainer(after);
+  if (!beforeIsContainer || !afterIsContainer || Array.isArray(before) !== Array.isArray(after)) {
+    return [buildChange(path, before, after)];
+  }
+
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const changes = [];
+  for (const key of keys) {
+    const childPath = `${path}/${escapeJsonPointer(key)}`;
+    if (!Object.hasOwn(before, key)) {
+      changes.push({ path: childPath, type: 'added', after: after[key] });
+    } else if (!Object.hasOwn(after, key)) {
+      changes.push({ path: childPath, type: 'removed', before: before[key] });
+    } else {
+      changes.push(...diffValues(before[key], after[key], childPath));
+    }
+  }
+  return changes;
+}
+
+function buildChange(path, before, after) {
+  if (before === undefined) return { path: path || '/', type: 'added', after };
+  if (after === undefined) return { path: path || '/', type: 'removed', before };
+  return { path: path || '/', type: 'changed', before, after };
+}
+
+function isContainer(value) {
+  return Array.isArray(value) || isPlainObject(value);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function escapeJsonPointer(value) {
+  return String(value).replace(/~/gu, '~0').replace(/\//gu, '~1');
+}
+
+function splitCommandPrefix(command) {
+  return String(command ?? '')
+    .trim()
+    .split(/\s+/u)
+    .filter(Boolean);
+}
+
+function assertSafePath(value, label) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 4096) {
+    throw new Error(`${label} must be a non-empty path`);
+  }
+  if (value.startsWith('-') || /\x00/u.test(value)) {
+    throw new Error(`${label} is not safe for argv usage: ${value}`);
+  }
+}
+
+function quoteCommand(args) {
+  return args.map(quoteArg).join(' ');
+}
+
+function quoteArg(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@+,-]+$/u.test(text)) return text;
+  return `'${text.replace(/'/gu, `'"'"'`)}'`;
+}
+
+function parseArgs(argv) {
+  const options = { dryRun: false, format: 'markdown' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (value == null || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    switch (arg) {
+      case '--dry-run': options.dryRun = true; break;
+      case '--before': options.beforePath = readValue(); break;
+      case '--after': options.afterPath = readValue(); break;
+      case '--target': options.targetPath = readValue(); break;
+      case '--evidence-dir': options.evidenceDir = readValue(); break;
+      case '--approval-cop': options.approvalCop = readValue(); break;
+      case '--format': options.format = readValue(); break;
+      case '--help': options.help = true; break;
+      default: throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  console.info(`Usage: node scripts/runtime-config-rollback-plan.mjs --dry-run --before BEFORE.json --after AFTER.json --target TARGET.json [--evidence-dir DIR] [--format markdown|json]\n\nGenerate a dry-run rollback plan for JSON runtime config changes. The helper compares a last-known-good before snapshot with the changed/failed after snapshot, writes commands for capturing rollback evidence, and routes the target restore copy through approval-cop/HITL. It never mutates the target config itself.`);
+}
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  if (!options.dryRun) {
+    throw new Error('Refusing to run without --dry-run; this helper only generates plans and never applies rollbacks');
+  }
+  if (!['markdown', 'json'].includes(options.format)) {
+    throw new Error('--format must be markdown or json');
+  }
+  const before = await loadRuntimeConfigSnapshot(options.beforePath);
+  const after = await loadRuntimeConfigSnapshot(options.afterPath);
+  const plan = buildRuntimeConfigRollbackPlan({ ...options, before, after });
+  console.info(options.format === 'json' ? JSON.stringify(plan, null, 2) : renderPlan(plan));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { chmod, lstat, open, readFile, rename, stat, unlink } from 'node:fs/promises';
+import { chmod, chown, lstat, open, rename, stat, unlink } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SNAPSHOT_LIMITS = Object.freeze({
@@ -16,11 +16,20 @@ const SNAPSHOT_LIMITS = Object.freeze({
 
 const ROLLBACK_HELPER_MODULE = import.meta.url;
 
-export async function fileSha256(filePath) {
-  return createHash('sha256').update(await readFile(filePath)).digest('hex');
+export async function readFileNoFollow(filePath, encoding) {
+  const handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    return await handle.readFile(encoding == null ? undefined : { encoding });
+  } finally {
+    await handle.close();
+  }
 }
 
-export async function writeFileNoFollow(filePath, data, mode = 0o600) {
+export async function fileSha256(filePath) {
+  return createHash('sha256').update(await readFileNoFollow(filePath)).digest('hex');
+}
+
+export async function writeFileNoFollow(filePath, data, mode = 0o600, owner) {
   await assertExistingPathIsNotSymlink(filePath);
   const tempPath = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
   const handle = await open(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, mode);
@@ -33,6 +42,10 @@ export async function writeFileNoFollow(filePath, data, mode = 0o600) {
   await chmod(tempPath, mode);
   try {
     await rename(tempPath, filePath);
+    if (owner && Number.isInteger(owner.uid) && Number.isInteger(owner.gid)) {
+      await chown(filePath, owner.uid, owner.gid);
+    }
+    await chmod(filePath, mode);
   } catch (error) {
     await unlink(tempPath).catch(() => undefined);
     throw error;
@@ -40,7 +53,7 @@ export async function writeFileNoFollow(filePath, data, mode = 0o600) {
 }
 
 export async function copyFileNoFollow(sourcePath, destinationPath, mode = 0o600) {
-  await writeFileNoFollow(destinationPath, await readFile(sourcePath), mode);
+  await writeFileNoFollow(destinationPath, await readFileNoFollow(sourcePath), mode);
 }
 
 async function assertExistingPathIsNotSymlink(filePath) {
@@ -56,15 +69,27 @@ async function assertExistingPathIsNotSymlink(filePath) {
 }
 
 export async function loadRuntimeConfigSnapshot(filePath) {
+  return (await loadRuntimeConfigSnapshotWithDigest(filePath)).snapshot;
+}
+
+export async function loadRuntimeConfigSnapshotWithDigest(filePath) {
   const info = await stat(filePath);
   if (info.size > SNAPSHOT_LIMITS.maxBytes) {
     throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${info.size} > ${SNAPSHOT_LIMITS.maxBytes}`);
   }
-  const raw = await readFile(filePath, 'utf8');
+  const raw = await readFileNoFollow(filePath, 'utf8');
   const rawBytes = Buffer.byteLength(raw, 'utf8');
   if (rawBytes > SNAPSHOT_LIMITS.maxBytes) {
     throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${rawBytes} > ${SNAPSHOT_LIMITS.maxBytes}`);
   }
+  const snapshot = parseRuntimeConfigSnapshot(raw, filePath);
+  return {
+    snapshot,
+    sha256: createHash('sha256').update(raw).digest('hex'),
+  };
+}
+
+function parseRuntimeConfigSnapshot(raw, filePath) {
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -76,6 +101,7 @@ export async function loadRuntimeConfigSnapshot(filePath) {
   if (!isPlainObject(parsed)) {
     throw new Error(`Runtime config snapshot ${filePath} must contain a JSON object`);
   }
+  validateRuntimeConfigSchema(parsed, filePath);
   return parsed;
 }
 
@@ -110,6 +136,8 @@ export function buildRuntimeConfigRollbackPlan(options) {
     throw new Error('approvalCop must name the approval-cop/HITL command; blank overrides are not allowed');
   }
 
+  validateRuntimeConfigSchema(before, beforePath);
+  validateRuntimeConfigSchema(after, afterPath);
   const detailedChanges = diffRuntimeConfig(before, after);
   const changes = detailedChanges.map(({ path, type }) => ({ path, type }));
   if (changes.length === 0) {
@@ -164,7 +192,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        `import { buildRuntimeConfigRollbackPlan, fileSha256, loadRuntimeConfigSnapshot, writeFileNoFollow } from ${helperImport}; const [out,rollbackPath,afterCapturePath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(rollbackPath); const after=await loadRuntimeConfigSnapshot(afterCapturePath); const [beforeSha256, afterSha256]=await Promise.all([fileSha256(rollbackPath), fileSha256(afterCapturePath)]); const plan=buildRuntimeConfigRollbackPlan({ beforePath: rollbackPath, afterPath: afterCapturePath, targetPath, evidenceDir, before, after, beforeSha256, afterSha256 }); await writeFileNoFollow(out, JSON.stringify(plan.changes, null, 2) + "\\n");`,
+        `import { buildRuntimeConfigRollbackPlan, loadRuntimeConfigSnapshotWithDigest, writeFileNoFollow } from ${helperImport}; const [out,rollbackPath,afterCapturePath,targetPath,evidenceDir]=process.argv.slice(1); const beforeResult=await loadRuntimeConfigSnapshotWithDigest(rollbackPath); const afterResult=await loadRuntimeConfigSnapshotWithDigest(afterCapturePath); const plan=buildRuntimeConfigRollbackPlan({ beforePath: rollbackPath, afterPath: afterCapturePath, targetPath, evidenceDir, before: beforeResult.snapshot, after: afterResult.snapshot, beforeSha256: beforeResult.sha256, afterSha256: afterResult.sha256 }); await writeFileNoFollow(out, JSON.stringify(plan.changes, null, 2) + "\\n");`,
         changesPath,
         rollbackConfigPath,
         afterConfigPath,
@@ -195,7 +223,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        `import { createHash } from "node:crypto"; import { lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; import { writeFileNoFollow } from ${helperImport}; const [rollback,target,after,expectedRollbackSha,expectedAfterSha]=process.argv.slice(1); const sha=data=>createHash("sha256").update(data).digest("hex"); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(\`Refusing symlinked runtime config path component: \${current}\`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [rollbackRaw,targetRaw,afterRaw]=await Promise.all([readFile(rollback), readFile(target), readFile(after)]); if (sha(rollbackRaw)!==expectedRollbackSha) throw new Error("Refusing rollback: rollback snapshot no longer matches approved before snapshot"); if (sha(afterRaw)!==expectedAfterSha) throw new Error("Refusing rollback: captured after snapshot no longer matches reviewed after snapshot"); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await writeFileNoFollow(target, rollbackRaw);`,
+        `import { createHash } from "node:crypto"; import { lstat, stat } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; import { readFileNoFollow, writeFileNoFollow } from ${helperImport}; const [rollback,target,after,expectedRollbackSha,expectedAfterSha]=process.argv.slice(1); const sha=data=>createHash("sha256").update(data).digest("hex"); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(\`Refusing symlinked runtime config path component: \${current}\`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const targetInfo=await stat(target); const [rollbackRaw,targetRaw,afterRaw]=await Promise.all([readFileNoFollow(rollback), readFileNoFollow(target), readFileNoFollow(after)]); if (sha(rollbackRaw)!==expectedRollbackSha) throw new Error("Refusing rollback: rollback snapshot no longer matches approved before snapshot"); if (sha(afterRaw)!==expectedAfterSha) throw new Error("Refusing rollback: captured after snapshot no longer matches reviewed after snapshot"); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await writeFileNoFollow(target, rollbackRaw, targetInfo.mode & 0o777, { uid: targetInfo.uid, gid: targetInfo.gid });`,
         rollbackConfigPath,
         targetPath,
         afterConfigPath,
@@ -279,6 +307,108 @@ function buildChange(path, before, after) {
   return { path: path || '/', type: 'changed', before, after };
 }
 
+function validateRuntimeConfigSchema(value, filePath) {
+  assertOptionalString(value.provider, 'provider', filePath);
+  assertOptionalString(value.objective, 'objective', filePath);
+  assertOptionalString(value.chunkDirectory, 'chunkDirectory', filePath);
+  assertOptionalString(value.model, 'model', filePath);
+  assertOptionalPositiveInteger(value.maxDurationMs, 'maxDurationMs', filePath);
+  assertOptionalNumber(value.maxTotalTokens, 'maxTotalTokens', filePath);
+  assertOptionalBoolean(value.reflection, 'reflection', filePath);
+  assertOptionalStringArray(value.skills, 'skills', filePath);
+  assertOptionalObject(value.llmConfig, 'llmConfig', filePath, validateLlmConfig);
+  assertOptionalObject(value.modules, 'modules', filePath, validateModulesConfig);
+  assertOptionalObject(value.gitConfig, 'gitConfig', filePath, validateGitConfig);
+  assertOptionalObject(value.promptConfig, 'promptConfig', filePath, validatePromptConfig);
+}
+
+function validateLlmConfig(value, path, filePath) {
+  assertKnownKeys(value, ['default', 'overrides'], path, filePath);
+  assertOptionalObject(value.default, `${path}.default`, filePath, validateLlmOverride);
+  if (value.overrides !== undefined) {
+    assertPlainObjectAt(value.overrides, `${path}.overrides`, filePath);
+    for (const [name, override] of Object.entries(value.overrides)) {
+      assertPlainObjectAt(override, `${path}.overrides.${name}`, filePath);
+      validateLlmOverride(override, `${path}.overrides.${name}`, filePath);
+    }
+  }
+}
+
+function validateLlmOverride(value, path, filePath) {
+  assertKnownKeys(value, ['provider', 'model'], path, filePath);
+  assertOptionalString(value.provider, `${path}.provider`, filePath);
+  assertOptionalString(value.model, `${path}.model`, filePath);
+}
+
+function validateModulesConfig(value, path, filePath) {
+  assertKnownKeys(value, ['firewall', 'skills', 'memory', 'planner', 'critique', 'governor', 'heartbeat'], path, filePath);
+  for (const key of Object.keys(value)) assertOptionalBoolean(value[key], `${path}.${key}`, filePath);
+}
+
+function validateGitConfig(value, path, filePath) {
+  assertKnownKeys(value, ['preset', 'baseBranch', 'branchPattern', 'prCreation', 'disableBranding', 'mergeStrategy', 'commitConvention'], path, filePath);
+  assertOptionalString(value.preset, `${path}.preset`, filePath);
+  assertOptionalString(value.baseBranch, `${path}.baseBranch`, filePath);
+  assertOptionalString(value.branchPattern, `${path}.branchPattern`, filePath);
+  assertOptionalEnum(value.prCreation, ['auto', 'manual', 'disabled'], `${path}.prCreation`, filePath);
+  assertOptionalBoolean(value.disableBranding, `${path}.disableBranding`, filePath);
+  assertOptionalEnum(value.mergeStrategy, ['merge', 'squash', 'rebase'], `${path}.mergeStrategy`, filePath);
+  assertOptionalString(value.commitConvention, `${path}.commitConvention`, filePath);
+}
+
+function validatePromptConfig(value, path, filePath) {
+  assertKnownKeys(value, ['text', 'files'], path, filePath);
+  assertOptionalString(value.text, `${path}.text`, filePath);
+  assertOptionalStringArray(value.files, `${path}.files`, filePath);
+}
+
+function assertKnownKeys(value, keys, path, filePath) {
+  for (const key of Object.keys(value)) {
+    if (!keys.includes(key)) throw new Error(`Runtime config snapshot ${filePath} has unsupported ${path}.${key}`);
+  }
+}
+
+function assertOptionalObject(value, path, filePath, validator) {
+  if (value === undefined) return;
+  assertPlainObjectAt(value, path, filePath);
+  validator(value, path, filePath);
+}
+
+function assertPlainObjectAt(value, path, filePath) {
+  if (!isPlainObject(value)) throw new Error(`Runtime config snapshot ${filePath} field ${path} must be an object`);
+}
+
+function assertOptionalString(value, path, filePath) {
+  if (value !== undefined && typeof value !== 'string') throw new Error(`Runtime config snapshot ${filePath} field ${path} must be a string`);
+}
+
+function assertOptionalBoolean(value, path, filePath) {
+  if (value !== undefined && typeof value !== 'boolean') throw new Error(`Runtime config snapshot ${filePath} field ${path} must be a boolean`);
+}
+
+function assertOptionalNumber(value, path, filePath) {
+  if (value !== undefined && typeof value !== 'number') throw new Error(`Runtime config snapshot ${filePath} field ${path} must be a number`);
+}
+
+function assertOptionalPositiveInteger(value, path, filePath) {
+  if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
+    throw new Error(`Runtime config snapshot ${filePath} field ${path} must be a positive integer`);
+  }
+}
+
+function assertOptionalStringArray(value, path, filePath) {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
+    throw new Error(`Runtime config snapshot ${filePath} field ${path} must be an array of strings`);
+  }
+}
+
+function assertOptionalEnum(value, allowed, path, filePath) {
+  if (value !== undefined && !allowed.includes(value)) {
+    throw new Error(`Runtime config snapshot ${filePath} field ${path} must be one of: ${allowed.join(', ')}`);
+  }
+}
+
 function validateSnapshotShape(value, filePath) {
   const stack = [{ value, depth: 1 }];
   let containers = 0;
@@ -343,7 +473,7 @@ function assertSafePath(value, label) {
 }
 
 function formatChangedPath(value) {
-  return JSON.stringify(String(value));
+  return JSON.stringify(String(value)).replace(/\u2028/gu, '\\u2028').replace(/\u2029/gu, '\\u2029');
 }
 
 function quoteCommand(args) {
@@ -397,10 +527,25 @@ async function main(argv) {
   if (!['markdown', 'json'].includes(options.format)) {
     throw new Error('--format must be markdown or json');
   }
-  const before = await loadRuntimeConfigSnapshot(options.beforePath);
-  const after = await loadRuntimeConfigSnapshot(options.afterPath);
-  const [beforeSha256, afterSha256] = await Promise.all([fileSha256(options.beforePath), fileSha256(options.afterPath)]);
-  const plan = buildRuntimeConfigRollbackPlan({ ...options, before, after, beforeSha256, afterSha256 });
+  const beforePath = resolve(options.beforePath);
+  const afterPath = resolve(options.afterPath);
+  const targetPath = resolve(options.targetPath);
+  const evidenceDir = options.evidenceDir === undefined ? defaultEvidenceDir(targetPath) : resolve(options.evidenceDir);
+  const [beforeResult, afterResult] = await Promise.all([
+    loadRuntimeConfigSnapshotWithDigest(beforePath),
+    loadRuntimeConfigSnapshotWithDigest(afterPath),
+  ]);
+  const plan = buildRuntimeConfigRollbackPlan({
+    ...options,
+    beforePath,
+    afterPath,
+    targetPath,
+    evidenceDir,
+    before: beforeResult.snapshot,
+    after: afterResult.snapshot,
+    beforeSha256: beforeResult.sha256,
+    afterSha256: afterResult.sha256,
+  });
   console.info(options.format === 'json' ? JSON.stringify(plan, null, 2) : renderPlan(plan));
 }
 

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { chmod, open, readFile, stat } from 'node:fs/promises';
+import { chmod, lstat, open, readFile, rename, stat, unlink } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { basename } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SNAPSHOT_LIMITS = Object.freeze({
@@ -14,23 +14,45 @@ const SNAPSHOT_LIMITS = Object.freeze({
   maxArrayItems: 50_000,
 });
 
+const ROLLBACK_HELPER_MODULE = import.meta.url;
 
 export async function fileSha256(filePath) {
   return createHash('sha256').update(await readFile(filePath)).digest('hex');
 }
 
 export async function writeFileNoFollow(filePath, data, mode = 0o600) {
-  const handle = await open(filePath, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW, mode);
+  await assertExistingPathIsNotSymlink(filePath);
+  const tempPath = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  const handle = await open(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, mode);
   try {
     await handle.writeFile(data);
+    await handle.sync();
   } finally {
     await handle.close();
   }
-  await chmod(filePath, mode);
+  await chmod(tempPath, mode);
+  try {
+    await rename(tempPath, filePath);
+  } catch (error) {
+    await unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function copyFileNoFollow(sourcePath, destinationPath, mode = 0o600) {
   await writeFileNoFollow(destinationPath, await readFile(sourcePath), mode);
+}
+
+async function assertExistingPathIsNotSymlink(filePath) {
+  try {
+    const info = await lstat(filePath);
+    if (info.isSymbolicLink()) {
+      throw new Error(`Refusing symlinked path: ${filePath}`);
+    }
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return;
+    throw error;
+  }
 }
 
 export async function loadRuntimeConfigSnapshot(filePath) {
@@ -93,14 +115,18 @@ export function buildRuntimeConfigRollbackPlan(options) {
   if (changes.length === 0) {
     throw new Error('No runtime config changes detected; rollback plan would be a no-op');
   }
+  if (!options.beforeSha256 || !options.afterSha256) {
+    throw new Error('beforeSha256 and afterSha256 are required so rollback approval verifies the captured snapshot file bytes');
+  }
 
   const rollbackConfigPath = `${evidenceDir}/rollback-config.json`;
   const afterConfigPath = `${evidenceDir}/after-config.json`;
   const changesPath = `${evidenceDir}/runtime-config-changes.json`;
   const rollbackCommentPath = `${evidenceDir}/rollback-comment.md`;
   const changedPaths = changes.map(change => change.path);
-  const beforeSha256 = options.beforeSha256 ?? createHash('sha256').update(JSON.stringify(before)).digest('hex');
-  const afterSha256 = options.afterSha256 ?? createHash('sha256').update(JSON.stringify(after)).digest('hex');
+  const beforeSha256 = options.beforeSha256;
+  const afterSha256 = options.afterSha256;
+  const helperImport = JSON.stringify(ROLLBACK_HELPER_MODULE);
 
   return {
     summary: `Dry-run runtime config rollback plan for ${targetPath}`,
@@ -122,7 +148,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { copyFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; await copyFileNoFollow(process.argv[1], process.argv[2]);',
+        `import { copyFileNoFollow } from ${helperImport}; await copyFileNoFollow(process.argv[1], process.argv[2]);`,
         beforePath,
         rollbackConfigPath,
       ],
@@ -130,7 +156,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { copyFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; await copyFileNoFollow(process.argv[1], process.argv[2]);',
+        `import { copyFileNoFollow } from ${helperImport}; await copyFileNoFollow(process.argv[1], process.argv[2]);`,
         afterPath,
         afterConfigPath,
       ],
@@ -138,10 +164,10 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { buildRuntimeConfigRollbackPlan, fileSha256, loadRuntimeConfigSnapshot, writeFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; const [out,beforePath,afterPath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(beforePath); const after=await loadRuntimeConfigSnapshot(afterPath); const [beforeSha256, afterSha256]=await Promise.all([fileSha256(beforePath), fileSha256(afterPath)]); const plan=buildRuntimeConfigRollbackPlan({ beforePath, afterPath, targetPath, evidenceDir, before, after, beforeSha256, afterSha256 }); await writeFileNoFollow(out, JSON.stringify(plan.changes, null, 2) + "\\n");',
+        `import { buildRuntimeConfigRollbackPlan, fileSha256, loadRuntimeConfigSnapshot, writeFileNoFollow } from ${helperImport}; const [out,rollbackPath,afterCapturePath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(rollbackPath); const after=await loadRuntimeConfigSnapshot(afterCapturePath); const [beforeSha256, afterSha256]=await Promise.all([fileSha256(rollbackPath), fileSha256(afterCapturePath)]); const plan=buildRuntimeConfigRollbackPlan({ beforePath: rollbackPath, afterPath: afterCapturePath, targetPath, evidenceDir, before, after, beforeSha256, afterSha256 }); await writeFileNoFollow(out, JSON.stringify(plan.changes, null, 2) + "\\n");`,
         changesPath,
-        beforePath,
-        afterPath,
+        rollbackConfigPath,
+        afterConfigPath,
         targetPath,
         evidenceDir,
       ],
@@ -149,7 +175,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { writeFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; await writeFileNoFollow(process.argv[1], `## Runtime config rollback postmortem\\n\\n- Target config: ${process.argv[2]}\\n- Before snapshot: ${process.argv[3]}\\n- After snapshot: ${process.argv[4]}\\n- Changed paths: ${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n`);',
+        `import { writeFileNoFollow } from ${helperImport}; await writeFileNoFollow(process.argv[1], \`## Runtime config rollback postmortem\\n\\n- Target config: \${process.argv[2]}\\n- Before snapshot: \${process.argv[3]}\\n- After snapshot: \${process.argv[4]}\\n- Changed paths: \${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n\`);`,
         rollbackCommentPath,
         targetPath,
         beforePath,
@@ -169,7 +195,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { createHash } from "node:crypto"; import { lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; import { writeFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; const [rollback,target,after,expectedRollbackSha,expectedAfterSha]=process.argv.slice(1); const sha=data=>createHash("sha256").update(data).digest("hex"); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked runtime config path component: ${current}`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [rollbackRaw,targetRaw,afterRaw]=await Promise.all([readFile(rollback), readFile(target), readFile(after)]); if (sha(rollbackRaw)!==expectedRollbackSha) throw new Error("Refusing rollback: rollback snapshot no longer matches approved before snapshot"); if (sha(afterRaw)!==expectedAfterSha) throw new Error("Refusing rollback: captured after snapshot no longer matches reviewed after snapshot"); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await writeFileNoFollow(target, rollbackRaw);',
+        `import { createHash } from "node:crypto"; import { lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; import { writeFileNoFollow } from ${helperImport}; const [rollback,target,after,expectedRollbackSha,expectedAfterSha]=process.argv.slice(1); const sha=data=>createHash("sha256").update(data).digest("hex"); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(\`Refusing symlinked runtime config path component: \${current}\`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [rollbackRaw,targetRaw,afterRaw]=await Promise.all([readFile(rollback), readFile(target), readFile(after)]); if (sha(rollbackRaw)!==expectedRollbackSha) throw new Error("Refusing rollback: rollback snapshot no longer matches approved before snapshot"); if (sha(afterRaw)!==expectedAfterSha) throw new Error("Refusing rollback: captured after snapshot no longer matches reviewed after snapshot"); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await writeFileNoFollow(target, rollbackRaw);`,
         rollbackConfigPath,
         targetPath,
         afterConfigPath,

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -19,6 +19,10 @@ export async function loadRuntimeConfigSnapshot(filePath) {
     throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${info.size} > ${SNAPSHOT_LIMITS.maxBytes}`);
   }
   const raw = await readFile(filePath, 'utf8');
+  const rawBytes = Buffer.byteLength(raw, 'utf8');
+  if (rawBytes > SNAPSHOT_LIMITS.maxBytes) {
+    throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${rawBytes} > ${SNAPSHOT_LIMITS.maxBytes}`);
+  }
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -64,7 +68,8 @@ export function buildRuntimeConfigRollbackPlan(options) {
     throw new Error('approvalCop must name the approval-cop/HITL command; blank overrides are not allowed');
   }
 
-  const changes = diffRuntimeConfig(before, after);
+  const detailedChanges = diffRuntimeConfig(before, after);
+  const changes = detailedChanges.map(({ path, type }) => ({ path, type }));
   if (changes.length === 0) {
     throw new Error('No runtime config changes detected; rollback plan would be a no-op');
   }
@@ -117,7 +122,13 @@ export function buildRuntimeConfigRollbackPlan(options) {
     approvalGatedActions: [
       [
         ...approvalPrefix,
-        'cp', rollbackConfigPath, targetPath,
+        'node',
+        '--input-type=module',
+        '-e',
+        'import { copyFile, lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; const [rollback,target,after]=process.argv.slice(1); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked runtime config path component: ${current}`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [targetRaw, afterRaw]=await Promise.all([readFile(target), readFile(after)]); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await copyFile(rollback, target);',
+        rollbackConfigPath,
+        targetPath,
+        afterPath,
       ],
     ],
     postRollbackVerification: [
@@ -145,7 +156,7 @@ export function renderPlan(plan) {
     `Target config: ${plan.targetPath}`,
     '',
     '## Changed runtime config paths',
-    ...plan.changes.map(change => `- \`${escapeMarkdownInlineCode(change.path)}\`: ${change.type}`),
+    ...plan.changes.map(change => `- ${formatChangedPath(change.path)}: ${change.type}`),
     '',
     '## 1. Capture read-only rollback evidence',
     ...plan.readOnlyCapture.map(command => `- ${quoteCommand(command)}`),
@@ -259,10 +270,8 @@ function assertSafePath(value, label) {
   }
 }
 
-function escapeMarkdownInlineCode(value) {
-  return String(value)
-    .replace(/`/gu, '\\`')
-    .replace(/[\r\n]+/gu, '\\n');
+function formatChangedPath(value) {
+  return JSON.stringify(String(value));
 }
 
 function quoteCommand(args) {

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -38,7 +38,7 @@ export async function loadRuntimeConfigSnapshot(filePath) {
 }
 
 export function diffRuntimeConfig(before, after) {
-  return diffValues(before, after, '').sort((left, right) => left.path.localeCompare(right.path));
+  return diffValues(before, after, '').sort((left, right) => Buffer.compare(Buffer.from(left.path), Buffer.from(right.path)));
 }
 
 export function defaultEvidenceDir(targetPath) {
@@ -75,6 +75,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
   }
 
   const rollbackConfigPath = `${evidenceDir}/rollback-config.json`;
+  const afterConfigPath = `${evidenceDir}/after-config.json`;
   const changesPath = `${evidenceDir}/runtime-config-changes.json`;
   const rollbackCommentPath = `${evidenceDir}/rollback-comment.md`;
   const changedPaths = changes.map(change => change.path);
@@ -88,14 +89,20 @@ export function buildRuntimeConfigRollbackPlan(options) {
     changedPaths,
     changes,
     readOnlyCapture: [
-      ['mkdir', '-p', evidenceDir],
-      ['chmod', '700', evidenceDir],
-      ['install', '-m', '600', beforePath, rollbackConfigPath],
       [
         'node',
         '--input-type=module',
         '-e',
-        'import { writeFileSync } from "node:fs"; import { buildRuntimeConfigRollbackPlan, loadRuntimeConfigSnapshot } from "./scripts/runtime-config-rollback-plan.mjs"; const [out,beforePath,afterPath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(beforePath); const after=await loadRuntimeConfigSnapshot(afterPath); const plan=buildRuntimeConfigRollbackPlan({ beforePath, afterPath, targetPath, evidenceDir, before, after }); writeFileSync(out, JSON.stringify(plan.changes, null, 2) + "\\n", { mode: 0o600 });',
+        'import { chmod, lstat, mkdir } from "node:fs/promises"; import { parse, relative, resolve, sep } from "node:path"; const [dir]=process.argv.slice(1); async function assertNoSymlinkExisting(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); try { const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked evidence path component: ${current}`); } catch (error) { if (error && error.code === "ENOENT") break; throw error; } } } await assertNoSymlinkExisting(dir); await mkdir(dir, { recursive: true }); await assertNoSymlinkExisting(dir); await chmod(dir, 0o700);',
+        evidenceDir,
+      ],
+      ['install', '-m', '600', beforePath, rollbackConfigPath],
+      ['install', '-m', '600', afterPath, afterConfigPath],
+      [
+        'node',
+        '--input-type=module',
+        '-e',
+        'import { chmodSync, writeFileSync } from "node:fs"; import { buildRuntimeConfigRollbackPlan, loadRuntimeConfigSnapshot } from "./scripts/runtime-config-rollback-plan.mjs"; const [out,beforePath,afterPath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(beforePath); const after=await loadRuntimeConfigSnapshot(afterPath); const plan=buildRuntimeConfigRollbackPlan({ beforePath, afterPath, targetPath, evidenceDir, before, after }); writeFileSync(out, JSON.stringify(plan.changes, null, 2) + "\\n"); chmodSync(out, 0o600);',
         changesPath,
         beforePath,
         afterPath,
@@ -128,7 +135,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'import { copyFile, lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; const [rollback,target,after]=process.argv.slice(1); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked runtime config path component: ${current}`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [targetRaw, afterRaw]=await Promise.all([readFile(target), readFile(after)]); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await copyFile(rollback, target);',
         rollbackConfigPath,
         targetPath,
-        afterPath,
+        afterConfigPath,
       ],
     ],
     postRollbackVerification: [
@@ -265,8 +272,8 @@ function assertSafePath(value, label) {
   if (typeof value !== 'string' || value.length === 0 || value.length > 4096) {
     throw new Error(`${label} must be a non-empty path`);
   }
-  if (value.startsWith('-') || /\x00/u.test(value)) {
-    throw new Error(`${label} is not safe for argv usage: ${value}`);
+  if (value.startsWith('-') || /[\x00-\x1F\x7F]/u.test(value)) {
+    throw new Error(`${label} is not safe for argv or Markdown usage: ${value}`);
   }
 }
 

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -1,9 +1,23 @@
 #!/usr/bin/env node
 
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const SNAPSHOT_LIMITS = Object.freeze({
+  maxBytes: 1_048_576,
+  maxDepth: 64,
+  maxContainers: 10_000,
+  maxObjectKeys: 20_000,
+  maxArrayItems: 50_000,
+});
+
 export async function loadRuntimeConfigSnapshot(filePath) {
+  const info = await stat(filePath);
+  if (info.size > SNAPSHOT_LIMITS.maxBytes) {
+    throw new Error(`Runtime config snapshot ${filePath} exceeds maxBytes: ${info.size} > ${SNAPSHOT_LIMITS.maxBytes}`);
+  }
   const raw = await readFile(filePath, 'utf8');
   let parsed;
   try {
@@ -12,6 +26,7 @@ export async function loadRuntimeConfigSnapshot(filePath) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(`Runtime config snapshot ${filePath} is not valid JSON: ${reason}`);
   }
+  validateSnapshotShape(parsed, filePath);
   if (!isPlainObject(parsed)) {
     throw new Error(`Runtime config snapshot ${filePath} must contain a JSON object`);
   }
@@ -22,6 +37,13 @@ export function diffRuntimeConfig(before, after) {
   return diffValues(before, after, '').sort((left, right) => left.path.localeCompare(right.path));
 }
 
+export function defaultEvidenceDir(targetPath) {
+  assertSafePath(targetPath, 'targetPath');
+  const targetName = basename(targetPath).replace(/[^A-Za-z0-9_.-]+/gu, '-').replace(/^-+/u, '') || 'runtime-config';
+  const digest = createHash('sha256').update(targetPath).digest('hex').slice(0, 12);
+  return `rollback-evidence/runtime-config-${targetName}-${digest}`;
+}
+
 export function buildRuntimeConfigRollbackPlan(options) {
   const {
     beforePath,
@@ -29,9 +51,9 @@ export function buildRuntimeConfigRollbackPlan(options) {
     targetPath,
     before,
     after,
-    evidenceDir = 'rollback-evidence/runtime-config',
     approvalCop = 'approval-cop run --',
   } = options;
+  const evidenceDir = options.evidenceDir ?? defaultEvidenceDir(targetPath);
 
   assertSafePath(beforePath, 'beforePath');
   assertSafePath(afterPath, 'afterPath');
@@ -61,10 +83,29 @@ export function buildRuntimeConfigRollbackPlan(options) {
     changedPaths,
     changes,
     readOnlyCapture: [
-      ['mkdir', '-p', evidenceDir],
-      ['cp', beforePath, rollbackConfigPath],
-      ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], JSON.stringify(JSON.parse(process.argv[2]), null, 2) + "\\n")', changesPath, JSON.stringify(changes)],
-      ['node', '-e', 'require("node:fs").writeFileSync(process.argv[1], `## Runtime config rollback postmortem\\n\\n- Target config: ${process.argv[2]}\\n- Before snapshot: ${process.argv[3]}\\n- After snapshot: ${process.argv[4]}\\n- Changed paths: ${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n`)', rollbackCommentPath, targetPath, beforePath, afterPath, changedPaths.join(', ')],
+      ['mkdir', '-m', '700', '-p', evidenceDir],
+      ['install', '-m', '600', beforePath, rollbackConfigPath],
+      [
+        'node',
+        '--input-type=module',
+        '-e',
+        'import { writeFileSync } from "node:fs"; import { buildRuntimeConfigRollbackPlan, loadRuntimeConfigSnapshot } from "./scripts/runtime-config-rollback-plan.mjs"; const [out,beforePath,afterPath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(beforePath); const after=await loadRuntimeConfigSnapshot(afterPath); const plan=buildRuntimeConfigRollbackPlan({ beforePath, afterPath, targetPath, evidenceDir, before, after }); writeFileSync(out, JSON.stringify(plan.changes, null, 2) + "\\n", { mode: 0o600 });',
+        changesPath,
+        beforePath,
+        afterPath,
+        targetPath,
+        evidenceDir,
+      ],
+      [
+        'node',
+        '-e',
+        'require("node:fs").writeFileSync(process.argv[1], `## Runtime config rollback postmortem\\n\\n- Target config: ${process.argv[2]}\\n- Before snapshot: ${process.argv[3]}\\n- After snapshot: ${process.argv[4]}\\n- Changed paths: ${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n`, { mode: 0o600 })',
+        rollbackCommentPath,
+        targetPath,
+        beforePath,
+        afterPath,
+        changedPaths.join(', '),
+      ],
     ],
     requiredDecisions: [
       `Confirm ${beforePath} is the last-known-good runtime config snapshot.`,
@@ -88,6 +129,7 @@ export function buildRuntimeConfigRollbackPlan(options) {
       'The generated rollback action copies the captured before snapshot back over the target config through approval-cop/HITL.',
       'Treat runtime config rollback as operationally risky: verify the affected run/beast launch path after approval-cop applies the copy.',
       'Use this for JSON runtime config snapshots, not arbitrary source-code rewrites or branch rollbacks.',
+      `Snapshot parsing is bounded to ${SNAPSHOT_LIMITS.maxBytes} bytes, depth ${SNAPSHOT_LIMITS.maxDepth}, ${SNAPSHOT_LIMITS.maxContainers} containers, ${SNAPSHOT_LIMITS.maxObjectKeys} object keys, and ${SNAPSHOT_LIMITS.maxArrayItems} array items.`,
     ],
   };
 }
@@ -151,6 +193,41 @@ function buildChange(path, before, after) {
   if (before === undefined) return { path: path || '/', type: 'added', after };
   if (after === undefined) return { path: path || '/', type: 'removed', before };
   return { path: path || '/', type: 'changed', before, after };
+}
+
+function validateSnapshotShape(value, filePath) {
+  const stack = [{ value, depth: 0 }];
+  let containers = 0;
+  let objectKeys = 0;
+  let arrayItems = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || !isContainer(current.value)) continue;
+    containers += 1;
+    if (containers > SNAPSHOT_LIMITS.maxContainers) {
+      throw new Error(`Runtime config snapshot ${filePath} exceeds maxContainers: ${containers} > ${SNAPSHOT_LIMITS.maxContainers}`);
+    }
+    if (current.depth > SNAPSHOT_LIMITS.maxDepth) {
+      throw new Error(`Runtime config snapshot ${filePath} exceeds maxDepth: ${current.depth} > ${SNAPSHOT_LIMITS.maxDepth}`);
+    }
+
+    if (Array.isArray(current.value)) {
+      arrayItems += current.value.length;
+      if (arrayItems > SNAPSHOT_LIMITS.maxArrayItems) {
+        throw new Error(`Runtime config snapshot ${filePath} exceeds maxArrayItems: ${arrayItems} > ${SNAPSHOT_LIMITS.maxArrayItems}`);
+      }
+      for (const item of current.value) stack.push({ value: item, depth: current.depth + 1 });
+      continue;
+    }
+
+    const values = Object.values(current.value);
+    objectKeys += values.length;
+    if (objectKeys > SNAPSHOT_LIMITS.maxObjectKeys) {
+      throw new Error(`Runtime config snapshot ${filePath} exceeds maxObjectKeys: ${objectKeys} > ${SNAPSHOT_LIMITS.maxObjectKeys}`);
+    }
+    for (const item of values) stack.push({ value: item, depth: current.depth + 1 });
+  }
 }
 
 function isContainer(value) {

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -3,7 +3,7 @@
 import { chmod, chown, lstat, open, rename, stat, unlink } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { basename, dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, parse, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SNAPSHOT_LIMITS = Object.freeze({
@@ -30,8 +30,9 @@ export async function fileSha256(filePath) {
 }
 
 export async function writeFileNoFollow(filePath, data, mode = 0o600, owner) {
-  await assertExistingPathIsNotSymlink(filePath);
-  const tempPath = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  const resolvedFilePath = resolve(filePath);
+  await assertExistingPathIsNotSymlinkOrParent(resolvedFilePath);
+  const tempPath = join(dirname(resolvedFilePath), `.${basename(resolvedFilePath)}.${process.pid}.${Date.now()}.tmp`);
   const handle = await open(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, mode);
   try {
     await handle.writeFile(data);
@@ -40,12 +41,12 @@ export async function writeFileNoFollow(filePath, data, mode = 0o600, owner) {
     await handle.close();
   }
   await chmod(tempPath, mode);
+  if (owner && Number.isInteger(owner.uid) && Number.isInteger(owner.gid)) {
+    await chown(tempPath, owner.uid, owner.gid);
+  }
   try {
-    await rename(tempPath, filePath);
-    if (owner && Number.isInteger(owner.uid) && Number.isInteger(owner.gid)) {
-      await chown(filePath, owner.uid, owner.gid);
-    }
-    await chmod(filePath, mode);
+    await rename(tempPath, resolvedFilePath);
+    await chmod(resolvedFilePath, mode);
   } catch (error) {
     await unlink(tempPath).catch(() => undefined);
     throw error;
@@ -56,15 +57,23 @@ export async function copyFileNoFollow(sourcePath, destinationPath, mode = 0o600
   await writeFileNoFollow(destinationPath, await readFileNoFollow(sourcePath), mode);
 }
 
-async function assertExistingPathIsNotSymlink(filePath) {
-  try {
-    const info = await lstat(filePath);
-    if (info.isSymbolicLink()) {
-      throw new Error(`Refusing symlinked path: ${filePath}`);
+async function assertExistingPathIsNotSymlinkOrParent(filePath) {
+  const absolute = resolve(filePath);
+  const parsed = parse(absolute);
+  let current = parsed.root;
+  const parts = relative(parsed.root, absolute).split(sep).filter(Boolean);
+
+  for (const part of parts) {
+    current = resolve(current, part);
+    try {
+      const info = await lstat(current);
+      if (info.isSymbolicLink()) {
+        throw new Error(`Refusing symlinked path component: ${current}`);
+      }
+    } catch (error) {
+      if (error && error.code === 'ENOENT') return;
+      throw error;
     }
-  } catch (error) {
-    if (error && error.code === 'ENOENT') return;
-    throw error;
   }
 }
 
@@ -113,7 +122,7 @@ export function defaultEvidenceDir(targetPath) {
   assertSafePath(targetPath, 'targetPath');
   const targetName = basename(targetPath).replace(/[^A-Za-z0-9_.-]+/gu, '-').replace(/^-+/u, '') || 'runtime-config';
   const digest = createHash('sha256').update(targetPath).digest('hex').slice(0, 12);
-  return `rollback-evidence/runtime-config-${targetName}-${digest}`;
+  return resolve(`rollback-evidence/runtime-config-${targetName}-${digest}`);
 }
 
 export function buildRuntimeConfigRollbackPlan(options) {

--- a/scripts/runtime-config-rollback-plan.mjs
+++ b/scripts/runtime-config-rollback-plan.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { readFile, stat } from 'node:fs/promises';
+import { chmod, open, readFile, stat } from 'node:fs/promises';
+import { constants } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,6 +13,25 @@ const SNAPSHOT_LIMITS = Object.freeze({
   maxObjectKeys: 20_000,
   maxArrayItems: 50_000,
 });
+
+
+export async function fileSha256(filePath) {
+  return createHash('sha256').update(await readFile(filePath)).digest('hex');
+}
+
+export async function writeFileNoFollow(filePath, data, mode = 0o600) {
+  const handle = await open(filePath, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW, mode);
+  try {
+    await handle.writeFile(data);
+  } finally {
+    await handle.close();
+  }
+  await chmod(filePath, mode);
+}
+
+export async function copyFileNoFollow(sourcePath, destinationPath, mode = 0o600) {
+  await writeFileNoFollow(destinationPath, await readFile(sourcePath), mode);
+}
 
 export async function loadRuntimeConfigSnapshot(filePath) {
   const info = await stat(filePath);
@@ -79,6 +99,8 @@ export function buildRuntimeConfigRollbackPlan(options) {
   const changesPath = `${evidenceDir}/runtime-config-changes.json`;
   const rollbackCommentPath = `${evidenceDir}/rollback-comment.md`;
   const changedPaths = changes.map(change => change.path);
+  const beforeSha256 = options.beforeSha256 ?? createHash('sha256').update(JSON.stringify(before)).digest('hex');
+  const afterSha256 = options.afterSha256 ?? createHash('sha256').update(JSON.stringify(after)).digest('hex');
 
   return {
     summary: `Dry-run runtime config rollback plan for ${targetPath}`,
@@ -96,13 +118,27 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'import { chmod, lstat, mkdir } from "node:fs/promises"; import { parse, relative, resolve, sep } from "node:path"; const [dir]=process.argv.slice(1); async function assertNoSymlinkExisting(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); try { const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked evidence path component: ${current}`); } catch (error) { if (error && error.code === "ENOENT") break; throw error; } } } await assertNoSymlinkExisting(dir); await mkdir(dir, { recursive: true }); await assertNoSymlinkExisting(dir); await chmod(dir, 0o700);',
         evidenceDir,
       ],
-      ['install', '-m', '600', beforePath, rollbackConfigPath],
-      ['install', '-m', '600', afterPath, afterConfigPath],
       [
         'node',
         '--input-type=module',
         '-e',
-        'import { chmodSync, writeFileSync } from "node:fs"; import { buildRuntimeConfigRollbackPlan, loadRuntimeConfigSnapshot } from "./scripts/runtime-config-rollback-plan.mjs"; const [out,beforePath,afterPath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(beforePath); const after=await loadRuntimeConfigSnapshot(afterPath); const plan=buildRuntimeConfigRollbackPlan({ beforePath, afterPath, targetPath, evidenceDir, before, after }); writeFileSync(out, JSON.stringify(plan.changes, null, 2) + "\\n"); chmodSync(out, 0o600);',
+        'import { copyFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; await copyFileNoFollow(process.argv[1], process.argv[2]);',
+        beforePath,
+        rollbackConfigPath,
+      ],
+      [
+        'node',
+        '--input-type=module',
+        '-e',
+        'import { copyFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; await copyFileNoFollow(process.argv[1], process.argv[2]);',
+        afterPath,
+        afterConfigPath,
+      ],
+      [
+        'node',
+        '--input-type=module',
+        '-e',
+        'import { buildRuntimeConfigRollbackPlan, fileSha256, loadRuntimeConfigSnapshot, writeFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; const [out,beforePath,afterPath,targetPath,evidenceDir]=process.argv.slice(1); const before=await loadRuntimeConfigSnapshot(beforePath); const after=await loadRuntimeConfigSnapshot(afterPath); const [beforeSha256, afterSha256]=await Promise.all([fileSha256(beforePath), fileSha256(afterPath)]); const plan=buildRuntimeConfigRollbackPlan({ beforePath, afterPath, targetPath, evidenceDir, before, after, beforeSha256, afterSha256 }); await writeFileNoFollow(out, JSON.stringify(plan.changes, null, 2) + "\\n");',
         changesPath,
         beforePath,
         afterPath,
@@ -111,8 +147,9 @@ export function buildRuntimeConfigRollbackPlan(options) {
       ],
       [
         'node',
+        '--input-type=module',
         '-e',
-        'require("node:fs").writeFileSync(process.argv[1], `## Runtime config rollback postmortem\\n\\n- Target config: ${process.argv[2]}\\n- Before snapshot: ${process.argv[3]}\\n- After snapshot: ${process.argv[4]}\\n- Changed paths: ${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n`, { mode: 0o600 })',
+        'import { writeFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; await writeFileNoFollow(process.argv[1], `## Runtime config rollback postmortem\\n\\n- Target config: ${process.argv[2]}\\n- Before snapshot: ${process.argv[3]}\\n- After snapshot: ${process.argv[4]}\\n- Changed paths: ${process.argv[5]}\\n- Approval-cop outcome/token: <fill before posting>\\n- Verification: compare the target to rollback-config.json and rerun the affected beast/runtime config launch path before resuming.\\n`);',
         rollbackCommentPath,
         targetPath,
         beforePath,
@@ -132,10 +169,12 @@ export function buildRuntimeConfigRollbackPlan(options) {
         'node',
         '--input-type=module',
         '-e',
-        'import { copyFile, lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; const [rollback,target,after]=process.argv.slice(1); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked runtime config path component: ${current}`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [targetRaw, afterRaw]=await Promise.all([readFile(target), readFile(after)]); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await copyFile(rollback, target);',
+        'import { createHash } from "node:crypto"; import { lstat, readFile } from "node:fs/promises"; import { dirname, parse, relative, resolve, sep } from "node:path"; import { writeFileNoFollow } from "./scripts/runtime-config-rollback-plan.mjs"; const [rollback,target,after,expectedRollbackSha,expectedAfterSha]=process.argv.slice(1); const sha=data=>createHash("sha256").update(data).digest("hex"); async function assertNoSymlink(path){ const absolute=resolve(path); const parsed=parse(absolute); let current=parsed.root; const parts=relative(parsed.root, absolute).split(sep).filter(Boolean); for (const part of parts){ current=resolve(current, part); const info=await lstat(current); if (info.isSymbolicLink()) throw new Error(`Refusing symlinked runtime config path component: ${current}`); } } await assertNoSymlink(dirname(target)); await assertNoSymlink(target); const [rollbackRaw,targetRaw,afterRaw]=await Promise.all([readFile(rollback), readFile(target), readFile(after)]); if (sha(rollbackRaw)!==expectedRollbackSha) throw new Error("Refusing rollback: rollback snapshot no longer matches approved before snapshot"); if (sha(afterRaw)!==expectedAfterSha) throw new Error("Refusing rollback: captured after snapshot no longer matches reviewed after snapshot"); if (!targetRaw.equals(afterRaw)) throw new Error("Refusing rollback: target runtime config no longer matches after snapshot"); await writeFileNoFollow(target, rollbackRaw);',
         rollbackConfigPath,
         targetPath,
         afterConfigPath,
+        beforeSha256,
+        afterSha256,
       ],
     ],
     postRollbackVerification: [
@@ -334,7 +373,8 @@ async function main(argv) {
   }
   const before = await loadRuntimeConfigSnapshot(options.beforePath);
   const after = await loadRuntimeConfigSnapshot(options.afterPath);
-  const plan = buildRuntimeConfigRollbackPlan({ ...options, before, after });
+  const [beforeSha256, afterSha256] = await Promise.all([fileSha256(options.beforePath), fileSha256(options.afterPath)]);
+  const plan = buildRuntimeConfigRollbackPlan({ ...options, before, after, beforeSha256, afterSha256 });
   console.info(options.format === 'json' ? JSON.stringify(plan, null, 2) : renderPlan(plan));
 }
 

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -1,7 +1,8 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { describe, expect, it, afterEach } from 'vitest';
 
 import {
@@ -13,6 +14,7 @@ import {
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
 const SCRIPT = resolve(ROOT, 'scripts/runtime-config-rollback-plan.mjs');
+const jsonSha = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
 let workDir: string | undefined;
 
@@ -47,12 +49,16 @@ describe('runtime config rollback plan dry-run helper', () => {
   });
 
   it('builds a dry-run rollback plan that restores the before snapshot through approval-cop', () => {
+    const before = { provider: 'claude', modules: { planner: true } };
+    const after = { provider: 'openai', modules: { planner: false, memory: true } };
     const plan = buildRuntimeConfigRollbackPlan({
       beforePath: 'snapshots/run-123.before.json',
       afterPath: 'snapshots/run-123.after.json',
       targetPath: '.fbeast/.build/run-configs/run-123.json',
-      before: { provider: 'claude', modules: { planner: true } },
-      after: { provider: 'openai', modules: { planner: false, memory: true } },
+      before,
+      after,
+      beforeSha256: jsonSha(before),
+      afterSha256: jsonSha(after),
       evidenceDir: 'rollback-evidence/runtime-run-123',
     });
 
@@ -65,6 +71,7 @@ describe('runtime config rollback plan dry-run helper', () => {
     ]));
     expect(plan.readOnlyCapture[0].join(' ')).toContain('Refusing symlinked evidence path component');
     expect(plan.readOnlyCapture[1].join(' ')).toContain('copyFileNoFollow(process.argv[1], process.argv[2])');
+    expect(plan.readOnlyCapture[1].join(' ')).toContain('file://');
     expect(plan.readOnlyCapture[1]).toEqual(expect.arrayContaining([
       'snapshots/run-123.before.json',
       'rollback-evidence/runtime-run-123/rollback-config.json',
@@ -76,8 +83,8 @@ describe('runtime config rollback plan dry-run helper', () => {
     ]));
     expect(plan.readOnlyCapture[3]).toEqual(expect.arrayContaining([
       'rollback-evidence/runtime-run-123/runtime-config-changes.json',
-      'snapshots/run-123.before.json',
-      'snapshots/run-123.after.json',
+      'rollback-evidence/runtime-run-123/rollback-config.json',
+      'rollback-evidence/runtime-run-123/after-config.json',
       '.fbeast/.build/run-configs/run-123.json',
       'rollback-evidence/runtime-run-123',
     ]));
@@ -101,6 +108,16 @@ describe('runtime config rollback plan dry-run helper', () => {
     );
     expect(plan.notes.join('\n')).toContain('dry-run only');
     expect(plan.notes.join('\n')).toContain('Snapshot parsing is bounded');
+  });
+
+  it('requires caller-provided snapshot file hashes for approval-gated plans', () => {
+    expect(() => buildRuntimeConfigRollbackPlan({
+      beforePath: 'before.json',
+      afterPath: 'after.json',
+      targetPath: 'current.json',
+      before: { provider: 'claude' },
+      after: { provider: 'openai' },
+    })).toThrow(/beforeSha256 and afterSha256 are required/u);
   });
 
   it('rejects snapshots with no runtime config change', () => {
@@ -202,6 +219,47 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(markdownResult.stdout).toContain('## 1. Capture read-only rollback evidence');
     expect(markdownResult.stdout).toContain('approval-cop run -- node');
     expect(markdownResult.stdout).toContain('Refusing symlinked evidence path component');
+  });
+
+  it('emits capture commands that work outside the repository root and describe captured evidence', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-cwd-'));
+    const before = join(workDir, 'before.json');
+    const after = join(workDir, 'after.json');
+    const target = join(workDir, 'current.json');
+    const evidence = join(workDir, 'evidence');
+    const operatorCwd = join(workDir, 'operator');
+    await mkdir(operatorCwd);
+    await writeFile(before, `${JSON.stringify({ provider: 'claude' }, null, 2)}\n`);
+    await writeFile(after, `${JSON.stringify({ provider: 'openai' }, null, 2)}\n`);
+    await writeFile(target, `${JSON.stringify({ provider: 'openai' }, null, 2)}\n`);
+
+    const jsonResult = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--format', 'json',
+      '--before', before,
+      '--after', after,
+      '--target', target,
+      '--evidence-dir', evidence,
+    ], { cwd: operatorCwd, encoding: 'utf8' });
+
+    expect(jsonResult.status).toBe(0);
+    const parsed = JSON.parse(jsonResult.stdout);
+    for (const command of parsed.readOnlyCapture.slice(0, 3)) {
+      const result = spawnSync(command[0], command.slice(1), { cwd: operatorCwd, encoding: 'utf8' });
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+    }
+
+    await writeFile(before, `${JSON.stringify({ provider: 'mutated-source' }, null, 2)}\n`);
+    for (const command of parsed.readOnlyCapture.slice(3)) {
+      const result = spawnSync(command[0], command.slice(1), { cwd: operatorCwd, encoding: 'utf8' });
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+    }
+
+    const changes = JSON.parse(await readFile(join(evidence, 'runtime-config-changes.json'), 'utf8'));
+    expect(changes).toEqual([{ path: '/provider', type: 'changed' }]);
+    await expect(readFile(join(evidence, 'rollback-config.json'), 'utf8')).resolves.toContain('claude');
+    await expect(readFile(join(evidence, 'rollback-comment.md'), 'utf8')).resolves.toContain('Changed paths: "/provider"');
   });
 
   it('encodes markdown control characters in rendered changed paths', async () => {

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -58,14 +58,17 @@ describe('runtime config rollback plan dry-run helper', () => {
 
     expect(plan.summary).toBe('Dry-run runtime config rollback plan for .fbeast/.build/run-configs/run-123.json');
     expect(plan.changedPaths).toEqual(['/modules/memory', '/modules/planner', '/provider']);
-    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'mkdir -p rollback-evidence/runtime-run-123',
-    );
-    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'chmod 700 rollback-evidence/runtime-run-123',
-    );
+    expect(plan.readOnlyCapture[0]).toEqual(expect.arrayContaining([
+      'node',
+      '--input-type=module',
+      'rollback-evidence/runtime-run-123',
+    ]));
+    expect(plan.readOnlyCapture[0].join(' ')).toContain('Refusing symlinked evidence path component');
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
       'install -m 600 snapshots/run-123.before.json rollback-evidence/runtime-run-123/rollback-config.json',
+    );
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'install -m 600 snapshots/run-123.after.json rollback-evidence/runtime-run-123/after-config.json',
     );
     expect(plan.readOnlyCapture[3]).toEqual(expect.arrayContaining([
       'rollback-evidence/runtime-run-123/runtime-config-changes.json',
@@ -80,7 +83,7 @@ describe('runtime config rollback plan dry-run helper', () => {
       '--input-type=module',
       'rollback-evidence/runtime-run-123/rollback-config.json',
       '.fbeast/.build/run-configs/run-123.json',
-      'snapshots/run-123.after.json',
+      'rollback-evidence/runtime-run-123/after-config.json',
     ]));
     expect(plan.approvalGatedActions[0].join(' ')).toContain('lstat');
     expect(plan.approvalGatedActions[0].join(' ')).toContain('target runtime config no longer matches after snapshot');
@@ -99,6 +102,16 @@ describe('runtime config rollback plan dry-run helper', () => {
       before: { provider: 'claude' },
       after: { provider: 'claude' },
     })).toThrow(/No runtime config changes/u);
+  });
+
+  it('rejects control characters in operator-rendered paths', () => {
+    expect(() => buildRuntimeConfigRollbackPlan({
+      beforePath: 'before.json',
+      afterPath: 'after.json',
+      targetPath: 'current\nforged.json',
+      before: { provider: 'claude' },
+      after: { provider: 'openai' },
+    })).toThrow(/not safe for argv or Markdown/u);
   });
 
   it('uses a deterministic unique evidence directory when none is provided', () => {
@@ -151,15 +164,16 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(jsonResult.status).toBe(0);
     const parsed = JSON.parse(jsonResult.stdout);
     expect(parsed.changedPaths).toEqual(['/provider']);
-    expect(parsed.readOnlyCapture[0]).toEqual(['mkdir', '-p', join(workDir, 'evidence')]);
-    expect(parsed.readOnlyCapture[1]).toEqual(['chmod', '700', join(workDir, 'evidence')]);
-    expect(parsed.readOnlyCapture[2]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
+    expect(parsed.readOnlyCapture[0]).toEqual(expect.arrayContaining(['node', '--input-type=module', join(workDir, 'evidence')]));
+    expect(parsed.readOnlyCapture[0].join(' ')).toContain('Refusing symlinked evidence path component');
+    expect(parsed.readOnlyCapture[1]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
+    expect(parsed.readOnlyCapture[2]).toEqual(['install', '-m', '600', after, join(workDir, 'evidence', 'after-config.json')]);
     expect(parsed.approvalGatedActions[0]).toEqual(expect.arrayContaining([
       'node',
       '--input-type=module',
       join(workDir, 'evidence', 'rollback-config.json'),
       target,
-      after,
+      join(workDir, 'evidence', 'after-config.json'),
     ]));
     expect(JSON.stringify(parsed.changes)).not.toContain('openai');
     await expect(readFile(target, 'utf8')).resolves.toContain('openai');
@@ -176,7 +190,7 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(markdownResult.status).toBe(0);
     expect(markdownResult.stdout).toContain('## 1. Capture read-only rollback evidence');
     expect(markdownResult.stdout).toContain('approval-cop run -- node');
-    expect(markdownResult.stdout).toContain('mkdir -p');
+    expect(markdownResult.stdout).toContain('Refusing symlinked evidence path component');
   });
 
   it('encodes markdown control characters in rendered changed paths', async () => {

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -59,19 +59,22 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(plan.summary).toBe('Dry-run runtime config rollback plan for .fbeast/.build/run-configs/run-123.json');
     expect(plan.changedPaths).toEqual(['/modules/memory', '/modules/planner', '/provider']);
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'mkdir -m 700 -p rollback-evidence/runtime-run-123',
+      'mkdir -p rollback-evidence/runtime-run-123',
+    );
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'chmod 700 rollback-evidence/runtime-run-123',
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
       'install -m 600 snapshots/run-123.before.json rollback-evidence/runtime-run-123/rollback-config.json',
     );
-    expect(plan.readOnlyCapture[2]).toEqual(expect.arrayContaining([
+    expect(plan.readOnlyCapture[3]).toEqual(expect.arrayContaining([
       'rollback-evidence/runtime-run-123/runtime-config-changes.json',
       'snapshots/run-123.before.json',
       'snapshots/run-123.after.json',
       '.fbeast/.build/run-configs/run-123.json',
       'rollback-evidence/runtime-run-123',
     ]));
-    expect(plan.readOnlyCapture[2].join(' ')).not.toContain('"provider":"openai"');
+    expect(plan.readOnlyCapture[3].join(' ')).not.toContain('"provider":"openai"');
     expect(plan.approvalGatedActions).toEqual([
       [
         'approval-cop',
@@ -113,13 +116,18 @@ describe('runtime config rollback plan dry-run helper', () => {
     const good = join(workDir, 'before.json');
     const bad = join(workDir, 'bad.json');
     const oversized = join(workDir, 'oversized.json');
+    const tooDeep = join(workDir, 'too-deep.json');
     await writeFile(good, JSON.stringify({ provider: 'claude' }));
     await writeFile(bad, JSON.stringify(['not', 'an', 'object']));
     await writeFile(oversized, `{"payload":"${'x'.repeat(1_048_577)}"}`);
+    let nested: unknown = 'leaf';
+    for (let index = 0; index < 65; index += 1) nested = { child: nested };
+    await writeFile(tooDeep, JSON.stringify(nested));
 
     await expect(loadRuntimeConfigSnapshot(good)).resolves.toEqual({ provider: 'claude' });
     await expect(loadRuntimeConfigSnapshot(bad)).rejects.toThrow(/must contain a JSON object/u);
     await expect(loadRuntimeConfigSnapshot(oversized)).rejects.toThrow(/exceeds maxBytes/u);
+    await expect(loadRuntimeConfigSnapshot(tooDeep)).rejects.toThrow(/exceeds maxDepth/u);
   });
 
   it('prints JSON and markdown dry-run plans without mutating the target config', async () => {
@@ -144,8 +152,9 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(jsonResult.status).toBe(0);
     const parsed = JSON.parse(jsonResult.stdout);
     expect(parsed.changedPaths).toEqual(['/provider']);
-    expect(parsed.readOnlyCapture[0]).toEqual(['mkdir', '-m', '700', '-p', join(workDir, 'evidence')]);
-    expect(parsed.readOnlyCapture[1]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
+    expect(parsed.readOnlyCapture[0]).toEqual(['mkdir', '-p', join(workDir, 'evidence')]);
+    expect(parsed.readOnlyCapture[1]).toEqual(['chmod', '700', join(workDir, 'evidence')]);
+    expect(parsed.readOnlyCapture[2]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
     expect(parsed.approvalGatedActions[0]).toEqual([
       'approval-cop',
       'run',
@@ -168,6 +177,28 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(markdownResult.status).toBe(0);
     expect(markdownResult.stdout).toContain('## 1. Capture read-only rollback evidence');
     expect(markdownResult.stdout).toContain('approval-cop run -- cp');
-    expect(markdownResult.stdout).toContain('mkdir -m 700 -p');
+    expect(markdownResult.stdout).toContain('mkdir -p');
+  });
+
+  it('escapes markdown control characters in rendered changed paths', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-markdown-'));
+    const before = join(workDir, 'before.json');
+    const after = join(workDir, 'after.json');
+    const target = join(workDir, 'current.json');
+    await writeFile(before, JSON.stringify({ 'safe\n## fake': 'old' }));
+    await writeFile(after, JSON.stringify({ 'safe\n## fake': 'new' }));
+    await writeFile(target, JSON.stringify({ 'safe\n## fake': 'new' }));
+
+    const markdownResult = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--before', before,
+      '--after', after,
+      '--target', target,
+    ], { cwd: ROOT, encoding: 'utf8' });
+
+    expect(markdownResult.status).toBe(0);
+    expect(markdownResult.stdout).toContain('`/safe\\n## fake`: changed');
+    expect(markdownResult.stdout).not.toContain('\n## fake`: changed');
   });
 });

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -75,16 +75,15 @@ describe('runtime config rollback plan dry-run helper', () => {
       'rollback-evidence/runtime-run-123',
     ]));
     expect(plan.readOnlyCapture[3].join(' ')).not.toContain('"provider":"openai"');
-    expect(plan.approvalGatedActions).toEqual([
-      [
-        'approval-cop',
-        'run',
-        '--',
-        'cp',
-        'rollback-evidence/runtime-run-123/rollback-config.json',
-        '.fbeast/.build/run-configs/run-123.json',
-      ],
-    ]);
+    expect(plan.approvalGatedActions[0]).toEqual(expect.arrayContaining([
+      'node',
+      '--input-type=module',
+      'rollback-evidence/runtime-run-123/rollback-config.json',
+      '.fbeast/.build/run-configs/run-123.json',
+      'snapshots/run-123.after.json',
+    ]));
+    expect(plan.approvalGatedActions[0].join(' ')).toContain('lstat');
+    expect(plan.approvalGatedActions[0].join(' ')).toContain('target runtime config no longer matches after snapshot');
     expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
       'cmp -s rollback-evidence/runtime-run-123/rollback-config.json .fbeast/.build/run-configs/run-123.json',
     );
@@ -155,14 +154,14 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(parsed.readOnlyCapture[0]).toEqual(['mkdir', '-p', join(workDir, 'evidence')]);
     expect(parsed.readOnlyCapture[1]).toEqual(['chmod', '700', join(workDir, 'evidence')]);
     expect(parsed.readOnlyCapture[2]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
-    expect(parsed.approvalGatedActions[0]).toEqual([
-      'approval-cop',
-      'run',
-      '--',
-      'cp',
+    expect(parsed.approvalGatedActions[0]).toEqual(expect.arrayContaining([
+      'node',
+      '--input-type=module',
       join(workDir, 'evidence', 'rollback-config.json'),
       target,
-    ]);
+      after,
+    ]));
+    expect(JSON.stringify(parsed.changes)).not.toContain('openai');
     await expect(readFile(target, 'utf8')).resolves.toContain('openai');
 
     const markdownResult = spawnSync(process.execPath, [
@@ -176,18 +175,18 @@ describe('runtime config rollback plan dry-run helper', () => {
 
     expect(markdownResult.status).toBe(0);
     expect(markdownResult.stdout).toContain('## 1. Capture read-only rollback evidence');
-    expect(markdownResult.stdout).toContain('approval-cop run -- cp');
+    expect(markdownResult.stdout).toContain('approval-cop run -- node');
     expect(markdownResult.stdout).toContain('mkdir -p');
   });
 
-  it('escapes markdown control characters in rendered changed paths', async () => {
+  it('encodes markdown control characters in rendered changed paths', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-markdown-'));
     const before = join(workDir, 'before.json');
     const after = join(workDir, 'after.json');
     const target = join(workDir, 'current.json');
-    await writeFile(before, JSON.stringify({ 'safe\n## fake': 'old' }));
-    await writeFile(after, JSON.stringify({ 'safe\n## fake': 'new' }));
-    await writeFile(target, JSON.stringify({ 'safe\n## fake': 'new' }));
+    await writeFile(before, JSON.stringify({ 'safe\n## fake`tick': 'old' }));
+    await writeFile(after, JSON.stringify({ 'safe\n## fake`tick': 'new' }));
+    await writeFile(target, JSON.stringify({ 'safe\n## fake`tick': 'new' }));
 
     const markdownResult = spawnSync(process.execPath, [
       SCRIPT,
@@ -198,7 +197,7 @@ describe('runtime config rollback plan dry-run helper', () => {
     ], { cwd: ROOT, encoding: 'utf8' });
 
     expect(markdownResult.status).toBe(0);
-    expect(markdownResult.stdout).toContain('`/safe\\n## fake`: changed');
-    expect(markdownResult.stdout).not.toContain('\n## fake`: changed');
+    expect(markdownResult.stdout).toContain('"/safe\\n## fake`tick": changed');
+    expect(markdownResult.stdout).not.toContain('\n## fake`tick": changed');
   });
 });

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -1,0 +1,148 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it, afterEach } from 'vitest';
+
+import {
+  buildRuntimeConfigRollbackPlan,
+  diffRuntimeConfig,
+  loadRuntimeConfigSnapshot,
+} from '../../scripts/runtime-config-rollback-plan.mjs';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/runtime-config-rollback-plan.mjs');
+
+let workDir: string | undefined;
+
+afterEach(async () => {
+  if (workDir) {
+    await rm(workDir, { recursive: true, force: true });
+    workDir = undefined;
+  }
+});
+
+describe('runtime config rollback plan dry-run helper', () => {
+  it('diffs runtime config snapshots into deterministic JSON-pointer changes', () => {
+    const before = {
+      provider: 'claude',
+      model: 'sonnet',
+      modules: { planner: true, skills: true },
+      skills: ['code-review'],
+    };
+    const after = {
+      provider: 'openai',
+      modules: { planner: false, memory: true, skills: true },
+      skills: ['code-review', 'testing'],
+    };
+
+    expect(diffRuntimeConfig(before, after)).toEqual([
+      { path: '/model', type: 'removed', before: 'sonnet' },
+      { path: '/modules/memory', type: 'added', after: true },
+      { path: '/modules/planner', type: 'changed', before: true, after: false },
+      { path: '/provider', type: 'changed', before: 'claude', after: 'openai' },
+      { path: '/skills/1', type: 'added', after: 'testing' },
+    ]);
+  });
+
+  it('builds a dry-run rollback plan that restores the before snapshot through approval-cop', () => {
+    const plan = buildRuntimeConfigRollbackPlan({
+      beforePath: 'snapshots/run-123.before.json',
+      afterPath: 'snapshots/run-123.after.json',
+      targetPath: '.fbeast/.build/run-configs/run-123.json',
+      before: { provider: 'claude', modules: { planner: true } },
+      after: { provider: 'openai', modules: { planner: false, memory: true } },
+      evidenceDir: 'rollback-evidence/runtime-run-123',
+    });
+
+    expect(plan.summary).toBe('Dry-run runtime config rollback plan for .fbeast/.build/run-configs/run-123.json');
+    expect(plan.changedPaths).toEqual(['/modules/memory', '/modules/planner', '/provider']);
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'mkdir -p rollback-evidence/runtime-run-123',
+    );
+    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
+      'cp snapshots/run-123.before.json rollback-evidence/runtime-run-123/rollback-config.json',
+    );
+    expect(plan.approvalGatedActions).toEqual([
+      [
+        'approval-cop',
+        'run',
+        '--',
+        'cp',
+        'rollback-evidence/runtime-run-123/rollback-config.json',
+        '.fbeast/.build/run-configs/run-123.json',
+      ],
+    ]);
+    expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
+      'cmp -s rollback-evidence/runtime-run-123/rollback-config.json .fbeast/.build/run-configs/run-123.json',
+    );
+    expect(plan.notes.join('\n')).toContain('dry-run only');
+  });
+
+  it('rejects snapshots with no runtime config change', () => {
+    expect(() => buildRuntimeConfigRollbackPlan({
+      beforePath: 'before.json',
+      afterPath: 'after.json',
+      targetPath: 'current.json',
+      before: { provider: 'claude' },
+      after: { provider: 'claude' },
+    })).toThrow(/No runtime config changes/u);
+  });
+
+  it('loads JSON object snapshots and rejects arrays', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-'));
+    const good = join(workDir, 'before.json');
+    const bad = join(workDir, 'bad.json');
+    await writeFile(good, JSON.stringify({ provider: 'claude' }));
+    await writeFile(bad, JSON.stringify(['not', 'an', 'object']));
+
+    await expect(loadRuntimeConfigSnapshot(good)).resolves.toEqual({ provider: 'claude' });
+    await expect(loadRuntimeConfigSnapshot(bad)).rejects.toThrow(/must contain a JSON object/u);
+  });
+
+  it('prints JSON and markdown dry-run plans without mutating the target config', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-cli-'));
+    const before = join(workDir, 'before.json');
+    const after = join(workDir, 'after.json');
+    const target = join(workDir, 'current.json');
+    await writeFile(before, `${JSON.stringify({ provider: 'claude' }, null, 2)}\n`);
+    await writeFile(after, `${JSON.stringify({ provider: 'openai' }, null, 2)}\n`);
+    await writeFile(target, `${JSON.stringify({ provider: 'openai' }, null, 2)}\n`);
+
+    const jsonResult = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--format', 'json',
+      '--before', before,
+      '--after', after,
+      '--target', target,
+      '--evidence-dir', join(workDir, 'evidence'),
+    ], { cwd: ROOT, encoding: 'utf8' });
+
+    expect(jsonResult.status).toBe(0);
+    const parsed = JSON.parse(jsonResult.stdout);
+    expect(parsed.changedPaths).toEqual(['/provider']);
+    expect(parsed.approvalGatedActions[0]).toEqual([
+      'approval-cop',
+      'run',
+      '--',
+      'cp',
+      join(workDir, 'evidence', 'rollback-config.json'),
+      target,
+    ]);
+    await expect(readFile(target, 'utf8')).resolves.toContain('openai');
+
+    const markdownResult = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--before', before,
+      '--after', after,
+      '--target', target,
+      '--evidence-dir', join(workDir, 'evidence'),
+    ], { cwd: ROOT, encoding: 'utf8' });
+
+    expect(markdownResult.status).toBe(0);
+    expect(markdownResult.stdout).toContain('## 1. Capture read-only rollback evidence');
+    expect(markdownResult.stdout).toContain('approval-cop run -- cp');
+  });
+});

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -64,12 +64,16 @@ describe('runtime config rollback plan dry-run helper', () => {
       'rollback-evidence/runtime-run-123',
     ]));
     expect(plan.readOnlyCapture[0].join(' ')).toContain('Refusing symlinked evidence path component');
-    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'install -m 600 snapshots/run-123.before.json rollback-evidence/runtime-run-123/rollback-config.json',
-    );
-    expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'install -m 600 snapshots/run-123.after.json rollback-evidence/runtime-run-123/after-config.json',
-    );
+    expect(plan.readOnlyCapture[1].join(' ')).toContain('copyFileNoFollow(process.argv[1], process.argv[2])');
+    expect(plan.readOnlyCapture[1]).toEqual(expect.arrayContaining([
+      'snapshots/run-123.before.json',
+      'rollback-evidence/runtime-run-123/rollback-config.json',
+    ]));
+    expect(plan.readOnlyCapture[2].join(' ')).toContain('copyFileNoFollow(process.argv[1], process.argv[2])');
+    expect(plan.readOnlyCapture[2]).toEqual(expect.arrayContaining([
+      'snapshots/run-123.after.json',
+      'rollback-evidence/runtime-run-123/after-config.json',
+    ]));
     expect(plan.readOnlyCapture[3]).toEqual(expect.arrayContaining([
       'rollback-evidence/runtime-run-123/runtime-config-changes.json',
       'snapshots/run-123.before.json',
@@ -85,7 +89,12 @@ describe('runtime config rollback plan dry-run helper', () => {
       '.fbeast/.build/run-configs/run-123.json',
       'rollback-evidence/runtime-run-123/after-config.json',
     ]));
+    expect(plan.approvalGatedActions[0].slice(-2)).toEqual([
+      expect.stringMatching(/^[a-f0-9]{64}$/u),
+      expect.stringMatching(/^[a-f0-9]{64}$/u),
+    ]);
     expect(plan.approvalGatedActions[0].join(' ')).toContain('lstat');
+    expect(plan.approvalGatedActions[0].join(' ')).toContain('rollback snapshot no longer matches approved before snapshot');
     expect(plan.approvalGatedActions[0].join(' ')).toContain('target runtime config no longer matches after snapshot');
     expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
       'cmp -s rollback-evidence/runtime-run-123/rollback-config.json .fbeast/.build/run-configs/run-123.json',
@@ -166,8 +175,10 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(parsed.changedPaths).toEqual(['/provider']);
     expect(parsed.readOnlyCapture[0]).toEqual(expect.arrayContaining(['node', '--input-type=module', join(workDir, 'evidence')]));
     expect(parsed.readOnlyCapture[0].join(' ')).toContain('Refusing symlinked evidence path component');
-    expect(parsed.readOnlyCapture[1]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
-    expect(parsed.readOnlyCapture[2]).toEqual(['install', '-m', '600', after, join(workDir, 'evidence', 'after-config.json')]);
+    expect(parsed.readOnlyCapture[1].join(' ')).toContain('copyFileNoFollow(process.argv[1], process.argv[2])');
+    expect(parsed.readOnlyCapture[1]).toEqual(expect.arrayContaining([before, join(workDir, 'evidence', 'rollback-config.json')]));
+    expect(parsed.readOnlyCapture[2].join(' ')).toContain('copyFileNoFollow(process.argv[1], process.argv[2])');
+    expect(parsed.readOnlyCapture[2]).toEqual(expect.arrayContaining([after, join(workDir, 'evidence', 'after-config.json')]));
     expect(parsed.approvalGatedActions[0]).toEqual(expect.arrayContaining([
       'node',
       '--input-type=module',

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 
 import {
   buildRuntimeConfigRollbackPlan,
+  defaultEvidenceDir,
   diffRuntimeConfig,
   loadRuntimeConfigSnapshot,
 } from '../../scripts/runtime-config-rollback-plan.mjs';
@@ -58,11 +59,19 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(plan.summary).toBe('Dry-run runtime config rollback plan for .fbeast/.build/run-configs/run-123.json');
     expect(plan.changedPaths).toEqual(['/modules/memory', '/modules/planner', '/provider']);
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'mkdir -p rollback-evidence/runtime-run-123',
+      'mkdir -m 700 -p rollback-evidence/runtime-run-123',
     );
     expect(plan.readOnlyCapture.map(command => command.join(' '))).toContain(
-      'cp snapshots/run-123.before.json rollback-evidence/runtime-run-123/rollback-config.json',
+      'install -m 600 snapshots/run-123.before.json rollback-evidence/runtime-run-123/rollback-config.json',
     );
+    expect(plan.readOnlyCapture[2]).toEqual(expect.arrayContaining([
+      'rollback-evidence/runtime-run-123/runtime-config-changes.json',
+      'snapshots/run-123.before.json',
+      'snapshots/run-123.after.json',
+      '.fbeast/.build/run-configs/run-123.json',
+      'rollback-evidence/runtime-run-123',
+    ]));
+    expect(plan.readOnlyCapture[2].join(' ')).not.toContain('"provider":"openai"');
     expect(plan.approvalGatedActions).toEqual([
       [
         'approval-cop',
@@ -77,6 +86,7 @@ describe('runtime config rollback plan dry-run helper', () => {
       'cmp -s rollback-evidence/runtime-run-123/rollback-config.json .fbeast/.build/run-configs/run-123.json',
     );
     expect(plan.notes.join('\n')).toContain('dry-run only');
+    expect(plan.notes.join('\n')).toContain('Snapshot parsing is bounded');
   });
 
   it('rejects snapshots with no runtime config change', () => {
@@ -89,15 +99,27 @@ describe('runtime config rollback plan dry-run helper', () => {
     })).toThrow(/No runtime config changes/u);
   });
 
-  it('loads JSON object snapshots and rejects arrays', async () => {
+  it('uses a deterministic unique evidence directory when none is provided', () => {
+    const first = defaultEvidenceDir('.fbeast/.build/run-configs/run-123.json');
+    const second = defaultEvidenceDir('.fbeast/.build/run-configs/run-456.json');
+
+    expect(first).toMatch(/^rollback-evidence\/runtime-config-run-123\.json-[a-f0-9]{12}$/u);
+    expect(second).toMatch(/^rollback-evidence\/runtime-config-run-456\.json-[a-f0-9]{12}$/u);
+    expect(first).not.toBe(second);
+  });
+
+  it('loads bounded JSON object snapshots and rejects arrays or oversized files', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-'));
     const good = join(workDir, 'before.json');
     const bad = join(workDir, 'bad.json');
+    const oversized = join(workDir, 'oversized.json');
     await writeFile(good, JSON.stringify({ provider: 'claude' }));
     await writeFile(bad, JSON.stringify(['not', 'an', 'object']));
+    await writeFile(oversized, `{"payload":"${'x'.repeat(1_048_577)}"}`);
 
     await expect(loadRuntimeConfigSnapshot(good)).resolves.toEqual({ provider: 'claude' });
     await expect(loadRuntimeConfigSnapshot(bad)).rejects.toThrow(/must contain a JSON object/u);
+    await expect(loadRuntimeConfigSnapshot(oversized)).rejects.toThrow(/exceeds maxBytes/u);
   });
 
   it('prints JSON and markdown dry-run plans without mutating the target config', async () => {
@@ -122,6 +144,8 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(jsonResult.status).toBe(0);
     const parsed = JSON.parse(jsonResult.stdout);
     expect(parsed.changedPaths).toEqual(['/provider']);
+    expect(parsed.readOnlyCapture[0]).toEqual(['mkdir', '-m', '700', '-p', join(workDir, 'evidence')]);
+    expect(parsed.readOnlyCapture[1]).toEqual(['install', '-m', '600', before, join(workDir, 'evidence', 'rollback-config.json')]);
     expect(parsed.approvalGatedActions[0]).toEqual([
       'approval-cop',
       'run',
@@ -144,5 +168,6 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(markdownResult.status).toBe(0);
     expect(markdownResult.stdout).toContain('## 1. Capture read-only rollback evidence');
     expect(markdownResult.stdout).toContain('approval-cop run -- cp');
+    expect(markdownResult.stdout).toContain('mkdir -m 700 -p');
   });
 });

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -10,6 +10,7 @@ import {
   defaultEvidenceDir,
   diffRuntimeConfig,
   loadRuntimeConfigSnapshot,
+  loadRuntimeConfigSnapshotWithDigest,
 } from '../../scripts/runtime-config-rollback-plan.mjs';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
@@ -101,6 +102,8 @@ describe('runtime config rollback plan dry-run helper', () => {
       expect.stringMatching(/^[a-f0-9]{64}$/u),
     ]);
     expect(plan.approvalGatedActions[0].join(' ')).toContain('lstat');
+    expect(plan.approvalGatedActions[0].join(' ')).toContain('readFileNoFollow');
+    expect(plan.approvalGatedActions[0].join(' ')).toContain('targetInfo.mode & 0o777');
     expect(plan.approvalGatedActions[0].join(' ')).toContain('rollback snapshot no longer matches approved before snapshot');
     expect(plan.approvalGatedActions[0].join(' ')).toContain('target runtime config no longer matches after snapshot');
     expect(plan.postRollbackVerification.map(command => command.join(' '))).toContain(
@@ -166,6 +169,21 @@ describe('runtime config rollback plan dry-run helper', () => {
     await expect(loadRuntimeConfigSnapshot(bad)).rejects.toThrow(/must contain a JSON object/u);
     await expect(loadRuntimeConfigSnapshot(oversized)).rejects.toThrow(/exceeds maxBytes/u);
     await expect(loadRuntimeConfigSnapshot(tooDeep)).rejects.toThrow(/exceeds maxDepth/u);
+  });
+
+  it('validates snapshots with runtime config rules and hashes the parsed bytes from one read', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-schema-'));
+    const pretty = join(workDir, 'pretty.json');
+    const invalid = join(workDir, 'invalid.json');
+    const raw = `${JSON.stringify({ provider: 'claude', maxDurationMs: 123, skills: ['safe'] }, null, 2)}\n`;
+    await writeFile(pretty, raw);
+    await writeFile(invalid, JSON.stringify({ maxDurationMs: 'later', modules: { planner: 'yes' } }));
+
+    await expect(loadRuntimeConfigSnapshot(invalid)).rejects.toThrow(/maxDurationMs.*positive integer/u);
+    await expect(loadRuntimeConfigSnapshotWithDigest(pretty)).resolves.toMatchObject({
+      snapshot: { provider: 'claude', maxDurationMs: 123, skills: ['safe'] },
+      sha256: createHash('sha256').update(raw).digest('hex'),
+    });
   });
 
   it('prints JSON and markdown dry-run plans without mutating the target config', async () => {
@@ -262,14 +280,43 @@ describe('runtime config rollback plan dry-run helper', () => {
     await expect(readFile(join(evidence, 'rollback-comment.md'), 'utf8')).resolves.toContain('Changed paths: "/provider"');
   });
 
+  it('emits absolute generated paths when invoked with relative CLI paths', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-relative-'));
+    await writeFile(join(workDir, 'before.json'), JSON.stringify({ provider: 'claude' }));
+    await writeFile(join(workDir, 'after.json'), JSON.stringify({ provider: 'openai' }));
+    await writeFile(join(workDir, 'current.json'), JSON.stringify({ provider: 'openai' }));
+
+    const jsonResult = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--format', 'json',
+      '--before', 'before.json',
+      '--after', 'after.json',
+      '--target', 'current.json',
+      '--evidence-dir', 'evidence',
+    ], { cwd: workDir, encoding: 'utf8' });
+
+    expect(jsonResult.status).toBe(0);
+    const parsed = JSON.parse(jsonResult.stdout);
+    expect(parsed.beforePath).toBe(join(workDir, 'before.json'));
+    expect(parsed.afterPath).toBe(join(workDir, 'after.json'));
+    expect(parsed.targetPath).toBe(join(workDir, 'current.json'));
+    expect(parsed.evidenceDir).toBe(join(workDir, 'evidence'));
+    expect(parsed.approvalGatedActions[0]).toEqual(expect.arrayContaining([
+      join(workDir, 'evidence', 'rollback-config.json'),
+      join(workDir, 'current.json'),
+      join(workDir, 'evidence', 'after-config.json'),
+    ]));
+  });
+
   it('encodes markdown control characters in rendered changed paths', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-markdown-'));
     const before = join(workDir, 'before.json');
     const after = join(workDir, 'after.json');
     const target = join(workDir, 'current.json');
-    await writeFile(before, JSON.stringify({ 'safe\n## fake`tick': 'old' }));
-    await writeFile(after, JSON.stringify({ 'safe\n## fake`tick': 'new' }));
-    await writeFile(target, JSON.stringify({ 'safe\n## fake`tick': 'new' }));
+    await writeFile(before, JSON.stringify({ 'safe\n## fake`tick': 'old', 'unicode\u2028separator': 'old' }));
+    await writeFile(after, JSON.stringify({ 'safe\n## fake`tick': 'new', 'unicode\u2028separator': 'new' }));
+    await writeFile(target, JSON.stringify({ 'safe\n## fake`tick': 'new', 'unicode\u2028separator': 'new' }));
 
     const markdownResult = spawnSync(process.execPath, [
       SCRIPT,
@@ -281,6 +328,7 @@ describe('runtime config rollback plan dry-run helper', () => {
 
     expect(markdownResult.status).toBe(0);
     expect(markdownResult.stdout).toContain('"/safe\\n## fake`tick": changed');
+    expect(markdownResult.stdout).toContain('"/unicode\\u2028separator": changed');
     expect(markdownResult.stdout).not.toContain('\n## fake`tick": changed');
   });
 });

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -204,6 +204,23 @@ describe('runtime config rollback plan dry-run helper', () => {
     });
   });
 
+  it('rejects non-regular snapshots before reading', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-non-regular-'));
+    await expect(loadRuntimeConfigSnapshot(workDir)).rejects.toThrow(/must be a regular file/u);
+  });
+
+  it('hashes snapshot bytes before UTF-8 decoding', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-raw-hash-'));
+    const snapshot = join(workDir, 'invalid-utf8-string.json');
+    const raw = Buffer.from('{"provider":"claude\xff"}', 'binary');
+    await writeFile(snapshot, raw);
+
+    await expect(loadRuntimeConfigSnapshotWithDigest(snapshot)).resolves.toMatchObject({
+      snapshot: { provider: 'claude�' },
+      sha256: createHash('sha256').update(raw).digest('hex'),
+    });
+  });
+
   it('prints JSON and markdown dry-run plans without mutating the target config', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-cli-'));
     const before = join(workDir, 'before.json');
@@ -296,6 +313,35 @@ describe('runtime config rollback plan dry-run helper', () => {
     expect(changes).toEqual([{ path: '/provider', type: 'changed' }]);
     await expect(readFile(join(evidence, 'rollback-config.json'), 'utf8')).resolves.toContain('claude');
     await expect(readFile(join(evidence, 'rollback-comment.md'), 'utf8')).resolves.toContain('Changed paths: "/provider"');
+  });
+
+  it('does not chmod pre-existing evidence directories', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-existing-evidence-'));
+    const before = join(workDir, 'before.json');
+    const after = join(workDir, 'after.json');
+    const target = join(workDir, 'current.json');
+    const evidence = join(workDir, 'evidence');
+    await mkdir(evidence);
+    await chmod(evidence, 0o755);
+    await writeFile(before, `${JSON.stringify({ provider: 'claude' }, null, 2)}\n`);
+    await writeFile(after, `${JSON.stringify({ provider: 'openai' }, null, 2)}\n`);
+    await writeFile(target, `${JSON.stringify({ provider: 'openai' }, null, 2)}\n`);
+
+    const jsonResult = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--format', 'json',
+      '--before', before,
+      '--after', after,
+      '--target', target,
+      '--evidence-dir', evidence,
+    ], { cwd: ROOT, encoding: 'utf8' });
+
+    expect(jsonResult.status).toBe(0);
+    const parsed = JSON.parse(jsonResult.stdout);
+    const result = spawnSync(parsed.readOnlyCapture[0][0], parsed.readOnlyCapture[0].slice(1), { cwd: ROOT, encoding: 'utf8' });
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect((await stat(evidence)).mode & 0o777).toBe(0o755);
   });
 
   it('emits absolute generated paths when invoked with relative CLI paths', async () => {

--- a/tests/unit/runtime-config-rollback-plan.test.ts
+++ b/tests/unit/runtime-config-rollback-plan.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -11,6 +11,7 @@ import {
   diffRuntimeConfig,
   loadRuntimeConfigSnapshot,
   loadRuntimeConfigSnapshotWithDigest,
+  writeFileNoFollow,
 } from '../../scripts/runtime-config-rollback-plan.mjs';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
@@ -147,9 +148,26 @@ describe('runtime config rollback plan dry-run helper', () => {
     const first = defaultEvidenceDir('.fbeast/.build/run-configs/run-123.json');
     const second = defaultEvidenceDir('.fbeast/.build/run-configs/run-456.json');
 
-    expect(first).toMatch(/^rollback-evidence\/runtime-config-run-123\.json-[a-f0-9]{12}$/u);
-    expect(second).toMatch(/^rollback-evidence\/runtime-config-run-456\.json-[a-f0-9]{12}$/u);
+    const firstPrefix = resolve('rollback-evidence/runtime-config-run-123.json-');
+    const secondPrefix = resolve('rollback-evidence/runtime-config-run-456.json-');
+
+    expect(first.startsWith(firstPrefix)).toBe(true);
+    expect(second.startsWith(secondPrefix)).toBe(true);
     expect(first).not.toBe(second);
+    expect(first.slice(firstPrefix.length)).toMatch(/^[a-f0-9]{12}$/u);
+    expect(second.slice(secondPrefix.length)).toMatch(/^[a-f0-9]{12}$/u);
+  });
+
+  it('rejects writes when evidence parent paths are symlinks', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'runtime-config-rollback-symlink-parent-'));
+    const realDir = join(workDir, 'real');
+    const linkDir = join(workDir, 'evidence-link');
+    const targetFile = join(linkDir, 'snapshot.json');
+
+    await mkdir(realDir);
+    await symlink(realDir, linkDir, 'dir');
+
+    await expect(writeFileNoFollow(targetFile, '{"x":1}\n')).rejects.toThrow(/Refusing symlinked path component/u);
   });
 
   it('loads bounded JSON object snapshots and rejects arrays or oversized files', async () => {


### PR DESCRIPTION
## Summary
- Add a dry-run runtime config rollback plan generator for JSON snapshots.
- Route the generated restore action through approval-cop/HITL and include read-only evidence/verification commands.
- Document operator usage and add unit/CLI coverage for diffing, no-op rejection, snapshot validation, and dry-run behavior.

## Test Plan
- [x] npm run test:root -- tests/unit/runtime-config-rollback-plan.test.ts
- [x] npm run test:root
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run build

Closes #1837
