### PR TITLE
feat(dr): block Kanban card resurrection

### DIFF
--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -14,3 +14,16 @@ Expected interpretation:
 - recovery guidance: review the cron drift and explicitly restore, merge, or skip the job; do not silently drop it and do not overwrite live schedules blindly.
 
 This fixture is covered by `packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts` so future restore-preview changes keep missing cron jobs visible in deterministic test output.
+
+## Kanban card resurrection guardrails
+
+Backup-only task records are treated as `blocker` conflicts. A backup-only task means the backup manifest contains a Kanban card that live state no longer has, so blindly restoring it could resurrect deleted, completed, reassigned, or otherwise intentionally removed work.
+
+Expected interpretation:
+
+- `area`: `tasks`
+- `type`: `backup-only`
+- `severity`: `blocker`
+- recovery guidance: do not automatically resurrect the card; confirm why the live card is absent, then explicitly recreate a new card or skip that backup record.
+
+This guardrail keeps restore-preview output consumable by PM/liveness tooling: backup-only cards require an explicit operator decision instead of being presented as safe informational drift.

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -123,7 +123,7 @@ function compareRecords(
         area,
         id,
         type: 'backup-only',
-        severity: area === 'approvals' ? 'blocker' : 'info',
+        severity: severityForBackupOnly(area),
         backup,
         recommendation: recommendationFor(area, 'backup-only'),
       });
@@ -193,6 +193,11 @@ function liveIsNewer(backup: RestorePreviewRecord, live: RestorePreviewRecord): 
   return Number.isFinite(backupTime) && Number.isFinite(liveTime) && liveTime > backupTime;
 }
 
+function severityForBackupOnly(area: ComparableArea): RestorePreviewSeverity {
+  if (area === 'approvals' || area === 'tasks') return 'blocker';
+  return 'info';
+}
+
 function severityFor(area: ComparableArea, type: RestorePreviewConflictType): RestorePreviewSeverity {
   if (area === 'approvals') return 'blocker';
   if (type === 'newer-live') return 'warning';
@@ -202,11 +207,13 @@ function severityFor(area: ComparableArea, type: RestorePreviewConflictType): Re
 function recommendationFor(area: ComparableArea, type: RestorePreviewConflictType): string {
   switch (area) {
     case 'tasks':
-      return type === 'newer-live'
-        ? 'Review and merge task/card changes or restore only selected stale fields; do not overwrite newer live task state blindly.'
-        : type === 'live-only'
-          ? 'preserve the live task/card unless the operator explicitly chooses to delete or archive it during restore.'
-          : 'Review task/card delta and choose overwrite, merge, or skip for this item.';
+      return type === 'backup-only'
+        ? 'Do not resurrect a backup-only Kanban card automatically. Confirm whether the live card was deleted, completed, or reassigned, then explicitly recreate a new card or skip this backup record.'
+        : type === 'newer-live'
+          ? 'Review and merge task/card changes or restore only selected stale fields; do not overwrite newer live task state blindly.'
+          : type === 'live-only'
+            ? 'preserve the live task/card unless the operator explicitly chooses to delete or archive it during restore.'
+            : 'Review task/card delta and choose overwrite, merge, or skip for this item.';
     case 'approvals':
       return 'Skip approval token restore and require re-approval so stale or changed approval state cannot authorize live actions.';
     case 'memory':

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -116,6 +116,37 @@ describe('restore preview conflict detector', () => {
     );
   });
 
+  it('blocks backup-only Kanban cards so restore cannot resurrect deleted live work silently', () => {
+    const preview = detectRestorePreviewConflicts(
+      {
+        schemaVersion: 1,
+        tasks: [
+          {
+            id: 't_deleted_live',
+            state: 'running',
+            digest: 'stale-card-body',
+            updatedAt: '2026-07-14T09:00:00.000Z',
+          },
+        ],
+        approvals: [],
+        memory: [],
+        cron: [],
+      },
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+    );
+
+    expect(preview.safeToRestore).toBe(false);
+    expect(preview.conflicts).toContainEqual(
+      expect.objectContaining({
+        area: 'tasks',
+        id: 't_deleted_live',
+        type: 'backup-only',
+        severity: 'blocker',
+        recommendation: expect.stringContaining('Do not resurrect'),
+      }),
+    );
+  });
+
   it('loads the missing cron job recovery fixture as an explicit backup-only cron conflict', () => {
     const fixture = readMissingCronJobRecoveryFixture();
     const preview = detectRestorePreviewConflicts(fixture.backup, fixture.live);


### PR DESCRIPTION
## Summary
- Treat backup-only Kanban task records as blocker restore-preview conflicts so disaster recovery cannot silently resurrect deleted/completed/reassigned cards.
- Add targeted restore-preview coverage for the guardrail.
- Document how operators/PM tooling should interpret backup-only task conflicts.

## Verification
- `npm ci`
- `npm run build --workspace @franken/types && npm run build --workspace @franken/observer && npm run build --workspace @franken/brain && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run build --workspace @franken/planner`
- `npm run test -- --run tests/unit/dr/restore-preview.test.ts` (from `packages/franken-orchestrator`)
- `npm run typecheck` (from `packages/franken-orchestrator`)
- `npm run lint` (from `packages/franken-orchestrator`; existing warnings only, 0 errors)
- `npm run build` (from `packages/franken-orchestrator`)

Closes #1834
