### PR TITLE
fix(orchestrator): preflight github token capabilities

### DIFF
--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -205,7 +205,7 @@ function buildEvidence(
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
-      roleTokenSpecific: repositoryPermissionsTokenSpecific,
+      roleTokenSpecific: false,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
     pullRequests: tokenAwareItem({
@@ -213,7 +213,7 @@ function buildEvidence(
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
-      roleTokenSpecific: repositoryPermissionsTokenSpecific,
+      roleTokenSpecific: false,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
     contents: tokenAwareItem({

--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -62,6 +62,7 @@ interface RepositoryPermissions {
 
 interface RepositoryInfo {
   readonly nodeId?: string | undefined;
+  readonly isPrivate?: boolean | undefined;
   readonly permissions: RepositoryPermissions;
 }
 
@@ -92,7 +93,7 @@ export function checkGitHubTokenCapabilities(options: GitHubTokenCapabilityCheck
     const scopeRead = readOauthScopes(options.exec);
     const repoInfo = readRepositoryInfo(options.exec, options.repo);
     const evidence = maybeProbeRequiredCapabilities(
-      buildEvidence(scopeRead.scopes, repoInfo.permissions),
+      buildEvidence(scopeRead.scopes, repoInfo),
       options,
       repoInfo,
     );
@@ -160,13 +161,19 @@ function readOauthScopes(exec: GitHubCapabilityExec): OAuthScopeReadResult {
 
 function readRepositoryInfo(exec: GitHubCapabilityExec, repo: string): RepositoryInfo {
   const output = exec('gh', ['api', `repos/${repo}`]);
-  const parsed = JSON.parse(output) as { node_id?: string | undefined; permissions?: RepositoryPermissions | undefined };
-  return { nodeId: parsed.node_id, permissions: parsed.permissions ?? {} };
+  const parsed = JSON.parse(output) as {
+    node_id?: string | undefined;
+    private?: boolean | undefined;
+    permissions?: RepositoryPermissions | undefined;
+  };
+  return { nodeId: parsed.node_id, isPrivate: parsed.private, permissions: parsed.permissions ?? {} };
 }
 
-function buildEvidence(scopes: readonly string[], permissions: RepositoryPermissions): GitHubTokenCapabilityEvidence {
+function buildEvidence(scopes: readonly string[], repoInfo: RepositoryInfo): GitHubTokenCapabilityEvidence {
+  const { permissions } = repoInfo;
   const hasClassicRepoScope = scopes.includes('repo');
   const hasClassicPublicRepoScope = scopes.includes('public_repo');
+  const hasClassicPublicRepoWriteScope = hasClassicPublicRepoScope && repoInfo.isPrivate !== true;
   const scopesObserved = scopes.length > 0;
   const repoRoleRead = permissions.admin === true
     || permissions.maintain === true
@@ -179,28 +186,28 @@ function buildEvidence(scopes: readonly string[], permissions: RepositoryPermiss
   return {
     oauthScopes: scopes,
     repo: tokenAwareItem({
-      scopeWrite: hasClassicRepoScope,
+      scopeWrite: hasClassicRepoScope || hasClassicPublicRepoWriteScope,
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope || repoRoleRead,
       scopesObserved,
       roleLevel: repoRoleLevel,
       source: repoRoleRead ? 'repository access check' : 'not exposed by GitHub API response',
     }),
     issues: tokenAwareItem({
-      scopeWrite: hasClassicRepoScope,
+      scopeWrite: hasClassicRepoScope || hasClassicPublicRepoWriteScope,
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
     pullRequests: tokenAwareItem({
-      scopeWrite: hasClassicRepoScope,
+      scopeWrite: hasClassicRepoScope || hasClassicPublicRepoWriteScope,
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
     contents: tokenAwareItem({
-      scopeWrite: hasClassicRepoScope,
+      scopeWrite: hasClassicRepoScope || hasClassicPublicRepoWriteScope,
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
@@ -218,7 +225,7 @@ function tokenAwareItem(options: {
 }): GitHubCapabilityEvidenceItem {
   if (options.scopeWrite) {
     if (options.roleLevel === 'write') {
-      return { available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true };
+      return { available: true, level: 'write', source: 'x-oauth-scopes: repo/public_repo + repository write access', tokenSpecific: true };
     }
     return { available: true, level: options.roleLevel === 'read' ? 'read' : 'none', source: 'x-oauth-scopes: repo without repository write access', tokenSpecific: true };
   }
@@ -319,8 +326,8 @@ function isDefinitivelyMissing(
   evidence: GitHubCapabilityEvidenceItem,
   required: Exclude<GitHubCapabilityLevel, 'none'>,
 ): boolean {
-  if (levelSatisfies(evidence.level, required)) return false;
-  if (required === 'write' && evidence.level === 'read') return true;
+  if (levelSatisfies(evidence.level, required) && (required !== 'write' || evidence.tokenSpecific)) return false;
+  if (required === 'write' && (evidence.level === 'read' || !evidence.tokenSpecific)) return true;
   return evidence.tokenSpecific || evidence.level === 'none';
 }
 

--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -217,7 +217,10 @@ function tokenAwareItem(options: {
   readonly source: string;
 }): GitHubCapabilityEvidenceItem {
   if (options.scopeWrite) {
-    return { available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true };
+    if (options.roleLevel === 'write') {
+      return { available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true };
+    }
+    return { available: true, level: options.roleLevel === 'read' ? 'read' : 'none', source: 'x-oauth-scopes: repo without repository write access', tokenSpecific: true };
   }
   if (options.scopeRead) {
     return {
@@ -260,7 +263,7 @@ function maybeProbeRequiredCapabilities(
 
 function probePullRequestWrite(exec: GitHubCapabilityExec, repositoryId?: string): boolean {
   if (!repositoryId) return false;
-  const query = 'mutation($repositoryId:ID!){createPullRequest(input:{repositoryId:$repositoryId,baseRefName:"__franken_capability_preflight_base__",headRefName:"__franken_capability_preflight_head__",title:"franken capability preflight",body:"preflight"}){pullRequest{id}}}';
+  const query = 'mutation($repositoryId:ID!){createPullRequest(input:{repositoryId:$repositoryId,baseRefName:"__franken_capability_preflight_base..invalid__",headRefName:"__franken_capability_preflight_head..invalid__",title:"franken capability preflight",body:"preflight"}){pullRequest{id}}}';
   try {
     exec('gh', ['api', 'graphql', '-f', `query=${query}`, '-f', `repositoryId=${repositoryId}`]);
     return true;

--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -60,6 +60,11 @@ interface RepositoryPermissions {
   readonly admin?: boolean | undefined;
 }
 
+interface RepositoryInfo {
+  readonly nodeId?: string | undefined;
+  readonly permissions: RepositoryPermissions;
+}
+
 interface OAuthScopeReadResult {
   readonly scopes: readonly string[];
   readonly warning?: GitHubCapabilityIssue | undefined;
@@ -85,8 +90,12 @@ const TOKEN_RE = /\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,
 export function checkGitHubTokenCapabilities(options: GitHubTokenCapabilityCheckOptions): GitHubTokenCapabilityCheckResult {
   try {
     const scopeRead = readOauthScopes(options.exec);
-    const repoPermissions = readRepositoryPermissions(options.exec, options.repo);
-    const evidence = buildEvidence(scopeRead.scopes, repoPermissions);
+    const repoInfo = readRepositoryInfo(options.exec, options.repo);
+    const evidence = maybeProbeRequiredCapabilities(
+      buildEvidence(scopeRead.scopes, repoInfo.permissions),
+      options,
+      repoInfo,
+    );
     const missingIssues = collectMissingRequiredCapabilities(evidence, options.required ?? {});
     const excessiveIssues = collectExcessiveWriteCapabilities(evidence, options.lowRiskPolicy);
     const warnings = [
@@ -149,10 +158,10 @@ function readOauthScopes(exec: GitHubCapabilityExec): OAuthScopeReadResult {
   return { scopes: [] };
 }
 
-function readRepositoryPermissions(exec: GitHubCapabilityExec, repo: string): RepositoryPermissions {
+function readRepositoryInfo(exec: GitHubCapabilityExec, repo: string): RepositoryInfo {
   const output = exec('gh', ['api', `repos/${repo}`]);
-  const parsed = JSON.parse(output) as { permissions?: RepositoryPermissions | undefined };
-  return parsed.permissions ?? {};
+  const parsed = JSON.parse(output) as { node_id?: string | undefined; permissions?: RepositoryPermissions | undefined };
+  return { nodeId: parsed.node_id, permissions: parsed.permissions ?? {} };
 }
 
 function buildEvidence(scopes: readonly string[], permissions: RepositoryPermissions): GitHubTokenCapabilityEvidence {
@@ -232,6 +241,45 @@ function tokenAwareItem(options: {
   return { available: false, level: 'none', source: options.source, tokenSpecific: false };
 }
 
+function maybeProbeRequiredCapabilities(
+  evidence: GitHubTokenCapabilityEvidence,
+  options: GitHubTokenCapabilityCheckOptions,
+  repoInfo: RepositoryInfo,
+): GitHubTokenCapabilityEvidence {
+  if (options.required?.pullRequests !== 'write' || evidence.pullRequests.tokenSpecific) {
+    return evidence;
+  }
+  const probe = probePullRequestWrite(options.exec, repoInfo.nodeId);
+  return {
+    ...evidence,
+    pullRequests: probe
+      ? { available: true, level: 'write', source: 'GraphQL createPullRequest validation probe', tokenSpecific: true }
+      : { available: false, level: 'none', source: 'GraphQL createPullRequest permission probe failed', tokenSpecific: true },
+  };
+}
+
+function probePullRequestWrite(exec: GitHubCapabilityExec, repositoryId?: string): boolean {
+  if (!repositoryId) return false;
+  const query = 'mutation($repositoryId:ID!){createPullRequest(input:{repositoryId:$repositoryId,baseRefName:"__franken_capability_preflight_base__",headRefName:"__franken_capability_preflight_head__",title:"franken capability preflight",body:"preflight"}){pullRequest{id}}}';
+  try {
+    exec('gh', ['api', 'graphql', '-f', `query=${query}`, '-f', `repositoryId=${repositoryId}`]);
+    return true;
+  } catch (error) {
+    const message = sanitizeErrorMessage(error).toLowerCase();
+    if (message.includes('resource not accessible')
+      || message.includes('not permitted')
+      || message.includes('permission')
+      || message.includes('forbidden')) {
+      return false;
+    }
+    return message.includes('could not resolve')
+      || message.includes('not exist')
+      || message.includes('validation')
+      || message.includes('base')
+      || message.includes('head');
+  }
+}
+
 function collectMissingRequiredCapabilities(
   evidence: GitHubTokenCapabilityEvidence,
   required: GitHubRequiredCapabilities,
@@ -269,6 +317,7 @@ function isDefinitivelyMissing(
   required: Exclude<GitHubCapabilityLevel, 'none'>,
 ): boolean {
   if (levelSatisfies(evidence.level, required)) return false;
+  if (required === 'write' && evidence.level === 'read') return true;
   return evidence.tokenSpecific || evidence.level === 'none';
 }
 

--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -1,0 +1,204 @@
+export type GitHubTokenCapability = 'repo' | 'issues' | 'pullRequests' | 'contents';
+export type GitHubCapabilityLevel = 'none' | 'read' | 'write';
+export type GitHubRequiredCapabilities = Partial<Record<GitHubTokenCapability, Exclude<GitHubCapabilityLevel, 'none'>>>;
+
+export type GitHubCapabilityExec = (command: string, args: readonly string[]) => string;
+
+export interface GitHubCapabilityEvidenceItem {
+  readonly available: boolean;
+  readonly level: GitHubCapabilityLevel;
+  readonly source: string;
+}
+
+export interface GitHubTokenCapabilityEvidence {
+  readonly oauthScopes: readonly string[];
+  readonly repo: GitHubCapabilityEvidenceItem;
+  readonly issues: GitHubCapabilityEvidenceItem;
+  readonly pullRequests: GitHubCapabilityEvidenceItem;
+  readonly contents: GitHubCapabilityEvidenceItem;
+}
+
+export type GitHubCapabilityIssueCode =
+  | 'github-api-unavailable'
+  | 'missing-capability'
+  | 'excessive-write-permission';
+
+export interface GitHubCapabilityIssue {
+  readonly code: GitHubCapabilityIssueCode;
+  readonly message: string;
+  readonly capability?: GitHubTokenCapability | undefined;
+  readonly required?: GitHubCapabilityLevel | undefined;
+  readonly actual?: GitHubCapabilityLevel | undefined;
+}
+
+export interface GitHubLowRiskCapabilityPolicy {
+  readonly mode: 'warn' | 'fail';
+  readonly allowedWriteCapabilities: readonly GitHubTokenCapability[];
+}
+
+export interface GitHubTokenCapabilityCheckOptions {
+  readonly repo: string;
+  readonly exec: GitHubCapabilityExec;
+  readonly required?: GitHubRequiredCapabilities | undefined;
+  readonly lowRiskPolicy?: GitHubLowRiskCapabilityPolicy | undefined;
+}
+
+export interface GitHubTokenCapabilityCheckResult {
+  readonly ok: boolean;
+  readonly evidence: GitHubTokenCapabilityEvidence;
+  readonly issues: readonly GitHubCapabilityIssue[];
+  readonly warnings: readonly GitHubCapabilityIssue[];
+}
+
+interface RepositoryPermissions {
+  readonly pull?: boolean | undefined;
+  readonly triage?: boolean | undefined;
+  readonly push?: boolean | undefined;
+  readonly maintain?: boolean | undefined;
+  readonly admin?: boolean | undefined;
+}
+
+const EMPTY_EVIDENCE: GitHubTokenCapabilityEvidence = {
+  oauthScopes: [],
+  repo: { available: false, level: 'none', source: 'unavailable' },
+  issues: { available: false, level: 'none', source: 'unavailable' },
+  pullRequests: { available: false, level: 'none', source: 'unavailable' },
+  contents: { available: false, level: 'none', source: 'unavailable' },
+};
+
+const TOKEN_RE = /\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,})\b/g;
+
+export function checkGitHubTokenCapabilities(options: GitHubTokenCapabilityCheckOptions): GitHubTokenCapabilityCheckResult {
+  try {
+    const scopes = readOauthScopes(options.exec);
+    const repoPermissions = readRepositoryPermissions(options.exec, options.repo);
+    const evidence = buildEvidence(scopes, repoPermissions);
+    const missingIssues = collectMissingRequiredCapabilities(evidence, options.required ?? {});
+    const excessiveIssues = collectExcessiveWriteCapabilities(evidence, options.lowRiskPolicy);
+    const warnings = options.lowRiskPolicy?.mode === 'warn' ? excessiveIssues : [];
+    const failures = options.lowRiskPolicy?.mode === 'fail'
+      ? [...missingIssues, ...excessiveIssues]
+      : missingIssues;
+
+    return {
+      ok: failures.length === 0,
+      evidence,
+      issues: failures,
+      warnings,
+    };
+  } catch (error) {
+    const message = sanitizeErrorMessage(error);
+    return {
+      ok: false,
+      evidence: EMPTY_EVIDENCE,
+      issues: [{
+        code: 'github-api-unavailable',
+        message: `Unable to inspect GitHub token capabilities: ${message}`,
+      }],
+      warnings: [],
+    };
+  }
+}
+
+function readOauthScopes(exec: GitHubCapabilityExec): readonly string[] {
+  const output = exec('gh', ['api', '-i', '/user']);
+  const headers = output.split(/\r?\n\r?\n/, 1)[0] ?? '';
+  for (const line of headers.split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator < 0) continue;
+    const name = line.slice(0, separator).trim().toLowerCase();
+    if (name !== 'x-oauth-scopes') continue;
+    return line
+      .slice(separator + 1)
+      .split(',')
+      .map(scope => scope.trim())
+      .filter(Boolean)
+      .sort();
+  }
+  return [];
+}
+
+function readRepositoryPermissions(exec: GitHubCapabilityExec, repo: string): RepositoryPermissions {
+  const output = exec('gh', ['api', `repos/${repo}`]);
+  const parsed = JSON.parse(output) as { permissions?: RepositoryPermissions | undefined };
+  return parsed.permissions ?? {};
+}
+
+function buildEvidence(scopes: readonly string[], permissions: RepositoryPermissions): GitHubTokenCapabilityEvidence {
+  const hasWrite = permissions.admin === true || permissions.maintain === true || permissions.push === true;
+  const hasRead = hasWrite || permissions.triage === true || permissions.pull === true;
+  const hasRepoScope = scopes.includes('repo');
+  const hasPublicRepoScope = scopes.includes('public_repo');
+  const fallbackRead = hasRepoScope || hasPublicRepoScope;
+  const fallbackWrite = hasRepoScope;
+
+  return {
+    oauthScopes: scopes,
+    repo: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
+    issues: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
+    pullRequests: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
+    contents: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
+  };
+}
+
+function buildItem(
+  permissionRead: boolean,
+  permissionWrite: boolean,
+  fallbackRead: boolean,
+  fallbackWrite: boolean,
+  readSource: string,
+  writeSource: string,
+): GitHubCapabilityEvidenceItem {
+  if (permissionWrite) return { available: true, level: 'write', source: writeSource };
+  if (permissionRead) return { available: true, level: 'read', source: readSource };
+  if (fallbackWrite) return { available: true, level: 'write', source: 'x-oauth-scopes: repo' };
+  if (fallbackRead) return { available: true, level: 'read', source: 'x-oauth-scopes: public_repo' };
+  return { available: false, level: 'none', source: 'not exposed by GitHub API response' };
+}
+
+function collectMissingRequiredCapabilities(
+  evidence: GitHubTokenCapabilityEvidence,
+  required: GitHubRequiredCapabilities,
+): readonly GitHubCapabilityIssue[] {
+  return (Object.entries(required) as Array<[GitHubTokenCapability, Exclude<GitHubCapabilityLevel, 'none'>]>)
+    .filter(([capability, level]) => !levelSatisfies(evidence[capability].level, level))
+    .map(([capability, level]) => ({
+      code: 'missing-capability' as const,
+      capability,
+      required: level,
+      actual: evidence[capability].level,
+      message: `GitHub token is missing ${level} capability for ${capability}.`,
+    }));
+}
+
+function collectExcessiveWriteCapabilities(
+  evidence: GitHubTokenCapabilityEvidence,
+  policy?: GitHubLowRiskCapabilityPolicy,
+): readonly GitHubCapabilityIssue[] {
+  if (!policy) return [];
+  const allowed = new Set(policy.allowedWriteCapabilities);
+  const capabilities: readonly GitHubTokenCapability[] = ['repo', 'issues', 'pullRequests', 'contents'];
+  return capabilities
+    .filter(capability => evidence[capability].level === 'write' && !allowed.has(capability))
+    .map(capability => ({
+      code: 'excessive-write-permission' as const,
+      capability,
+      actual: 'write' as const,
+      message: `GitHub token exposes write capability for ${capability}, which this low-risk lane does not allow.`,
+    }));
+}
+
+function levelSatisfies(actual: GitHubCapabilityLevel, required: Exclude<GitHubCapabilityLevel, 'none'>): boolean {
+  if (required === 'read') return actual === 'read' || actual === 'write';
+  return actual === 'write';
+}
+
+function sanitizeErrorMessage(error: unknown): string {
+  const err = error as { message?: unknown; stderr?: unknown };
+  const raw = typeof err.stderr === 'string'
+    ? err.stderr
+    : typeof err.message === 'string'
+      ? err.message
+      : String(error);
+  return raw.replace(TOKEN_RE, '<redacted>');
+}

--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -68,6 +68,7 @@ interface RepositoryInfo {
 
 interface OAuthScopeReadResult {
   readonly scopes: readonly string[];
+  readonly repositoryPermissionsTokenSpecific?: boolean | undefined;
   readonly warning?: GitHubCapabilityIssue | undefined;
 }
 
@@ -93,7 +94,7 @@ export function checkGitHubTokenCapabilities(options: GitHubTokenCapabilityCheck
     const scopeRead = readOauthScopes(options.exec);
     const repoInfo = readRepositoryInfo(options.exec, options.repo);
     const evidence = maybeProbeRequiredCapabilities(
-      buildEvidence(scopeRead.scopes, repoInfo),
+      buildEvidence(scopeRead.scopes, repoInfo, scopeRead.repositoryPermissionsTokenSpecific === true),
       options,
       repoInfo,
     );
@@ -132,11 +133,13 @@ function readOauthScopes(exec: GitHubCapabilityExec): OAuthScopeReadResult {
   try {
     output = exec('gh', ['api', '-i', '/user']);
   } catch (error) {
+    const message = sanitizeErrorMessage(error);
     return {
       scopes: [],
+      repositoryPermissionsTokenSpecific: /resource not accessible by integration|GH_TOKEN|GitHub Actions/i.test(message),
       warning: {
         code: 'github-api-unavailable',
-        message: `OAuth scope headers were unavailable from /user; continuing with repository capability evidence only. ${sanitizeErrorMessage(error)}`,
+        message: `OAuth scope headers were unavailable from /user; continuing with repository capability evidence only. ${message}`,
       },
     };
   }
@@ -169,7 +172,11 @@ function readRepositoryInfo(exec: GitHubCapabilityExec, repo: string): Repositor
   return { nodeId: parsed.node_id, isPrivate: parsed.private, permissions: parsed.permissions ?? {} };
 }
 
-function buildEvidence(scopes: readonly string[], repoInfo: RepositoryInfo): GitHubTokenCapabilityEvidence {
+function buildEvidence(
+  scopes: readonly string[],
+  repoInfo: RepositoryInfo,
+  repositoryPermissionsTokenSpecific = false,
+): GitHubTokenCapabilityEvidence {
   const { permissions } = repoInfo;
   const hasClassicRepoScope = scopes.includes('repo');
   const hasClassicPublicRepoScope = scopes.includes('public_repo');
@@ -190,6 +197,7 @@ function buildEvidence(scopes: readonly string[], repoInfo: RepositoryInfo): Git
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope || repoRoleRead,
       scopesObserved,
       roleLevel: repoRoleLevel,
+      roleTokenSpecific: repositoryPermissionsTokenSpecific,
       source: repoRoleRead ? 'repository access check' : 'not exposed by GitHub API response',
     }),
     issues: tokenAwareItem({
@@ -197,6 +205,7 @@ function buildEvidence(scopes: readonly string[], repoInfo: RepositoryInfo): Git
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
+      roleTokenSpecific: repositoryPermissionsTokenSpecific,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
     pullRequests: tokenAwareItem({
@@ -204,6 +213,7 @@ function buildEvidence(scopes: readonly string[], repoInfo: RepositoryInfo): Git
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
+      roleTokenSpecific: repositoryPermissionsTokenSpecific,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
     contents: tokenAwareItem({
@@ -211,6 +221,7 @@ function buildEvidence(scopes: readonly string[], repoInfo: RepositoryInfo): Git
       scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
       scopesObserved,
       roleLevel: repoRoleLevel,
+      roleTokenSpecific: repositoryPermissionsTokenSpecific,
       source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
     }),
   };
@@ -221,6 +232,7 @@ function tokenAwareItem(options: {
   readonly scopeRead: boolean;
   readonly scopesObserved: boolean;
   readonly roleLevel: GitHubCapabilityLevel;
+  readonly roleTokenSpecific?: boolean | undefined;
   readonly source: string;
 }): GitHubCapabilityEvidenceItem {
   if (options.scopeWrite) {
@@ -246,7 +258,7 @@ function tokenAwareItem(options: {
     };
   }
   if (options.roleLevel !== 'none') {
-    return { available: true, level: options.roleLevel, source: options.source, tokenSpecific: false };
+    return { available: true, level: options.roleLevel, source: options.source, tokenSpecific: options.roleTokenSpecific === true };
   }
   return { available: false, level: 'none', source: options.source, tokenSpecific: false };
 }

--- a/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
+++ b/packages/franken-orchestrator/src/closure/github-token-capability-check.ts
@@ -8,6 +8,8 @@ export interface GitHubCapabilityEvidenceItem {
   readonly available: boolean;
   readonly level: GitHubCapabilityLevel;
   readonly source: string;
+  /** True only when evidence comes from token-specific OAuth scope data. */
+  readonly tokenSpecific: boolean;
 }
 
 export interface GitHubTokenCapabilityEvidence {
@@ -58,24 +60,39 @@ interface RepositoryPermissions {
   readonly admin?: boolean | undefined;
 }
 
+interface OAuthScopeReadResult {
+  readonly scopes: readonly string[];
+  readonly warning?: GitHubCapabilityIssue | undefined;
+}
+
+const UNAVAILABLE_ITEM: GitHubCapabilityEvidenceItem = {
+  available: false,
+  level: 'none',
+  source: 'unavailable',
+  tokenSpecific: false,
+};
+
 const EMPTY_EVIDENCE: GitHubTokenCapabilityEvidence = {
   oauthScopes: [],
-  repo: { available: false, level: 'none', source: 'unavailable' },
-  issues: { available: false, level: 'none', source: 'unavailable' },
-  pullRequests: { available: false, level: 'none', source: 'unavailable' },
-  contents: { available: false, level: 'none', source: 'unavailable' },
+  repo: UNAVAILABLE_ITEM,
+  issues: UNAVAILABLE_ITEM,
+  pullRequests: UNAVAILABLE_ITEM,
+  contents: UNAVAILABLE_ITEM,
 };
 
 const TOKEN_RE = /\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,})\b/g;
 
 export function checkGitHubTokenCapabilities(options: GitHubTokenCapabilityCheckOptions): GitHubTokenCapabilityCheckResult {
   try {
-    const scopes = readOauthScopes(options.exec);
+    const scopeRead = readOauthScopes(options.exec);
     const repoPermissions = readRepositoryPermissions(options.exec, options.repo);
-    const evidence = buildEvidence(scopes, repoPermissions);
+    const evidence = buildEvidence(scopeRead.scopes, repoPermissions);
     const missingIssues = collectMissingRequiredCapabilities(evidence, options.required ?? {});
     const excessiveIssues = collectExcessiveWriteCapabilities(evidence, options.lowRiskPolicy);
-    const warnings = options.lowRiskPolicy?.mode === 'warn' ? excessiveIssues : [];
+    const warnings = [
+      ...(scopeRead.warning ? [scopeRead.warning] : []),
+      ...(options.lowRiskPolicy?.mode === 'warn' ? excessiveIssues : []),
+    ];
     const failures = options.lowRiskPolicy?.mode === 'fail'
       ? [...missingIssues, ...excessiveIssues]
       : missingIssues;
@@ -93,29 +110,43 @@ export function checkGitHubTokenCapabilities(options: GitHubTokenCapabilityCheck
       evidence: EMPTY_EVIDENCE,
       issues: [{
         code: 'github-api-unavailable',
-        message: `Unable to inspect GitHub token capabilities: ${message}`,
+        message: `Unable to inspect GitHub repository capabilities: ${message}`,
       }],
       warnings: [],
     };
   }
 }
 
-function readOauthScopes(exec: GitHubCapabilityExec): readonly string[] {
-  const output = exec('gh', ['api', '-i', '/user']);
+function readOauthScopes(exec: GitHubCapabilityExec): OAuthScopeReadResult {
+  let output: string;
+  try {
+    output = exec('gh', ['api', '-i', '/user']);
+  } catch (error) {
+    return {
+      scopes: [],
+      warning: {
+        code: 'github-api-unavailable',
+        message: `OAuth scope headers were unavailable from /user; continuing with repository capability evidence only. ${sanitizeErrorMessage(error)}`,
+      },
+    };
+  }
+
   const headers = output.split(/\r?\n\r?\n/, 1)[0] ?? '';
   for (const line of headers.split(/\r?\n/)) {
     const separator = line.indexOf(':');
     if (separator < 0) continue;
     const name = line.slice(0, separator).trim().toLowerCase();
     if (name !== 'x-oauth-scopes') continue;
-    return line
-      .slice(separator + 1)
-      .split(',')
-      .map(scope => scope.trim())
-      .filter(Boolean)
-      .sort();
+    return {
+      scopes: line
+        .slice(separator + 1)
+        .split(',')
+        .map(scope => scope.trim())
+        .filter(Boolean)
+        .sort(),
+    };
   }
-  return [];
+  return { scopes: [] };
 }
 
 function readRepositoryPermissions(exec: GitHubCapabilityExec, repo: string): RepositoryPermissions {
@@ -125,35 +156,80 @@ function readRepositoryPermissions(exec: GitHubCapabilityExec, repo: string): Re
 }
 
 function buildEvidence(scopes: readonly string[], permissions: RepositoryPermissions): GitHubTokenCapabilityEvidence {
-  const hasWrite = permissions.admin === true || permissions.maintain === true || permissions.push === true;
-  const hasRead = hasWrite || permissions.triage === true || permissions.pull === true;
-  const hasRepoScope = scopes.includes('repo');
-  const hasPublicRepoScope = scopes.includes('public_repo');
-  const fallbackRead = hasRepoScope || hasPublicRepoScope;
-  const fallbackWrite = hasRepoScope;
+  const hasClassicRepoScope = scopes.includes('repo');
+  const hasClassicPublicRepoScope = scopes.includes('public_repo');
+  const scopesObserved = scopes.length > 0;
+  const repoRoleRead = permissions.admin === true
+    || permissions.maintain === true
+    || permissions.push === true
+    || permissions.triage === true
+    || permissions.pull === true;
+  const repoRoleWrite = permissions.admin === true || permissions.maintain === true || permissions.push === true;
+  const repoRoleLevel: GitHubCapabilityLevel = repoRoleWrite ? 'write' : repoRoleRead ? 'read' : 'none';
 
   return {
     oauthScopes: scopes,
-    repo: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
-    issues: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
-    pullRequests: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
-    contents: buildItem(hasRead, hasWrite, fallbackRead, fallbackWrite, 'repository.permissions.pull', 'repository.permissions.push'),
+    repo: tokenAwareItem({
+      scopeWrite: hasClassicRepoScope,
+      scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope || repoRoleRead,
+      scopesObserved,
+      roleLevel: repoRoleLevel,
+      source: repoRoleRead ? 'repository access check' : 'not exposed by GitHub API response',
+    }),
+    issues: tokenAwareItem({
+      scopeWrite: hasClassicRepoScope,
+      scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
+      scopesObserved,
+      roleLevel: repoRoleLevel,
+      source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
+    }),
+    pullRequests: tokenAwareItem({
+      scopeWrite: hasClassicRepoScope,
+      scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
+      scopesObserved,
+      roleLevel: repoRoleLevel,
+      source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
+    }),
+    contents: tokenAwareItem({
+      scopeWrite: hasClassicRepoScope,
+      scopeRead: hasClassicRepoScope || hasClassicPublicRepoScope,
+      scopesObserved,
+      roleLevel: repoRoleLevel,
+      source: repoRoleRead ? 'repository.permissions (actor role; not token-specific)' : 'not exposed by GitHub API response',
+    }),
   };
 }
 
-function buildItem(
-  permissionRead: boolean,
-  permissionWrite: boolean,
-  fallbackRead: boolean,
-  fallbackWrite: boolean,
-  readSource: string,
-  writeSource: string,
-): GitHubCapabilityEvidenceItem {
-  if (permissionWrite) return { available: true, level: 'write', source: writeSource };
-  if (permissionRead) return { available: true, level: 'read', source: readSource };
-  if (fallbackWrite) return { available: true, level: 'write', source: 'x-oauth-scopes: repo' };
-  if (fallbackRead) return { available: true, level: 'read', source: 'x-oauth-scopes: public_repo' };
-  return { available: false, level: 'none', source: 'not exposed by GitHub API response' };
+function tokenAwareItem(options: {
+  readonly scopeWrite: boolean;
+  readonly scopeRead: boolean;
+  readonly scopesObserved: boolean;
+  readonly roleLevel: GitHubCapabilityLevel;
+  readonly source: string;
+}): GitHubCapabilityEvidenceItem {
+  if (options.scopeWrite) {
+    return { available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true };
+  }
+  if (options.scopeRead) {
+    return {
+      available: true,
+      level: options.roleLevel === 'write' ? 'write' : 'read',
+      source: options.source,
+      tokenSpecific: false,
+    };
+  }
+  if (options.scopesObserved) {
+    return {
+      available: false,
+      level: 'none',
+      source: 'x-oauth-scopes lacks repo/public_repo',
+      tokenSpecific: true,
+    };
+  }
+  if (options.roleLevel !== 'none') {
+    return { available: true, level: options.roleLevel, source: options.source, tokenSpecific: false };
+  }
+  return { available: false, level: 'none', source: options.source, tokenSpecific: false };
 }
 
 function collectMissingRequiredCapabilities(
@@ -161,7 +237,7 @@ function collectMissingRequiredCapabilities(
   required: GitHubRequiredCapabilities,
 ): readonly GitHubCapabilityIssue[] {
   return (Object.entries(required) as Array<[GitHubTokenCapability, Exclude<GitHubCapabilityLevel, 'none'>]>)
-    .filter(([capability, level]) => !levelSatisfies(evidence[capability].level, level))
+    .filter(([capability, level]) => isDefinitivelyMissing(evidence[capability], level))
     .map(([capability, level]) => ({
       code: 'missing-capability' as const,
       capability,
@@ -179,13 +255,21 @@ function collectExcessiveWriteCapabilities(
   const allowed = new Set(policy.allowedWriteCapabilities);
   const capabilities: readonly GitHubTokenCapability[] = ['repo', 'issues', 'pullRequests', 'contents'];
   return capabilities
-    .filter(capability => evidence[capability].level === 'write' && !allowed.has(capability))
+    .filter(capability => evidence[capability].tokenSpecific && evidence[capability].level === 'write' && !allowed.has(capability))
     .map(capability => ({
       code: 'excessive-write-permission' as const,
       capability,
       actual: 'write' as const,
       message: `GitHub token exposes write capability for ${capability}, which this low-risk lane does not allow.`,
     }));
+}
+
+function isDefinitivelyMissing(
+  evidence: GitHubCapabilityEvidenceItem,
+  required: Exclude<GitHubCapabilityLevel, 'none'>,
+): boolean {
+  if (levelSatisfies(evidence.level, required)) return false;
+  return evidence.tokenSpecific || evidence.level === 'none';
 }
 
 function levelSatisfies(actual: GitHubCapabilityLevel, required: Exclude<GitHubCapabilityLevel, 'none'>): boolean {

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -356,7 +356,7 @@ export class PrCreator {
       }
       const failure = this.commandFailure('gh', 'gh pr create', error, { rawCommand: 'gh pr create' });
       if (isGhAuthFailure(error, failure)) {
-        throw buildGhAuthRequiredAction(branch, failure);
+        throw buildGhAuthRequiredAction(branch, failure, { branchPushed: true });
       }
       logger?.error('PrCreator: failed to create PR', failure);
       return null;
@@ -475,7 +475,7 @@ export class PrCreator {
         rawCommand: formatCommand('gh', args),
       });
       if (isGhAuthFailure(error, failure)) {
-        throw buildGhAuthRequiredAction(branch, failure);
+        throw buildGhAuthRequiredAction(branch, failure, { branchPushed: false });
       }
       logger?.error('PrCreator: failed to list PRs', failure);
       return null;
@@ -549,13 +549,13 @@ function formatCaughtError(error: unknown): { error: string; name?: string | und
 }
 
 function parseGitHubOwnerRepo(remoteUrl: string): string | null {
-  const match = remoteUrl.match(/github\.com[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
+  const match = remoteUrl.match(/github\.com(?::\d+)?[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
   if (!match) return null;
   return `${match[1]}/${match[2]}`;
 }
 
 function isHttpsGitHubRemote(remoteUrl: string): boolean {
-  return /^https?:\/\/(?:[^@/\s]+@)?github\.com\//i.test(remoteUrl.trim());
+  return /^https?:\/\/(?:[^@/\s]+@)?github\.com(?::\d+)?\//i.test(remoteUrl.trim());
 }
 
 interface GitContext {
@@ -802,7 +802,11 @@ function isGhAuthFailure(error: unknown, failure: { stdout?: string; stderr?: st
   return GH_AUTH_FAILURE_RE.test(text);
 }
 
-function buildGhAuthRequiredAction(branch: string, details: unknown): PrCreationRequiredActionError {
+function buildGhAuthRequiredAction(
+  branch: string,
+  details: unknown,
+  options: { readonly branchPushed: boolean },
+): PrCreationRequiredActionError {
   const detailText = [
     stringifyError(details),
     readErrorText((details as { stderr?: unknown }).stderr),
@@ -812,12 +816,14 @@ function buildGhAuthRequiredAction(branch: string, details: unknown): PrCreation
   const isActionsTokenFailure = /GH_TOKEN|GitHub Actions workflow/i.test(detailText);
   const isIntegrationPermissionFailure = /resource not accessible by (?:integration|personal access token)/i.test(detailText);
   const isActionsPrPermissionFailure = /GitHub Actions is not permitted to create or approve pull requests/i.test(detailText);
+  const retryTarget = options.branchPushed ? 'the pushed branch' : `branch ${branch}`;
+  const pushedNote = options.branchPushed ? `branch ${branch} is pushed.` : `branch ${branch} was not pushed.`;
   const action = isActionsTokenFailure || isIntegrationPermissionFailure || isActionsPrPermissionFailure
-    ? 'Set the `GH_TOKEN` environment variable with pull-request permissions, then retry PR creation for the pushed branch.'
-    : 'Run `gh auth login`, then retry PR creation for the pushed branch.';
+    ? `Set the \`GH_TOKEN\` environment variable with pull-request permissions, then retry PR creation for ${retryTarget}.`
+    : `Run \`gh auth login\`, then retry PR creation for ${retryTarget}.`;
   const message = isActionsTokenFailure || isIntegrationPermissionFailure || isActionsPrPermissionFailure
-    ? `PR not created: set \`GH_TOKEN\` with pull-request permissions for GitHub CLI; branch ${branch} is pushed.`
-    : `PR not created: run \`gh auth login\`; branch ${branch} is pushed.`;
+    ? `PR not created: set \`GH_TOKEN\` with pull-request permissions for GitHub CLI; ${pushedNote}`
+    : `PR not created: run \`gh auth login\`; ${pushedNote}`;
 
   return new PrCreationRequiredActionError({
     message,

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -402,7 +402,6 @@ export class PrCreator {
     }
 
     const required: GitHubRequiredCapabilities = {
-      ...(remoteInfo.tokenBackedPush ? { contents: 'write' as const } : {}),
       ...(options.requirePullRequestsWrite === false ? {} : { pullRequests: 'write' as const }),
       ...this.config.githubCapabilityCheck?.required,
     };
@@ -549,9 +548,20 @@ function formatCaughtError(error: unknown): { error: string; name?: string | und
 }
 
 function parseGitHubOwnerRepo(remoteUrl: string): string | null {
-  const match = remoteUrl.match(/github\.com(?::\d+)?[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
-  if (!match) return null;
-  return `${match[1]}/${match[2]}`;
+  const trimmed = remoteUrl.trim();
+  const scpLikeMatch = trimmed.match(/^(?:[^@/\s]+@)?github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i);
+  if (scpLikeMatch) return `${scpLikeMatch[1]}/${scpLikeMatch[2]}`;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (url.hostname.toLowerCase() !== 'github.com') return null;
+  const pathMatch = url.pathname.match(/^\/([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
+  if (!pathMatch) return null;
+  return `${pathMatch[1]}/${pathMatch[2]}`;
 }
 
 function isHttpsGitHubRemote(remoteUrl: string): boolean {

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -287,8 +287,6 @@ export class PrCreator {
       targetBranch = 'main';
     }
 
-    this.assertGitHubCapabilities(branch, options?.issueNumber, logger);
-
     if (!this.pushBranch(branch, logger)) {
       return null;
     }
@@ -301,6 +299,8 @@ export class PrCreator {
       logger?.info('PrCreator: PR already exists', { branch, url: existing[0]?.url });
       return null;
     }
+
+    this.assertGitHubCapabilities(branch, logger);
 
     // Gather git context for PR description
     const gitContext = this.gatherGitContext(targetBranch, logger);
@@ -374,7 +374,7 @@ export class PrCreator {
     }
   }
 
-  private assertGitHubCapabilities(branch: string, issueNumber?: number, logger?: ILogger): void {
+  private assertGitHubCapabilities(branch: string, logger?: ILogger): void {
     if (this.config.githubCapabilityCheck?.disabled === true) {
       return;
     }
@@ -386,10 +386,7 @@ export class PrCreator {
     }
 
     const required: GitHubRequiredCapabilities = {
-      repo: 'read',
-      contents: 'write',
       pullRequests: 'write',
-      ...(issueNumber != null ? { issues: 'write' as const } : {}),
       ...this.config.githubCapabilityCheck?.required,
     };
     const result = checkGitHubTokenCapabilities({
@@ -408,8 +405,7 @@ export class PrCreator {
         message: 'GitHub token capability preflight failed before push/PR creation.',
         action: [
           'Update the GitHub token or lane policy before retrying',
-          'required capabilities: repo read, contents write, pull-requests write',
-          issueNumber != null ? 'issues write' : undefined,
+          'required capability: pull-requests write',
         ].filter(Boolean).join('; '),
         branch,
         details: result,

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -4,6 +4,11 @@ import type { BeastResult, TaskOutcome } from '../types.js';
 import type { ILogger } from '../deps.js';
 import { commandFailureFromExecError } from '../errors/command-failure.js';
 import { completeWithCacheHint } from '../cache/cached-cli-llm-client.js';
+import {
+  checkGitHubTokenCapabilities,
+  type GitHubLowRiskCapabilityPolicy,
+  type GitHubRequiredCapabilities,
+} from './github-token-capability-check.js';
 
 export interface PrCreationRequiredActionErrorOptions {
   readonly message: string;
@@ -33,6 +38,11 @@ export interface PrCreatorConfig {
   readonly remote: string;
   readonly disableBranding?: boolean;
   readonly commitConvention?: 'conventional' | 'freeform';
+  readonly githubCapabilityCheck?: {
+    readonly disabled?: boolean;
+    readonly required?: GitHubRequiredCapabilities;
+    readonly lowRiskPolicy?: GitHubLowRiskCapabilityPolicy;
+  } | undefined;
 }
 
 export interface PrCreateOptions {
@@ -113,6 +123,7 @@ export class PrCreator {
       remote: config.remote ?? 'origin',
       disableBranding: config.disableBranding ?? false,
       commitConvention: config.commitConvention ?? 'conventional',
+      githubCapabilityCheck: config.githubCapabilityCheck,
     };
     this.exec = exec;
     this.llm = llm;
@@ -276,6 +287,8 @@ export class PrCreator {
       targetBranch = 'main';
     }
 
+    this.assertGitHubCapabilities(branch, options?.issueNumber, logger);
+
     if (!this.pushBranch(branch, logger)) {
       return null;
     }
@@ -359,6 +372,60 @@ export class PrCreator {
       logger?.error('PrCreator: failed to push branch', this.commandFailure('git', formatCommand('git', args), error, { branch }));
       return false;
     }
+  }
+
+  private assertGitHubCapabilities(branch: string, issueNumber?: number, logger?: ILogger): void {
+    if (this.config.githubCapabilityCheck?.disabled === true) {
+      return;
+    }
+
+    const repo = this.resolveGitHubRepo(logger);
+    if (!repo) {
+      logger?.warn('PrCreator: skipped GitHub token capability preflight because the GitHub repo could not be resolved');
+      return;
+    }
+
+    const required: GitHubRequiredCapabilities = {
+      repo: 'read',
+      contents: 'write',
+      pullRequests: 'write',
+      ...(issueNumber != null ? { issues: 'write' as const } : {}),
+      ...this.config.githubCapabilityCheck?.required,
+    };
+    const result = checkGitHubTokenCapabilities({
+      repo,
+      exec: this.exec,
+      required,
+      lowRiskPolicy: this.config.githubCapabilityCheck?.lowRiskPolicy,
+    });
+
+    for (const warning of result.warnings) {
+      logger?.warn('PrCreator: GitHub token capability preflight warning', warning);
+    }
+
+    if (!result.ok) {
+      throw new PrCreationRequiredActionError({
+        message: 'GitHub token capability preflight failed before push/PR creation.',
+        action: [
+          'Update the GitHub token or lane policy before retrying',
+          'required capabilities: repo read, contents write, pull-requests write',
+          issueNumber != null ? 'issues write' : undefined,
+        ].filter(Boolean).join('; '),
+        branch,
+        details: result,
+      });
+    }
+
+    logger?.info('PrCreator: GitHub token capability preflight passed', {
+      repo,
+      evidence: result.evidence,
+    });
+  }
+
+  private resolveGitHubRepo(logger?: ILogger): string | null {
+    const remoteUrl = this.safeExec('git', ['remote', 'get-url', this.config.remote], logger)?.trim();
+    if (!remoteUrl) return null;
+    return parseGitHubOwnerRepo(remoteUrl);
   }
 
   private findExistingPr(branch: string, logger?: ILogger): Array<{ url?: string }> | null {
@@ -447,6 +514,12 @@ function formatCaughtError(error: unknown): { error: string; name?: string | und
     return { error: error.message, name: error.name };
   }
   return { error: String(error) };
+}
+
+function parseGitHubOwnerRepo(remoteUrl: string): string | null {
+  const match = remoteUrl.match(/github\.com[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
+  if (!match) return null;
+  return `${match[1]}/${match[2]}`;
 }
 
 interface GitContext {

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -287,6 +287,8 @@ export class PrCreator {
       targetBranch = 'main';
     }
 
+    this.assertGitHubCapabilities(branch, logger);
+
     if (!this.pushBranch(branch, logger)) {
       return null;
     }
@@ -299,8 +301,6 @@ export class PrCreator {
       logger?.info('PrCreator: PR already exists', { branch, url: existing[0]?.url });
       return null;
     }
-
-    this.assertGitHubCapabilities(branch, logger);
 
     // Gather git context for PR description
     const gitContext = this.gatherGitContext(targetBranch, logger);

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -49,6 +49,17 @@ export interface PrCreateOptions {
   readonly issueNumber?: number | undefined;
 }
 
+interface PrBodyInfo {
+  readonly title: string;
+  readonly body: string;
+}
+
+interface GitHubRemoteInfo {
+  readonly repo: string;
+  readonly url: string;
+  readonly tokenBackedPush: boolean;
+}
+
 /**
  * Executes a subprocess as a binary name plus a discrete argument array.
  * Arguments are never concatenated into a shell string, so branch, remote and
@@ -379,18 +390,19 @@ export class PrCreator {
       return;
     }
 
-    const repo = this.resolveGitHubRepo(logger);
-    if (!repo) {
+    const remoteInfo = this.resolveGitHubRemote(logger);
+    if (!remoteInfo) {
       logger?.warn('PrCreator: skipped GitHub token capability preflight because the GitHub repo could not be resolved');
       return;
     }
 
     const required: GitHubRequiredCapabilities = {
+      ...(remoteInfo.tokenBackedPush ? { contents: 'write' as const } : {}),
       pullRequests: 'write',
       ...this.config.githubCapabilityCheck?.required,
     };
     const result = checkGitHubTokenCapabilities({
-      repo,
+      repo: remoteInfo.repo,
       exec: this.exec,
       required,
       lowRiskPolicy: this.config.githubCapabilityCheck?.lowRiskPolicy,
@@ -403,25 +415,44 @@ export class PrCreator {
     if (!result.ok) {
       throw new PrCreationRequiredActionError({
         message: 'GitHub token capability preflight failed before push/PR creation.',
-        action: [
-          'Update the GitHub token or lane policy before retrying',
-          'required capability: pull-requests write',
-        ].filter(Boolean).join('; '),
+        action: this.formatCapabilityFailureAction(result, required),
         branch,
         details: result,
       });
     }
 
     logger?.info('PrCreator: GitHub token capability preflight passed', {
-      repo,
+      repo: remoteInfo.repo,
       evidence: result.evidence,
     });
   }
 
-  private resolveGitHubRepo(logger?: ILogger): string | null {
+  private resolveGitHubRemote(logger?: ILogger): GitHubRemoteInfo | null {
+    const configured = this.config.remote.trim();
+    const configuredRepo = parseGitHubOwnerRepo(configured);
+    if (configuredRepo) {
+      return { repo: configuredRepo, url: configured, tokenBackedPush: isHttpsGitHubRemote(configured) };
+    }
+
     const remoteUrl = this.safeExec('git', ['remote', 'get-url', this.config.remote], logger)?.trim();
     if (!remoteUrl) return null;
-    return parseGitHubOwnerRepo(remoteUrl);
+    const repo = parseGitHubOwnerRepo(remoteUrl);
+    if (!repo) return null;
+    return { repo, url: remoteUrl, tokenBackedPush: isHttpsGitHubRemote(remoteUrl) };
+  }
+
+  private formatCapabilityFailureAction(
+    result: ReturnType<typeof checkGitHubTokenCapabilities>,
+    required: GitHubRequiredCapabilities,
+  ): string {
+    if (result.issues.some(issue => issue.code === 'github-api-unavailable')) {
+      return 'Install/login gh or restore GitHub API connectivity before retrying';
+    }
+    const capabilityLabel = (capability: string): string => capability.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+    const requiredText = Object.entries(required)
+      .map(([capability, level]) => `${capabilityLabel(capability)} ${level}`)
+      .join(', ');
+    return `Update the GitHub token or lane policy before retrying; required capabilities: ${requiredText}`;
   }
 
   private findExistingPr(branch: string, logger?: ILogger): Array<{ url?: string }> | null {
@@ -516,6 +547,10 @@ function parseGitHubOwnerRepo(remoteUrl: string): string | null {
   const match = remoteUrl.match(/github\.com[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
   if (!match) return null;
   return `${match[1]}/${match[2]}`;
+}
+
+function isHttpsGitHubRemote(remoteUrl: string): boolean {
+  return /^https?:\/\/github\.com\//i.test(remoteUrl.trim());
 }
 
 interface GitContext {

--- a/packages/franken-orchestrator/src/closure/pr-creator.ts
+++ b/packages/franken-orchestrator/src/closure/pr-creator.ts
@@ -298,16 +298,17 @@ export class PrCreator {
       targetBranch = 'main';
     }
 
-    this.assertGitHubCapabilities(branch, logger);
+    const existing = this.findExistingPr(branch, logger);
+    if (existing === null) {
+      return null;
+    }
+
+    this.assertGitHubCapabilities(branch, logger, { requirePullRequestsWrite: existing.length === 0 });
 
     if (!this.pushBranch(branch, logger)) {
       return null;
     }
 
-    const existing = this.findExistingPr(branch, logger);
-    if (existing === null) {
-      return null;
-    }
     if (existing.length > 0) {
       logger?.info('PrCreator: PR already exists', { branch, url: existing[0]?.url });
       return null;
@@ -385,7 +386,11 @@ export class PrCreator {
     }
   }
 
-  private assertGitHubCapabilities(branch: string, logger?: ILogger): void {
+  private assertGitHubCapabilities(
+    branch: string,
+    logger?: ILogger,
+    options: { readonly requirePullRequestsWrite?: boolean } = {},
+  ): void {
     if (this.config.githubCapabilityCheck?.disabled === true) {
       return;
     }
@@ -398,7 +403,7 @@ export class PrCreator {
 
     const required: GitHubRequiredCapabilities = {
       ...(remoteInfo.tokenBackedPush ? { contents: 'write' as const } : {}),
-      pullRequests: 'write',
+      ...(options.requirePullRequestsWrite === false ? {} : { pullRequests: 'write' as const }),
       ...this.config.githubCapabilityCheck?.required,
     };
     const result = checkGitHubTokenCapabilities({
@@ -550,7 +555,7 @@ function parseGitHubOwnerRepo(remoteUrl: string): string | null {
 }
 
 function isHttpsGitHubRemote(remoteUrl: string): boolean {
-  return /^https?:\/\/github\.com\//i.test(remoteUrl.trim());
+  return /^https?:\/\/(?:[^@/\s]+@)?github\.com\//i.test(remoteUrl.trim());
 }
 
 interface GitContext {

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -422,7 +422,7 @@ describe('PrCreator argv subprocess safety', () => {
     expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
   });
 
-  it('runs GitHub token capability preflight before pushing to a GitHub remote', async () => {
+  it('runs GitHub token capability preflight before creating a PR on a GitHub remote', async () => {
     const calls: ExecCall[] = [];
     const exec = (command: string, args: readonly string[] = []): string => {
       calls.push({ command, args });
@@ -448,13 +448,15 @@ describe('PrCreator argv subprocess safety', () => {
     const userIndex = calls.findIndex(c => c.command === 'gh' && c.args.join(' ') === 'api -i /user');
     const repoIndex = calls.findIndex(c => c.command === 'gh' && c.args.join(' ') === 'api repos/djm204/frankenbeast');
     const pushIndex = calls.findIndex(c => c.command === 'git' && c.args.includes('push'));
+    const createIndex = calls.findIndex(c => c.command === 'gh' && c.args.includes('create'));
     expect(remoteIndex).toBeGreaterThanOrEqual(0);
+    expect(pushIndex).toBeGreaterThanOrEqual(0);
     expect(userIndex).toBeGreaterThan(remoteIndex);
     expect(repoIndex).toBeGreaterThan(userIndex);
-    expect(pushIndex).toBeGreaterThan(repoIndex);
+    expect(createIndex).toBeGreaterThan(repoIndex);
   });
 
-  it('fails capability preflight before push when required GitHub permissions are missing', async () => {
+  it('fails capability preflight before PR creation when required GitHub permissions are missing', async () => {
     const calls: ExecCall[] = [];
     const exec = (command: string, args: readonly string[] = []): string => {
       calls.push({ command, args });
@@ -464,6 +466,7 @@ describe('PrCreator argv subprocess safety', () => {
       if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
         return JSON.stringify({ permissions: { pull: true, push: false, triage: false, maintain: false, admin: false } });
       }
+      if (command === 'gh' && args.includes('list')) return '[]';
       return '';
     };
     const creator = new PrCreator(
@@ -477,7 +480,7 @@ describe('PrCreator argv subprocess safety', () => {
       action: expect.stringContaining('pull-requests write'),
       branch: 'feature/missing-capability',
     });
-    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
     expect(calls.some(c => c.command === 'gh' && c.args.includes('create'))).toBe(false);
   });
 

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -450,10 +450,10 @@ describe('PrCreator argv subprocess safety', () => {
     const pushIndex = calls.findIndex(c => c.command === 'git' && c.args.includes('push'));
     const createIndex = calls.findIndex(c => c.command === 'gh' && c.args.includes('create'));
     expect(remoteIndex).toBeGreaterThanOrEqual(0);
-    expect(pushIndex).toBeGreaterThanOrEqual(0);
     expect(userIndex).toBeGreaterThan(remoteIndex);
     expect(repoIndex).toBeGreaterThan(userIndex);
-    expect(createIndex).toBeGreaterThan(repoIndex);
+    expect(pushIndex).toBeGreaterThan(repoIndex);
+    expect(createIndex).toBeGreaterThan(pushIndex);
   });
 
   it('fails capability preflight before PR creation when required GitHub permissions are missing', async () => {
@@ -480,7 +480,7 @@ describe('PrCreator argv subprocess safety', () => {
       action: expect.stringContaining('pull-requests write'),
       branch: 'feature/missing-capability',
     });
-    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
     expect(calls.some(c => c.command === 'gh' && c.args.includes('create'))).toBe(false);
   });
 

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -483,6 +483,32 @@ describe('PrCreator argv subprocess safety', () => {
     expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
   });
 
+  it.each([
+    'ssh://git@github.com:22/djm204/frankenbeast.git',
+    'https://github.com:443/djm204/frankenbeast.git',
+  ])('parses GitHub remote URLs with explicit ports: %s', async (remoteUrl) => {
+    const calls: ExecCall[] = [];
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/ported-remote\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return `${remoteUrl}\n`;
+      if (command === 'gh' && args.includes('list')) return '[]';
+      if (command === 'gh' && args.join(' ') === 'api -i /user') return 'HTTP/2 200\nx-oauth-scopes: repo\n\n{}\n';
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ private: true, permissions: { pull: true, push: true, triage: true, maintain: false, admin: false } });
+      }
+      if (command === 'gh' && args.includes('create')) return 'https://example.com/pr/1\n';
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).resolves.toEqual({ url: 'https://example.com/pr/1' });
+    expect(calls.some(c => c.command === 'gh' && c.args.join(' ') === 'api repos/djm204/frankenbeast')).toBe(true);
+  });
+
   it('does not require pull-request write when reusing an existing PR', async () => {
     const calls: ExecCall[] = [];
     const exec = (command: string, args: readonly string[] = []): string => {

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -422,6 +422,65 @@ describe('PrCreator argv subprocess safety', () => {
     expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
   });
 
+  it('runs GitHub token capability preflight before pushing to a GitHub remote', async () => {
+    const calls: ExecCall[] = [];
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/capability-check\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return 'https://github.com/djm204/frankenbeast.git\n';
+      if (command === 'gh' && args.join(' ') === 'api -i /user') return 'HTTP/2 200\nx-oauth-scopes: repo\n\n{}\n';
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ permissions: { pull: true, push: true, triage: true, maintain: false, admin: false } });
+      }
+      if (command === 'gh' && args.includes('list')) return '[]';
+      if (command === 'gh' && args.includes('create')) return 'https://example.com/pr/1\n';
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    const result = await creator.create(makeResult(), undefined, { issueNumber: 1706 });
+
+    expect(result).toEqual({ url: 'https://example.com/pr/1' });
+    const remoteIndex = calls.findIndex(c => c.command === 'git' && c.args.join(' ') === 'remote get-url origin');
+    const userIndex = calls.findIndex(c => c.command === 'gh' && c.args.join(' ') === 'api -i /user');
+    const repoIndex = calls.findIndex(c => c.command === 'gh' && c.args.join(' ') === 'api repos/djm204/frankenbeast');
+    const pushIndex = calls.findIndex(c => c.command === 'git' && c.args.includes('push'));
+    expect(remoteIndex).toBeGreaterThanOrEqual(0);
+    expect(userIndex).toBeGreaterThan(remoteIndex);
+    expect(repoIndex).toBeGreaterThan(userIndex);
+    expect(pushIndex).toBeGreaterThan(repoIndex);
+  });
+
+  it('fails capability preflight before push when required GitHub permissions are missing', async () => {
+    const calls: ExecCall[] = [];
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/missing-capability\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return 'git@github.com:djm204/frankenbeast.git\n';
+      if (command === 'gh' && args.join(' ') === 'api -i /user') return 'HTTP/2 200\nx-oauth-scopes: read:org\n\n{}\n';
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ permissions: { pull: true, push: false, triage: false, maintain: false, admin: false } });
+      }
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).rejects.toMatchObject({
+      name: PrCreationRequiredActionError.name,
+      message: expect.stringContaining('capability preflight failed'),
+      action: expect.stringContaining('pull-requests write'),
+      branch: 'feature/missing-capability',
+    });
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
+    expect(calls.some(c => c.command === 'gh' && c.args.includes('create'))).toBe(false);
+  });
+
   // Argument-injection and invalid-ref guards must still hold.
   it.each([
     '-evil',

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -458,7 +458,7 @@ describe('PrCreator argv subprocess safety', () => {
     expect(createIndex).toBeGreaterThan(pushIndex);
   });
 
-  it('treats credentialed HTTPS GitHub remotes as token-backed before push', async () => {
+  it('honors explicitly required contents write before pushing to a credentialed HTTPS GitHub remote', async () => {
     const calls: ExecCall[] = [];
     const exec = (command: string, args: readonly string[] = []): string => {
       calls.push({ command, args });
@@ -472,7 +472,7 @@ describe('PrCreator argv subprocess safety', () => {
       return '';
     };
     const creator = new PrCreator(
-      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      { targetBranch: 'main', disabled: false, remote: 'origin', githubCapabilityCheck: { required: { contents: 'write' } } },
       exec,
     );
 
@@ -481,6 +481,35 @@ describe('PrCreator argv subprocess safety', () => {
       action: expect.stringContaining('contents write'),
     });
     expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
+  });
+
+  it('does not require contents write merely because a GitHub remote uses HTTPS', async () => {
+    const calls: ExecCall[] = [];
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/fine-grained-pat\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return 'https://github.com/djm204/frankenbeast.git\n';
+      if (command === 'gh' && args.includes('list')) return '[]';
+      if (command === 'gh' && args.join(' ') === 'api -i /user') return 'HTTP/2 200\nx-oauth-scopes: \n\n{}\n';
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ node_id: 'R_test', private: true, permissions: { pull: true, push: true, triage: true, maintain: false, admin: false } });
+      }
+      if (command === 'gh' && args[0] === 'api' && args[1] === 'graphql') {
+        const error = new Error('Command failed: gh api graphql') as Error & { stderr: string; status: number };
+        error.stderr = 'Validation Failed: Head ref must exist';
+        error.status = 1;
+        throw error;
+      }
+      if (command === 'gh' && args.includes('create')) return 'https://example.com/pr/1\n';
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).resolves.toEqual({ url: 'https://example.com/pr/1' });
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
   });
 
   it.each([
@@ -507,6 +536,28 @@ describe('PrCreator argv subprocess safety', () => {
 
     await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).resolves.toEqual({ url: 'https://example.com/pr/1' });
     expect(calls.some(c => c.command === 'gh' && c.args.join(' ') === 'api repos/djm204/frankenbeast')).toBe(true);
+  });
+
+  it('skips GitHub preflight for non-GitHub remotes whose path contains github.com', async () => {
+    const calls: ExecCall[] = [];
+    const remoteUrl = 'ssh://git@git.corp/github.com/djm204/frankenbeast.git';
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/internal-mirror\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return `${remoteUrl}\n`;
+      if (command === 'gh' && args.includes('list')) return '[]';
+      if (command === 'gh' && args.includes('create')) return 'https://example.com/pr/1\n';
+      if (command === 'gh' && args.join(' ').startsWith('api repos/')) throw new Error(`unexpected ${command} ${args.join(' ')}`);
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).resolves.toEqual({ url: 'https://example.com/pr/1' });
+    expect(calls.some(c => c.command === 'gh' && c.args.join(' ').startsWith('api repos/'))).toBe(false);
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
   });
 
   it('does not require pull-request write when reusing an existing PR', async () => {

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -312,7 +312,7 @@ describe('PrCreator argv subprocess safety', () => {
       action: expect.stringContaining('GH_TOKEN'),
       branch: 'feature/actions-auth-warning',
     });
-    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
   });
 
   it('surfaces GitHub integration permission failures as actionable required-action errors', async () => {
@@ -447,13 +447,63 @@ describe('PrCreator argv subprocess safety', () => {
     const remoteIndex = calls.findIndex(c => c.command === 'git' && c.args.join(' ') === 'remote get-url origin');
     const userIndex = calls.findIndex(c => c.command === 'gh' && c.args.join(' ') === 'api -i /user');
     const repoIndex = calls.findIndex(c => c.command === 'gh' && c.args.join(' ') === 'api repos/djm204/frankenbeast');
+    const listIndex = calls.findIndex(c => c.command === 'gh' && c.args.includes('list'));
     const pushIndex = calls.findIndex(c => c.command === 'git' && c.args.includes('push'));
     const createIndex = calls.findIndex(c => c.command === 'gh' && c.args.includes('create'));
     expect(remoteIndex).toBeGreaterThanOrEqual(0);
-    expect(userIndex).toBeGreaterThan(remoteIndex);
+    expect(listIndex).toBeGreaterThanOrEqual(0);
+    expect(userIndex).toBeGreaterThan(listIndex);
     expect(repoIndex).toBeGreaterThan(userIndex);
     expect(pushIndex).toBeGreaterThan(repoIndex);
     expect(createIndex).toBeGreaterThan(pushIndex);
+  });
+
+  it('treats credentialed HTTPS GitHub remotes as token-backed before push', async () => {
+    const calls: ExecCall[] = [];
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/credentialed-remote\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return 'https://x-access-token:secret@github.com/djm204/frankenbeast.git\n';
+      if (command === 'gh' && args.includes('list')) return '[]';
+      if (command === 'gh' && args.join(' ') === 'api -i /user') return 'HTTP/2 200\nx-oauth-scopes: read:org\n\n{}\n';
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ private: true, permissions: { pull: true, push: true, triage: true, maintain: false, admin: false } });
+      }
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).rejects.toMatchObject({
+      name: PrCreationRequiredActionError.name,
+      action: expect.stringContaining('contents write'),
+    });
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(false);
+  });
+
+  it('does not require pull-request write when reusing an existing PR', async () => {
+    const calls: ExecCall[] = [];
+    const exec = (command: string, args: readonly string[] = []): string => {
+      calls.push({ command, args });
+      if (command === 'git' && args.includes('--show-current')) return 'feature/existing-pr\n';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return 'git@github.com:djm204/frankenbeast.git\n';
+      if (command === 'gh' && args.includes('list')) return '[{"url":"https://github.com/djm204/frankenbeast/pull/1"}]';
+      if (command === 'gh' && args.join(' ') === 'api -i /user') return 'HTTP/2 200\nx-oauth-scopes: read:org\n\n{}\n';
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ permissions: { pull: true, push: true, triage: true, maintain: false, admin: false } });
+      }
+      return '';
+    };
+    const creator = new PrCreator(
+      { targetBranch: 'main', disabled: false, remote: 'origin' },
+      exec,
+    );
+
+    await expect(creator.create(makeResult(), undefined, { issueNumber: 1706 })).resolves.toBeNull();
+    expect(calls.some(c => c.command === 'git' && c.args.includes('push'))).toBe(true);
+    expect(calls.some(c => c.command === 'gh' && c.args.includes('create'))).toBe(false);
   });
 
   it('fails capability preflight before PR creation when required GitHub permissions are missing', async () => {

--- a/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
+++ b/packages/franken-orchestrator/test/closure/pr-creator-argv.test.ts
@@ -200,7 +200,7 @@ describe('PrCreator argv subprocess safety', () => {
   ])('accepts repository URL %s as a push remote', async (remote) => {
     const { exec, calls } = makeExecRecorder('feature/foo');
     const creator = new PrCreator(
-      { targetBranch: 'main', disabled: false, remote },
+      { targetBranch: 'main', disabled: false, remote, githubCapabilityCheck: { disabled: true } },
       exec,
     );
 

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -38,10 +38,10 @@ describe('GitHub token capability check', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
-    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
-    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
-    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
+    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
     expect(result.evidence.oauthScopes).toEqual(['repo', 'workflow']);
     expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
   });

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -149,7 +149,7 @@ describe('GitHub token capability check', () => {
     const result = checkGitHubTokenCapabilities({
       repo: 'djm204/frankenbeast',
       exec,
-      required: { pullRequests: 'write' },
+      required: { pullRequests: 'write', contents: 'write' },
     });
 
     expect(result.ok).toBe(true);

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -97,7 +97,13 @@ describe('GitHub token capability check', () => {
         throw error;
       }
       if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
-        return JSON.stringify({ permissions: { pull: true, push: true, admin: false, maintain: false, triage: true } });
+        return JSON.stringify({ node_id: 'R_test', permissions: { pull: true, push: true, admin: false, maintain: false, triage: true } });
+      }
+      if (command === 'gh' && args[0] === 'api' && args[1] === 'graphql') {
+        const error = new Error('Command failed: gh api graphql') as Error & { stderr: string; status: number };
+        error.stderr = 'Validation Failed: Head ref must exist';
+        error.status = 1;
+        throw error;
       }
       throw new Error(`unexpected args ${args.join(' ')}`);
     };

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -38,10 +38,10 @@ describe('GitHub token capability check', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
-    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
-    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
-    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
+    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
+    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
+    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
+    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo', tokenSpecific: true });
     expect(result.evidence.oauthScopes).toEqual(['repo', 'workflow']);
     expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
   });
@@ -88,25 +88,29 @@ describe('GitHub token capability check', () => {
     ]));
   });
 
-  it('turns GitHub API auth failures into sanitized capability issues', () => {
+  it('continues when OAuth scopes are unavailable for installation tokens', () => {
     const exec: GitHubCapabilityExec = (command, args) => {
       if (command === 'gh' && args.join(' ') === 'api -i /user') {
         const error = new Error('Command failed: gh api -i /user') as Error & { stderr: string; status: number };
-        error.stderr = 'HTTP 401: Bad credentials for token ghp_should_not_leak';
+        error.stderr = 'HTTP 403: Resource not accessible by integration for token ghp_should_not_leak';
         error.status = 1;
         throw error;
       }
-      throw new Error('unexpected command');
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ permissions: { pull: true, push: true, admin: false, maintain: false, triage: true } });
+      }
+      throw new Error(`unexpected args ${args.join(' ')}`);
     };
 
     const result = checkGitHubTokenCapabilities({
       repo: 'djm204/frankenbeast',
       exec,
-      required: { repo: 'read' },
+      required: { pullRequests: 'write' },
     });
 
-    expect(result.ok).toBe(false);
-    expect(result.issues[0]).toEqual(expect.objectContaining({ code: 'github-api-unavailable' }));
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.warnings[0]).toEqual(expect.objectContaining({ code: 'github-api-unavailable' }));
     expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
     expect(JSON.stringify(result)).toContain('<redacted>');
   });

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -38,10 +38,10 @@ describe('GitHub token capability check', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
-    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
-    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
-    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo/public_repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo/public_repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo/public_repo + repository write access', tokenSpecific: true });
+    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'x-oauth-scopes: repo/public_repo + repository write access', tokenSpecific: true });
     expect(result.evidence.oauthScopes).toEqual(['repo', 'workflow']);
     expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
   });
@@ -85,6 +85,44 @@ describe('GitHub token capability check', () => {
       expect.objectContaining({ code: 'excessive-write-permission', capability: 'contents' }),
       expect.objectContaining({ code: 'excessive-write-permission', capability: 'issues' }),
       expect.objectContaining({ code: 'excessive-write-permission', capability: 'pullRequests' }),
+    ]));
+  });
+
+  it('treats public_repo on public repositories as token-specific write evidence for low-risk checks', () => {
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec: makeExec('HTTP/2 200\nx-oauth-scopes: public_repo', {
+        private: false,
+        permissions: { pull: true, push: true, admin: false, maintain: false, triage: true },
+      }),
+      required: { repo: 'read' },
+      lowRiskPolicy: {
+        mode: 'fail',
+        allowedWriteCapabilities: [],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.evidence.contents).toEqual(expect.objectContaining({ level: 'write', tokenSpecific: true }));
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'excessive-write-permission', capability: 'contents' }),
+    ]));
+  });
+
+  it('does not accept repository actor role as proof of required contents write', () => {
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec: makeExec('HTTP/2 200\nx-oauth-scopes: read:org', {
+        private: true,
+        permissions: { pull: true, push: true, admin: false, maintain: false, triage: true },
+      }),
+      required: { contents: 'write' },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.evidence.contents).toEqual(expect.objectContaining({ level: 'none', tokenSpecific: true }));
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'missing-capability', capability: 'contents' }),
     ]));
   });
 

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkGitHubTokenCapabilities,
+  type GitHubCapabilityExec,
+} from '../../../src/closure/github-token-capability-check.js';
+
+function makeExec(headers: string, repoPayload: unknown): GitHubCapabilityExec {
+  return (command, args) => {
+    if (command !== 'gh') throw new Error(`unexpected command ${command}`);
+    if (args.join(' ') === 'api -i /user') {
+      return `${headers}\n\n{"login":"octocat"}\n`;
+    }
+    if (args.join(' ') === 'api repos/djm204/frankenbeast') {
+      return `${JSON.stringify(repoPayload)}\n`;
+    }
+    throw new Error(`unexpected args ${args.join(' ')}`);
+  };
+}
+
+describe('GitHub token capability check', () => {
+  it('reports scoped evidence for repo, issue, PR, and contents capabilities without leaking token values', () => {
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec: makeExec(
+        [
+          'HTTP/2 200',
+          'x-oauth-scopes: repo, workflow',
+          'x-accepted-oauth-scopes: user',
+        ].join('\n'),
+        { permissions: { pull: true, push: true, admin: false, maintain: false, triage: true } },
+      ),
+      required: {
+        repo: 'read',
+        issues: 'write',
+        pullRequests: 'write',
+        contents: 'write',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.repo).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
+    expect(result.evidence.issues).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
+    expect(result.evidence.pullRequests).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
+    expect(result.evidence.contents).toEqual({ available: true, level: 'write', source: 'repository.permissions.push' });
+    expect(result.evidence.oauthScopes).toEqual(['repo', 'workflow']);
+    expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
+  });
+
+  it('fails fast when required GitHub capabilities are missing', () => {
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec: makeExec('HTTP/2 200\nx-oauth-scopes: read:org', {
+        permissions: { pull: true, push: false, admin: false, maintain: false, triage: false },
+      }),
+      required: {
+        issues: 'write',
+        pullRequests: 'write',
+        contents: 'write',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'missing-capability', capability: 'issues' }),
+      expect.objectContaining({ code: 'missing-capability', capability: 'pullRequests' }),
+      expect.objectContaining({ code: 'missing-capability', capability: 'contents' }),
+    ]));
+  });
+
+  it('can fail low-risk lanes when the token exposes excessive write permissions', () => {
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec: makeExec('HTTP/2 200\nx-oauth-scopes: repo', {
+        permissions: { pull: true, push: true, admin: false, maintain: false, triage: true },
+      }),
+      required: { repo: 'read' },
+      lowRiskPolicy: {
+        mode: 'fail',
+        allowedWriteCapabilities: [],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'excessive-write-permission', capability: 'contents' }),
+      expect.objectContaining({ code: 'excessive-write-permission', capability: 'issues' }),
+      expect.objectContaining({ code: 'excessive-write-permission', capability: 'pullRequests' }),
+    ]));
+  });
+
+  it('turns GitHub API auth failures into sanitized capability issues', () => {
+    const exec: GitHubCapabilityExec = (command, args) => {
+      if (command === 'gh' && args.join(' ') === 'api -i /user') {
+        const error = new Error('Command failed: gh api -i /user') as Error & { stderr: string; status: number };
+        error.stderr = 'HTTP 401: Bad credentials for token ghp_should_not_leak';
+        error.status = 1;
+        throw error;
+      }
+      throw new Error('unexpected command');
+    };
+
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec,
+      required: { repo: 'read' },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]).toEqual(expect.objectContaining({ code: 'github-api-unavailable' }));
+    expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
+    expect(JSON.stringify(result)).toContain('<redacted>');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
+++ b/packages/franken-orchestrator/tests/unit/closure/github-token-capability-check.test.ts
@@ -158,4 +158,38 @@ describe('GitHub token capability check', () => {
     expect(JSON.stringify(result)).not.toContain('ghp_should_not_leak');
     expect(JSON.stringify(result)).toContain('<redacted>');
   });
+
+  it('probes pull-request write for installation tokens before trusting repository push permissions', () => {
+    const exec: GitHubCapabilityExec = (command, args) => {
+      if (command === 'gh' && args.join(' ') === 'api -i /user') {
+        const error = new Error('Command failed: gh api -i /user') as Error & { stderr: string; status: number };
+        error.stderr = 'HTTP 403: Resource not accessible by integration';
+        error.status = 1;
+        throw error;
+      }
+      if (command === 'gh' && args.join(' ') === 'api repos/djm204/frankenbeast') {
+        return JSON.stringify({ node_id: 'R_test', permissions: { pull: true, push: true, admin: false, maintain: false, triage: true } });
+      }
+      if (command === 'gh' && args[0] === 'api' && args[1] === 'graphql') {
+        const error = new Error('Command failed: gh api graphql') as Error & { stderr: string; status: number };
+        error.stderr = 'GraphQL: Resource not accessible by integration';
+        error.status = 1;
+        throw error;
+      }
+      throw new Error(`unexpected args ${args.join(' ')}`);
+    };
+
+    const result = checkGitHubTokenCapabilities({
+      repo: 'djm204/frankenbeast',
+      exec,
+      required: { pullRequests: 'write', contents: 'write' },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.evidence.contents).toEqual(expect.objectContaining({ level: 'write', tokenSpecific: true }));
+    expect(result.evidence.pullRequests).toEqual(expect.objectContaining({ level: 'none', tokenSpecific: true }));
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'missing-capability', capability: 'pullRequests' }),
+    ]));
+  });
 });


### PR DESCRIPTION
## Summary
- add a reusable GitHub token capability preflight that inspects OAuth scopes and repository permissions without exposing token values
- integrate the preflight into PR creation before branch push / gh PR calls
- add mocked tests for missing, excessive, sanitized, and successful capability checks

## Test plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm test --workspace @franken/orchestrator -- test/closure/pr-creator-argv.test.ts tests/unit/closure/github-token-capability-check.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1706
