### PR TITLE
feat(availability): audit model provider failover

### DIFF
--- a/docs/guides/add-llm-provider.md
+++ b/docs/guides/add-llm-provider.md
@@ -32,7 +32,7 @@ npm --workspace @franken/orchestrator test -- tests/unit/skills
 1. Add the provider implementation under `packages/franken-orchestrator/src/providers/` following the existing provider registry/client patterns.
 2. Add config schema support under `packages/franken-orchestrator/src/config/` if the provider needs new settings.
 3. Keep secrets referenced through the configured secret backend or environment variables; do not hard-code tokens in config examples.
-4. Add unit tests for request construction, error handling, and config parsing.
+4. Add unit tests for request construction, error handling, config parsing, and failover audit metadata. API-provider failover through `ProviderRegistry` emits a `model-provider.failover` audit event with `from`, `to`, `reason`, `brainSnapshotHash`, `category: "availability"`, and operator guidance; keep that payload structured so dashboard/liveness tooling can correlate a provider outage with the handoff snapshot.
 5. Verify from the repo root:
 
 ```bash

--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -1,5 +1,8 @@
 import { SqliteBrain } from '@franken/brain';
-import { ProviderRegistry } from '../providers/provider-registry.js';
+import {
+  createModelProviderFailoverAuditPayload,
+  ProviderRegistry,
+} from '../providers/provider-registry.js';
 import { createLlmProvider, type ProviderConfig } from '../providers/provider-config.js';
 import type { EgressAuditSink, EgressPolicyConfig } from '../network/egress-policy.js';
 import { now as deterministicNow } from '@franken/types';
@@ -127,6 +130,12 @@ export function createBeastDeps(
   const providers = buildProviderList(config.providers, config.network?.egressPolicy, recordProviderEgressDecision);
   const registry = new ProviderRegistry(providers, brain, {
     onProviderSwitch: (event) => {
+      auditTrail.append(
+        createAuditEvent('model-provider.failover', createModelProviderFailoverAuditPayload(event), {
+          phase: 'execution',
+          provider: event.to,
+        }),
+      );
       auditTrail.append(
         createAuditEvent('provider.switch', event, {
           phase: 'execution',

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -120,6 +120,15 @@ export {
   assessPmHandoffQuality,
   formatHandoff,
 } from './providers/format-handoff.js';
+export {
+  createModelProviderFailoverAuditPayload,
+  ProviderRegistry as LlmProviderRegistry,
+} from './providers/provider-registry.js';
+export type {
+  ModelProviderFailoverAuditPayload,
+  ProviderRegistryOptions as LlmProviderRegistryOptions,
+  ProviderSwitchEvent,
+} from './providers/provider-registry.js';
 export type {
   PmHandoffQualityAssessment,
   PmHandoffRubricCriterion,

--- a/packages/franken-orchestrator/src/providers/index.ts
+++ b/packages/franken-orchestrator/src/providers/index.ts
@@ -1,5 +1,12 @@
-export { ProviderRegistry } from './provider-registry.js';
-export type { ProviderRegistryOptions } from './provider-registry.js';
+export {
+  createModelProviderFailoverAuditPayload,
+  ProviderRegistry,
+} from './provider-registry.js';
+export type {
+  ModelProviderFailoverAuditPayload,
+  ProviderRegistryOptions,
+  ProviderSwitchEvent,
+} from './provider-registry.js';
 export { TokenAggregator } from './token-aggregator.js';
 export type { AggregatedTokenUsage } from './token-aggregator.js';
 export { formatHandoff, truncateSnapshot } from './format-handoff.js';

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -17,12 +17,35 @@ export interface ProviderRegistryOptions {
   /** Rate limit backoff multiplier */
   backoffMultiplier?: number;
   /** Callback fired when switching providers */
-  onProviderSwitch?: (event: {
-    from: string;
-    to: string;
-    reason: string;
-    brainSnapshotHash: string;
-  }) => void;
+  onProviderSwitch?: (event: ProviderSwitchEvent) => void;
+}
+
+export interface ProviderSwitchEvent {
+  from: string;
+  to: string;
+  reason: string;
+  brainSnapshotHash: string;
+}
+
+export interface ModelProviderFailoverAuditPayload extends ProviderSwitchEvent {
+  event: 'model-provider.failover';
+  category: 'availability';
+  operatorGuidance: string;
+}
+
+export function createModelProviderFailoverAuditPayload(
+  event: ProviderSwitchEvent,
+): ModelProviderFailoverAuditPayload {
+  return {
+    event: 'model-provider.failover',
+    category: 'availability',
+    from: event.from,
+    to: event.to,
+    reason: event.reason,
+    brainSnapshotHash: event.brainSnapshotHash,
+    operatorGuidance:
+      'Provider failover occurred. Inspect the failed provider health/credentials and use brainSnapshotHash to correlate the handoff state.',
+  };
 }
 
 interface ResolvedOptions {

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -99,6 +99,7 @@ export class ProviderRegistry {
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
     let lastError: Error | undefined;
+    let lastFailedProviderName: string | undefined;
     const unavailableProviders: string[] = [];
     let attemptedProviders = 0;
 
@@ -109,6 +110,8 @@ export class ProviderRegistry {
 
       if (!(await provider.isAvailable())) {
         unavailableProviders.push(provider.name);
+        lastFailedProviderName = provider.name;
+        lastError = new Error(`Provider ${provider.name} is unavailable`);
         continue;
       }
       attemptedProviders++;
@@ -116,8 +119,8 @@ export class ProviderRegistry {
       let effectiveRequest = request;
       if (i > 0) {
         const snapshot = this.brain.serialize();
-        const previousProvider = this.providers[this.currentProviderIndex]!;
-        snapshot.metadata.lastProvider = previousProvider.name;
+        const failedProviderName = lastFailedProviderName ?? this.providers[this.currentProviderIndex]!.name;
+        snapshot.metadata.lastProvider = failedProviderName;
         snapshot.metadata.switchReason = lastError?.message ?? 'unknown';
 
         if (this.opts.onProviderSwitch) {
@@ -125,7 +128,7 @@ export class ProviderRegistry {
           const hash =
             'sha256:' + createHash('sha256').update(json).digest('hex');
           this.opts.onProviderSwitch({
-            from: previousProvider.name,
+            from: failedProviderName,
             to: provider.name,
             reason: lastError?.message ?? 'unknown',
             brainSnapshotHash: hash,
@@ -169,6 +172,7 @@ export class ProviderRegistry {
             }
             if (event.type === 'error' && !event.retryable) {
               lastError = new Error(event.error);
+              lastFailedProviderName = provider.name;
               throw lastError; // discard buffer, failover
             }
             buffer.push(event);
@@ -188,10 +192,13 @@ export class ProviderRegistry {
             }
           }
 
+          lastError = new Error('stream ended without done');
+          lastFailedProviderName = provider.name;
           break; // stream ended without done — failover
         } catch (error) {
           lastError =
             error instanceof Error ? error : new Error(String(error));
+          lastFailedProviderName = provider.name;
           break; // failover to next provider
         }
       }

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -99,6 +99,7 @@ export class ProviderRegistry {
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
     let lastError: Error | undefined;
+    let terminalError: Error | undefined;
     let lastFailedProviderName: string | undefined;
     const unavailableProviders: string[] = [];
     let attemptedProviders = 0;
@@ -110,8 +111,10 @@ export class ProviderRegistry {
 
       if (!(await provider.isAvailable())) {
         unavailableProviders.push(provider.name);
+        const availabilityError = new Error(`Provider ${provider.name} is unavailable`);
         lastFailedProviderName = provider.name;
-        lastError = new Error(`Provider ${provider.name} is unavailable`);
+        lastError = availabilityError;
+        terminalError ??= availabilityError;
         continue;
       }
       attemptedProviders++;
@@ -170,8 +173,9 @@ export class ProviderRegistry {
               retried = true;
               break; // discard buffer, retry same provider
             }
-            if (event.type === 'error' && !event.retryable) {
+            if (event.type === 'error') {
               lastError = new Error(event.error);
+              terminalError = lastError;
               lastFailedProviderName = provider.name;
               throw lastError; // discard buffer, failover
             }
@@ -198,6 +202,7 @@ export class ProviderRegistry {
         } catch (error) {
           lastError =
             error instanceof Error ? error : new Error(String(error));
+          terminalError = lastError;
           lastFailedProviderName = provider.name;
           break; // failover to next provider
         }
@@ -209,14 +214,14 @@ export class ProviderRegistry {
       runId: 'failover-exhausted',
       phase: 'provider-failover',
       step: 0,
-      context: { lastError: lastError?.message },
+      context: { lastError: (terminalError ?? lastError)?.message },
       timestamp: isoNow(),
     });
 
     const exhaustionReason = attemptedProviders === 0
       ? `No providers available. Checked: ${unavailableProviders.join(', ')}. `
         + 'Install or authenticate at least one configured provider CLI, or configure provider overrides.'
-      : `All providers exhausted. Last error: ${lastError?.message ?? 'unknown'}. `;
+      : `All providers exhausted. Last error: ${(terminalError ?? lastError)?.message ?? 'unknown'}. `;
 
     throw new Error(
       exhaustionReason + 'Brain state checkpointed for recovery.',

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -112,8 +112,10 @@ export class ProviderRegistry {
       if (!(await provider.isAvailable())) {
         unavailableProviders.push(provider.name);
         const availabilityError = new Error(`Provider ${provider.name} is unavailable`);
-        lastFailedProviderName = provider.name;
-        lastError = availabilityError;
+        if (!lastError) {
+          lastFailedProviderName = provider.name;
+          lastError = availabilityError;
+        }
         terminalError ??= availabilityError;
         continue;
       }
@@ -197,6 +199,7 @@ export class ProviderRegistry {
           }
 
           lastError = new Error('stream ended without done');
+          terminalError = lastError;
           lastFailedProviderName = provider.name;
           break; // stream ended without done — failover
         } catch (error) {

--- a/packages/franken-orchestrator/tests/integration/providers/provider-switch-audit.test.ts
+++ b/packages/franken-orchestrator/tests/integration/providers/provider-switch-audit.test.ts
@@ -3,9 +3,12 @@ import type {
   ILlmProvider,
   LlmStreamEvent,
   ProviderCapabilities,
-  BrainSnapshot,
 } from '@franken/types';
-import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import {
+  createModelProviderFailoverAuditPayload,
+  ProviderRegistry,
+  type ProviderSwitchEvent,
+} from '../../../src/providers/provider-registry.js';
 import { AuditTrail, createAuditEvent } from '@franken/observer';
 
 function mockProvider(
@@ -46,10 +49,10 @@ function mockBrain() {
 }
 
 describe('Provider switch audit integration', () => {
-  it('emits provider.switch audit event on failover', async () => {
+  it('emits model-provider.failover audit event on failover', async () => {
     const auditTrail = new AuditTrail();
-    const onSwitch = vi.fn((event: { from: string; to: string; reason: string; brainSnapshotHash: string }) => {
-      auditTrail.append(createAuditEvent('provider.switch', event, {
+    const onSwitch = vi.fn((event: ProviderSwitchEvent) => {
+      auditTrail.append(createAuditEvent('model-provider.failover', createModelProviderFailoverAuditPayload(event), {
         phase: 'execution',
         provider: event.to,
       }));
@@ -73,10 +76,15 @@ describe('Provider switch audit integration', () => {
       brainSnapshotHash: expect.stringMatching(/^sha256:/),
     }));
 
-    const switchEvents = auditTrail.getByType('provider.switch');
-    expect(switchEvents).toHaveLength(1);
-    expect((switchEvents[0]!.payload as Record<string, string>)['from']).toBe('primary');
-    expect((switchEvents[0]!.payload as Record<string, string>)['to']).toBe('secondary');
+    const failoverEvents = auditTrail.getByType('model-provider.failover');
+    expect(failoverEvents).toHaveLength(1);
+    const payload = failoverEvents[0]!.payload as Record<string, string>;
+    expect(payload['event']).toBe('model-provider.failover');
+    expect(payload['category']).toBe('availability');
+    expect(payload['from']).toBe('primary');
+    expect(payload['to']).toBe('secondary');
+    expect(payload['reason']).toBe('crashed');
+    expect(payload['operatorGuidance']).toContain('Provider failover occurred');
   });
 
   it('does not emit event when no switch occurs', async () => {
@@ -87,7 +95,9 @@ describe('Provider switch audit integration', () => {
       { onProviderSwitch: onSwitch },
     );
 
-    for await (const _ of registry.execute({ systemPrompt: '', messages: [] })) { /* consume */ }
+    for await (const event of registry.execute({ systemPrompt: '', messages: [] })) {
+      expect(event.type).toBeDefined();
+    }
     expect(onSwitch).not.toHaveBeenCalled();
   });
 
@@ -105,7 +115,9 @@ describe('Provider switch audit integration', () => {
       },
     );
 
-    for await (const _ of registry.execute({ systemPrompt: '', messages: [] })) { /* consume */ }
+    for await (const event of registry.execute({ systemPrompt: '', messages: [] })) {
+      expect(event.type).toBeDefined();
+    }
 
     expect(capturedHash).toHaveLength(1);
     expect(capturedHash[0]).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -325,6 +325,26 @@ describe('ProviderRegistry', () => {
       );
     });
 
+    it('preserves the executed failure across unavailable fallback providers', async () => {
+      const p1 = mockProvider('primary', { failOnExecute: new Error('primary crashed') });
+      const p2 = mockProvider('secondary', { available: false });
+      const p3 = mockProvider('tertiary');
+      const onSwitch = vi.fn();
+
+      const registry = new ProviderRegistry([p1, p2, p3], mockBrain(), {
+        onProviderSwitch: onSwitch,
+      });
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(onSwitch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'primary',
+          to: 'tertiary',
+          reason: 'primary crashed',
+        }),
+      );
+    });
+
     it('checkpoints brain when all providers exhausted', async () => {
       const p1 = mockProvider('p1', { failOnExecute: new Error('err1') });
       const p2 = mockProvider('p2', { failOnExecute: new Error('err2') });
@@ -433,6 +453,24 @@ describe('ProviderRegistry', () => {
       expect(brain.recovery.checkpoint).toHaveBeenCalledWith(
         expect.objectContaining({
           context: { lastError: 'runner crashed' },
+        }),
+      );
+    });
+
+    it('reports no-done streams as the terminal exhaustion error', async () => {
+      const p1 = mockProvider('unavailable-primary', { available: false });
+      const p2 = mockProvider('silent', {
+        events: [{ type: 'text' as const, content: 'partial' }],
+      });
+      const brain = mockBrain();
+      const registry = new ProviderRegistry([p1, p2], brain);
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow('stream ended without done');
+      expect(brain.recovery.checkpoint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { lastError: 'stream ended without done' },
         }),
       );
     });

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -296,6 +296,35 @@ describe('ProviderRegistry', () => {
       );
     });
 
+    it('reports the actual failed provider during chained failover', async () => {
+      const p1 = mockProvider('primary', { failOnExecute: new Error('primary crashed') });
+      const p2 = mockProvider('secondary', { failOnExecute: new Error('secondary crashed') });
+      const p3 = mockProvider('tertiary');
+      const onSwitch = vi.fn();
+
+      const registry = new ProviderRegistry([p1, p2, p3], mockBrain(), {
+        onProviderSwitch: onSwitch,
+      });
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(onSwitch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          from: 'primary',
+          to: 'secondary',
+          reason: 'primary crashed',
+        }),
+      );
+      expect(onSwitch).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          from: 'secondary',
+          to: 'tertiary',
+          reason: 'secondary crashed',
+        }),
+      );
+    });
+
     it('checkpoints brain when all providers exhausted', async () => {
       const p1 = mockProvider('p1', { failOnExecute: new Error('err1') });
       const p2 = mockProvider('p2', { failOnExecute: new Error('err2') });

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -394,6 +394,49 @@ describe('ProviderRegistry', () => {
       expect(delay2).toBeGreaterThanOrEqual(80); // 100ms with some tolerance
     });
 
+    it('uses the exhausted retryable error as failover reason', async () => {
+      const p1: ILlmProvider = {
+        ...mockProvider('rate-limited'),
+        execute: vi.fn(async function* () {
+          yield { type: 'error' as const, error: 'rate limit', retryable: true };
+        }),
+      };
+      const p2 = mockProvider('backup');
+      const onSwitch = vi.fn();
+
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        maxRetriesPerProvider: 1,
+        retryDelayMs: 1,
+        onProviderSwitch: onSwitch,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(onSwitch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'rate-limited',
+          to: 'backup',
+          reason: 'rate limit',
+        }),
+      );
+    });
+
+    it('preserves execution failure as terminal error when later providers are unavailable', async () => {
+      const p1 = mockProvider('runner', { failOnExecute: new Error('runner crashed') });
+      const p2 = mockProvider('unavailable-backup', { available: false });
+      const brain = mockBrain();
+      const registry = new ProviderRegistry([p1, p2], brain);
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow('runner crashed');
+      expect(brain.recovery.checkpoint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { lastError: 'runner crashed' },
+        }),
+      );
+    });
+
     it('discards partial output from failed provider on failover', async () => {
       // p1 streams some text then errors — those text events should NOT appear
       const p1: ILlmProvider = {


### PR DESCRIPTION
## Summary
- Adds a dedicated `model-provider.failover` audit event payload for provider failovers while preserving the existing `provider.switch` compatibility event.
- Exports typed failover audit metadata for downstream dashboard/liveness consumers.
- Updates provider documentation with the failover audit payload contract.

## Verification
- `npm install`
- `npm --workspace @franken/orchestrator test -- tests/integration/providers/provider-switch-audit.test.ts tests/unit/providers/provider-registry.test.ts`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/brain`
- `npm run build --workspace @franken/observer`
- `npm run build --workspace @franken/critique`
- `npm run build --workspace @franken/governor`
- `npm run build --workspace @franken/planner`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run lint` (passes with pre-existing warnings)
- `npm --workspace @franken/orchestrator run build`

Closes #1827