### PR TITLE
fix(stability): add stale checkpoint lock detector

### DIFF
--- a/docs/runbooks/checkpoint-locks.md
+++ b/docs/runbooks/checkpoint-locks.md
@@ -25,7 +25,7 @@ The structured result includes:
 
 ## Safe unlock policy
 
-Only remove a lock manually when `safeToRemove` is `true`. The hint names the exact lock file to remove with `rm -- "<checkpoint>.lock"`.
+Only remove a lock manually when `safeToRemove` is `true`. The hint names the exact lock file to remove with a shell-quoted `rm -- '<checkpoint>.lock'` command.
 
 Do not remove a lock when the detector reports `status: 'held'` and `safeToRemove: false`. Inspect the owner process first, for example:
 

--- a/docs/runbooks/checkpoint-locks.md
+++ b/docs/runbooks/checkpoint-locks.md
@@ -1,0 +1,40 @@
+# Checkpoint lock recovery
+
+Frankenbeast checkpoint stores create `<checkpoint>.lock` files while writing recovery state. A lock file should normally disappear as soon as the write finishes. If an agent, worker, or host crashes mid-write, later checkpoint writes may report a lock timeout.
+
+## Read-only stale-lock detector
+
+Use `detectCheckpointLock(checkpointPath)` from `@franken/orchestrator` before deleting a lock by hand. The detector mirrors the runtime reaping rules and never mutates the filesystem.
+
+Example:
+
+```ts
+import { detectCheckpointLock } from '@franken/orchestrator';
+
+const diagnostic = detectCheckpointLock('/path/to/.fbeast/.build/my-plan.checkpoint');
+console.log(diagnostic.status, diagnostic.reason, diagnostic.unlockHint);
+```
+
+The structured result includes:
+
+- `status: 'absent' | 'held' | 'stale'`
+- `safeToRemove: boolean`
+- `ownerPid` and `ownerAlive` when the lock has a parseable owner record
+- `reason`, suitable for logs or PM/liveness reports
+- `unlockHint`, a conservative human-readable instruction
+
+## Safe unlock policy
+
+Only remove a lock manually when `safeToRemove` is `true`. The hint names the exact lock file to remove with `rm -- "<checkpoint>.lock"`.
+
+Do not remove a lock when the detector reports `status: 'held'` and `safeToRemove: false`. Inspect the owner process first, for example:
+
+```bash
+ps -p <ownerPid> -o pid,ppid,etime,command
+```
+
+Malformed or truncated owner records are treated as a crash window at first, not immediately stale. Re-run the detector after the grace window; old malformed locks become safe to remove with an explicit hint.
+
+## Runtime behavior
+
+`FileCheckpointStore` already reaps stale locks during normal writes when the owner is dead, the PID has been reused, or an unreadable owner record exceeds the crash-recovery grace window. The detector exists for liveness and operator tooling that need a read-only diagnosis before choosing a manual unlock.

--- a/docs/runbooks/checkpoint-locks.md
+++ b/docs/runbooks/checkpoint-locks.md
@@ -25,7 +25,7 @@ The structured result includes:
 
 ## Safe unlock policy
 
-Only remove a lock manually when `safeToRemove` is `true`. The hint names the exact lock file to remove with a shell-quoted `rm -- '<checkpoint>.lock'` command.
+Only remove a lock manually when `safeToRemove` is `true`. The hint names the exact lock file to remove with a shell-quoted `rm -- '<checkpoint>.lock'` command, but operators must first quiesce checkpoint writers and re-run the detector so a newly acquired live lock is not removed.
 
 Do not remove a lock when the detector reports `status: 'held'` and `safeToRemove: false`. Inspect the owner process first, for example:
 

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -115,7 +115,7 @@ function staleDiagnostic(
     ownerPid,
     ownerAlive,
     reason,
-    unlockHint: `Safe unlock hint: ${ownerText}; the lock is ${formatLockAge(ageMs)}. Remove only this lock file with: rm -- ${shellSingleQuote(lockPath)}`,
+    unlockHint: `Safe unlock hint: ${ownerText}; the lock is ${formatLockAge(ageMs)}. Quiesce checkpoint writers, re-run this detector to confirm the same stale owner, then remove only this lock file with: rm -- ${shellSingleQuote(lockPath)}`,
   };
 }
 
@@ -469,12 +469,13 @@ export class FileCheckpointStore implements ICheckpointStore {
       const pid = Number.parseInt(ownerMatch[1]!, 10);
       const recordedStart = ownerMatch[2]!;
       if (isProcessAlive(pid)) {
-        if (recordedStart !== '0' && processStartTime(pid) === recordedStart) {
+        const currentStart = processStartTime(pid);
+        if (recordedStart !== '0' && currentStart === recordedStart) {
           // Verified live owner (PID + start time match rules out reuse) —
           // never break its lock, however long it holds it.
           return;
         }
-        if (recordedStart === '0') {
+        if (recordedStart === '0' || currentStart === '0') {
           // Owner identity cannot be verified (no start time available):
           // the age ceiling is the only backstop against PID reuse.
           try {
@@ -485,7 +486,7 @@ export class FileCheckpointStore implements ICheckpointStore {
             return;
           }
         }
-        // Live PID with a mismatched start time is a reused PID — reap.
+        // Live PID with a mismatched, verified start time is a reused PID — reap.
       }
       // Dead owner, reused PID, or unverifiable past the ceiling — reap.
     } else {

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -95,6 +95,10 @@ function formatLockAge(ageMs: number | undefined): string {
   return `${Math.max(0, Math.round(ageMs))}ms old`;
 }
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 function staleDiagnostic(
   lockPath: string,
   reason: string,
@@ -111,7 +115,7 @@ function staleDiagnostic(
     ownerPid,
     ownerAlive,
     reason,
-    unlockHint: `Safe unlock hint: ${ownerText}; the lock is ${formatLockAge(ageMs)}. Remove only this lock file with: rm -- ${JSON.stringify(lockPath)}`,
+    unlockHint: `Safe unlock hint: ${ownerText}; the lock is ${formatLockAge(ageMs)}. Remove only this lock file with: rm -- ${shellSingleQuote(lockPath)}`,
   };
 }
 
@@ -180,7 +184,7 @@ export function detectCheckpointLock(
     };
   }
 
-  if (recordedStart === '0' && (ageMs ?? 0) < LIVE_LOCK_AGE_CEILING_MS) {
+  if (ownerAlive && (recordedStart === '0' || currentStart === '0') && (ageMs ?? 0) < LIVE_LOCK_AGE_CEILING_MS) {
     return {
       lockPath,
       status: 'held',

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -106,7 +106,10 @@ function staleDiagnostic(
   ownerPid?: number | undefined,
   ownerAlive?: boolean | undefined,
 ): CheckpointLockDiagnostic {
-  const ownerText = ownerPid === undefined ? 'no verified owner' : `owner pid ${ownerPid}${ownerAlive ? ' is not the recorded process' : ' is not running'}`;
+  const ownerText =
+    ownerPid === undefined
+      ? 'no verified owner'
+      : `owner pid ${ownerPid}${ownerAlive ? (reason.includes('unverifiable') ? ' is alive but could not be verified' : ' is not the recorded process') : ' is not running'}`;
   return {
     lockPath,
     status: 'stale',
@@ -129,22 +132,40 @@ export function detectCheckpointLock(
   options: DetectCheckpointLockOptions = {},
 ): CheckpointLockDiagnostic {
   const lockPath = `${checkpointPath}.lock`;
-  let owner: string;
+  let owner: string | undefined;
   let ageMs: number | undefined;
-  try {
-    owner = readFileSync(lockPath, 'utf-8');
-    ageMs = (options.nowMs ?? Date.now()) - statSync(lockPath).mtimeMs;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return {
-        lockPath,
-        status: 'absent',
-        safeToRemove: false,
-        reason: 'checkpoint lock file is absent',
-        unlockHint: 'No unlock action is needed; retry the checkpoint operation normally.',
-      };
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const before = statSync(lockPath);
+      owner = readFileSync(lockPath, 'utf-8');
+      const after = statSync(lockPath);
+      if (before.mtimeMs === after.mtimeMs && before.size === after.size) {
+        ageMs = (options.nowMs ?? Date.now()) - after.mtimeMs;
+        break;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        if (attempt === 0) continue;
+        return {
+          lockPath,
+          status: 'absent',
+          safeToRemove: false,
+          reason: 'checkpoint lock file is absent',
+          unlockHint: 'No unlock action is needed; retry the checkpoint operation normally.',
+        };
+      }
+      throw error;
     }
-    throw error;
+  }
+
+  if (owner === undefined) {
+    return {
+      lockPath,
+      status: 'held',
+      safeToRemove: false,
+      reason: 'checkpoint lock changed while being inspected',
+      unlockHint: 'Do not remove this lock. Re-run the detector to inspect a stable lock snapshot.',
+    };
   }
 
   const ownerMatch = owner.match(/^(\d+):(\d+):[0-9a-f]{16}$/);

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -30,6 +30,24 @@ const UNREADABLE_LOCK_REAP_MS = 2000;
 const LIVE_LOCK_AGE_CEILING_MS = 60_000;
 const MAX_ENTRY_LENGTH = 4096;
 
+export type CheckpointLockStatus = 'absent' | 'held' | 'stale';
+
+export interface CheckpointLockDiagnostic {
+  readonly lockPath: string;
+  readonly status: CheckpointLockStatus;
+  readonly safeToRemove: boolean;
+  readonly ageMs?: number | undefined;
+  readonly ownerPid?: number | undefined;
+  readonly ownerAlive?: boolean | undefined;
+  readonly reason: string;
+  readonly unlockHint: string;
+}
+
+export interface DetectCheckpointLockOptions {
+  readonly lockTimeoutMs?: number | undefined;
+  readonly nowMs?: number | undefined;
+}
+
 function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -39,7 +57,6 @@ function isValidEntry(line: string): boolean {
     return false;
   }
   // Corrupted regions (interleaved or torn writes) surface as NUL bytes or control chars.
-  // eslint-disable-next-line no-control-regex
   return !/[\u0000-\u0008\u000B-\u001F\u007F]/.test(line);
 }
 
@@ -71,6 +88,120 @@ function writeAll(fd: number, payload: string): void {
   while (written < buf.length) {
     written += writeSync(fd, buf, written, buf.length - written);
   }
+}
+
+function formatLockAge(ageMs: number | undefined): string {
+  if (ageMs === undefined) return 'unknown age';
+  return `${Math.max(0, Math.round(ageMs))}ms old`;
+}
+
+function staleDiagnostic(
+  lockPath: string,
+  reason: string,
+  ageMs: number | undefined,
+  ownerPid?: number | undefined,
+  ownerAlive?: boolean | undefined,
+): CheckpointLockDiagnostic {
+  const ownerText = ownerPid === undefined ? 'no verified owner' : `owner pid ${ownerPid}${ownerAlive ? ' is not the recorded process' : ' is not running'}`;
+  return {
+    lockPath,
+    status: 'stale',
+    safeToRemove: true,
+    ageMs,
+    ownerPid,
+    ownerAlive,
+    reason,
+    unlockHint: `Safe unlock hint: ${ownerText}; the lock is ${formatLockAge(ageMs)}. Remove only this lock file with: rm -- ${JSON.stringify(lockPath)}`,
+  };
+}
+
+/**
+ * Read-only detector for checkpoint lock files. It mirrors FileCheckpointStore's
+ * reap rules but never mutates the filesystem, so PM/liveness tooling can show
+ * operators whether a lock is held or safely removable before a manual unlock.
+ */
+export function detectCheckpointLock(
+  checkpointPath: string,
+  options: DetectCheckpointLockOptions = {},
+): CheckpointLockDiagnostic {
+  const lockPath = `${checkpointPath}.lock`;
+  let owner: string;
+  let ageMs: number | undefined;
+  try {
+    owner = readFileSync(lockPath, 'utf-8');
+    ageMs = (options.nowMs ?? Date.now()) - statSync(lockPath).mtimeMs;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        lockPath,
+        status: 'absent',
+        safeToRemove: false,
+        reason: 'checkpoint lock file is absent',
+        unlockHint: 'No unlock action is needed; retry the checkpoint operation normally.',
+      };
+    }
+    throw error;
+  }
+
+  const ownerMatch = owner.match(/^(\d+):(\d+):[0-9a-f]{16}$/);
+  if (!ownerMatch) {
+    const reapAgeMs = Math.min(UNREADABLE_LOCK_REAP_MS, (options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS) / 2);
+    if ((ageMs ?? 0) >= reapAgeMs) {
+      return staleDiagnostic(lockPath, 'lock owner record is missing, truncated, or malformed', ageMs);
+    }
+    return {
+      lockPath,
+      status: 'held',
+      safeToRemove: false,
+      ageMs,
+      reason: 'lock owner record is not readable yet, but it is still inside the crash-recovery grace window',
+      unlockHint: `Do not remove yet. Wait until the lock is at least ${reapAgeMs}ms old, then re-run the detector before unlocking.`,
+    };
+  }
+
+  const pid = Number.parseInt(ownerMatch[1]!, 10);
+  const recordedStart = ownerMatch[2]!;
+  const ownerAlive = isProcessAlive(pid);
+  if (!ownerAlive) {
+    return staleDiagnostic(lockPath, 'recorded owner process is no longer running', ageMs, pid, false);
+  }
+
+  const currentStart = processStartTime(pid);
+  if (recordedStart !== '0' && currentStart === recordedStart) {
+    return {
+      lockPath,
+      status: 'held',
+      safeToRemove: false,
+      ageMs,
+      ownerPid: pid,
+      ownerAlive: true,
+      reason: 'recorded owner process is alive and matches the lock start time',
+      unlockHint: `Do not remove this lock. Inspect the live owner first, for example: ps -p ${pid} -o pid,ppid,etime,command`,
+    };
+  }
+
+  if (recordedStart === '0' && (ageMs ?? 0) < LIVE_LOCK_AGE_CEILING_MS) {
+    return {
+      lockPath,
+      status: 'held',
+      safeToRemove: false,
+      ageMs,
+      ownerPid: pid,
+      ownerAlive: true,
+      reason: 'owner process is alive but this platform cannot verify process start time yet',
+      unlockHint: `Do not remove this lock unless process ${pid} exits or the lock exceeds ${LIVE_LOCK_AGE_CEILING_MS}ms; then re-run the detector.`,
+    };
+  }
+
+  return staleDiagnostic(
+    lockPath,
+    recordedStart === '0'
+      ? 'owner process start time is unverifiable and the lock exceeded the live-owner age ceiling'
+      : 'recorded PID has been reused by a different process',
+    ageMs,
+    pid,
+    true,
+  );
 }
 
 /** Best-effort directory fsync so a rename survives power loss; ignored where unsupported. */

--- a/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
+++ b/packages/franken-orchestrator/src/checkpoint/file-checkpoint-store.ts
@@ -137,12 +137,14 @@ export function detectCheckpointLock(
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
       const before = statSync(lockPath);
-      owner = readFileSync(lockPath, 'utf-8');
+      const sampledOwner = readFileSync(lockPath, 'utf-8');
       const after = statSync(lockPath);
       if (before.mtimeMs === after.mtimeMs && before.size === after.size) {
+        owner = sampledOwner;
         ageMs = (options.nowMs ?? Date.now()) - after.mtimeMs;
         break;
       }
+      owner = undefined;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         if (attempt === 0) continue;

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -167,7 +167,8 @@ export type { ICliProvider, ProviderOpts } from './skills/providers/index.js';
 export { ProviderRegistry, createDefaultRegistry } from './skills/providers/index.js';
 
 // Checkpoint
-export { FileCheckpointStore } from './checkpoint/file-checkpoint-store.js';
+export { FileCheckpointStore, detectCheckpointLock } from './checkpoint/file-checkpoint-store.js';
+export type { CheckpointLockDiagnostic, CheckpointLockStatus, DetectCheckpointLockOptions } from './checkpoint/file-checkpoint-store.js';
 
 // Beasts
 export type {

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -322,11 +322,9 @@ describe('FileCheckpointStore', () => {
         reason: 'recorded owner process is no longer running',
       });
       expect(stale.unlockHint).toContain('Safe unlock hint');
-      expect(stale.unlockHint).toContain(`rm -- \"${filePath}.lock\"`);
+      expect(stale.unlockHint).toContain(`rm -- '${filePath}.lock'`);
 
-      const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf-8');
-      const start = stat.slice(stat.lastIndexOf(')') + 2).split(' ')[19];
-      writeFileSync(`${filePath}.lock`, `${process.pid}:${start}:0123456789abcdef`);
+      writeFileSync(`${filePath}.lock`, `${process.pid}:0:0123456789abcdef`);
       const live = detectCheckpointLock(filePath);
       expect(live).toMatchObject({
         status: 'held',
@@ -335,6 +333,23 @@ describe('FileCheckpointStore', () => {
         ownerAlive: true,
       });
       expect(live.unlockHint).toContain('Do not remove this lock');
+    });
+
+    it('shell-quotes stale lock removal hints without allowing command substitution', async () => {
+      const unsafeCheckpoint = join(tmpDir, "checkpoint-$(touch should-not-run)'x.log");
+      const deadPid: number = await new Promise((res, rej) => {
+        const child = execFile(process.execPath, ['-e', ''], (err: unknown) =>
+          err ? rej(err) : res(child.pid!),
+        );
+      });
+      writeFileSync(`${unsafeCheckpoint}.lock`, `${deadPid}:12345:deadbeefdeadbeef`);
+
+      const stale = detectCheckpointLock(unsafeCheckpoint);
+
+      expect(stale.safeToRemove).toBe(true);
+      expect(stale.unlockHint).toContain("rm -- '");
+      expect(stale.unlockHint).toContain("'\\''x.log.lock'");
+      expect(stale.unlockHint).not.toContain('rm -- "');
     });
 
     it('keeps malformed fresh locks inside the grace window and marks old malformed locks safe', () => {

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync, utimesSync } from 'node:fs';
 import { execFile } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { promisify } from 'node:util';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { FileCheckpointStore } from '../../src/checkpoint/file-checkpoint-store.js';
+import { FileCheckpointStore, detectCheckpointLock } from '../../src/checkpoint/file-checkpoint-store.js';
 import type { ICheckpointStore } from '../../src/deps.js';
 
 const rootRequire = createRequire(new URL('../../../../package.json', import.meta.url));
@@ -298,6 +298,64 @@ describe('FileCheckpointStore', () => {
       expect(() => impatient.write('blocked')).toThrow(/Timed out acquiring checkpoint lock/);
       // The live holder's lock must still be there, untouched.
       expect(readFileSync(`${filePath}.lock`, 'utf-8')).toBe(`${process.pid}:0:0123456789abcdef`);
+    });
+
+    it('detects absent, stale, and live checkpoint locks with safe operator hints', async () => {
+      expect(detectCheckpointLock(filePath)).toMatchObject({
+        lockPath: `${filePath}.lock`,
+        status: 'absent',
+        safeToRemove: false,
+      });
+
+      const deadPid: number = await new Promise((res, rej) => {
+        const child = execFile(process.execPath, ['-e', ''], (err: unknown) =>
+          err ? rej(err) : res(child.pid!),
+        );
+      });
+      writeFileSync(`${filePath}.lock`, `${deadPid}:12345:deadbeefdeadbeef`);
+      const stale = detectCheckpointLock(filePath);
+      expect(stale).toMatchObject({
+        status: 'stale',
+        safeToRemove: true,
+        ownerPid: deadPid,
+        ownerAlive: false,
+        reason: 'recorded owner process is no longer running',
+      });
+      expect(stale.unlockHint).toContain('Safe unlock hint');
+      expect(stale.unlockHint).toContain(`rm -- \"${filePath}.lock\"`);
+
+      const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf-8');
+      const start = stat.slice(stat.lastIndexOf(')') + 2).split(' ')[19];
+      writeFileSync(`${filePath}.lock`, `${process.pid}:${start}:0123456789abcdef`);
+      const live = detectCheckpointLock(filePath);
+      expect(live).toMatchObject({
+        status: 'held',
+        safeToRemove: false,
+        ownerPid: process.pid,
+        ownerAlive: true,
+      });
+      expect(live.unlockHint).toContain('Do not remove this lock');
+    });
+
+    it('keeps malformed fresh locks inside the grace window and marks old malformed locks safe', () => {
+      writeFileSync(`${filePath}.lock`, '1');
+
+      const fresh = detectCheckpointLock(filePath, { lockTimeoutMs: 5_000 });
+      expect(fresh).toMatchObject({
+        status: 'held',
+        safeToRemove: false,
+      });
+      expect(fresh.reason).toContain('crash-recovery grace window');
+
+      const past = new Date(Date.now() - 60_000);
+      utimesSync(`${filePath}.lock`, past, past);
+
+      const stale = detectCheckpointLock(filePath, { lockTimeoutMs: 5_000 });
+      expect(stale).toMatchObject({
+        status: 'stale',
+        safeToRemove: true,
+        reason: 'lock owner record is missing, truncated, or malformed',
+      });
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/file-checkpoint-store.test.ts
@@ -322,6 +322,7 @@ describe('FileCheckpointStore', () => {
         reason: 'recorded owner process is no longer running',
       });
       expect(stale.unlockHint).toContain('Safe unlock hint');
+      expect(stale.unlockHint).toContain('Quiesce checkpoint writers');
       expect(stale.unlockHint).toContain(`rm -- '${filePath}.lock'`);
 
       writeFileSync(`${filePath}.lock`, `${process.pid}:0:0123456789abcdef`);


### PR DESCRIPTION
## Summary
- adds a read-only `detectCheckpointLock()` helper that classifies absent, held, and stale checkpoint locks
- returns structured diagnostics and conservative safe-unlock hints for operator/PM tooling
- documents checkpoint lock recovery policy and manual unlock guidance

## Test Plan
- `npm test --workspace @franken/orchestrator -- --run tests/unit/file-checkpoint-store.test.ts`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`

Closes #1813
