### PR TITLE
test(brain): add state schema migration smoke tests

### DIFF
--- a/docs/guides/state-schema-migration-smoke-tests.md
+++ b/docs/guides/state-schema-migration-smoke-tests.md
@@ -1,0 +1,16 @@
+# State schema migration smoke tests
+
+Frankenbeast state schema migrations are guarded by a focused smoke suite in `packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts`.
+
+The smoke tests cover two operator-critical paths:
+
+1. A legacy v0 memory-state SQLite database can be opened by the current runtime, upgraded in place, and still returns durable working memory, episodic events, and recovery checkpoints.
+2. A database that advertises a future unsupported schema version fails closed before migration code creates or alters runtime state tables.
+
+Run the smoke suite from the repository root:
+
+```bash
+npm run test --workspace @franken/brain -- state-schema-migration-smoke.test.ts
+```
+
+If this suite fails during a schema change, treat it as a migration compatibility blocker. Either add an explicit migration path that preserves existing durable state, or update the unsupported-version failure path so operators get a deterministic fail-closed error instead of partial database drift.

--- a/packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts
+++ b/packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_MEMORY_SCHEMA_VERSION,
+  SqliteBrain,
+  UnsupportedMemorySchemaVersionError,
+} from '../../src/sqlite-brain.js';
+
+const storeNames = [
+  'working_memory',
+  'episodic_events',
+  'checkpoints',
+  'memory_review_candidates',
+  'memory_review_provenance',
+  'memory_review_suppressions',
+  'memory_deletion_guards',
+  'memory_deletion_hash_keys',
+] as const;
+
+const readColumns = (db: Database.Database, table: string): string[] =>
+  (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name);
+
+describe('state schema migration smoke tests', () => {
+  it('opens and upgrades a legacy v0 memory-state database without losing durable state', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'franken-state-schema-smoke-'));
+    const dbPath = join(dir, 'brain.db');
+
+    try {
+      const legacy = new Database(dbPath);
+      legacy.exec(`
+        CREATE TABLE working_memory (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+        CREATE TABLE episodic_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          type TEXT NOT NULL,
+          step TEXT,
+          summary TEXT NOT NULL,
+          details TEXT,
+          embedding BLOB,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL, created_at TEXT NOT NULL);
+        INSERT INTO working_memory (key, value, updated_at)
+          VALUES ('operator-guidance', '"preserve me"', '2026-07-15T00:00:00.000Z');
+        INSERT INTO episodic_events (type, step, summary, details, created_at)
+          VALUES ('decision', 'migration-smoke', 'legacy event survives migration', '{"scope":"issue-1812"}', '2026-07-15T00:00:01.000Z');
+        INSERT INTO checkpoints (state, created_at)
+          VALUES ('{"runId":"legacy-run","phase":"migration","step":1,"context":{"scope":"issue-1812"},"timestamp":"2026-07-15T00:00:02.000Z"}', '2026-07-15T00:00:02.000Z');
+      `);
+      legacy.close();
+
+      const brain = new SqliteBrain(dbPath);
+      expect(brain.working.get('operator-guidance')).toBe('preserve me');
+      expect(brain.episodic.recall('legacy event survives migration', 5)).toHaveLength(1);
+      expect(brain.recovery.lastCheckpoint()).toMatchObject({
+        runId: 'legacy-run',
+        phase: 'migration',
+        step: 1,
+      });
+      expect(brain.getMemorySchemaMetadata().stores).toEqual(
+        storeNames.map((store) => ({
+          store,
+          version: CURRENT_MEMORY_SCHEMA_VERSION,
+          recordCount: store === 'working_memory' || store === 'episodic_events' || store === 'checkpoints' ? 1 : 0,
+        })),
+      );
+      brain.close();
+
+      const migrated = new Database(dbPath, { readonly: true });
+      for (const store of storeNames) {
+        expect(readColumns(migrated, store)).toContain('schema_version');
+      }
+      expect(
+        (migrated.prepare('SELECT COUNT(*) AS count FROM memory_schema_versions').get() as { count: number }).count,
+      ).toBe(storeNames.length);
+      migrated.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed on future state schema versions before changing the database shape', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'franken-state-schema-future-smoke-'));
+    const dbPath = join(dir, 'brain.db');
+
+    try {
+      const future = new Database(dbPath);
+      future.exec(`
+        CREATE TABLE memory_schema_versions (store TEXT PRIMARY KEY, version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+        INSERT INTO memory_schema_versions (store, version, migrated_at)
+          VALUES ('working_memory', ${CURRENT_MEMORY_SCHEMA_VERSION + 1}, '2026-07-15T00:00:00.000Z');
+      `);
+      future.close();
+
+      expect(() => SqliteBrain.migrateMemorySchema(dbPath, { dryRun: true })).toThrow(
+        UnsupportedMemorySchemaVersionError,
+      );
+      expect(() => new SqliteBrain(dbPath)).toThrow(UnsupportedMemorySchemaVersionError);
+
+      const afterRejectedMigration = new Database(dbPath, { readonly: true });
+      expect(
+        afterRejectedMigration
+          .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name ASC`)
+          .all()
+          .map((row) => (row as { name: string }).name),
+      ).toEqual(['memory_schema_versions']);
+      afterRejectedMigration.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tasks/issue-1812-state-schema-migration-smoke-tests-progress.md
+++ b/tasks/issue-1812-state-schema-migration-smoke-tests-progress.md
@@ -1,0 +1,9 @@
+# Issue 1812 — State schema migration smoke tests
+
+- [x] Read shared lessons and issue context.
+- [x] Create isolated issue branch/worktree.
+- [x] Inspect existing state schema migration coverage.
+- [x] Add focused smoke tests for legacy migration and future-schema failure.
+- [x] Add operator guidance for interpreting the smoke coverage.
+- [x] Run targeted tests and package gates.
+- [ ] Commit, push, open PR, and complete Codex/CI/merge gate.


### PR DESCRIPTION
## Summary
- Adds a dedicated @franken/brain state schema migration smoke test suite for legacy v0 SQLite memory-state upgrades.
- Covers fail-closed handling for future unsupported state schema versions before runtime tables are created or altered.
- Documents how operators should run and interpret the smoke suite.

## Verification
- npm run test --workspace @franken/brain -- state-schema-migration-smoke.test.ts
- npm run test --workspace @franken/brain -- sqlite-brain.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/brain
- npm run build --workspace @franken/brain
- npm run lint --workspace @franken/brain

Closes #1812