### PR TITLE
feat(orchestrator): add stale dependency cache fallback

### DIFF
--- a/docs/beast-loop-explained.md
+++ b/docs/beast-loop-explained.md
@@ -132,6 +132,7 @@ The live orchestrator execution phase runs topological parallel waves: parallel-
 - CLI-backed and HITL-gated tasks are serialized because they share a checkout and operator approval channel
 - A failed task is recorded but not added to the completed set
 - Later waves continue with tasks whose dependencies are satisfied; dependents of failed tasks are later skipped as unmet dependencies
+- On resume, completed-task outputs are read from checkpoint sidecars so downstream dependency inputs can be rehydrated. If the primary sidecar is missing or corrupted but a previous known-good output exists, execution uses that stale dependency cache, emits a `dependency-output-cache:stale-fallback` audit event, and logs the reason so operators can decide whether to rerun the upstream task.
 
 **Linear planner strategy** (`@franken/planner/src/planners/linear.ts`) — planner strategy module, not the live orchestrator execution loop
 - Tasks execute one at a time in topological order

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -1,6 +1,5 @@
 import {
   closeSync,
-  copyFileSync,
   existsSync,
   fsyncSync,
   mkdirSync,
@@ -245,16 +244,26 @@ export class FileCheckpointStore implements ICheckpointStore {
   }
 
   private copyTaskOutputToStale(outputPath: string): void {
+    let payload: string;
     try {
-      copyFileSync(outputPath, `${outputPath}.stale`);
+      payload = readFileSync(outputPath, 'utf-8');
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw error;
       }
+      return;
     }
+    try {
+      deserialize(Buffer.from(payload, 'base64'));
+    } catch {
+      // Do not replace a known-good stale cache with an unreadable primary.
+      return;
+    }
+    this.atomicWriteFile(`${outputPath}.stale`, payload);
   }
 
   private promoteTaskOutputToStale(outputPath: string): void {
+    mkdirSync(dirname(outputPath), { recursive: true });
     this.withLock(() => {
       this.copyTaskOutputToStale(outputPath);
       this.deleteTaskOutput(outputPath);

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -1,5 +1,6 @@
 import {
   closeSync,
+  copyFileSync,
   existsSync,
   fsyncSync,
   mkdirSync,
@@ -143,37 +144,40 @@ export class FileCheckpointStore implements ICheckpointStore {
       const serialized = serialize(output);
       const rehydrated = deserialize(serialized);
       if (!isDeepStrictEqual(rehydrated, output)) {
-        this.deleteTaskOutput(outputPath);
+        this.promoteTaskOutputToStale(outputPath);
         return;
       }
       payload = serialized.toString('base64');
     } catch {
       // Checkpoint markers must never fail a successful task just because its
       // output cannot be cloned or faithfully rehydrated. Persist what can be
-      // safely rehydrated and fall back to marker-only recovery otherwise.
-      this.deleteTaskOutput(outputPath);
+      // safely rehydrated and fall back to the last known-good dependency cache
+      // otherwise. That preserves availability for downstream resume paths while
+      // keeping the primary cache honest for future writes.
+      this.promoteTaskOutputToStale(outputPath);
       return;
     }
     mkdirSync(dirname(outputPath), { recursive: true });
     this.withLock(() => {
+      this.copyTaskOutputToStale(outputPath);
       this.atomicWriteFile(outputPath, payload);
     });
   }
 
-  readTaskOutput(taskId: string): { found: boolean; output?: unknown } {
+  readTaskOutput(taskId: string): { found: boolean; output?: unknown; stale?: boolean | undefined; staleReason?: 'missing-primary' | 'corrupt-primary' | undefined } {
     let payload: string;
     try {
       payload = readFileSync(this.taskOutputPath(taskId), 'utf-8');
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return { found: false };
+        return this.readStaleTaskOutput(taskId, 'missing-primary');
       }
       throw error;
     }
     try {
       return { found: true, output: deserialize(Buffer.from(payload, 'base64')) };
     } catch {
-      return { found: false };
+      return this.readStaleTaskOutput(taskId, 'corrupt-primary');
     }
   }
 
@@ -215,8 +219,46 @@ export class FileCheckpointStore implements ICheckpointStore {
     return join(this.taskOutputDir, `${outputKey}.v8`);
   }
 
+  private staleTaskOutputPath(taskId: string): string {
+    return `${this.taskOutputPath(taskId)}.stale`;
+  }
+
+  private readStaleTaskOutput(
+    taskId: string,
+    staleReason: 'missing-primary' | 'corrupt-primary',
+  ): { found: boolean; output?: unknown; stale?: boolean | undefined; staleReason?: 'missing-primary' | 'corrupt-primary' | undefined } {
+    try {
+      const payload = readFileSync(this.staleTaskOutputPath(taskId), 'utf-8');
+      return {
+        found: true,
+        output: deserialize(Buffer.from(payload, 'base64')),
+        stale: true,
+        staleReason,
+      };
+    } catch {
+      return { found: false };
+    }
+  }
+
   private get taskOutputDir(): string {
     return `${this.checkpointPath}.outputs`;
+  }
+
+  private copyTaskOutputToStale(outputPath: string): void {
+    try {
+      copyFileSync(outputPath, `${outputPath}.stale`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  private promoteTaskOutputToStale(outputPath: string): void {
+    this.withLock(() => {
+      this.copyTaskOutputToStale(outputPath);
+      this.deleteTaskOutput(outputPath);
+    });
   }
 
   private deleteTaskOutput(outputPath: string): void {

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -209,6 +209,10 @@ export interface McpToolInfo {
 export interface CheckpointTaskOutput {
   readonly found: boolean;
   readonly output?: unknown;
+  /** True when the primary output sidecar was unavailable and a previous known-good value was used. */
+  readonly stale?: boolean | undefined;
+  /** Operator-facing reason a stale dependency output had to be used. */
+  readonly staleReason?: 'missing-primary' | 'corrupt-primary' | undefined;
 }
 
 export interface ICheckpointStore {

--- a/packages/franken-orchestrator/src/phases/execution.ts
+++ b/packages/franken-orchestrator/src/phases/execution.ts
@@ -203,6 +203,18 @@ export async function runExecution(
       // Skip tasks already completed in a previous run (checkpoint recovery)
       if (checkpoint?.has(`${task.id}:done`)) {
         const checkpointedOutput = checkpoint.readTaskOutput?.(task.id);
+        if (checkpointedOutput?.stale) {
+          logger.warn('Execution: using stale dependency output cache for checkpointed task', {
+            taskId: task.id,
+            reason: checkpointedOutput.staleReason,
+            checkpointPath: checkpoint.checkpointPath,
+          });
+          ctx.addAudit('executor', 'dependency-output-cache:stale-fallback', {
+            taskId: task.id,
+            reason: checkpointedOutput.staleReason,
+            checkpointPath: checkpoint.checkpointPath,
+          });
+        }
         logger.info('Execution: Skipping checkpointed task', { taskId: task.id });
         const outcome = { taskId: task.id, status: 'success' as const, output: checkpointedOutput?.output };
         if (checkpointedOutput?.found) {

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -180,6 +180,29 @@ describe('FileCheckpointStore', () => {
       });
     });
 
+    it('preserves a known-good stale cache when the primary sidecar is corrupted before promotion', () => {
+      store.writeTaskOutput('task-1', 'old-output');
+      store.writeTaskOutput('task-1', 'new-output');
+      const outputFile = readdirSync(`${filePath}.outputs`).find((entry) => !entry.endsWith('.stale'));
+      writeFileSync(join(`${filePath}.outputs`, outputFile!), 'not-valid-base64-v8-payload');
+
+      expect(() => store.writeTaskOutput('task-1', () => 'not cloneable')).not.toThrow();
+
+      expect(store.readTaskOutput('task-1')).toEqual({
+        found: true,
+        output: 'old-output',
+        stale: true,
+        staleReason: 'missing-primary',
+      });
+    });
+
+    it('does not throw when first output is unserializable for a nested checkpoint path', () => {
+      const nestedStore = new FileCheckpointStore(join(tmpDir, 'nested', 'checkpoint.log'));
+
+      expect(() => nestedStore.writeTaskOutput('task-1', () => 'not cloneable')).not.toThrow();
+      expect(nestedStore.readTaskOutput('task-1')).toEqual({ found: false });
+    });
+
     it('reports missing task output when no stale cache exists', () => {
       store.writeTaskOutput('task-1', 'only-output');
       const outputFile = readdirSync(`${filePath}.outputs`).find((entry) => !entry.endsWith('.stale'));

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -153,18 +153,37 @@ describe('FileCheckpointStore', () => {
       expect(store.readTaskOutput('task-1')).toEqual({ found: false });
     });
 
-    it('removes stale task output when falling back to marker-only recovery', () => {
+    it('falls back to the stale dependency cache when a newer output cannot be serialized', () => {
       store.writeTaskOutput('task-1', 'old-output');
 
       expect(() => store.writeTaskOutput('task-1', () => 'not cloneable')).not.toThrow();
 
-      expect(store.readTaskOutput('task-1')).toEqual({ found: false });
+      expect(store.readTaskOutput('task-1')).toEqual({
+        found: true,
+        output: 'old-output',
+        stale: true,
+        staleReason: 'missing-primary',
+      });
     });
 
-    it('treats corrupted task output sidecars as missing', () => {
+    it('falls back to stale dependency cache when the primary output sidecar is corrupted', () => {
       store.writeTaskOutput('task-1', 'old-output');
-      const [outputFile] = readdirSync(`${filePath}.outputs`);
+      store.writeTaskOutput('task-1', 'new-output');
+      const outputFile = readdirSync(`${filePath}.outputs`).find((entry) => !entry.endsWith('.stale'));
       writeFileSync(join(`${filePath}.outputs`, outputFile!), 'not-valid-base64-v8-payload');
+
+      expect(store.readTaskOutput('task-1')).toEqual({
+        found: true,
+        output: 'old-output',
+        stale: true,
+        staleReason: 'corrupt-primary',
+      });
+    });
+
+    it('reports missing task output when no stale cache exists', () => {
+      store.writeTaskOutput('task-1', 'only-output');
+      const outputFile = readdirSync(`${filePath}.outputs`).find((entry) => !entry.endsWith('.stale'));
+      rmSync(join(`${filePath}.outputs`, outputFile!));
 
       expect(store.readTaskOutput('task-1')).toEqual({ found: false });
     });

--- a/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
+++ b/packages/franken-orchestrator/tests/unit/phases/execution.test.ts
@@ -450,6 +450,60 @@ describe('runExecution', () => {
     expect(outcomes[1]!.output).toEqual({ message: 'persisted-alpha-output' });
   });
 
+  it('warns and audits when a checkpointed dependency output uses the stale cache fallback', async () => {
+    const execute = vi.fn(async (_skillId: string, input: SkillInput) => ({
+      output: input.dependencyOutputs.get('t1'),
+      tokensUsed: 1,
+    }));
+    const skills = makeSkills({
+      hasSkill: vi.fn(() => true),
+      execute,
+    });
+    const checkpointEntries = new Set<string>(['t1:done']);
+    const checkpoint = {
+      checkpointPath: '/tmp/franken-checkpoint.txt',
+      has: vi.fn((key: string) => checkpointEntries.has(key)),
+      write: vi.fn((key: string) => checkpointEntries.add(key)),
+      readAll: vi.fn(() => new Set(checkpointEntries)),
+      clear: vi.fn(),
+      recordCommit: vi.fn(),
+      lastCommit: vi.fn(),
+      readTaskOutput: vi.fn(() => ({
+        found: true,
+        output: { message: 'stale-alpha-output' },
+        stale: true,
+        staleReason: 'corrupt-primary' as const,
+      })),
+      writeTaskOutput: vi.fn(),
+    };
+    const logger = makeLogger();
+    const c = ctx([
+      { id: 't1', objective: 'first', requiredSkills: ['alpha'], dependsOn: [] },
+      { id: 't2', objective: 'second', requiredSkills: ['beta'], dependsOn: ['t1'] },
+    ]);
+
+    const outcomes = await runExecution(c, skills, makeGovernor(), makeMemory(), makeObserver(), undefined, logger, undefined, checkpoint);
+
+    expect(outcomes[1]!.output).toEqual({ message: 'stale-alpha-output' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Execution: using stale dependency output cache for checkpointed task',
+      {
+        taskId: 't1',
+        reason: 'corrupt-primary',
+        checkpointPath: '/tmp/franken-checkpoint.txt',
+      },
+    );
+    expect(c.audit).toContainEqual(expect.objectContaining({
+      module: 'executor',
+      action: 'dependency-output-cache:stale-fallback',
+      detail: {
+        taskId: 't1',
+        reason: 'corrupt-primary',
+        checkpointPath: '/tmp/franken-checkpoint.txt',
+      },
+    }));
+  });
+
   it('passes through dependency output when no skills are required', async () => {
     const execute = vi.fn(async (skillId: string) => ({
       output: `${skillId}-output`,

--- a/tasks/issue-1828-stale-dependency-cache-fallback-progress.md
+++ b/tasks/issue-1828-stale-dependency-cache-fallback-progress.md
@@ -1,0 +1,11 @@
+# Issue #1828 — Stale Dependency Cache Fallback Progress
+
+- [x] Read issue and shared lessons.
+- [x] Create isolated worktree and set git identity.
+- [x] Add stale dependency output fallback implementation.
+- [x] Add checkpoint-store and execution-phase regression tests.
+- [x] Document resume behavior in beast loop docs.
+- [x] Run targeted tests: `npm --prefix packages/franken-orchestrator test -- tests/unit/file-checkpoint-store.test.ts tests/unit/phases/execution.test.ts`.
+- [x] Run package lint: `npm --prefix packages/franken-orchestrator run lint` (passes with existing warnings).
+- [x] Build internal dependencies, then run package typecheck/build.
+- [ ] Commit, push, open PR, and run Codex gate.


### PR DESCRIPTION
## Summary
- preserve a previous known-good task output sidecar as a stale dependency cache
- rehydrate checkpointed dependency outputs from the stale cache when the primary sidecar is missing or corrupted
- emit warning/audit telemetry and document resume behavior

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/file-checkpoint-store.test.ts tests/unit/phases/execution.test.ts
- npm --prefix packages/franken-orchestrator run lint
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/observer && npm run build --workspace @franken/brain && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build

Closes #1828