### PR TITLE
test(orchestrator): add flaky liveness replay fixture

### DIFF
--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -68,6 +68,16 @@ npm run test:coverage --workspace=@franken/orchestrator
 
 Integration and E2E scripts enable broader runtime paths with `INTEGRATION=true` or `E2E=true`; use them when the needed local services, credentials, and fixtures are available.
 
+## Flaky liveness fixture replay
+
+Issue-worker liveness/backpressure regressions can be reproduced with colocated JSON replay fixtures in `packages/franken-orchestrator/tests/unit/issues/fixtures/`. The `flaky-liveness-replay.json` fixture captures each liveness tick as thresholds, signals, checkpoint state, and the expected PM-visible worker route. Add new flaky liveness cases there when a capacity spike, dependency breaker, or recovery edge needs deterministic coverage, then run:
+
+```bash
+npm test --workspace=@franken/orchestrator -- tests/unit/issues/issue-runner.test.ts
+```
+
+Keep fixture snapshots narrow and deterministic: prefer structured `signals`, exact `expectedReasons`, and explicit `expectedRoute` values over wall-clock sleeps or prose-only assertions.
+
 ## Security limits
 
 Context snapshot imports are size-limited before JSON parsing to reduce resource-exhaustion risk from untrusted or corrupted resume/import files. `loadContext(filePath)` defaults to a 1 MiB cap, opens snapshots in nonblocking mode, rejects non-regular paths from the opened file descriptor, and enforces the same byte cap while reading so oversized content is rejected even if the file changes after metadata inspection. Trusted tooling that intentionally owns a larger snapshot must opt in per import with `loadContext(filePath, { maxBytes })`; invalid overrides such as `0`, negative, non-finite, or unsafe integer values fail closed.

--- a/packages/franken-orchestrator/tests/unit/issues/fixtures/flaky-liveness-replay.json
+++ b/packages/franken-orchestrator/tests/unit/issues/fixtures/flaky-liveness-replay.json
@@ -1,0 +1,114 @@
+{
+  "description": "Flaky liveness replay fixture for deterministic issue-worker routing tests. Each snapshot captures one liveness tick and the expected PM-visible routing result.",
+  "issue": { "number": 1806, "title": "test(stability): add flaky liveness fixture replay harness", "labels": ["P2", "reliability"] },
+  "thresholds": {
+    "maxActiveProcesses": 5,
+    "maxFailedStarts": 1,
+    "maxInFlightBacklog": 4,
+    "maxPendingIssueCount": 10,
+    "maxOldestQueueAgeMs": 300000,
+    "maxSystemLoadAverage": 8,
+    "minProviderBudgetTokensRemaining": 100000,
+    "dependencyCircuitBreakers": {
+      "github": { "maxConsecutiveFailures": 2, "pauseOnStatuses": ["unavailable"] }
+    }
+  },
+  "snapshots": [
+    {
+      "name": "process-capacity-spike-defers-fresh-worker",
+      "checkpointHasIssueProgress": false,
+      "graphHasCheckpointProgress": false,
+      "signals": {
+        "activeProcesses": 5,
+        "failedStarts": 0,
+        "inFlightBacklog": 1,
+        "pendingIssueCount": 2,
+        "oldestQueueAgeMs": 120000,
+        "systemLoadAverage": 2.5,
+        "providerBudgetTokensRemaining": 500000,
+        "dependencyStatuses": [
+          { "dependency": "github", "status": "healthy", "consecutiveFailures": 0 }
+        ]
+      },
+      "expectedAllowed": false,
+      "expectedReasons": ["active processes 5 reached limit 5"],
+      "expectedRoute": {
+        "mode": "degraded",
+        "action": "defer-fresh-start",
+        "reason": "backpressure: active processes 5 reached limit 5"
+      }
+    },
+    {
+      "name": "github-flake-resumes-checkpointed-worker",
+      "checkpointHasIssueProgress": true,
+      "graphHasCheckpointProgress": true,
+      "signals": {
+        "activeProcesses": 1,
+        "failedStarts": 0,
+        "inFlightBacklog": 0,
+        "pendingIssueCount": 1,
+        "oldestQueueAgeMs": 0,
+        "systemLoadAverage": 1.75,
+        "providerBudgetTokensRemaining": 500000,
+        "dependencyStatuses": [
+          { "dependency": "github", "status": "degraded", "consecutiveFailures": 2 }
+        ]
+      },
+      "expectedAllowed": false,
+      "expectedReasons": ["github consecutive failures 2 reached circuit breaker limit 2"],
+      "expectedRoute": {
+        "mode": "degraded",
+        "action": "resume-checkpointed",
+        "reason": "backpressure: github consecutive failures 2 reached circuit breaker limit 2"
+      }
+    },
+    {
+      "name": "recovered-liveness-starts-fresh-worker",
+      "checkpointHasIssueProgress": false,
+      "graphHasCheckpointProgress": false,
+      "signals": {
+        "activeProcesses": 1,
+        "failedStarts": 0,
+        "inFlightBacklog": 0,
+        "pendingIssueCount": 1,
+        "oldestQueueAgeMs": 0,
+        "systemLoadAverage": 1.5,
+        "providerBudgetTokensRemaining": 500000,
+        "dependencyStatuses": [
+          { "dependency": "github", "status": "healthy", "consecutiveFailures": 0 }
+        ]
+      },
+      "expectedAllowed": true,
+      "expectedReasons": [],
+      "expectedRoute": {
+        "mode": "normal",
+        "action": "start-fresh"
+      }
+    }
+  ],
+  "edgeCases": [
+    {
+      "name": "unconfigured-unrelated-dependency-does-not-pause-liveness",
+      "checkpointHasIssueProgress": false,
+      "graphHasCheckpointProgress": false,
+      "signals": {
+        "activeProcesses": 1,
+        "failedStarts": 0,
+        "inFlightBacklog": 0,
+        "pendingIssueCount": 1,
+        "oldestQueueAgeMs": 0,
+        "systemLoadAverage": 1.5,
+        "providerBudgetTokensRemaining": 500000,
+        "dependencyStatuses": [
+          { "dependency": "grafana", "status": "unavailable", "consecutiveFailures": 99 }
+        ]
+      },
+      "expectedAllowed": true,
+      "expectedReasons": [],
+      "expectedRoute": {
+        "mode": "normal",
+        "action": "start-fresh"
+      }
+    }
+  ]
+}

--- a/packages/franken-orchestrator/tests/unit/issues/fixtures/flaky-liveness-replay.json
+++ b/packages/franken-orchestrator/tests/unit/issues/fixtures/flaky-liveness-replay.json
@@ -56,6 +56,7 @@
       },
       "expectedAllowed": false,
       "expectedReasons": ["github consecutive failures 2 reached circuit breaker limit 2"],
+      "stopRemainingReason": "backpressure: github consecutive failures 2 reached circuit breaker limit 2",
       "expectedRoute": {
         "mode": "degraded",
         "action": "resume-checkpointed",

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -63,6 +63,7 @@ interface FlakyLivenessReplaySnapshot {
   readonly name: string;
   readonly checkpointHasIssueProgress: boolean;
   readonly graphHasCheckpointProgress: boolean;
+  readonly stopRemainingReason?: string;
   readonly signals: IssueBackpressureSignals;
   readonly expectedAllowed: boolean;
   readonly expectedReasons: readonly string[];
@@ -116,6 +117,14 @@ function makeIssue(overrides: Partial<GithubIssue> & { number: number }): Github
     url: `https://github.com/org/repo/issues/${overrides.number}`,
     ...overrides,
   };
+}
+
+function makeFixtureIssue(fixtureIssue: BurstDispatchIssueFixture): GithubIssue {
+  return makeIssue({
+    number: fixtureIssue.number,
+    title: fixtureIssue.title,
+    labels: [...fixtureIssue.labels],
+  });
 }
 
 function makeTriage(issueNumber: number, complexity: 'one-shot' | 'chunked' = 'one-shot'): TriageResult {
@@ -581,7 +590,7 @@ describe('IssueRunner', () => {
         const decision = await evaluateIssueBackpressure(
           { thresholds: fixture.thresholds, signals: () => snapshot.signals },
           {
-            issue: makeIssue(fixture.issues[0]!),
+            issue: makeFixtureIssue(fixture.issues[0]!),
             index: 0,
             totalIssues: fixture.issues.length,
             pendingIssueCount: fixture.issues.length,
@@ -604,7 +613,7 @@ describe('IssueRunner', () => {
       const decision = await evaluateIssueBackpressure(
         { thresholds: edgeCase!.thresholds, signals: () => edgeCase!.signals },
         {
-          issue: makeIssue(fixture.issues[0]!),
+          issue: makeFixtureIssue(fixture.issues[0]!),
           index: 0,
           totalIssues: fixture.issues.length,
           pendingIssueCount: fixture.issues.length,
@@ -624,18 +633,18 @@ describe('IssueRunner', () => {
 
       expect(fixture.description).toContain('Flaky liveness replay fixture');
       expect(fixture.issue.number).toBe(1806);
-      expect(replayCases.map(testCase => testCase.name)).toEqual([
+      expect(replayCases.map(testCase => testCase.name)).toEqual(expect.arrayContaining([
         'process-capacity-spike-defers-fresh-worker',
         'github-flake-resumes-checkpointed-worker',
         'recovered-liveness-starts-fresh-worker',
         'unconfigured-unrelated-dependency-does-not-pause-liveness',
-      ]);
+      ]));
 
       for (const testCase of replayCases) {
         const decision = await evaluateIssueBackpressure(
           { thresholds: fixture.thresholds, signals: () => testCase.signals },
           {
-            issue: makeIssue(fixture.issue),
+            issue: makeFixtureIssue(fixture.issue),
             index: 0,
             totalIssues: 1,
             pendingIssueCount: 1,
@@ -645,10 +654,11 @@ describe('IssueRunner', () => {
           },
         );
         const route = routeIssueWorkerForDegradedMode({
-          issue: makeIssue(fixture.issue),
+          issue: makeFixtureIssue(fixture.issue),
           checkpointHasIssueProgress: testCase.checkpointHasIssueProgress,
           graphHasCheckpointProgress: testCase.graphHasCheckpointProgress,
           backpressureDecision: decision,
+          stopRemainingReason: testCase.stopRemainingReason,
         });
 
         expect(decision.allowed, testCase.name).toBe(testCase.expectedAllowed);

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -53,10 +53,40 @@ interface BurstDispatchLoadFixture {
   readonly edgeCases: readonly BurstDispatchLoadFixtureCase[];
 }
 
+interface FlakyLivenessReplayRouteExpectation {
+  readonly mode: 'normal' | 'degraded';
+  readonly action: 'start-fresh' | 'resume-checkpointed' | 'complete-checkpointed' | 'defer-fresh-start';
+  readonly reason?: string;
+}
+
+interface FlakyLivenessReplaySnapshot {
+  readonly name: string;
+  readonly checkpointHasIssueProgress: boolean;
+  readonly graphHasCheckpointProgress: boolean;
+  readonly signals: IssueBackpressureSignals;
+  readonly expectedAllowed: boolean;
+  readonly expectedReasons: readonly string[];
+  readonly expectedRoute: FlakyLivenessReplayRouteExpectation;
+}
+
+interface FlakyLivenessReplayFixture {
+  readonly description: string;
+  readonly issue: BurstDispatchIssueFixture;
+  readonly thresholds: IssueBackpressureThresholds;
+  readonly snapshots: readonly FlakyLivenessReplaySnapshot[];
+  readonly edgeCases: readonly FlakyLivenessReplaySnapshot[];
+}
+
 function readBurstDispatchLoadFixture(): BurstDispatchLoadFixture {
   return JSON.parse(
     readFileSync(join(__dirname, 'fixtures', 'burst-dispatch-load.json'), 'utf8'),
   ) as BurstDispatchLoadFixture;
+}
+
+function readFlakyLivenessReplayFixture(): FlakyLivenessReplayFixture {
+  return JSON.parse(
+    readFileSync(join(__dirname, 'fixtures', 'flaky-liveness-replay.json'), 'utf8'),
+  ) as FlakyLivenessReplayFixture;
 }
 
 vi.mock('../../../src/beast-loop.js', () => {
@@ -586,6 +616,45 @@ describe('IssueRunner', () => {
 
       expect(decision.allowed).toBe(false);
       expect(decision.reasons).toEqual(edgeCase!.expectedReasons);
+    });
+
+    it('replays flaky liveness fixture snapshots into worker routing decisions', async () => {
+      const fixture = readFlakyLivenessReplayFixture();
+      const replayCases = [...fixture.snapshots, ...fixture.edgeCases];
+
+      expect(fixture.description).toContain('Flaky liveness replay fixture');
+      expect(fixture.issue.number).toBe(1806);
+      expect(replayCases.map(testCase => testCase.name)).toEqual([
+        'process-capacity-spike-defers-fresh-worker',
+        'github-flake-resumes-checkpointed-worker',
+        'recovered-liveness-starts-fresh-worker',
+        'unconfigured-unrelated-dependency-does-not-pause-liveness',
+      ]);
+
+      for (const testCase of replayCases) {
+        const decision = await evaluateIssueBackpressure(
+          { thresholds: fixture.thresholds, signals: () => testCase.signals },
+          {
+            issue: makeIssue(fixture.issue),
+            index: 0,
+            totalIssues: 1,
+            pendingIssueCount: 1,
+            cumulativeTokens: 0,
+            budgetTokens: 1_000_000,
+            providerBudgetTokensRemaining: 1_000_000,
+          },
+        );
+        const route = routeIssueWorkerForDegradedMode({
+          issue: makeIssue(fixture.issue),
+          checkpointHasIssueProgress: testCase.checkpointHasIssueProgress,
+          graphHasCheckpointProgress: testCase.graphHasCheckpointProgress,
+          backpressureDecision: decision,
+        });
+
+        expect(decision.allowed, testCase.name).toBe(testCase.expectedAllowed);
+        expect(decision.reasons, testCase.name).toEqual(testCase.expectedReasons);
+        expect(route, testCase.name).toMatchObject(testCase.expectedRoute);
+      }
     });
 
     it('skips fresh issue starts when active process capacity is exhausted and explains the throttle', async () => {

--- a/tasks/resolve-issue-1806-progress.md
+++ b/tasks/resolve-issue-1806-progress.md
@@ -1,0 +1,8 @@
+# Resolve issue #1806 progress
+
+- [x] Read issue #1806, task handoff, repository instructions, and shared lessons.
+- [x] Create isolated branch/worktree `resolve/issue-1806-test-stability-add-flaky-liveness-fixture-replay`.
+- [x] Add a focused flaky liveness fixture replay harness with success and edge/failure coverage.
+- [x] Document how operators/developers use the fixture replay harness.
+- [x] Run targeted orchestrator tests and relevant package checks.
+- [ ] Commit, push, open PR closing #1806, run Codex review/CI, and merge or block with exact blocker.


### PR DESCRIPTION
## Summary
- add a deterministic flaky liveness replay fixture for issue-worker backpressure/routing snapshots
- replay the fixture through `evaluateIssueBackpressure` and degraded-mode worker routing, including recovery and unrelated-dependency edge cases
- document how to add and run flaky liveness replay cases

## Verification
- `npm test --workspace=@franken/orchestrator -- tests/unit/issues/issue-runner.test.ts`
- `npm run build --workspace=@franken/types`
- `npm run build --workspace=@franken/observer`
- `npm run build --workspace=@franken/brain`
- `npm run build --workspace=@franken/critique`
- `npm run build --workspace=@franken/governor`
- `npm run build --workspace=@franken/planner`
- `npm run typecheck --workspace=@franken/orchestrator`
- `npm run build --workspace=@franken/orchestrator`
- `npm run lint --workspace=@franken/orchestrator` (passes with existing warnings)

Closes #1806