### PR TITLE
feat(dr): add restore dry-run JSON output

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -16,6 +16,7 @@ export type Subcommand =
   | 'beasts-daemon'
   | 'network'
   | 'memory'
+  | 'dr'
   | 'skill'
   | 'security'
   | undefined;
@@ -50,6 +51,7 @@ export type BeastAction =
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
 export type MemoryAction = 'snapshot-diff' | 'verify-backup' | undefined;
+export type DrAction = 'restore-dry-run' | undefined;
 
 export interface CliArgs {
   subcommand: Subcommand;
@@ -61,6 +63,9 @@ export interface CliArgs {
   memorySnapshotBefore?: string | undefined;
   memorySnapshotAfter?: string | undefined;
   memoryBackupPath?: string | undefined;
+  drAction?: DrAction;
+  drBackupManifestPath?: string | undefined;
+  drLiveManifestPath?: string | undefined;
   networkDetached: boolean;
   networkSet?: string[] | undefined;
   skillAction?: SkillAction;
@@ -108,9 +113,10 @@ export interface CliArgs {
   moduleConfig?: import('../beasts/types.js').ModuleConfig | undefined;
 }
 
-const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'skill', 'security']);
+const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'dr', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
 const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff', 'verify-backup']);
+const VALID_DR_ACTIONS = new Set(['restore-dry-run']);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
@@ -175,6 +181,7 @@ Subcommands:
   beasts-daemon           Run the standalone Beast control-plane daemon
   network                 Manage Frankenbeast request-serving services
   memory                  Inspect persisted BrainSnapshot JSON artifacts and SQLite backups
+  dr                      Disaster-recovery restore preview utilities
   skill                   Manage MCP skill plugins
   security                View or change security profile
 
@@ -236,6 +243,10 @@ Memory Commands:
                                   Print a structured JSON diff between two BrainSnapshot files
   memory verify-backup <backup.sqlite>
                                   Verify a read-only SQLite memory backup and print structured JSON
+
+Disaster-Recovery Commands:
+  dr restore-dry-run <backup-manifest.json> <live-manifest.json>
+                                  Compare backup/live restore manifests and print read-only JSON output
 
 Beast Commands:
   beasts catalog                      List fixed Beast definitions
@@ -516,6 +527,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let memorySnapshotBefore: string | undefined;
   let memorySnapshotAfter: string | undefined;
   let memoryBackupPath: string | undefined;
+  let drAction: DrAction;
+  let drBackupManifestPath: string | undefined;
+  let drLiveManifestPath: string | undefined;
   let skillAction: SkillAction;
   let skillTarget: string | undefined;
   let skillCommand: string | undefined;
@@ -562,6 +576,19 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       if (positionals.length > 3) {
         throw new TypeError(`Unexpected argument '${positionals[3]}'. memory snapshot-diff accepts exactly two snapshot files`);
       }
+    }
+  } else if (subcommand === 'dr') {
+    const actionCandidate = positionals[0];
+    if (actionCandidate !== undefined) {
+      if (!VALID_DR_ACTIONS.has(actionCandidate)) {
+        throw new TypeError(`Unknown dr action: ${actionCandidate}`);
+      }
+      drAction = actionCandidate as DrAction;
+    }
+    drBackupManifestPath = positionals[1];
+    drLiveManifestPath = positionals[2];
+    if (positionals.length > 3) {
+      throw new TypeError(`Unexpected argument '${positionals[3]}'. dr restore-dry-run accepts exactly two manifest files`);
     }
   } else if (subcommand === 'skill') {
     const actionCandidate = positionals[0];
@@ -699,6 +726,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     memorySnapshotBefore,
     memorySnapshotAfter,
     memoryBackupPath,
+    drAction,
+    drBackupManifestPath,
+    drLiveManifestPath,
     networkDetached: values.detached ?? false,
     networkSet: values.set,
     skillAction,

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -24,9 +24,20 @@ function validateRecordArray(manifestPath: string, manifest: Record<string, unkn
     throw new Error(`Invalid restore manifest ${manifestPath}: ${field} must be an array when present`);
   }
   const ids = new Set<string>();
+  const allowedFields = new Set(['id', 'digest', 'state', 'updatedAt', 'value']);
   for (const [index, record] of value.entries()) {
     if (!isRecord(record) || typeof record.id !== 'string' || record.id.length === 0) {
       throw new Error(`Invalid restore manifest ${manifestPath}: ${field}[${index}] must include a non-empty string id`);
+    }
+    for (const recordField of Object.keys(record)) {
+      if (!allowedFields.has(recordField)) {
+        throw new Error(`Invalid restore manifest ${manifestPath}: ${field}[${index}] includes unsupported field '${recordField}'`);
+      }
+    }
+    for (const stringField of ['digest', 'state', 'updatedAt']) {
+      if (record[stringField] !== undefined && typeof record[stringField] !== 'string') {
+        throw new Error(`Invalid restore manifest ${manifestPath}: ${field}[${index}].${stringField} must be a string when present`);
+      }
     }
     if (ids.has(record.id)) {
       throw new Error(`Invalid restore manifest ${manifestPath}: ${field} contains duplicate id '${record.id}'`);

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises';
+
+import {
+  buildRestoreDryRunReport,
+  type RestorePreviewManifest,
+} from '../dr/restore-preview.js';
+
+export interface DrCommandDeps {
+  readonly action: 'restore-dry-run' | undefined;
+  readonly backupManifestPath?: string | undefined;
+  readonly liveManifestPath?: string | undefined;
+  readonly generatedAt?: string | undefined;
+  readonly print: (message: string) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateRecordArray(manifestPath: string, manifest: Record<string, unknown>, field: string): void {
+  const value = manifest[field];
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid restore manifest ${manifestPath}: ${field} must be an array when present`);
+  }
+  for (const [index, record] of value.entries()) {
+    if (!isRecord(record) || typeof record.id !== 'string' || record.id.length === 0) {
+      throw new Error(`Invalid restore manifest ${manifestPath}: ${field}[${index}] must include a non-empty string id`);
+    }
+  }
+}
+
+export async function readRestoreManifest(manifestPath: string): Promise<RestorePreviewManifest> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(manifestPath, 'utf8')) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read restore manifest ${manifestPath}: ${message}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(`Invalid restore manifest ${manifestPath}: expected a JSON object`);
+  }
+  if (!Number.isSafeInteger(parsed.schemaVersion)) {
+    throw new Error(`Invalid restore manifest ${manifestPath}: schemaVersion must be a safe integer`);
+  }
+  for (const field of ['tasks', 'approvals', 'memory', 'cron']) {
+    validateRecordArray(manifestPath, parsed, field);
+  }
+
+  return parsed as unknown as RestorePreviewManifest;
+}
+
+export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
+  const { action, backupManifestPath, liveManifestPath, print } = deps;
+  if (action !== 'restore-dry-run') {
+    throw new Error('Usage: frankenbeast dr restore-dry-run <backup-manifest.json> <live-manifest.json>');
+  }
+  if (!backupManifestPath || !liveManifestPath) {
+    throw new Error('dr restore-dry-run requires two manifest JSON files: <backup-manifest.json> <live-manifest.json>');
+  }
+
+  const [backup, live] = await Promise.all([
+    readRestoreManifest(backupManifestPath),
+    readRestoreManifest(liveManifestPath),
+  ]);
+
+  print(JSON.stringify(buildRestoreDryRunReport(backup, live, {
+    ...(deps.generatedAt === undefined ? {} : { generatedAt: deps.generatedAt }),
+    backupPath: backupManifestPath,
+    livePath: liveManifestPath,
+  }), null, 2));
+}

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 
 import {
   buildRestoreDryRunReport,
@@ -23,10 +23,15 @@ function validateRecordArray(manifestPath: string, manifest: Record<string, unkn
   if (!Array.isArray(value)) {
     throw new Error(`Invalid restore manifest ${manifestPath}: ${field} must be an array when present`);
   }
+  const ids = new Set<string>();
   for (const [index, record] of value.entries()) {
     if (!isRecord(record) || typeof record.id !== 'string' || record.id.length === 0) {
       throw new Error(`Invalid restore manifest ${manifestPath}: ${field}[${index}] must include a non-empty string id`);
     }
+    if (ids.has(record.id)) {
+      throw new Error(`Invalid restore manifest ${manifestPath}: ${field} contains duplicate id '${record.id}'`);
+    }
+    ids.add(record.id);
   }
 }
 
@@ -45,6 +50,9 @@ export async function readRestoreManifest(manifestPath: string): Promise<Restore
   if (!Number.isSafeInteger(parsed.schemaVersion)) {
     throw new Error(`Invalid restore manifest ${manifestPath}: schemaVersion must be a safe integer`);
   }
+  if (parsed.schemaVersion !== 1) {
+    throw new Error(`Invalid restore manifest ${manifestPath}: unsupported schemaVersion ${String(parsed.schemaVersion)}`);
+  }
   for (const field of ['tasks', 'approvals', 'memory', 'cron']) {
     validateRecordArray(manifestPath, parsed, field);
   }
@@ -61,14 +69,22 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
     throw new Error('dr restore-dry-run requires two manifest JSON files: <backup-manifest.json> <live-manifest.json>');
   }
 
+  const [resolvedBackupPath, resolvedLivePath] = await Promise.all([
+    realpath(backupManifestPath),
+    realpath(liveManifestPath),
+  ]);
+  if (resolvedBackupPath === resolvedLivePath) {
+    throw new Error('dr restore-dry-run requires distinct backup and live manifest files');
+  }
+
   const [backup, live] = await Promise.all([
-    readRestoreManifest(backupManifestPath),
-    readRestoreManifest(liveManifestPath),
+    readRestoreManifest(resolvedBackupPath),
+    readRestoreManifest(resolvedLivePath),
   ]);
 
   print(JSON.stringify(buildRestoreDryRunReport(backup, live, {
     ...(deps.generatedAt === undefined ? {} : { generatedAt: deps.generatedAt }),
-    backupPath: backupManifestPath,
-    livePath: liveManifestPath,
+    backupPath: resolvedBackupPath,
+    livePath: resolvedLivePath,
   }), null, 2));
 }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -17,6 +17,7 @@ import { handleInitCommand } from './init-command.js';
 import { handleSkillCommand } from './skill-cli.js';
 import { handleSecurityCommand } from './security-cli.js';
 import { handleMemoryCommand } from './memory-snapshot-diff.js';
+import { handleDrCommand } from './dr-restore.js';
 import { loadConfig } from './config-loader.js';
 import { cleanupBuild } from './cleanup.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
@@ -1272,6 +1273,21 @@ export async function main(): Promise<void> {
         beforePath: args.memorySnapshotBefore,
         afterPath: args.memorySnapshotAfter,
         backupPath: args.memoryBackupPath,
+        print: printLine,
+      });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (args.subcommand === 'dr') {
+    try {
+      await handleDrCommand({
+        action: args.drAction,
+        backupManifestPath: args.drBackupManifestPath,
+        liveManifestPath: args.drLiveManifestPath,
         print: printLine,
       });
     } catch (err) {

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -143,6 +143,7 @@ export interface RestoreDryRunConflictRecordSummary {
   readonly id: string;
   readonly state?: string;
   readonly digestPresent?: boolean;
+  readonly valuePresent?: boolean;
   readonly updatedAt?: string;
 }
 
@@ -392,22 +393,22 @@ function redactPreviewForDryRun(preview: RestorePreviewResult): RestoreDryRunPre
     ...preview,
     conflicts: preview.conflicts.map((conflict) => ({
       ...conflict,
-      ...(conflict.backup === undefined ? {} : { backup: redactConflictRecord(conflict.area, conflict.backup) }),
-      ...(conflict.live === undefined ? {} : { live: redactConflictRecord(conflict.area, conflict.live) }),
+      ...(conflict.backup === undefined ? {} : { backup: redactConflictRecord(conflict.backup) }),
+      ...(conflict.live === undefined ? {} : { live: redactConflictRecord(conflict.live) }),
     })),
   };
 }
 
 function redactConflictRecord(
-  area: RestorePreviewArea,
   record: RestorePreviewRecord | { readonly schemaVersion: number },
-): RestorePreviewRecord | RestoreDryRunConflictRecordSummary | { readonly schemaVersion: number } {
-  if (area !== 'approvals' || !('id' in record)) return record;
+): RestoreDryRunConflictRecordSummary | { readonly schemaVersion: number } {
+  if (!('id' in record)) return record;
   return {
     id: record.id,
-    ...(record.state === undefined ? {} : { state: record.state }),
-    ...(record.digest === undefined ? {} : { digestPresent: true }),
-    ...(record.updatedAt === undefined ? {} : { updatedAt: record.updatedAt }),
+    ...(typeof record.state === 'string' ? { state: record.state } : {}),
+    ...(typeof record.digest === 'string' ? { digestPresent: true } : {}),
+    ...('value' in record && record.value !== undefined ? { valuePresent: true } : {}),
+    ...(typeof record.updatedAt === 'string' ? { updatedAt: record.updatedAt } : {}),
   };
 }
 

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -132,6 +132,35 @@ export interface RestorePreviewResult {
   readonly conflicts: readonly RestorePreviewConflict[];
 }
 
+export interface RestoreDryRunReportOptions {
+  /** ISO timestamp for deterministic automation/tests; defaults to the current time. */
+  readonly generatedAt?: string;
+  readonly backupPath?: string;
+  readonly livePath?: string;
+}
+
+export interface RestoreDryRunReport {
+  readonly ok: true;
+  readonly command: 'dr restore-dry-run';
+  readonly formatVersion: 1;
+  readonly generatedAt: string;
+  readonly dryRun: true;
+  readonly wouldWrite: false;
+  readonly inputs: {
+    readonly backupPath?: string;
+    readonly livePath?: string;
+  };
+  readonly summary: {
+    readonly safeToRestore: boolean;
+    readonly conflictCount: number;
+    readonly blockerCount: number;
+    readonly warningCount: number;
+    readonly infoCount: number;
+  };
+  readonly preview: RestorePreviewResult;
+  readonly operatorGuidance: string;
+}
+
 type ComparableArea = Exclude<RestorePreviewArea, 'schema'>;
 
 const AREA_ACCESSORS = {
@@ -296,6 +325,41 @@ export function detectRestorePreviewConflicts(
       compatible: schemaCompatible,
     },
     conflicts,
+  };
+}
+
+export function buildRestoreDryRunReport(
+  backup: RestorePreviewManifest,
+  live: RestorePreviewManifest,
+  options: RestoreDryRunReportOptions = {},
+): RestoreDryRunReport {
+  const preview = detectRestorePreviewConflicts(backup, live);
+  const blockerCount = preview.conflicts.filter((conflict) => conflict.severity === 'blocker').length;
+  const warningCount = preview.conflicts.filter((conflict) => conflict.severity === 'warning').length;
+  const infoCount = preview.conflicts.filter((conflict) => conflict.severity === 'info').length;
+
+  return {
+    ok: true,
+    command: 'dr restore-dry-run',
+    formatVersion: 1,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    dryRun: true,
+    wouldWrite: false,
+    inputs: {
+      ...(options.backupPath === undefined ? {} : { backupPath: options.backupPath }),
+      ...(options.livePath === undefined ? {} : { livePath: options.livePath }),
+    },
+    summary: {
+      safeToRestore: preview.safeToRestore,
+      conflictCount: preview.conflicts.length,
+      blockerCount,
+      warningCount,
+      infoCount,
+    },
+    preview,
+    operatorGuidance: preview.safeToRestore
+      ? 'Dry-run only: no restore writes were performed. Review the JSON report, then execute restore separately if an operator explicitly approves it.'
+      : 'Dry-run only: no restore writes were performed; do not execute restore until blocker/warning conflicts have explicit restore, merge, skip, or quarantine decisions.',
   };
 }
 

--- a/packages/franken-orchestrator/src/dr/restore-preview.ts
+++ b/packages/franken-orchestrator/src/dr/restore-preview.ts
@@ -139,6 +139,30 @@ export interface RestoreDryRunReportOptions {
   readonly livePath?: string;
 }
 
+export interface RestoreDryRunConflictRecordSummary {
+  readonly id: string;
+  readonly state?: string;
+  readonly digestPresent?: boolean;
+  readonly updatedAt?: string;
+}
+
+export interface RestoreDryRunConflict {
+  readonly area: RestorePreviewArea;
+  readonly id: string;
+  readonly type: RestorePreviewConflictType;
+  readonly severity: RestorePreviewSeverity;
+  readonly backup?: RestorePreviewRecord | RestoreDryRunConflictRecordSummary | { readonly schemaVersion: number };
+  readonly live?: RestorePreviewRecord | RestoreDryRunConflictRecordSummary | { readonly schemaVersion: number };
+  readonly recommendation: string;
+}
+
+export interface RestoreDryRunPreviewResult {
+  readonly wouldWrite: false;
+  readonly safeToRestore: boolean;
+  readonly schema: RestorePreviewResult['schema'];
+  readonly conflicts: readonly RestoreDryRunConflict[];
+}
+
 export interface RestoreDryRunReport {
   readonly ok: true;
   readonly command: 'dr restore-dry-run';
@@ -157,7 +181,7 @@ export interface RestoreDryRunReport {
     readonly warningCount: number;
     readonly infoCount: number;
   };
-  readonly preview: RestorePreviewResult;
+  readonly preview: RestoreDryRunPreviewResult;
   readonly operatorGuidance: string;
 }
 
@@ -356,10 +380,34 @@ export function buildRestoreDryRunReport(
       warningCount,
       infoCount,
     },
-    preview,
+    preview: redactPreviewForDryRun(preview),
     operatorGuidance: preview.safeToRestore
       ? 'Dry-run only: no restore writes were performed. Review the JSON report, then execute restore separately if an operator explicitly approves it.'
       : 'Dry-run only: no restore writes were performed; do not execute restore until blocker/warning conflicts have explicit restore, merge, skip, or quarantine decisions.',
+  };
+}
+
+function redactPreviewForDryRun(preview: RestorePreviewResult): RestoreDryRunPreviewResult {
+  return {
+    ...preview,
+    conflicts: preview.conflicts.map((conflict) => ({
+      ...conflict,
+      ...(conflict.backup === undefined ? {} : { backup: redactConflictRecord(conflict.area, conflict.backup) }),
+      ...(conflict.live === undefined ? {} : { live: redactConflictRecord(conflict.area, conflict.live) }),
+    })),
+  };
+}
+
+function redactConflictRecord(
+  area: RestorePreviewArea,
+  record: RestorePreviewRecord | { readonly schemaVersion: number },
+): RestorePreviewRecord | RestoreDryRunConflictRecordSummary | { readonly schemaVersion: number } {
+  if (area !== 'approvals' || !('id' in record)) return record;
+  return {
+    id: record.id,
+    ...(record.state === undefined ? {} : { state: record.state }),
+    ...(record.digest === undefined ? {} : { digestPresent: true }),
+    ...(record.updatedAt === undefined ? {} : { updatedAt: record.updatedAt }),
   };
 }
 

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -221,6 +221,7 @@ export type { ModuleHealth } from './resilience/module-initializer.js';
 export {
   buildApprovalLedgerRecoveryReport,
   buildBackupEncryptionVerificationReport,
+  buildRestoreDryRunReport,
   detectRestorePreviewConflicts,
 } from './dr/restore-preview.js';
 export type {
@@ -238,6 +239,11 @@ export type {
   BackupEncryptionVerificationReport,
   BackupEncryptionVerificationSeverity,
   BackupEncryptionVerificationStatus,
+  RestoreDryRunConflict,
+  RestoreDryRunConflictRecordSummary,
+  RestoreDryRunPreviewResult,
+  RestoreDryRunReport,
+  RestoreDryRunReportOptions,
   RestorePreviewArea,
   RestorePreviewConflict,
   RestorePreviewConflictType,

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -83,4 +83,65 @@ describe('dr restore-dry-run CLI', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('fails closed when a manifest has duplicate record IDs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const backupPath = join(dir, 'backup.json');
+    const livePath = join(dir, 'live.json');
+    await writeFile(backupPath, JSON.stringify({
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', digest: 'old' }, { id: 'task-1', digest: 'new' }],
+      approvals: [],
+      memory: [],
+      cron: [],
+    }), 'utf8');
+    await writeFile(livePath, JSON.stringify({ schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] }), 'utf8');
+
+    try {
+      await expect(handleDrCommand({
+        action: 'restore-dry-run',
+        backupManifestPath: backupPath,
+        liveManifestPath: livePath,
+        print: () => undefined,
+      })).rejects.toThrow(/duplicate id 'task-1'/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for unsupported schema versions', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const backupPath = join(dir, 'backup.json');
+    const livePath = join(dir, 'live.json');
+    await writeFile(backupPath, JSON.stringify({ schemaVersion: 2, tasks: [], approvals: [], memory: [], cron: [] }), 'utf8');
+    await writeFile(livePath, JSON.stringify({ schemaVersion: 2, tasks: [], approvals: [], memory: [], cron: [] }), 'utf8');
+
+    try {
+      await expect(handleDrCommand({
+        action: 'restore-dry-run',
+        backupManifestPath: backupPath,
+        liveManifestPath: livePath,
+        print: () => undefined,
+      })).rejects.toThrow(/unsupported schemaVersion 2/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects identical backup and live manifest paths', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const manifestPath = join(dir, 'manifest.json');
+    await writeFile(manifestPath, JSON.stringify({ schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] }), 'utf8');
+
+    try {
+      await expect(handleDrCommand({
+        action: 'restore-dry-run',
+        backupManifestPath: manifestPath,
+        liveManifestPath: manifestPath,
+        print: () => undefined,
+      })).rejects.toThrow(/requires distinct backup and live manifest files/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseArgs } from '../../../src/cli/args.js';
+import { handleDrCommand } from '../../../src/cli/dr-restore.js';
+
+describe('dr restore-dry-run CLI', () => {
+  it('parses restore-dry-run manifest paths', () => {
+    const args = parseArgs(['dr', 'restore-dry-run', '/backup/manifest.json', '/live/manifest.json']);
+
+    expect(args.subcommand).toBe('dr');
+    expect(args.drAction).toBe('restore-dry-run');
+    expect(args.drBackupManifestPath).toBe('/backup/manifest.json');
+    expect(args.drLiveManifestPath).toBe('/live/manifest.json');
+  });
+
+  it('prints structured dry-run JSON without mutating input manifests', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const backupPath = join(dir, 'backup.json');
+    const livePath = join(dir, 'live.json');
+    const backup = {
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', digest: 'old-task' }],
+      approvals: [{ id: 'approval-1', state: 'pending' }],
+      memory: [],
+      cron: [],
+    };
+    const live = { schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] };
+    await writeFile(backupPath, JSON.stringify(backup), 'utf8');
+    await writeFile(livePath, JSON.stringify(live), 'utf8');
+    const output: string[] = [];
+
+    try {
+      await handleDrCommand({
+        action: 'restore-dry-run',
+        backupManifestPath: backupPath,
+        liveManifestPath: livePath,
+        generatedAt: '2026-07-14T12:30:00.000Z',
+        print: (message) => output.push(message),
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    const report = JSON.parse(output.join('\n')) as {
+      command: string;
+      dryRun: boolean;
+      wouldWrite: boolean;
+      summary: { blockerCount: number; conflictCount: number };
+      preview: { conflicts: Array<{ area: string; severity: string }> };
+    };
+    expect(report.command).toBe('dr restore-dry-run');
+    expect(report.dryRun).toBe(true);
+    expect(report.wouldWrite).toBe(false);
+    expect(report.summary.conflictCount).toBe(2);
+    expect(report.summary.blockerCount).toBe(2);
+    expect(report.preview.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ area: 'tasks', severity: 'blocker' }),
+        expect.objectContaining({ area: 'approvals', severity: 'blocker' }),
+      ]),
+    );
+  });
+
+  it('fails closed with an actionable message when a manifest is malformed', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const backupPath = join(dir, 'backup.json');
+    const livePath = join(dir, 'live.json');
+    await writeFile(backupPath, '{not-json', 'utf8');
+    await writeFile(livePath, JSON.stringify({ schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] }), 'utf8');
+
+    try {
+      await expect(handleDrCommand({
+        action: 'restore-dry-run',
+        backupManifestPath: backupPath,
+        liveManifestPath: livePath,
+        print: () => undefined,
+      })).rejects.toThrow(/Unable to read restore manifest/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -23,8 +23,8 @@ describe('dr restore-dry-run CLI', () => {
     const livePath = join(dir, 'live.json');
     const backup = {
       schemaVersion: 1,
-      tasks: [{ id: 'task-1', digest: 'old-task' }],
-      approvals: [{ id: 'approval-1', state: 'pending' }],
+      tasks: [{ id: 'task-1', digest: 'old-task', value: { title: 'secret task title' } }],
+      approvals: [{ id: 'approval-1', state: 'pending', value: 'secret approval token' }],
       memory: [],
       cron: [],
     };
@@ -50,7 +50,7 @@ describe('dr restore-dry-run CLI', () => {
       dryRun: boolean;
       wouldWrite: boolean;
       summary: { blockerCount: number; conflictCount: number };
-      preview: { conflicts: Array<{ area: string; severity: string }> };
+      preview: { conflicts: Array<{ area: string; severity: string; backup?: { valuePresent?: boolean } }> };
     };
     expect(report.command).toBe('dr restore-dry-run');
     expect(report.dryRun).toBe(true);
@@ -59,10 +59,12 @@ describe('dr restore-dry-run CLI', () => {
     expect(report.summary.blockerCount).toBe(2);
     expect(report.preview.conflicts).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ area: 'tasks', severity: 'blocker' }),
-        expect.objectContaining({ area: 'approvals', severity: 'blocker' }),
+        expect.objectContaining({ area: 'tasks', severity: 'blocker', backup: expect.objectContaining({ valuePresent: true }) }),
+        expect.objectContaining({ area: 'approvals', severity: 'blocker', backup: expect.objectContaining({ valuePresent: true }) }),
       ]),
     );
+    expect(output.join('\n')).not.toContain('secret task title');
+    expect(output.join('\n')).not.toContain('secret approval token');
   });
 
   it('fails closed with an actionable message when a manifest is malformed', async () => {
@@ -123,6 +125,31 @@ describe('dr restore-dry-run CLI', () => {
         liveManifestPath: livePath,
         print: () => undefined,
       })).rejects.toThrow(/unsupported schemaVersion 2/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for unsupported record fields and malformed summary fields', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const backupPath = join(dir, 'backup.json');
+    const livePath = join(dir, 'live.json');
+    await writeFile(backupPath, JSON.stringify({
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', title: 'unsupported direct field' }],
+      approvals: [{ id: 'approval-1', state: { token: 'secret' } }],
+      memory: [],
+      cron: [],
+    }), 'utf8');
+    await writeFile(livePath, JSON.stringify({ schemaVersion: 1, tasks: [], approvals: [], memory: [], cron: [] }), 'utf8');
+
+    try {
+      await expect(handleDrCommand({
+        action: 'restore-dry-run',
+        backupManifestPath: backupPath,
+        liveManifestPath: livePath,
+        print: () => undefined,
+      })).rejects.toThrow(/unsupported field 'title'/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -99,7 +99,7 @@ describe('restore preview conflict detector', () => {
     const backup: RestorePreviewManifest = {
       schemaVersion: 1,
       tasks: [{ id: 'task-1', digest: 'old-task', updatedAt: '2026-07-14T10:00:00.000Z' }],
-      approvals: [{ id: 'approval-1', state: 'pending', digest: 'pending-token' }],
+      approvals: [{ id: 'approval-1', state: 'pending', digest: 'pending-token', value: 'secret-token-value' }],
       memory: [],
       cron: [],
     };
@@ -135,9 +135,20 @@ describe('restore preview conflict detector', () => {
         warningCount: 1,
         infoCount: 1,
       },
-      preview: expect.objectContaining({ wouldWrite: false, safeToRestore: false }),
+      preview: expect.objectContaining({
+        wouldWrite: false,
+        safeToRestore: false,
+        conflicts: expect.arrayContaining([
+          expect.objectContaining({
+            area: 'approvals',
+            backup: { id: 'approval-1', state: 'pending', digestPresent: true },
+          }),
+        ]),
+      }),
       operatorGuidance: expect.stringContaining('do not execute restore'),
     });
+    expect(JSON.stringify(report)).not.toContain('secret-token-value');
+    expect(JSON.stringify(report)).not.toContain('pending-token');
   });
 
   it('treats backup-only approval tokens as blockers', () => {

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildApprovalLedgerRecoveryReport,
   buildBackupEncryptionVerificationReport,
+  buildRestoreDryRunReport,
   detectRestorePreviewConflicts,
   type RestorePreviewManifest,
 } from '../../../src/dr/restore-preview.js';
@@ -92,6 +93,51 @@ describe('restore preview conflict detector', () => {
         expect.objectContaining({ area: 'cron', id: 'hourly-watchdog', type: 'live-only', recommendation: expect.stringContaining('preserve') }),
       ]),
     );
+  });
+
+  it('builds deterministic restore dry-run JSON output for automation', () => {
+    const backup: RestorePreviewManifest = {
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', digest: 'old-task', updatedAt: '2026-07-14T10:00:00.000Z' }],
+      approvals: [{ id: 'approval-1', state: 'pending', digest: 'pending-token' }],
+      memory: [],
+      cron: [],
+    };
+    const live: RestorePreviewManifest = {
+      schemaVersion: 1,
+      tasks: [{ id: 'task-1', digest: 'new-task', updatedAt: '2026-07-14T11:00:00.000Z' }],
+      approvals: [],
+      memory: [{ id: 'memory:user', digest: 'live-only-memory' }],
+      cron: [],
+    };
+
+    const report = buildRestoreDryRunReport(backup, live, {
+      generatedAt: '2026-07-14T12:30:00.000Z',
+      backupPath: '/backups/manifest.json',
+      livePath: '/state/live-manifest.json',
+    });
+
+    expect(report).toEqual({
+      ok: true,
+      command: 'dr restore-dry-run',
+      formatVersion: 1,
+      generatedAt: '2026-07-14T12:30:00.000Z',
+      dryRun: true,
+      wouldWrite: false,
+      inputs: {
+        backupPath: '/backups/manifest.json',
+        livePath: '/state/live-manifest.json',
+      },
+      summary: {
+        safeToRestore: false,
+        conflictCount: 3,
+        blockerCount: 1,
+        warningCount: 1,
+        infoCount: 1,
+      },
+      preview: expect.objectContaining({ wouldWrite: false, safeToRestore: false }),
+      operatorGuidance: expect.stringContaining('do not execute restore'),
+    });
   });
 
   it('treats backup-only approval tokens as blockers', () => {

--- a/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/restore-preview.test.ts
@@ -140,8 +140,12 @@ describe('restore preview conflict detector', () => {
         safeToRestore: false,
         conflicts: expect.arrayContaining([
           expect.objectContaining({
+            area: 'tasks',
+            backup: expect.objectContaining({ id: 'task-1', digestPresent: true }),
+          }),
+          expect.objectContaining({
             area: 'approvals',
-            backup: { id: 'approval-1', state: 'pending', digestPresent: true },
+            backup: { id: 'approval-1', state: 'pending', digestPresent: true, valuePresent: true },
           }),
         ]),
       }),

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -17,6 +17,7 @@
 ## 2026-07-14 — Restore preview conflict detector drift coverage
 - Restore preview comparisons must include record metadata (`state`, `updatedAt`) alongside content digests; digest-only equality can hide approval-state or task-timestamp drift that a restore would roll back.
 - Treat backup-only approval/session-token records as blocker-severity conflicts, not informational drift, because restoring them can reintroduce stale authorization state that live has already cleared.
+- Restore dry-run CLI outputs should be machine-stable JSON with `dryRun: true`, `wouldWrite: false`, summarized blocker/warning/info counts, and explicit operator guidance; keep manifest parsing read-only and fail closed on malformed JSON before any restore path is reachable.
 
 ## 2026-07-13 — Lesson contradiction detector Codex edge cases
 - For lesson-contradiction heuristics, compare negation per corrective/directive guidance fragment rather than across a whole lesson blob; multi-finding lessons can otherwise mask one reversed clause with an unrelated negated clause.


### PR DESCRIPTION
## Summary
- add structured restore dry-run report generation with stable JSON fields and conflict summary counts
- add a read-only dr restore-dry-run CLI that compares backup/live manifests and emits JSON
- cover parser, malformed manifest, core report, and CLI output behavior with targeted Vitest tests

## Test Plan
- npm run build --workspace @franken/types && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run build --workspace @franken/planner
- npm run test --workspace @franken/orchestrator -- tests/unit/cli/dr-restore.test.ts tests/unit/dr/restore-preview.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator -- src/cli/dr-restore.ts tests/unit/cli/dr-restore.test.ts src/dr/restore-preview.ts tests/unit/dr/restore-preview.test.ts src/cli/args.ts src/cli/run.ts
- node packages/franken-orchestrator/dist/cli/run.js dr restore-dry-run <backup.json> <live.json>

Closes #1831