### PR TITLE
feat(dr): add approval ledger recovery report

### DIFF
--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -48,6 +48,38 @@ Interpretation guidance:
 
 Tests cover verified metadata, missing metadata, malformed runtime-loaded metadata, unsupported algorithms, and missing restore-critical references so future DR changes keep the report machine-readable and actionable.
 
+## Approval ledger recovery report
+
+`buildApprovalLedgerRecoveryReport(backupManifest, liveManifest, options)` is the dedicated approval-ledger recovery tool. It is read-only, deterministic, and returns structured output for operators and PM/liveness automation:
+
+- `status`: `clean`, `review-required`, or `blocked`
+- `wouldWrite`: always `false`
+- `safeToApplyAutomatically`: always `false`; approval recovery must not silently replay tokens
+- `findings`: machine-readable records keyed by approval id and finding code
+- `operatorSummary`: a concise handoff for the restore operator
+
+The report intentionally redacts approval token material. It summarizes only whether a digest is present plus safe metadata such as approval `state` and `updatedAt`.
+
+Interpretation guidance:
+
+- `clean`: backup and live approval ledger records match. The report is still read-only and should be attached to the restore evidence bundle.
+- `review-required`: live-only approval entries exist. Preserve live approval evidence unless an operator explicitly expires it; never let a backup delete live approvals silently.
+- `blocked`: backup-only, changed, newer-live, or schema-mismatched approval records exist. Quarantine the backup approval entry and require fresh human re-approval before any action can reuse that authorization.
+
+Example finding:
+
+```json
+{
+  "code": "approval-backup-only",
+  "approvalId": "approval-stale",
+  "severity": "blocker",
+  "backup": { "state": "approved", "digestPresent": true },
+  "recommendation": "Quarantine this backup approval entry and require a fresh human re-approval before any action can reuse the approval."
+}
+```
+
+Tests cover clean approval ledgers, backup-only stale tokens, changed/newer-live ledgers, live-only warnings, and token redaction so disaster-recovery tooling remains safe for automated handoffs.
+
 ## Kanban card resurrection guardrails
 
 Backup-only task records are treated as `blocker` conflicts. A backup-only task means the backup manifest contains a Kanban card that live state no longer has, so blindly restoring it could resurrect deleted, completed, reassigned, or otherwise intentionally removed work.

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -42,6 +42,48 @@ export interface BackupEncryptionVerificationOptions {
   readonly allowedAlgorithms?: readonly string[];
 }
 
+export type ApprovalLedgerRecoveryStatus = 'clean' | 'review-required' | 'blocked';
+
+export type ApprovalLedgerRecoverySeverity = 'info' | 'warning' | 'blocker';
+
+export type ApprovalLedgerRecoveryFindingCode =
+  | 'schema-mismatch'
+  | 'approval-backup-only'
+  | 'approval-live-only'
+  | 'approval-changed'
+  | 'approval-newer-live';
+
+export interface ApprovalLedgerRecordSummary {
+  readonly state?: string;
+  readonly digestPresent: boolean;
+  readonly updatedAt?: string;
+}
+
+export interface ApprovalLedgerRecoveryFinding {
+  readonly code: ApprovalLedgerRecoveryFindingCode;
+  readonly approvalId: string;
+  readonly severity: ApprovalLedgerRecoverySeverity;
+  readonly message: string;
+  readonly recommendation: string;
+  readonly backup?: ApprovalLedgerRecordSummary;
+  readonly live?: ApprovalLedgerRecordSummary;
+}
+
+export interface ApprovalLedgerRecoveryReport {
+  /** ISO timestamp for when the report was generated, supplied by callers for deterministic tests. */
+  readonly checkedAt: string;
+  /** Explicitly records that approval-ledger recovery planning is read-only and performs no restore writes. */
+  readonly wouldWrite: false;
+  readonly status: ApprovalLedgerRecoveryStatus;
+  readonly safeToApplyAutomatically: false;
+  readonly findings: readonly ApprovalLedgerRecoveryFinding[];
+  readonly operatorSummary: string;
+}
+
+export interface ApprovalLedgerRecoveryOptions {
+  readonly checkedAt?: string;
+}
+
 export type RestorePreviewConflictType =
   | 'schema-mismatch'
   | 'changed'
@@ -184,6 +226,43 @@ export function buildBackupEncryptionVerificationReport(
   };
 }
 
+export function buildApprovalLedgerRecoveryReport(
+  backup: RestorePreviewManifest,
+  live: RestorePreviewManifest,
+  options: ApprovalLedgerRecoveryOptions = {},
+): ApprovalLedgerRecoveryReport {
+  const checkedAt = options.checkedAt ?? new Date().toISOString();
+  const preview = detectRestorePreviewConflicts(backup, live);
+  const findings: ApprovalLedgerRecoveryFinding[] = [];
+
+  if (!preview.schema.compatible) {
+    findings.push({
+      code: 'schema-mismatch',
+      approvalId: 'schema-version',
+      severity: 'blocker',
+      message: `Backup schema version ${preview.schema.backupVersion} does not match live schema version ${preview.schema.liveVersion}.`,
+      recommendation:
+        'Do not recover approval ledger entries until the backup has been migrated to the live schema version or the restore is run against a compatible live store.',
+    });
+  }
+
+  for (const conflict of preview.conflicts) {
+    if (conflict.area !== 'approvals') continue;
+    findings.push(findingForApprovalConflict(conflict));
+  }
+
+  const status = statusForApprovalLedgerFindings(findings);
+
+  return {
+    checkedAt,
+    wouldWrite: false,
+    status,
+    safeToApplyAutomatically: false,
+    findings,
+    operatorSummary: operatorSummaryForApprovalLedgerReport(status, findings.length),
+  };
+}
+
 export function detectRestorePreviewConflicts(
   backup: RestorePreviewManifest,
   live: RestorePreviewManifest,
@@ -228,6 +307,77 @@ function statusForEncryptionFindings(
   return 'verified';
 }
 
+function findingForApprovalConflict(conflict: RestorePreviewConflict): ApprovalLedgerRecoveryFinding {
+  const backup = summarizeApprovalRecord(conflict.backup);
+  const live = summarizeApprovalRecord(conflict.live);
+
+  switch (conflict.type) {
+    case 'backup-only':
+      return {
+        code: 'approval-backup-only',
+        approvalId: conflict.id,
+        severity: 'blocker',
+        message: 'Backup contains an approval ledger entry that is absent from live state.',
+        recommendation:
+          'Quarantine this backup approval entry and require a fresh human re-approval before any action can reuse the approval.',
+        ...(backup === undefined ? {} : { backup }),
+      };
+    case 'live-only':
+      return {
+        code: 'approval-live-only',
+        approvalId: conflict.id,
+        severity: 'warning',
+        message: 'Live state contains an approval ledger entry that is absent from the backup.',
+        recommendation:
+          'Preserve the live approval ledger entry during recovery unless an operator explicitly expires it; do not let the backup delete live approval evidence silently.',
+        ...(live === undefined ? {} : { live }),
+      };
+    case 'newer-live':
+      return {
+        code: 'approval-newer-live',
+        approvalId: conflict.id,
+        severity: 'blocker',
+        message: 'Live approval ledger state is newer than the backup copy.',
+        recommendation:
+          'Preserve the live approval state and require fresh re-approval for any action whose approval evidence differs from the backup.',
+        ...(backup === undefined ? {} : { backup }),
+        ...(live === undefined ? {} : { live }),
+      };
+    case 'changed':
+    default:
+      return {
+        code: 'approval-changed',
+        approvalId: conflict.id,
+        severity: 'blocker',
+        message: 'Backup and live approval ledger entries differ.',
+        recommendation:
+          'Do not merge or replay this approval token automatically; require fresh re-approval and keep both ledger snapshots for audit review.',
+        ...(backup === undefined ? {} : { backup }),
+        ...(live === undefined ? {} : { live }),
+      };
+  }
+}
+
+function summarizeApprovalRecord(
+  record: RestorePreviewConflict['backup'] | RestorePreviewConflict['live'],
+): ApprovalLedgerRecordSummary | undefined {
+  if (!isRecord(record) || 'schemaVersion' in record) return undefined;
+  const summarySource = record as Record<string, unknown>;
+  return {
+    ...(typeof summarySource.state === 'string' ? { state: summarySource.state } : {}),
+    digestPresent: typeof summarySource.digest === 'string' && summarySource.digest.length > 0,
+    ...(typeof summarySource.updatedAt === 'string' ? { updatedAt: summarySource.updatedAt } : {}),
+  };
+}
+
+function statusForApprovalLedgerFindings(
+  findings: readonly ApprovalLedgerRecoveryFinding[],
+): ApprovalLedgerRecoveryStatus {
+  if (findings.some((finding) => finding.severity === 'blocker')) return 'blocked';
+  if (findings.length > 0) return 'review-required';
+  return 'clean';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -243,6 +393,15 @@ function operatorSummaryForEncryptionReport(
   if (status === 'verified') return 'Backup encryption is verified; no encryption blockers or warnings were found.';
   if (status === 'warning') return `Backup encryption is present but has ${findingCount} warning(s) requiring operator review.`;
   return `Backup encryption verification failed with ${findingCount} blocker/warning finding(s); do not restore blindly.`;
+}
+
+function operatorSummaryForApprovalLedgerReport(
+  status: ApprovalLedgerRecoveryStatus,
+  findingCount: number,
+): string {
+  if (status === 'clean') return 'Approval ledger recovery check is clean; no approval ledger drift was found.';
+  if (status === 'review-required') return `Approval ledger recovery found ${findingCount} warning(s); preserve live approval evidence unless an operator explicitly expires it.`;
+  return `Approval ledger recovery is blocked by ${findingCount} finding(s); stale or changed approvals require fresh human re-approval before restore.`;
 }
 
 function compareRecords(

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -218,8 +218,19 @@ export { checkModuleHealth, allHealthy } from './resilience/module-initializer.j
 export type { ModuleHealth } from './resilience/module-initializer.js';
 
 // Disaster recovery
-export { buildBackupEncryptionVerificationReport, detectRestorePreviewConflicts } from './dr/restore-preview.js';
+export {
+  buildApprovalLedgerRecoveryReport,
+  buildBackupEncryptionVerificationReport,
+  detectRestorePreviewConflicts,
+} from './dr/restore-preview.js';
 export type {
+  ApprovalLedgerRecordSummary,
+  ApprovalLedgerRecoveryFinding,
+  ApprovalLedgerRecoveryFindingCode,
+  ApprovalLedgerRecoveryOptions,
+  ApprovalLedgerRecoveryReport,
+  ApprovalLedgerRecoverySeverity,
+  ApprovalLedgerRecoveryStatus,
   BackupEncryptionMetadata,
   BackupEncryptionVerificationFinding,
   BackupEncryptionVerificationFindingCode,

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 import {
+  buildApprovalLedgerRecoveryReport,
   buildBackupEncryptionVerificationReport,
   detectRestorePreviewConflicts,
   type RestorePreviewManifest,
@@ -363,6 +364,113 @@ describe('restore preview conflict detector', () => {
         expect.objectContaining({ code: 'missing-key-reference', severity: 'warning' }),
         expect.objectContaining({ code: 'missing-artifact-digest', severity: 'warning' }),
       ]),
+    );
+  });
+
+  it('returns a clean read-only approval ledger recovery report when approvals match', () => {
+    const backup: RestorePreviewManifest = {
+      schemaVersion: 1,
+      tasks: [],
+      approvals: [{ id: 'approval-1', state: 'approved', digest: 'sha256:approval', updatedAt: '2026-07-14T12:00:00.000Z' }],
+      memory: [],
+      cron: [],
+    };
+
+    const report = buildApprovalLedgerRecoveryReport(backup, clone(backup), {
+      checkedAt: '2026-07-14T12:30:00.000Z',
+    });
+
+    expect(report).toEqual({
+      checkedAt: '2026-07-14T12:30:00.000Z',
+      wouldWrite: false,
+      status: 'clean',
+      safeToApplyAutomatically: false,
+      findings: [],
+      operatorSummary: 'Approval ledger recovery check is clean; no approval ledger drift was found.',
+    });
+  });
+
+  it('blocks approval ledger recovery for stale backup-only approval tokens', () => {
+    const report = buildApprovalLedgerRecoveryReport(
+      {
+        schemaVersion: 1,
+        tasks: [],
+        approvals: [{ id: 'approval-stale', state: 'approved', digest: 'sha256:stale-token' }],
+        memory: [],
+        cron: [],
+      },
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('blocked');
+    expect(report.safeToApplyAutomatically).toBe(false);
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: 'approval-backup-only',
+        approvalId: 'approval-stale',
+        severity: 'blocker',
+        backup: { state: 'approved', digestPresent: true },
+        recommendation: expect.stringContaining('fresh human re-approval'),
+      }),
+    );
+  });
+
+  it('blocks changed approval ledger entries without echoing token values', () => {
+    const report = buildApprovalLedgerRecoveryReport(
+      {
+        schemaVersion: 1,
+        tasks: [],
+        approvals: [{ id: 'approval-drift', state: 'pending', digest: 'sha256:backup-secret-token', updatedAt: '2026-07-14T11:00:00.000Z' }],
+        memory: [],
+        cron: [],
+      },
+      {
+        schemaVersion: 1,
+        tasks: [],
+        approvals: [{ id: 'approval-drift', state: 'approved', digest: 'sha256:live-secret-token', updatedAt: '2026-07-14T12:00:00.000Z' }],
+        memory: [],
+        cron: [],
+      },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('blocked');
+    expect(JSON.stringify(report)).not.toContain('secret-token');
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: 'approval-newer-live',
+        approvalId: 'approval-drift',
+        severity: 'blocker',
+        backup: { state: 'pending', digestPresent: true, updatedAt: '2026-07-14T11:00:00.000Z' },
+        live: { state: 'approved', digestPresent: true, updatedAt: '2026-07-14T12:00:00.000Z' },
+        recommendation: expect.stringContaining('fresh re-approval'),
+      }),
+    );
+  });
+
+  it('surfaces live-only approval ledger entries as operator review warnings', () => {
+    const report = buildApprovalLedgerRecoveryReport(
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+      {
+        schemaVersion: 1,
+        tasks: [],
+        approvals: [{ id: 'approval-live', state: 'approved', digest: 'sha256:live-token' }],
+        memory: [],
+        cron: [],
+      },
+      { checkedAt: '2026-07-14T12:30:00.000Z' },
+    );
+
+    expect(report.status).toBe('review-required');
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: 'approval-live-only',
+        approvalId: 'approval-live',
+        severity: 'warning',
+        live: { state: 'approved', digestPresent: true },
+        recommendation: expect.stringContaining('Preserve the live approval ledger entry'),
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Adds a read-only approval ledger recovery report for DR restore previews.
- Blocks stale, changed, schema-mismatched, and newer-live approval ledger drift from being auto-applied.
- Redacts approval token material while documenting operator recovery guidance.

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/dr/restore-preview.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1833