### PR TITLE
fix(orchestrator): detect duplicate worker-card processes

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -146,6 +146,11 @@ await evaluateIssueBackpressure({
 }, context)
 ```
 
+
+## Duplicate worker-card process detector
+
+PM and liveness callers that inventory worker-card processes can call `detectDuplicateWorkerCardProcesses(snapshots)` before starting or refilling issue work. Provide one snapshot per observed worker process with `cardId`, `pid`, optional `runId`, `issueNumber`, `owner`, `status`, `alive`, `startedAt`, and `lastHeartbeatAt`. The detector ignores terminal/dead/invalid snapshots and reports only cards with two or more distinct live PIDs. Each finding is structured for automation: `cardId`, `processCount`, sorted `pids`, `runIds`, `owners`, `statuses`, timestamps, a `message`, and operator `guidance` telling the PM to keep one live owner, stop or park the duplicate, and record the survivor in liveness output.
+
 ## Scheduler fairness report
 
 Before execution starts, `IssueRunner` emits `[issues] Scheduler fairness report` with structured data that PM/liveness tooling can consume without parsing prose. The report includes:

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -149,7 +149,7 @@ await evaluateIssueBackpressure({
 
 ## Duplicate worker-card process detector
 
-PM and liveness callers that inventory worker-card processes can call `detectDuplicateWorkerCardProcesses(snapshots)` before starting or refilling issue work. Provide one snapshot per observed worker process with `cardId`, `pid`, optional `runId`, `issueNumber`, `owner`, `status`, `alive`, `startedAt`, and `lastHeartbeatAt`. The detector ignores terminal/dead/invalid snapshots and reports only cards with two or more distinct live PIDs. Each finding is structured for automation: `cardId`, `processCount`, sorted `pids`, `runIds`, `owners`, `statuses`, timestamps, a `message`, and operator `guidance` telling the PM to keep one live owner, stop or park the duplicate, and record the survivor in liveness output.
+PM and liveness callers that inventory worker-card processes can call `detectDuplicateWorkerCardProcesses(snapshots)` before starting or refilling issue work. Provide one snapshot per observed worker process with `cardId`, `pid`, optional string `runId`, `issueNumber`, `owner`, `status`, `alive`, `startedAt`, and `lastHeartbeatAt`. The detector ignores terminal/dead/invalid snapshots while preserving live blocked workers and reports only cards with two or more distinct live PIDs. Each finding is structured for automation: `cardId`, `processCount`, sorted `pids`, `runIds`, `owners`, `statuses`, timestamps, a `message`, and operator `guidance` telling the PM to keep one live owner, stop or park the duplicate, and record the survivor in liveness output.
 
 ## Scheduler fairness report
 

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from './types.js';
 
 // Issues
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode } from './issues/index.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses } from './issues/index.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -68,6 +68,8 @@ export type {
   IssueDependencyStatus,
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
+  IssueWorkerCardProcessSnapshot,
+  DuplicateWorkerCardProcessFinding,
 } from './issues/index.js';
 
 // Config

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,7 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses } from './issue-runner.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -30,6 +30,8 @@ export type {
   IssueDependencyStatus,
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
+  IssueWorkerCardProcessSnapshot,
+  DuplicateWorkerCardProcessFinding,
 } from './issue-runner.js';
 export { IssueReview } from './issue-review.js';
 export type { ReviewIO, ReviewDecision, IssueReviewOptions } from './issue-review.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -160,7 +160,7 @@ export interface IssueWorkerCardProcessSnapshot {
   /** Operating-system process id observed by liveness tooling. */
   readonly pid: number;
   /** Optional run id for tools that distinguish multiple attempts on one card. */
-  readonly runId?: number | undefined;
+  readonly runId?: string | undefined;
   /** Optional linked GitHub issue for operator summaries. */
   readonly issueNumber?: number | undefined;
   /** Worker owner, profile, or host label that reported the process. */
@@ -178,7 +178,7 @@ export interface DuplicateWorkerCardProcessFinding {
   readonly severity: 'warning';
   readonly processCount: number;
   readonly pids: readonly number[];
-  readonly runIds: readonly number[];
+  readonly runIds: readonly string[];
   readonly issueNumbers: readonly number[];
   readonly owners: readonly string[];
   readonly statuses: readonly string[];
@@ -507,19 +507,20 @@ export async function evaluateIssueBackpressure(
 
 const TERMINAL_WORKER_CARD_STATUSES = new Set([
   'archived',
-  'blocked',
   'cancelled',
   'canceled',
   'closed',
   'complete',
   'completed',
   'crashed',
+  'deleted',
   'done',
   'exited',
   'failed',
   'merged',
   'removed',
   'skipped',
+  'stopped',
 ]);
 
 function activeWorkerCardProcess(snapshot: IssueWorkerCardProcessSnapshot): boolean {
@@ -591,7 +592,7 @@ export function detectDuplicateWorkerCardProcesses(
       severity: 'warning',
       processCount: pids.length,
       pids,
-      runIds: uniqueSortedNumbers(cardSnapshots.map(snapshot => snapshot.runId)),
+      runIds: uniqueSortedStrings(cardSnapshots.map(snapshot => snapshot.runId)),
       issueNumbers,
       owners: uniqueSortedStrings(cardSnapshots.map(snapshot => snapshot.owner)),
       statuses: uniqueSortedStrings(cardSnapshots.map(snapshot => snapshot.status)),

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -153,6 +153,41 @@ export interface IssueDegradedModeWorkerRouteInput {
   readonly stopRemainingReason?: string | undefined;
 }
 
+
+export interface IssueWorkerCardProcessSnapshot {
+  /** Stable Kanban/PM worker card id that owns this process. */
+  readonly cardId: string;
+  /** Operating-system process id observed by liveness tooling. */
+  readonly pid: number;
+  /** Optional run id for tools that distinguish multiple attempts on one card. */
+  readonly runId?: number | undefined;
+  /** Optional linked GitHub issue for operator summaries. */
+  readonly issueNumber?: number | undefined;
+  /** Worker owner, profile, or host label that reported the process. */
+  readonly owner?: string | undefined;
+  /** Runtime status reported by the worker/card process monitor. */
+  readonly status?: string | undefined;
+  /** Explicit liveness probe result; omitted means the snapshot is considered live. */
+  readonly alive?: boolean | undefined;
+  readonly startedAt?: string | number | Date | undefined;
+  readonly lastHeartbeatAt?: string | number | Date | undefined;
+}
+
+export interface DuplicateWorkerCardProcessFinding {
+  readonly cardId: string;
+  readonly severity: 'warning';
+  readonly processCount: number;
+  readonly pids: readonly number[];
+  readonly runIds: readonly number[];
+  readonly issueNumbers: readonly number[];
+  readonly owners: readonly string[];
+  readonly statuses: readonly string[];
+  readonly newestStartedAt?: string | undefined;
+  readonly lastHeartbeatAt?: string | undefined;
+  readonly message: string;
+  readonly guidance: string;
+}
+
 export interface IssueSchedulerFairnessBucket {
   readonly severity: 'critical' | 'high' | 'medium' | 'low' | 'unprioritized';
   readonly issueNumbers: readonly number[];
@@ -467,6 +502,107 @@ export async function evaluateIssueBackpressure(
     alerts,
     dependencyCircuitBreakers,
   };
+}
+
+
+const TERMINAL_WORKER_CARD_STATUSES = new Set([
+  'archived',
+  'blocked',
+  'cancelled',
+  'canceled',
+  'closed',
+  'complete',
+  'completed',
+  'crashed',
+  'done',
+  'exited',
+  'failed',
+  'merged',
+  'removed',
+  'skipped',
+]);
+
+function activeWorkerCardProcess(snapshot: IssueWorkerCardProcessSnapshot): boolean {
+  if (snapshot.alive === false) return false;
+  if (!snapshot.cardId.trim()) return false;
+  if (!Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
+  const status = snapshot.status?.trim().toLowerCase();
+  return status === undefined || !TERMINAL_WORKER_CARD_STATUSES.has(status);
+}
+
+function isoTimestamp(value: string | number | Date | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+function uniqueSortedNumbers(values: Iterable<number | undefined>): number[] {
+  return [...new Set([...values].filter((value): value is number => Number.isSafeInteger(value)))]
+    .sort((a, b) => a - b);
+}
+
+function uniqueSortedStrings(values: Iterable<string | undefined>): string[] {
+  return [...new Set([...values]
+    .map(value => value?.trim())
+    .filter((value): value is string => value !== undefined && value.length > 0))]
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function maxIsoTimestamp(values: Iterable<string | number | Date | undefined>): string | undefined {
+  let maxMs = Number.NEGATIVE_INFINITY;
+  let maxIso: string | undefined;
+  for (const value of values) {
+    const iso = isoTimestamp(value);
+    if (!iso) continue;
+    const ms = new Date(iso).getTime();
+    if (ms > maxMs) {
+      maxMs = ms;
+      maxIso = iso;
+    }
+  }
+  return maxIso;
+}
+
+export function detectDuplicateWorkerCardProcesses(
+  snapshots: readonly IssueWorkerCardProcessSnapshot[],
+): DuplicateWorkerCardProcessFinding[] {
+  const byCard = new Map<string, IssueWorkerCardProcessSnapshot[]>();
+
+  for (const snapshot of snapshots) {
+    if (!activeWorkerCardProcess(snapshot)) continue;
+    const cardId = snapshot.cardId.trim();
+    const existingForCard = byCard.get(cardId);
+    if (existingForCard) {
+      existingForCard.push(snapshot);
+    } else {
+      byCard.set(cardId, [snapshot]);
+    }
+  }
+
+  const findings: DuplicateWorkerCardProcessFinding[] = [];
+  for (const [cardId, cardSnapshots] of byCard) {
+    const pids = uniqueSortedNumbers(cardSnapshots.map(snapshot => snapshot.pid));
+    if (pids.length < 2) continue;
+
+    const issueNumbers = uniqueSortedNumbers(cardSnapshots.map(snapshot => snapshot.issueNumber));
+    findings.push({
+      cardId,
+      severity: 'warning',
+      processCount: pids.length,
+      pids,
+      runIds: uniqueSortedNumbers(cardSnapshots.map(snapshot => snapshot.runId)),
+      issueNumbers,
+      owners: uniqueSortedStrings(cardSnapshots.map(snapshot => snapshot.owner)),
+      statuses: uniqueSortedStrings(cardSnapshots.map(snapshot => snapshot.status)),
+      newestStartedAt: maxIsoTimestamp(cardSnapshots.map(snapshot => snapshot.startedAt)),
+      lastHeartbeatAt: maxIsoTimestamp(cardSnapshots.map(snapshot => snapshot.lastHeartbeatAt)),
+      message: `Worker card ${cardId} has ${pids.length} live processes: ${pids.join(', ')}`,
+      guidance: 'Keep one live owner for the worker card, stop or park the duplicate process, then record the surviving PID/run id in PM/liveness output.',
+    });
+  }
+
+  return findings.sort((a, b) => a.cardId.localeCompare(b.cardId));
 }
 
 function extractSeverity(labels: readonly string[]): number {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode } from '../../../src/issues/issue-runner.js';
+import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses } from '../../../src/issues/issue-runner.js';
 import type { IssueBackpressureSignals, IssueBackpressureThresholds, IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
 import type { PlanGraph, ICheckpointStore, ILogger, BeastLoopDeps } from '../../../src/deps.js';
@@ -220,6 +220,67 @@ function makeIssueRuntimeSupport(): IssueRuntimeSupport {
     })),
   };
 }
+
+
+describe('duplicate worker-card process detector', () => {
+  it('reports duplicate live process ownership for the same worker card with structured guidance', () => {
+    const findings = detectDuplicateWorkerCardProcesses([
+      {
+        cardId: 't_worker_1',
+        pid: 4202,
+        runId: 10,
+        issueNumber: 1809,
+        owner: 'worker-a',
+        status: 'running',
+        startedAt: '2026-07-15T09:00:00.000Z',
+        lastHeartbeatAt: '2026-07-15T09:10:00.000Z',
+      },
+      {
+        cardId: 't_worker_1',
+        pid: 4201,
+        runId: 9,
+        issueNumber: 1809,
+        owner: 'worker-b',
+        status: 'claimed',
+        startedAt: '2026-07-15T09:05:00.000Z',
+        lastHeartbeatAt: '2026-07-15T09:12:00.000Z',
+      },
+      { cardId: 't_worker_2', pid: 4300, runId: 11, issueNumber: 1810, owner: 'worker-c', status: 'running' },
+    ]);
+
+    expect(findings).toEqual([
+      {
+        cardId: 't_worker_1',
+        severity: 'warning',
+        processCount: 2,
+        pids: [4201, 4202],
+        runIds: [9, 10],
+        issueNumbers: [1809],
+        owners: ['worker-a', 'worker-b'],
+        statuses: ['claimed', 'running'],
+        newestStartedAt: '2026-07-15T09:05:00.000Z',
+        lastHeartbeatAt: '2026-07-15T09:12:00.000Z',
+        message: 'Worker card t_worker_1 has 2 live processes: 4201, 4202',
+        guidance: 'Keep one live owner for the worker card, stop or park the duplicate process, then record the surviving PID/run id in PM/liveness output.',
+      },
+    ]);
+  });
+
+  it('ignores terminal, dead, invalid, and repeated-PID snapshots so false positives stay quiet', () => {
+    const findings = detectDuplicateWorkerCardProcesses([
+      { cardId: 't_complete', pid: 5001, status: 'completed' },
+      { cardId: 't_complete', pid: 5002, status: 'done' },
+      { cardId: 't_dead', pid: 5003, alive: false, status: 'running' },
+      { cardId: 't_dead', pid: 5004, alive: false, status: 'claimed' },
+      { cardId: 't_same_pid', pid: 5005, status: 'running' },
+      { cardId: 't_same_pid', pid: 5005, status: 'claimed' },
+      { cardId: '', pid: 5006, status: 'running' },
+      { cardId: 't_invalid_pid', pid: 0, status: 'running' },
+    ]);
+
+    expect(findings).toEqual([]);
+  });
+});
 
 describe('degraded-mode worker routing policy', () => {
   it('defers fresh worker starts during degraded backpressure with operator guidance', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -228,7 +228,7 @@ describe('duplicate worker-card process detector', () => {
       {
         cardId: 't_worker_1',
         pid: 4202,
-        runId: 10,
+        runId: 'run-10',
         issueNumber: 1809,
         owner: 'worker-a',
         status: 'running',
@@ -238,14 +238,14 @@ describe('duplicate worker-card process detector', () => {
       {
         cardId: 't_worker_1',
         pid: 4201,
-        runId: 9,
+        runId: 'run-9',
         issueNumber: 1809,
         owner: 'worker-b',
         status: 'claimed',
         startedAt: '2026-07-15T09:05:00.000Z',
         lastHeartbeatAt: '2026-07-15T09:12:00.000Z',
       },
-      { cardId: 't_worker_2', pid: 4300, runId: 11, issueNumber: 1810, owner: 'worker-c', status: 'running' },
+      { cardId: 't_worker_2', pid: 4300, runId: 'run-11', issueNumber: 1810, owner: 'worker-c', status: 'running' },
     ]);
 
     expect(findings).toEqual([
@@ -254,7 +254,7 @@ describe('duplicate worker-card process detector', () => {
         severity: 'warning',
         processCount: 2,
         pids: [4201, 4202],
-        runIds: [9, 10],
+        runIds: ['run-10', 'run-9'],
         issueNumbers: [1809],
         owners: ['worker-a', 'worker-b'],
         statuses: ['claimed', 'running'],
@@ -266,10 +266,31 @@ describe('duplicate worker-card process detector', () => {
     ]);
   });
 
+
+
+  it('keeps blocked live workers visible while ignoring stopped or deleted cards', () => {
+    const findings = detectDuplicateWorkerCardProcesses([
+      { cardId: 't_blocked', pid: 5101, status: 'blocked', alive: true, runId: 'run-blocked-a' },
+      { cardId: 't_blocked', pid: 5102, status: 'blocked', alive: true, runId: 'run-blocked-b' },
+      { cardId: 't_stopped', pid: 5103, status: 'stopped' },
+      { cardId: 't_stopped', pid: 5104, status: 'deleted' },
+    ]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_blocked',
+      pids: [5101, 5102],
+      runIds: ['run-blocked-a', 'run-blocked-b'],
+      statuses: ['blocked'],
+    });
+  });
+
   it('ignores terminal, dead, invalid, and repeated-PID snapshots so false positives stay quiet', () => {
     const findings = detectDuplicateWorkerCardProcesses([
       { cardId: 't_complete', pid: 5001, status: 'completed' },
       { cardId: 't_complete', pid: 5002, status: 'done' },
+      { cardId: 't_stopped', pid: 5011, status: 'stopped' },
+      { cardId: 't_stopped', pid: 5012, status: 'deleted' },
       { cardId: 't_dead', pid: 5003, alive: false, status: 'running' },
       { cardId: 't_dead', pid: 5004, alive: false, status: 'claimed' },
       { cardId: 't_same_pid', pid: 5005, status: 'running' },


### PR DESCRIPTION
## Summary
- add a structured duplicate worker-card process detector for PM/liveness callers
- export detector types and function from the orchestrator issue module
- document detector inputs, false-positive filtering, and operator guidance

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)

Closes #1809