### PR TITLE
fix(orchestrator): bound provider failure retries

### DIFF
--- a/docs/guides/add-llm-provider.md
+++ b/docs/guides/add-llm-provider.md
@@ -33,7 +33,8 @@ npm --workspace @franken/orchestrator test -- tests/unit/skills
 2. Add config schema support under `packages/franken-orchestrator/src/config/` if the provider needs new settings.
 3. Keep secrets referenced through the configured secret backend or environment variables; do not hard-code tokens in config examples.
 4. Add unit tests for request construction, error handling, config parsing, and failover audit metadata. API-provider failover through `ProviderRegistry` emits a `model-provider.failover` audit event with `from`, `to`, `reason`, `brainSnapshotHash`, `category: "availability"`, and operator guidance; keep that payload structured so dashboard/liveness tooling can correlate a provider outage with the handoff snapshot.
-5. Verify from the repo root:
+5. Keep provider-failure retries bounded. `ProviderRegistry` retries only retryable provider stream errors before failing over, defaults to one retry per provider, rejects `maxRetriesPerProvider` values outside `0..5`, and caps exponential backoff delays at `maxRetryDelayMs` (default `30000`). Use the injectable `sleep` hook in tests so retry/backoff behavior is deterministic and does not slow the suite.
+6. Verify from the repo root:
 
 ```bash
 npm --workspace @franken/orchestrator run typecheck

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -10,12 +10,20 @@ import { TokenAggregator, type AggregatedTokenUsage } from './token-aggregator.j
 import { truncateSnapshot } from './format-handoff.js';
 
 export interface ProviderRegistryOptions {
-  /** Maximum retries per provider before failing over */
+  /**
+   * Maximum retries per provider before failing over. Default: 1.
+   * Must be an integer between 0 and 5 so provider outages cannot create
+   * unbounded retry loops across long fallback chains.
+   */
   maxRetriesPerProvider?: number;
-  /** Delay between retries in ms */
+  /** Initial delay between retries in ms */
   retryDelayMs?: number;
+  /** Maximum delay between retries in ms */
+  maxRetryDelayMs?: number;
   /** Rate limit backoff multiplier */
   backoffMultiplier?: number;
+  /** Injectable sleep for deterministic tests */
+  sleep?: (ms: number) => Promise<void>;
   /** Callback fired when switching providers */
   onProviderSwitch?: (event: ProviderSwitchEvent) => void;
 }
@@ -51,8 +59,41 @@ export function createModelProviderFailoverAuditPayload(
 interface ResolvedOptions {
   maxRetriesPerProvider: number;
   retryDelayMs: number;
+  maxRetryDelayMs: number;
   backoffMultiplier: number;
+  sleep: (ms: number) => Promise<void>;
   onProviderSwitch?: ProviderRegistryOptions['onProviderSwitch'];
+}
+
+const MAX_RETRIES_PER_PROVIDER = 5;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+function normalizeMaxRetriesPerProvider(value: number | undefined): number {
+  const normalized = value ?? 1;
+  if (!Number.isInteger(normalized) || normalized < 0 || normalized > MAX_RETRIES_PER_PROVIDER) {
+    throw new Error(`maxRetriesPerProvider must be an integer between 0 and ${MAX_RETRIES_PER_PROVIDER}`);
+  }
+  return normalized;
+}
+
+function normalizeNonNegativeFinite(
+  name: 'retryDelayMs' | 'maxRetryDelayMs',
+  value: number | undefined,
+  defaultValue: number,
+): number {
+  const normalized = value ?? defaultValue;
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    throw new Error(`${name} must be a finite non-negative number`);
+  }
+  return normalized;
+}
+
+function normalizeBackoffMultiplier(value: number | undefined): number {
+  const normalized = value ?? 2;
+  if (!Number.isFinite(normalized) || normalized < 1) {
+    throw new Error('backoffMultiplier must be a finite number greater than or equal to 1');
+  }
+  return normalized;
 }
 
 export class ProviderRegistry {
@@ -72,10 +113,14 @@ export class ProviderRegistry {
     }
     this.providers = providers;
     this.brain = brain;
+    const retryDelayMs = normalizeNonNegativeFinite('retryDelayMs', options.retryDelayMs, 1000);
+    const maxRetryDelayMs = normalizeNonNegativeFinite('maxRetryDelayMs', options.maxRetryDelayMs, MAX_RETRY_DELAY_MS);
     this.opts = {
-      maxRetriesPerProvider: options.maxRetriesPerProvider ?? 1,
-      retryDelayMs: options.retryDelayMs ?? 1000,
-      backoffMultiplier: options.backoffMultiplier ?? 2,
+      maxRetriesPerProvider: normalizeMaxRetriesPerProvider(options.maxRetriesPerProvider),
+      retryDelayMs,
+      maxRetryDelayMs,
+      backoffMultiplier: normalizeBackoffMultiplier(options.backoffMultiplier),
+      sleep: options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))),
       onProviderSwitch: options.onProviderSwitch,
     };
   }
@@ -168,10 +213,12 @@ export class ProviderRegistry {
               retry < this.opts.maxRetriesPerProvider
             ) {
               lastError = new Error(event.error);
-              const delay =
+              const delay = Math.min(
                 this.opts.retryDelayMs *
-                Math.pow(this.opts.backoffMultiplier, retry);
-              await new Promise((resolve) => setTimeout(resolve, delay));
+                Math.pow(this.opts.backoffMultiplier, retry),
+                this.opts.maxRetryDelayMs,
+              );
+              await this.opts.sleep(delay);
               retried = true;
               break; // discard buffer, retry same provider
             }

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -414,6 +414,56 @@ describe('ProviderRegistry', () => {
       expect(delay2).toBeGreaterThanOrEqual(80); // 100ms with some tolerance
     });
 
+    it('caps retry delays and exposes them to deterministic sleep hooks', async () => {
+      const sleep = vi.fn().mockResolvedValue(undefined);
+      const p1: ILlmProvider = {
+        ...mockProvider('rate-limited'),
+        execute: vi.fn(async function* () {
+          yield { type: 'error' as const, error: 'rate limit', retryable: true };
+        }),
+      };
+      const p2 = mockProvider('backup');
+
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        maxRetriesPerProvider: 3,
+        retryDelayMs: 1_000,
+        maxRetryDelayMs: 1_500,
+        backoffMultiplier: 10,
+        sleep,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(sleep.mock.calls.map((call) => call[0])).toEqual([1_000, 1_500, 1_500]);
+    });
+
+    it('rejects unbounded retry policy options before executing a provider', () => {
+      const invalidOptions = [
+        { maxRetriesPerProvider: -1 },
+        { maxRetriesPerProvider: Number.NaN },
+        { maxRetriesPerProvider: Number.POSITIVE_INFINITY },
+        { maxRetriesPerProvider: 1.5 },
+        { maxRetriesPerProvider: 6 },
+        { retryDelayMs: -1 },
+        { retryDelayMs: Number.NaN },
+        { retryDelayMs: Number.POSITIVE_INFINITY },
+        { maxRetryDelayMs: -1 },
+        { maxRetryDelayMs: Number.NaN },
+        { maxRetryDelayMs: Number.POSITIVE_INFINITY },
+        { backoffMultiplier: 0 },
+        { backoffMultiplier: Number.NaN },
+        { backoffMultiplier: Number.POSITIVE_INFINITY },
+      ];
+
+      for (const options of invalidOptions) {
+        const provider = mockProvider('guarded');
+        expect(() => new ProviderRegistry([provider], mockBrain(), options)).toThrow(
+          /maxRetriesPerProvider|retryDelayMs|maxRetryDelayMs|backoffMultiplier/,
+        );
+        expect(provider.execute).not.toHaveBeenCalled();
+      }
+    });
+
     it('uses the exhausted retryable error as failover reason', async () => {
       const p1: ILlmProvider = {
         ...mockProvider('rate-limited'),


### PR DESCRIPTION
## Summary
- Bounds retryable provider failures in `ProviderRegistry` with validation for retry counts and finite delay/backoff settings
- Adds a capped retry delay and injectable sleep hook for deterministic tests
- Documents bounded provider retry behavior in the LLM provider guide

## Verification
- `npm --workspace @franken/orchestrator test -- tests/unit/providers/provider-registry.test.ts` (32 passed)
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run build`
- `npm --workspace @franken/orchestrator run lint` (0 errors; existing warnings remain)

Closes #1807
