### PR TITLE
feat(dr): add point-in-time backup manifest

### DIFF
--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -80,6 +80,37 @@ Example finding:
 
 Tests cover clean approval ledgers, backup-only stale tokens, changed/newer-live ledgers, live-only warnings, and token redaction so disaster-recovery tooling remains safe for automated handoffs.
 
+## Point-in-time backup manifest
+
+`buildPointInTimeBackupManifest(manifest, options)` wraps a restore-preview manifest with deterministic point-in-time metadata so operators can tell exactly which state was captured before comparing or restoring a backup. The helper is read-only: it returns a new manifest and does not mutate the caller's source manifest.
+
+The point-in-time block includes:
+
+- `capturedAt`: the logical instant represented by the backup. Restores should assume state after this instant is absent.
+- `generatedAt`: the instant the manifest was written.
+- `includedAreas`: every restore-preview area accounted for by the manifest: `tasks`, `approvals`, `memory`, and `cron`.
+- `recordCounts`: deterministic counts for each included area, including zero-count areas, so partial backups are visible before restore.
+- optional `source` and `manifestDigest` fields for operator handoff and integrity checks.
+
+Example:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-14T12:05:00.000Z",
+  "pointInTime": {
+    "capturedAt": "2026-07-14T12:00:00.000Z",
+    "generatedAt": "2026-07-14T12:05:00.000Z",
+    "source": "prod-primary",
+    "includedAreas": ["tasks", "approvals", "memory", "cron"],
+    "recordCounts": { "tasks": 1, "approvals": 1, "memory": 0, "cron": 0 },
+    "manifestDigest": "sha256:..."
+  }
+}
+```
+
+Invalid timestamps fail explicitly, and `capturedAt` may not be later than `generatedAt`; that prevents a manifest from claiming future state that the backup could not contain.
+
 ## Kanban card resurrection guardrails
 
 Backup-only task records are treated as `blocker` conflicts. A backup-only task means the backup manifest contains a Kanban card that live state no longer has, so blindly restoring it could resurrect deleted, completed, reassigned, or otherwise intentionally removed work.

--- a/docs/dr/restore-preview.md
+++ b/docs/dr/restore-preview.md
@@ -88,8 +88,8 @@ The point-in-time block includes:
 
 - `capturedAt`: the logical instant represented by the backup. Restores should assume state after this instant is absent.
 - `generatedAt`: the instant the manifest was written.
-- `includedAreas`: every restore-preview area accounted for by the manifest: `tasks`, `approvals`, `memory`, and `cron`.
-- `recordCounts`: deterministic counts for each included area, including zero-count areas, so partial backups are visible before restore.
+- `includedAreas`: restore-preview areas explicitly present in the manifest. Omitted areas stay omitted so partial or legacy backups are not mistaken for complete captures.
+- `recordCounts`: deterministic counts for each explicitly included area, including zero counts for areas that were captured empty.
 - optional `source` and `manifestDigest` fields for operator handoff and integrity checks.
 
 Example:

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -84,6 +84,39 @@ export interface ApprovalLedgerRecoveryOptions {
   readonly checkedAt?: string;
 }
 
+export interface PointInTimeBackupManifestMetadata {
+  /** Instant the backup logically represents. Restores should not assume state after this time is present. */
+  readonly capturedAt: string;
+  /** Instant this manifest was written, supplied by callers for deterministic tests and audit logs. */
+  readonly generatedAt: string;
+  /** Operator-readable source such as an environment, backup job id, or storage URI. */
+  readonly source?: string;
+  /** Every restore-preview area covered by this point-in-time manifest. */
+  readonly includedAreas: readonly ComparableArea[];
+  /** Record counts captured for each restore-preview area so partial backups are visible before restore. */
+  readonly recordCounts: Readonly<Record<ComparableArea, number>>;
+  /** Optional digest for the manifest payload or archive that contains it. */
+  readonly manifestDigest?: string;
+}
+
+export interface PointInTimeBackupManifest extends RestorePreviewManifest {
+  readonly generatedAt: string;
+  readonly pointInTime: PointInTimeBackupManifestMetadata;
+  readonly tasks: readonly RestorePreviewRecord[];
+  readonly approvals: readonly RestorePreviewRecord[];
+  readonly memory: readonly RestorePreviewRecord[];
+  readonly cron: readonly RestorePreviewRecord[];
+}
+
+export interface PointInTimeBackupManifestOptions {
+  /** Instant the backup logically represents. Defaults to generatedAt when omitted. */
+  readonly capturedAt?: string;
+  /** Instant this manifest was generated. Defaults to the current wall-clock time. */
+  readonly generatedAt?: string;
+  readonly source?: string;
+  readonly manifestDigest?: string;
+}
+
 export type RestorePreviewConflictType =
   | 'schema-mismatch'
   | 'changed'
@@ -103,6 +136,8 @@ export interface RestorePreviewRecord {
 
 export interface RestorePreviewManifest {
   readonly schemaVersion: number;
+  readonly generatedAt?: string;
+  readonly pointInTime?: PointInTimeBackupManifestMetadata;
   readonly encryption?: BackupEncryptionMetadata;
   readonly tasks?: readonly RestorePreviewRecord[];
   readonly approvals?: readonly RestorePreviewRecord[];
@@ -196,6 +231,48 @@ const AREA_ACCESSORS = {
 } satisfies Record<ComparableArea, (manifest: RestorePreviewManifest) => readonly RestorePreviewRecord[]>;
 
 const DEFAULT_ALLOWED_BACKUP_ENCRYPTION_ALGORITHMS = ['aes-256-gcm', 'xchacha20-poly1305'] as const;
+
+export function buildPointInTimeBackupManifest(
+  manifest: RestorePreviewManifest,
+  options: PointInTimeBackupManifestOptions = {},
+): PointInTimeBackupManifest {
+  const generatedAt = normalizeIsoInstant(options.generatedAt ?? new Date().toISOString(), 'generatedAt');
+  const capturedAt = normalizeIsoInstant(options.capturedAt ?? generatedAt, 'capturedAt');
+
+  if (Date.parse(capturedAt) > Date.parse(generatedAt)) {
+    throw new Error('Point-in-time backup manifest capturedAt must not be later than generatedAt.');
+  }
+
+  const tasks = cloneRecords(manifest.tasks);
+  const approvals = cloneRecords(manifest.approvals);
+  const memory = cloneRecords(manifest.memory);
+  const cron = cloneRecords(manifest.cron);
+  const recordCounts: Record<ComparableArea, number> = {
+    tasks: tasks.length,
+    approvals: approvals.length,
+    memory: memory.length,
+    cron: cron.length,
+  };
+  const pointInTime: PointInTimeBackupManifestMetadata = {
+    capturedAt,
+    generatedAt,
+    ...(options.source === undefined ? {} : { source: options.source }),
+    includedAreas: [...(Object.keys(AREA_ACCESSORS) as ComparableArea[])],
+    recordCounts,
+    ...(options.manifestDigest === undefined ? {} : { manifestDigest: options.manifestDigest }),
+  };
+
+  return {
+    schemaVersion: manifest.schemaVersion,
+    generatedAt,
+    pointInTime,
+    ...(manifest.encryption === undefined ? {} : { encryption: { ...manifest.encryption } }),
+    tasks,
+    approvals,
+    memory,
+    cron,
+  };
+}
 
 export function buildBackupEncryptionVerificationReport(
   manifest: RestorePreviewManifest,
@@ -497,6 +574,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
+}
+
+function normalizeIsoInstant(value: string, fieldName: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Point-in-time backup manifest ${fieldName} must be a valid ISO timestamp.`);
+  }
+  return new Date(parsed).toISOString();
+}
+
+function cloneRecords(records: readonly RestorePreviewRecord[] | undefined): readonly RestorePreviewRecord[] {
+  return (records ?? []).map((record) => ({
+    ...record,
+    ...(record.value === undefined ? {} : { value: cloneJsonValue(record.value) }),
+  }));
+}
+
+function cloneJsonValue(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map((item) => cloneJsonValue(item));
+  const object = value as Record<string, unknown>;
+  return Object.fromEntries(Object.entries(object).map(([key, item]) => [key, cloneJsonValue(item)]));
 }
 
 function operatorSummaryForEncryptionReport(

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -91,10 +91,10 @@ export interface PointInTimeBackupManifestMetadata {
   readonly generatedAt: string;
   /** Operator-readable source such as an environment, backup job id, or storage URI. */
   readonly source?: string;
-  /** Every restore-preview area covered by this point-in-time manifest. */
+  /** Restore-preview areas explicitly present in this point-in-time manifest. */
   readonly includedAreas: readonly ComparableArea[];
-  /** Record counts captured for each restore-preview area so partial backups are visible before restore. */
-  readonly recordCounts: Readonly<Record<ComparableArea, number>>;
+  /** Record counts for explicitly captured areas so omitted areas remain visible before restore. */
+  readonly recordCounts: Readonly<Partial<Record<ComparableArea, number>>>;
   /** Optional digest for the manifest payload or archive that contains it. */
   readonly manifestDigest?: string;
 }
@@ -102,10 +102,6 @@ export interface PointInTimeBackupManifestMetadata {
 export interface PointInTimeBackupManifest extends RestorePreviewManifest {
   readonly generatedAt: string;
   readonly pointInTime: PointInTimeBackupManifestMetadata;
-  readonly tasks: readonly RestorePreviewRecord[];
-  readonly approvals: readonly RestorePreviewRecord[];
-  readonly memory: readonly RestorePreviewRecord[];
-  readonly cron: readonly RestorePreviewRecord[];
 }
 
 export interface PointInTimeBackupManifestOptions {
@@ -243,21 +239,17 @@ export function buildPointInTimeBackupManifest(
     throw new Error('Point-in-time backup manifest capturedAt must not be later than generatedAt.');
   }
 
-  const tasks = cloneRecords(manifest.tasks);
-  const approvals = cloneRecords(manifest.approvals);
-  const memory = cloneRecords(manifest.memory);
-  const cron = cloneRecords(manifest.cron);
-  const recordCounts: Record<ComparableArea, number> = {
-    tasks: tasks.length,
-    approvals: approvals.length,
-    memory: memory.length,
-    cron: cron.length,
-  };
+  const capturedAreas = (Object.keys(AREA_ACCESSORS) as ComparableArea[]).filter(
+    (area) => manifest[area] !== undefined,
+  );
+  const recordCounts = Object.fromEntries(
+    capturedAreas.map((area) => [area, AREA_ACCESSORS[area](manifest).length]),
+  ) as Partial<Record<ComparableArea, number>>;
   const pointInTime: PointInTimeBackupManifestMetadata = {
     capturedAt,
     generatedAt,
     ...(options.source === undefined ? {} : { source: options.source }),
-    includedAreas: [...(Object.keys(AREA_ACCESSORS) as ComparableArea[])],
+    includedAreas: capturedAreas,
     recordCounts,
     ...(options.manifestDigest === undefined ? {} : { manifestDigest: options.manifestDigest }),
   };
@@ -267,10 +259,7 @@ export function buildPointInTimeBackupManifest(
     generatedAt,
     pointInTime,
     ...(manifest.encryption === undefined ? {} : { encryption: { ...manifest.encryption } }),
-    tasks,
-    approvals,
-    memory,
-    cron,
+    ...copyCapturedRecords(manifest),
   };
 }
 
@@ -578,10 +567,18 @@ function optionalString(value: unknown): string | undefined {
 
 function normalizeIsoInstant(value: string, fieldName: string): string {
   const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) {
-    throw new Error(`Point-in-time backup manifest ${fieldName} must be a valid ISO timestamp.`);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+    throw new Error(`Point-in-time backup manifest ${fieldName} must be a valid canonical ISO timestamp.`);
   }
   return new Date(parsed).toISOString();
+}
+
+function copyCapturedRecords(manifest: RestorePreviewManifest): Partial<Record<ComparableArea, readonly RestorePreviewRecord[]>> {
+  return Object.fromEntries(
+    (Object.keys(AREA_ACCESSORS) as ComparableArea[])
+      .filter((area) => manifest[area] !== undefined)
+      .map((area) => [area, cloneRecords(manifest[area])]),
+  ) as Partial<Record<ComparableArea, readonly RestorePreviewRecord[]>>;
 }
 
 function cloneRecords(records: readonly RestorePreviewRecord[] | undefined): readonly RestorePreviewRecord[] {

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -221,6 +221,7 @@ export type { ModuleHealth } from './resilience/module-initializer.js';
 export {
   buildApprovalLedgerRecoveryReport,
   buildBackupEncryptionVerificationReport,
+  buildPointInTimeBackupManifest,
   buildRestoreDryRunReport,
   detectRestorePreviewConflicts,
 } from './dr/restore-preview.js';
@@ -239,6 +240,9 @@ export type {
   BackupEncryptionVerificationReport,
   BackupEncryptionVerificationSeverity,
   BackupEncryptionVerificationStatus,
+  PointInTimeBackupManifest,
+  PointInTimeBackupManifestMetadata,
+  PointInTimeBackupManifestOptions,
   RestoreDryRunConflict,
   RestoreDryRunConflictRecordSummary,
   RestoreDryRunPreviewResult,

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildApprovalLedgerRecoveryReport,
   buildBackupEncryptionVerificationReport,
+  buildPointInTimeBackupManifest,
   buildRestoreDryRunReport,
   detectRestorePreviewConflicts,
   type RestorePreviewManifest,
@@ -37,6 +38,75 @@ function readMissingCronJobRecoveryFixture(): MissingCronJobRecoveryFixture {
 }
 
 describe('restore preview conflict detector', () => {
+  it('builds a deterministic point-in-time manifest with record counts for every restore area', () => {
+    const backup: RestorePreviewManifest = {
+      schemaVersion: 1,
+      encryption: {
+        encrypted: true,
+        algorithm: 'aes-256-gcm',
+        keyRef: 'dr/backups/prod-primary',
+        artifactDigest: 'sha256:archive',
+      },
+      tasks: [{ id: 'task-1', digest: 'task-digest', value: { nested: ['kept'] } }],
+      approvals: [{ id: 'approval-1', state: 'pending', digest: 'approval-digest' }],
+      memory: [],
+    };
+    const before = clone(backup);
+
+    const manifest = buildPointInTimeBackupManifest(backup, {
+      capturedAt: '2026-07-14T12:00:00.000Z',
+      generatedAt: '2026-07-14T12:05:00.000Z',
+      source: 'prod-primary',
+      manifestDigest: 'sha256:manifest',
+    });
+
+    expect(manifest).toEqual({
+      schemaVersion: 1,
+      generatedAt: '2026-07-14T12:05:00.000Z',
+      pointInTime: {
+        capturedAt: '2026-07-14T12:00:00.000Z',
+        generatedAt: '2026-07-14T12:05:00.000Z',
+        source: 'prod-primary',
+        includedAreas: ['tasks', 'approvals', 'memory', 'cron'],
+        recordCounts: {
+          tasks: 1,
+          approvals: 1,
+          memory: 0,
+          cron: 0,
+        },
+        manifestDigest: 'sha256:manifest',
+      },
+      encryption: backup.encryption,
+      tasks: backup.tasks,
+      approvals: backup.approvals,
+      memory: [],
+      cron: [],
+    });
+    expect(manifest.pointInTime.includedAreas).toEqual(['tasks', 'approvals', 'memory', 'cron']);
+    expect(backup).toEqual(before);
+  });
+
+  it('fails explicitly when point-in-time metadata would claim a future capture', () => {
+    expect(() =>
+      buildPointInTimeBackupManifest(
+        { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+        {
+          capturedAt: '2026-07-14T12:10:00.000Z',
+          generatedAt: '2026-07-14T12:05:00.000Z',
+        },
+      ),
+    ).toThrow('capturedAt must not be later than generatedAt');
+  });
+
+  it('fails explicitly when point-in-time timestamps are malformed', () => {
+    expect(() =>
+      buildPointInTimeBackupManifest(
+        { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+        { capturedAt: 'not-a-timestamp', generatedAt: '2026-07-14T12:05:00.000Z' },
+      ),
+    ).toThrow('capturedAt must be a valid ISO timestamp');
+  });
+
   it('returns a clean no-write preview when backup manifest matches live state', () => {
     const backup: RestorePreviewManifest = {
       schemaVersion: 1,

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -38,7 +38,7 @@ function readMissingCronJobRecoveryFixture(): MissingCronJobRecoveryFixture {
 }
 
 describe('restore preview conflict detector', () => {
-  it('builds a deterministic point-in-time manifest with record counts for every restore area', () => {
+  it('builds a deterministic point-in-time manifest with record counts for explicitly captured restore areas', () => {
     const backup: RestorePreviewManifest = {
       schemaVersion: 1,
       encryption: {
@@ -67,12 +67,11 @@ describe('restore preview conflict detector', () => {
         capturedAt: '2026-07-14T12:00:00.000Z',
         generatedAt: '2026-07-14T12:05:00.000Z',
         source: 'prod-primary',
-        includedAreas: ['tasks', 'approvals', 'memory', 'cron'],
+        includedAreas: ['tasks', 'approvals', 'memory'],
         recordCounts: {
           tasks: 1,
           approvals: 1,
           memory: 0,
-          cron: 0,
         },
         manifestDigest: 'sha256:manifest',
       },
@@ -80,10 +79,24 @@ describe('restore preview conflict detector', () => {
       tasks: backup.tasks,
       approvals: backup.approvals,
       memory: [],
-      cron: [],
     });
-    expect(manifest.pointInTime.includedAreas).toEqual(['tasks', 'approvals', 'memory', 'cron']);
+    expect(manifest.pointInTime.includedAreas).toEqual(['tasks', 'approvals', 'memory']);
+    expect(manifest).not.toHaveProperty('cron');
     expect(backup).toEqual(before);
+  });
+
+  it('distinguishes explicitly captured empty areas from omitted partial-backup areas', () => {
+    const manifest = buildPointInTimeBackupManifest(
+      { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+      {
+        capturedAt: '2026-07-14T12:00:00.000Z',
+        generatedAt: '2026-07-14T12:05:00.000Z',
+      },
+    );
+
+    expect(manifest.pointInTime.includedAreas).toEqual(['tasks', 'approvals', 'memory', 'cron']);
+    expect(manifest.pointInTime.recordCounts).toEqual({ tasks: 0, approvals: 0, memory: 0, cron: 0 });
+    expect(manifest.cron).toEqual([]);
   });
 
   it('fails explicitly when point-in-time metadata would claim a future capture', () => {
@@ -98,13 +111,20 @@ describe('restore preview conflict detector', () => {
     ).toThrow('capturedAt must not be later than generatedAt');
   });
 
-  it('fails explicitly when point-in-time timestamps are malformed', () => {
+  it('fails explicitly when point-in-time timestamps are malformed or normalized by JavaScript', () => {
     expect(() =>
       buildPointInTimeBackupManifest(
         { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
         { capturedAt: 'not-a-timestamp', generatedAt: '2026-07-14T12:05:00.000Z' },
       ),
-    ).toThrow('capturedAt must be a valid ISO timestamp');
+    ).toThrow('capturedAt must be a valid canonical ISO timestamp');
+
+    expect(() =>
+      buildPointInTimeBackupManifest(
+        { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] },
+        { capturedAt: '2026-02-30T00:00:00.000Z', generatedAt: '2026-03-02T00:00:00.000Z' },
+      ),
+    ).toThrow('capturedAt must be a valid canonical ISO timestamp');
   });
 
   it('returns a clean no-write preview when backup manifest matches live state', () => {


### PR DESCRIPTION
## Summary
- Add `buildPointInTimeBackupManifest` for deterministic point-in-time DR backup manifests.
- Record `capturedAt`, `generatedAt`, included restore areas, per-area record counts, optional source, and manifest digest.
- Document operator interpretation and cover malformed/future timestamp edge cases.

## Verification
- `npm run test --workspace @franken/orchestrator -- tests/unit/dr/restore-preview.test.ts` (16 passed)
- `npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- `npm run test --workspace @franken/orchestrator` (257 files / 3267 tests passed)

Closes #1830
