### PR TITLE
fix(orchestrator): journal atomic state writes

### DIFF
--- a/docs/runbooks/state-write-transaction-journal.md
+++ b/docs/runbooks/state-write-transaction-journal.md
@@ -1,0 +1,23 @@
+# State write transaction journal
+
+Frankenbeast state files that use `atomicWriteFileSync()` are protected by a sidecar transaction journal at `<state-file>.journal` while a write is in flight.
+
+## Normal write path
+
+1. The writer records a journal with the target path, temporary file path, phase, and timestamps.
+2. The writer writes the replacement state to `<state-file>.tmp.*`, fsyncs it, and renames it over the target.
+3. The writer removes `<state-file>.journal` and fsyncs the parent directory.
+
+A successful write leaves only the final state file. Operators should not see `.tmp.*` or `.journal` files during steady state.
+
+## Recovery behavior
+
+Before the next atomic state write, Frankenbeast calls `recoverStateWriteTransaction()` for the target path. Recovery is deterministic:
+
+- If the journal names a leftover temp file, the temp file is removed and the target remains the last complete state file, or the already-renamed replacement if the crash happened after rename.
+- If the journal is left behind but the temp file is gone, the journal is removed as a completed write marker.
+- If the journal JSON is malformed or unsupported, the journal is quarantined with a `.corrupt.*` suffix instead of being trusted.
+
+## Operator guidance
+
+A lingering `<state-file>.journal` means the process stopped during an atomic write. Restarting the component or performing another write to the same state file will clean the journaled temp file. If the journal is quarantined, inspect the `.corrupt.*` file before deleting it; malformed journals indicate a disk/process interruption while recording recovery metadata.

--- a/docs/runbooks/state-write-transaction-journal.md
+++ b/docs/runbooks/state-write-transaction-journal.md
@@ -4,7 +4,7 @@ Frankenbeast state files that use `atomicWriteFileSync()` are protected by a sid
 
 ## Normal write path
 
-1. The writer records a journal with the target path, temporary file path, phase, and timestamps.
+1. The writer records a journal with the target path, temporary file path, phase, and timestamps. Journal phase updates are written through a temporary journal file and renamed into place so a crash cannot truncate the last valid journal record.
 2. The writer writes the replacement state to `<state-file>.tmp.*`, fsyncs it, and renames it over the target.
 3. The writer removes `<state-file>.journal` and fsyncs the parent directory.
 
@@ -14,10 +14,12 @@ A successful write leaves only the final state file. Operators should not see `.
 
 Before the next atomic state write, Frankenbeast calls `recoverStateWriteTransaction()` for the target path. Recovery is deterministic:
 
-- If the journal names a leftover temp file, the temp file is removed and the target remains the last complete state file, or the already-renamed replacement if the crash happened after rename.
+- If the journal names a leftover temp file and its timestamp is stale, the temp file is removed and the target remains the last complete state file, or the already-renamed replacement if the crash happened after rename.
+- If the journal names a temp file that still appears active, recovery leaves the journal and temp file in place so a concurrent writer is not disrupted.
+- If the journal records a temp path outside the expected `<state-file>.tmp.*` sidecar namespace, the journal is quarantined instead of unlinking the recorded path.
 - If the journal is left behind but the temp file is gone, the journal is removed as a completed write marker.
 - If the journal JSON is malformed or unsupported, the journal is quarantined with a `.corrupt.*` suffix instead of being trusted.
 
 ## Operator guidance
 
-A lingering `<state-file>.journal` means the process stopped during an atomic write. Restarting the component or performing another write to the same state file will clean the journaled temp file. If the journal is quarantined, inspect the `.corrupt.*` file before deleting it; malformed journals indicate a disk/process interruption while recording recovery metadata.
+A lingering `<state-file>.journal` means the process stopped during an atomic write or another process is still writing the same state file. Restarting the component or performing another write to the same state file after the journal becomes stale will clean the journaled temp file. If the journal is quarantined, inspect the `.corrupt.*` file before deleting it; malformed or invalid journals indicate a disk/process interruption or unsafe recovery metadata.

--- a/docs/runbooks/state-write-transaction-journal.md
+++ b/docs/runbooks/state-write-transaction-journal.md
@@ -14,9 +14,9 @@ A successful write leaves only the final state file. Operators should not see `.
 
 Before the next atomic state write, Frankenbeast calls `recoverStateWriteTransaction()` for the target path. Recovery is deterministic:
 
-- If the journal names a leftover temp file and its timestamp is stale, the temp file is removed and the target remains the last complete state file, or the already-renamed replacement if the crash happened after rename.
-- If the journal names a temp file that still appears active, recovery leaves the journal and temp file in place so a concurrent writer is not disrupted.
-- If the journal records a temp path outside the expected `<state-file>.tmp.*` sidecar namespace, the journal is quarantined instead of unlinking the recorded path.
+- If the journal names a leftover temp file and its wall-clock timestamp is stale, the temp file is removed and the target remains the last complete state file, or the already-renamed replacement if the crash happened after rename.
+- If the journal names a temp file or preparing phase that still appears active, recovery leaves the journal and temp file in place so a concurrent writer is not disrupted.
+- If the journal records a temp path outside the expected direct sibling `<state-file>.tmp.*` sidecar namespace, the journal is quarantined instead of unlinking the recorded path.
 - If the journal is left behind but the temp file is gone, the journal is removed as a completed write marker.
 - If the journal JSON is malformed or unsupported, the journal is quarantined with a `.corrupt.*` suffix instead of being trusted.
 

--- a/docs/runbooks/state-write-transaction-journal.md
+++ b/docs/runbooks/state-write-transaction-journal.md
@@ -4,7 +4,7 @@ Frankenbeast state files that use `atomicWriteFileSync()` are protected by a sid
 
 ## Normal write path
 
-1. The writer records a journal with the target path, temporary file path, phase, and timestamps. Journal phase updates are written through a temporary journal file and renamed into place so a crash cannot truncate the last valid journal record.
+1. The writer records a journal with the target path, temporary file path, phase, and wall-clock timestamps. Journal phase updates are written through a temporary journal file and renamed into place so a crash cannot truncate the last valid journal record. Long writes refresh the journal periodically before durability boundaries.
 2. The writer writes the replacement state to `<state-file>.tmp.*`, fsyncs it, and renames it over the target.
 3. The writer removes `<state-file>.journal` and fsyncs the parent directory.
 

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -75,9 +75,20 @@ function writeStateWriteJournal(filePath: string, entry: Omit<StateWriteTransact
     updatedAt: journalTimestamp(),
   };
   const journalPath = stateWriteJournalPath(filePath);
-  const journalTempPath = `${journalPath}.tmp.${writeCounter++}.${deterministicUuid('state-write-journal')}`;
   const payload = JSON.stringify(updatedEntry, null, 2);
-  const fd = openSync(journalTempPath, 'wx', 0o600);
+  let journalTempPath = `${journalPath}.tmp.${writeCounter++}.${deterministicUuid('state-write-journal')}`;
+  let fd: number;
+  for (;;) {
+    try {
+      fd = openSync(journalTempPath, 'wx', 0o600);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+      journalTempPath = `${journalPath}.tmp.${writeCounter++}.${deterministicUuid('state-write-journal')}`;
+    }
+  }
   try {
     writeAll(fd, payload);
     fsyncSync(fd);
@@ -109,8 +120,14 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
   if (typeof value.startedAt !== 'string' || value.startedAt.length === 0) {
     throw new Error(`state write journal ${journalPath} startedAt must be a non-empty string`);
   }
+  if (!Number.isFinite(Date.parse(value.startedAt))) {
+    throw new Error(`state write journal ${journalPath} startedAt must be a valid ISO timestamp`);
+  }
   if (typeof value.updatedAt !== 'string' || value.updatedAt.length === 0) {
     throw new Error(`state write journal ${journalPath} updatedAt must be a non-empty string`);
+  }
+  if (!Number.isFinite(Date.parse(value.updatedAt))) {
+    throw new Error(`state write journal ${journalPath} updatedAt must be a valid ISO timestamp`);
   }
   return {
     schemaVersion: 1,
@@ -141,15 +158,46 @@ function pathsReferenceSameFile(left: string, right: string): boolean {
 function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boolean {
   const resolvedTempPath = resolve(tempPath);
   const resolvedTargetPath = resolve(filePath);
+  if (dirname(resolvedTempPath) !== dirname(resolvedTargetPath)) {
+    return false;
+  }
   return resolvedTempPath.startsWith(`${resolvedTargetPath}.tmp.`);
 }
 
 function isStaleJournal(journal: StateWriteTransactionJournal): boolean {
   const updatedAtMs = Date.parse(journal.updatedAt);
-  if (!Number.isFinite(updatedAtMs)) {
-    return false;
+  return Date.now() - updatedAtMs >= STALE_JOURNAL_AGE_MS;
+}
+
+function sameStateWriteTransaction(
+  left: StateWriteTransactionJournal,
+  right: Omit<StateWriteTransactionJournal, 'updatedAt' | 'phase'>,
+): boolean {
+  return (
+    left.schemaVersion === right.schemaVersion &&
+    pathsReferenceSameFile(left.targetPath, right.targetPath) &&
+    pathsReferenceSameFile(left.tempPath, right.tempPath) &&
+    left.startedAt === right.startedAt
+  );
+}
+
+function removeStateWriteJournalIfCurrent(
+  filePath: string,
+  expected: Omit<StateWriteTransactionJournal, 'updatedAt' | 'phase'>,
+): void {
+  const journalPath = stateWriteJournalPath(filePath);
+  try {
+    const journal = parseStateWriteJournal(readFileSync(journalPath, 'utf8'), journalPath);
+    if (!sameStateWriteTransaction(journal, expected)) {
+      return;
+    }
+    rmSync(journalPath, { force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw error;
   }
-  return deterministicNow() - updatedAtMs >= STALE_JOURNAL_AGE_MS;
 }
 
 /**
@@ -207,6 +255,16 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
       tempPath: journal.tempPath,
       action: 'removed-stale-temp',
       reason: `Recovered interrupted ${journal.phase} state write by removing the journaled temp file; target remains the last complete file or the already-renamed replacement.`,
+    };
+  }
+
+  if (targetMatches && journal.phase === 'preparing' && !isStaleJournal(journal)) {
+    return {
+      journalPath,
+      targetPath: journal.targetPath,
+      tempPath: journal.tempPath,
+      action: 'retained-active-journal',
+      reason: `State write journal ${journalPath} is still preparing; refusing to remove live journal for ${journal.tempPath}.`,
     };
   }
 
@@ -270,18 +328,14 @@ export function atomicWriteFileSync(
     }
     writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'renaming' });
     renameSync(tmpPath, filePath);
-    rmSync(stateWriteJournalPath(filePath), { force: true });
+    removeStateWriteJournalIfCurrent(filePath, { ...journalBase, tempPath: resolve(tmpPath) });
   } catch (error) {
     try {
       unlinkSync(tmpPath);
     } catch {
       // Temp file never created or already renamed.
     }
-    try {
-      rmSync(stateWriteJournalPath(filePath), { force: true });
-    } catch {
-      // The journal was never written or has already been recovered.
-    }
+    removeStateWriteJournalIfCurrent(filePath, { ...journalBase, tempPath: resolve(tmpPath) });
     throw error;
   }
   fsyncDir(dirname(filePath));

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -177,21 +177,45 @@ function pathsReferenceSameFile(left: string, right: string): boolean {
   }
 }
 
+function canonicalSidecarPath(value: string): string | undefined {
+  try {
+    return join(realpathSync.native(dirname(value)), basename(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function generatedStateTempPattern(filePath: string): RegExp {
+  const uuidPattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+  return new RegExp(`^${escapeRegExp(basename(filePath))}\\.tmp\\.[0-9]+\\.${uuidPattern}$`);
+}
+
 function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boolean {
-  const resolvedTempPath = resolve(tempPath);
-  const resolvedTargetPath = resolve(filePath);
-  if (dirname(resolvedTempPath) !== dirname(resolvedTargetPath)) {
+  const canonicalTempPath = canonicalSidecarPath(tempPath) ?? resolve(tempPath);
+  const canonicalTargetPath = canonicalSidecarPath(filePath) ?? resolve(filePath);
+  if (dirname(canonicalTempPath) !== dirname(canonicalTargetPath)) {
     return false;
   }
-  if (!resolvedTempPath.startsWith(`${resolvedTargetPath}.tmp.`)) {
+  if (!canonicalTempPath.startsWith(`${canonicalTargetPath}.tmp.`)) {
     return false;
   }
   try {
-    return statSync(resolvedTempPath).isFile();
+    return statSync(canonicalTempPath).isFile();
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return true;
     }
+    return false;
+  }
+}
+
+function journalTempIsEmptyGeneratedSidecar(tempPath: string, filePath: string): boolean {
+  if (!journalTempPathBelongsToTarget(tempPath, filePath)) {
+    return false;
+  }
+  try {
+    return statSync(tempPath).size === 0;
+  } catch {
     return false;
   }
 }
@@ -290,7 +314,7 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
     };
   }
 
-  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath);
+  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath) || journalPath === stateWriteJournalPath(filePath);
   if (targetMatches && !journalTempPathBelongsToTarget(journal.tempPath, filePath)) {
     const quarantinePath = quarantineFile(journalPath);
     return {
@@ -311,6 +335,18 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
         tempPath: journal.tempPath,
         action: 'retained-active-journal',
         reason: `State write journal ${journalPath} is still preparing; refusing to remove live journal for ${journal.tempPath}.`,
+      };
+    }
+    if (journalTempIsEmptyGeneratedSidecar(journal.tempPath, filePath)) {
+      rmSync(journal.tempPath, { force: true });
+      rmSync(journalPath, { force: true });
+      fsyncDir(dirname(filePath));
+      return {
+        journalPath,
+        targetPath: journal.targetPath,
+        tempPath: journal.tempPath,
+        action: 'removed-stale-temp',
+        reason: `Removed stale preparing state write journal and empty generated temp file from an interrupted writer after temp creation.`,
       };
     }
     rmSync(journalPath, { force: true });

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -4,6 +4,7 @@ import {
   fsyncSync,
   openSync,
   readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   statSync,
@@ -11,7 +12,7 @@ import {
   writeSync,
 } from 'node:fs';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 
 const STALE_JOURNAL_AGE_MS = 5 * 60_000;
 const JOURNAL_REFRESH_INTERVAL_MS = 5_000;
@@ -179,6 +180,41 @@ function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boo
   }
 }
 
+function cleanupStaleJournalTempFiles(filePath: string): void {
+  const journalPath = stateWriteJournalPath(filePath);
+  const journalTempPrefix = `${basename(journalPath)}.tmp.`;
+  let removed = false;
+  try {
+    for (const entry of readdirSync(dirname(journalPath))) {
+      if (!entry.startsWith(journalTempPrefix)) {
+        continue;
+      }
+      const tempPath = join(dirname(journalPath), entry);
+      try {
+        if (Date.now() - statSync(tempPath).mtimeMs >= STALE_JOURNAL_AGE_MS) {
+          rmSync(tempPath, { force: true });
+          removed = true;
+        }
+      } catch {
+        // The temp may have been renamed or removed by another recovery attempt.
+      }
+    }
+  } catch {
+    return;
+  }
+  if (removed) {
+    fsyncDir(dirname(filePath));
+  }
+}
+
+function journalTempFileWasCreatedAfterJournal(tempPath: string, journal: StateWriteTransactionJournal): boolean {
+  try {
+    return statSync(tempPath).mtimeMs >= Date.parse(journal.updatedAt);
+  } catch {
+    return false;
+  }
+}
+
 function isStaleJournal(journal: StateWriteTransactionJournal): boolean {
   const updatedAtMs = Date.parse(journal.updatedAt);
   return Date.now() - updatedAtMs >= STALE_JOURNAL_AGE_MS;
@@ -221,6 +257,7 @@ function removeStateWriteJournalIfCurrent(
  * the last complete state or has already been atomically replaced by rename().
  */
 export function recoverStateWriteTransaction(filePath: string): StateWriteJournalRecovery | undefined {
+  cleanupStaleJournalTempFiles(filePath);
   const journalPath = stateWriteJournalPath(filePath);
   let journal: StateWriteTransactionJournal;
   try {
@@ -259,6 +296,18 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
         tempPath: journal.tempPath,
         action: 'retained-active-journal',
         reason: `State write journal ${journalPath} is still preparing; refusing to remove live journal for ${journal.tempPath}.`,
+      };
+    }
+    if (existsSync(journal.tempPath) && journalTempFileWasCreatedAfterJournal(journal.tempPath, journal)) {
+      rmSync(journal.tempPath, { force: true });
+      rmSync(journalPath, { force: true });
+      fsyncDir(dirname(filePath));
+      return {
+        journalPath,
+        targetPath: journal.targetPath,
+        tempPath: journal.tempPath,
+        action: 'removed-stale-temp',
+        reason: `Removed stale preparing state write journal and temp file because the temp appears to have been created after the journal was recorded.`,
       };
     }
     rmSync(journalPath, { force: true });
@@ -366,6 +415,7 @@ export function atomicWriteFileSync(
     }
     writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'renaming' });
     renameSync(tmpPath, filePath);
+    fsyncDir(dirname(filePath));
     removeStateWriteJournalIfCurrent(filePath, { ...journalBase, tempPath: resolve(tmpPath) });
   } catch (error) {
     try {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -10,8 +10,9 @@ import {
   writeSync,
 } from 'node:fs';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
+const STALE_JOURNAL_AGE_MS = 30_000;
 let writeCounter = 0;
 
 export type StateWriteJournalPhase = 'preparing' | 'writing-temp' | 'renaming';
@@ -30,7 +31,11 @@ export interface StateWriteJournalRecovery {
   readonly targetPath?: string | undefined;
   readonly tempPath?: string | undefined;
   readonly quarantinePath?: string | undefined;
-  readonly action: 'removed-stale-temp' | 'removed-completed-journal' | 'quarantined-invalid-journal';
+  readonly action:
+    | 'removed-stale-temp'
+    | 'removed-completed-journal'
+    | 'quarantined-invalid-journal'
+    | 'retained-active-journal';
   readonly reason: string;
 }
 
@@ -70,14 +75,16 @@ function writeStateWriteJournal(filePath: string, entry: Omit<StateWriteTransact
     updatedAt: journalTimestamp(),
   };
   const journalPath = stateWriteJournalPath(filePath);
+  const journalTempPath = `${journalPath}.tmp.${writeCounter++}.${deterministicUuid('state-write-journal')}`;
   const payload = JSON.stringify(updatedEntry, null, 2);
-  const fd = openSync(journalPath, 'w', 0o600);
+  const fd = openSync(journalTempPath, 'wx', 0o600);
   try {
     writeAll(fd, payload);
     fsyncSync(fd);
   } finally {
     closeSync(fd);
   }
+  renameSync(journalTempPath, journalPath);
   fsyncDir(dirname(filePath));
 }
 
@@ -127,6 +134,24 @@ export function readStateWriteTransactionJournal(filePath: string): StateWriteTr
   }
 }
 
+function pathsReferenceSameFile(left: string, right: string): boolean {
+  return resolve(left) === resolve(right);
+}
+
+function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boolean {
+  const resolvedTempPath = resolve(tempPath);
+  const resolvedTargetPath = resolve(filePath);
+  return resolvedTempPath.startsWith(`${resolvedTargetPath}.tmp.`);
+}
+
+function isStaleJournal(journal: StateWriteTransactionJournal): boolean {
+  const updatedAtMs = Date.parse(journal.updatedAt);
+  if (!Number.isFinite(updatedAtMs)) {
+    return false;
+  }
+  return deterministicNow() - updatedAtMs >= STALE_JOURNAL_AGE_MS;
+}
+
 /**
  * Recovers an interrupted state write transaction recorded by the sidecar journal.
  * A leftover temp file is always discarded because the target path is either still
@@ -150,8 +175,29 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
     };
   }
 
-  const targetMatches = journal.targetPath === filePath;
+  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath);
+  if (targetMatches && !journalTempPathBelongsToTarget(journal.tempPath, filePath)) {
+    const quarantinePath = quarantineFile(journalPath);
+    return {
+      journalPath,
+      targetPath: journal.targetPath,
+      tempPath: journal.tempPath,
+      ...(quarantinePath === undefined ? {} : { quarantinePath }),
+      action: 'quarantined-invalid-journal',
+      reason: `State write journal tempPath ${journal.tempPath} is not an expected sidecar for ${filePath}.`,
+    };
+  }
+
   if (targetMatches && existsSync(journal.tempPath)) {
+    if (!isStaleJournal(journal)) {
+      return {
+        journalPath,
+        targetPath: journal.targetPath,
+        tempPath: journal.tempPath,
+        action: 'retained-active-journal',
+        reason: `State write journal ${journalPath} is still active; refusing to remove live temp file ${journal.tempPath}.`,
+      };
+    }
     rmSync(journal.tempPath, { force: true });
     rmSync(journalPath, { force: true });
     fsyncDir(dirname(filePath));
@@ -189,7 +235,10 @@ export function atomicWriteFileSync(
   contents: string,
   options: { mode?: number } = {},
 ): void {
-  recoverStateWriteTransaction(filePath);
+  const recovery = recoverStateWriteTransaction(filePath);
+  if (recovery?.action === 'retained-active-journal') {
+    throw new Error(recovery.reason);
+  }
   let tmpPath = `${filePath}.tmp.${writeCounter++}.${deterministicUuid('atomic-file-write')}`;
   const startedAt = journalTimestamp();
   const journalBase = {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -196,7 +196,7 @@ function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boo
   if (dirname(canonicalTempPath) !== dirname(canonicalTargetPath)) {
     return false;
   }
-  if (!canonicalTempPath.startsWith(`${canonicalTargetPath}.tmp.`)) {
+  if (!generatedStateTempPattern(canonicalTargetPath).test(basename(canonicalTempPath))) {
     return false;
   }
   try {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -243,15 +243,15 @@ export function atomicWriteFileSync(
   const startedAt = journalTimestamp();
   const journalBase = {
     schemaVersion: 1 as const,
-    targetPath: filePath,
-    tempPath: tmpPath,
+    targetPath: resolve(filePath),
+    tempPath: resolve(tmpPath),
     startedAt,
   };
   try {
     let fd: number;
     for (;;) {
       try {
-        writeStateWriteJournal(filePath, { ...journalBase, tempPath: tmpPath, phase: 'preparing' });
+        writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'preparing' });
         fd = openSync(tmpPath, 'wx', options.mode);
         break;
       } catch (error) {
@@ -262,13 +262,13 @@ export function atomicWriteFileSync(
       }
     }
     try {
-      writeStateWriteJournal(filePath, { ...journalBase, tempPath: tmpPath, phase: 'writing-temp' });
+      writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'writing-temp' });
       writeAll(fd, contents);
       fsyncSync(fd);
     } finally {
       closeSync(fd);
     }
-    writeStateWriteJournal(filePath, { ...journalBase, tempPath: tmpPath, phase: 'renaming' });
+    writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'renaming' });
     renameSync(tmpPath, filePath);
     rmSync(stateWriteJournalPath(filePath), { force: true });
   } catch (error) {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -7,7 +7,6 @@ import {
   renameSync,
   rmSync,
   unlinkSync,
-  writeFileSync,
   writeSync,
 } from 'node:fs';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
@@ -70,7 +69,15 @@ function writeStateWriteJournal(filePath: string, entry: Omit<StateWriteTransact
     ...entry,
     updatedAt: journalTimestamp(),
   };
-  writeFileSync(stateWriteJournalPath(filePath), JSON.stringify(updatedEntry, null, 2), 'utf8');
+  const journalPath = stateWriteJournalPath(filePath);
+  const payload = JSON.stringify(updatedEntry, null, 2);
+  const fd = openSync(journalPath, 'w', 0o600);
+  try {
+    writeAll(fd, payload);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
   fsyncDir(dirname(filePath));
 }
 

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -213,6 +213,9 @@ function journalTempIsEmptyGeneratedSidecar(tempPath: string, filePath: string):
   if (!journalTempPathBelongsToTarget(tempPath, filePath)) {
     return false;
   }
+  if (!generatedStateTempPattern(filePath).test(basename(tempPath))) {
+    return false;
+  }
   try {
     return statSync(tempPath).size === 0;
   } catch {
@@ -314,7 +317,7 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
     };
   }
 
-  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath) || journalPath === stateWriteJournalPath(filePath);
+  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath);
   if (targetMatches && !journalTempPathBelongsToTarget(journal.tempPath, filePath)) {
     const quarantinePath = quarantineFile(journalPath);
     return {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -251,6 +251,27 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
     };
   }
 
+  if (targetMatches && journal.phase === 'preparing') {
+    if (!isStaleJournal(journal)) {
+      return {
+        journalPath,
+        targetPath: journal.targetPath,
+        tempPath: journal.tempPath,
+        action: 'retained-active-journal',
+        reason: `State write journal ${journalPath} is still preparing; refusing to remove live journal for ${journal.tempPath}.`,
+      };
+    }
+    rmSync(journalPath, { force: true });
+    fsyncDir(dirname(filePath));
+    return {
+      journalPath,
+      targetPath: journal.targetPath,
+      tempPath: journal.tempPath,
+      action: 'removed-completed-journal',
+      reason: `Removed stale preparing state write journal without deleting ${journal.tempPath}; preparing journals do not prove ownership of an existing temp file.`,
+    };
+  }
+
   if (targetMatches && existsSync(journal.tempPath)) {
     if (!isStaleJournal(journal)) {
       return {
@@ -270,16 +291,6 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
       tempPath: journal.tempPath,
       action: 'removed-stale-temp',
       reason: `Recovered interrupted ${journal.phase} state write by removing the journaled temp file; target remains the last complete file or the already-renamed replacement.`,
-    };
-  }
-
-  if (targetMatches && journal.phase === 'preparing' && !isStaleJournal(journal)) {
-    return {
-      journalPath,
-      targetPath: journal.targetPath,
-      tempPath: journal.tempPath,
-      action: 'retained-active-journal',
-      reason: `State write journal ${journalPath} is still preparing; refusing to remove live journal for ${journal.tempPath}.`,
     };
   }
 

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -180,13 +180,19 @@ function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boo
   }
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function cleanupStaleJournalTempFiles(filePath: string): void {
   const journalPath = stateWriteJournalPath(filePath);
-  const journalTempPrefix = `${basename(journalPath)}.tmp.`;
+  const journalTempPattern = new RegExp(
+    `^${escapeRegExp(basename(journalPath))}\\.tmp\\.[0-9]+\\.[0-9a-f-]{8,}$`,
+  );
   let removed = false;
   try {
     for (const entry of readdirSync(dirname(journalPath))) {
-      if (!entry.startsWith(journalTempPrefix)) {
+      if (!journalTempPattern.test(entry)) {
         continue;
       }
       const tempPath = join(dirname(journalPath), entry);
@@ -204,14 +210,6 @@ function cleanupStaleJournalTempFiles(filePath: string): void {
   }
   if (removed) {
     fsyncDir(dirname(filePath));
-  }
-}
-
-function journalTempFileWasCreatedAfterJournal(tempPath: string, journal: StateWriteTransactionJournal): boolean {
-  try {
-    return statSync(tempPath).mtimeMs >= Date.parse(journal.updatedAt);
-  } catch {
-    return false;
   }
 }
 
@@ -275,7 +273,7 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
     };
   }
 
-  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath);
+  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath) || journalPath === stateWriteJournalPath(filePath);
   if (targetMatches && !journalTempPathBelongsToTarget(journal.tempPath, filePath)) {
     const quarantinePath = quarantineFile(journalPath);
     return {
@@ -296,18 +294,6 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
         tempPath: journal.tempPath,
         action: 'retained-active-journal',
         reason: `State write journal ${journalPath} is still preparing; refusing to remove live journal for ${journal.tempPath}.`,
-      };
-    }
-    if (existsSync(journal.tempPath) && journalTempFileWasCreatedAfterJournal(journal.tempPath, journal)) {
-      rmSync(journal.tempPath, { force: true });
-      rmSync(journalPath, { force: true });
-      fsyncDir(dirname(filePath));
-      return {
-        journalPath,
-        targetPath: journal.targetPath,
-        tempPath: journal.tempPath,
-        action: 'removed-stale-temp',
-        reason: `Removed stale preparing state write journal and temp file because the temp appears to have been created after the journal was recorded.`,
       };
     }
     rmSync(journalPath, { force: true });

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -6,13 +6,16 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeSync,
 } from 'node:fs';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
 import { dirname, resolve } from 'node:path';
 
-const STALE_JOURNAL_AGE_MS = 30_000;
+const STALE_JOURNAL_AGE_MS = 5 * 60_000;
+const JOURNAL_REFRESH_INTERVAL_MS = 5_000;
+const WRITE_CHUNK_BYTES = 1024 * 1024;
 let writeCounter = 0;
 
 export type StateWriteJournalPhase = 'preparing' | 'writing-temp' | 'renaming';
@@ -39,11 +42,13 @@ export interface StateWriteJournalRecovery {
   readonly reason: string;
 }
 
-function writeAll(fd: number, payload: string): void {
+function writeAll(fd: number, payload: string, onProgress?: () => void): void {
   const buf = Buffer.from(payload, 'utf8');
   let written = 0;
   while (written < buf.length) {
-    written += writeSync(fd, buf, written, buf.length - written);
+    const bytesToWrite = Math.min(WRITE_CHUNK_BYTES, buf.length - written);
+    written += writeSync(fd, buf, written, bytesToWrite);
+    onProgress?.();
   }
 }
 
@@ -66,7 +71,7 @@ export function stateWriteJournalPath(filePath: string): string {
 }
 
 function journalTimestamp(): string {
-  return new Date(deterministicNow()).toISOString();
+  return new Date().toISOString();
 }
 
 function writeStateWriteJournal(filePath: string, entry: Omit<StateWriteTransactionJournal, 'updatedAt'>): void {
@@ -161,7 +166,17 @@ function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boo
   if (dirname(resolvedTempPath) !== dirname(resolvedTargetPath)) {
     return false;
   }
-  return resolvedTempPath.startsWith(`${resolvedTargetPath}.tmp.`);
+  if (!resolvedTempPath.startsWith(`${resolvedTargetPath}.tmp.`)) {
+    return false;
+  }
+  try {
+    return statSync(resolvedTempPath).isFile();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return true;
+    }
+    return false;
+  }
 }
 
 function isStaleJournal(journal: StateWriteTransactionJournal): boolean {
@@ -320,9 +335,21 @@ export function atomicWriteFileSync(
       }
     }
     try {
-      writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'writing-temp' });
-      writeAll(fd, contents);
+      const writingJournal = { ...journalBase, tempPath: resolve(tmpPath), phase: 'writing-temp' as const };
+      let lastJournalRefreshMs = Date.now();
+      const refreshWritingJournal = (): void => {
+        const nowMs = Date.now();
+        if (nowMs - lastJournalRefreshMs < JOURNAL_REFRESH_INTERVAL_MS) {
+          return;
+        }
+        writeStateWriteJournal(filePath, writingJournal);
+        lastJournalRefreshMs = nowMs;
+      };
+      writeStateWriteJournal(filePath, writingJournal);
+      writeAll(fd, contents, refreshWritingJournal);
+      writeStateWriteJournal(filePath, writingJournal);
       fsyncSync(fd);
+      writeStateWriteJournal(filePath, writingJournal);
     } finally {
       closeSync(fd);
     }

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -1,16 +1,39 @@
 import {
   closeSync,
+  existsSync,
   fsyncSync,
   openSync,
   readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
+  writeFileSync,
   writeSync,
 } from 'node:fs';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
 import { dirname } from 'node:path';
 
 let writeCounter = 0;
+
+export type StateWriteJournalPhase = 'preparing' | 'writing-temp' | 'renaming';
+
+export interface StateWriteTransactionJournal {
+  readonly schemaVersion: 1;
+  readonly targetPath: string;
+  readonly tempPath: string;
+  readonly phase: StateWriteJournalPhase;
+  readonly startedAt: string;
+  readonly updatedAt: string;
+}
+
+export interface StateWriteJournalRecovery {
+  readonly journalPath: string;
+  readonly targetPath?: string | undefined;
+  readonly tempPath?: string | undefined;
+  readonly quarantinePath?: string | undefined;
+  readonly action: 'removed-stale-temp' | 'removed-completed-journal' | 'quarantined-invalid-journal';
+  readonly reason: string;
+}
 
 function writeAll(fd: number, payload: string): void {
   const buf = Buffer.from(payload, 'utf8');
@@ -34,21 +57,145 @@ function fsyncDir(dirPath: string): void {
   }
 }
 
+export function stateWriteJournalPath(filePath: string): string {
+  return `${filePath}.journal`;
+}
+
+function journalTimestamp(): string {
+  return new Date(deterministicNow()).toISOString();
+}
+
+function writeStateWriteJournal(filePath: string, entry: Omit<StateWriteTransactionJournal, 'updatedAt'>): void {
+  const updatedEntry: StateWriteTransactionJournal = {
+    ...entry,
+    updatedAt: journalTimestamp(),
+  };
+  writeFileSync(stateWriteJournalPath(filePath), JSON.stringify(updatedEntry, null, 2), 'utf8');
+  fsyncDir(dirname(filePath));
+}
+
+function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTransactionJournal {
+  const parsed = JSON.parse(raw) as unknown;
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`state write journal ${journalPath} must be a JSON object`);
+  }
+  const value = parsed as Partial<StateWriteTransactionJournal>;
+  if (value.schemaVersion !== 1) {
+    throw new Error(`state write journal ${journalPath} has unsupported schemaVersion`);
+  }
+  if (typeof value.targetPath !== 'string' || value.targetPath.length === 0) {
+    throw new Error(`state write journal ${journalPath} targetPath must be a non-empty string`);
+  }
+  if (typeof value.tempPath !== 'string' || value.tempPath.length === 0) {
+    throw new Error(`state write journal ${journalPath} tempPath must be a non-empty string`);
+  }
+  if (value.phase !== 'preparing' && value.phase !== 'writing-temp' && value.phase !== 'renaming') {
+    throw new Error(`state write journal ${journalPath} phase is unsupported`);
+  }
+  if (typeof value.startedAt !== 'string' || value.startedAt.length === 0) {
+    throw new Error(`state write journal ${journalPath} startedAt must be a non-empty string`);
+  }
+  if (typeof value.updatedAt !== 'string' || value.updatedAt.length === 0) {
+    throw new Error(`state write journal ${journalPath} updatedAt must be a non-empty string`);
+  }
+  return {
+    schemaVersion: 1,
+    targetPath: value.targetPath,
+    tempPath: value.tempPath,
+    phase: value.phase,
+    startedAt: value.startedAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+export function readStateWriteTransactionJournal(filePath: string): StateWriteTransactionJournal | undefined {
+  const journalPath = stateWriteJournalPath(filePath);
+  try {
+    return parseStateWriteJournal(readFileSync(journalPath, 'utf8'), journalPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Recovers an interrupted state write transaction recorded by the sidecar journal.
+ * A leftover temp file is always discarded because the target path is either still
+ * the last complete state or has already been atomically replaced by rename().
+ */
+export function recoverStateWriteTransaction(filePath: string): StateWriteJournalRecovery | undefined {
+  const journalPath = stateWriteJournalPath(filePath);
+  let journal: StateWriteTransactionJournal;
+  try {
+    journal = parseStateWriteJournal(readFileSync(journalPath, 'utf8'), journalPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    const quarantinePath = quarantineFile(journalPath);
+    return {
+      journalPath,
+      ...(quarantinePath === undefined ? {} : { quarantinePath }),
+      action: 'quarantined-invalid-journal',
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const targetMatches = journal.targetPath === filePath;
+  if (targetMatches && existsSync(journal.tempPath)) {
+    rmSync(journal.tempPath, { force: true });
+    rmSync(journalPath, { force: true });
+    fsyncDir(dirname(filePath));
+    return {
+      journalPath,
+      targetPath: journal.targetPath,
+      tempPath: journal.tempPath,
+      action: 'removed-stale-temp',
+      reason: `Recovered interrupted ${journal.phase} state write by removing the journaled temp file; target remains the last complete file or the already-renamed replacement.`,
+    };
+  }
+
+  rmSync(journalPath, { force: true });
+  fsyncDir(dirname(filePath));
+  return {
+    journalPath,
+    targetPath: journal.targetPath,
+    tempPath: journal.tempPath,
+    action: 'removed-completed-journal',
+    reason: targetMatches
+      ? 'Recovered completed state write by removing a journal whose temp file was already gone.'
+      : 'Removed state write journal because it does not belong to this target path.',
+  };
+}
+
 /**
  * Write-to-temp + fsync + rename + dir fsync so readers never observe a
  * torn/partial file, mirroring the pattern used by FileCheckpointStore.
- * The parent directory must already exist.
+ * The parent directory must already exist. A sidecar `<target>.journal` records
+ * the in-flight state write so the next writer can remove interrupted temp files
+ * and operators can tell whether a stale temp file is from an incomplete write.
  */
 export function atomicWriteFileSync(
   filePath: string,
   contents: string,
   options: { mode?: number } = {},
 ): void {
+  recoverStateWriteTransaction(filePath);
   let tmpPath = `${filePath}.tmp.${writeCounter++}.${deterministicUuid('atomic-file-write')}`;
+  const startedAt = journalTimestamp();
+  const journalBase = {
+    schemaVersion: 1 as const,
+    targetPath: filePath,
+    tempPath: tmpPath,
+    startedAt,
+  };
   try {
     let fd: number;
     for (;;) {
       try {
+        writeStateWriteJournal(filePath, { ...journalBase, tempPath: tmpPath, phase: 'preparing' });
         fd = openSync(tmpPath, 'wx', options.mode);
         break;
       } catch (error) {
@@ -59,17 +206,25 @@ export function atomicWriteFileSync(
       }
     }
     try {
+      writeStateWriteJournal(filePath, { ...journalBase, tempPath: tmpPath, phase: 'writing-temp' });
       writeAll(fd, contents);
       fsyncSync(fd);
     } finally {
       closeSync(fd);
     }
+    writeStateWriteJournal(filePath, { ...journalBase, tempPath: tmpPath, phase: 'renaming' });
     renameSync(tmpPath, filePath);
+    rmSync(stateWriteJournalPath(filePath), { force: true });
   } catch (error) {
     try {
       unlinkSync(tmpPath);
     } catch {
       // Temp file never created or already renamed.
+    }
+    try {
+      rmSync(stateWriteJournalPath(filePath), { force: true });
+    } catch {
+      // The journal was never written or has already been recovered.
     }
     throw error;
   }

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -5,6 +5,7 @@ import {
   openSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -158,7 +159,22 @@ export function readStateWriteTransactionJournal(filePath: string): StateWriteTr
 }
 
 function pathsReferenceSameFile(left: string, right: string): boolean {
-  return resolve(left) === resolve(right);
+  if (resolve(left) === resolve(right)) {
+    return true;
+  }
+  try {
+    const leftStat = statSync(left);
+    const rightStat = statSync(right);
+    return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino;
+  } catch {
+    // Fall back to comparing the canonical parent directory when the target
+    // file itself does not exist yet.
+  }
+  try {
+    return join(realpathSync.native(dirname(left)), basename(left)) === join(realpathSync.native(dirname(right)), basename(right));
+  } catch {
+    return false;
+  }
 }
 
 function journalTempPathBelongsToTarget(tempPath: string, filePath: string): boolean {
@@ -186,8 +202,9 @@ function escapeRegExp(value: string): string {
 
 function cleanupStaleJournalTempFiles(filePath: string): void {
   const journalPath = stateWriteJournalPath(filePath);
+  const uuidPattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
   const journalTempPattern = new RegExp(
-    `^${escapeRegExp(basename(journalPath))}\\.tmp\\.[0-9]+\\.[0-9a-f-]{8,}$`,
+    `^${escapeRegExp(basename(journalPath))}\\.tmp\\.[0-9]+\\.${uuidPattern}$`,
   );
   let removed = false;
   try {
@@ -273,7 +290,7 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
     };
   }
 
-  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath) || journalPath === stateWriteJournalPath(filePath);
+  const targetMatches = pathsReferenceSameFile(journal.targetPath, filePath);
   if (targetMatches && !journalTempPathBelongsToTarget(journal.tempPath, filePath)) {
     const quarantinePath = quarantineFile(journalPath);
     return {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -229,6 +229,35 @@ describe('atomic-file', () => {
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
     });
 
+    it('removes empty generated temp files from stale preparing journals', () => {
+      const dir = makeTmpDir('state-write-journal-stale-preparing-owned-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000000`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'preparing',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery).toMatchObject({
+        action: 'removed-stale-temp',
+        tempPath,
+      });
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
     it('removes stale journal temp files that never reached the final journal rename', () => {
       const dir = makeTmpDir('state-write-journal-temp-orphan-');
       const filePath = join(dir, 'state.json');
@@ -267,7 +296,7 @@ describe('atomic-file', () => {
       symlinkSync(realDir, symlinkDir, 'dir');
       const realFilePath = join(realDir, 'state.json');
       const symlinkFilePath = join(symlinkDir, 'state.json');
-      const tempPath = `${symlinkFilePath}.tmp.live`;
+      const tempPath = `${realFilePath}.tmp.live`;
       writeFileSync(realFilePath, '{"old":true}');
       writeFileSync(tempPath, '{"new":');
       writeFileSync(

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -84,8 +84,8 @@ describe('atomic-file', () => {
           targetPath: filePath,
           tempPath,
           phase: 'writing-temp',
-          startedAt: '2026-07-15T00:00:00.000Z',
-          updatedAt: '2026-07-15T00:00:01.000Z',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
         }),
         'utf8',
       );
@@ -112,8 +112,8 @@ describe('atomic-file', () => {
           targetPath: filePath,
           tempPath,
           phase: 'renaming',
-          startedAt: '2026-07-15T00:00:00.000Z',
-          updatedAt: '2026-07-15T00:00:01.000Z',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
         }),
         'utf8',
       );
@@ -187,8 +187,8 @@ describe('atomic-file', () => {
           targetPath: filePath,
           tempPath: victimPath,
           phase: 'writing-temp',
-          startedAt: '2026-07-15T00:00:00.000Z',
-          updatedAt: '2026-07-15T00:00:01.000Z',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
         }),
         'utf8',
       );
@@ -214,8 +214,8 @@ describe('atomic-file', () => {
           targetPath: join(dir, '.', 'state.json'),
           tempPath,
           phase: 'writing-temp',
-          startedAt: '2026-07-15T00:00:00.000Z',
-          updatedAt: '2026-07-15T00:00:01.000Z',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
         }),
         'utf8',
       );

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   atomicWriteFileSync,
@@ -142,6 +142,89 @@ describe('atomic-file', () => {
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
       const quarantine = readdirSync(dir).filter((file) => file.includes('.journal.corrupt.'));
       expect(quarantine).toHaveLength(1);
+    });
+
+    it('retains active journals so concurrent writers do not remove live temp files', () => {
+      const dir = makeTmpDir('state-write-journal-active-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.live`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2999-01-01T00:00:00.000Z',
+          updatedAt: '2999-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery).toMatchObject({
+        action: 'retained-active-journal',
+        tempPath,
+      });
+      expect(existsSync(tempPath)).toBe(true);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(true);
+      expect(() => atomicWriteFileSync(filePath, '{"new":true}')).toThrow(/still active/);
+    });
+
+    it('quarantines journals with temp paths outside the target sidecar namespace', () => {
+      const dir = makeTmpDir('state-write-journal-invalid-temp-');
+      const filePath = join(dir, 'state.json');
+      const victimPath = join(dir, 'important.json');
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(victimPath, '{"important":true}');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath: victimPath,
+          phase: 'writing-temp',
+          startedAt: '2026-07-15T00:00:00.000Z',
+          updatedAt: '2026-07-15T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery?.action).toBe('quarantined-invalid-journal');
+      expect(existsSync(victimPath)).toBe(true);
+      expect(readFileSync(victimPath, 'utf-8')).toBe('{"important":true}');
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
+    it('normalizes target paths before deciding whether a journal belongs to the file', () => {
+      const dir = makeTmpDir('state-write-journal-normalized-target-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.stale`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: join(dir, '.', 'state.json'),
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2026-07-15T00:00:00.000Z',
+          updatedAt: '2026-07-15T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(resolve(dir, 'state.json'));
+
+      expect(recovery?.action).toBe('removed-stale-temp');
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -144,6 +144,60 @@ describe('atomic-file', () => {
       expect(quarantine).toHaveLength(1);
     });
 
+    it('quarantines syntactically valid journals with invalid timestamps', () => {
+      const dir = makeTmpDir('state-write-journal-invalid-time-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.invalid-time`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: 'not-a-date',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery?.action).toBe('quarantined-invalid-journal');
+      expect(existsSync(tempPath)).toBe(true);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
+    it('retains active preparing journals even before the temp file exists', () => {
+      const dir = makeTmpDir('state-write-journal-active-preparing-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.pending`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'preparing',
+          startedAt: '2999-01-01T00:00:00.000Z',
+          updatedAt: '2999-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery).toMatchObject({
+        action: 'retained-active-journal',
+        tempPath,
+      });
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(true);
+    });
+
     it('retains active journals so concurrent writers do not remove live temp files', () => {
       const dir = makeTmpDir('state-write-journal-active-');
       const filePath = join(dir, 'state.json');
@@ -199,6 +253,37 @@ describe('atomic-file', () => {
       expect(existsSync(victimPath)).toBe(true);
       expect(readFileSync(victimPath, 'utf-8')).toBe('{"important":true}');
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
+    it('quarantines journals with nested paths under a matching temp prefix', () => {
+      const dir = makeTmpDir('state-write-journal-nested-temp-');
+      const filePath = join(dir, 'state.json');
+      const nestedDir = `${filePath}.tmp.backup`;
+      const nestedPath = join(nestedDir, 'important.json');
+      writeFileSync(filePath, '{"old":true}');
+      rmSync(nestedDir, { recursive: true, force: true });
+      // mkdtempSync cannot target this exact name, so create via the filesystem API.
+      writeFileSync(`${filePath}.tmp.backup-placeholder`, 'placeholder');
+      rmSync(`${filePath}.tmp.backup-placeholder`, { force: true });
+      mkdirSync(nestedDir);
+      writeFileSync(nestedPath, '{"important":true}');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath: nestedPath,
+          phase: 'writing-temp',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery?.action).toBe('quarantined-invalid-journal');
+      expect(existsSync(nestedPath)).toBe(true);
     });
 
     it('normalizes target paths before deciding whether a journal belongs to the file', () => {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -229,39 +229,10 @@ describe('atomic-file', () => {
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
     });
 
-    it('removes temp files from stale preparing journals when the temp was created after the journal', () => {
-      const dir = makeTmpDir('state-write-journal-owned-preparing-');
-      const filePath = join(dir, 'state.json');
-      const tempPath = `${filePath}.tmp.owned`;
-      writeFileSync(filePath, '{"old":true}');
-      writeFileSync(
-        stateWriteJournalPath(filePath),
-        JSON.stringify({
-          schemaVersion: 1,
-          targetPath: filePath,
-          tempPath,
-          phase: 'preparing',
-          startedAt: '1970-01-01T00:00:00.000Z',
-          updatedAt: '1970-01-01T00:00:01.000Z',
-        }),
-        'utf8',
-      );
-      writeFileSync(tempPath, '{"new":');
-
-      const recovery = recoverStateWriteTransaction(filePath);
-
-      expect(recovery).toMatchObject({
-        action: 'removed-stale-temp',
-        tempPath,
-      });
-      expect(existsSync(tempPath)).toBe(false);
-      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
-    });
-
     it('removes stale journal temp files that never reached the final journal rename', () => {
       const dir = makeTmpDir('state-write-journal-temp-orphan-');
       const filePath = join(dir, 'state.json');
-      const orphanJournalTempPath = `${stateWriteJournalPath(filePath)}.tmp.orphan`;
+      const orphanJournalTempPath = `${stateWriteJournalPath(filePath)}.tmp.123.00000000-0000-0000-0000-000000000000`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(orphanJournalTempPath, '{"schemaVersion":1');
       utimesSync(
@@ -273,6 +244,19 @@ describe('atomic-file', () => {
       recoverStateWriteTransaction(filePath);
 
       expect(existsSync(orphanJournalTempPath)).toBe(false);
+    });
+
+    it('does not remove non-journal siblings that merely share the journal temp prefix', () => {
+      const dir = makeTmpDir('state-write-journal-temp-sibling-');
+      const filePath = join(dir, 'state.json');
+      const siblingPath = `${stateWriteJournalPath(filePath)}.tmp.sibling.json`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(siblingPath, '{"real":true}');
+      utimesSync(siblingPath, new Date('1970-01-01T00:00:00.000Z'), new Date('1970-01-01T00:00:00.000Z'));
+
+      recoverStateWriteTransaction(filePath);
+
+      expect(readFileSync(siblingPath, 'utf-8')).toBe('{"real":true}');
     });
 
     it('retains active journals so concurrent writers do not remove live temp files', () => {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -250,13 +250,47 @@ describe('atomic-file', () => {
       const dir = makeTmpDir('state-write-journal-temp-sibling-');
       const filePath = join(dir, 'state.json');
       const siblingPath = `${stateWriteJournalPath(filePath)}.tmp.sibling.json`;
-      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(filePath, '{"real":true}');
       writeFileSync(siblingPath, '{"real":true}');
       utimesSync(siblingPath, new Date('1970-01-01T00:00:00.000Z'), new Date('1970-01-01T00:00:00.000Z'));
 
       recoverStateWriteTransaction(filePath);
 
       expect(readFileSync(siblingPath, 'utf-8')).toBe('{"real":true}');
+    });
+
+    it('matches active journals by file identity across symlinked directories', () => {
+      const dir = makeTmpDir('state-write-journal-symlink-');
+      const realDir = join(dir, 'real');
+      const symlinkDir = join(dir, 'link');
+      mkdirSync(realDir);
+      symlinkSync(realDir, symlinkDir, 'dir');
+      const realFilePath = join(realDir, 'state.json');
+      const symlinkFilePath = join(symlinkDir, 'state.json');
+      const tempPath = `${symlinkFilePath}.tmp.live`;
+      writeFileSync(realFilePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(symlinkFilePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: realFilePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2999-01-01T00:00:00.000Z',
+          updatedAt: '2999-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(symlinkFilePath);
+
+      expect(recovery).toMatchObject({
+        action: 'retained-active-journal',
+        tempPath,
+      });
+      expect(existsSync(tempPath)).toBe(true);
+      expect(existsSync(stateWriteJournalPath(symlinkFilePath))).toBe(true);
     });
 
     it('retains active journals so concurrent writers do not remove live temp files', () => {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -74,7 +74,7 @@ describe('atomic-file', () => {
     it('journals and recovers an interrupted temp-file write before the next save', () => {
       const dir = makeTmpDir('atomic-write-recover-');
       const filePath = join(dir, 'session.json');
-      const tempPath = `${filePath}.tmp.interrupted`;
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000010`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(tempPath, '{"new":');
       writeFileSync(
@@ -102,7 +102,7 @@ describe('atomic-file', () => {
     it('reports stale temp-file cleanup from a valid journal', () => {
       const dir = makeTmpDir('state-write-journal-recover-');
       const filePath = join(dir, 'state.json');
-      const tempPath = `${filePath}.tmp.stale`;
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000001`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(tempPath, '{"new":');
       writeFileSync(
@@ -173,7 +173,7 @@ describe('atomic-file', () => {
     it('retains active preparing journals even before the temp file exists', () => {
       const dir = makeTmpDir('state-write-journal-active-preparing-');
       const filePath = join(dir, 'state.json');
-      const tempPath = `${filePath}.tmp.pending`;
+      const tempPath = `${filePath}.tmp.124.00000000-0000-0000-0000-000000000002`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(
         stateWriteJournalPath(filePath),
@@ -198,7 +198,7 @@ describe('atomic-file', () => {
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(true);
     });
 
-    it('does not delete temp files from stale preparing journals because ownership is unproven', () => {
+    it('quarantines stale preparing journals that name non-generated temp files without deleting the temp', () => {
       const dir = makeTmpDir('state-write-journal-stale-preparing-');
       const filePath = join(dir, 'state.json');
       const tempPath = `${filePath}.tmp.preexisting`;
@@ -221,7 +221,7 @@ describe('atomic-file', () => {
       const recovery = recoverStateWriteTransaction(filePath);
 
       expect(recovery).toMatchObject({
-        action: 'removed-completed-journal',
+        action: 'quarantined-invalid-journal',
         tempPath,
       });
       expect(existsSync(tempPath)).toBe(true);
@@ -296,7 +296,7 @@ describe('atomic-file', () => {
       symlinkSync(realDir, symlinkDir, 'dir');
       const realFilePath = join(realDir, 'state.json');
       const symlinkFilePath = join(symlinkDir, 'state.json');
-      const tempPath = `${realFilePath}.tmp.live`;
+      const tempPath = `${realFilePath}.tmp.125.00000000-0000-0000-0000-000000000003`;
       writeFileSync(realFilePath, '{"old":true}');
       writeFileSync(tempPath, '{"new":');
       writeFileSync(
@@ -325,7 +325,7 @@ describe('atomic-file', () => {
     it('retains active journals so concurrent writers do not remove live temp files', () => {
       const dir = makeTmpDir('state-write-journal-active-');
       const filePath = join(dir, 'state.json');
-      const tempPath = `${filePath}.tmp.live`;
+      const tempPath = `${filePath}.tmp.126.00000000-0000-0000-0000-000000000004`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(tempPath, '{"new":');
       writeFileSync(
@@ -438,7 +438,7 @@ describe('atomic-file', () => {
     it('normalizes target paths before deciding whether a journal belongs to the file', () => {
       const dir = makeTmpDir('state-write-journal-normalized-target-');
       const filePath = join(dir, 'state.json');
-      const tempPath = `${filePath}.tmp.stale`;
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000001`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(tempPath, '{"new":');
       writeFileSync(

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -198,6 +198,36 @@ describe('atomic-file', () => {
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(true);
     });
 
+    it('does not delete temp files from stale preparing journals because ownership is unproven', () => {
+      const dir = makeTmpDir('state-write-journal-stale-preparing-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.preexisting`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"belongs":"elsewhere"}');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'preparing',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery).toMatchObject({
+        action: 'removed-completed-journal',
+        tempPath,
+      });
+      expect(existsSync(tempPath)).toBe(true);
+      expect(readFileSync(tempPath, 'utf-8')).toBe('{"belongs":"elsewhere"}');
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
     it('retains active journals so concurrent writers do not remove live temp files', () => {
       const dir = makeTmpDir('state-write-journal-active-');
       const filePath = join(dir, 'state.json');

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -204,6 +204,7 @@ describe('atomic-file', () => {
       const tempPath = `${filePath}.tmp.preexisting`;
       writeFileSync(filePath, '{"old":true}');
       writeFileSync(tempPath, '{"belongs":"elsewhere"}');
+      utimesSync(tempPath, new Date('1970-01-01T00:00:00.000Z'), new Date('1970-01-01T00:00:00.000Z'));
       writeFileSync(
         stateWriteJournalPath(filePath),
         JSON.stringify({
@@ -226,6 +227,52 @@ describe('atomic-file', () => {
       expect(existsSync(tempPath)).toBe(true);
       expect(readFileSync(tempPath, 'utf-8')).toBe('{"belongs":"elsewhere"}');
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
+    it('removes temp files from stale preparing journals when the temp was created after the journal', () => {
+      const dir = makeTmpDir('state-write-journal-owned-preparing-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.owned`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'preparing',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+      writeFileSync(tempPath, '{"new":');
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery).toMatchObject({
+        action: 'removed-stale-temp',
+        tempPath,
+      });
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+    });
+
+    it('removes stale journal temp files that never reached the final journal rename', () => {
+      const dir = makeTmpDir('state-write-journal-temp-orphan-');
+      const filePath = join(dir, 'state.json');
+      const orphanJournalTempPath = `${stateWriteJournalPath(filePath)}.tmp.orphan`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(orphanJournalTempPath, '{"schemaVersion":1');
+      utimesSync(
+        orphanJournalTempPath,
+        new Date('1970-01-01T00:00:00.000Z'),
+        new Date('1970-01-01T00:00:00.000Z'),
+      );
+
+      recoverStateWriteTransaction(filePath);
+
+      expect(existsSync(orphanJournalTempPath)).toBe(false);
     });
 
     it('retains active journals so concurrent writers do not remove live temp files', () => {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -286,6 +286,31 @@ describe('atomic-file', () => {
       expect(existsSync(nestedPath)).toBe(true);
     });
 
+    it('quarantines journals whose temp path is a sidecar directory', () => {
+      const dir = makeTmpDir('state-write-journal-dir-temp-');
+      const filePath = join(dir, 'state.json');
+      const dirTempPath = `${filePath}.tmp.directory`;
+      writeFileSync(filePath, '{"old":true}');
+      mkdirSync(dirTempPath);
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath: dirTempPath,
+          phase: 'writing-temp',
+          startedAt: '1970-01-01T00:00:00.000Z',
+          updatedAt: '1970-01-01T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery?.action).toBe('quarantined-invalid-journal');
+      expect(existsSync(dirTempPath)).toBe(true);
+    });
+
     it('normalizes target paths before deciding whether a journal belongs to the file', () => {
       const dir = makeTmpDir('state-write-journal-normalized-target-');
       const filePath = join(dir, 'state.json');

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { atomicWriteFileSync, quarantineFile, readJsonFileOrQuarantine } from '../../../src/session/atomic-file.js';
+import {
+  atomicWriteFileSync,
+  quarantineFile,
+  readJsonFileOrQuarantine,
+  readStateWriteTransactionJournal,
+  recoverStateWriteTransaction,
+  stateWriteJournalPath,
+} from '../../../src/session/atomic-file.js';
 
 describe('atomic-file', () => {
   const tmpDirs: string[] = [];
@@ -29,7 +36,7 @@ describe('atomic-file', () => {
       expect(readFileSync(filePath, 'utf-8')).toBe('{"a":1}');
     });
 
-    it('leaves no temp files behind after a write', () => {
+    it('leaves no temp files or state write journal behind after a write', () => {
       const dir = makeTmpDir('atomic-write-tmp-');
       const filePath = join(dir, 'session.json');
 
@@ -38,6 +45,7 @@ describe('atomic-file', () => {
 
       const leftovers = readdirSync(dir).filter((f) => f !== 'session.json');
       expect(leftovers).toEqual([]);
+      expect(readStateWriteTransactionJournal(filePath)).toBeUndefined();
     });
 
     it('replaces existing content atomically via rename (never a partially written final file)', () => {
@@ -52,15 +60,88 @@ describe('atomic-file', () => {
       expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');
     });
 
-    it('cleans up the temp file if the write fails', () => {
+    it('cleans up the temp file and journal if the write fails', () => {
       const dir = makeTmpDir('atomic-write-fail-');
-      // Target directory does not exist -> rename fails.
+      // Target directory does not exist -> journal/open fails.
       const filePath = join(dir, 'missing-subdir', 'session.json');
 
       expect(() => atomicWriteFileSync(filePath, '{}')).toThrow();
 
       const leftovers = readdirSync(dir);
       expect(leftovers).toEqual([]);
+    });
+
+    it('journals and recovers an interrupted temp-file write before the next save', () => {
+      const dir = makeTmpDir('atomic-write-recover-');
+      const filePath = join(dir, 'session.json');
+      const tempPath = `${filePath}.tmp.interrupted`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2026-07-15T00:00:00.000Z',
+          updatedAt: '2026-07-15T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      atomicWriteFileSync(filePath, '{"new":true}');
+
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+      expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');
+    });
+  });
+
+  describe('recoverStateWriteTransaction()', () => {
+    it('reports stale temp-file cleanup from a valid journal', () => {
+      const dir = makeTmpDir('state-write-journal-recover-');
+      const filePath = join(dir, 'state.json');
+      const tempPath = `${filePath}.tmp.stale`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'renaming',
+          startedAt: '2026-07-15T00:00:00.000Z',
+          updatedAt: '2026-07-15T00:00:01.000Z',
+        }),
+        'utf8',
+      );
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery).toMatchObject({
+        journalPath: stateWriteJournalPath(filePath),
+        targetPath: filePath,
+        tempPath,
+        action: 'removed-stale-temp',
+      });
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+      expect(readFileSync(filePath, 'utf-8')).toBe('{"old":true}');
+    });
+
+    it('quarantines malformed journal JSON instead of throwing', () => {
+      const dir = makeTmpDir('state-write-journal-malformed-');
+      const filePath = join(dir, 'state.json');
+      writeFileSync(stateWriteJournalPath(filePath), '{"targetPath":');
+
+      const recovery = recoverStateWriteTransaction(filePath);
+
+      expect(recovery?.action).toBe('quarantined-invalid-journal');
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+      const quarantine = readdirSync(dir).filter((file) => file.includes('.journal.corrupt.'));
+      expect(quarantine).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a sidecar transaction journal for `atomicWriteFileSync()` state writes.
- Recover interrupted journaled writes by removing stale temp files or completed journals before the next save.
- Quarantine malformed journals and document operator recovery behavior.

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/session/atomic-file.test.ts`
- `npm run build --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)

Closes #1804
