### PR TITLE
feat(availability): add dependency circuit breakers

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -122,6 +122,28 @@ The deterministic burst-load fixture at `packages/franken-orchestrator/tests/uni
 
 For live operator awareness before a hard pause, set `thresholds.capacityWatermarkRatio` to a value between `0` and `1` (for example `0.8`). The runner then emits `[issues] Capacity watermark alert for issue #<n>` with structured `alerts[]` whenever capacity-style signals such as `activeProcesses`, `inFlightBacklog`, `pendingIssueCount`, `oldestQueueAgeMs`, or `systemLoadAverage` reach that percentage of their configured threshold. Watermark alerts do not skip the issue; they are warning telemetry for PM/liveness tooling. Values below the watermark remain quiet so normal refill output is not noisy.
 
+Dependency-specific circuit breakers are available under `thresholds.dependencyCircuitBreakers`. Each key is an external dependency name reported by `signals().dependencyStatuses[]`, so callers can pause only the work that depends on GitHub, Slack, Chroma, or another named service instead of applying a global stop. A breaker opens when its configured dependency reports a paused status such as `unavailable`, reaches `maxConsecutiveFailures`, or carries a future `openUntil` timestamp; unrelated dependency signals are ignored unless they have their own configured breaker. Open breakers add structured `dependencyCircuitBreakers[]` data to the decision and a `backpressure: <dependency> ...` skip reason for operator/liveness output.
+
+Example:
+
+```ts
+await evaluateIssueBackpressure({
+  thresholds: {
+    dependencyCircuitBreakers: {
+      github: { maxConsecutiveFailures: 3, pauseOnStatuses: ['unavailable'] },
+    },
+  },
+  signals: () => ({
+    activeProcesses: 0,
+    failedStarts: 0,
+    inFlightBacklog: 0,
+    dependencyStatuses: [
+      { dependency: 'github', status: 'degraded', consecutiveFailures: 3 },
+    ],
+  }),
+}, context)
+```
+
 ## Scheduler fairness report
 
 Before execution starts, `IssueRunner` emits `[issues] Scheduler fairness report` with structured data that PM/liveness tooling can consume without parsing prose. The report includes:

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -59,6 +59,10 @@ export type {
   IssueBackpressureSignalSource,
   IssueBackpressureThresholds,
   IssueCapacityWatermarkAlert,
+  IssueDependencyCircuitBreakerConfig,
+  IssueDependencyCircuitBreakerState,
+  IssueDependencySignal,
+  IssueDependencyStatus,
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
 } from './issues/index.js';

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -21,6 +21,10 @@ export type {
   IssueBackpressureSignalSource,
   IssueBackpressureThresholds,
   IssueCapacityWatermarkAlert,
+  IssueDependencyCircuitBreakerConfig,
+  IssueDependencyCircuitBreakerState,
+  IssueDependencySignal,
+  IssueDependencyStatus,
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
 } from './issue-runner.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -43,6 +43,22 @@ export interface IssueBackpressureSignals {
   readonly systemLoadAverage?: number | undefined;
   readonly providerBudgetTokensRemaining?: number | undefined;
   readonly pendingIssueCount?: number | undefined;
+  readonly dependencyStatuses?: readonly IssueDependencySignal[] | undefined;
+}
+
+export type IssueDependencyStatus = 'healthy' | 'degraded' | 'unavailable';
+
+export interface IssueDependencySignal {
+  readonly dependency: string;
+  readonly status: IssueDependencyStatus;
+  readonly consecutiveFailures?: number | undefined;
+  readonly openUntil?: string | number | Date | undefined;
+  readonly error?: string | undefined;
+}
+
+export interface IssueDependencyCircuitBreakerConfig {
+  readonly maxConsecutiveFailures?: number | undefined;
+  readonly pauseOnStatuses?: readonly IssueDependencyStatus[] | undefined;
 }
 
 export interface IssueBackpressureSignalContext {
@@ -67,6 +83,13 @@ export interface IssueBackpressureThresholds {
   readonly maxOldestQueueAgeMs?: number | undefined;
   readonly maxSystemLoadAverage?: number | undefined;
   readonly minProviderBudgetTokensRemaining?: number | undefined;
+  /**
+   * Optional dependency-specific circuit breakers. Each key is a dependency
+   * name reported by `signals().dependencyStatuses`; only matching dependencies
+   * can pause fresh starts, so a degraded non-critical dependency does not
+   * silently stop unrelated work.
+   */
+  readonly dependencyCircuitBreakers?: Readonly<Record<string, IssueDependencyCircuitBreakerConfig>> | undefined;
   /**
    * Optional live alert ratio for capacity-style limits. For example, 0.8 emits
    * a warning when a signal reaches 80% of its configured limit while still
@@ -93,6 +116,15 @@ export interface IssueBackpressureDecision {
   readonly reasons: readonly string[];
   readonly signals: IssueBackpressureSignals;
   readonly alerts: readonly IssueCapacityWatermarkAlert[];
+  readonly dependencyCircuitBreakers: readonly IssueDependencyCircuitBreakerState[];
+}
+
+export interface IssueDependencyCircuitBreakerState {
+  readonly dependency: string;
+  readonly status: IssueDependencyStatus;
+  readonly state: 'closed' | 'open';
+  readonly reason?: string | undefined;
+  readonly retryAfterMs?: number | undefined;
 }
 
 export interface IssueSchedulerFairnessBucket {
@@ -150,6 +182,80 @@ function providerBudgetAtReserve(value: number | undefined, reserve: number | un
 
 function validWatermarkRatio(value: number | undefined): value is number {
   return value !== undefined && Number.isFinite(value) && value > 0 && value < 1;
+}
+
+function configuredPauseStatuses(
+  config: IssueDependencyCircuitBreakerConfig,
+): readonly IssueDependencyStatus[] {
+  return config.pauseOnStatuses ?? ['unavailable'];
+}
+
+function retryAfterMs(openUntil: string | number | Date | undefined, nowMs: number): number | undefined {
+  if (openUntil === undefined) return undefined;
+  const untilMs = openUntil instanceof Date ? openUntil.getTime() : new Date(openUntil).getTime();
+  if (!Number.isFinite(untilMs) || untilMs <= nowMs) return undefined;
+  return untilMs - nowMs;
+}
+
+function evaluateDependencyCircuitBreakers(
+  signals: IssueBackpressureSignals,
+  thresholds: IssueBackpressureThresholds,
+  nowMs: number = Date.now(),
+): IssueDependencyCircuitBreakerState[] {
+  const configs = thresholds.dependencyCircuitBreakers ?? {};
+  const states: IssueDependencyCircuitBreakerState[] = [];
+
+  for (const signal of signals.dependencyStatuses ?? []) {
+    const config = configs[signal.dependency];
+    if (!config) continue;
+
+    const retryMs = retryAfterMs(signal.openUntil, nowMs);
+    if (retryMs !== undefined) {
+      states.push({
+        dependency: signal.dependency,
+        status: signal.status,
+        state: 'open',
+        retryAfterMs: retryMs,
+        reason: `${signal.dependency} circuit breaker is open for another ${retryMs}ms`,
+      });
+      continue;
+    }
+
+    const maxFailures = config.maxConsecutiveFailures;
+    if (
+      maxFailures !== undefined
+      && maxFailures > 0
+      && signal.consecutiveFailures !== undefined
+      && signal.consecutiveFailures >= maxFailures
+    ) {
+      states.push({
+        dependency: signal.dependency,
+        status: signal.status,
+        state: 'open',
+        reason: `${signal.dependency} consecutive failures ${signal.consecutiveFailures} reached circuit breaker limit ${maxFailures}`,
+      });
+      continue;
+    }
+
+    const pauseStatuses = configuredPauseStatuses(config);
+    if (pauseStatuses.includes(signal.status)) {
+      states.push({
+        dependency: signal.dependency,
+        status: signal.status,
+        state: 'open',
+        reason: `${signal.dependency} dependency status ${signal.status} opened circuit breaker`,
+      });
+      continue;
+    }
+
+    states.push({
+      dependency: signal.dependency,
+      status: signal.status,
+      state: 'closed',
+    });
+  }
+
+  return states;
 }
 
 function capacityAlert(
@@ -258,12 +364,19 @@ export async function evaluateIssueBackpressure(
       `provider budget remaining ${signals.providerBudgetTokensRemaining} tokens is at or below reserve ${thresholds.minProviderBudgetTokensRemaining}`,
     );
   }
+  const dependencyCircuitBreakers = evaluateDependencyCircuitBreakers(signals, thresholds);
+  for (const breaker of dependencyCircuitBreakers) {
+    if (breaker.state === 'open' && breaker.reason) {
+      reasons.push(breaker.reason);
+    }
+  }
 
   return {
     allowed: reasons.length === 0,
     reasons,
     signals,
     alerts,
+    dependencyCircuitBreakers,
   };
 }
 
@@ -650,6 +763,7 @@ export class IssueRunner {
           issueNumber: issue.number,
           reasons: backpressureDecision.reasons,
           signals: backpressureDecision.signals,
+          dependencyCircuitBreakers: backpressureDecision.dependencyCircuitBreakers,
         },
         'issues',
       );

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -589,6 +589,82 @@ describe('IssueRunner', () => {
       });
     });
 
+    it('opens dependency-specific circuit breakers without blocking unrelated degraded dependencies', async () => {
+      const decision = await evaluateIssueBackpressure(
+        {
+          thresholds: {
+            dependencyCircuitBreakers: {
+              github: { maxConsecutiveFailures: 3 },
+            },
+          },
+          signals: () => ({
+            activeProcesses: 0,
+            failedStarts: 0,
+            inFlightBacklog: 0,
+            dependencyStatuses: [
+              { dependency: 'github', status: 'degraded', consecutiveFailures: 3 },
+              { dependency: 'grafana', status: 'unavailable', consecutiveFailures: 99 },
+            ],
+          }),
+        },
+        {
+          issue: makeIssue({ number: 16 }),
+          index: 0,
+          totalIssues: 1,
+          pendingIssueCount: 1,
+          cumulativeTokens: 0,
+          budgetTokens: 1_000_000,
+          providerBudgetTokensRemaining: 1_000_000,
+        },
+      );
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.reasons).toEqual([
+        'github consecutive failures 3 reached circuit breaker limit 3',
+      ]);
+      expect(decision.dependencyCircuitBreakers).toEqual([
+        expect.objectContaining({ dependency: 'github', status: 'degraded', state: 'open' }),
+      ]);
+    });
+
+    it('honors explicit dependency open-until windows as an edge-case pause', async () => {
+      const decision = await evaluateIssueBackpressure(
+        {
+          thresholds: {
+            dependencyCircuitBreakers: {
+              slack: { pauseOnStatuses: ['unavailable'] },
+            },
+          },
+          signals: () => ({
+            activeProcesses: 0,
+            failedStarts: 0,
+            inFlightBacklog: 0,
+            dependencyStatuses: [
+              { dependency: 'slack', status: 'healthy', openUntil: Date.now() + 60_000 },
+            ],
+          }),
+        },
+        {
+          issue: makeIssue({ number: 17 }),
+          index: 0,
+          totalIssues: 1,
+          pendingIssueCount: 1,
+          cumulativeTokens: 0,
+          budgetTokens: 1_000_000,
+          providerBudgetTokensRemaining: 1_000_000,
+        },
+      );
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.reasons[0]).toContain('slack circuit breaker is open for another');
+      expect(decision.dependencyCircuitBreakers[0]).toEqual(expect.objectContaining({
+        dependency: 'slack',
+        status: 'healthy',
+        state: 'open',
+        retryAfterMs: expect.any(Number),
+      }));
+    });
+
     it('recovers automatically when backpressure signals return to normal on the next issue', async () => {
       const snapshots = [
         { activeProcesses: 0, failedStarts: 3, inFlightBacklog: 0, oldestQueueAgeMs: 0 },

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-15 — Issue-runner dependency circuit breaker verification
+- For availability/refill features that add dependency-specific throttles, model the dependency name in structured signals and configure named breakers so unrelated degraded dependencies do not create a global outage. Regression tests should cover the intended open condition plus an unrelated dependency and a retry/open-until edge case.
+- After `npm ci` in a fresh worktree, package-local orchestrator typecheck may fail until dependent workspaces have been built; run `npm run build` (or build the needed workspace packages) before re-running package-local `tsc --noEmit`.
+
 ## 2026-07-14 — Type-safety hardening regressions
 - For removing unsafe TypeScript double-casts, pair the runtime regression with a source-inspection guard that names the exact bypass (`as unknown as ...`) and the intended type-coupling construct (`satisfies z.ZodType<...>` or typed null-object helpers) so future changes cannot silently reintroduce the cast while preserving behavior.
 - Disabled/null-object implementations should return structurally complete domain objects rather than partial objects cast through `unknown`; include required lifecycle/status/time fields in the helper so `tsc --noEmit` enforces drift against upstream type changes.


### PR DESCRIPTION
## Summary
- Adds dependency-specific circuit breaker signals/configuration to issue-runner backpressure decisions.
- Emits structured dependency breaker state in pause logs and public exports for PM/liveness consumers.
- Documents the dependency breaker configuration path and records shared lessons for future issue workers.

## Verification
- npm ci
- npm test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts
- npm run build
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1817
