### PR TITLE
feat(governor): add approval queue backpressure

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -385,6 +385,23 @@ Features:
 - **Signature verification**: Optionally validates HMAC-SHA256 signatures on responses
 - **Session tokens**: Optionally creates scoped, time-limited tokens on APPROVE
 - **Audit**: Records every decision via the `AuditRecorder` interface
+- **HTTP queue backpressure**: `createGovernorApp({ approvalQueueBackpressure })` can reject new unique approval requests with HTTP 429 when too many approvals are already pending
+
+### HTTP approval queue backpressure
+
+Standalone governor HTTP apps can put an explicit high-water mark on pending approvals so automated producers slow down instead of growing an unbounded operator queue:
+
+```typescript
+const app = createGovernorApp({
+  signingSecret: process.env.FRANKEN_GOVERNOR_SIGNING_SECRET,
+  approvalQueueBackpressure: {
+    maxPendingApprovals: 25,
+    retryAfterSeconds: 60,
+  },
+});
+```
+
+When `pendingApprovals` reaches `maxPendingApprovals`, `POST /v1/approval/request` rejects new request IDs with `429` and an `approval_queue_backpressure` error body. If `retryAfterSeconds` is set, the response includes `Retry-After`. Reposting an existing pending `requestId` is still accepted so producers can refresh visible metadata without increasing queue depth. `GET /health` reports `approvalQueueBackpressure.enabled`, `atCapacity`, `maxPendingApprovals`, and `remainingCapacity` for scheduler/liveness tooling.
 
 ## Audit Trail
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -30,6 +30,17 @@ export interface GovernorAppOptions {
   sessionTokenStore?: SessionTokenStore;
   /** JSON file used to share session tokens across governor processes. */
   sessionTokenStorePath?: string;
+  /**
+   * Optional backpressure guard for the approval queue. When configured,
+   * new unique approval requests are rejected with HTTP 429 once the pending
+   * queue reaches `maxPendingApprovals`; refreshing an existing requestId is
+   * still allowed so operators can update visible request metadata without
+   * growing the queue.
+   */
+  approvalQueueBackpressure?: {
+    readonly maxPendingApprovals: number;
+    readonly retryAfterSeconds?: number;
+  };
 }
 
 /** Maximum age (seconds) for a Slack request timestamp before it is rejected as a replay. */
@@ -101,6 +112,22 @@ function parseJsonBody(rawBody: Buffer): ParsedJsonBody | null {
   }
 }
 
+function normalizeApprovalQueueBackpressure(
+  options: GovernorAppOptions['approvalQueueBackpressure'],
+): { maxPendingApprovals: number; retryAfterSeconds?: number } | undefined {
+  if (!options) return undefined;
+  if (!Number.isSafeInteger(options.maxPendingApprovals) || options.maxPendingApprovals < 1) {
+    throw new Error('approvalQueueBackpressure.maxPendingApprovals must be a positive safe integer');
+  }
+  if (
+    options.retryAfterSeconds !== undefined
+    && (!Number.isSafeInteger(options.retryAfterSeconds) || options.retryAfterSeconds < 1)
+  ) {
+    throw new Error('approvalQueueBackpressure.retryAfterSeconds must be a positive safe integer when provided');
+  }
+  return options;
+}
+
 /**
  * Produce a signature for a resolved `ApprovalResponse` matching the format
  * `ApprovalGateway.verifySignature` expects (HMAC-SHA256 hex digest of
@@ -154,6 +181,7 @@ function normalizeSlackDecision(actionId: unknown): ResponseCode | null {
 export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   const app = new Hono();
   const registry = options.registry ?? new ApprovalWaiterRegistry();
+  const approvalQueueBackpressure = normalizeApprovalQueueBackpressure(options.approvalQueueBackpressure);
   let sessionTokenStore: SessionTokenStore | undefined = options.sessionTokenStore;
   if (!sessionTokenStore && options.sessionTokenStorePath) {
     try {
@@ -165,10 +193,21 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
   // Health check
   app.get('/health', (c) => {
+    const remainingCapacity = approvalQueueBackpressure
+      ? Math.max(approvalQueueBackpressure.maxPendingApprovals - registry.size, 0)
+      : undefined;
     return c.json({
       status: 'ok',
       service: 'franken-governor',
       pendingApprovals: registry.size,
+      approvalQueueBackpressure: approvalQueueBackpressure
+        ? {
+            enabled: true,
+            atCapacity: remainingCapacity === 0,
+            maxPendingApprovals: approvalQueueBackpressure.maxPendingApprovals,
+            remainingCapacity,
+          }
+        : { enabled: false },
     });
   });
 
@@ -214,6 +253,24 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
         { error: { message: 'Missing required fields: requestId, taskId, summary' } },
         400,
       );
+    }
+
+    if (
+      approvalQueueBackpressure
+      && !registry.has(body.requestId)
+      && registry.size >= approvalQueueBackpressure.maxPendingApprovals
+    ) {
+      if (approvalQueueBackpressure.retryAfterSeconds) {
+        c.header('Retry-After', String(approvalQueueBackpressure.retryAfterSeconds));
+      }
+      return c.json({
+        error: {
+          code: 'approval_queue_backpressure',
+          message: 'Approval queue is at capacity; retry after operators resolve pending approvals.',
+          pendingApprovals: registry.size,
+          maxPendingApprovals: approvalQueueBackpressure.maxPendingApprovals,
+        },
+      }, 429);
     }
 
     registry.register(body.requestId, body.taskId, body.summary);

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -111,6 +111,69 @@ describe('Governor Hono Server', () => {
 
       expect(res.status).toBe(400);
     });
+
+    it('applies backpressure when the pending approval queue reaches capacity', async () => {
+      const app = createGovernorApp({
+        allowUnsignedApprovalsForTests: true,
+        approvalQueueBackpressure: { maxPendingApprovals: 2, retryAfterSeconds: 45 },
+      });
+
+      for (const requestId of ['req-1', 'req-2']) {
+        const accepted = await app.request('/v1/approval/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ requestId, taskId: 'task-1', summary: 'Deploy' }),
+        });
+        expect(accepted.status).toBe(201);
+      }
+
+      const rejected = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: 'req-3', taskId: 'task-1', summary: 'Deploy' }),
+      });
+
+      expect(rejected.status).toBe(429);
+      expect(rejected.headers.get('Retry-After')).toBe('45');
+      const body = await rejected.json();
+      expect(body.error.code).toBe('approval_queue_backpressure');
+      expect(body.error.message).toContain('Approval queue is at capacity');
+      expect(body.error.pendingApprovals).toBe(2);
+      expect(body.error.maxPendingApprovals).toBe(2);
+
+      const healthBody = await (await app.request('/health')).json();
+      expect(healthBody.pendingApprovals).toBe(2);
+      expect(healthBody.approvalQueueBackpressure).toEqual({
+        enabled: true,
+        atCapacity: true,
+        maxPendingApprovals: 2,
+        remainingCapacity: 0,
+      });
+    });
+
+    it('allows an existing pending approval to be refreshed while the queue is at capacity', async () => {
+      const app = createGovernorApp({
+        allowUnsignedApprovalsForTests: true,
+        approvalQueueBackpressure: { maxPendingApprovals: 1 },
+      });
+
+      const created = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: 'req-1', taskId: 'task-1', summary: 'Deploy' }),
+      });
+      expect(created.status).toBe(201);
+
+      const refreshed = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: 'req-1', taskId: 'task-1', summary: 'Updated summary' }),
+      });
+
+      expect(refreshed.status).toBe(201);
+      const healthBody = await (await app.request('/health')).json();
+      expect(healthBody.pendingApprovals).toBe(1);
+    });
   });
 
   describe('POST /v1/approval/respond', () => {


### PR DESCRIPTION
## Summary
- add an optional `approvalQueueBackpressure` high-water guard to the governor HTTP app
- return HTTP 429 with structured `approval_queue_backpressure` details and optional `Retry-After` when unique approval requests exceed capacity
- expose capacity state in `/health` and document operator/scheduler guidance

## Test Plan
- [x] `npm run build --workspace @franken/types`
- [x] `npm run typecheck --workspace @franken/governor`
- [x] `npm run lint --workspace @franken/governor` (passes with pre-existing warnings in `tests/integration/full-approval-flow.test.ts`)
- [x] `npm test --workspace @franken/governor`
- [x] `npm run build --workspace @franken/governor`

Closes #1822
