### PR TITLE
feat(dr): verify memory backups

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -49,7 +49,7 @@ export type BeastAction =
 
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
-export type MemoryAction = 'snapshot-diff' | undefined;
+export type MemoryAction = 'snapshot-diff' | 'verify-backup' | undefined;
 
 export interface CliArgs {
   subcommand: Subcommand;
@@ -60,6 +60,7 @@ export interface CliArgs {
   memoryAction?: MemoryAction;
   memorySnapshotBefore?: string | undefined;
   memorySnapshotAfter?: string | undefined;
+  memoryBackupPath?: string | undefined;
   networkDetached: boolean;
   networkSet?: string[] | undefined;
   skillAction?: SkillAction;
@@ -109,7 +110,7 @@ export interface CliArgs {
 
 const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
-const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff']);
+const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff', 'verify-backup']);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
@@ -173,7 +174,7 @@ Subcommands:
   chat-server             Run the local HTTP+WebSocket chat server for franken-web
   beasts-daemon           Run the standalone Beast control-plane daemon
   network                 Manage Frankenbeast request-serving services
-  memory                  Inspect persisted BrainSnapshot JSON artifacts
+  memory                  Inspect persisted BrainSnapshot JSON artifacts and SQLite backups
   skill                   Manage MCP skill plugins
   security                View or change security profile
 
@@ -233,6 +234,8 @@ Network Commands:
 Memory Commands:
   memory snapshot-diff <before> <after>
                                   Print a structured JSON diff between two BrainSnapshot files
+  memory verify-backup <backup.sqlite>
+                                  Verify a read-only SQLite memory backup and print structured JSON
 
 Beast Commands:
   beasts catalog                      List fixed Beast definitions
@@ -512,6 +515,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let memoryAction: MemoryAction;
   let memorySnapshotBefore: string | undefined;
   let memorySnapshotAfter: string | undefined;
+  let memoryBackupPath: string | undefined;
   let skillAction: SkillAction;
   let skillTarget: string | undefined;
   let skillCommand: string | undefined;
@@ -547,10 +551,17 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       }
       memoryAction = actionCandidate as MemoryAction;
     }
-    memorySnapshotBefore = positionals[1];
-    memorySnapshotAfter = positionals[2];
-    if (positionals.length > 3) {
-      throw new TypeError(`Unexpected argument '${positionals[3]}'. memory snapshot-diff accepts exactly two snapshot files`);
+    if (memoryAction === 'verify-backup') {
+      memoryBackupPath = positionals[1];
+      if (positionals.length > 2) {
+        throw new TypeError(`Unexpected argument '${positionals[2]}'. memory verify-backup accepts exactly one backup file`);
+      }
+    } else {
+      memorySnapshotBefore = positionals[1];
+      memorySnapshotAfter = positionals[2];
+      if (positionals.length > 3) {
+        throw new TypeError(`Unexpected argument '${positionals[3]}'. memory snapshot-diff accepts exactly two snapshot files`);
+      }
     }
   } else if (subcommand === 'skill') {
     const actionCandidate = positionals[0];
@@ -687,6 +698,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     memoryAction,
     memorySnapshotBefore,
     memorySnapshotAfter,
+    memoryBackupPath,
     networkDetached: values.detached ?? false,
     networkSet: values.set,
     skillAction,

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -4,12 +4,12 @@ import { BrainSnapshotSchema, type BrainSnapshot, type EpisodicEvent } from '@fr
 
 const CURRENT_MEMORY_SCHEMA_VERSION = 1;
 const REQUIRED_BACKUP_TABLES = [
-  'memory_schema_versions',
   'working_memory',
   'episodic_events',
   'checkpoints',
 ] as const;
 const MEMORY_BACKUP_TABLES = [
+  'memory_schema_versions',
   ...REQUIRED_BACKUP_TABLES,
   'memory_deletion_guards',
   'memory_deletion_hash_keys',
@@ -18,6 +18,14 @@ const JSON_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
   working_memory: ['value'],
   episodic_events: ['details'],
   checkpoints: ['state'],
+};
+const REQUIRED_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
+  working_memory: ['key', 'value', 'updated_at'],
+  episodic_events: ['id', 'type', 'step', 'summary', 'details', 'created_at'],
+  checkpoints: ['id', 'state', 'created_at'],
+  memory_schema_versions: ['store', 'version', 'migrated_at'],
+  memory_deletion_guards: ['selector_hash', 'guard_kind', 'value_hash', 'created_at'],
+  memory_deletion_hash_keys: ['id', 'key_material', 'created_at'],
 };
 const ENCRYPTED_MEMORY_PREFIX = 'enc:v1:';
 
@@ -166,7 +174,27 @@ function countRows(db: Database.Database, table: string, tables: Set<string>): n
   return row.count;
 }
 
-function verifyJsonColumns(db: Database.Database, table: string, columns: Set<string>): void {
+function readEncryptedStores(db: Database.Database, tables: Set<string>): Set<string> {
+  if (!tables.has('memory_encryption_status')) return new Set();
+  const columns = readTableColumns(db, 'memory_encryption_status');
+  const missingColumns = ['store', 'encrypted'].filter((column) => !columns.has(column));
+  if (missingColumns.length > 0) {
+    throw new Error(`Memory backup table memory_encryption_status is missing required column(s): ${missingColumns.join(', ')}`);
+  }
+  const rows = db
+    .prepare(`SELECT store, encrypted FROM memory_encryption_status WHERE encrypted = 1`)
+    .all() as Array<{ store: string; encrypted: number }>;
+  return new Set(rows.map((row) => row.store));
+}
+
+function validateEncryptedPayload(table: string, column: string, rowid: number, value: string): void {
+  const parts = value.slice(ENCRYPTED_MEMORY_PREFIX.length).split(':');
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    throw new Error(`Malformed encrypted payload in ${table}.${column} row ${rowid}`);
+  }
+}
+
+function verifyJsonColumns(db: Database.Database, table: string, columns: Set<string>, encryptedStores: Set<string>): void {
   const jsonColumns = JSON_COLUMNS_BY_TABLE[table] ?? [];
   for (const column of jsonColumns) {
     if (!columns.has(column)) continue;
@@ -174,7 +202,15 @@ function verifyJsonColumns(db: Database.Database, table: string, columns: Set<st
       .prepare(`SELECT rowid AS rowid, ${sqliteIdentifier(column)} AS value FROM ${sqliteIdentifier(table)} WHERE ${sqliteIdentifier(column)} IS NOT NULL`)
       .all() as Array<{ rowid: number; value: unknown }>;
     for (const row of rows) {
-      if (typeof row.value !== 'string' || row.value.startsWith(ENCRYPTED_MEMORY_PREFIX)) continue;
+      if (typeof row.value !== 'string') continue;
+      if (row.value.startsWith(ENCRYPTED_MEMORY_PREFIX)) {
+        if (!encryptedStores.has(table)) {
+          throw new Error(`Unexpected encrypted payload marker in plaintext ${table}.${column} row ${row.rowid}`);
+        }
+        validateEncryptedPayload(table, column, row.rowid, row.value);
+        continue;
+      }
+      if (table === 'working_memory' && column === 'value') continue;
       try {
         JSON.parse(row.value) as unknown;
       } catch (error) {
@@ -185,8 +221,22 @@ function verifyJsonColumns(db: Database.Database, table: string, columns: Set<st
   }
 }
 
+function verifyRequiredColumns(table: string, columns: Set<string>): void {
+  const requiredColumns = REQUIRED_COLUMNS_BY_TABLE[table] ?? [];
+  const missingColumns = requiredColumns.filter((column) => !columns.has(column));
+  if (missingColumns.length > 0) {
+    throw new Error(`Memory backup table ${table} is missing required column(s): ${missingColumns.join(', ')}`);
+  }
+}
+
 function readSchemaStores(db: Database.Database, tables: Set<string>): MemoryBackupVerificationReport['schema']['stores'] {
-  if (!tables.has('memory_schema_versions')) return [];
+  if (!tables.has('memory_schema_versions')) {
+    return REQUIRED_BACKUP_TABLES.map((store) => ({
+      store,
+      version: 0,
+      recordCount: countRows(db, store, tables),
+    }));
+  }
   return (db
     .prepare(`SELECT store, version FROM memory_schema_versions ORDER BY store ASC`)
     .all() as Array<{ store: string; version: number }>).map((row) => {
@@ -265,12 +315,11 @@ export function verifyMemoryBackup(path: string): MemoryBackupVerificationReport
       throw new Error(`Memory backup is missing required table(s): ${missingTables.join(', ')}`);
     }
 
+    const encryptedStores = readEncryptedStores(db, tables);
     for (const table of MEMORY_BACKUP_TABLES) {
       if (!tables.has(table)) continue;
       const columns = readTableColumns(db, table);
-      if (!columns.has('schema_version') && table !== 'memory_schema_versions') {
-        throw new Error(`Memory backup table ${table} is missing schema_version column`);
-      }
+      verifyRequiredColumns(table, columns);
       if (columns.has('schema_version')) {
         const future = db
           .prepare(`SELECT schema_version FROM ${sqliteIdentifier(table)} WHERE schema_version > ? LIMIT 1`)
@@ -281,7 +330,7 @@ export function verifyMemoryBackup(path: string): MemoryBackupVerificationReport
           );
         }
       }
-      verifyJsonColumns(db, table, columns);
+      verifyJsonColumns(db, table, columns, encryptedStores);
     }
 
     const stores = readSchemaStores(db, tables);

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -1,12 +1,17 @@
 import { readFile } from 'node:fs/promises';
 import Database from 'better-sqlite3';
-import { BrainSnapshotSchema, type BrainSnapshot, type EpisodicEvent } from '@franken/types';
+import { BrainSnapshotSchema, ExecutionStateSchema, type BrainSnapshot, type EpisodicEvent } from '@franken/types';
 
 const CURRENT_MEMORY_SCHEMA_VERSION = 1;
 const REQUIRED_BACKUP_TABLES = [
   'working_memory',
   'episodic_events',
   'checkpoints',
+] as const;
+const CURRENT_SCHEMA_REQUIRED_TABLES = [
+  ...REQUIRED_BACKUP_TABLES,
+  'memory_deletion_guards',
+  'memory_deletion_hash_keys',
 ] as const;
 const MEMORY_BACKUP_TABLES = [
   'memory_schema_versions',
@@ -33,6 +38,7 @@ const REQUIRED_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
   memory_deletion_hash_keys: ['id', 'key_material', 'created_at'],
 };
 const ENCRYPTED_MEMORY_PREFIX = 'enc:v1:';
+const DELETION_HASH_KEY_ID = 'right-to-forget-hmac-v1';
 
 export interface SnapshotDiff<T = unknown> {
   readonly added: Record<string, T>;
@@ -200,9 +206,20 @@ function readEncryptedStores(db: Database.Database, tables: Set<string>): Set<st
   return stores;
 }
 function validateEncryptedPayload(table: string, column: string, rowid: number, value: string): void {
+  if (!value.startsWith(ENCRYPTED_MEMORY_PREFIX)) {
+    throw new Error(`Malformed encrypted payload in ${table}.${column} row ${rowid}: missing ${ENCRYPTED_MEMORY_PREFIX} marker`);
+  }
   const parts = value.slice(ENCRYPTED_MEMORY_PREFIX.length).split(':');
   if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
     throw new Error(`Malformed encrypted payload in ${table}.${column} row ${rowid}`);
+  }
+}
+
+function verifyCheckpointStateShape(rowid: number, value: string): void {
+  const parsed = JSON.parse(value) as unknown;
+  const result = ExecutionStateSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`Invalid checkpoint state in checkpoints.state row ${rowid}: ${result.error.issues.map((issue) => issue.path.join('.') + ' ' + issue.message).join('; ')}`);
   }
 }
 
@@ -218,7 +235,9 @@ function verifyPayloadColumn(
     .prepare(`SELECT rowid AS rowid, ${sqliteIdentifier(column)} AS value FROM ${sqliteIdentifier(table)} WHERE ${sqliteIdentifier(column)} IS NOT NULL`)
     .iterate() as Iterable<{ rowid: number; value: unknown }>;
   for (const row of rows) {
-    if (typeof row.value !== 'string') continue;
+    if (typeof row.value !== 'string') {
+      throw new Error(`Non-text payload in ${table}.${column} row ${row.rowid}`);
+    }
     if (row.value.startsWith(ENCRYPTED_MEMORY_PREFIX)) {
       if (!encryptedStore) {
         throw new Error(`Unexpected encrypted payload marker in plaintext ${table}.${column} row ${row.rowid}`);
@@ -231,7 +250,11 @@ function verifyPayloadColumn(
     }
     if (!options.requireJsonWhenPlaintext) continue;
     try {
-      JSON.parse(row.value) as unknown;
+      if (table === 'checkpoints' && column === 'state') {
+        verifyCheckpointStateShape(row.rowid, row.value);
+      } else {
+        JSON.parse(row.value) as unknown;
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid JSON payload in ${table}.${column} row ${row.rowid}: ${message}`);
@@ -257,6 +280,17 @@ function verifyRequiredColumns(table: string, columns: Set<string>): void {
   const missingColumns = requiredColumns.filter((column) => !columns.has(column));
   if (missingColumns.length > 0) {
     throw new Error(`Memory backup table ${table} is missing required column(s): ${missingColumns.join(', ')}`);
+  }
+}
+
+function verifyDeletionGuardKeyLink(db: Database.Database, tables: Set<string>): void {
+  const deletionGuards = countRows(db, 'memory_deletion_guards', tables);
+  if (deletionGuards === 0) return;
+  const row = db
+    .prepare(`SELECT id FROM memory_deletion_hash_keys WHERE id = ? LIMIT 1`)
+    .get(DELETION_HASH_KEY_ID) as { id: string } | undefined;
+  if (!row) {
+    throw new Error(`Memory backup has deletion guards but is missing canonical deletion hash key ${DELETION_HASH_KEY_ID}`);
   }
 }
 
@@ -345,6 +379,12 @@ export function verifyMemoryBackup(path: string): MemoryBackupVerificationReport
     if (missingTables.length > 0) {
       throw new Error(`Memory backup is missing required table(s): ${missingTables.join(', ')}`);
     }
+    if (tables.has('memory_schema_versions')) {
+      const missingCurrentTables = CURRENT_SCHEMA_REQUIRED_TABLES.filter((table) => !tables.has(table));
+      if (missingCurrentTables.length > 0) {
+        throw new Error(`Current memory backup is missing required table(s): ${missingCurrentTables.join(', ')}`);
+      }
+    }
 
     const encryptedStores = readEncryptedStores(db, tables);
     for (const table of MEMORY_BACKUP_TABLES) {
@@ -363,6 +403,7 @@ export function verifyMemoryBackup(path: string): MemoryBackupVerificationReport
       }
       verifyPayloadColumns(db, table, columns, encryptedStores);
     }
+    verifyDeletionGuardKeyLink(db, tables);
 
     const stores = readSchemaStores(db, tables);
     return {

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -1,5 +1,25 @@
 import { readFile } from 'node:fs/promises';
+import Database from 'better-sqlite3';
 import { BrainSnapshotSchema, type BrainSnapshot, type EpisodicEvent } from '@franken/types';
+
+const CURRENT_MEMORY_SCHEMA_VERSION = 1;
+const REQUIRED_BACKUP_TABLES = [
+  'memory_schema_versions',
+  'working_memory',
+  'episodic_events',
+  'checkpoints',
+] as const;
+const MEMORY_BACKUP_TABLES = [
+  ...REQUIRED_BACKUP_TABLES,
+  'memory_deletion_guards',
+  'memory_deletion_hash_keys',
+] as const;
+const JSON_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
+  working_memory: ['value'],
+  episodic_events: ['details'],
+  checkpoints: ['state'],
+};
+const ENCRYPTED_MEMORY_PREFIX = 'enc:v1:';
 
 export interface SnapshotDiff<T = unknown> {
   readonly added: Record<string, T>;
@@ -31,10 +51,33 @@ export interface MemorySnapshotDiffReport {
   };
 }
 
+export interface MemoryBackupVerificationReport {
+  readonly ok: true;
+  readonly command: 'memory verify-backup';
+  readonly path: string;
+  readonly integrity: {
+    readonly integrityCheck: string;
+    readonly quickCheck: string;
+  };
+  readonly schema: {
+    readonly version: number;
+    readonly requiredTablesPresent: boolean;
+    readonly stores: Array<{ readonly store: string; readonly version: number; readonly recordCount: number }>;
+  };
+  readonly summary: {
+    readonly workingEntries: number;
+    readonly episodicEvents: number;
+    readonly checkpoints: number;
+    readonly deletionGuards: number;
+    readonly deletionHashKeys: number;
+  };
+}
+
 export interface MemoryCommandDeps {
-  readonly action: 'snapshot-diff' | undefined;
+  readonly action: 'snapshot-diff' | 'verify-backup' | undefined;
   readonly beforePath?: string | undefined;
   readonly afterPath?: string | undefined;
+  readonly backupPath?: string | undefined;
   readonly print: (message: string) => void;
 }
 
@@ -97,6 +140,69 @@ function indexEvents(events: EpisodicEvent[]): Record<string, EpisodicEvent> {
   return Object.fromEntries(events.map((event, index) => [eventDiffKey(event, index), event]));
 }
 
+function sqliteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/gu, '""')}"`;
+}
+
+function readSinglePragmaValue(db: Database.Database, pragma: string): string {
+  const row = db.prepare(`PRAGMA ${pragma}`).get() as Record<string, unknown> | undefined;
+  const value = row ? Object.values(row)[0] : undefined;
+  return typeof value === 'string' ? value : String(value ?? '');
+}
+
+function readTables(db: Database.Database): Set<string> {
+  const rows = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+function readTableColumns(db: Database.Database, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${sqliteIdentifier(table)})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+function countRows(db: Database.Database, table: string, tables: Set<string>): number {
+  if (!tables.has(table)) return 0;
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${sqliteIdentifier(table)}`).get() as { count: number };
+  return row.count;
+}
+
+function verifyJsonColumns(db: Database.Database, table: string, columns: Set<string>): void {
+  const jsonColumns = JSON_COLUMNS_BY_TABLE[table] ?? [];
+  for (const column of jsonColumns) {
+    if (!columns.has(column)) continue;
+    const rows = db
+      .prepare(`SELECT rowid AS rowid, ${sqliteIdentifier(column)} AS value FROM ${sqliteIdentifier(table)} WHERE ${sqliteIdentifier(column)} IS NOT NULL`)
+      .all() as Array<{ rowid: number; value: unknown }>;
+    for (const row of rows) {
+      if (typeof row.value !== 'string' || row.value.startsWith(ENCRYPTED_MEMORY_PREFIX)) continue;
+      try {
+        JSON.parse(row.value) as unknown;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Invalid JSON payload in ${table}.${column} row ${row.rowid}: ${message}`);
+      }
+    }
+  }
+}
+
+function readSchemaStores(db: Database.Database, tables: Set<string>): MemoryBackupVerificationReport['schema']['stores'] {
+  if (!tables.has('memory_schema_versions')) return [];
+  return (db
+    .prepare(`SELECT store, version FROM memory_schema_versions ORDER BY store ASC`)
+    .all() as Array<{ store: string; version: number }>).map((row) => {
+    if (row.version > CURRENT_MEMORY_SCHEMA_VERSION) {
+      throw new Error(
+        `Memory store ${row.store} uses schema version ${row.version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+      );
+    }
+    return {
+      store: row.store,
+      version: row.version,
+      recordCount: countRows(db, row.store, tables),
+    };
+  });
+}
+
 export function diffMemorySnapshots(
   beforePath: string,
   before: BrainSnapshot,
@@ -134,6 +240,74 @@ export function diffMemorySnapshots(
   };
 }
 
+export function verifyMemoryBackup(path: string): MemoryBackupVerificationReport {
+  let db: Database.Database;
+  try {
+    db = new Database(path, { readonly: true, fileMustExist: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to open memory backup ${path}: ${message}`);
+  }
+
+  try {
+    const integrityCheck = readSinglePragmaValue(db, 'integrity_check');
+    if (integrityCheck !== 'ok') {
+      throw new Error(`SQLite integrity_check failed: ${integrityCheck}`);
+    }
+    const quickCheck = readSinglePragmaValue(db, 'quick_check');
+    if (quickCheck !== 'ok') {
+      throw new Error(`SQLite quick_check failed: ${quickCheck}`);
+    }
+
+    const tables = readTables(db);
+    const missingTables = REQUIRED_BACKUP_TABLES.filter((table) => !tables.has(table));
+    if (missingTables.length > 0) {
+      throw new Error(`Memory backup is missing required table(s): ${missingTables.join(', ')}`);
+    }
+
+    for (const table of MEMORY_BACKUP_TABLES) {
+      if (!tables.has(table)) continue;
+      const columns = readTableColumns(db, table);
+      if (!columns.has('schema_version') && table !== 'memory_schema_versions') {
+        throw new Error(`Memory backup table ${table} is missing schema_version column`);
+      }
+      if (columns.has('schema_version')) {
+        const future = db
+          .prepare(`SELECT schema_version FROM ${sqliteIdentifier(table)} WHERE schema_version > ? LIMIT 1`)
+          .get(CURRENT_MEMORY_SCHEMA_VERSION) as { schema_version: number } | undefined;
+        if (future) {
+          throw new Error(
+            `Memory table ${table} contains record schema version ${future.schema_version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
+          );
+        }
+      }
+      verifyJsonColumns(db, table, columns);
+    }
+
+    const stores = readSchemaStores(db, tables);
+    return {
+      ok: true,
+      command: 'memory verify-backup',
+      path,
+      integrity: { integrityCheck, quickCheck },
+      schema: {
+        version: Math.max(...stores.map((store) => store.version), CURRENT_MEMORY_SCHEMA_VERSION),
+        requiredTablesPresent: true,
+        stores,
+      },
+      summary: {
+        workingEntries: countRows(db, 'working_memory', tables),
+        episodicEvents: countRows(db, 'episodic_events', tables),
+        checkpoints: countRows(db, 'checkpoints', tables),
+        deletionGuards: countRows(db, 'memory_deletion_guards', tables),
+        deletionHashKeys: countRows(db, 'memory_deletion_hash_keys', tables),
+      },
+    };
+  } finally {
+    db.close();
+  }
+}
+
 async function readSnapshot(path: string): Promise<BrainSnapshot> {
   let parsed: unknown;
   try {
@@ -151,9 +325,16 @@ async function readSnapshot(path: string): Promise<BrainSnapshot> {
 }
 
 export async function handleMemoryCommand(deps: MemoryCommandDeps): Promise<void> {
-  const { action, beforePath, afterPath, print } = deps;
+  const { action, beforePath, afterPath, backupPath, print } = deps;
+  if (action === 'verify-backup') {
+    if (!backupPath) {
+      throw new Error('memory verify-backup requires one SQLite backup file: <backup.sqlite>');
+    }
+    print(JSON.stringify(verifyMemoryBackup(backupPath), null, 2));
+    return;
+  }
   if (action !== 'snapshot-diff') {
-    throw new Error('Usage: frankenbeast memory snapshot-diff <before-snapshot.json> <after-snapshot.json>');
+    throw new Error('Usage: frankenbeast memory snapshot-diff <before-snapshot.json> <after-snapshot.json> OR frankenbeast memory verify-backup <backup.sqlite>');
   }
   if (!beforePath || !afterPath) {
     throw new Error('memory snapshot-diff requires two BrainSnapshot JSON files: <before> <after>');

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -15,9 +15,14 @@ const MEMORY_BACKUP_TABLES = [
   'memory_deletion_hash_keys',
 ] as const;
 const JSON_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
-  working_memory: ['value'],
   episodic_events: ['details'],
   checkpoints: ['state'],
+};
+const ENCRYPTED_PAYLOAD_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
+  working_memory: ['value'],
+  episodic_events: ['summary', 'details'],
+  checkpoints: ['state'],
+  memory_deletion_hash_keys: ['key_material'],
 };
 const REQUIRED_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
   working_memory: ['key', 'value', 'updated_at'],
@@ -177,16 +182,23 @@ function countRows(db: Database.Database, table: string, tables: Set<string>): n
 function readEncryptedStores(db: Database.Database, tables: Set<string>): Set<string> {
   if (!tables.has('memory_encryption_status')) return new Set();
   const columns = readTableColumns(db, 'memory_encryption_status');
-  const missingColumns = ['store', 'encrypted'].filter((column) => !columns.has(column));
+  const missingColumns = ['store', 'encrypted', 'verifier'].filter((column) => !columns.has(column));
   if (missingColumns.length > 0) {
     throw new Error(`Memory backup table memory_encryption_status is missing required column(s): ${missingColumns.join(', ')}`);
   }
   const rows = db
-    .prepare(`SELECT store, encrypted FROM memory_encryption_status WHERE encrypted = 1`)
-    .all() as Array<{ store: string; encrypted: number }>;
-  return new Set(rows.map((row) => row.store));
+    .prepare(`SELECT store, encrypted, verifier FROM memory_encryption_status WHERE encrypted = 1`)
+    .all() as Array<{ store: string; encrypted: number; verifier: string | null }>;
+  const stores = new Set<string>();
+  for (const row of rows) {
+    if (!row.verifier) {
+      throw new Error(`Encrypted memory store ${row.store} is missing verifier metadata`);
+    }
+    validateEncryptedPayload('memory_encryption_status', 'verifier', 0, row.verifier);
+    stores.add(row.store);
+  }
+  return stores;
 }
-
 function validateEncryptedPayload(table: string, column: string, rowid: number, value: string): void {
   const parts = value.slice(ENCRYPTED_MEMORY_PREFIX.length).split(':');
   if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
@@ -194,30 +206,49 @@ function validateEncryptedPayload(table: string, column: string, rowid: number, 
   }
 }
 
-function verifyJsonColumns(db: Database.Database, table: string, columns: Set<string>, encryptedStores: Set<string>): void {
-  const jsonColumns = JSON_COLUMNS_BY_TABLE[table] ?? [];
-  for (const column of jsonColumns) {
-    if (!columns.has(column)) continue;
-    const rows = db
-      .prepare(`SELECT rowid AS rowid, ${sqliteIdentifier(column)} AS value FROM ${sqliteIdentifier(table)} WHERE ${sqliteIdentifier(column)} IS NOT NULL`)
-      .all() as Array<{ rowid: number; value: unknown }>;
-    for (const row of rows) {
-      if (typeof row.value !== 'string') continue;
-      if (row.value.startsWith(ENCRYPTED_MEMORY_PREFIX)) {
-        if (!encryptedStores.has(table)) {
-          throw new Error(`Unexpected encrypted payload marker in plaintext ${table}.${column} row ${row.rowid}`);
-        }
-        validateEncryptedPayload(table, column, row.rowid, row.value);
-        continue;
+function verifyPayloadColumn(
+  db: Database.Database,
+  table: string,
+  column: string,
+  encryptedStores: Set<string>,
+  options: { readonly requireJsonWhenPlaintext: boolean },
+): void {
+  const encryptedStore = encryptedStores.has(table);
+  const rows = db
+    .prepare(`SELECT rowid AS rowid, ${sqliteIdentifier(column)} AS value FROM ${sqliteIdentifier(table)} WHERE ${sqliteIdentifier(column)} IS NOT NULL`)
+    .iterate() as Iterable<{ rowid: number; value: unknown }>;
+  for (const row of rows) {
+    if (typeof row.value !== 'string') continue;
+    if (row.value.startsWith(ENCRYPTED_MEMORY_PREFIX)) {
+      if (!encryptedStore) {
+        throw new Error(`Unexpected encrypted payload marker in plaintext ${table}.${column} row ${row.rowid}`);
       }
-      if (table === 'working_memory' && column === 'value') continue;
-      try {
-        JSON.parse(row.value) as unknown;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Invalid JSON payload in ${table}.${column} row ${row.rowid}: ${message}`);
-      }
+      validateEncryptedPayload(table, column, row.rowid, row.value);
+      continue;
     }
+    if (encryptedStore) {
+      throw new Error(`Plaintext payload in encrypted memory store ${table}.${column} row ${row.rowid}`);
+    }
+    if (!options.requireJsonWhenPlaintext) continue;
+    try {
+      JSON.parse(row.value) as unknown;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid JSON payload in ${table}.${column} row ${row.rowid}: ${message}`);
+    }
+  }
+}
+
+function verifyPayloadColumns(db: Database.Database, table: string, columns: Set<string>, encryptedStores: Set<string>): void {
+  const payloadColumns = new Set([
+    ...(JSON_COLUMNS_BY_TABLE[table] ?? []),
+    ...(ENCRYPTED_PAYLOAD_COLUMNS_BY_TABLE[table] ?? []),
+  ]);
+  for (const column of payloadColumns) {
+    if (!columns.has(column)) continue;
+    verifyPayloadColumn(db, table, column, encryptedStores, {
+      requireJsonWhenPlaintext: (JSON_COLUMNS_BY_TABLE[table] ?? []).includes(column),
+    });
   }
 }
 
@@ -330,7 +361,7 @@ export function verifyMemoryBackup(path: string): MemoryBackupVerificationReport
           );
         }
       }
-      verifyJsonColumns(db, table, columns, encryptedStores);
+      verifyPayloadColumns(db, table, columns, encryptedStores);
     }
 
     const stores = readSchemaStores(db, tables);

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1271,6 +1271,7 @@ export async function main(): Promise<void> {
         action: args.memoryAction,
         beforePath: args.memorySnapshotBefore,
         afterPath: args.memorySnapshotAfter,
+        backupPath: args.memoryBackupPath,
         print: printLine,
       });
     } catch (err) {

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import { SqliteBrain } from '@franken/brain';
 import type { BrainSnapshot } from '@franken/types';
 import { parseArgs } from '../../../src/cli/args.js';
-import { diffMemorySnapshots, handleMemoryCommand } from '../../../src/cli/memory-snapshot-diff.js';
+import { diffMemorySnapshots, handleMemoryCommand, verifyMemoryBackup } from '../../../src/cli/memory-snapshot-diff.js';
 
 const baseSnapshot: BrainSnapshot = {
   version: 1,
@@ -48,6 +50,20 @@ describe('memory snapshot-diff CLI args', () => {
 
   it('rejects unknown memory actions explicitly', () => {
     expect(() => parseArgs(['memory', 'unknown'])).toThrow(/Unknown memory action: unknown/);
+  });
+
+  it('parses the memory verify-backup command and backup path', () => {
+    const args = parseArgs(['memory', 'verify-backup', 'memory-backup.sqlite']);
+
+    expect(args.subcommand).toBe('memory');
+    expect(args.memoryAction).toBe('verify-backup');
+    expect(args.memoryBackupPath).toBe('memory-backup.sqlite');
+  });
+
+  it('rejects extra verify-backup positionals with actionable guidance', () => {
+    expect(() => parseArgs(['memory', 'verify-backup', 'backup.sqlite', 'extra'])).toThrow(
+      /memory verify-backup accepts exactly one backup file/,
+    );
   });
 });
 
@@ -150,5 +166,57 @@ describe('handleMemoryCommand', () => {
       afterPath,
       print: () => undefined,
     })).rejects.toThrow(/Invalid memory snapshot/);
+  });
+
+  it('prints structured JSON for a valid read-only SQLite memory backup', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-'));
+    const dbPath = join(dir, 'memory.sqlite');
+    const backupPath = join(dir, 'memory-backup.sqlite');
+    const brain = new SqliteBrain(dbPath);
+    brain.working.set('operator', { name: 'beast' });
+    brain.episodic.record({
+      type: 'observation',
+      summary: 'backup verification fixture',
+      createdAt: '2026-07-11T00:00:00.000Z',
+    });
+    brain.recovery.checkpoint({
+      runId: 'run-verify-backup',
+      phase: 'backup',
+      step: 1,
+      context: { fixture: true },
+      timestamp: '2026-07-11T00:00:01.000Z',
+    });
+    brain.flush();
+    brain.close();
+
+    const liveDb = new Database(dbPath);
+    liveDb.exec(`VACUUM INTO '${backupPath.replace(/'/gu, "''")}'`);
+    liveDb.close();
+
+    const printed: string[] = [];
+    await handleMemoryCommand({
+      action: 'verify-backup',
+      backupPath,
+      print: (message) => printed.push(message),
+    });
+
+    expect(printed).toHaveLength(1);
+    expect(JSON.parse(printed[0]!)).toMatchObject({
+      ok: true,
+      command: 'memory verify-backup',
+      integrity: { integrityCheck: 'ok', quickCheck: 'ok' },
+      schema: { requiredTablesPresent: true },
+      summary: { workingEntries: 1, episodicEvents: 1, checkpoints: 1 },
+    });
+  });
+
+  it('fails explicitly when a backup is missing required memory tables', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-invalid-'));
+    const backupPath = join(dir, 'partial.sqlite');
+    const db = new Database(backupPath);
+    db.exec('CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL, schema_version INTEGER NOT NULL DEFAULT 1)');
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/missing required table\(s\): memory_schema_versions, episodic_events, checkpoints/);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -38,6 +38,8 @@ const baseSnapshot: BrainSnapshot = {
   },
 };
 
+const VALID_CHECKPOINT_STATE_SQL = '{"runId":"run-1","phase":"execute","step":1,"context":{},"timestamp":"2026-07-11T00:00:02.000Z"}';
+
 describe('memory snapshot-diff CLI args', () => {
   it('parses the memory snapshot-diff command and snapshot paths', () => {
     const args = parseArgs(['memory', 'snapshot-diff', 'before.json', 'after.json']);
@@ -220,7 +222,7 @@ describe('handleMemoryCommand', () => {
       CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
       INSERT INTO working_memory (key, value, updated_at) VALUES ('legacy', 'plaintext', '2026-07-11T00:00:00.000Z');
       INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'legacy event', '{"source":"legacy"}', '2026-07-11T00:00:01.000Z');
-      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('${VALID_CHECKPOINT_STATE_SQL}', '2026-07-11T00:00:02.000Z');
     `);
     db.close();
 
@@ -247,7 +249,7 @@ describe('handleMemoryCommand', () => {
       CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
       CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
       INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'bad marker', 'enc:v1:not-really-json', '2026-07-11T00:00:01.000Z');
-      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('${VALID_CHECKPOINT_STATE_SQL}', '2026-07-11T00:00:02.000Z');
     `);
     db.close();
 
@@ -328,7 +330,7 @@ describe('handleMemoryCommand', () => {
       CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
       INSERT INTO memory_encryption_status (store, encrypted, algorithm, verifier, updated_at) VALUES ('episodic_events', 1, 'aes-256-gcm', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:00.000Z');
       INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'plaintext summary', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:01.000Z');
-      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('${VALID_CHECKPOINT_STATE_SQL}', '2026-07-11T00:00:02.000Z');
     `);
     db.close();
 
@@ -345,12 +347,95 @@ describe('handleMemoryCommand', () => {
       CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
       CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
       INSERT INTO memory_encryption_status (store, encrypted, algorithm, verifier, updated_at) VALUES ('working_memory', 1, 'aes-256-gcm', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:00.000Z');
-      INSERT INTO working_memory (key, value, updated_at) VALUES ('mixed', '{"ok":true}', '2026-07-11T00:00:01.000Z');
-      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+      INSERT INTO working_memory (key, value, updated_at) VALUES ('mixed', '${VALID_CHECKPOINT_STATE_SQL}', '2026-07-11T00:00:01.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('${VALID_CHECKPOINT_STATE_SQL}', '2026-07-11T00:00:02.000Z');
     `);
     db.close();
 
     expect(() => verifyMemoryBackup(backupPath)).toThrow(/Plaintext payload in encrypted memory store working_memory\.value/);
+  });
+
+  it('rejects non-text JSON payload columns', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-blob-payload-'));
+    const backupPath = join(dir, 'blob-payload.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      INSERT INTO checkpoints (state, created_at) VALUES (X'010203', '2026-07-11T00:00:02.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Non-text payload in checkpoints\.state/);
+  });
+
+  it('rejects malformed encryption verifier markers', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-verifier-marker-'));
+    const backupPath = join(dir, 'verifier-marker.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
+      INSERT INTO memory_encryption_status VALUES ('working_memory', 1, 'aes-256-gcm', 'xxxxxxxiv:tag:ciphertext', '2026-07-11T00:00:00.000Z');
+      INSERT INTO working_memory (key, value, updated_at) VALUES ('secret', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:01.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/missing enc:v1: marker/);
+  });
+
+  it('requires current-schema deletion guard tables when schema metadata exists', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-current-tables-'));
+    const backupPath = join(dir, 'current-missing-deletion.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_schema_versions (store TEXT PRIMARY KEY, version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+      INSERT INTO memory_schema_versions VALUES ('working_memory', 1, '2026-07-11T00:00:00.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Current memory backup is missing required table\(s\): memory_deletion_guards, memory_deletion_hash_keys/);
+  });
+
+  it('validates checkpoint state shape', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-checkpoint-shape-'));
+    const backupPath = join(dir, 'bad-checkpoint.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Invalid checkpoint state/);
+  });
+
+  it('requires canonical deletion hash key when deletion guards exist', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-deletion-key-'));
+    const backupPath = join(dir, 'missing-canonical-key.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_schema_versions (store TEXT PRIMARY KEY, version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+      CREATE TABLE memory_deletion_guards (selector_hash TEXT NOT NULL, guard_kind TEXT NOT NULL, value_hash TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_deletion_hash_keys (id TEXT PRIMARY KEY, key_material TEXT NOT NULL, created_at TEXT NOT NULL);
+      INSERT INTO memory_schema_versions VALUES ('working_memory', 1, '2026-07-11T00:00:00.000Z');
+      INSERT INTO memory_deletion_guards VALUES ('selector', 'working-key', 'value', '2026-07-11T00:00:01.000Z');
+      INSERT INTO memory_deletion_hash_keys VALUES ('other-key', 'material', '2026-07-11T00:00:01.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/missing canonical deletion hash key right-to-forget-hmac-v1/);
   });
 
   it('fails explicitly when a backup is missing required memory tables', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -254,6 +254,39 @@ describe('handleMemoryCommand', () => {
     expect(() => verifyMemoryBackup(backupPath)).toThrow(/Unexpected encrypted payload marker in plaintext episodic_events\.details/);
   });
 
+  it('rejects plaintext payloads in stores marked encrypted', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-encrypted-plaintext-'));
+    const backupPath = join(dir, 'encrypted-plaintext.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
+      INSERT INTO memory_encryption_status VALUES ('episodic_events', 1, 'aes-256-gcm', 'enc:v1:nonce:tag:ciphertext', '2026-07-11T00:00:00.000Z');
+      INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'plaintext summary', 'enc:v1:nonce:tag:ciphertext', '2026-07-11T00:00:01.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Plaintext payload in encrypted memory store episodic_events\.summary/);
+  });
+
+  it('requires verifier metadata for encrypted memory stores', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-missing-verifier-'));
+    const backupPath = join(dir, 'missing-verifier.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
+      INSERT INTO memory_encryption_status VALUES ('working_memory', 1, 'aes-256-gcm', NULL, '2026-07-11T00:00:00.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Encrypted memory store working_memory is missing verifier metadata/);
+  });
+
   it('validates required columns before reporting a backup as valid', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-columns-'));
     const backupPath = join(dir, 'malformed.sqlite');
@@ -266,6 +299,58 @@ describe('handleMemoryCommand', () => {
     db.close();
 
     expect(() => verifyMemoryBackup(backupPath)).toThrow(/working_memory is missing required column\(s\): value/);
+  });
+
+  it('rejects encrypted stores without verifier metadata', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-missing-verifier-'));
+    const backupPath = join(dir, 'missing-verifier.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
+      INSERT INTO memory_encryption_status (store, encrypted, algorithm, verifier, updated_at) VALUES ('working_memory', 1, 'aes-256-gcm', NULL, '2026-07-11T00:00:00.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/working_memory is missing verifier metadata/);
+  });
+
+  it('validates encrypted episodic summaries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-encrypted-summary-'));
+    const backupPath = join(dir, 'encrypted-summary.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
+      INSERT INTO memory_encryption_status (store, encrypted, algorithm, verifier, updated_at) VALUES ('episodic_events', 1, 'aes-256-gcm', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:00.000Z');
+      INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'plaintext summary', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:01.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Plaintext payload in encrypted memory store episodic_events\.summary/);
+  });
+
+  it('rejects plaintext rows in encrypted stores', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-mixed-encryption-'));
+    const backupPath = join(dir, 'mixed-encryption.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      CREATE TABLE memory_encryption_status (store TEXT PRIMARY KEY, encrypted INTEGER NOT NULL, algorithm TEXT, verifier TEXT, updated_at TEXT NOT NULL);
+      INSERT INTO memory_encryption_status (store, encrypted, algorithm, verifier, updated_at) VALUES ('working_memory', 1, 'aes-256-gcm', 'enc:v1:iv:tag:ciphertext', '2026-07-11T00:00:00.000Z');
+      INSERT INTO working_memory (key, value, updated_at) VALUES ('mixed', '{"ok":true}', '2026-07-11T00:00:01.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Plaintext payload in encrypted memory store working_memory\.value/);
   });
 
   it('fails explicitly when a backup is missing required memory tables', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -210,6 +210,64 @@ describe('handleMemoryCommand', () => {
     });
   });
 
+  it('accepts legacy pre-migration backups without schema metadata or row versions', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-legacy-'));
+    const backupPath = join(dir, 'legacy.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      INSERT INTO working_memory (key, value, updated_at) VALUES ('legacy', 'plaintext', '2026-07-11T00:00:00.000Z');
+      INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'legacy event', '{"source":"legacy"}', '2026-07-11T00:00:01.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+    `);
+    db.close();
+
+    expect(verifyMemoryBackup(backupPath)).toMatchObject({
+      schema: {
+        version: 1,
+        requiredTablesPresent: true,
+        stores: [
+          { store: 'working_memory', version: 0, recordCount: 1 },
+          { store: 'episodic_events', version: 0, recordCount: 1 },
+          { store: 'checkpoints', version: 0, recordCount: 1 },
+        ],
+      },
+      summary: { workingEntries: 1, episodicEvents: 1, checkpoints: 1 },
+    });
+  });
+
+  it('rejects encrypted-looking plaintext JSON payloads unless metadata marks the store encrypted', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-encryption-marker-'));
+    const backupPath = join(dir, 'marker.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+      INSERT INTO episodic_events (type, step, summary, details, created_at) VALUES ('observation', NULL, 'bad marker', 'enc:v1:not-really-json', '2026-07-11T00:00:01.000Z');
+      INSERT INTO checkpoints (state, created_at) VALUES ('{"ok":true}', '2026-07-11T00:00:02.000Z');
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/Unexpected encrypted payload marker in plaintext episodic_events\.details/);
+  });
+
+  it('validates required columns before reporting a backup as valid', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-columns-'));
+    const backupPath = join(dir, 'malformed.sqlite');
+    const db = new Database(backupPath);
+    db.exec(`
+      CREATE TABLE working_memory (key TEXT PRIMARY KEY, updated_at TEXT NOT NULL);
+      CREATE TABLE episodic_events (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, step TEXT, summary TEXT NOT NULL, details TEXT, embedding BLOB, created_at TEXT NOT NULL);
+      CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+    `);
+    db.close();
+
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/working_memory is missing required column\(s\): value/);
+  });
+
   it('fails explicitly when a backup is missing required memory tables', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'memory-backup-verify-invalid-'));
     const backupPath = join(dir, 'partial.sqlite');
@@ -217,6 +275,6 @@ describe('handleMemoryCommand', () => {
     db.exec('CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL, schema_version INTEGER NOT NULL DEFAULT 1)');
     db.close();
 
-    expect(() => verifyMemoryBackup(backupPath)).toThrow(/missing required table\(s\): memory_schema_versions, episodic_events, checkpoints/);
+    expect(() => verifyMemoryBackup(backupPath)).toThrow(/missing required table\(s\): episodic_events, checkpoints/);
   });
 });


### PR DESCRIPTION
## Summary
- Add `frankenbeast memory verify-backup <backup.sqlite>` to validate SQLite memory-store backups read-only.
- Report structured JSON for integrity checks, schema/store metadata, and memory table counts.
- Cover valid backup output, argument parsing/help, and explicit missing-table failure behavior.

## Verification
- `npm ci`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/planner`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm test --workspace @franken/orchestrator -- tests/unit/cli/memory-snapshot-diff.test.ts`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- Built CLI smoke: `node packages/franken-orchestrator/dist/cli/run.js memory verify-backup <backup.sqlite>`

Closes #1835
