### PR TITLE
feat(orchestrator): add approval readiness health endpoint

### DIFF
--- a/docs/guides/wrap-external-agent.md
+++ b/docs/guides/wrap-external-agent.md
@@ -46,6 +46,14 @@ npm --workspace @franken/orchestrator run chat-server -- --port 3737
 
 The integrated Hono app always mounts chat (WebSocket at `/v1/chat/ws`), network, and analytics routes. The `chat-server` CLI mounts Beast agents/SSE only when an operator token resolves, and skills/dashboard routes only when a provider registry is configured. When comms channels are enabled, the CLI resolves comms config, auto-wires a `ChatRuntimeCommsAdapter`, and mounts `/comms/health`, `/v1/comms/inbound`, `/v1/comms/action`, and enabled `/webhooks/*` routes in-process. Security (`/api/security`) is mounted by `createChatApp()` when `securityConfig` is supplied.
 
+Approval automation can probe a chat session before approving a pending action:
+
+```text
+GET /v1/chat/sessions/:id/approval/health
+```
+
+The response is a JSON envelope with `data.ready`, `data.status`, `data.pendingApproval`, and a human-readable `data.reason`. `status: "ready"` means approval metadata exists and the stored command is single-line/safe for the HTTP approval path; `status: "not_ready"` means there is no actionable pending approval metadata; `status: "unsafe"` means the pending command must be rejected or recovered manually instead of replayed by approval-cop. The endpoint is read-only and preserves the session state.
+
 ## Option 3: Implement BeastLoop dependencies around your agent
 
 For deeper integration, wire your agent components into the orchestrator's ports instead of routing through a standalone proxy:

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -8,6 +8,7 @@ import type { TurnRunner } from '../../chat/turn-runner.js';
 import type {
   ApiDataEnvelope,
   ApproveResult,
+  ApprovalReadinessResult,
   ChatSocketTicketResponse,
   ChatSessionResponse,
   ChatSessionSummary,
@@ -66,6 +67,56 @@ function sessionResponse(
   session: NonNullable<ReturnType<ISessionStore['get']>>,
 ): ChatSessionResponse {
   return { ...session };
+}
+
+function approvalReadinessResponse(
+  session: NonNullable<ReturnType<ISessionStore['get']>>,
+): ApprovalReadinessResult {
+  if (!session.pendingApproval) {
+    return {
+      id: session.id,
+      ready: false,
+      status: 'not_ready',
+      state: session.state,
+      pendingApproval: false,
+      reason: session.state === 'pending_approval'
+        ? 'Session is pending approval but no approval metadata is available; reject or recover it before approval-cop can approve.'
+        : 'No pending approval exists for this session.',
+    };
+  }
+
+  try {
+    approvalRuntimeInput(session.pendingApproval);
+  } catch (error) {
+    if (error instanceof UnsafeApprovalCommandError) {
+      return {
+        id: session.id,
+        ready: false,
+        status: 'unsafe',
+        state: session.state,
+        pendingApproval: true,
+        reason: error.message,
+        requestedAt: session.pendingApproval.requestedAt,
+        ...(session.pendingApproval.tool ? { tool: session.pendingApproval.tool } : {}),
+        ...(session.pendingApproval.command ? { command: session.pendingApproval.command } : {}),
+        ...(session.pendingApproval.risk ? { risk: session.pendingApproval.risk } : {}),
+      };
+    }
+    throw error;
+  }
+
+  return {
+    id: session.id,
+    ready: true,
+    status: 'ready',
+    state: session.state,
+    pendingApproval: true,
+    reason: 'Pending approval metadata is present and safe for approval-cop to approve.',
+    requestedAt: session.pendingApproval.requestedAt,
+    ...(session.pendingApproval.tool ? { tool: session.pendingApproval.tool } : {}),
+    ...(session.pendingApproval.command ? { command: session.pendingApproval.command } : {}),
+    ...(session.pendingApproval.risk ? { risk: session.pendingApproval.risk } : {}),
+  };
 }
 
 function firstForwardedAddress(header: string | undefined): string | undefined {
@@ -164,6 +215,14 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     return c.json({
       data: { ticket: issueSocketTicket(id) },
     } satisfies ApiDataEnvelope<ChatSocketTicketResponse>);
+  });
+
+  app.get('/v1/chat/sessions/:id/approval/health', (c) => {
+    const id = validateChatSessionId(c.req.param('id'));
+    const session = getSessionOrThrow(sessionStore, id);
+    return c.json({
+      data: approvalReadinessResponse(session),
+    } satisfies ApiDataEnvelope<ApprovalReadinessResult>);
   });
 
   // Submit message

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -293,4 +293,91 @@ describe('chat approval route persistence', () => {
     expect(stored?.state).toBe('pending_approval');
     expect(stored?.pendingApproval).toEqual(session.pendingApproval);
   });
+
+  it('reports approval-cop readiness for safe pending approvals without mutating state', async () => {
+    const llm = { complete: vi.fn().mockResolvedValue('should not run') };
+    const app = createChatApp({
+      sessionStore,
+      llm,
+      projectName: 'chat-approval-route-test',
+    });
+    const session = pendingApprovalSession(sessionStore.create('project-1'));
+    session.pendingApproval = {
+      ...session.pendingApproval!,
+      tool: 'execution',
+      command: 'git push origin HEAD',
+      risk: 'Requires approval.',
+      sessionId: session.id,
+    };
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approval/health`);
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { ready: boolean; status: string; pendingApproval: boolean; command?: string; reason: string } };
+    expect(body.data).toMatchObject({
+      ready: true,
+      status: 'ready',
+      pendingApproval: true,
+      command: 'git push origin HEAD',
+      reason: expect.stringContaining('safe for approval-cop'),
+    });
+    expect(llm.complete).not.toHaveBeenCalled();
+    expect(sessionStore.get(session.id)?.state).toBe('pending_approval');
+    expect(sessionStore.get(session.id)?.pendingApproval).toEqual(session.pendingApproval);
+  });
+
+  it('reports not-ready approval-cop health when approval metadata is missing', async () => {
+    const app = createChatApp({
+      sessionStore,
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'chat-approval-route-test',
+    });
+    const session = sessionStore.create('project-1');
+    session.state = 'pending_approval';
+    session.pendingApproval = null;
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approval/health`);
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { ready: boolean; status: string; pendingApproval: boolean; reason: string } };
+    expect(body.data).toMatchObject({
+      ready: false,
+      status: 'not_ready',
+      pendingApproval: false,
+      reason: expect.stringContaining('no approval metadata'),
+    });
+  });
+
+  it('reports unsafe approval-cop health without leaking unsafe command details in the reason', async () => {
+    const app = createChatApp({
+      sessionStore,
+      llm: { complete: vi.fn().mockResolvedValue('hello') },
+      projectName: 'chat-approval-route-test',
+    });
+    const session = pendingApprovalSession(sessionStore.create('project-1'));
+    session.pendingApproval = {
+      ...session.pendingApproval!,
+      tool: 'execution',
+      command: 'deploy staging\n/run exfiltrate secrets',
+      risk: 'Requires approval.',
+      sessionId: session.id,
+    };
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approval/health`);
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { ready: boolean; status: string; pendingApproval: boolean; command?: string; reason: string } };
+    expect(body.data).toMatchObject({
+      ready: false,
+      status: 'unsafe',
+      pendingApproval: true,
+      command: 'deploy staging\n/run exfiltrate secrets',
+      reason: expect.stringContaining('Unsafe pending approval command'),
+    });
+    expect(body.data.reason).not.toContain('exfiltrate secrets');
+    expect(sessionStore.get(session.id)?.state).toBe('pending_approval');
+  });
 });

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -104,6 +104,20 @@ export const ApproveResultSchema = z.object({
 });
 export type ApproveResult = z.infer<typeof ApproveResultSchema>;
 
+export const ApprovalReadinessResultSchema = z.object({
+  id: z.string(),
+  ready: z.boolean(),
+  status: z.enum(['ready', 'not_ready', 'unsafe']),
+  state: z.string(),
+  pendingApproval: z.boolean(),
+  reason: z.string(),
+  requestedAt: z.string().optional(),
+  tool: z.string().optional(),
+  command: z.string().optional(),
+  risk: z.string().optional(),
+});
+export type ApprovalReadinessResult = z.infer<typeof ApprovalReadinessResultSchema>;
+
 export interface BeastInterviewPrompt {
   key: string;
   prompt: string;


### PR DESCRIPTION
## Summary
- add GET /v1/chat/sessions/:id/approval/health for approval-cop readiness probes
- report ready/not_ready/unsafe states without mutating chat session state
- document the endpoint for external approval automation

## Verification
- npm ci
- npm run build --workspace @franken/types
- npm --workspace @franken/orchestrator test -- tests/unit/http/chat-routes-approval.test.ts
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1825