### PR TITLE
fix(orchestrator): add dispatcher startup integrity checks

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -140,7 +140,7 @@ When a wrapper or service manager starts `frankenbeast` from outside the target 
 
 ## 5. Beast dispatch system
 
-Beasts are named process-level runs managed by the dispatcher.
+Beasts are named process-level runs managed by the dispatcher. On daemon/chat-server startup, the dispatcher runs fail-closed integrity checks before it accepts Beast work. The checks verify that the catalog has uniquely named definitions, each definition has valid metadata/prompts/telemetry labels, and every default execution mode has a wired executor with `start`, `stop`, and `kill` lifecycle handlers. If a check fails, startup throws a `DispatcherStartupIntegrityError` with structured `errors[]` entries and operator guidance; fix the catalog or executor wiring before retrying instead of dispatching into a partially wired runtime.
 
 ```bash
 # See available Beast definitions

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -9,6 +9,7 @@ import { ProcessSupervisor } from './execution/process-supervisor.js';
 import { SQLiteBeastRepository } from './repository/sqlite-beast-repository.js';
 import { BeastCatalogService } from './services/beast-catalog-service.js';
 import { BeastDispatchService } from './services/beast-dispatch-service.js';
+import { assertDispatcherStartupIntegrity } from './services/dispatcher-startup-integrity.js';
 import { BeastInterviewService } from './services/beast-interview-service.js';
 import { AgentService } from './services/agent-service.js';
 import { BeastRunService } from './services/beast-run-service.js';
@@ -68,6 +69,11 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
       },
     }),
   };
+
+  assertDispatcherStartupIntegrity({
+    definitions: catalog.listDefinitions(),
+    executors,
+  });
 
   runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus });
 

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-startup-integrity.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-startup-integrity.ts
@@ -141,12 +141,12 @@ function validateDefinition(
   const shape = (definition.configSchema as { shape?: Record<string, unknown> }).shape;
   const promptKeys = new Set<string>();
   for (const prompt of definition.interviewPrompts) {
-    const key = prompt.key.trim();
-    if (key.length === 0 || prompt.prompt.trim().length === 0 || promptKeys.has(key) || !VALID_PROMPT_KINDS.has(prompt.kind) || (shape && !(key in shape))) {
+    const key = prompt.key;
+    if (key.length === 0 || key !== key.trim() || prompt.prompt.trim().length === 0 || promptKeys.has(key) || !VALID_PROMPT_KINDS.has(prompt.kind) || (shape && !(key in shape))) {
       findings.push({
         code: 'invalid_prompt_contract',
         definitionId,
-        message: `prompt '${prompt.key}' must have a unique non-empty key accepted by the config schema, non-empty prompt, and supported kind`,
+        message: `prompt '${prompt.key}' must have a unique non-empty unpadded key accepted by the config schema, non-empty prompt, and supported kind`,
       });
     }
     promptKeys.add(key);

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-startup-integrity.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-startup-integrity.ts
@@ -1,0 +1,206 @@
+import type { BeastDefinition, BeastExecutionMode } from '../types.js';
+import type { BeastExecutors } from './beast-dispatch-service.js';
+
+export interface DispatcherStartupIntegrityFinding {
+  readonly code:
+    | 'no_definitions'
+    | 'duplicate_definition_id'
+    | 'invalid_definition_id'
+    | 'invalid_definition_version'
+    | 'missing_definition_metadata'
+    | 'invalid_execution_mode'
+    | 'missing_executor'
+    | 'invalid_executor_contract'
+    | 'invalid_prompt_contract'
+    | 'invalid_telemetry_labels'
+    | 'invalid_process_spec_builder';
+  readonly message: string;
+  readonly definitionId?: string | undefined;
+  readonly mode?: string | undefined;
+}
+
+export interface DispatcherStartupIntegrityReport {
+  readonly ok: boolean;
+  readonly definitionsChecked: number;
+  readonly executorModes: readonly string[];
+  readonly errors: readonly DispatcherStartupIntegrityFinding[];
+  readonly operatorGuidance: string;
+}
+
+export class DispatcherStartupIntegrityError extends Error {
+  constructor(readonly report: DispatcherStartupIntegrityReport) {
+    super(formatDispatcherStartupIntegrityError(report));
+    this.name = 'DispatcherStartupIntegrityError';
+  }
+}
+
+const VALID_EXECUTION_MODES = new Set<BeastExecutionMode>(['process', 'container']);
+const VALID_PROMPT_KINDS = new Set(['string', 'boolean', 'file', 'directory']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExecutorContract(value: unknown): boolean {
+  return isRecord(value)
+    && typeof value.start === 'function'
+    && typeof value.stop === 'function'
+    && typeof value.kill === 'function';
+}
+
+function availableExecutorModes(executors: Partial<BeastExecutors>): string[] {
+  return (['process', 'container'] as const).filter((mode) => hasExecutorContract(executors[mode]));
+}
+
+function formatDispatcherStartupIntegrityError(report: DispatcherStartupIntegrityReport): string {
+  const details = report.errors.map((finding) => {
+    const target = finding.definitionId ? ` ${finding.definitionId}` : finding.mode ? ` ${finding.mode}` : '';
+    return `${finding.code}${target}: ${finding.message}`;
+  }).join('; ');
+  return `Beast dispatcher startup integrity check failed: ${details}`;
+}
+
+function validateExecutorContracts(executors: Partial<BeastExecutors>): DispatcherStartupIntegrityFinding[] {
+  return (['process', 'container'] as const).flatMap((mode) => {
+    return hasExecutorContract(executors[mode])
+      ? []
+      : [{
+        code: 'invalid_executor_contract' as const,
+        mode,
+        message: `dispatcher executor '${mode}' must expose start, stop, and kill functions`,
+      }];
+  });
+}
+
+function validateDefinition(
+  definition: BeastDefinition,
+  seenIds: Map<string, BeastDefinition>,
+  executors: Partial<BeastExecutors>,
+): DispatcherStartupIntegrityFinding[] {
+  const findings: DispatcherStartupIntegrityFinding[] = [];
+  const definitionId = definition.id;
+
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(definitionId)) {
+    findings.push({
+      code: 'invalid_definition_id',
+      definitionId,
+      message: 'definition id must be a non-empty lowercase kebab-case identifier',
+    });
+  }
+
+  const firstDefinition = seenIds.get(definitionId);
+  if (firstDefinition && firstDefinition !== definition) {
+    findings.push({
+      code: 'duplicate_definition_id',
+      definitionId,
+      message: `definition id '${definitionId}' is registered more than once`,
+    });
+  } else {
+    seenIds.set(definitionId, definition);
+  }
+
+  if (!Number.isInteger(definition.version) || definition.version < 1) {
+    findings.push({
+      code: 'invalid_definition_version',
+      definitionId,
+      message: 'definition version must be a positive integer',
+    });
+  }
+
+  if (definition.label.trim().length === 0 || definition.description.trim().length === 0) {
+    findings.push({
+      code: 'missing_definition_metadata',
+      definitionId,
+      message: 'definition label and description must both be non-empty',
+    });
+  }
+
+  if (!VALID_EXECUTION_MODES.has(definition.executionModeDefault)) {
+    findings.push({
+      code: 'invalid_execution_mode',
+      definitionId,
+      mode: String(definition.executionModeDefault),
+      message: `definition default execution mode '${String(definition.executionModeDefault)}' is not supported`,
+    });
+  } else if (!hasExecutorContract(executors[definition.executionModeDefault])) {
+    findings.push({
+      code: 'missing_executor',
+      definitionId,
+      mode: definition.executionModeDefault,
+      message: `definition default execution mode '${definition.executionModeDefault}' has no usable executor`,
+    });
+  }
+
+  if (typeof definition.buildProcessSpec !== 'function') {
+    findings.push({
+      code: 'invalid_process_spec_builder',
+      definitionId,
+      message: 'definition must expose a process spec builder function',
+    });
+  }
+
+  const promptKeys = new Set<string>();
+  for (const prompt of definition.interviewPrompts) {
+    const key = prompt.key.trim();
+    if (key.length === 0 || prompt.prompt.trim().length === 0 || promptKeys.has(key) || !VALID_PROMPT_KINDS.has(prompt.kind)) {
+      findings.push({
+        code: 'invalid_prompt_contract',
+        definitionId,
+        message: `prompt '${prompt.key}' must have a unique non-empty key, non-empty prompt, and supported kind`,
+      });
+    }
+    promptKeys.add(key);
+  }
+
+  if (!isRecord(definition.telemetryLabels)
+    || Object.entries(definition.telemetryLabels).some(([key, value]) => key.trim().length === 0 || value.trim().length === 0)) {
+    findings.push({
+      code: 'invalid_telemetry_labels',
+      definitionId,
+      message: 'telemetry labels must be a record of non-empty string keys and values',
+    });
+  }
+
+  return findings;
+}
+
+export function checkDispatcherStartupIntegrity(input: {
+  readonly definitions: readonly BeastDefinition[];
+  readonly executors: Partial<BeastExecutors>;
+}): DispatcherStartupIntegrityReport {
+  const errors: DispatcherStartupIntegrityFinding[] = [];
+  const seenIds = new Map<string, BeastDefinition>();
+
+  if (input.definitions.length === 0) {
+    errors.push({
+      code: 'no_definitions',
+      message: 'dispatcher catalog must register at least one Beast definition',
+    });
+  }
+
+  errors.push(...validateExecutorContracts(input.executors));
+  for (const definition of input.definitions) {
+    errors.push(...validateDefinition(definition, seenIds, input.executors));
+  }
+
+  return {
+    ok: errors.length === 0,
+    definitionsChecked: input.definitions.length,
+    executorModes: availableExecutorModes(input.executors),
+    errors,
+    operatorGuidance: errors.length === 0
+      ? 'Dispatcher startup integrity checks passed; catalog definitions and executor contracts are ready for dispatch.'
+      : 'Fix the dispatcher catalog or executor wiring before accepting Beast dispatch requests. Startup fails closed so operators are not left with silent drift.',
+  };
+}
+
+export function assertDispatcherStartupIntegrity(input: {
+  readonly definitions: readonly BeastDefinition[];
+  readonly executors: Partial<BeastExecutors>;
+}): DispatcherStartupIntegrityReport {
+  const report = checkDispatcherStartupIntegrity(input);
+  if (!report.ok) {
+    throw new DispatcherStartupIntegrityError(report);
+  }
+  return report;
+}

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-startup-integrity.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-startup-integrity.ts
@@ -57,7 +57,7 @@ function formatDispatcherStartupIntegrityError(report: DispatcherStartupIntegrit
     const target = finding.definitionId ? ` ${finding.definitionId}` : finding.mode ? ` ${finding.mode}` : '';
     return `${finding.code}${target}: ${finding.message}`;
   }).join('; ');
-  return `Beast dispatcher startup integrity check failed: ${details}`;
+  return `Beast dispatcher startup integrity check failed: ${details}. ${report.operatorGuidance}`;
 }
 
 function validateExecutorContracts(executors: Partial<BeastExecutors>): DispatcherStartupIntegrityFinding[] {
@@ -88,8 +88,7 @@ function validateDefinition(
     });
   }
 
-  const firstDefinition = seenIds.get(definitionId);
-  if (firstDefinition && firstDefinition !== definition) {
+  if (seenIds.has(definitionId)) {
     findings.push({
       code: 'duplicate_definition_id',
       definitionId,
@@ -139,21 +138,22 @@ function validateDefinition(
     });
   }
 
+  const shape = (definition.configSchema as { shape?: Record<string, unknown> }).shape;
   const promptKeys = new Set<string>();
   for (const prompt of definition.interviewPrompts) {
     const key = prompt.key.trim();
-    if (key.length === 0 || prompt.prompt.trim().length === 0 || promptKeys.has(key) || !VALID_PROMPT_KINDS.has(prompt.kind)) {
+    if (key.length === 0 || prompt.prompt.trim().length === 0 || promptKeys.has(key) || !VALID_PROMPT_KINDS.has(prompt.kind) || (shape && !(key in shape))) {
       findings.push({
         code: 'invalid_prompt_contract',
         definitionId,
-        message: `prompt '${prompt.key}' must have a unique non-empty key, non-empty prompt, and supported kind`,
+        message: `prompt '${prompt.key}' must have a unique non-empty key accepted by the config schema, non-empty prompt, and supported kind`,
       });
     }
     promptKeys.add(key);
   }
 
   if (!isRecord(definition.telemetryLabels)
-    || Object.entries(definition.telemetryLabels).some(([key, value]) => key.trim().length === 0 || value.trim().length === 0)) {
+    || Object.entries(definition.telemetryLabels).some(([key, value]) => key.trim().length === 0 || typeof value !== 'string' || value.trim().length === 0)) {
     findings.push({
       code: 'invalid_telemetry_labels',
       definitionId,

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-startup-integrity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-startup-integrity.test.ts
@@ -137,4 +137,20 @@ describe('dispatcher startup integrity checks', () => {
       expect.objectContaining({ code: 'invalid_prompt_contract', definitionId: 'example-beast' }),
     ]));
   });
+
+  it('rejects whitespace-padded prompt keys because interview config uses raw keys', () => {
+    const report = checkDispatcherStartupIntegrity({
+      definitions: [definition({
+        interviewPrompts: [
+          { key: ' objective ', prompt: 'What should this Beast do?', kind: 'string', required: true },
+        ],
+      })],
+      executors,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'invalid_prompt_contract', definitionId: 'example-beast' }),
+    ]));
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-startup-integrity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-startup-integrity.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { BEAST_DEFINITIONS } from '../../../src/beasts/definitions/catalog.js';
+import type { BeastDefinition } from '../../../src/beasts/types.js';
+import {
+  assertDispatcherStartupIntegrity,
+  checkDispatcherStartupIntegrity,
+  DispatcherStartupIntegrityError,
+} from '../../../src/beasts/services/dispatcher-startup-integrity.js';
+
+const executors = {
+  process: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+  container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+};
+
+function definition(overrides: Partial<BeastDefinition> = {}): BeastDefinition {
+  return {
+    id: 'example-beast',
+    version: 1,
+    label: 'Example Beast',
+    description: 'Example definition used by startup integrity tests.',
+    executionModeDefault: 'process',
+    configSchema: z.object({ objective: z.string().min(1) }).strict(),
+    interviewPrompts: [
+      { key: 'objective', prompt: 'What should this Beast do?', kind: 'string', required: true },
+    ],
+    buildProcessSpec: (config) => ({
+      command: process.execPath,
+      args: ['frankenbeast', 'run', String(config.objective)],
+    }),
+    telemetryLabels: { family: 'example' },
+    ...overrides,
+  };
+}
+
+describe('dispatcher startup integrity checks', () => {
+  it('passes the shipped catalog and executor wiring with structured operator guidance', () => {
+    const report = assertDispatcherStartupIntegrity({
+      definitions: BEAST_DEFINITIONS,
+      executors,
+    });
+
+    expect(report).toMatchObject({
+      ok: true,
+      definitionsChecked: BEAST_DEFINITIONS.length,
+      executorModes: ['process', 'container'],
+      errors: [],
+    });
+    expect(report.operatorGuidance).toContain('passed');
+  });
+
+  it('fails closed when a definition defaults to an executor that is not wired at startup', () => {
+    const report = checkDispatcherStartupIntegrity({
+      definitions: [definition({ executionModeDefault: 'container' })],
+      executors: { process: executors.process },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'invalid_executor_contract',
+        mode: 'container',
+      }),
+      expect.objectContaining({
+        code: 'missing_executor',
+        definitionId: 'example-beast',
+        mode: 'container',
+      }),
+    ]));
+    expect(report.operatorGuidance).toContain('fails closed');
+  });
+
+  it('reports duplicate catalog ids and invalid prompt contracts before dispatch accepts work', () => {
+    const invalid = definition({
+      interviewPrompts: [
+        { key: 'objective', prompt: 'Objective?', kind: 'string' },
+        { key: 'objective', prompt: '', kind: 'file' },
+      ],
+    });
+
+    expect(() => assertDispatcherStartupIntegrity({
+      definitions: [definition(), invalid],
+      executors,
+    })).toThrow(DispatcherStartupIntegrityError);
+
+    try {
+      assertDispatcherStartupIntegrity({ definitions: [definition(), invalid], executors });
+    } catch (error) {
+      expect(error).toBeInstanceOf(DispatcherStartupIntegrityError);
+      expect((error as DispatcherStartupIntegrityError).report.errors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: 'duplicate_definition_id', definitionId: 'example-beast' }),
+        expect.objectContaining({ code: 'invalid_prompt_contract', definitionId: 'example-beast' }),
+      ]));
+      expect(String(error)).toContain('Beast dispatcher startup integrity check failed');
+    }
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-startup-integrity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-startup-integrity.test.ts
@@ -92,6 +92,49 @@ describe('dispatcher startup integrity checks', () => {
         expect.objectContaining({ code: 'invalid_prompt_contract', definitionId: 'example-beast' }),
       ]));
       expect(String(error)).toContain('Beast dispatcher startup integrity check failed');
+      expect(String(error)).toContain('Fix the dispatcher catalog or executor wiring');
     }
+  });
+
+  it('treats repeated references to the same definition object as duplicate catalog ids', () => {
+    const repeated = definition();
+
+    const report = checkDispatcherStartupIntegrity({
+      definitions: [repeated, repeated],
+      executors,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'duplicate_definition_id', definitionId: 'example-beast' }),
+    ]));
+  });
+
+  it('keeps malformed telemetry diagnostics structured instead of throwing TypeError', () => {
+    const report = checkDispatcherStartupIntegrity({
+      definitions: [definition({ telemetryLabels: { family: 42 } as unknown as Record<string, string> })],
+      executors,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'invalid_telemetry_labels', definitionId: 'example-beast' }),
+    ]));
+  });
+
+  it('rejects prompt keys that the definition config schema cannot parse', () => {
+    const report = checkDispatcherStartupIntegrity({
+      definitions: [definition({
+        interviewPrompts: [
+          { key: 'goaal', prompt: 'What should this Beast do?', kind: 'string', required: true },
+        ],
+      })],
+      executors,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'invalid_prompt_contract', definitionId: 'example-beast' }),
+    ]));
   });
 });


### PR DESCRIPTION
## Summary
- add fail-closed dispatcher startup integrity checks for Beast catalog/executor wiring
- surface structured startup reports/errors with operator guidance
- document the startup integrity behavior for Beast dispatch operators

## Verification
- npm --prefix packages/franken-orchestrator test -- --run tests/unit/beasts/dispatcher-startup-integrity.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1815