### PR TITLE
feat(availability): add scheduler fairness report

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -121,3 +121,14 @@ Issue execution has a programmatic backpressure policy for orchestrator/refill c
 The deterministic burst-load fixture at `packages/franken-orchestrator/tests/unit/issues/fixtures/burst-dispatch-load.json` captures an overloaded dispatch tick, a recovered-capacity tick, and a queue-depth edge case. Use it when changing availability/refill policy so tests can prove both the pause reason and the automatic recovery behavior remain machine-readable.
 
 For live operator awareness before a hard pause, set `thresholds.capacityWatermarkRatio` to a value between `0` and `1` (for example `0.8`). The runner then emits `[issues] Capacity watermark alert for issue #<n>` with structured `alerts[]` whenever capacity-style signals such as `activeProcesses`, `inFlightBacklog`, `pendingIssueCount`, `oldestQueueAgeMs`, or `systemLoadAverage` reach that percentage of their configured threshold. Watermark alerts do not skip the issue; they are warning telemetry for PM/liveness tooling. Values below the watermark remain quiet so normal refill output is not noisy.
+
+## Scheduler fairness report
+
+Before execution starts, `IssueRunner` emits `[issues] Scheduler fairness report` with structured data that PM/liveness tooling can consume without parsing prose. The report includes:
+
+- `totalIssues`: number of approved issues considered for this run.
+- `scheduledIssueNumbers`: the actual severity-ordered execution order.
+- `buckets[]`: counts and issue numbers for `critical`, `high`, `medium`, `low`, and `unprioritized` work.
+- `warnings[]`: explicit edge cases, such as unprioritized issues that will run after prioritized work or approved issues missing triage results.
+
+Library callers can produce the same deterministic payload directly with `buildIssueSchedulerFairnessReport(issues, triageResults)`. Treat non-empty `warnings[]` as operator guidance: either add the missing labels/triage data before approving the run, or record why the fallback order is acceptable.

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from './types.js';
 
 // Issues
-export { IssueRunner, evaluateIssueBackpressure } from './issues/index.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport } from './issues/index.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -59,6 +59,8 @@ export type {
   IssueBackpressureSignalSource,
   IssueBackpressureThresholds,
   IssueCapacityWatermarkAlert,
+  IssueSchedulerFairnessBucket,
+  IssueSchedulerFairnessReport,
 } from './issues/index.js';
 
 // Config

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,7 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner, evaluateIssueBackpressure } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport } from './issue-runner.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -21,6 +21,8 @@ export type {
   IssueBackpressureSignalSource,
   IssueBackpressureThresholds,
   IssueCapacityWatermarkAlert,
+  IssueSchedulerFairnessBucket,
+  IssueSchedulerFairnessReport,
 } from './issue-runner.js';
 export { IssueReview } from './issue-review.js';
 export type { ReviewIO, ReviewDecision, IssueReviewOptions } from './issue-review.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -95,6 +95,19 @@ export interface IssueBackpressureDecision {
   readonly alerts: readonly IssueCapacityWatermarkAlert[];
 }
 
+export interface IssueSchedulerFairnessBucket {
+  readonly severity: 'critical' | 'high' | 'medium' | 'low' | 'unprioritized';
+  readonly issueNumbers: readonly number[];
+  readonly count: number;
+}
+
+export interface IssueSchedulerFairnessReport {
+  readonly totalIssues: number;
+  readonly scheduledIssueNumbers: readonly number[];
+  readonly buckets: readonly IssueSchedulerFairnessBucket[];
+  readonly warnings: readonly string[];
+}
+
 export interface IssueRunnerConfig {
   readonly issues: readonly GithubIssue[];
   readonly triageResults: readonly TriageResult[];
@@ -262,8 +275,61 @@ function extractSeverity(labels: readonly string[]): number {
   return NO_SEVERITY;
 }
 
+function severityName(rank: number): IssueSchedulerFairnessBucket['severity'] {
+  switch (rank) {
+    case 0:
+      return 'critical';
+    case 1:
+      return 'high';
+    case 2:
+      return 'medium';
+    case 3:
+      return 'low';
+    default:
+      return 'unprioritized';
+  }
+}
+
 function sortBySeverity(issues: readonly GithubIssue[]): GithubIssue[] {
   return [...issues].sort((a, b) => extractSeverity(a.labels) - extractSeverity(b.labels));
+}
+
+export function buildIssueSchedulerFairnessReport(
+  issues: readonly GithubIssue[],
+  triageResults: readonly TriageResult[],
+): IssueSchedulerFairnessReport {
+  const scheduled = sortBySeverity(issues);
+  const triagedIssueNumbers = new Set(triageResults.map(triage => triage.issueNumber));
+  const buckets = new Map<IssueSchedulerFairnessBucket['severity'], number[]>();
+  const warnings: string[] = [];
+
+  for (const severity of ['critical', 'high', 'medium', 'low', 'unprioritized'] as const) {
+    buckets.set(severity, []);
+  }
+
+  for (const issue of scheduled) {
+    const severity = severityName(extractSeverity(issue.labels));
+    buckets.get(severity)!.push(issue.number);
+
+    if (severity === 'unprioritized') {
+      warnings.push(`issue #${issue.number} has no recognized severity label and is scheduled after prioritized work`);
+    }
+
+    if (!triagedIssueNumbers.has(issue.number)) {
+      warnings.push(`issue #${issue.number} has no triage result and will fail before execution if approved`);
+    }
+  }
+
+  return {
+    totalIssues: issues.length,
+    scheduledIssueNumbers: scheduled.map(issue => issue.number),
+    buckets: [...buckets.entries()].map(([severity, issueNumbers]) => ({
+      severity,
+      issueNumbers,
+      count: issueNumbers.length,
+    })),
+    warnings,
+  };
 }
 
 function findTriage(triages: readonly TriageResult[], issueNumber: number): TriageResult | undefined {
@@ -456,6 +522,7 @@ export class IssueRunner {
     if (issues.length === 0) return [];
 
     const sorted = sortBySeverity(issues);
+    logger?.info('[issues] Scheduler fairness report', buildIssueSchedulerFairnessReport(issues, triageResults), 'issues');
     const budgetTokens = budget * TOKENS_PER_DOLLAR;
     let cumulativeTokens = 0;
     let budgetExceeded = false;

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { IssueRunner, evaluateIssueBackpressure } from '../../../src/issues/issue-runner.js';
+import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport } from '../../../src/issues/issue-runner.js';
 import type { IssueBackpressureSignals, IssueBackpressureThresholds, IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
 import type { PlanGraph, ICheckpointStore, ILogger, BeastLoopDeps } from '../../../src/deps.js';
@@ -282,6 +282,61 @@ describe('IssueRunner', () => {
 
       const order = outcomes.map(o => o.issueNumber);
       expect(order).toEqual([2, 4, 3, 1]);
+    });
+
+    it('builds a structured scheduler fairness report for PM/liveness output', () => {
+      const issues = [
+        makeIssue({ number: 31, labels: [] }),
+        makeIssue({ number: 32, labels: ['low'] }),
+        makeIssue({ number: 33, labels: ['critical'] }),
+        makeIssue({ number: 34, labels: ['medium'] }),
+      ];
+      const triages = [makeTriage(31), makeTriage(32), makeTriage(33), makeTriage(34)];
+
+      const report = buildIssueSchedulerFairnessReport(issues, triages);
+
+      expect(report).toEqual({
+        totalIssues: 4,
+        scheduledIssueNumbers: [33, 34, 32, 31],
+        buckets: [
+          { severity: 'critical', issueNumbers: [33], count: 1 },
+          { severity: 'high', issueNumbers: [], count: 0 },
+          { severity: 'medium', issueNumbers: [34], count: 1 },
+          { severity: 'low', issueNumbers: [32], count: 1 },
+          { severity: 'unprioritized', issueNumbers: [31], count: 1 },
+        ],
+        warnings: ['issue #31 has no recognized severity label and is scheduled after prioritized work'],
+      });
+    });
+
+    it('reports missing triage as an explicit scheduler fairness edge case', () => {
+      const report = buildIssueSchedulerFairnessReport(
+        [makeIssue({ number: 41, labels: ['high'] })],
+        [],
+      );
+
+      expect(report.warnings).toEqual([
+        'issue #41 has no triage result and will fail before execution if approved',
+      ]);
+    });
+
+    it('logs the scheduler fairness report before executing approved issues', async () => {
+      const logger = mockLogger();
+      const issues = [makeIssue({ number: 51, labels: ['low'] }), makeIssue({ number: 52, labels: ['critical'] })];
+      const triages = [makeTriage(51), makeTriage(52)];
+      const config = makeConfig({ issues, triageResults: triages, logger });
+
+      await runner.run(config);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[issues] Scheduler fairness report',
+        expect.objectContaining({
+          totalIssues: 2,
+          scheduledIssueNumbers: [52, 51],
+          warnings: [],
+        }),
+        'issues',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- add a deterministic issue scheduler fairness report with severity buckets, scheduled order, and warning edge cases
- emit the report through IssueRunner logging before approved issue execution
- export the report builder/types and document how PM/liveness tooling should interpret it

## Test Plan
- npm --workspace @franken/orchestrator test -- --run tests/unit/issues/issue-runner.test.ts
- npm --workspace @franken/orchestrator run lint
- npm run build
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator run build

Closes #1821