### PR TITLE
feat(dr): add backup encryption verification report

### DIFF
--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -14,3 +14,36 @@ Expected interpretation:
 - recovery guidance: review the cron drift and explicitly restore, merge, or skip the job; do not silently drop it and do not overwrite live schedules blindly.
 
 This fixture is covered by `packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts` so future restore-preview changes keep missing cron jobs visible in deterministic test output.
+
+## Backup encryption verification report
+
+`buildBackupEncryptionVerificationReport(manifest, options)` produces a deterministic, structured report that operators and PM/liveness tooling can inspect before trusting a disaster-recovery backup artifact. The report is read-only and includes:
+
+- `status`: `verified`, `warning`, or `failed`
+- `encrypted`: whether the manifest explicitly reports encryption is enabled
+- `metadata`: the manifest's encryption metadata when present
+- `findings`: blocker/warning records with actionable recommendations
+- `operatorSummary`: a concise human-readable interpretation
+
+A backup manifest should include:
+
+```json
+{
+  "schemaVersion": 1,
+  "encryption": {
+    "encrypted": true,
+    "algorithm": "aes-256-gcm",
+    "keyRef": "dr/backups/prod-primary",
+    "artifactDigest": "sha256:...",
+    "generatedAt": "2026-07-14T12:00:00.000Z"
+  }
+}
+```
+
+Interpretation guidance:
+
+- `failed`: do not restore blindly. Encryption metadata is missing, encryption is disabled, or the cipher suite is absent.
+- `warning`: encryption is present, but the report lacks restore-critical evidence such as an allowed algorithm, logical key reference, or encrypted artifact digest. Require operator review before restore.
+- `verified`: encryption is present, uses an allowed algorithm, and includes key/digest evidence for disaster-recovery handoff.
+
+Tests cover verified metadata, missing metadata, unsupported algorithms, and missing restore-critical references so future DR changes keep the report machine-readable and actionable.

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -1,5 +1,47 @@
 export type RestorePreviewArea = 'schema' | 'tasks' | 'approvals' | 'memory' | 'cron';
 
+export type BackupEncryptionVerificationStatus = 'verified' | 'warning' | 'failed';
+
+export type BackupEncryptionVerificationSeverity = 'info' | 'warning' | 'blocker';
+
+export type BackupEncryptionVerificationFindingCode =
+  | 'missing-encryption-metadata'
+  | 'backup-not-encrypted'
+  | 'missing-algorithm'
+  | 'unsupported-algorithm'
+  | 'missing-key-reference'
+  | 'missing-artifact-digest';
+
+export interface BackupEncryptionMetadata {
+  readonly encrypted: boolean;
+  readonly algorithm?: string;
+  readonly keyRef?: string;
+  readonly artifactDigest?: string;
+  readonly generatedAt?: string;
+}
+
+export interface BackupEncryptionVerificationFinding {
+  readonly code: BackupEncryptionVerificationFindingCode;
+  readonly severity: BackupEncryptionVerificationSeverity;
+  readonly message: string;
+  readonly recommendation: string;
+}
+
+export interface BackupEncryptionVerificationReport {
+  /** ISO timestamp for when the report was generated, supplied by callers for deterministic tests. */
+  readonly checkedAt: string;
+  readonly status: BackupEncryptionVerificationStatus;
+  readonly encrypted: boolean;
+  readonly metadata?: BackupEncryptionMetadata;
+  readonly findings: readonly BackupEncryptionVerificationFinding[];
+  readonly operatorSummary: string;
+}
+
+export interface BackupEncryptionVerificationOptions {
+  readonly checkedAt?: string;
+  readonly allowedAlgorithms?: readonly string[];
+}
+
 export type RestorePreviewConflictType =
   | 'schema-mismatch'
   | 'changed'
@@ -19,6 +61,7 @@ export interface RestorePreviewRecord {
 
 export interface RestorePreviewManifest {
   readonly schemaVersion: number;
+  readonly encryption?: BackupEncryptionMetadata;
   readonly tasks?: readonly RestorePreviewRecord[];
   readonly approvals?: readonly RestorePreviewRecord[];
   readonly memory?: readonly RestorePreviewRecord[];
@@ -56,6 +99,87 @@ const AREA_ACCESSORS = {
   cron: (manifest: RestorePreviewManifest) => manifest.cron ?? [],
 } satisfies Record<ComparableArea, (manifest: RestorePreviewManifest) => readonly RestorePreviewRecord[]>;
 
+const DEFAULT_ALLOWED_BACKUP_ENCRYPTION_ALGORITHMS = ['aes-256-gcm', 'xchacha20-poly1305'] as const;
+
+export function buildBackupEncryptionVerificationReport(
+  manifest: RestorePreviewManifest,
+  options: BackupEncryptionVerificationOptions = {},
+): BackupEncryptionVerificationReport {
+  const checkedAt = options.checkedAt ?? new Date().toISOString();
+  const encryption = manifest.encryption;
+  const findings: BackupEncryptionVerificationFinding[] = [];
+  const allowedAlgorithms = new Set(
+    (options.allowedAlgorithms ?? DEFAULT_ALLOWED_BACKUP_ENCRYPTION_ALGORITHMS).map((algorithm) =>
+      algorithm.toLowerCase(),
+    ),
+  );
+
+  if (encryption === undefined) {
+    findings.push({
+      code: 'missing-encryption-metadata',
+      severity: 'blocker',
+      message: 'Backup manifest does not include encryption metadata.',
+      recommendation:
+        'Do not restore or archive this backup as verified; regenerate it with encryption metadata before proceeding.',
+    });
+  } else {
+    if (!encryption.encrypted) {
+      findings.push({
+        code: 'backup-not-encrypted',
+        severity: 'blocker',
+        message: 'Backup manifest explicitly reports that the backup artifact is not encrypted.',
+        recommendation: 'Regenerate the backup with encryption enabled before using it for disaster recovery.',
+      });
+    }
+
+    const algorithm = encryption.algorithm?.trim();
+    if (algorithm === undefined || algorithm.length === 0) {
+      findings.push({
+        code: 'missing-algorithm',
+        severity: 'blocker',
+        message: 'Backup encryption metadata is missing the encryption algorithm.',
+        recommendation: 'Record the cipher suite used for the backup so operators can verify it before restore.',
+      });
+    } else if (!allowedAlgorithms.has(algorithm.toLowerCase())) {
+      findings.push({
+        code: 'unsupported-algorithm',
+        severity: 'warning',
+        message: `Backup encryption algorithm ${algorithm} is not in the allowed algorithm list.`,
+        recommendation: `Use one of: ${[...allowedAlgorithms].sort().join(', ')}; otherwise require an explicit operator exception.`,
+      });
+    }
+
+    if (encryption.keyRef === undefined || encryption.keyRef.trim() === '') {
+      findings.push({
+        code: 'missing-key-reference',
+        severity: 'warning',
+        message: 'Backup encryption metadata is missing the logical key reference.',
+        recommendation: 'Record the logical key reference so restore operators can locate the correct decrypt key.',
+      });
+    }
+
+    if (encryption.artifactDigest === undefined || encryption.artifactDigest.trim() === '') {
+      findings.push({
+        code: 'missing-artifact-digest',
+        severity: 'warning',
+        message: 'Backup encryption metadata is missing the encrypted artifact digest.',
+        recommendation: 'Record the encrypted artifact digest so operators can detect tampering or partial backups.',
+      });
+    }
+  }
+
+  const status = statusForEncryptionFindings(findings);
+
+  return {
+    checkedAt,
+    status,
+    encrypted: encryption?.encrypted === true,
+    ...(encryption === undefined ? {} : { metadata: { ...encryption } }),
+    findings,
+    operatorSummary: operatorSummaryForEncryptionReport(status, findings.length),
+  };
+}
+
 export function detectRestorePreviewConflicts(
   backup: RestorePreviewManifest,
   live: RestorePreviewManifest,
@@ -90,6 +214,23 @@ export function detectRestorePreviewConflicts(
     },
     conflicts,
   };
+}
+
+function statusForEncryptionFindings(
+  findings: readonly BackupEncryptionVerificationFinding[],
+): BackupEncryptionVerificationStatus {
+  if (findings.some((finding) => finding.severity === 'blocker')) return 'failed';
+  if (findings.some((finding) => finding.severity === 'warning')) return 'warning';
+  return 'verified';
+}
+
+function operatorSummaryForEncryptionReport(
+  status: BackupEncryptionVerificationStatus,
+  findingCount: number,
+): string {
+  if (status === 'verified') return 'Backup encryption is verified; no encryption blockers or warnings were found.';
+  if (status === 'warning') return `Backup encryption is present but has ${findingCount} warning(s) requiring operator review.`;
+  return `Backup encryption verification failed with ${findingCount} blocker/warning finding(s); do not restore blindly.`;
 }
 
 function compareRecords(

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -132,7 +132,7 @@ export function buildBackupEncryptionVerificationReport(
       });
     }
 
-    const algorithm = encryption.algorithm?.trim();
+    const algorithm = optionalString(encryption.algorithm)?.trim();
     if (algorithm === undefined || algorithm.length === 0) {
       findings.push({
         code: 'missing-algorithm',
@@ -149,7 +149,8 @@ export function buildBackupEncryptionVerificationReport(
       });
     }
 
-    if (encryption.keyRef === undefined || encryption.keyRef.trim() === '') {
+    const keyRef = optionalString(encryption.keyRef)?.trim();
+    if (keyRef === undefined || keyRef.length === 0) {
       findings.push({
         code: 'missing-key-reference',
         severity: 'warning',
@@ -158,7 +159,8 @@ export function buildBackupEncryptionVerificationReport(
       });
     }
 
-    if (encryption.artifactDigest === undefined || encryption.artifactDigest.trim() === '') {
+    const artifactDigest = optionalString(encryption.artifactDigest)?.trim();
+    if (artifactDigest === undefined || artifactDigest.length === 0) {
       findings.push({
         code: 'missing-artifact-digest',
         severity: 'warning',
@@ -222,6 +224,10 @@ function statusForEncryptionFindings(
   if (findings.some((finding) => finding.severity === 'blocker')) return 'failed';
   if (findings.some((finding) => finding.severity === 'warning')) return 'warning';
   return 'verified';
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
 }
 
 function operatorSummaryForEncryptionReport(

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -123,11 +123,11 @@ export function buildBackupEncryptionVerificationReport(
         'Do not restore or archive this backup as verified; regenerate it with encryption metadata before proceeding.',
     });
   } else {
-    if (!encryption.encrypted) {
+    if (encryption.encrypted !== true) {
       findings.push({
         code: 'backup-not-encrypted',
         severity: 'blocker',
-        message: 'Backup manifest explicitly reports that the backup artifact is not encrypted.',
+        message: 'Backup manifest does not explicitly report that the backup artifact is encrypted.',
         recommendation: 'Regenerate the backup with encryption enabled before using it for disaster recovery.',
       });
     }

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -106,7 +106,9 @@ export function buildBackupEncryptionVerificationReport(
   options: BackupEncryptionVerificationOptions = {},
 ): BackupEncryptionVerificationReport {
   const checkedAt = options.checkedAt ?? new Date().toISOString();
-  const encryption = manifest.encryption;
+  const encryption = isRecord(manifest.encryption)
+    ? (manifest.encryption as unknown as BackupEncryptionMetadata)
+    : undefined;
   const findings: BackupEncryptionVerificationFinding[] = [];
   const allowedAlgorithms = new Set(
     (options.allowedAlgorithms ?? DEFAULT_ALLOWED_BACKUP_ENCRYPTION_ALGORITHMS).map((algorithm) =>
@@ -224,6 +226,10 @@ function statusForEncryptionFindings(
   if (findings.some((finding) => finding.severity === 'blocker')) return 'failed';
   if (findings.some((finding) => finding.severity === 'warning')) return 'warning';
   return 'verified';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function optionalString(value: unknown): string | undefined {

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -218,8 +218,15 @@ export { checkModuleHealth, allHealthy } from './resilience/module-initializer.j
 export type { ModuleHealth } from './resilience/module-initializer.js';
 
 // Disaster recovery
-export { detectRestorePreviewConflicts } from './dr/restore-preview.js';
+export { buildBackupEncryptionVerificationReport, detectRestorePreviewConflicts } from './dr/restore-preview.js';
 export type {
+  BackupEncryptionMetadata,
+  BackupEncryptionVerificationFinding,
+  BackupEncryptionVerificationFindingCode,
+  BackupEncryptionVerificationOptions,
+  BackupEncryptionVerificationReport,
+  BackupEncryptionVerificationSeverity,
+  BackupEncryptionVerificationStatus,
   RestorePreviewArea,
   RestorePreviewConflict,
   RestorePreviewConflictType,

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -232,6 +232,26 @@ describe('restore preview conflict detector', () => {
     );
   });
 
+  it('fails backup encryption verification instead of throwing when encryption metadata is null', () => {
+    const report = buildBackupEncryptionVerificationReport(
+      {
+        schemaVersion: 1,
+        encryption: null,
+        tasks: [],
+        approvals: [],
+        memory: [],
+        cron: [],
+      } as unknown as RestorePreviewManifest,
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('failed');
+    expect(report.encrypted).toBe(false);
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ code: 'missing-encryption-metadata', severity: 'blocker' }),
+    );
+  });
+
   it('fails closed when loaded encryption metadata has a non-boolean encrypted flag', () => {
     const report = buildBackupEncryptionVerificationReport(
       {

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -257,6 +257,35 @@ describe('restore preview conflict detector', () => {
     );
   });
 
+  it('returns findings instead of throwing when loaded encryption metadata has non-string fields', () => {
+    const report = buildBackupEncryptionVerificationReport(
+      {
+        schemaVersion: 1,
+        encryption: {
+          encrypted: true,
+          algorithm: 1,
+          keyRef: ['dr/backups/prod-primary'],
+          artifactDigest: { sha256: 'abcdef' },
+        } as unknown as RestorePreviewManifest['encryption'],
+        tasks: [],
+        approvals: [],
+        memory: [],
+        cron: [],
+      },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('failed');
+    expect(report.encrypted).toBe(true);
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing-algorithm', severity: 'blocker' }),
+        expect.objectContaining({ code: 'missing-key-reference', severity: 'warning' }),
+        expect.objectContaining({ code: 'missing-artifact-digest', severity: 'warning' }),
+      ]),
+    );
+  });
+
   it('warns when encryption is present but the report lacks restore-critical references', () => {
     const report = buildBackupEncryptionVerificationReport(
       {

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 import {
+  buildBackupEncryptionVerificationReport,
   detectRestorePreviewConflicts,
   type RestorePreviewManifest,
 } from '../../../src/dr/restore-preview.js';
@@ -179,6 +180,84 @@ describe('restore preview conflict detector', () => {
         severity: 'blocker',
         recommendation: expect.stringContaining('Do not restore'),
       }),
+    );
+  });
+
+  it('reports verified backup encryption metadata for operator handoff', () => {
+    const manifest: RestorePreviewManifest = {
+      schemaVersion: 1,
+      encryption: {
+        encrypted: true,
+        algorithm: 'aes-256-gcm',
+        keyRef: 'dr/backups/prod-primary',
+        artifactDigest: 'sha256:abcdef',
+        generatedAt: '2026-07-14T12:00:00.000Z',
+      },
+      tasks: [],
+      approvals: [],
+      memory: [],
+      cron: [],
+    };
+
+    const before = clone(manifest);
+    const report = buildBackupEncryptionVerificationReport(manifest, {
+      checkedAt: '2026-07-14T12:30:00.000Z',
+    });
+
+    expect(report).toEqual({
+      checkedAt: '2026-07-14T12:30:00.000Z',
+      status: 'verified',
+      encrypted: true,
+      metadata: manifest.encryption,
+      findings: [],
+      operatorSummary: 'Backup encryption is verified; no encryption blockers or warnings were found.',
+    });
+    expect(manifest).toEqual(before);
+  });
+
+  it('fails backup encryption verification when encryption metadata is missing', () => {
+    const report = buildBackupEncryptionVerificationReport(
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('failed');
+    expect(report.encrypted).toBe(false);
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: 'missing-encryption-metadata',
+        severity: 'blocker',
+        recommendation: expect.stringContaining('regenerate'),
+      }),
+    );
+  });
+
+  it('warns when encryption is present but the report lacks restore-critical references', () => {
+    const report = buildBackupEncryptionVerificationReport(
+      {
+        schemaVersion: 1,
+        encryption: {
+          encrypted: true,
+          algorithm: 'aes-128-cbc',
+          keyRef: '',
+          artifactDigest: '',
+        },
+        tasks: [],
+        approvals: [],
+        memory: [],
+        cron: [],
+      },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('warning');
+    expect(report.encrypted).toBe(true);
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'unsupported-algorithm', severity: 'warning' }),
+        expect.objectContaining({ code: 'missing-key-reference', severity: 'warning' }),
+        expect.objectContaining({ code: 'missing-artifact-digest', severity: 'warning' }),
+      ]),
     );
   });
 });

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -232,6 +232,31 @@ describe('restore preview conflict detector', () => {
     );
   });
 
+  it('fails closed when loaded encryption metadata has a non-boolean encrypted flag', () => {
+    const report = buildBackupEncryptionVerificationReport(
+      {
+        schemaVersion: 1,
+        encryption: {
+          encrypted: 'false',
+          algorithm: 'aes-256-gcm',
+          keyRef: 'dr/backups/prod-primary',
+          artifactDigest: 'sha256:abcdef',
+        } as unknown as RestorePreviewManifest['encryption'],
+        tasks: [],
+        approvals: [],
+        memory: [],
+        cron: [],
+      },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('failed');
+    expect(report.encrypted).toBe(false);
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ code: 'backup-not-encrypted', severity: 'blocker' }),
+    );
+  });
+
   it('warns when encryption is present but the report lacks restore-critical references', () => {
     const report = buildBackupEncryptionVerificationReport(
       {


### PR DESCRIPTION
## Summary
- Adds a structured backup encryption verification report for DR restore-preview manifests.
- Flags missing encryption metadata, disabled encryption, unsupported algorithms, and missing key/digest evidence with deterministic findings.
- Documents the operator interpretation for verified/warning/failed encryption report states.

## Test Plan
- `npm test --workspace @franken/orchestrator -- --run tests/unit/dr/restore-preview.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/planner`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)

Closes #1839